### PR TITLE
Release v1.13.6

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -42,6 +42,8 @@ jobs:
           # Auto-tag from version in pyproject.toml on main
           git clone --depth 1 --branch main "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" /tmp/repo
           cd /tmp/repo
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' backend/pyproject.toml || true)
           TAG="v${VERSION}"
           if [ -z "$VERSION" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Thumbs.db
 # Testing
 coverage/
 htmlcov/
+.coverage
 
 # Local data
 storage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.13.6] - 2026-03-09
+
+### Mobile Upload Queue & Update-UI
+
+Upload-Queue für Mobile-Geräte und Verbesserungen an der Update-Seite
+(Dev-Branch-Indikator, Versions-Tab jetzt auch in Production sichtbar).
+Speicher-Anzeige nutzt jetzt verfügbaren statt freien Speicher.
+
+### Added
+
+- **Upload queue endpoint** — Neuer API-Endpoint und Schemas für Mobile-Upload-Queue
+- **Dev branch indicator** — Update-Seite zeigt aktiven Branch im Dev-Modus
+- **Versions tab in production** — Versions-Tab jetzt auch in Production sichtbar
+
+### Fixed
+
+- **Memory info** — Verfügbarer Speicher statt freiem Speicher für akkurate Anzeige
+- **Version sync** — Korrekte Version in `__init__.py` und `package-lock.json`
+- **CI auto-tag** — Git-Identität für auto-tag im Merge-Workflow
+
+### Changed
+
+- **pytest-cov** — Coverage-Reporting zu Test-Dependencies hinzugefügt
+
+---
+
 ## [1.13.5] - 2026-03-08
 
 ### System Variables & VPN Improvements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,4 +63,4 @@ client/
 - **Issues**: GitHub Issues (repository URL needed)
 - **Documentation**: See `docs/` directory
 - **Maintainer**: Xveyn
-- **Version**: 1.13.5 (as of Mar 2026)
+- **Version**: 1.13.6 (as of Mar 2026)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.13.5"
+__version__ = "1.13.6"

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.13.3"
+__version__ = "1.13.5"

--- a/backend/app/api/routes/mobile.py
+++ b/backend/app/api/routes/mobile.py
@@ -22,8 +22,9 @@ from app.schemas.mobile import (
     CameraBackupStatus,
     SyncFolder as SyncFolderSchema,
     SyncFolderCreate,
+    UploadQueueListResponse,
 )
-from app.models.mobile import MobileDevice
+from app.models.mobile import MobileDevice, UploadQueue
 from app.services.mobile import MobileService
 
 logger = logging.getLogger(__name__)
@@ -435,6 +436,33 @@ async def create_sync_folder(
         device_id=device_id,
         folder_data=folder_data
     )
+
+
+# Upload Queue Endpoints
+
+
+@router.get("/upload/queue/{device_id}", response_model=UploadQueueListResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def get_upload_queue(
+    request: Request,
+    response: Response,
+    device_id: str,
+    db: Session = Depends(get_db),
+    current_user: UserPublic = Depends(get_current_user),
+):
+    """
+    Get pending/in-progress uploads for a device.
+    """
+    items = (
+        db.query(UploadQueue)
+        .filter(
+            UploadQueue.device_id == device_id,
+            UploadQueue.status.in_(["pending", "uploading", "failed"]),
+        )
+        .order_by(UploadQueue.created_at.desc())
+        .all()
+    )
+    return UploadQueueListResponse(items=items)
 
 
 # Power Summary Endpoint

--- a/backend/app/schemas/mobile.py
+++ b/backend/app/schemas/mobile.py
@@ -132,6 +132,30 @@ class UploadProgress(BaseModel):
     eta_seconds: Optional[int] = None
 
 
+class UploadQueueItem(BaseModel):
+    """Schema for a single upload queue entry."""
+    id: str
+    device_id: str
+    folder_id: Optional[str] = None
+    filename: str
+    remote_path: str
+    file_size: int = Field(0, alias="file_size_bytes")
+    uploaded_bytes: int = 0
+    status: str = "pending"
+    error_message: Optional[str] = None
+    retry_count: int = 0
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+        populate_by_name = True
+
+
+class UploadQueueListResponse(BaseModel):
+    """Response schema for upload queue list."""
+    items: List[UploadQueueItem] = []
+
+
 class ExpirationNotification(BaseModel):
     """Schema for expiration notification history."""
     id: str

--- a/backend/app/schemas/update.py
+++ b/backend/app/schemas/update.py
@@ -61,6 +61,19 @@ class UpdateCheckResponse(BaseModel):
         default=True,
         description="Whether update can proceed (no blockers)"
     )
