### PR TITLE
ci: add manual deploy trigger (workflow_dispatch)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,6 +3,7 @@ name: Deploy Production
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: production-deploy


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` to deploy-production.yml for manual triggering
- First real deploy test — /opt/baluhost already updated with PGPASSWORD fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)