### PR TITLE
fix: extract PGPASSWORD for deploy scripts

### DIFF
--- a/deploy/scripts/ci-deploy.sh
+++ b/deploy/scripts/ci-deploy.sh
@@ -27,6 +27,23 @@ DB_NAME="baluhost"
 DB_USER="baluhost"
 BACKUP_RETENTION=10
 
+# Extract PGPASSWORD from DATABASE_URL in .env.production
+load_db_password() {
+    local env_file="$INSTALL_DIR/.env.production"
+    if [[ -f "$env_file" ]]; then
+        local db_url
+        db_url=$(grep -m1 '^DATABASE_URL=' "$env_file" | cut -d= -f2-)
+        # Parse password from postgresql://user:password@host:port/db
+        export PGPASSWORD
+        PGPASSWORD=$(echo "$db_url" | sed -n 's|.*://[^:]*:\([^@]*\)@.*|\1|p')
+    fi
+    if [[ -z "${PGPASSWORD:-}" ]]; then
+        echo "ERROR: Could not extract database password from $env_file" >&2
+        exit 1
+    fi
+}
+load_db_password
+
 # Services to restart (order matters)
 SERVICES=(
     baluhost-backend

--- a/deploy/scripts/db-backup-daily.sh
+++ b/deploy/scripts/db-backup-daily.sh
@@ -11,6 +11,23 @@ BACKUP_DIR="${BACKUP_DIR:-/opt/baluhost/backups/daily}"
 RETENTION_DAYS="${RETENTION_DAYS:-14}"
 DB_NAME="${DB_NAME:-baluhost}"
 DB_USER="${DB_USER:-baluhost}"
+INSTALL_DIR="${INSTALL_DIR:-/opt/baluhost}"
+
+# Extract PGPASSWORD from DATABASE_URL in .env.production
+load_db_password() {
+    local env_file="$INSTALL_DIR/.env.production"
+    if [[ -f "$env_file" ]]; then
+        local db_url
+        db_url=$(grep -m1 '^DATABASE_URL=' "$env_file" | cut -d= -f2-)
+        export PGPASSWORD
+        PGPASSWORD=$(echo "$db_url" | sed -n 's|.*://[^:]*:\([^@]*\)@.*|\1|p')
+    fi
+    if [[ -z "${PGPASSWORD:-}" ]]; then
+        echo "ERROR: Could not extract database password from $env_file" >&2
+        exit 1
+    fi
+}
+load_db_password
 
 mkdir -p "$BACKUP_DIR"
 

--- a/deploy/scripts/db-restore.sh
+++ b/deploy/scripts/db-restore.sh
@@ -18,6 +18,21 @@ VENV_BIN="$INSTALL_DIR/backend/.venv/bin"
 DB_NAME="baluhost"
 DB_USER="baluhost"
 
+# Extract PGPASSWORD from DATABASE_URL in .env.production
+load_db_password() {
+    local env_file="$INSTALL_DIR/.env.production"
+    if [[ -f "$env_file" ]]; then
+        local db_url
+        db_url=$(grep -m1 '^DATABASE_URL=' "$env_file" | cut -d= -f2-)
+        export PGPASSWORD
+        PGPASSWORD=$(echo "$db_url" | sed -n 's|.*://[^:]*:\([^@]*\)@.*|\1|p')
+    fi
+    if [[ -z "${PGPASSWORD:-}" ]]; then
+        log_warn "Could not extract database password. pg_dump/psql may prompt for password."
+    fi
+}
+load_db_password
+
 SERVICES=(
     baluhost-backend
     baluhost-scheduler


### PR DESCRIPTION
## Summary
- Deploy script (`ci-deploy.sh`) fails on `pg_dump` because no password is supplied
- All 3 DB scripts now parse `PGPASSWORD` from `DATABASE_URL` in `.env.production`

## Changes
- `deploy/scripts/ci-deploy.sh` — added `load_db_password()` function
- `deploy/scripts/db-backup-daily.sh` — same
- `deploy/scripts/db-restore.sh` — same (warning instead of hard fail)

## Test plan
- [ ] `ci-deploy.sh` runs `pg_dump` without password prompt
- [ ] Daily backup cron succeeds
- [ ] `db-restore.sh` still works for manual restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)