+    # Dev branch info (informational only)
+    dev_version_available: bool = Field(
+        default=False,
+        description="Whether development branch has unreleased commits ahead of latest tag"
+    )
+    dev_version: Optional[VersionInfo] = Field(
+        default=None,
+        description="Development branch tip info"
+    )
+    dev_commits_ahead: Optional[int] = Field(
+        default=None,
+        description="Commits ahead of latest release"
+    )
 
 
 class UpdateStartRequest(BaseModel):

--- a/backend/app/services/system.py
+++ b/backend/app/services/system.py
@@ -250,8 +250,8 @@ def get_system_info() -> SystemInfo:
         memory_free = telemetry_memory_sample.total - telemetry_memory_sample.used
     else:
         memory_total = virtual_mem.total
-        memory_used = virtual_mem.used
-        memory_free = virtual_mem.free
+        memory_used = virtual_mem.total - virtual_mem.available
+        memory_free = virtual_mem.available
 
     # Use server uptime (since backend started)
     server_uptime = telemetry_service.get_server_uptime()

--- a/backend/app/services/update/backend.py
+++ b/backend/app/services/update/backend.py
@@ -94,3 +94,12 @@ class UpdateBackend(ABC):
     async def get_all_releases(self) -> ReleaseListResponse:
         """Get list of all releases (git tags)."""
         pass
+
+    async def check_dev_branch(self) -> tuple[bool, Optional[VersionInfo], Optional[int]]:
+        """Check if the development branch has unreleased commits ahead of latest tag.
+
+        Returns:
+            Tuple of (dev_available, dev_version_info, commits_ahead).
+            Default implementation returns no dev version.
+        """
+        return False, None, None

--- a/backend/app/services/update/dev_backend.py
+++ b/backend/app/services/update/dev_backend.py
@@ -219,6 +219,21 @@ class DevUpdateBackend(UpdateBackend):
         """Simulate health check."""
         return True, []
 
+    async def check_dev_branch(self) -> tuple[bool, Optional[VersionInfo], Optional[int]]:
+        """Return mock dev branch info for dev mode."""
+        base_version = version_to_string(self._simulated_version)
+        commits_ahead = 5
+        dev_version_str = f"{base_version}+dev.{commits_ahead}"
+
+        dev_info = VersionInfo(
+            version=dev_version_str,
+            commit="dev9876543210abcdef9876543210abcdef98",
+            commit_short="dev9876",
+            tag=None,
+            date=datetime.now(timezone.utc),
+        )
+        return True, dev_info, commits_ahead
+
     async def get_commit_history(self) -> CommitHistoryResponse:
         """Return mock commit history for dev mode."""
         now = datetime.now(timezone.utc).isoformat()

--- a/backend/app/services/update/prod_backend.py
+++ b/backend/app/services/update/prod_backend.py
@@ -541,6 +541,68 @@ class ProdUpdateBackend(UpdateBackend):
             diff=diff_text,
         )
 
+    async def check_dev_branch(self) -> tuple[bool, Optional[VersionInfo], Optional[int]]:
+        """Check if origin/development has unreleased commits ahead of latest tag."""
+        # Fetch all refs including tags
+        success, _, err = self._run_git("fetch", "--all", "--tags", "--prune")
+        if not success:
+            logger.warning(f"Failed to fetch for dev branch check: {err}")
+            return False, None, None
+
+        # Get latest tag by semver
+        success, tags_output, _ = self._run_git("tag", "-l", "--sort=-version:refname")
+        if not success or not tags_output.strip():
+            return False, None, None
+
+        tags = [t.strip() for t in tags_output.split("\n") if t.strip()]
+        if not tags:
+            return False, None, None
+        latest_tag = tags[0]
+
+        # Check if origin/development exists
+        success, _, _ = self._run_git("rev-parse", "--verify", "origin/development")
+        if not success:
+            return False, None, None
+
+        # Count commits ahead
+        success, count_str, _ = self._run_git(
+            "rev-list", "--count", f"{latest_tag}..origin/development"
+        )
+        if not success or not count_str.strip():
+            return False, None, None
+
+        commits_ahead = int(count_str.strip())
+        if commits_ahead <= 0:
+            return False, None, None
+
+        # Get tip commit info
+        success, tip_output, _ = self._run_git(
+            "log", "-1", "--format=%H|%h|%aI", "origin/development"
+        )
+        if not success or not tip_output.strip():
+            return False, None, None
+
+        parts = tip_output.split("|", 2)
+        if len(parts) < 3:
+            return False, None, None
+
+        full_hash, short_hash, date_str = parts
+        tip_date = datetime.fromisoformat(date_str) if date_str else None
+
+        # Format version as X.Y.Z+dev.N
+        base_version = latest_tag.lstrip("v")
+        dev_version_str = f"{base_version}+dev.{commits_ahead}"
+
+        dev_info = VersionInfo(
+            version=dev_version_str,
+            commit=full_hash,
+            commit_short=short_hash,
+            tag=None,
+            date=tip_date,
+        )
+
+        return True, dev_info, commits_ahead
+
     async def get_all_releases(self) -> ReleaseListResponse:
         """Get list of all releases from git tags."""
         # Get all tags sorted by semver (newest first)

