### PR TITLE
Release v1.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.15.6] - 2026-03-15
+
+### Added
+
+- **Uptime tracking** — New UptimeSample model with server + system uptime, historical DB persistence, 30-day retention
+- **Uptime API endpoints** — `GET /api/monitoring/uptime/current` and `/history` with live fallback computation
+- **Uptime tab** — System Monitor > System > Uptime with live counters, restart detection, and area chart
+- **Dashboard dual uptime** — Server uptime as main value, system uptime as subtitle, clickable to uptime tab
+- **BaluPi setup** — Admin route, setup component, and API client for Pi device management
+- **Pi mode guards** — Disable notifications and plugins in Pi mode to avoid unnecessary requests
+
+### Changed
+
+- **SystemInfo schema** — Added `system_uptime` field to `/api/system/info` response
+
+---
+
 ## [1.15.5] - 2026-03-15
 
 ### Refactoring, Performance & Code Quality

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,4 +75,4 @@ client/
 - **Issues**: GitHub Issues (repository URL needed)
 - **Documentation**: See `docs/` directory
 - **Maintainer**: Xveyn
-- **Version**: 1.15.5 (as of Mar 2026)
+- **Version**: 1.15.6 (as of Mar 2026)

--- a/backend/alembic/versions/043_add_uptime_samples.py
+++ b/backend/alembic/versions/043_add_uptime_samples.py
@@ -1,0 +1,35 @@
+"""Add uptime_samples table
+
+Revision ID: 043_add_uptime_samples
+Revises: 042_remove_email_notif
+Create Date: 2026-03-15
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "043_add_uptime_samples"
+down_revision = "042_remove_email_notif"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "uptime_samples",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+        sa.Column("server_uptime_seconds", sa.BigInteger(), nullable=False),
+        sa.Column("system_uptime_seconds", sa.BigInteger(), nullable=False),
+        sa.Column("server_start_time", sa.DateTime(), nullable=False),
+        sa.Column("system_boot_time", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_uptime_samples_id"), "uptime_samples", ["id"], unique=False)
+    op.create_index(op.f("ix_uptime_samples_timestamp"), "uptime_samples", ["timestamp"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_uptime_samples_timestamp"), table_name="uptime_samples")
+    op.drop_index(op.f("ix_uptime_samples_id"), table_name="uptime_samples")
+    op.drop_table("uptime_samples")

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -10,6 +10,7 @@ from app.api.routes import (
     backend_logs,
     activity,
     firebase_config,
+    balupi,
 )
 
 api_router = APIRouter()
@@ -60,5 +61,6 @@ api_router.include_router(env_config.router, prefix="/admin", tags=["admin"])
 api_router.include_router(backend_logs.router, tags=["admin"])
 api_router.include_router(activity.router, prefix="/activity", tags=["activity"])
 api_router.include_router(firebase_config.router, tags=["admin", "firebase"])
+api_router.include_router(balupi.router, prefix="/admin", tags=["admin", "balupi"])
 
 __all__ = ["api_router"]

--- a/backend/app/api/routes/balupi.py
+++ b/backend/app/api/routes/balupi.py
@@ -1,0 +1,216 @@
+"""BaluPi setup & management routes (admin only).
+
+Provides endpoints to configure, test, and monitor the BaluPi companion device
+connection from the NAS admin UI.
+"""
+
+import logging
+import secrets
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_admin
+from app.core.config import settings
+from app.core.database import get_db
+from app.core.rate_limiter import user_limiter, get_limit
+from app.schemas.user import UserPublic
+from app.services.audit.logger_db import get_audit_logger_db
+from app.services import env_config as env_config_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/balupi", tags=["admin", "balupi"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+class BaluPiConfigResponse(BaseModel):
+    """Current BaluPi configuration (sensitive values masked)."""
+    enabled: bool
+    url: str
+    has_secret: bool
+    secret_preview: str  # first 4 chars + "..." or empty
+
+
+class BaluPiConfigUpdate(BaseModel):
+    """Update BaluPi configuration."""
+    enabled: bool | None = None
+    url: str | None = None
+    secret: str | None = None
+
+
+class BaluPiTestResult(BaseModel):
+    """Result of a connection test to the BaluPi."""
+    reachable: bool
+    version: str | None = None
+    hostname: str | None = None
+    error: str | None = None
+
+
+class BaluPiGenerateSecretResponse(BaseModel):
+    """Generated shared secret."""
+    secret: str
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/config", response_model=BaluPiConfigResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def get_balupi_config(
+    request: Request,
+    response: Response,
+    current_user: UserPublic = Depends(get_current_admin),
+) -> BaluPiConfigResponse:
+    """Get current BaluPi configuration (admin only)."""
+    secret = settings.balupi_handshake_secret
+    return BaluPiConfigResponse(
+        enabled=settings.balupi_enabled,
+        url=settings.balupi_url,
+        has_secret=bool(secret),
+        secret_preview=f"{secret[:4]}..." if secret and len(secret) >= 4 else "",
+    )
+
+
+@router.put("/config")
+@user_limiter.limit(get_limit("admin_operations"))
+async def update_balupi_config(
+    request: Request,
+    response: Response,
+    payload: BaluPiConfigUpdate,
+    current_user: UserPublic = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    """Update BaluPi configuration (admin only).
+
+    Writes changes to the backend .env file and updates runtime settings.
+    """
+    audit_logger = get_audit_logger_db()
+    updates = []
+    changed_fields = []
+
+    if payload.enabled is not None:
+        updates.append({"key": "BALUPI_ENABLED", "value": str(payload.enabled).lower()})
+        changed_fields.append("enabled")
+
+    if payload.url is not None:
+        url = payload.url.rstrip("/")
+        updates.append({"key": "BALUPI_URL", "value": url})
+        changed_fields.append("url")
+
+    if payload.secret is not None:
+        if payload.secret and len(payload.secret) < 32:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Handshake secret must be at least 32 characters",
+            )
+        updates.append({"key": "BALUPI_HANDSHAKE_SECRET", "value": payload.secret})
+        changed_fields.append("secret")
+
+    if not updates:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No fields to update",
+        )
+
+    # Write to .env file
+    try:
+        env_config_service.update_vars("backend", updates)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to write config: {e}",
+        )
+
+    # Update runtime settings (take effect immediately without restart)
+    if payload.enabled is not None:
+        settings.balupi_enabled = payload.enabled
+    if payload.url is not None:
+        settings.balupi_url = payload.url.rstrip("/")
+    if payload.secret is not None:
+        settings.balupi_handshake_secret = payload.secret
+
+    audit_logger.log_security_event(
+        action="balupi_config_updated",
+        user=current_user.username,
+        details={"changed_fields": changed_fields},
+        success=True,
+        db=db,
+    )
+
+    return {"changed": changed_fields}
+
+
+@router.post("/test", response_model=BaluPiTestResult)
+@user_limiter.limit(get_limit("admin_operations"))
+async def test_balupi_connection(
+    request: Request,
+    response: Response,
+    current_user: UserPublic = Depends(get_current_admin),
+) -> BaluPiTestResult:
+    """Test connection to the BaluPi device (admin only).
+
+    Sends a GET request to the Pi's /api/health endpoint.
+    """
+    url = settings.balupi_url
+    if not url:
+        return BaluPiTestResult(
+            reachable=False,
+            error="BaluPi URL not configured",
+        )
+
+    health_url = f"{url.rstrip('/')}/api/health"
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(5.0, connect=3.0)) as client:
+            resp = await client.get(health_url)
+
+        if resp.status_code == 200:
+            data = resp.json()
+            return BaluPiTestResult(
+                reachable=True,
+                version=data.get("version"),
+                hostname=data.get("hostname"),
+            )
+        else:
+            return BaluPiTestResult(
+                reachable=False,
+                error=f"HTTP {resp.status_code}",
+            )
+    except httpx.ConnectError:
+        return BaluPiTestResult(
+            reachable=False,
+            error="Connection refused — is BaluPi running?",
+        )
+    except httpx.TimeoutException:
+        return BaluPiTestResult(
+            reachable=False,
+            error="Connection timed out",
+        )
+    except httpx.HTTPError as exc:
+        return BaluPiTestResult(
+            reachable=False,
+            error=str(exc),
+        )
+
+
+@router.post("/generate-secret", response_model=BaluPiGenerateSecretResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def generate_shared_secret(
+    request: Request,
+    response: Response,
+    current_user: UserPublic = Depends(get_current_admin),
+) -> BaluPiGenerateSecretResponse:
+    """Generate a cryptographically secure shared secret (admin only).
+
+    Returns a 48-character URL-safe token. The admin must copy this
+    to the BaluPi's .env as BALUPI_HANDSHAKE_SECRET.
+    """
+    return BaluPiGenerateSecretResponse(
+        secret=secrets.token_urlsafe(36),
+    )

--- a/backend/app/api/routes/monitoring.py
+++ b/backend/app/api/routes/monitoring.py
@@ -26,11 +26,13 @@ from app.schemas.monitoring import (
     CurrentNetworkResponse,
     CurrentDiskIoResponse,
     CurrentProcessResponse,
+    CurrentUptimeResponse,
     CpuHistoryResponse,
     MemoryHistoryResponse,
     NetworkHistoryResponse,
     DiskIoHistoryResponse,
     ProcessHistoryResponse,
+    UptimeHistoryResponse,
     RetentionConfigResponse,
     RetentionConfigUpdate,
     RetentionConfigListResponse,
@@ -431,6 +433,97 @@ async def get_processes_history(
         sample_count=total_samples,
         source=source_str,
         crashes_detected=crashes,
+    )
+
+
+# ===== Uptime Endpoints =====
+
+@router.get("/uptime/current", response_model=CurrentUptimeResponse)
+@user_limiter.limit(get_limit("system_monitor"))
+async def get_uptime_current(
+    request: Request,
+    response: Response,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get current server and system uptime."""
+    orchestrator = get_monitoring_orchestrator()
+    sample = orchestrator.get_uptime_current_with_db_fallback(db)
+
+    if sample is not None:
+        return CurrentUptimeResponse(
+            timestamp=sample.timestamp,
+            server_uptime_seconds=sample.server_uptime_seconds,
+            system_uptime_seconds=sample.system_uptime_seconds,
+            server_start_time=sample.server_start_time,
+            system_boot_time=sample.system_boot_time,
+        )
+
+    # Fallback: compute live (uptime is always available)
+    import time
+    import psutil
+    from app.services.telemetry import _SERVER_START_TIME
+    from app.core.config import settings
+
+    now = time.time()
+    server_uptime = int(now - _SERVER_START_TIME)
+    server_start = datetime.fromtimestamp(_SERVER_START_TIME, tz=timezone.utc)
+
+    if getattr(settings, "is_dev_mode", False):
+        system_boot = server_start
+        system_uptime = server_uptime
+    else:
+        try:
+            boot_time = psutil.boot_time()
+            system_boot = datetime.fromtimestamp(boot_time, tz=timezone.utc)
+            system_uptime = int(now - boot_time)
+        except Exception:
+            system_boot = server_start
+            system_uptime = server_uptime
+
+    return CurrentUptimeResponse(
+        timestamp=datetime.now(timezone.utc),
+        server_uptime_seconds=server_uptime,
+        system_uptime_seconds=system_uptime,
+        server_start_time=server_start,
+        system_boot_time=system_boot,
+    )
+
+
+@router.get("/uptime/history", response_model=UptimeHistoryResponse)
+@user_limiter.limit(get_limit("system_monitor"))
+async def get_uptime_history(
+    request: Request,
+    response: Response,
+    time_range: TimeRangeEnum = Query(default=TimeRangeEnum.ONE_HOUR),
+    source: DataSource = Query(default=DataSource.AUTO),
+    limit: int = Query(default=1000, ge=1, le=10000),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Get uptime metrics history."""
+    orchestrator = get_monitoring_orchestrator()
+    duration = _parse_time_range(time_range)
+
+    if source == DataSource.MEMORY or (source == DataSource.AUTO and duration <= timedelta(minutes=10)):
+        samples = orchestrator.get_uptime_history(limit)
+        source_str = "memory"
+        if not samples:
+            start = datetime.now(timezone.utc) - duration
+            samples = orchestrator.uptime_collector.get_history_db(db, start=start, limit=limit)
+            source_str = "database (fallback)"
+    else:
+        start = datetime.now(timezone.utc) - duration
+        samples = orchestrator.uptime_collector.get_history_db(db, start=start, limit=limit)
+        source_str = "database"
+        if not samples:
+            samples = orchestrator.get_uptime_history(limit)
+            source_str = "memory (fallback)"
+
+    return UptimeHistoryResponse(
+        samples=samples,
+        sample_count=len(samples),
+        source=source_str,
     )
 
 

--- a/backend/app/models/monitoring.py
+++ b/backend/app/models/monitoring.py
@@ -26,6 +26,7 @@ class MetricType(str, enum.Enum):
     DISK_IO = "disk_io"
     PROCESS = "process"
     POWER = "power"
+    UPTIME = "uptime"
 
 
 class CpuSample(Base):
@@ -158,6 +159,29 @@ class ProcessSample(Base):
 
     def __repr__(self) -> str:
         return f"<ProcessSample(name={self.process_name}, pid={self.pid}, cpu={self.cpu_percent}%)>"
+
+
+class UptimeSample(Base):
+    """
+    Uptime metrics sample.
+
+    Stores server and system uptime measurements for historical analysis
+    and restart detection.
+    """
+
+    __tablename__ = "uptime_samples"
+
+    id = Column(Integer, primary_key=True, index=True)
+    timestamp = Column(DateTime, nullable=False, index=True, default=datetime.utcnow)
+
+    # Uptime metrics
+    server_uptime_seconds = Column(BigInteger, nullable=False)  # BaluHost backend uptime
+    system_uptime_seconds = Column(BigInteger, nullable=False)  # OS/Hardware uptime
+    server_start_time = Column(DateTime, nullable=False)  # When backend was started
+    system_boot_time = Column(DateTime, nullable=False)  # When OS was last booted
+
+    def __repr__(self) -> str:
+        return f"<UptimeSample(server={self.server_uptime_seconds}s, system={self.system_uptime_seconds}s, timestamp={self.timestamp})>"
 
 
 class MonitoringConfig(Base):

--- a/backend/app/schemas/monitoring.py
+++ b/backend/app/schemas/monitoring.py
@@ -23,6 +23,7 @@ class MetricTypeEnum(str, Enum):
     NETWORK = "network"
     DISK_IO = "disk_io"
     PROCESS = "process"
+    UPTIME = "uptime"
 
 
 class DataSource(str, Enum):
@@ -99,6 +100,18 @@ class ProcessSampleSchema(BaseModel):
     memory_mb: float
     status: str
     is_alive: bool = True
+
+    class Config:
+        from_attributes = True
+
+
+class UptimeSampleSchema(BaseModel):
+    """Uptime metrics sample."""
+    timestamp: datetime
+    server_uptime_seconds: int
+    system_uptime_seconds: int
+    server_start_time: datetime
+    system_boot_time: datetime
 
     class Config:
         from_attributes = True
@@ -210,6 +223,22 @@ class ProcessHistoryResponse(BaseModel):
     sample_count: int
     source: str
     crashes_detected: int = 0
+
+
+class CurrentUptimeResponse(BaseModel):
+    """Current uptime metrics response."""
+    timestamp: datetime
+    server_uptime_seconds: int
+    system_uptime_seconds: int
+    server_start_time: datetime
+    system_boot_time: datetime
+
+
+class UptimeHistoryResponse(BaseModel):
+    """Uptime history response."""
+    samples: List[UptimeSampleSchema]
+    sample_count: int
+    source: str
 
 
 # ===== Retention Configuration =====

--- a/backend/app/schemas/system.py
+++ b/backend/app/schemas/system.py
@@ -40,6 +40,7 @@ class SystemInfo(BaseModel):
     memory: MemoryStats
     disk: DiskStats
     uptime: float
+    system_uptime: float | None = None
     dev_mode: bool = False
 
 

--- a/backend/app/services/monitoring/__init__.py
+++ b/backend/app/services/monitoring/__init__.py
@@ -14,6 +14,7 @@ from app.services.monitoring.memory_collector import MemoryMetricCollector
 from app.services.monitoring.network_collector import NetworkMetricCollector
 from app.services.monitoring.disk_io_collector import DiskIoMetricCollector
 from app.services.monitoring.process_tracker import ProcessTracker
+from app.services.monitoring.uptime_collector import UptimeCollector
 from app.services.monitoring.retention_manager import RetentionManager
 from app.services.monitoring.orchestrator import MonitoringOrchestrator
 
@@ -24,6 +25,7 @@ __all__ = [
     "NetworkMetricCollector",
     "DiskIoMetricCollector",
     "ProcessTracker",
+    "UptimeCollector",
     "RetentionManager",
     "MonitoringOrchestrator",
 ]

--- a/backend/app/services/monitoring/orchestrator.py
+++ b/backend/app/services/monitoring/orchestrator.py
@@ -19,12 +19,14 @@ from app.schemas.monitoring import (
     MemorySampleSchema,
     NetworkSampleSchema,
     DiskIoSampleSchema,
+    UptimeSampleSchema,
 )
 from app.services.monitoring.cpu_collector import CpuMetricCollector
 from app.services.monitoring.memory_collector import MemoryMetricCollector
 from app.services.monitoring.network_collector import NetworkMetricCollector
 from app.services.monitoring.disk_io_collector import DiskIoMetricCollector
 from app.services.monitoring.process_tracker import ProcessTracker
+from app.services.monitoring.uptime_collector import UptimeCollector
 from app.services.monitoring.retention_manager import RetentionManager
 
 logger = logging.getLogger(__name__)
@@ -85,6 +87,10 @@ class MonitoringOrchestrator:
             persist_interval=persist_interval,
         )
         self.process_tracker = ProcessTracker(buffer_size=60)
+        self.uptime_collector = UptimeCollector(
+            buffer_size=buffer_size,
+            persist_interval=persist_interval,
+        )
         self.retention_manager = RetentionManager()
 
         # State
@@ -199,6 +205,7 @@ class MonitoringOrchestrator:
             self.cpu_collector.process_sample(db)
             self.memory_collector.process_sample(db)
             self.network_collector.process_sample(db)
+            self.uptime_collector.process_sample(db)
 
             # Disk I/O collects multiple samples (one per disk)
             disk_samples = self.disk_io_collector.collect_all_samples()
@@ -380,6 +387,25 @@ class MonitoringOrchestrator:
             }
         return {}
 
+    def get_uptime_current(self) -> Optional[UptimeSampleSchema]:
+        """Get current uptime sample from memory."""
+        return self.uptime_collector.get_current()
+
+    def get_uptime_current_with_db_fallback(self, db: Session) -> Optional[UptimeSampleSchema]:
+        """Get current uptime sample (in-memory -> DB fallback)."""
+        sample = self.uptime_collector.get_current()
+        if sample is not None:
+            return sample
+        from app.models.monitoring import UptimeSample
+        db_record = db.query(UptimeSample).order_by(UptimeSample.timestamp.desc()).first()
+        if db_record:
+            return self.uptime_collector.db_to_sample(db_record)
+        return None
+
+    def get_uptime_history(self, limit: Optional[int] = None) -> List:
+        """Get uptime history from memory."""
+        return self.uptime_collector.get_history_memory(limit)
+
     def get_process_current(self):
         """Get current process status."""
         return self.process_tracker.get_current_status()
@@ -497,6 +523,7 @@ class MonitoringOrchestrator:
                 "network": self.network_collector.is_enabled(),
                 "disk_io": self.disk_io_collector.is_enabled(),
                 "process": True,
+                "uptime": self.uptime_collector.is_enabled(),
             },
         }
 

--- a/backend/app/services/monitoring/retention_manager.py
+++ b/backend/app/services/monitoring/retention_manager.py
@@ -20,6 +20,7 @@ from app.models.monitoring import (
     NetworkSample,
     DiskIoSample,
     ProcessSample,
+    UptimeSample,
 )
 from app.models.power_sample import PowerSample
 
@@ -33,6 +34,7 @@ DEFAULT_RETENTION = {
     MetricType.DISK_IO: 168,   # 7 days
     MetricType.PROCESS: 72,    # 3 days
     MetricType.POWER: 720,     # 30 days
+    MetricType.UPTIME: 720,    # 30 days
 }
 
 # Mapping of metric types to their database models
@@ -43,6 +45,7 @@ METRIC_MODELS = {
     MetricType.DISK_IO: DiskIoSample,
     MetricType.PROCESS: ProcessSample,
     MetricType.POWER: PowerSample,
+    MetricType.UPTIME: UptimeSample,
 }
 
 
@@ -238,6 +241,7 @@ class RetentionManager:
             MetricType.DISK_IO: 100,
             MetricType.PROCESS: 120,
             MetricType.POWER: 60,
+            MetricType.UPTIME: 40,
         }
 
         sizes = {}

--- a/backend/app/services/monitoring/uptime_collector.py
+++ b/backend/app/services/monitoring/uptime_collector.py
@@ -1,0 +1,107 @@
+"""
+Uptime metrics collector.
+
+Collects server uptime (BaluHost backend) and system uptime (OS/hardware).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Optional, Type
+
+import psutil
+
+from app.models.base import Base
+from app.models.monitoring import UptimeSample
+from app.schemas.monitoring import UptimeSampleSchema
+from app.services.monitoring.base import MetricCollector
+
+logger = logging.getLogger(__name__)
+
+
+class UptimeCollector(MetricCollector[UptimeSampleSchema]):
+    """
+    Collector for uptime metrics.
+
+    Collects:
+    - Server uptime (time since BaluHost backend started)
+    - System uptime (time since OS last booted)
+    - Server start time
+    - System boot time
+    """
+
+    def __init__(
+        self,
+        buffer_size: int = 120,
+        persist_interval: int = 12,
+    ):
+        super().__init__(
+            metric_name="Uptime",
+            buffer_size=buffer_size,
+            persist_interval=persist_interval,
+        )
+
+    def collect_sample(self) -> Optional[UptimeSampleSchema]:
+        """Collect uptime metrics sample."""
+        try:
+            from app.services.telemetry import _SERVER_START_TIME
+            from app.core.config import settings
+
+            timestamp = datetime.now(timezone.utc)
+            now = time.time()
+
+            # Server uptime
+            server_uptime = int(now - _SERVER_START_TIME)
+            server_start = datetime.fromtimestamp(_SERVER_START_TIME, tz=timezone.utc)
+
+            # System uptime
+            if getattr(settings, "is_dev_mode", False):
+                # Dev mode: system uptime = server uptime
+                system_boot = server_start
+                system_uptime = server_uptime
+            else:
+                try:
+                    boot_time = psutil.boot_time()
+                    system_boot = datetime.fromtimestamp(boot_time, tz=timezone.utc)
+                    system_uptime = int(now - boot_time)
+                except Exception:
+                    # Fallback to server uptime
+                    system_boot = server_start
+                    system_uptime = server_uptime
+
+            return UptimeSampleSchema(
+                timestamp=timestamp,
+                server_uptime_seconds=server_uptime,
+                system_uptime_seconds=system_uptime,
+                server_start_time=server_start,
+                system_boot_time=system_boot,
+            )
+        except Exception as e:
+            logger.error(f"Failed to collect uptime sample: {e}")
+            return None
+
+    def get_db_model(self) -> Type[Base]:
+        """Get the UptimeSample model class."""
+        return UptimeSample
+
+    def sample_to_db_dict(self, sample: UptimeSampleSchema) -> dict:
+        """Convert schema to database dict."""
+        return {
+            "timestamp": sample.timestamp,
+            "server_uptime_seconds": sample.server_uptime_seconds,
+            "system_uptime_seconds": sample.system_uptime_seconds,
+            "server_start_time": sample.server_start_time,
+            "system_boot_time": sample.system_boot_time,
+        }
+
+    def db_to_sample(self, db_record: UptimeSample) -> UptimeSampleSchema:
+        """Convert database record to schema."""
+        return UptimeSampleSchema(
+            timestamp=db_record.timestamp,
+            server_uptime_seconds=db_record.server_uptime_seconds,
+            system_uptime_seconds=db_record.system_uptime_seconds,
+            server_start_time=db_record.server_start_time,
+            system_boot_time=db_record.system_boot_time,
+        )

--- a/backend/app/services/system.py
+++ b/backend/app/services/system.py
@@ -202,6 +202,7 @@ def get_system_info() -> SystemInfo:
             memory=MemoryStats(total=memory_total, used=memory_used, free=memory_free, speed_mts=ram_speed, type=ram_type),
             disk=DiskStats(total=total_storage, used=used_storage, free=free_storage),
             uptime=uptime_seconds,
+            system_uptime=uptime_seconds,  # Dev mode: same as server uptime
             dev_mode=True,
         )
 
