### PR TITLE
Release v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.14.0] - 2026-03-10
+
+### Notification Settings & Stability Fixes
+
+Notification-Einstellungen in die Settings-Seite integriert, verbesserte
+Rate-Limiter-Konfiguration und mehrere Bugfixes für Notifications und Pi-hole.
+
+### Added
+
+- **Notification Settings tab** — Benachrichtigungseinstellungen als neuen Tab in die Settings-Seite verschoben
+
+### Fixed
+
+- **Rate-Limiter** — File/Sync-Limits erhöht und neue `mobile_sync`-Kategorie hinzugefügt
+- **Notifications** — Naive datetime in `time_ago`-Berechnung korrekt behandelt
+- **Notifications** — System-Benachrichtigungen (user_id=NULL) für Admin-Benutzer eingeschlossen
+- **Pi-hole** — 127.0.0.1 statt localhost verwenden um ConnectError nach Deploy zu vermeiden
+- **i18n** — Fehlende Notification-Center-Übersetzungsschlüssel ergänzt
+- **Frontend** — Unbenutzte eta-Variable im Layout.tsx Restart-Handler entfernt
+
+---
+
 ## [1.13.9] - 2026-03-10
 
 ### Backend Logs, Power Menu & API Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,4 +63,4 @@ client/
 - **Issues**: GitHub Issues (repository URL needed)
 - **Documentation**: See `docs/` directory
 - **Maintainer**: Xveyn
-- **Version**: 1.13.9 (as of Mar 2026)
+- **Version**: 1.14.0 (as of Mar 2026)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.13.9"
+__version__ = "1.14.0"

