### PR TITLE
fix: use DEPLOY_PAT for auto-merge to trigger deploy

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Find and merge PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.DEPLOY_PAT }}
           REPO: ${{ github.repository }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |


### PR DESCRIPTION
## Summary
- Auto-merge with `github.token` doesn't trigger `deploy-production.yml` (GitHub security rule)
- Switched to `secrets.DEPLOY_PAT` so the merge push is attributed to a real user
- Also includes PGPASSWORD fix from previous PR

## Test plan
- [ ] Auto-merge triggers after CI Check passes
- [ ] Deploy Production workflow triggers after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)