### PR TITLE
Release v1.13.4

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -32,9 +32,6 @@ jobs:
 
           echo "Auto-merging PR #$PR_NUMBER (branch: $HEAD_BRANCH)"
 
-          # Get PR title before merging (for tag extraction)
-          PR_TITLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title --jq '.title')
-
           if [ "$HEAD_BRANCH" = "development" ]; then
             # Never delete the development branch
             gh pr merge "$PR_NUMBER" --repo "$REPO" --merge
@@ -42,15 +39,18 @@ jobs:
             gh pr merge "$PR_NUMBER" --repo "$REPO" --merge --delete-branch
           fi
 
-          # Auto-tag if PR title starts with "v" (e.g. "v1.13.2: ...")
-          TAG=$(echo "$PR_TITLE" | grep -oP '^v\d+\.\d+\.\d+' || true)
-          if [ -n "$TAG" ]; then
-            echo "Creating tag $TAG from PR title"
-            git clone --depth 1 --branch main "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" /tmp/repo
-            cd /tmp/repo
+          # Auto-tag from version in pyproject.toml on main
+          git clone --depth 1 --branch main "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" /tmp/repo
+          cd /tmp/repo
+          VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' backend/pyproject.toml || true)
+          TAG="v${VERSION}"
+          if [ -z "$VERSION" ]; then
+            echo "Could not read version from pyproject.toml — skipping auto-tag"
+          elif git tag -l "$TAG" | grep -q .; then
+            echo "Tag $TAG already exists — skipping"
+          else
+            echo "Creating tag $TAG from pyproject.toml"
             git tag -a "$TAG" -m "Release $TAG"
             git push origin "$TAG"
             echo "Tag $TAG pushed — release workflow will create GitHub Release"
-          else
-            echo "PR title does not start with version tag — skipping auto-tag"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.13.4] - 2026-03-08
+
+### Scheduler Dashboard & Mobile API
+
+Worker Health Status im Scheduler Dashboard zeigt jetzt den Zustand aller
+Worker-Prozesse an. Stale Executions werden korrekt als CANCELLED markiert,
+und ein neuer Mobile Power Summary Endpoint erweitert die Mobile-API.
+
+### Added
+
+- **Worker health status** — Scheduler Dashboard zeigt Worker-Prozess-Status
+- **Mobile power summary** — Neuer API-Endpoint für mobile Energieübersicht
+
+### Fixed
+
+- **Stale execution recovery** — CANCELLED statt FAILED für abgebrochene Executions
+- **WebSocket StrictMode** — Verzögerter Connect verhindert ECONNRESET
+- **Frontend API URLs** — Korrekte URLs in allen API-Clients
+- **Scheduler heartbeat** — Timezone-naive Heartbeat-Behandlung
+
+### Changed
+
+- **CI release workflow** — Liest Version aus pyproject.toml statt PR-Titel
+
+---
+
 ## [1.13.3] - 2026-03-07
 
 ### Dev-Mode Stabilität & Architektur

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,4 +63,4 @@ client/
 - **Issues**: GitHub Issues (repository URL needed)
 - **Documentation**: See `docs/` directory
 - **Maintainer**: Xveyn
-- **Version**: 1.13.3 (as of Mar 2026)
+- **Version**: 1.13.4 (as of Mar 2026)

--- a/backend/app/api/routes/mobile.py
+++ b/backend/app/api/routes/mobile.py
@@ -1,5 +1,7 @@
 """API routes for mobile device management (BaluMobile)."""
 
+import logging
+from datetime import datetime, timezone
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException, status, Request, Response
 from sqlalchemy.orm import Session