--- a/backend/app/api/routes/mobile.py
+++ b/backend/app/api/routes/mobile.py
@@ -404,7 +404,7 @@ async def update_camera_backup_settings(
 
 
 @router.get("/sync/folders/{device_id}", response_model=List[SyncFolderSchema])
-@user_limiter.limit(get_limit("admin_operations"))
+@user_limiter.limit(get_limit("mobile_sync"))
 async def get_sync_folders(
     request: Request,
     response: Response,
@@ -419,7 +419,7 @@ async def get_sync_folders(
 
 
 @router.post("/sync/folders/{device_id}", response_model=SyncFolderSchema)
-@user_limiter.limit(get_limit("admin_operations"))
+@user_limiter.limit(get_limit("mobile_sync"))
 async def create_sync_folder(
     request: Request,
     response: Response,
@@ -439,7 +439,7 @@ async def create_sync_folder(
 
 
 @router.delete("/sync/folders/{folder_id}", status_code=204)
-@user_limiter.limit(get_limit("admin_operations"))
+@user_limiter.limit(get_limit("mobile_sync"))
 async def delete_sync_folder(
     request: Request,
     response: Response,
@@ -457,7 +457,7 @@ async def delete_sync_folder(
 
 
 @router.get("/upload/queue/{device_id}", response_model=UploadQueueListResponse)
-@user_limiter.limit(get_limit("admin_operations"))
+@user_limiter.limit(get_limit("mobile_sync"))
 async def get_upload_queue(
     request: Request,
     response: Response,

--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -22,6 +22,7 @@ from app.schemas.notification import (
 )
 from app.services.notification_service import get_notification_service
 from app.services import auth as auth_service
+from app.services.permissions import is_privileged
 
 router = APIRouter(prefix="/notifications", tags=["notifications"])
 
@@ -47,6 +48,7 @@ async def get_notifications(
     """
     service = get_notification_service()
     offset = (page - 1) * page_size
+    admin = is_privileged(current_user)
 
     notifications = service.get_user_notifications(
         db=db,
@@ -59,9 +61,10 @@ async def get_notifications(
         created_before=created_before,
         limit=page_size,
         offset=offset,
+        is_admin=admin,
     )
 
-    unread_count = service.get_unread_count(db, current_user.id)
+    unread_count = service.get_unread_count(db, current_user.id, is_admin=admin)
 
     # Get total count for pagination using SQL COUNT(*)
     total = service.count_user_notifications(
@@ -73,6 +76,7 @@ async def get_notifications(
         notification_type=notification_type,
         created_after=created_after,
         created_before=created_before,
+        is_admin=admin,
     )
 
     return NotificationListResponse(
@@ -100,7 +104,7 @@ async def get_unread_count(
     service = get_notification_service()
 
     # Single GROUP BY query instead of 9 separate queries
-    counts = service.get_unread_counts(db, current_user.id)
+    counts = service.get_unread_counts(db, current_user.id, is_admin=is_privileged(current_user))
     total = counts.pop("total", 0)
 
     return UnreadCountResponse(
@@ -119,7 +123,7 @@ async def mark_notification_as_read(
 ) -> NotificationResponse:
     """Mark a specific notification as read."""
     service = get_notification_service()
-    notification = service.mark_as_read(db, notification_id, current_user.id)
+    notification = service.mark_as_read(db, notification_id, current_user.id, is_admin=is_privileged(current_user))
 
     if not notification:
         raise HTTPException(
@@ -145,7 +149,7 @@ async def mark_all_as_read(
     service = get_notification_service()
     category = body.category if body else None
 
-    count = service.mark_all_as_read(db, current_user.id, category=category)
+    count = service.mark_all_as_read(db, current_user.id, category=category, is_admin=is_privileged(current_user))
 
     return MarkReadResponse(success=True, count=count)
 
@@ -163,7 +167,7 @@ async def dismiss_notification(
     Dismissed notifications are hidden from the default list but can be retrieved with include_dismissed=true.
     """
     service = get_notification_service()
-    notification = service.dismiss(db, notification_id, current_user.id)
+    notification = service.dismiss(db, notification_id, current_user.id, is_admin=is_privileged(current_user))
 
     if not notification:
         raise HTTPException(
@@ -189,7 +193,7 @@ async def snooze_notification(
     until the snooze period expires.
     """
     service = get_notification_service()
-    notification = service.snooze(db, notification_id, current_user.id, duration_hours)
+    notification = service.snooze(db, notification_id, current_user.id, duration_hours, is_admin=is_privileged(current_user))
 
     if not notification:
         raise HTTPException(
@@ -414,7 +418,7 @@ async def notification_websocket(
         service = get_notification_service()
         db = SessionLocal()
         try:
-            unread_count = service.get_unread_count(db, user_id)
+            unread_count = service.get_unread_count(db, user_id, is_admin=is_admin)
             await websocket.send_json({
                 "type": "unread_count",
                 "payload": {"count": unread_count},
@@ -437,8 +441,8 @@ async def notification_websocket(
                         # Use fresh db session for mark_read
                         db = SessionLocal()
                         try:
-                            service.mark_as_read(db, notification_id, user_id)
-                            unread_count = service.get_unread_count(db, user_id)
+                            service.mark_as_read(db, notification_id, user_id, is_admin=is_admin)
+                            unread_count = service.get_unread_count(db, user_id, is_admin=is_admin)
                             await websocket.send_json({
                                 "type": "unread_count",
                                 "payload": {"count": unread_count},

--- a/backend/app/core/rate_limiter.py
+++ b/backend/app/core/rate_limiter.py
@@ -73,8 +73,8 @@ RATE_LIMITS = {
     
     # File operations - moderate limits
     "file_upload": "50000/minute",
-    "file_download": "100/minute",
-    "file_list": "60/minute",
+    "file_download": "500/minute",
+    "file_list": "200/minute",
     "file_delete": "30/minute",
     "file_write": "30/minute",
     
@@ -100,8 +100,11 @@ RATE_LIMITS = {
     # Backup operations - strict limits (resource intensive)
     "backup_operations": "10/minute",
 
-    # Sync operations - moderate limits
-    "sync_operations": "30/minute",
+    # Sync operations - generous limits for folder sync
+    "sync_operations": "300/minute",
+
+    # Mobile sync & upload queue - generous limits for folder sync
+    "mobile_sync": "300/minute",
 
     # Chunked upload operations
     "file_chunked": "50000/minute",

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -79,7 +79,10 @@ class NotificationResponse(NotificationBase):
         """Convert database model to response schema."""
         time_ago = None
         if notification.created_at:
-            delta = datetime.now(timezone.utc) - notification.created_at.replace(tzinfo=None)
+            created = notification.created_at
+            if created.tzinfo is None:
+                created = created.replace(tzinfo=timezone.utc)
+            delta = datetime.now(timezone.utc) - created
             if delta.days > 0:
                 time_ago = f"{delta.days}d ago" if delta.days < 7 else notification.created_at.strftime("%d.%m.%Y")
             elif delta.seconds >= 3600:

--- a/backend/app/services/notifications/service.py
+++ b/backend/app/services/notifications/service.py
@@ -30,6 +30,27 @@ class NotificationService:
         self._websocket_manager = None
         self._email_service = None
 
+    @staticmethod
+    def _user_filter(user_id: int, is_admin: bool = False):
+        """Build SQLAlchemy filter for user-owned + system notifications.
+
+        Admin/system notifications are stored with user_id=NULL.
+        Admin users should see these alongside their personal notifications.
+
+        Args:
+            user_id: The current user's ID
+            is_admin: Whether the user has admin role
+
+        Returns:
+            SQLAlchemy filter expression
+        """
+        if is_admin:
+            return or_(
+                Notification.user_id == user_id,
+                Notification.user_id.is_(None),
+            )
+        return Notification.user_id == user_id
+
     def set_websocket_manager(self, manager: Any) -> None:
         """Set the WebSocket manager for real-time delivery.
 
@@ -305,6 +326,7 @@ class NotificationService:
         created_before: Optional[datetime] = None,
         limit: int = 50,
         offset: int = 0,
+        is_admin: bool = False,
     ) -> list[Notification]:
         """Get notifications for a user.
 
@@ -319,11 +341,12 @@ class NotificationService:
             created_before: Only return notifications created before this time
             limit: Maximum number of results
             offset: Number of results to skip
+            is_admin: Whether the user is an admin (includes system notifications)
 
         Returns:
             List of Notification objects
         """
-        query = db.query(Notification).filter(Notification.user_id == user_id)
+        query = db.query(Notification).filter(self._user_filter(user_id, is_admin))
 
         # Exclude snoozed notifications from default queries
         if hasattr(Notification, "snoozed_until"):
@@ -367,6 +390,7 @@ class NotificationService:
         notification_type: Optional[str] = None,
         created_after: Optional[datetime] = None,
         created_before: Optional[datetime] = None,
+        is_admin: bool = False,
     ) -> int:
         """Count notifications for a user using SQL COUNT(*).
 
@@ -382,12 +406,13 @@ class NotificationService:
             notification_type: Filter by type (info, warning, critical)
             created_after: Only count notifications created after this time
             created_before: Only count notifications created before this time
+            is_admin: Whether the user is an admin (includes system notifications)
 
         Returns:
             Integer count of matching notifications
         """
         query = db.query(func.count(Notification.id)).filter(
-            Notification.user_id == user_id
+            self._user_filter(user_id, is_admin)
         )
 
         # Exclude snoozed notifications from default queries
@@ -423,6 +448,7 @@ class NotificationService:
         self,
         db: Session,
         user_id: int,
+        is_admin: bool = False,
     ) -> dict[str, int]:
         """Get unread notification counts grouped by category in a single query.
 
@@ -431,6 +457,7 @@ class NotificationService:
         Args:
             db: Database session
             user_id: User ID
+            is_admin: Whether the user is an admin (includes system notifications)
 
         Returns:
             Dict mapping category names to their unread counts,
@@ -440,7 +467,7 @@ class NotificationService:
             Notification.category,
             func.count(Notification.id),
         ).filter(
-            Notification.user_id == user_id,
+            self._user_filter(user_id, is_admin),
             Notification.is_read == False,
             Notification.is_dismissed == False,
         )
@@ -465,6 +492,7 @@ class NotificationService:
         db: Session,
         user_id: int,
         category: Optional[str] = None,
+        is_admin: bool = False,
     ) -> int:
         """Get count of unread notifications for a user.
 
@@ -472,12 +500,13 @@ class NotificationService:
             db: Database session
             user_id: User ID
             category: Optional category filter
+            is_admin: Whether the user is an admin (includes system notifications)
 
         Returns:
             Count of unread notifications
         """
         query = db.query(Notification).filter(
-            Notification.user_id == user_id,
+            self._user_filter(user_id, is_admin),
             Notification.is_read == False,
             Notification.is_dismissed == False,
         )
@@ -501,6 +530,7 @@ class NotificationService:
         db: Session,
         notification_id: int,
         user_id: int,
+        is_admin: bool = False,
     ) -> Optional[Notification]:
         """Mark a notification as read.
 
@@ -508,13 +538,14 @@ class NotificationService:
             db: Database session
             notification_id: Notification ID
             user_id: User ID (for ownership check)
+            is_admin: Whether the user is an admin (can mark system notifications)
 
         Returns:
             Updated Notification or None if not found
         """
         notification = db.query(Notification).filter(
             Notification.id == notification_id,
-            Notification.user_id == user_id,
+            self._user_filter(user_id, is_admin),
         ).first()
 
         if notification:
@@ -530,6 +561,7 @@ class NotificationService:
         db: Session,
         user_id: int,
         category: Optional[str] = None,
+        is_admin: bool = False,
     ) -> int:
         """Mark all notifications as read for a user.
 
@@ -537,12 +569,13 @@ class NotificationService:
             db: Database session
             user_id: User ID
             category: Optional category filter
+            is_admin: Whether the user is an admin (includes system notifications)
 
         Returns:
             Number of notifications updated
         """
         query = db.query(Notification).filter(
-            Notification.user_id == user_id,
+            self._user_filter(user_id, is_admin),
             Notification.is_read == False,
         )
 
@@ -560,6 +593,7 @@ class NotificationService:
         db: Session,
         notification_id: int,
         user_id: int,
+        is_admin: bool = False,
     ) -> Optional[Notification]:
         """Dismiss a notification.
 
@@ -567,13 +601,14 @@ class NotificationService:
             db: Database session
             notification_id: Notification ID
             user_id: User ID (for ownership check)
+            is_admin: Whether the user is an admin (can dismiss system notifications)
 
         Returns:
             Updated Notification or None if not found
         """
         notification = db.query(Notification).filter(
             Notification.id == notification_id,
-            Notification.user_id == user_id,
+            self._user_filter(user_id, is_admin),
         ).first()
 
         if notification:
@@ -591,6 +626,7 @@ class NotificationService:
         notification_id: int,
         user_id: int,
         duration_hours: int,
+        is_admin: bool = False,
     ) -> Optional[Notification]:
         """Snooze a notification for a given duration.
 
@@ -599,6 +635,7 @@ class NotificationService:
             notification_id: Notification ID
             user_id: User ID (for ownership check)
             duration_hours: Number of hours to snooze
+            is_admin: Whether the user is an admin (can snooze system notifications)
 
         Returns:
             Updated Notification or None if not found
@@ -607,7 +644,7 @@ class NotificationService:
 
         notification = db.query(Notification).filter(
             Notification.id == notification_id,
-            Notification.user_id == user_id,
+            self._user_filter(user_id, is_admin),
         ).first()
 
         if notification and hasattr(notification, "snoozed_until"):

--- a/backend/app/services/pihole/api_client.py
+++ b/backend/app/services/pihole/api_client.py
@@ -88,7 +88,7 @@ class PiholeApiClient:
             write_shm(self._sid_filename(), {"sid": self._sid, "csrf": self._csrf, "base_url": self._base_url})
             logger.debug("Pi-hole authenticated, SID obtained and shared via SHM")
         except httpx.HTTPError as exc:
-            logger.error("Pi-hole authentication failed: %s: %s", type(exc).__name__, exc)
+            logger.error("Pi-hole authentication failed (%s): %s: %s", self._base_url, type(exc).__name__, exc)
             raise
 
     async def _logout(self, sid: str) -> None:

--- a/backend/app/services/pihole/docker_backend.py
+++ b/backend/app/services/pihole/docker_backend.py
@@ -499,7 +499,7 @@ class LocalDockerPiholeBackend:
         # Reinitialize API client with actual deploy port and new password
         if result.get("password"):
             new_password = result["password"]
-            new_url = f"http://localhost:{web_port}"
+            new_url = f"http://127.0.0.1:{web_port}"
             await self._api.close()
             self._api = PiholeApiClient(new_url, new_password)
             self._pihole_url = new_url

--- a/backend/app/services/pihole/service.py
+++ b/backend/app/services/pihole/service.py
@@ -41,7 +41,10 @@ def _create_backend(mode: str, pihole_url: str = "", password: str = "", web_por
     """Create a backend instance based on mode."""
     if mode == "docker":
         from app.services.pihole.docker_backend import LocalDockerPiholeBackend
-        url = pihole_url or f"http://localhost:{web_port}"
+        # Always use 127.0.0.1 for docker mode — avoids IPv6 resolution issues
+        # and DNS lookup failures when Pi-hole IS the DNS server on the host.
+        # The pihole_url config field is for remote mode only.
+        url = f"http://127.0.0.1:{web_port}"
         return LocalDockerPiholeBackend(url, password)
     elif mode == "remote":
         from app.services.pihole.remote_backend import RemotePiholeBackend
@@ -199,7 +202,13 @@ class PiholeService:
         _backend = _create_backend(effective_mode, config.pihole_url or "", password, config.web_port)
         _backend_mode = effective_mode
         _backend_created_at = time.time()
-        logger.info("Pi-hole backend initialized: %s", effective_mode)
+        has_pw = "with password" if password else "no password"
+        if effective_mode == "docker":
+            logger.info("Pi-hole backend initialized: %s → http://127.0.0.1:%d (%s)", effective_mode, config.web_port, has_pw)
+        elif effective_mode == "remote":
+            logger.info("Pi-hole backend initialized: %s → %s (%s)", effective_mode, config.pihole_url, has_pw)
+        else:
+            logger.info("Pi-hole backend initialized: %s", effective_mode)
         return _backend
 
     @property

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baluhost-backend"
-version = "1.13.9"
+version = "1.14.0"
 description = "Mocked NAS management backend built with FastAPI"
 authors = [{ name = "Baluhost" }]
 requires-python = ">=3.11"

--- a/backend/tests/test_pihole.py
+++ b/backend/tests/test_pihole.py
@@ -445,10 +445,10 @@ class TestPiholeService:
         svc.update_config(mode="docker", web_port=9090)
 
         backend = _create_backend("docker", pihole_url="", password="test", web_port=9090)
-        assert backend._pihole_url == "http://localhost:9090"
-        # Explicit URL takes precedence
+        assert backend._pihole_url == "http://127.0.0.1:9090"
+        # Docker mode always uses 127.0.0.1, ignoring pihole_url
         backend2 = _create_backend("docker", pihole_url="http://10.0.0.5:80", password="", web_port=9090)
-        assert backend2._pihole_url == "http://10.0.0.5:80"
+        assert backend2._pihole_url == "http://127.0.0.1:9090"
 
     def test_deploy_resets_backend_singleton(self, db_session: Session):
         """After deploy_container(), the backend singleton is reset."""

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baluhost-client",
-  "version": "1.13.9",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baluhost-client",
-      "version": "1.13.9",
+      "version": "1.14.0",
       "dependencies": {
         "axios": "^1.13.1",
         "i18next": "^25.8.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baluhost-client",
   "private": true,
-  "version": "1.13.9",
+  "version": "1.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -44,7 +44,6 @@ const AdminDatabase = isDesktop ? lazyWithRetry(() => import('./pages/AdminDatab
 const DevicesPage = isDesktop ? lazyWithRetry(() => import('./pages/DevicesPage')) : null;
 const SystemControlPage = isDesktop ? lazyWithRetry(() => import('./pages/SystemControlPage')) : null;
 const PluginsPage = isDesktop ? lazyWithRetry(() => import('./pages/PluginsPage')) : null;
-const NotificationPreferencesPage = isDesktop ? lazyWithRetry(() => import('./pages/NotificationPreferencesPage')) : null;
 const NotificationsArchivePage = isDesktop ? lazyWithRetry(() => import('./pages/NotificationsArchivePage')) : null;
 const UpdatePage = isDesktop ? lazyWithRetry(() => import('./pages/UpdatePage')) : null;
 const CloudImportPage = isDesktop ? lazyWithRetry(() => import('./pages/CloudImportPage')) : null;
@@ -206,9 +205,9 @@ function AppRoutes() {
         {SettingsPage && <Route path="/settings" element={user ? <Layout><SettingsPage /></Layout> : <Navigate to="/login" />} />}
         {DevicesPage && <Route path="/devices" element={user ? <Layout><DevicesPage /></Layout> : <Navigate to="/login" />} />}
         {SystemControlPage && <Route path="/admin/system-control" element={isAdmin ? <Layout><SystemControlPage /></Layout> : <Navigate to="/" />} />}
-        {NotificationPreferencesPage && <Route path="/settings/notifications" element={user ? <Layout><NotificationPreferencesPage /></Layout> : <Navigate to="/login" />} />}
+        {isDesktop && <Route path="/settings/notifications" element={<Navigate to="/settings?tab=notifications" replace />} />}
         {NotificationsArchivePage && <Route path="/notifications" element={user ? <Layout><NotificationsArchivePage /></Layout> : <Navigate to="/login" />} />}
-        {NotificationPreferencesPage && <Route path="/notifications/settings" element={user ? <Layout><NotificationPreferencesPage /></Layout> : <Navigate to="/login" />} />}
+        {isDesktop && <Route path="/notifications/settings" element={<Navigate to="/settings?tab=notifications" replace />} />}
         {SyncSettings && <Route path="/sync" element={user ? <Layout><SyncSettings /></Layout> : <Navigate to="/login" />} />}
         {ApiCenterPage && <Route path="/docs" element={user ? <Layout><ApiCenterPage /></Layout> : <Navigate to="/login" />} />}
         {PluginsPage && <Route path="/plugins" element={isAdmin ? <Layout><PluginsPage /></Layout> : <Navigate to="/" />} />}

--- a/client/src/components/NotificationCenter.tsx
+++ b/client/src/components/NotificationCenter.tsx
@@ -153,7 +153,7 @@ export const NotificationCenter: React.FC<NotificationCenterProps> = ({ classNam
               <button
                 onClick={() => {
                   setIsOpen(false);
-                  navigate('/settings/notifications');
+                  navigate('/settings?tab=notifications');
                 }}
                 className="flex items-center justify-center rounded-lg p-1.5 text-slate-400 transition hover:bg-slate-800 hover:text-slate-100"
                 title={t('settings')}

--- a/client/src/data/api-endpoints/sections-features.ts
+++ b/client/src/data/api-endpoints/sections-features.ts
@@ -10,7 +10,7 @@ export const featureSections: ApiSection[] = [
     title: 'Updates',
     icon: icon(Download),
     endpoints: [
-      { method: 'GET', path: '/api/updates/version', description: 'Get Current Version', requiresAuth: true, response: '{ "version": "1.13.9", "build_date": "2026-03-03" }' },
+      { method: 'GET', path: '/api/updates/version', description: 'Get Current Version', requiresAuth: true, response: '{ "version": "1.14.0", "build_date": "2026-03-03" }' },
       { method: 'GET', path: '/api/updates/release-notes', description: 'Get Release Notes', requiresAuth: true, response: '{ "notes": [...] }' },
       { method: 'GET', path: '/api/updates/check', description: 'Check for Updates', requiresAuth: true, response: '{ "available": true, "latest_version": "1.5.2", "changelog": "..." }' },
       {

--- a/client/src/i18n/locales/de/notifications.json
+++ b/client/src/i18n/locales/de/notifications.json
@@ -41,5 +41,13 @@
     "saved": "Einstellungen gespeichert",
     "loadFailed": "Fehler beim Laden der Einstellungen",
     "saveFailed": "Fehler beim Speichern"
-  }
+  },
+  "noNotifications": "Keine Benachrichtigungen",
+  "connected": "Verbunden",
+  "markedAllRead": "Alle als gelesen markiert",
+  "markError": "Fehler beim Markieren",
+  "allRead": "Alle gelesen",
+  "settings": "Einstellungen",
+  "viewAll": "Alle anzeigen",
+  "markAllRead": "Alle als gelesen markieren"
 }

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -10,7 +10,8 @@
     "vpn": "VPN",
     "vcl": "Versionskontrolle",
     "language": "Sprache",
-    "apiKeys": "API-Schlüssel"
+    "apiKeys": "API-Schlüssel",
+    "notifications": "Benachrichtigungen"
   },
   "profile": {
     "title": "Profilinformationen",

--- a/client/src/i18n/locales/en/notifications.json
+++ b/client/src/i18n/locales/en/notifications.json
@@ -41,5 +41,13 @@
     "saved": "Settings saved",
     "loadFailed": "Failed to load settings",
     "saveFailed": "Failed to save"
-  }
+  },
+  "noNotifications": "No notifications",
+  "connected": "Connected",
+  "markedAllRead": "All marked as read",
+  "markError": "Failed to mark as read",
+  "allRead": "All read",
+  "settings": "Settings",
+  "viewAll": "View all",
+  "markAllRead": "Mark all as read"
 }

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -10,7 +10,8 @@
     "vpn": "VPN",
     "vcl": "Version Control",
     "language": "Language",
-    "apiKeys": "API Keys"
+    "apiKeys": "API Keys",
+    "notifications": "Notifications"
   },
   "profile": {
     "title": "Profile Information",

--- a/client/src/pages/NotificationPreferencesPage.tsx
+++ b/client/src/pages/NotificationPreferencesPage.tsx
@@ -46,7 +46,7 @@ const PRIORITY_LABELS = [
   { value: 3, label: 'priority.critical', description: 'priority.criticalDesc' },
 ];
 
-export default function NotificationPreferencesPage() {
+export default function NotificationPreferencesPage({ embedded = false }: { embedded?: boolean } = {}) {
   const { t } = useTranslation(['notifications', 'common']);
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
@@ -142,34 +142,56 @@ export default function NotificationPreferencesPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <button
-            onClick={() => navigate(-1)}
-            className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-800 text-slate-400 transition hover:border-sky-500/50 hover:text-sky-400"
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
+      {embedded ? (
+        <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-slate-100">{t('title')}</h1>
             <p className="text-sm text-slate-400">
               {t('description')}
             </p>
           </div>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="flex items-center gap-2 rounded-xl border border-sky-500 bg-sky-500/10 px-4 py-2 text-sm font-medium text-sky-400 transition hover:bg-sky-500/20 disabled:opacity-50"
+          >
+            {saving ? (
+              <RefreshCw className="h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="h-4 w-4" />
+            )}
+            {t('buttons.save')}
+          </button>
         </div>
-        <button
-          onClick={handleSave}
-          disabled={saving}
-          className="flex items-center gap-2 rounded-xl border border-sky-500 bg-sky-500/10 px-4 py-2 text-sm font-medium text-sky-400 transition hover:bg-sky-500/20 disabled:opacity-50"
-        >
-          {saving ? (
-            <RefreshCw className="h-4 w-4 animate-spin" />
-          ) : (
-            <Save className="h-4 w-4" />
-          )}
-          {t('buttons.save')}
-        </button>
-      </div>
+      ) : (
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => navigate(-1)}
+              className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-800 text-slate-400 transition hover:border-sky-500/50 hover:text-sky-400"
+            >
+              <ChevronLeft className="h-5 w-5" />
+            </button>
+            <div>
+              <h1 className="text-2xl font-bold text-slate-100">{t('title')}</h1>
+              <p className="text-sm text-slate-400">
+                {t('description')}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="flex items-center gap-2 rounded-xl border border-sky-500 bg-sky-500/10 px-4 py-2 text-sm font-medium text-sky-400 transition hover:bg-sky-500/20 disabled:opacity-50"
+          >
+            {saving ? (
+              <RefreshCw className="h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="h-4 w-4" />
+            )}
+            {t('buttons.save')}
+          </button>
+        </div>
+      )}
 
       {/* Global Channel Settings */}
       <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">

--- a/client/src/pages/NotificationsArchivePage.tsx
+++ b/client/src/pages/NotificationsArchivePage.tsx
@@ -123,7 +123,7 @@ export default function NotificationsArchivePage() {
             Alle gelesen
           </button>
           <button
-            onClick={() => navigate('/settings/notifications')}
+            onClick={() => navigate('/settings?tab=notifications')}
             className="flex items-center gap-1.5 rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 transition hover:border-sky-500/50 hover:text-sky-400"
           >
             <Settings className="h-4 w-4" />

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
-import { User, Lock, Mail, Image, HardDrive, Clock, Download, Globe, Shield, ShieldCheck, ShieldOff, Copy, RefreshCw, KeyRound, GitBranch } from 'lucide-react';
+import { User, Lock, Mail, Image, HardDrive, Clock, Download, Globe, Shield, ShieldCheck, ShieldOff, Copy, RefreshCw, KeyRound, GitBranch, Bell } from 'lucide-react';
 import ApiKeysTab from '../components/settings/ApiKeysTab';
 import VCLTrackingPanel from '../components/vcl/VCLTrackingPanel';
 import { apiClient } from '../lib/api';
@@ -9,6 +10,8 @@ import LanguageSettings from '../components/LanguageSettings';
 import ByteUnitSettings from '../components/ByteUnitSettings';
 import { formatBytes } from '../lib/formatters';
 import { get2FAStatus, setup2FA, verifySetup2FA, disable2FA, regenerateBackupCodes, type TwoFactorStatus, type TwoFactorSetupData } from '../api/two-factor';
+
+const NotificationPreferencesPage = lazy(() => import('./NotificationPreferencesPage'));
 
 interface UserProfile {
   id: number;
@@ -404,10 +407,22 @@ function TwoFactorCard() {
 
 export default function SettingsPage() {
   const { t } = useTranslation('settings');
+  const [searchParams, setSearchParams] = useSearchParams();
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [activeTab, setActiveTab] = useState<'profile' | 'security' | 'storage' | 'language' | 'api-keys' | 'vcl'>('profile');
+
+  type SettingsTab = 'profile' | 'security' | 'storage' | 'language' | 'api-keys' | 'vcl' | 'notifications';
+  const validTabs: SettingsTab[] = ['profile', 'security', 'storage', 'language', 'api-keys', 'vcl', 'notifications'];
+  const tabParam = searchParams.get('tab') as SettingsTab | null;
+  const [activeTab, setActiveTab] = useState<SettingsTab>(
+    tabParam && validTabs.includes(tabParam) ? tabParam : 'profile'
+  );
+
+  const handleTabChange = (tab: SettingsTab) => {
+    setActiveTab(tab);
+    setSearchParams(tab === 'profile' ? {} : { tab });
+  };
   
   // Profile update
   const [email, setEmail] = useState('');
@@ -594,11 +609,12 @@ export default function SettingsPage() {
               { id: 'storage' as const, label: t('tabs.storage'), icon: HardDrive },
               { id: 'vcl' as const, label: 'VCL', icon: GitBranch },
               { id: 'language' as const, label: t('tabs.language'), icon: Globe },
+              { id: 'notifications' as const, label: t('tabs.notifications'), icon: Bell },
               ...(profile?.role === 'admin' ? [{ id: 'api-keys' as const, label: t('tabs.apiKeys'), icon: KeyRound }] : []),
             ]).map(tab => (
               <button
                 key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
+                onClick={() => handleTabChange(tab.id)}
                 className={`flex items-center gap-2 rounded-xl px-4 py-2 sm:py-2.5 text-sm sm:text-base font-semibold transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
                   activeTab === tab.id
                     ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40 shadow-lg shadow-blue-500/10'
@@ -931,6 +947,13 @@ export default function SettingsPage() {
         )}
 
         {activeTab === 'vcl' && <VCLTrackingPanel />}
+
+        {/* Notifications Tab */}
+        {activeTab === 'notifications' && (
+          <Suspense fallback={<div className="text-center py-8 text-slate-400">{t('profile.loading')}</div>}>
+            <NotificationPreferencesPage embedded />
+          </Suspense>
+        )}
 
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **Notification Settings tab** — Benachrichtigungseinstellungen als neuen Tab in die Settings-Seite verschoben
- **Rate-Limiter** — File/Sync-Limits erhöht und neue `mobile_sync`-Kategorie hinzugefügt
- **Notifications** — Naive datetime und System-Benachrichtigungen für Admin-Benutzer gefixt
- **Pi-hole** — 127.0.0.1 statt localhost um ConnectError nach Deploy zu vermeiden
- **i18n** — Fehlende Notification-Center-Übersetzungsschlüssel ergänzt

## Test plan

- [ ] Notification Settings Tab in Settings-Seite prüfen
- [ ] Rate-Limiter-Konfiguration für file/sync/mobile_sync verifizieren
- [ ] Admin sieht System-Benachrichtigungen (user_id=NULL)
- [ ] Pi-hole Verbindung nach Deploy testen

🤖 Generated with [Claude Code](https://claude.com/claude-code)