### PR TITLE
Release v1.13.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.13.7] - 2026-03-09
+## [1.13.8] - 2026-03-10
 
-### Version History & Mobile Sync
+### Energy Dashboard Fix & Version History
 
-Automatische Versionsverfolgung bei jedem Server-Start, Delete-Endpoint
-für Sync-Ordner und Verbesserungen an der Update-Seite.
+Kritischer Bugfix für das Energy Dashboard auf PostgreSQL (Production),
+plus neue Features für Versionsverfolgung und Mobile Sync.
 
 ### Added
 
@@ -23,6 +23,8 @@ für Sync-Ordner und Verbesserungen an der Update-Seite.
 
 ### Fixed
 
+- **Energy dashboard 500 on PostgreSQL** — `get_hourly_samples()` nutzte SQLite-spezifisches `func.strftime()`, jetzt cross-database kompatibel mit `date_trunc()` für PostgreSQL
+- **Dashboard error handling** — `get_current_power()` ValueError wird jetzt im Dashboard-Handler abgefangen
 - **CI auto-tag** — Globale Git-Config für auto-tag im geklonten Repo
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,4 +63,4 @@ client/
 - **Issues**: GitHub Issues (repository URL needed)
 - **Documentation**: See `docs/` directory
 - **Maintainer**: Xveyn
-- **Version**: 1.13.7 (as of Mar 2026)
+- **Version**: 1.13.8 (as of Mar 2026)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.13.7"
+__version__ = "1.13.8"

--- a/backend/app/api/routes/energy.py
+++ b/backend/app/api/routes/energy.py
@@ -63,7 +63,16 @@ async def get_energy_dashboard(
     ]
 
     # Get current power from live monitoring
-    current_power_data = power_monitor.get_current_power(device_id, db)
+    try:
+        current_power_data = power_monitor.get_current_power(device_id, db)
+    except ValueError:
+        # Device exists in DB but power monitor has no data yet
+        from datetime import datetime, timezone
+        class _FallbackPower:
+            current_watts = 0.0
+            is_online = False
+            timestamp = datetime.now(timezone.utc)
+        current_power_data = _FallbackPower()
 
     # Convert EnergyPeriod objects to Pydantic models
     today_model = None

--- a/backend/app/services/power/energy.py
+++ b/backend/app/services/power/energy.py
@@ -17,6 +17,7 @@ from app.models.power_sample import PowerSample
 from app.models.tapo_device import TapoDevice
 from app.models.energy_price_config import EnergyPriceConfig
 from app.core.config import settings
+from app.core.database import DATABASE_URL
 
 logger = logging.getLogger(__name__)
 
@@ -210,10 +211,15 @@ def get_hourly_samples(
     """
     start_time = datetime.now(timezone.utc) - timedelta(hours=hours)
 
-    # Query and group by hour (SQLite compatible using strftime)
-    # strftime('%Y-%m-%d %H:00:00', timestamp) groups by hour
+    # Cross-database compatible hour grouping
+    if DATABASE_URL.startswith("sqlite"):
+        hour_expr = func.strftime('%Y-%m-%d %H:00:00', PowerSample.timestamp)
+    else:
+        # PostgreSQL
+        hour_expr = func.date_trunc('hour', PowerSample.timestamp)
+
     hourly_data = db.query(
-        func.strftime('%Y-%m-%d %H:00:00', PowerSample.timestamp).label('hour'),
+        hour_expr.label('hour'),
         func.avg(PowerSample.watts).label('avg_watts'),
         func.count(PowerSample.id).label('sample_count')
     ).filter(
@@ -226,7 +232,7 @@ def get_hourly_samples(
 
     return [
         {
-            'timestamp': row.hour,  # Already formatted as ISO-like string
+            'timestamp': str(row.hour) if not isinstance(row.hour, str) else row.hour,
             'avg_watts': round(row.avg_watts, 1),
             'sample_count': row.sample_count
         }

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baluhost-backend"
-version = "1.13.7"
+version = "1.13.8"
 description = "Mocked NAS management backend built with FastAPI"
 authors = [{ name = "Baluhost" }]
 requires-python = ">=3.11"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baluhost-client",
-  "version": "1.13.7",
+  "version": "1.13.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baluhost-client",
-      "version": "1.13.7",
+      "version": "1.13.8",
       "dependencies": {
         "axios": "^1.13.1",
         "i18next": "^25.8.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baluhost-client",
   "private": true,
-  "version": "1.13.7",
+  "version": "1.13.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/data/api-endpoints/sections-features.ts
+++ b/client/src/data/api-endpoints/sections-features.ts
@@ -10,7 +10,7 @@ export const featureSections: ApiSection[] = [
     title: 'Updates',
     icon: icon(Download),
     endpoints: [
-      { method: 'GET', path: '/api/updates/version', description: 'Get Current Version', requiresAuth: true, response: '{ "version": "1.13.7", "build_date": "2026-03-03" }' },
+      { method: 'GET', path: '/api/updates/version', description: 'Get Current Version', requiresAuth: true, response: '{ "version": "1.13.8", "build_date": "2026-03-03" }' },
       { method: 'GET', path: '/api/updates/release-notes', description: 'Get Release Notes', requiresAuth: true, response: '{ "notes": [...] }' },
       { method: 'GET', path: '/api/updates/check', description: 'Check for Updates', requiresAuth: true, response: '{ "available": true, "latest_version": "1.5.2", "changelog": "..." }' },
       {


### PR DESCRIPTION
## Summary
- **fix(energy):** Energy dashboard returned HTTP 500 on PostgreSQL — `get_hourly_samples()` used SQLite-specific `func.strftime()`, now uses `date_trunc()` for PostgreSQL
- **fix(energy):** Added ValueError handling for `get_current_power()` in dashboard handler
- **feat(updates):** Version history tracking across startups with UI
- **feat(mobile):** Delete sync folder endpoint
- **fix(ci):** Global git config for auto-tag in cloned repo

## Test plan
- [x] 14/14 energy service tests passing
- [ ] Verify `GET /api/energy/dashboard/{id}` returns 200 on PostgreSQL
- [ ] Verify version displays as v1.13.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)