@@ -265,6 +266,7 @@ def get_system_info() -> SystemInfo:
         memory=MemoryStats(total=memory_total, used=memory_used, free=memory_free, speed_mts=ram_speed, type=ram_type),
         disk=DiskStats(total=disk_usage.total, used=disk_usage.used, free=disk_usage.free),
         uptime=server_uptime,
+        system_uptime=uptime_seconds,
         dev_mode=False,
     )
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baluhost-backend"
-version = "1.15.5"
+version = "1.15.6"
 description = "Mocked NAS management backend built with FastAPI"
 authors = [{ name = "Baluhost" }]
 requires-python = ">=3.11"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baluhost-client",
   "private": true,
-  "version": "1.15.5",
+  "version": "1.15.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/api/balupi.ts
+++ b/client/src/api/balupi.ts
@@ -1,0 +1,45 @@
+import { apiClient } from '../lib/api';
+
+export interface BaluPiConfig {
+  enabled: boolean;
+  url: string;
+  has_secret: boolean;
+  secret_preview: string;
+}
+
+export interface BaluPiConfigUpdate {
+  enabled?: boolean;
+  url?: string;
+  secret?: string;
+}
+
+export interface BaluPiTestResult {
+  reachable: boolean;
+  version?: string | null;
+  hostname?: string | null;
+  error?: string | null;
+}
+
+export interface BaluPiGenerateSecretResponse {
+  secret: string;
+}
+
+export async function getBaluPiConfig(): Promise<BaluPiConfig> {
+  const { data } = await apiClient.get<BaluPiConfig>('/api/admin/balupi/config');
+  return data;
+}
+
+export async function updateBaluPiConfig(update: BaluPiConfigUpdate): Promise<{ changed: string[] }> {
+  const { data } = await apiClient.put<{ changed: string[] }>('/api/admin/balupi/config', update);
+  return data;
+}
+
+export async function testBaluPiConnection(): Promise<BaluPiTestResult> {
+  const { data } = await apiClient.post<BaluPiTestResult>('/api/admin/balupi/test');
+  return data;
+}
+
+export async function generateBaluPiSecret(): Promise<BaluPiGenerateSecretResponse> {
+  const { data } = await apiClient.post<BaluPiGenerateSecretResponse>('/api/admin/balupi/generate-secret');
+  return data;
+}