@@ -14,6 +16,8 @@ from app.schemas.mobile import (
     MobileDeviceUpdate,
     MobileRegistrationToken,
     MobileRegistrationResponse,
+    MobilePowerSummary,
+    TapoDevicePowerInfo,
     CameraBackupSettings,
     CameraBackupStatus,
     SyncFolder as SyncFolderSchema,
@@ -21,6 +25,8 @@ from app.schemas.mobile import (
 )
 from app.models.mobile import MobileDevice
 from app.services.mobile import MobileService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/mobile", tags=["mobile"])
 
@@ -417,4 +423,134 @@ async def create_sync_folder(
         db=db,
         device_id=device_id,
         folder_data=folder_data
+    )
+
+
+# Power Summary Endpoint
+
+
+@router.get("/power-summary", response_model=MobilePowerSummary)
+@user_limiter.limit(get_limit("admin_operations"))
+async def get_power_summary(
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+    current_user: UserPublic = Depends(get_current_user),
+):
+    """
+    Get combined power consumption summary for mobile app.
+
+    Returns CPU power profile, Tapo device power readings,
+    today's energy statistics, and cost estimates in a single call.
+    """
+    from app.services.power.manager import get_power_manager
+    from app.services.power import energy as energy_stats
+    from app.services.power import monitor as power_monitor
+    from app.models.tapo_device import TapoDevice
+
+    now = datetime.now(timezone.utc)
+
+    # 1. CPU power profile (in-memory, fast)
+    power_profile = None
+    power_profile_frequency_mhz = None
+    auto_scaling_enabled = False
+    active_demands_count = 0
+
+    try:
+        manager = get_power_manager()
+        power_status = await manager.get_power_status()
+        power_profile = power_status.current_profile
+        power_profile_frequency_mhz = power_status.current_frequency_mhz
+        auto_scaling_enabled = power_status.auto_scaling_enabled
+        active_demands_count = len(power_status.active_demands) if power_status.active_demands else 0
+    except Exception as e:
+        logger.warning(f"Failed to get power status: {e}")
+
+    # 2. Tapo devices
+    devices_info: List[TapoDevicePowerInfo] = []
+    total_current_watts = 0.0
+    devices_online = 0
+    today_energy_kwh = 0.0
+    today_avg_watts_sum = 0.0
+    today_max_watts = 0.0
+    has_today_stats = False
+
+    try:
+        tapo_devices = db.query(TapoDevice).filter(TapoDevice.is_active == True).all()
+    except Exception as e:
+        logger.warning(f"Failed to query Tapo devices: {e}")
+        tapo_devices = []
+
+    for device in tapo_devices:
+        current_watts = 0.0
+        is_online = False
+        device_energy_today = None
+
+        # Current power from in-memory buffer
+        try:
+            current_power = power_monitor.get_current_power(device.id, db)
+            current_watts = current_power.current_watts
+            is_online = current_power.is_online
+        except Exception as e:
+            logger.debug(f"No current power for device {device.id}: {e}")
+
+        # Today's stats from DB
+        try:
+            today_stats = energy_stats.get_today_stats(db, device.id)
+            if today_stats:
+                has_today_stats = True
+                device_energy_today = today_stats.total_energy_kwh
+                today_energy_kwh += today_stats.total_energy_kwh
+                today_avg_watts_sum += today_stats.avg_watts
+                if today_stats.max_watts > today_max_watts:
+                    today_max_watts = today_stats.max_watts
+        except Exception as e:
+            logger.debug(f"No today stats for device {device.id}: {e}")
+
+        if is_online:
+            devices_online += 1
+            total_current_watts += current_watts
+
+        devices_info.append(TapoDevicePowerInfo(
+            device_id=device.id,
+            device_name=device.name,
+            current_watts=current_watts,
+            is_online=is_online,
+            energy_today_kwh=device_energy_today,
+        ))
+
+    # 3. Energy price config
+    cost_per_kwh = None
+    currency = None
+    estimated_cost_today = None
+
+    try:
+        price_config = energy_stats.get_energy_price_config(db)
+        cost_per_kwh = price_config.cost_per_kwh
+        currency = price_config.currency
+        if has_today_stats and cost_per_kwh:
+            estimated_cost_today = round(today_energy_kwh * cost_per_kwh, 4)
+    except Exception as e:
+        logger.debug(f"Failed to get energy price config: {e}")
+
+    devices_total = len(tapo_devices)
+    today_avg = round(today_avg_watts_sum / devices_total, 1) if devices_total and has_today_stats else None
+
+    return MobilePowerSummary(
+        total_current_watts=round(total_current_watts, 1),
+        devices_online=devices_online,
+        devices_total=devices_total,
+        devices=devices_info,
+        today_energy_kwh=round(today_energy_kwh, 3) if has_today_stats else None,
+        today_avg_watts=today_avg,
+        today_max_watts=round(today_max_watts, 1) if has_today_stats else None,
+        estimated_cost_today=estimated_cost_today,
+        cost_per_kwh=cost_per_kwh,
+        currency=currency,
+        power_profile=power_profile,
+        power_profile_frequency_mhz=power_profile_frequency_mhz,
+        auto_scaling_enabled=auto_scaling_enabled,
+        active_demands_count=active_demands_count,
+        has_tapo_devices=devices_total > 0,
+        timestamp=now,
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -614,12 +614,8 @@ async def _lifespan(app: FastAPI):  # pragma: no cover - startup/shutdown hook
             logger.info("Recovered %d stale benchmark(s) from previous run", recovered)
     kill_orphan_fio_processes()
 
-    # Recover stale scheduler executions from previous run
-    from app.services.scheduler.execution import recover_stale_executions
-    with SessionLocal() as sched_db:
-        recovered = recover_stale_executions(sched_db)
-        if recovered:
-            logger.info("Recovered %d stale scheduler execution(s) from previous run", recovered)
+    # NOTE: Scheduler execution recovery is handled by the worker process
+    # itself in _recover_stale_executions() to avoid duplicate recovery.
 
     # Ensure home directories for all users and Shared folder
     from app.services.users import ensure_user_home_directories

--- a/backend/app/schemas/mobile.py
+++ b/backend/app/schemas/mobile.py
@@ -1,7 +1,7 @@
 """Pydantic schemas for mobile device management and registration."""
 
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 from pydantic import BaseModel, Field
 
 
@@ -142,6 +142,44 @@ class ExpirationNotification(BaseModel):
     fcm_message_id: Optional[str] = None
     error_message: Optional[str] = None
     device_expires_at: datetime
-    
+
     class Config:
         from_attributes = True
+
+
+class TapoDevicePowerInfo(BaseModel):
+    """Power info for a single Tapo device."""
+    device_id: int
+    device_name: str
+    current_watts: float = 0.0
+    is_online: bool = False
+    energy_today_kwh: Optional[float] = None
+
+
+class MobilePowerSummary(BaseModel):
+    """Combined power summary for mobile app."""
+    # Aggregated device power
+    total_current_watts: float = 0.0
+    devices_online: int = 0
+    devices_total: int = 0
+    devices: List[TapoDevicePowerInfo] = []
+
+    # Today's energy
+    today_energy_kwh: Optional[float] = None
+    today_avg_watts: Optional[float] = None
+    today_max_watts: Optional[float] = None
+
+    # Cost
+    estimated_cost_today: Optional[float] = None
+    cost_per_kwh: Optional[float] = None
+    currency: Optional[str] = None
+
+    # CPU power profile
+    power_profile: Optional[str] = None
+    power_profile_frequency_mhz: Optional[int] = None
+    auto_scaling_enabled: bool = False
+    active_demands_count: int = 0
+
+    # Meta
+    has_tapo_devices: bool = False
+    timestamp: datetime

--- a/backend/app/schemas/scheduler.py
+++ b/backend/app/schemas/scheduler.py
@@ -60,6 +60,10 @@ class SchedulerListResponse(BaseModel):
     schedulers: list[SchedulerStatusResponse]
     total_running: int = Field(description="Number of running schedulers")
     total_enabled: int = Field(description="Number of enabled schedulers")
+    worker_healthy: Optional[bool] = Field(
+        default=None,
+        description="Global worker health: True if worker heartbeat is recent, False if stale, None if unknown",
+    )
 
 
 class SchedulerExecutionResponse(BaseModel):

--- a/backend/app/services/scheduler/execution.py
+++ b/backend/app/services/scheduler/execution.py
@@ -45,7 +45,10 @@ def _is_worker_healthy(state: Optional[SchedulerState]) -> Optional[bool]:
     """Check if the worker heartbeat is recent enough."""
     if state is None or state.last_heartbeat is None:
         return None
-    age = (datetime.now(timezone.utc) - state.last_heartbeat).total_seconds()
+    hb = state.last_heartbeat
+    if hb.tzinfo is None:
+        hb = hb.replace(tzinfo=timezone.utc)
+    age = (datetime.now(timezone.utc) - hb).total_seconds()
     return age < WORKER_HEARTBEAT_MAX_AGE
 
 

--- a/backend/app/services/scheduler/execution.py
+++ b/backend/app/services/scheduler/execution.py
@@ -53,7 +53,7 @@ def _is_worker_healthy(state: Optional[SchedulerState]) -> Optional[bool]:
 
 
 def recover_stale_executions(db: Session) -> int:
-    """Mark any RUNNING scheduler executions as FAILED after a server restart."""
+    """Mark any RUNNING scheduler executions as CANCELLED after a server restart."""
     stale = (
         db.query(SchedulerExecution)
         .filter(SchedulerExecution.status == SchedulerStatus.RUNNING.value)
@@ -63,7 +63,7 @@ def recover_stale_executions(db: Session) -> int:
         return 0
     now = datetime.now(timezone.utc)
     for execution in stale:
-        execution.status = SchedulerStatus.FAILED.value
+        execution.status = SchedulerStatus.CANCELLED.value
         execution.error_message = "Server restarted during execution"
         execution.completed_at = now
         if execution.started_at:

--- a/backend/app/services/scheduler/service.py
+++ b/backend/app/services/scheduler/service.py
@@ -54,10 +54,19 @@ class SchedulerService:
         running = sum(1 for s in schedulers if s.is_running)
         enabled = sum(1 for s in schedulers if s.is_enabled)
 
+        # Global worker health: True if any scheduler reports healthy,
+        # False if all report unhealthy, None if no heartbeat data
+        health_values = [s.worker_healthy for s in schedulers if s.worker_healthy is not None]
+        if health_values:
+            worker_healthy = any(health_values)
+        else:
+            worker_healthy = None
+
         return SchedulerListResponse(
             schedulers=schedulers,
             total_running=running,
             total_enabled=enabled,
+            worker_healthy=worker_healthy,
         )
 
     def get_scheduler(self, name: str) -> Optional[SchedulerStatusResponse]:
@@ -80,12 +89,13 @@ class SchedulerService:
         )
 
         worker_healthy = _is_worker_healthy(state)
-        is_running = state.is_running if state else False
+        raw_is_running = state.is_running if state else False
+        is_running = raw_is_running and worker_healthy is not False
         is_enabled = self._check_scheduler_enabled(name)
         interval = self._get_scheduler_interval(name, info)
 
-        # next_run_at from worker state (accurate, from APScheduler)
-        next_run_at = state.next_run_at if state else None
+        # next_run_at only meaningful when worker is alive
+        next_run_at = state.next_run_at if (state and worker_healthy is not False) else None
 
         # Get last execution from DB
         last_exec = (

--- a/backend/app/services/scheduler/worker.py
+++ b/backend/app/services/scheduler/worker.py
@@ -634,7 +634,7 @@ class SchedulerWorker:
     # --- Recovery ----------------------------------------------------------
 
     def _recover_stale_executions(self) -> None:
-        """Mark stale RUNNING and REQUESTED executions as FAILED after restart."""
+        """Mark stale RUNNING and REQUESTED executions as CANCELLED after restart."""
         db = SessionLocal()
         try:
             now = datetime.now(timezone.utc)
@@ -646,8 +646,8 @@ class SchedulerWorker:
                 .all()
             )
             for execution in stale_running:
-                execution.status = SchedulerStatus.FAILED.value
-                execution.error_message = "Worker restarted during execution"
+                execution.status = SchedulerStatus.CANCELLED.value
+                execution.error_message = "[recovery] Worker restarted during execution"
                 execution.completed_at = now
                 started_at = execution.started_at
                 if started_at:
@@ -665,8 +665,8 @@ class SchedulerWorker:
                 .all()
             )
             for execution in stale_requested:
-                execution.status = SchedulerStatus.FAILED.value
-                execution.error_message = "Request expired (worker was not running)"
+                execution.status = SchedulerStatus.CANCELLED.value
+                execution.error_message = "[recovery] Request expired (worker was not running)"
                 execution.completed_at = now
                 started_at = execution.started_at
                 if started_at:
@@ -710,7 +710,7 @@ class SchedulerWorker:
             for execution in running:
                 execution.status = SchedulerStatus.CANCELLED.value
                 execution.completed_at = now
-                execution.error_message = "Worker shutdown during execution"
+                execution.error_message = "[recovery] Worker shutdown during execution"
                 started_at = execution.started_at
                 if started_at:
                     delta = now - _ensure_aware(started_at)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baluhost-backend"
-version = "1.13.3"
+version = "1.13.4"
 description = "Mocked NAS management backend built with FastAPI"
 authors = [{ name = "Baluhost" }]
 requires-python = ">=3.11"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baluhost-client",
   "private": true,
-  "version": "1.13.3",
+  "version": "1.13.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/api/schedulers.ts
+++ b/client/src/api/schedulers.ts
@@ -96,7 +96,7 @@ export interface SchedulerConfigUpdate {
  * Get status for all schedulers (admin only)
  */
 export async function getSchedulers(): Promise<SchedulerListResponse> {
-  const response = await apiClient.get<SchedulerListResponse>('/api/schedulers');
+  const response = await apiClient.get<SchedulerListResponse>('/api/schedulers/');
   return response.data;
 }
 

--- a/client/src/api/schedulers.ts
+++ b/client/src/api/schedulers.ts
@@ -44,6 +44,7 @@ export interface SchedulerListResponse {
   schedulers: SchedulerStatus[];
   total_running: number;
   total_enabled: number;
+  worker_healthy: boolean | null;
 }
 
 export interface SchedulerExecution {

--- a/client/src/components/scheduler/SchedulerCard.tsx
+++ b/client/src/components/scheduler/SchedulerCard.tsx
@@ -149,11 +149,21 @@ export function SchedulerCard({
             </span>
           )}
         </div>
-        {scheduler.last_error && (
-          <div className="mt-2 text-xs text-red-400 bg-red-900/20 rounded px-2 py-1 truncate">
-            {scheduler.last_error}
-          </div>
-        )}
+        {scheduler.last_error && (() => {
+          const isRecovery = scheduler.last_error.startsWith('[recovery]');
+          const displayError = isRecovery
+            ? scheduler.last_error.replace(/^\[recovery\]\s*/, '')
+            : scheduler.last_error;
+          return (
+            <div className={`mt-2 text-xs rounded px-2 py-1 truncate ${
+              isRecovery
+                ? 'text-amber-400 bg-amber-900/20'
+                : 'text-red-400 bg-red-900/20'
+            }`}>
+              {displayError}
+            </div>
+          );
+        })()}
       </div>
 
       {/* Actions */}

--- a/client/src/data/api-endpoints/sections-features.ts
+++ b/client/src/data/api-endpoints/sections-features.ts
@@ -10,7 +10,7 @@ export const featureSections: ApiSection[] = [
     title: 'Updates',
     icon: icon(Download),
     endpoints: [
-      { method: 'GET', path: '/api/updates/version', description: 'Get Current Version', requiresAuth: true, response: '{ "version": "1.13.3", "build_date": "2026-03-03" }' },
+      { method: 'GET', path: '/api/updates/version', description: 'Get Current Version', requiresAuth: true, response: '{ "version": "1.13.4", "build_date": "2026-03-03" }' },
       { method: 'GET', path: '/api/updates/release-notes', description: 'Get Release Notes', requiresAuth: true, response: '{ "notes": [...] }' },
       { method: 'GET', path: '/api/updates/check', description: 'Check for Updates', requiresAuth: true, response: '{ "available": true, "latest_version": "1.5.2", "changelog": "..." }' },
       {

--- a/client/src/hooks/useNotificationSocket.ts
+++ b/client/src/hooks/useNotificationSocket.ts
@@ -223,11 +223,17 @@ export function useNotificationSocket(options: UseNotificationSocketOptions = {}
   }, []);
 
   // 1) Mount: connect if ready. Unmount: disconnect.
+  //    Delayed to avoid ECONNRESET from React StrictMode double-mount.
   useEffect(() => {
-    if (enabledRef.current && tokenRef.current) {
-      void connect();
-    }
-    return () => { disconnect(); };
+    const timer = setTimeout(() => {
+      if (enabledRef.current && tokenRef.current) {
+        void connect();
+      }
+    }, 50);
+    return () => {
+      clearTimeout(timer);
+      disconnect();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Runs ONCE on mount, cleanup on unmount
 

--- a/client/src/hooks/useSchedulers.ts
+++ b/client/src/hooks/useSchedulers.ts
@@ -28,6 +28,7 @@ interface UseSchedulersReturn {
   schedulers: SchedulerStatus[];
   totalRunning: number;
   totalEnabled: number;
+  workerHealthy: boolean | null;
   loading: boolean;
   error: string | null;
   refetch: () => Promise<void>;
@@ -131,6 +132,7 @@ export function useSchedulers(options: UseSchedulersOptions = {}): UseSchedulers
     schedulers: data?.schedulers || [],
     totalRunning: data?.total_running || 0,
     totalEnabled: data?.total_enabled || 0,
+    workerHealthy: data?.worker_healthy ?? null,
     loading,
     error,
     refetch: loadData,

--- a/client/src/i18n/locales/de/scheduler.json
+++ b/client/src/i18n/locales/de/scheduler.json
@@ -136,6 +136,11 @@
     "running": "läuft",
     "recentFailures": "Letzte Fehler"
   },
+  "worker": {
+    "unhealthy": "Scheduler-Worker antwortet nicht",
+    "unhealthyDescription": "Der Scheduler-Worker hat seit über 60 Sekunden keinen Heartbeat gesendet. Geplante Aufgaben werden möglicherweise nicht ausgeführt.",
+    "down": "Worker inaktiv"
+  },
   "card": {
     "active": "Aktiv",
     "disabled": "Deaktiviert",

--- a/client/src/i18n/locales/en/scheduler.json
+++ b/client/src/i18n/locales/en/scheduler.json
@@ -136,6 +136,11 @@
     "running": "running",
     "recentFailures": "Recent Failures"
   },
+  "worker": {
+    "unhealthy": "Scheduler Worker Not Responding",
+    "unhealthyDescription": "The scheduler worker has not sent a heartbeat in over 60 seconds. Scheduled tasks may not be running.",
+    "down": "Worker Down"
+  },
   "card": {
     "active": "Active",
     "disabled": "Disabled",

--- a/client/src/lib/localApi.ts
+++ b/client/src/lib/localApi.ts
@@ -11,7 +11,7 @@ import { getToken, storeToken, clearToken } from './secureStore';
 // In production: use same origin (via Nginx proxy)
 // In development: use localhost:3001
 const isDevelopment = import.meta.env.DEV;
-const LOCAL_API_BASE = isDevelopment ? 'http://127.0.0.1:3001' : '';
+const LOCAL_API_BASE = isDevelopment ? 'http://127.0.0.1:8000' : '';
 const API_PREFIX = '/api';
 
 export interface LocalApiConfig {

--- a/client/src/pages/SchedulerDashboard.tsx
+++ b/client/src/pages/SchedulerDashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Calendar, Clock, History, Settings, Wrench, RefreshCw, Loader2, BarChart3 } from 'lucide-react';
+import { Calendar, Clock, History, Settings, Wrench, RefreshCw, Loader2, BarChart3, AlertTriangle } from 'lucide-react';
 import { useSchedulers, useSchedulerHistory } from '../hooks/useSchedulers';
 import { SchedulerCard } from '../components/scheduler/SchedulerCard';
 import { SchedulerConfigModal } from '../components/scheduler/SchedulerConfigModal';
@@ -39,6 +39,7 @@ export default function SchedulerDashboard() {
     schedulers,
     totalRunning,
     totalEnabled,
+    workerHealthy,
     loading: schedulersLoading,
     error: schedulersError,
     refetch: refetchSchedulers,
@@ -167,6 +168,17 @@ export default function SchedulerDashboard() {
           </button>
         </div>
       </div>
+
+      {/* Worker Health Warning */}
+      {workerHealthy === false && (
+        <div className="flex items-start gap-3 rounded-lg border border-amber-800 bg-amber-900/20 px-4 py-3">
+          <AlertTriangle className="h-5 w-5 text-amber-400 mt-0.5 flex-shrink-0" />
+          <div>
+            <p className="text-sm font-medium text-amber-300">{t('worker.unhealthy')}</p>
+            <p className="text-xs text-amber-400/80 mt-0.5">{t('worker.unhealthyDescription')}</p>
+          </div>
+        </div>
+      )}
 
       {/* Tabs */}
       <div className="relative">

--- a/client/tests/e2e/fixtures/auth.fixture.ts
+++ b/client/tests/e2e/fixtures/auth.fixture.ts
@@ -96,7 +96,7 @@ async function mockDashboardRoutes(context: BrowserContext) {
   await context.route('**/api/system/raid/status', (r) => r.fulfill(json(MOCK_RAID_STATUS)));
   // Scheduler history must be registered before the catch-all /api/schedulers route
   await context.route('**/api/schedulers/history/**', (r) => r.fulfill(json(MOCK_SCHEDULER_HISTORY)));
-  await context.route('**/api/schedulers', (r) => r.fulfill(json(MOCK_SCHEDULERS)));
+  await context.route('**/api/schedulers/', (r) => r.fulfill(json(MOCK_SCHEDULERS)));
   await context.route('**/api/admin/debug', (r) => r.fulfill(json(MOCK_ADMIN_DEBUG)));
   await context.route('**/api/fans/status', (r) => r.fulfill(json(MOCK_FAN_STATUS)));
   await context.route('**/api/power/status', (r) => r.fulfill(json(MOCK_POWER_STATUS)));

--- a/client/tests/e2e/fixtures/mock-data.ts
+++ b/client/tests/e2e/fixtures/mock-data.ts
@@ -120,9 +120,9 @@ export const MOCK_RAID_STATUS = {
 export const MOCK_SCHEDULERS = {
   schedulers: [
     {
-      name: 'smart_short',
-      display_name: 'SMART Short Test',
-      description: 'Short SMART self-test',
+      name: 'smart_scan',
+      display_name: 'SMART Scan',
+      description: 'Scans disk health using SMART data to detect potential failures',
       is_running: false,
       is_enabled: true,
       interval_seconds: 86400,

--- a/client/tests/e2e/schedulers.spec.ts
+++ b/client/tests/e2e/schedulers.spec.ts
@@ -3,11 +3,11 @@ import { test, expect } from './fixtures/auth.fixture';
 // E2E: Mock backend API calls so tests run without a live backend
 test('schedulers: mock API + trigger Run Now for SMART and RAID', async ({ authenticatedContext }) => {
   // Mock run-now endpoints for each scheduler
-  await authenticatedContext.route('**/api/schedulers/smart_short/run-now', async (route) => {
+  await authenticatedContext.route('**/api/schedulers/smart_scan/run-now', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ success: true, message: 'SMART Short Test started successfully' }),
+      body: JSON.stringify({ success: true, message: 'SMART Scan started successfully' }),
     });
   });
 
@@ -24,16 +24,16 @@ test('schedulers: mock API + trigger Run Now for SMART and RAID', async ({ authe
   await page.waitForLoadState('networkidle');
 
   // Verify scheduler cards are visible
-  await expect(page.locator('text=SMART Short Test').first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator('text=SMART Scan').first()).toBeVisible({ timeout: 10000 });
   await expect(page.locator('text=RAID Scrub').first()).toBeVisible();
 
   // Find Run Now buttons (one per scheduler card)
   const runNowButtons = page.locator('button:has-text("Run Now")');
   await expect(runNowButtons.first()).toBeVisible();
 
-  // Click the first Run Now (SMART Short Test)
+  // Click the first Run Now (SMART Scan)
   await runNowButtons.nth(0).click();
-  await expect(page.locator('text=SMART Short Test started successfully').first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator('text=SMART Scan started successfully').first()).toBeVisible({ timeout: 10000 });
 
   // Click the second Run Now (RAID Scrub)
   await runNowButtons.nth(1).click();


### PR DESCRIPTION
## Summary
- **Worker health status** im Scheduler Dashboard
- **Mobile power summary** API-Endpoint
- **Stale execution recovery** — CANCELLED statt FAILED
- **WebSocket/API URL fixes** — StrictMode ECONNRESET, korrekte Frontend URLs
- **Scheduler heartbeat** — Timezone-naive Behandlung
- **CI** — Release-Version aus pyproject.toml
- **E2E fix** — Scheduler Mock von `smart_short` auf `smart_scan` aktualisiert

## Changelog
See [CHANGELOG.md](CHANGELOG.md#1134---2026-03-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)