--- a/backend/app/services/update/service.py
+++ b/backend/app/services/update/service.py
@@ -113,6 +113,9 @@ class UpdateService:
         # Check for updates
         available, latest, changelog = await self.backend.check_for_updates(config.channel)
 
+        # Check dev branch for unreleased commits
+        dev_available, dev_version, dev_commits_ahead = await self.backend.check_dev_branch()
+
         # Update last check time
         db_config = self.db.query(UpdateConfig).first()
         if db_config:
@@ -130,6 +133,9 @@ class UpdateService:
             last_checked=datetime.now(timezone.utc),
             blockers=blockers,
             can_update=available and len(blockers) == 0,
+            dev_version_available=dev_available,
+            dev_version=dev_version,
+            dev_commits_ahead=dev_commits_ahead,
         )
 
     async def get_release_notes(self) -> ReleaseNotesResponse:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baluhost-backend"
-version = "1.13.5"
+version = "1.13.6"
 description = "Mocked NAS management backend built with FastAPI"
 authors = [{ name = "Baluhost" }]
 requires-python = ">=3.11"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -54,7 +54,8 @@ dev = [
   "requests>=2.31.0,<3.0.0",
   "qrcode>=7.0.0",
   "apscheduler>=3.10.0,<4.0.0",
-  "pytest-timeout>=2.2.0,<3.0.0"
+  "pytest-timeout>=2.2.0,<3.0.0",
+  "pytest-cov>=4.1.0,<5.0.0"
 ]
 
 scheduler = [
@@ -82,3 +83,24 @@ exclude = ["storage*", "tmp*", "tests*"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+addopts = "--cov=app --cov-report=term-missing --cov-report=html"
+
+[tool.coverage.run]
+source = ["app"]
+omit = [
+    "app/main.py",
+    "app/core/config.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_empty = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+    "pass",
+]
+
+[tool.coverage.html]
+directory = "htmlcov"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baluhost-client",
-  "version": "1.13.3",
+  "version": "1.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baluhost-client",
-      "version": "1.13.3",
+      "version": "1.13.5",
       "dependencies": {
         "axios": "^1.13.1",
         "i18next": "^25.8.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baluhost-client",
   "private": true,
-  "version": "1.13.5",
+  "version": "1.13.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/api/updates.ts
+++ b/client/src/api/updates.ts
@@ -48,6 +48,9 @@ export interface UpdateCheckResponse {
   last_checked: string | null;
   blockers: string[];
   can_update: boolean;
+  dev_version_available: boolean;
+  dev_version: VersionInfo | null;
+  dev_commits_ahead: number | null;
 }
 
 // Start request/response

--- a/client/src/data/api-endpoints/sections-features.ts
+++ b/client/src/data/api-endpoints/sections-features.ts
@@ -10,7 +10,7 @@ export const featureSections: ApiSection[] = [
     title: 'Updates',
     icon: icon(Download),
     endpoints: [
-      { method: 'GET', path: '/api/updates/version', description: 'Get Current Version', requiresAuth: true, response: '{ "version": "1.13.5", "build_date": "2026-03-03" }' },
+      { method: 'GET', path: '/api/updates/version', description: 'Get Current Version', requiresAuth: true, response: '{ "version": "1.13.6", "build_date": "2026-03-03" }' },
       { method: 'GET', path: '/api/updates/release-notes', description: 'Get Release Notes', requiresAuth: true, response: '{ "notes": [...] }' },
       { method: 'GET', path: '/api/updates/check', description: 'Check for Updates', requiresAuth: true, response: '{ "available": true, "latest_version": "1.5.2", "changelog": "..." }' },
       {

--- a/client/src/i18n/locales/de/updates.json
+++ b/client/src/i18n/locales/de/updates.json
@@ -23,7 +23,9 @@
     "upToDate": "Aktuell",
     "upToDateDesc": "Sie verwenden die neueste Version.",
     "lastChecked": "Zuletzt geprüft:",
-    "channel": "{{channel}} Channel"
+    "channel": "{{channel}} Channel",
+    "devVersionAvailable": "Dev-Version verfügbar",
+    "devCommitsAhead": "{{count}} Commit(s) voraus"
   },
   "blockers": {
     "title": "Update blockiert",

--- a/client/src/i18n/locales/en/updates.json
+++ b/client/src/i18n/locales/en/updates.json
@@ -23,7 +23,9 @@
     "upToDate": "Up to Date",
     "upToDateDesc": "You're running the latest version.",
     "lastChecked": "Last checked:",
-    "channel": "{{channel}} Channel"
+    "channel": "{{channel}} Channel",
+    "devVersionAvailable": "Dev version available",
+    "devCommitsAhead": "{{count}} commit(s) ahead"
   },
   "blockers": {
     "title": "Update Blocked",

--- a/client/src/pages/UpdatePage.tsx
+++ b/client/src/pages/UpdatePage.tsx
@@ -457,7 +457,7 @@ export default function UpdatePage() {
                       </div>
                       <div className="flex items-center gap-3 text-xs text-slate-400">
                         <span className="font-mono">{checkResult.dev_version.commit_short}</span>
-                        <span>{t('version.devCommitsAhead', { count: checkResult.dev_commits_ahead })}</span>
+                        <span>{t('version.devCommitsAhead', { count: checkResult.dev_commits_ahead ?? 0 })}</span>
                       </div>
                     </div>
                   )}

--- a/client/src/pages/UpdatePage.tsx
+++ b/client/src/pages/UpdatePage.tsx
@@ -74,15 +74,12 @@ interface Tab {
   icon: React.ReactNode;
 }
 
-const baseTabs: Tab[] = [
+const tabs: Tab[] = [
   { id: 'overview', label: 'tabs.overview', icon: <Package className="h-4 w-4" /> },
   { id: 'history', label: 'tabs.history', icon: <History className="h-4 w-4" /> },
   { id: 'settings', label: 'tabs.settings', icon: <Settings className="h-4 w-4" /> },
+  { id: 'versions', label: 'tabs.versions', icon: <GitCommit className="h-4 w-4" /> },
 ];
-
-const tabs: Tab[] = __BUILD_TYPE__ === 'dev'
-  ? [...baseTabs, { id: 'versions' as TabId, label: 'tabs.versions', icon: <GitCommit className="h-4 w-4" /> }]
-  : baseTabs;
 
 const CATEGORY_ICONS: Record<string, React.ReactNode> = {
   sparkles: <Sparkles className="h-4 w-4" />,
@@ -412,12 +409,16 @@ export default function UpdatePage() {
               className={`bg-slate-800 rounded-lg p-5 border ${
                 checkResult?.update_available
                   ? 'border-blue-500/50 bg-blue-500/5'
-                  : 'border-slate-700'
+                  : !checkResult?.update_available && checkResult?.dev_version_available
+                    ? 'border-amber-500/30 bg-amber-500/5'
+                    : 'border-slate-700'
               }`}
             >
               <div className="flex items-center gap-2 mb-4">
                 {checkResult?.update_available ? (
                   <Zap className="h-5 w-5 text-blue-400" />
+                ) : !checkResult?.update_available && checkResult?.dev_version_available ? (
+                  <GitBranch className="h-5 w-5 text-amber-400" />
                 ) : (
                   <CheckCircle className="h-5 w-5 text-emerald-400" />
                 )}
@@ -444,9 +445,23 @@ export default function UpdatePage() {
                   )}
                 </div>
               ) : (
-                <p className="text-slate-400">
-                  {t('version.upToDateDesc')}
-                </p>
+                <div className="space-y-3">
+                  <p className="text-slate-400">
+                    {t('version.upToDateDesc')}
+                  </p>
+                  {checkResult?.dev_version_available && checkResult.dev_version && (
+                    <div className="pt-2 border-t border-slate-700/50 space-y-1.5">
+                      <div className="flex items-center gap-2 text-sm text-amber-400">
+                        <GitBranch className="h-3.5 w-3.5" />
+                        <span className="font-medium">{t('version.devVersionAvailable')}</span>
+                      </div>
+                      <div className="flex items-center gap-3 text-xs text-slate-400">
+                        <span className="font-mono">{checkResult.dev_version.commit_short}</span>
+                        <span>{t('version.devCommitsAhead', { count: checkResult.dev_commits_ahead })}</span>
+                      </div>
+                    </div>
+                  )}
+                </div>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary

- **Upload queue endpoint** — Neuer API-Endpoint und Schemas für Mobile-Upload-Queue
- **Dev branch indicator** — Update-Seite zeigt aktiven Branch und Versions-Tab in Production
- **Memory info fix** — Verfügbarer Speicher statt freiem Speicher für akkurate Anzeige
- **CI fix** — Git-Identität für auto-tag im Merge-Workflow
- **pytest-cov** — Coverage-Reporting hinzugefügt

## Changelog

See [CHANGELOG.md](./CHANGELOG.md#1136---2026-03-09) for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)