--- a/client/src/api/monitoring.ts
+++ b/client/src/api/monitoring.ts
@@ -66,6 +66,14 @@ export interface ProcessSample {
   is_alive: boolean;
 }
 
+export interface UptimeSample {
+  timestamp: string;
+  server_uptime_seconds: number;
+  system_uptime_seconds: number;
+  server_start_time: string;
+  system_boot_time: string;
+}
+
 // ===== Current Response Types =====
 
 export interface CurrentCpuResponse {
@@ -106,6 +114,14 @@ export interface CurrentProcessResponse {
   processes: Record<string, ProcessSample | null>;
 }
 
+export interface CurrentUptimeResponse {
+  timestamp: string;
+  server_uptime_seconds: number;
+  system_uptime_seconds: number;
+  server_start_time: string;
+  system_boot_time: string;
+}
+
 // ===== History Response Types =====
 
 export interface CpuHistoryResponse {
@@ -138,6 +154,12 @@ export interface ProcessHistoryResponse {
   sample_count: number;
   source: string;
   crashes_detected: number;
+}
+
+export interface UptimeHistoryResponse {
+  samples: UptimeSample[];
+  sample_count: number;
+  source: string;
 }
 
 // ===== Retention Config Types =====
@@ -274,6 +296,23 @@ export async function getProcessesHistory(
   if (processName) params.process_name = processName;
   const response = await apiClient.get<ProcessHistoryResponse>('/api/monitoring/processes/history', {
     params,
+  });
+  return response.data;
+}
+
+// Uptime
+export async function getUptimeCurrent(): Promise<CurrentUptimeResponse> {
+  const response = await apiClient.get<CurrentUptimeResponse>('/api/monitoring/uptime/current');
+  return response.data;
+}
+
+export async function getUptimeHistory(
+  timeRange: TimeRange = '1h',
+  source: DataSource = 'auto',
+  limit: number = 1000
+): Promise<UptimeHistoryResponse> {
+  const response = await apiClient.get<UptimeHistoryResponse>('/api/monitoring/uptime/history', {
+    params: { time_range: timeRange, source, limit },
   });
   return response.data;
 }

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -12,6 +12,7 @@ import { Plug, CloudDownload, Shield } from 'lucide-react';
 import NotificationCenter from './NotificationCenter';
 import PowerMenu from './PowerMenu';
 import { UploadProgressBar } from './UploadProgressBar';
+import { isPi } from '../lib/features';
 
 interface LayoutProps {
   children: ReactNode;
@@ -260,8 +261,11 @@ export default function Layout({ children }: LayoutProps) {
     }
   ];
 
+  // Pi mode: only show Dashboard + System
+  const piNavPaths = new Set(['/', '/system']);
+
   // Add plugin navigation items
-  const pluginItems = pluginNavItems
+  const pluginItems = isPi ? [] : pluginNavItems
     .filter((item) => !item.admin_only || isAdmin)
     .map((item) => ({
       path: `/plugins/${item.path}`,
@@ -271,12 +275,12 @@ export default function Layout({ children }: LayoutProps) {
       adminOnly: item.admin_only
     }));
 
-  // Filter nav items based on user role
+  // Filter nav items based on user role (and device mode)
   const filteredNavItems = navItems
-    .filter(item => !item.adminOnly || isAdmin);
+    .filter(item => isPi ? piNavPaths.has(item.path) : (!item.adminOnly || isAdmin));
 
   // Find where admin items start (for showing separator)
-  const adminStartIndex = filteredNavItems.findIndex(item => item.adminOnly);
+  const adminStartIndex = isPi ? -1 : filteredNavItems.findIndex(item => item.adminOnly);
 
   // Combine nav items with plugin items for final list
   const allNavItems = [...filteredNavItems, ...pluginItems];
@@ -291,10 +295,14 @@ export default function Layout({ children }: LayoutProps) {
           <div className="px-6 pt-10 pb-8">
             <div className="flex items-center gap-3">
               <div className="relative flex h-12 w-12 items-center justify-center rounded-full bg-slate-950-tertiary p-[3px]">
-                <img src={logoMark} alt="BalùHost logo" className="h-full w-full rounded-full" />
+                {isPi ? (
+                  <div className="flex h-full w-full items-center justify-center rounded-full bg-gradient-to-br from-sky-500 to-indigo-600 text-sm font-bold text-white">BP</div>
+                ) : (
+                  <img src={logoMark} alt="BalùHost logo" className="h-full w-full rounded-full" />
+                )}
               </div>
               <div>
-                <p className="text-lg font-semibold tracking-wide">BalùHost</p>
+                <p className="text-lg font-semibold tracking-wide">{isPi ? 'BaluPi' : 'BalùHost'}</p>
                 <p className="text-xs uppercase tracking-[0.35em] text-slate-100-tertiary">{formattedVersion}{__BUILD_TYPE__ === 'dev' && <span className="font-mono"> · {__GIT_COMMIT__}</span>}</p>
                 <DeveloperBadge />
               </div>
@@ -365,10 +373,14 @@ export default function Layout({ children }: LayoutProps) {
           <div className="flex items-center justify-between px-6 pt-6 pb-4">
             <div className="flex items-center gap-3">
               <div className="relative flex h-10 w-10 items-center justify-center rounded-full bg-slate-950-tertiary p-[3px]">
-                <img src={logoMark} alt="BalùHost logo" className="h-full w-full rounded-full" />
+                {isPi ? (
+                  <div className="flex h-full w-full items-center justify-center rounded-full bg-gradient-to-br from-sky-500 to-indigo-600 text-xs font-bold text-white">BP</div>
+                ) : (
+                  <img src={logoMark} alt="BalùHost logo" className="h-full w-full rounded-full" />
+                )}
               </div>
               <div>
-                <p className="text-base font-semibold tracking-wide">BalùHost</p>
+                <p className="text-base font-semibold tracking-wide">{isPi ? 'BaluPi' : 'BalùHost'}</p>
                 <p className="text-[10px] uppercase tracking-[0.3em] text-slate-100-tertiary">{formattedVersion}{__BUILD_TYPE__ === 'dev' && <span className="font-mono"> · {__GIT_COMMIT__}</span>}</p>
                 <DeveloperBadge />
               </div>
@@ -476,9 +488,13 @@ export default function Layout({ children }: LayoutProps) {
                 </button>
                 <div className="flex items-center gap-2">
                   <div className="relative flex h-8 w-8 items-center justify-center rounded-full bg-slate-950-tertiary p-[2px]">
-                    <img src={logoMark} alt="BalùHost" className="h-full w-full rounded-full" />
+                    {isPi ? (
+                      <div className="flex h-full w-full items-center justify-center rounded-full bg-gradient-to-br from-sky-500 to-indigo-600 text-[10px] font-bold text-white">BP</div>
+                    ) : (
+                      <img src={logoMark} alt="BalùHost" className="h-full w-full rounded-full" />
+                    )}
                   </div>
-                  <span className="text-sm font-semibold">BalùHost</span>
+                  <span className="text-sm font-semibold">{isPi ? 'BaluPi' : 'BalùHost'}</span>
                 </div>
               </div>
 
@@ -487,14 +503,24 @@ export default function Layout({ children }: LayoutProps) {
 
               {/* Header Right */}
               <div className="flex items-center gap-3">
-                <NotificationCenter />
+                {!isPi && <NotificationCenter />}
                 <div className="hidden md:flex items-center gap-3 rounded-xl border border-slate-800 bg-slate-900/40 px-3 py-1.5 transition hover:border-sky-500/50 hover:shadow-[0_0_12px_rgba(56,189,248,0.15)]">
                   <div className="flex flex-col">
                     <span className="text-sm font-medium text-slate-100">{user?.username}</span>
                     <span className="text-[11px] text-slate-100-tertiary">{isAdmin ? 'Admin' : 'User'}</span>
                   </div>
                 </div>
-                <PowerMenu
+                {isPi ? (
+                  <button
+                    onClick={logout}
+                    className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-800 text-slate-400 hover:border-sky-500/50 hover:text-sky-400 transition"
+                    title="Logout"
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" strokeWidth={1.6} className="h-5 w-5">
+                      <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4M16 17l5-5-5-5M21 12H9" />
+                    </svg>
+                  </button>
+                ) : <PowerMenu
                   isAdmin={isAdmin}
                   onShutdown={async () => {
                     setPendingAction('shutdown');
@@ -552,7 +578,7 @@ export default function Layout({ children }: LayoutProps) {
                     }
                   }}
                   onLogout={logout}
-                />
+                />}
               </div>
             </div>
           </header>
@@ -562,7 +588,7 @@ export default function Layout({ children }: LayoutProps) {
               {children}
             </div>
           </main>
-          <UploadProgressBar />
+          {!isPi && <UploadProgressBar />}
         </div>
       </div>
     </div>

--- a/client/src/components/balupi/BaluPiSetup.tsx
+++ b/client/src/components/balupi/BaluPiSetup.tsx
@@ -1,0 +1,432 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Cpu,
+  Wifi,
+  WifiOff,
+  RefreshCw,
+  Copy,
+  Check,
+  Key,
+  Loader2,
+  AlertCircle,
+  CheckCircle2,
+  ExternalLink,
+  Power,
+} from 'lucide-react';
+import toast from 'react-hot-toast';
+import {
+  getBaluPiConfig,
+  updateBaluPiConfig,
+  testBaluPiConnection,
+  generateBaluPiSecret,
+  type BaluPiConfig,
+  type BaluPiTestResult,
+} from '../../api/balupi';
+
+export default function BaluPiSetup() {
+  const { t } = useTranslation('common');
+
+  const [config, setConfig] = useState<BaluPiConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<BaluPiTestResult | null>(null);
+  const [generating, setGenerating] = useState(false);
+
+  // Form state
+  const [enabled, setEnabled] = useState(false);
+  const [url, setUrl] = useState('');
+  const [secret, setSecret] = useState('');
+  const [secretDirty, setSecretDirty] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const fetchConfig = async () => {
+    try {
+      const data = await getBaluPiConfig();
+      setConfig(data);
+      setEnabled(data.enabled);
+      setUrl(data.url);
+      setSecret('');
+      setSecretDirty(false);
+    } catch {
+      toast.error(t('toast.loadFailed'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchConfig();
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const update: Record<string, unknown> = {};
+      if (enabled !== config?.enabled) update.enabled = enabled;
+      if (url !== config?.url) update.url = url;
+      if (secretDirty && secret) update.secret = secret;
+
+      if (Object.keys(update).length === 0) {
+        toast.error('No changes to save');
+        return;
+      }
+
+      await updateBaluPiConfig(update);
+      toast.success(t('toast.saved'));
+      await fetchConfig();
+      setTestResult(null);
+    } catch {
+      toast.error(t('toast.saveFailed'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await testBaluPiConnection();
+      setTestResult(result);
+    } catch {
+      setTestResult({ reachable: false, error: 'Request failed' });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleGenerateSecret = async () => {
+    setGenerating(true);
+    try {
+      const { secret: newSecret } = await generateBaluPiSecret();
+      setSecret(newSecret);
+      setSecretDirty(true);
+    } catch {
+      toast.error('Failed to generate secret');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleCopySecret = async () => {
+    if (!secret) return;
+    await navigator.clipboard.writeText(secret);
+    setCopied(true);
+    toast.success('Secret copied');
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const hasChanges =
+    enabled !== config?.enabled ||
+    url !== config?.url ||
+    (secretDirty && secret.length > 0);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-sky-500 to-indigo-600 text-sm font-bold text-white">
+            BP
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-white">BaluPi Companion</h2>
+            <p className="text-xs text-slate-400">
+              Raspberry Pi companion device for WoL, energy monitoring & DNS failover
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={fetchConfig}
+          className="flex items-center gap-1.5 rounded-md border border-slate-700 bg-slate-800 px-2.5 py-1.5 text-xs text-slate-400 transition hover:border-slate-600 hover:text-slate-300"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          {t('refresh')}
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* Connection Settings */}
+        <div className="rounded-xl border border-slate-800 bg-slate-900/80 p-5">
+          <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-white">
+            <Wifi className="h-4 w-4 text-sky-400" />
+            Connection Settings
+          </h3>
+
+          <div className="space-y-4">
+            {/* Enable Toggle */}
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-slate-200">Enable BaluPi</p>
+                <p className="text-xs text-slate-500">
+                  Send shutdown/startup notifications to Pi
+                </p>
+              </div>
+              <button
+                onClick={() => setEnabled(!enabled)}
+                className={`relative h-6 w-11 rounded-full transition-colors ${
+                  enabled ? 'bg-sky-500' : 'bg-slate-700'
+                }`}
+              >
+                <span
+                  className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                    enabled ? 'translate-x-5' : ''
+                  }`}
+                />
+              </button>
+            </div>
+
+            {/* Pi URL */}
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-slate-400">
+                BaluPi URL
+              </label>
+              <input
+                type="text"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="http://192.168.178.20:8000"
+                className="w-full rounded-lg border border-slate-700 bg-slate-800/60 px-3 py-2 text-sm text-slate-200 placeholder-slate-600 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+              />
+              <p className="mt-1 text-xs text-slate-500">
+                The BaluPi backend API address on your local network
+              </p>
+            </div>
+
+            {/* Shared Secret */}
+            <div>
+              <label className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-slate-400">
+                <Key className="h-3 w-3" />
+                HMAC Shared Secret
+              </label>
+              <div className="flex gap-2">
+                <div className="relative flex-1">
+                  <input
+                    type="text"
+                    value={secret}
+                    onChange={(e) => {
+                      setSecret(e.target.value);
+                      setSecretDirty(true);
+                    }}
+                    placeholder={
+                      config?.has_secret
+                        ? `${config.secret_preview} (configured)`
+                        : 'Not configured'
+                    }
+                    className="w-full rounded-lg border border-slate-700 bg-slate-800/60 px-3 py-2 pr-9 font-mono text-xs text-slate-200 placeholder-slate-600 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+                  />
+                  {secret && (
+                    <button
+                      onClick={handleCopySecret}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300"
+                      title="Copy"
+                    >
+                      {copied ? (
+                        <Check className="h-3.5 w-3.5 text-emerald-400" />
+                      ) : (
+                        <Copy className="h-3.5 w-3.5" />
+                      )}
+                    </button>
+                  )}
+                </div>
+                <button
+                  onClick={handleGenerateSecret}
+                  disabled={generating}
+                  className="flex items-center gap-1.5 whitespace-nowrap rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-xs text-slate-300 transition hover:border-slate-600 hover:text-white disabled:opacity-50"
+                >
+                  {generating ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Key className="h-3.5 w-3.5" />
+                  )}
+                  Generate
+                </button>
+              </div>
+              <p className="mt-1 text-xs text-slate-500">
+                Must match BALUPI_HANDSHAKE_SECRET on the Pi (min. 32 chars)
+              </p>
+            </div>
+
+            {/* Save Button */}
+            <button
+              onClick={handleSave}
+              disabled={saving || !hasChanges}
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-sky-600 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {saving ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Check className="h-4 w-4" />
+              )}
+              Save Configuration
+            </button>
+          </div>
+        </div>
+
+        {/* Connection Test & Status */}
+        <div className="space-y-4">
+          {/* Test Connection */}
+          <div className="rounded-xl border border-slate-800 bg-slate-900/80 p-5">
+            <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-white">
+              <Power className="h-4 w-4 text-emerald-400" />
+              Connection Test
+            </h3>
+
+            <button
+              onClick={handleTest}
+              disabled={testing || !config?.url}
+              className="flex w-full items-center justify-center gap-2 rounded-lg border border-slate-700 bg-slate-800 px-4 py-2.5 text-sm font-medium text-slate-300 transition hover:border-sky-500/50 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {testing ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Testing...
+                </>
+              ) : (
+                <>
+                  <Wifi className="h-4 w-4" />
+                  Test Connection
+                </>
+              )}
+            </button>
+
+            {testResult && (
+              <div
+                className={`mt-3 rounded-lg border p-3 ${
+                  testResult.reachable
+                    ? 'border-emerald-500/30 bg-emerald-500/10'
+                    : 'border-rose-500/30 bg-rose-500/10'
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  {testResult.reachable ? (
+                    <CheckCircle2 className="h-4 w-4 text-emerald-400" />
+                  ) : (
+                    <AlertCircle className="h-4 w-4 text-rose-400" />
+                  )}
+                  <span
+                    className={`text-sm font-medium ${
+                      testResult.reachable ? 'text-emerald-300' : 'text-rose-300'
+                    }`}
+                  >
+                    {testResult.reachable ? 'Connected' : 'Unreachable'}
+                  </span>
+                </div>
+                {testResult.reachable && (
+                  <div className="mt-2 space-y-1 text-xs text-emerald-200/70">
+                    {testResult.version && (
+                      <p>
+                        Version: <span className="font-mono text-emerald-300">{testResult.version}</span>
+                      </p>
+                    )}
+                    {testResult.hostname && (
+                      <p>
+                        Hostname: <span className="font-mono text-emerald-300">{testResult.hostname}</span>
+                      </p>
+                    )}
+                  </div>
+                )}
+                {testResult.error && (
+                  <p className="mt-1.5 text-xs text-rose-300/80">{testResult.error}</p>
+                )}
+              </div>
+            )}
+
+            {!config?.url && (
+              <p className="mt-2 flex items-center gap-1.5 text-xs text-amber-400/80">
+                <AlertCircle className="h-3 w-3" />
+                Configure the BaluPi URL first
+              </p>
+            )}
+          </div>
+
+          {/* How it works */}
+          <div className="rounded-xl border border-slate-800/60 bg-slate-900/40 p-5">
+            <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-300">
+              <Cpu className="h-4 w-4 text-slate-500" />
+              How it works
+            </h3>
+            <ul className="space-y-2.5 text-xs text-slate-400">
+              <li className="flex gap-2">
+                <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-sky-500/20 text-[10px] font-bold text-sky-400">
+                  1
+                </span>
+                <span>
+                  NAS sends shutdown snapshot to Pi via HMAC-signed request
+                </span>
+              </li>
+              <li className="flex gap-2">
+                <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-sky-500/20 text-[10px] font-bold text-sky-400">
+                  2
+                </span>
+                <span>
+                  Pi switches <span className="font-mono text-slate-300">baluhost.local</span> DNS to itself via Pi-hole
+                </span>
+              </li>
+              <li className="flex gap-2">
+                <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-sky-500/20 text-[10px] font-bold text-sky-400">
+                  3
+                </span>
+                <span>
+                  Pi serves status page, accepts SMB uploads to inbox, monitors energy via Tapo
+                </span>
+              </li>
+              <li className="flex gap-2">
+                <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-sky-500/20 text-[10px] font-bold text-sky-400">
+                  4
+                </span>
+                <span>
+                  User can Wake-on-LAN the NAS from Pi dashboard
+                </span>
+              </li>
+              <li className="flex gap-2">
+                <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-sky-500/20 text-[10px] font-bold text-sky-400">
+                  5
+                </span>
+                <span>
+                  On boot, NAS notifies Pi — inbox is flushed via rsync, DNS switches back
+                </span>
+              </li>
+            </ul>
+          </div>
+
+          {/* Current Status */}
+          <div className="rounded-xl border border-slate-800/60 bg-slate-900/40 p-5">
+            <h3 className="mb-3 text-sm font-semibold text-slate-300">Current Status</h3>
+            <div className="space-y-2 text-xs">
+              <div className="flex items-center justify-between">
+                <span className="text-slate-500">Integration</span>
+                <span className={`flex items-center gap-1.5 font-medium ${config?.enabled ? 'text-emerald-400' : 'text-slate-500'}`}>
+                  <div className={`h-1.5 w-1.5 rounded-full ${config?.enabled ? 'bg-emerald-500' : 'bg-slate-600'}`} />
+                  {config?.enabled ? 'Enabled' : 'Disabled'}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-slate-500">URL</span>
+                <span className="font-mono text-slate-300">
+                  {config?.url || '—'}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-slate-500">Secret</span>
+                <span className={config?.has_secret ? 'text-emerald-400' : 'text-amber-400'}>
+                  {config?.has_secret ? 'Configured' : 'Not set'}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/balupi/BaluPiSetup.tsx
+++ b/client/src/components/balupi/BaluPiSetup.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import {
   Cpu,
   Wifi,
-  WifiOff,
   RefreshCw,
   Copy,
   Check,
@@ -11,7 +10,6 @@ import {
   Loader2,
   AlertCircle,
   CheckCircle2,
-  ExternalLink,
   Power,
 } from 'lucide-react';
 import toast from 'react-hot-toast';

--- a/client/src/components/system-monitor/UptimeTab.tsx
+++ b/client/src/components/system-monitor/UptimeTab.tsx
@@ -1,0 +1,195 @@
+/**
+ * UptimeTab -- Uptime monitoring tab with live counters, restart history, and charts.
+ */
+
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MetricChart } from '../monitoring';
+import type { TimeRange } from '../../api/monitoring';
+import {
+  getUptimeCurrent,
+  getUptimeHistory,
+  type CurrentUptimeResponse,
+  type UptimeSample,
+} from '../../api/monitoring';
+import { StatCard } from '../ui/StatCard';
+import { formatUptime } from '../../lib/formatters';
+
+interface RestartEvent {
+  timestamp: string;
+  sessionDuration: number;
+}
+
+function formatDateTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+export function UptimeTab({ timeRange }: { timeRange: TimeRange }) {
+  const { t } = useTranslation(['system', 'common']);
+  const [current, setCurrent] = useState<CurrentUptimeResponse | null>(null);
+  const [history, setHistory] = useState<UptimeSample[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Tick counter for live update between polls
+  const [tick, setTick] = useState(0);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [currentData, historyData] = await Promise.all([
+        getUptimeCurrent(),
+        getUptimeHistory(timeRange),
+      ]);
+      setCurrent(currentData);
+      setHistory(historyData.samples);
+      setError(null);
+    } catch (err) {
+      if (!current) {
+        setError(err instanceof Error ? err.message : 'Failed to load uptime data');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [timeRange]);
+
+  // Initial fetch + polling
+  useEffect(() => {
+    fetchData();
+    const interval = setInterval(fetchData, 10000);
+    return () => clearInterval(interval);
+  }, [fetchData]);
+
+  // Client-side 1s tick for live counter
+  useEffect(() => {
+    const interval = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Compute live uptime values (add tick seconds to last known values)
+  const liveServerUptime = useMemo(() => {
+    if (!current) return 0;
+    return current.server_uptime_seconds + tick;
+  }, [current, tick]);
+
+  const liveSystemUptime = useMemo(() => {
+    if (!current) return 0;
+    return current.system_uptime_seconds + tick;
+  }, [current, tick]);
+
+  // Reset tick when fresh data arrives
+  useEffect(() => {
+    setTick(0);
+  }, [current?.timestamp]);
+
+  // Detect restarts from history (where server_uptime_seconds drops)
+  const restarts = useMemo<RestartEvent[]>(() => {
+    if (history.length < 2) return [];
+    const events: RestartEvent[] = [];
+    for (let i = 1; i < history.length; i++) {
+      if (history[i].server_uptime_seconds < history[i - 1].server_uptime_seconds) {
+        events.push({
+          timestamp: history[i].timestamp,
+          sessionDuration: history[i - 1].server_uptime_seconds,
+        });
+      }
+    }
+    return events;
+  }, [history]);
+
+  // Chart data
+  const chartData = useMemo(() => {
+    return history.map((s) => ({
+      time: s.timestamp,
+      server: Math.round(s.server_uptime_seconds / 3600 * 100) / 100,
+      system: Math.round(s.system_uptime_seconds / 3600 * 100) / 100,
+    }));
+  }, [history]);
+
+  if (error && !current) {
+    return <div className="text-red-400 text-center py-8">{error}</div>;
+  }
+
+  return (
+    <div className="space-y-4 sm:space-y-6 min-w-0">
+      {/* Current Stats */}
+      <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-3 sm:gap-5">
+        <StatCard
+          label={t('monitor.uptime.serverUptime')}
+          value={formatUptime(liveServerUptime)}
+          unit=""
+          color="blue"
+          icon={<span className="text-blue-400 text-base sm:text-xl">S</span>}
+          subValue={current ? formatDateTime(current.server_start_time) : undefined}
+        />
+        <StatCard
+          label={t('monitor.uptime.systemUptime')}
+          value={formatUptime(liveSystemUptime)}
+          unit=""
+          color="green"
+          icon={<span className="text-green-400 text-base sm:text-xl">OS</span>}
+          subValue={current ? formatDateTime(current.system_boot_time) : undefined}
+        />
+      </div>
+
+      {/* Restart History */}
+      <div>
+        <h3 className="text-base sm:text-lg font-semibold text-white mb-3">
+          {t('monitor.uptime.restartHistory')}
+        </h3>
+        {restarts.length === 0 ? (
+          <div className="card border-slate-800/60 bg-slate-900/60 p-4">
+            <p className="text-sm text-slate-400">{t('monitor.uptime.noRestarts')}</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {restarts.map((restart, idx) => (
+              <div
+                key={idx}
+                className="card border-slate-800/60 bg-slate-900/60 p-3 flex items-center justify-between"
+              >
+                <div>
+                  <p className="text-sm font-medium text-white">
+                    {formatDateTime(restart.timestamp)}
+                  </p>
+                  <p className="text-xs text-slate-400">
+                    {t('monitor.uptime.sessionDuration')}: {formatUptime(restart.sessionDuration)}
+                  </p>
+                </div>
+                <div className="rounded-full bg-amber-500/20 px-2 py-1">
+                  <span className="text-xs text-amber-400">{t('monitor.uptime.restart')}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Uptime Chart */}
+      <div>
+        <h3 className="text-base sm:text-lg font-semibold text-white mb-3">
+          {t('monitor.uptime.uptimeChart')}
+        </h3>
+        <div className="card border-slate-800/60 bg-slate-900/60 p-3 sm:p-5">
+          <MetricChart
+            data={chartData}
+            lines={[
+              { dataKey: 'server', name: t('monitor.uptime.serverLabel'), color: '#3b82f6' },
+              { dataKey: 'system', name: t('monitor.uptime.systemLabel'), color: '#22c55e' },
+            ]}
+            yAxisLabel={t('monitor.uptime.hours')}
+            yAxisDomain={[0, 'auto']}
+            showArea
+            loading={loading}
+            emptyMessage={t('monitor.uptime.noData')}
+            timeRange={timeRange}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/system-monitor/index.ts
+++ b/client/src/components/system-monitor/index.ts
@@ -3,3 +3,4 @@ export { DiskIoTab } from './DiskIoTab';
 export { MemoryTab } from './MemoryTab';
 export { NetworkTab } from './NetworkTab';
 export { PowerTab } from './PowerTab';
+export { UptimeTab } from './UptimeTab';

--- a/client/src/contexts/NotificationContext.tsx
+++ b/client/src/contexts/NotificationContext.tsx
@@ -14,6 +14,7 @@ import {
 } from '../api/notifications';
 import { useNotificationSocket } from '../hooks/useNotificationSocket';
 import { useAuth } from './AuthContext';
+import { isPi } from '../lib/features';
 
 interface NotificationContextValue {
   notifications: Notification[];
@@ -35,7 +36,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   const [loading, setLoading] = useState(false);
 
   const { isConnected } = useNotificationSocket({
-    enabled: !!token,
+    enabled: !!token && !isPi,
     onNotification: (notification) => {
       setNotifications((prev) => [notification, ...prev.slice(0, 49)]);
       if (notification.notification_type === 'critical') {
@@ -50,7 +51,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   });
 
   const fetchNotifications = useCallback(async () => {
-    if (!token) return;
+    if (!token || isPi) return;
     setLoading(true);
     try {
       const [notifResponse, countResponse] = await Promise.all([

--- a/client/src/contexts/PluginContext.tsx
+++ b/client/src/contexts/PluginContext.tsx
@@ -12,6 +12,7 @@ import {
   getUIManifest,
 } from '../api/plugins';
 import { useAuth } from './AuthContext';
+import { isPi } from '../lib/features';
 
 interface PluginContextType {
   plugins: PluginInfo[];
@@ -36,8 +37,8 @@ export function PluginProvider({ children }: PluginProviderProps) {
   const [error, setError] = useState<string | null>(null);
 
   const loadPlugins = useCallback(async () => {
-    // Only load plugins if user is authenticated
-    if (!token) {
+    // Only load plugins if user is authenticated (skip on Pi — no plugin support)
+    if (!token || isPi) {
       setIsLoading(false);
       return;
     }

--- a/client/src/hooks/useSystemTelemetry.ts
+++ b/client/src/hooks/useSystemTelemetry.ts
@@ -29,6 +29,7 @@ interface SystemInfoResponse {
   memory: MemoryInfo;
   disk: DiskInfo;
   uptime: number;
+  system_uptime?: number;
 }
 
 interface StorageInfoResponse {

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -181,7 +181,8 @@
       "sleep": "Schlafmodus",
       "ssdCache": "SSD Cache",
       "envConfig": "Systemvariablen",
-      "firebase": "Firebase"
+      "firebase": "Firebase",
+      "balupi": "BaluPi"
     }
   },
   "devices": {

--- a/client/src/i18n/locales/de/dashboard.json
+++ b/client/src/i18n/locales/de/dashboard.json
@@ -17,6 +17,8 @@
     "memory": "Speicher",
     "totalStorage": "Effektive Gesamtkapazität",
     "uptime": "Betriebszeit",
+    "serverUptime": "Server-Betriebszeit",
+    "systemUptimeLabel": "System: {{uptime}}",
     "totalFiles": "Dateien gesamt",
     "totalUsers": "Benutzer gesamt",
     "activeConnections": "Aktive Verbindungen",

--- a/client/src/i18n/locales/de/system.json
+++ b/client/src/i18n/locales/de/system.json
@@ -20,7 +20,21 @@
       "health": "Gesundheit",
       "logs": "Protokolle",
       "activity": "Aktivität",
-      "backendLogs": "Backend-Logs"
+      "backendLogs": "Backend-Logs",
+      "uptime": "Betriebszeit"
+    },
+    "uptime": {
+      "serverUptime": "Server-Betriebszeit",
+      "systemUptime": "System-Betriebszeit",
+      "restartHistory": "Neustart-Historie",
+      "noRestarts": "Keine Neustarts in diesem Zeitraum erkannt",
+      "uptimeChart": "Betriebszeit im Verlauf",
+      "serverLabel": "Server",
+      "systemLabel": "System",
+      "hours": "Stunden",
+      "noData": "Noch keine Betriebszeit-Daten verfügbar",
+      "restart": "Neustart",
+      "sessionDuration": "Vorherige Sitzung"
     },
     "backendLogs": {
       "title": "Backend-Logs",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -181,7 +181,8 @@
       "sleep": "Sleep",
       "ssdCache": "SSD Cache",
       "envConfig": "System Variables",
-      "firebase": "Firebase"
+      "firebase": "Firebase",
+      "balupi": "BaluPi"
     }
   },
   "devices": {

--- a/client/src/i18n/locales/en/dashboard.json
+++ b/client/src/i18n/locales/en/dashboard.json
@@ -17,6 +17,8 @@
     "memory": "Memory",
     "totalStorage": "Total Effective Storage",
     "uptime": "Uptime",
+    "serverUptime": "Server Uptime",
+    "systemUptimeLabel": "System: {{uptime}}",
     "totalFiles": "Total Files",
     "totalUsers": "Total Users",
     "activeConnections": "Active Connections",

--- a/client/src/i18n/locales/en/system.json
+++ b/client/src/i18n/locales/en/system.json
@@ -20,7 +20,21 @@
       "health": "Health",
       "logs": "Logs",
       "activity": "Activity",
-      "backendLogs": "Backend Logs"
+      "backendLogs": "Backend Logs",
+      "uptime": "Uptime"
+    },
+    "uptime": {
+      "serverUptime": "Server Uptime",
+      "systemUptime": "System Uptime",
+      "restartHistory": "Restart History",
+      "noRestarts": "No restarts detected in this time range",
+      "uptimeChart": "Uptime Over Time",
+      "serverLabel": "Server",
+      "systemLabel": "System",
+      "hours": "Hours",
+      "noData": "No uptime data available yet",
+      "restart": "Restart",
+      "sessionDuration": "Previous session"
     },
     "backendLogs": {
       "title": "Backend Logs",

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -29,6 +29,7 @@ interface SystemStats {
   memoryUsed: number;
   memoryTotal: number;
   uptime: number;
+  systemUptime: number;
 }
 
 interface StorageStats {
@@ -146,8 +147,9 @@ export default function Dashboard() {
     const memoryUsed = systemInfo?.memory.used ?? 0;
     const memoryTotal = systemInfo?.memory.total ?? 0;
     const uptime = systemInfo?.uptime ?? 0;
+    const systemUptime = systemInfo?.system_uptime ?? systemInfo?.uptime ?? 0;
 
-    return { cpuUsage, cpuCores, memoryUsed, memoryTotal, uptime };
+    return { cpuUsage, cpuCores, memoryUsed, memoryTotal, uptime, systemUptime };
   }, [systemInfo]);
 
   const storageStats = useMemo<StorageStats>(() => {
@@ -376,9 +378,9 @@ export default function Dashboard() {
     },
     {
       id: 'uptime',
-      title: t('stats.uptime'),
+      title: t('stats.serverUptime'),
       value: formatUptime(systemStats.uptime),
-      meta: t('stats.systemAvailability'),
+      meta: t('stats.systemUptimeLabel', { uptime: formatUptime(systemStats.systemUptime) }),
       delta: { label: 'Live', tone: 'live' },
       accent: 'from-emerald-500 to-teal-500',
       progress: 100,
@@ -432,6 +434,7 @@ export default function Dashboard() {
               const handleClick = stat.id === 'cpu' ? handleCpuClick
                 : stat.id === 'memory' ? handleMemoryClick
                 : stat.id === 'storage' ? handleStorageClick
+                : stat.id === 'uptime' ? () => navigate('/system?tab=uptime')
                 : undefined;
 
               const isClickable = !!handleClick;

--- a/client/src/pages/PiDashboard.tsx
+++ b/client/src/pages/PiDashboard.tsx
@@ -137,7 +137,7 @@ export default function PiDashboard() {
         apiClient.get<HandshakeStatus>('/api/handshake/status'),
         apiClient.get<EnergyCurrent>('/api/energy/current'),
         apiClient.get<PiSystem>('/api/system/status'),
-        apiClient.get<SnapshotData>('/api/snapshot'),
+        apiClient.get<SnapshotData>('/api/handshake/snapshot'),
       ]);
       if (hs.status === 'fulfilled') setHandshake(hs.value.data);
       if (en.status === 'fulfilled') setEnergy(en.value.data);

--- a/client/src/pages/SystemControlPage.tsx
+++ b/client/src/pages/SystemControlPage.tsx
@@ -8,7 +8,7 @@
 
 import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Zap, Fan, HardDrive, Archive, Shield, Server, History, Plug, Gauge, FolderOpen, Share2, Cpu, Globe, Settings, Moon, Variable, Bell } from 'lucide-react';
+import { Zap, Fan, HardDrive, Archive, Shield, Server, History, Plug, Gauge, FolderOpen, Share2, Cpu, Globe, Settings, Moon, Variable, Bell, CircuitBoard } from 'lucide-react';
 import PowerManagement from './PowerManagement';
 import FanControl from './FanControl';
 import RaidManagement from './RaidManagement';
@@ -24,8 +24,9 @@ import SleepMode from './SleepMode';
 import SsdFileCacheTab from '../components/ssd-cache/SsdFileCacheTab';
 import { SystemVariablesTab } from '../components/env-config';
 import FirebaseManagementCard from '../components/firebase/FirebaseManagementCard';
+import BaluPiSetup from '../components/balupi/BaluPiSetup';
 
-type TabType = 'energy' | 'fan' | 'sleep' | 'raid' | 'backup' | 'ssdcache' | 'vpn' | 'webdav' | 'samba' | 'firebase' | 'services' | 'vcl' | 'smart' | 'ratelimits' | 'envconfig';
+type TabType = 'energy' | 'fan' | 'sleep' | 'raid' | 'backup' | 'ssdcache' | 'vpn' | 'webdav' | 'samba' | 'firebase' | 'services' | 'vcl' | 'smart' | 'ratelimits' | 'envconfig' | 'balupi';
 type CategoryType = 'hardware' | 'storage' | 'network' | 'system';
 
 interface TabConfig {
@@ -83,6 +84,7 @@ const CATEGORIES: CategoryConfig[] = [
       { id: 'smart', labelKey: 'systemControl.tabs.smart', icon: <Plug className="h-5 w-5" /> },
       { id: 'ratelimits', labelKey: 'systemControl.tabs.rateLimits', icon: <Gauge className="h-5 w-5" /> },
       { id: 'envconfig', labelKey: 'systemControl.tabs.envConfig', icon: <Variable className="h-5 w-5" /> },
+      { id: 'balupi', labelKey: 'systemControl.tabs.balupi', icon: <CircuitBoard className="h-5 w-5" /> },
     ],
   },
 ];
@@ -196,6 +198,7 @@ export default function SystemControlPage() {
         {activeTab === 'samba' && <SambaManagementCard />}
         {activeTab === 'firebase' && <FirebaseManagementCard />}
         {activeTab === 'envconfig' && <SystemVariablesTab />}
+        {activeTab === 'balupi' && <BaluPiSetup />}
       </div>
     </div>
   );

--- a/client/src/pages/SystemMonitor.tsx
+++ b/client/src/pages/SystemMonitor.tsx
@@ -9,7 +9,7 @@
 import { useState, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Cpu, ArrowLeftRight, Settings, FileText, Terminal } from 'lucide-react';
+import { Cpu, ArrowLeftRight, Settings, FileText, Terminal, Clock } from 'lucide-react';
 import { TimeRangeSelector } from '../components/monitoring';
 import type { TimeRange } from '../api/monitoring';
 import { ServicesStatusTab } from '../components/services';
@@ -23,9 +23,10 @@ import { MemoryTab } from '../components/system-monitor/MemoryTab';
 import { NetworkTab } from '../components/system-monitor/NetworkTab';
 import { DiskIoTab } from '../components/system-monitor/DiskIoTab';
 import { PowerTab } from '../components/system-monitor/PowerTab';
+import { UptimeTab } from '../components/system-monitor/UptimeTab';
 import { useAuth } from '../contexts/AuthContext';
 
-type TabType = 'cpu' | 'memory' | 'network' | 'disk-io' | 'power' | 'services' | 'health' | 'backend-logs' | 'logs' | 'activity';
+type TabType = 'cpu' | 'memory' | 'network' | 'disk-io' | 'power' | 'uptime' | 'services' | 'health' | 'backend-logs' | 'logs' | 'activity';
 type CategoryType = 'hardware' | 'io' | 'system' | 'logs';
 
 interface TabConfig {
@@ -132,6 +133,11 @@ const CATEGORIES: CategoryConfig[] = [
         ),
       },
       {
+        id: 'uptime',
+        labelKey: 'monitor.tabs.uptime',
+        icon: <Clock className="h-5 w-5" />,
+      },
+      {
         id: 'backend-logs',
         labelKey: 'monitor.tabs.backendLogs',
         icon: <Terminal className="h-5 w-5" />,
@@ -178,7 +184,7 @@ const TAB_TO_CATEGORY: Record<TabType, CategoryType> = Object.fromEntries(
 const VALID_TABS = new Set(CATEGORIES.flatMap((cat) => cat.tabs.map((tab) => tab.id)));
 
 // Tabs that show the TimeRangeSelector
-const METRIC_TABS = new Set<TabType>(['cpu', 'memory', 'network', 'disk-io']);
+const METRIC_TABS = new Set<TabType>(['cpu', 'memory', 'network', 'disk-io', 'uptime']);
 
 // Main Component
 export default function SystemMonitor() {
@@ -292,6 +298,7 @@ export default function SystemMonitor() {
         {activeTab === 'network' && <NetworkTab timeRange={timeRange} />}
         {activeTab === 'disk-io' && <DiskIoTab timeRange={timeRange} />}
         {activeTab === 'power' && <PowerTab />}
+        {activeTab === 'uptime' && <UptimeTab timeRange={timeRange} />}
         {activeTab === 'services' && <ServicesStatusTab isAdmin={isAdmin} />}
         {activeTab === 'health' && <HealthTab />}
         {activeTab === 'backend-logs' && <BackendLogsTab />}


### PR DESCRIPTION
## Summary
- **Uptime tracking**: Server + system uptime with DB persistence, API endpoints, live fallback
- **Uptime UI**: System Monitor tab with live counters, restart detection, area chart; Dashboard dual uptime widget
- **BaluPi**: Setup route, component, API client; Pi mode guards for notifications/plugins

## Changelog
See [CHANGELOG.md](./CHANGELOG.md) for full details.

## Test plan
- [ ] `GET /api/monitoring/uptime/current` returns server + system uptime
- [ ] `GET /api/monitoring/uptime/history` returns historical samples
- [ ] System Monitor > System > Uptime tab shows live counters and chart
- [ ] Dashboard uptime widget shows dual values and navigates to uptime tab
- [ ] Existing tests pass (`python -m pytest tests/ -x`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)