### PR TITLE
Release v1.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.16.2] - 2026-03-16
+
+### Fixed
+
+- Monitoring uptime bars showing no data for short time ranges
+- Update service using actual version in changelog instead of literal "latest"
+
+### Tests
+
+- Test coverage for pure-logic and DB-CRUD services (Batch 1)
+- Test coverage for async services and dev-mode stubs (Batch 2)
+- Test coverage for plugin manager and cloud scheduler (Batch 3)
+
+---
+
 ## [1.16.1] - 2026-03-15
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,4 +75,4 @@ client/
 - **Issues**: GitHub Issues (repository URL needed)
 - **Documentation**: See `docs/` directory
 - **Maintainer**: Xveyn
-- **Version**: 1.16.1 (as of Mar 2026)
+- **Version**: 1.16.2 (as of Mar 2026)

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -104,6 +104,15 @@ elif DATABASE_URL.startswith("postgresql"):
         **pool_config
     )
 
+    # Ensure all connections use UTC timezone to prevent implicit timestamp
+    # conversion when storing timezone-aware datetimes in TIMESTAMP WITHOUT
+    # TIME ZONE columns.
+    @event.listens_for(engine, "connect")
+    def _set_pg_timezone(dbapi_conn, _connection_record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("SET timezone = 'UTC'")
+        cursor.close()
+
 else:
     # Unknown database type, use basic configuration
     logger.warning(f"Unknown database type in URL: {DATABASE_URL}")

--- a/backend/app/services/update/prod_backend.py
+++ b/backend/app/services/update/prod_backend.py
@@ -146,11 +146,11 @@ class ProdUpdateBackend(UpdateBackend):
         )
 
         # Build changelog from commit messages between versions
-        changelog = await self._build_changelog(current.commit, commit)
+        changelog = await self._build_changelog(current.commit, commit, version_to_string(latest_version))
 
         return True, latest, changelog
 
-    async def _build_changelog(self, from_commit: str, to_commit: str) -> list[ChangelogEntry]:
+    async def _build_changelog(self, from_commit: str, to_commit: str, version: str = "unknown") -> list[ChangelogEntry]:
         """Build changelog from git log between commits."""
         success, log_output, _ = self._run_git(
             "log", f"{from_commit}..{to_commit}",
@@ -168,7 +168,7 @@ class ProdUpdateBackend(UpdateBackend):
 
         return [
             ChangelogEntry(
-                version="latest",
+                version=version,
                 date=datetime.now(timezone.utc),
                 changes=regular[:20],  # Limit to 20 changes
                 breaking_changes=breaking,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baluhost-backend"
-version = "1.16.1"
+version = "1.16.2"
 description = "Mocked NAS management backend built with FastAPI"
 authors = [{ name = "Baluhost" }]
 requires-python = ">=3.11"

--- a/backend/tests/plugins/test_plugin_manager.py
+++ b/backend/tests/plugins/test_plugin_manager.py
@@ -1,0 +1,221 @@
+"""Tests for plugins/manager.py — PluginManager lifecycle, discovery, hooks."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.plugins.manager import PluginLoadError, PluginManager
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    """Reset the PluginManager singleton between tests."""
+    PluginManager.reset_instance()
+    yield
+    PluginManager.reset_instance()
+
+
+@pytest.fixture
+def empty_plugins_dir(tmp_path: Path) -> Path:
+    """An empty temporary plugins directory."""
+    d = tmp_path / "plugins"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def plugins_dir_with_plugin(tmp_path: Path) -> Path:
+    """A plugins directory containing a valid test plugin."""
+    d = tmp_path / "plugins"
+    d.mkdir()
+    plugin_dir = d / "test_plugin"
+    plugin_dir.mkdir()
+    (plugin_dir / "__init__.py").write_text(
+        '''
+from app.plugins.base import PluginBase, PluginMetadata
+
+
+class TestPlugin(PluginBase):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="test_plugin",
+            version="1.0.0",
+            display_name="Test Plugin",
+            description="A test plugin",
+            author="Test",
+            required_permissions=[],
+        )
+
+    async def on_startup(self):
+        pass
+
+    async def on_shutdown(self):
+        pass
+'''
+    )
+    return d
+
+
+class TestSingleton:
+    def test_get_instance_returns_same_object(self):
+        a = PluginManager.get_instance()
+        b = PluginManager.get_instance()
+        assert a is b
+
+    def test_reset_instance_clears(self):
+        a = PluginManager.get_instance()
+        PluginManager.reset_instance()
+        b = PluginManager.get_instance()
+        assert a is not b
+
+
+class TestDiscoverPlugins:
+    def test_empty_directory(self, empty_plugins_dir: Path):
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        assert mgr.discover_plugins() == []
+
+    def test_discovers_plugin(self, plugins_dir_with_plugin: Path):
+        mgr = PluginManager(plugins_dir=plugins_dir_with_plugin)
+        discovered = mgr.discover_plugins()
+        assert "test_plugin" in discovered
+
+    def test_ignores_non_packages(self, empty_plugins_dir: Path):
+        # Create a directory without __init__.py
+        (empty_plugins_dir / "not_a_plugin").mkdir()
+        # Create a plain file
+        (empty_plugins_dir / "readme.txt").write_text("hi")
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        assert mgr.discover_plugins() == []
+
+    def test_nonexistent_directory(self, tmp_path: Path):
+        mgr = PluginManager(plugins_dir=tmp_path / "doesnotexist")
+        assert mgr.discover_plugins() == []
+
+
+class TestLoadPlugin:
+    def test_loads_valid_plugin(self, plugins_dir_with_plugin: Path):
+        mgr = PluginManager(plugins_dir=plugins_dir_with_plugin)
+        plugin = mgr.load_plugin("test_plugin")
+        assert plugin.metadata.name == "test_plugin"
+        assert plugin.metadata.version == "1.0.0"
+
+    def test_caches_loaded_plugin(self, plugins_dir_with_plugin: Path):
+        mgr = PluginManager(plugins_dir=plugins_dir_with_plugin)
+        first = mgr.load_plugin("test_plugin")
+        second = mgr.load_plugin("test_plugin")
+        assert first is second
+
+    def test_raises_for_missing_plugin(self, empty_plugins_dir: Path):
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        with pytest.raises(PluginLoadError, match="not found"):
+            mgr.load_plugin("nonexistent")
+
+    def test_raises_for_no_init(self, empty_plugins_dir: Path):
+        (empty_plugins_dir / "bad_plugin").mkdir()
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        with pytest.raises(PluginLoadError, match="__init__.py"):
+            mgr.load_plugin("bad_plugin")
+
+    def test_raises_for_no_plugin_class(self, empty_plugins_dir: Path):
+        plugin_dir = empty_plugins_dir / "empty_plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "__init__.py").write_text("# Nothing here\n")
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        with pytest.raises(PluginLoadError, match="No PluginBase subclass"):
+            mgr.load_plugin("empty_plugin")
+
+
+class TestPluginProperties:
+    def test_plugins_dir_property(self, empty_plugins_dir: Path):
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        assert mgr.plugins_dir == empty_plugins_dir
+
+    def test_get_plugin_returns_none_when_not_loaded(self, empty_plugins_dir: Path):
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        assert mgr.get_plugin("nonexistent") is None
+
+    def test_get_plugin_returns_loaded(self, plugins_dir_with_plugin: Path):
+        mgr = PluginManager(plugins_dir=plugins_dir_with_plugin)
+        mgr.load_plugin("test_plugin")
+        assert mgr.get_plugin("test_plugin") is not None
+
+    def test_is_enabled_false_initially(self, plugins_dir_with_plugin: Path):
+        mgr = PluginManager(plugins_dir=plugins_dir_with_plugin)
+        mgr.load_plugin("test_plugin")
+        assert mgr.is_enabled("test_plugin") is False
+
+
+@pytest.mark.asyncio
+class TestEnableDisablePlugin:
+    async def test_enable_plugin(self, plugins_dir_with_plugin: Path, db_session: Session):
+        mgr = PluginManager(plugins_dir=plugins_dir_with_plugin)
+        result = await mgr.enable_plugin("test_plugin", [], db_session)
+        assert result is True
+        assert mgr.is_enabled("test_plugin")
+
+    async def test_enable_nonexistent_plugin(self, empty_plugins_dir: Path, db_session: Session):
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        result = await mgr.enable_plugin("nonexistent", [], db_session)
+        assert result is False
+
+    async def test_disable_plugin(self, plugins_dir_with_plugin: Path, db_session: Session):
+        mgr = PluginManager(plugins_dir=plugins_dir_with_plugin)
+        await mgr.enable_plugin("test_plugin", [], db_session)
+        result = await mgr.disable_plugin("test_plugin")
+        assert result is True
+        assert not mgr.is_enabled("test_plugin")
+
+    async def test_disable_not_enabled_is_noop(self, empty_plugins_dir: Path):
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        result = await mgr.disable_plugin("nonexistent")
+        assert result is True
+
+    async def test_enable_with_missing_permissions(self, plugins_dir_with_plugin: Path, db_session: Session):
+        """Plugin that requires permissions not in granted list should fail."""
+        mgr = PluginManager(plugins_dir=plugins_dir_with_plugin)
+        plugin = mgr.load_plugin("test_plugin")
+        # Patch required_permissions to need something
+        original_meta = plugin.metadata
+        with patch.object(
+            type(plugin), "metadata", new_callable=lambda: property(
+                lambda self: original_meta.model_copy(update={"required_permissions": ["file:write"]})
+            )
+        ):
+            result = await mgr.enable_plugin("test_plugin", [], db_session)
+            assert result is False
+
+
+@pytest.mark.asyncio
+class TestShutdownAll:
+    async def test_shutdown_disables_all(self, plugins_dir_with_plugin: Path, db_session: Session):
+        mgr = PluginManager(plugins_dir=plugins_dir_with_plugin)
+        await mgr.enable_plugin("test_plugin", [], db_session)
+        await mgr.shutdown_all()
+        assert not mgr.is_enabled("test_plugin")
+
+
+class TestEmitHook:
+    def test_unknown_hook_returns_empty(self, empty_plugins_dir: Path):
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        result = mgr.emit_hook("nonexistent_hook")
+        assert result == []
+
+
+class TestGetRouter:
+    def test_returns_router(self, empty_plugins_dir: Path):
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        router = mgr.get_router()
+        assert router is not None
+        assert router.prefix == "/plugins"
+
+
+class TestGetUiManifest:
+    def test_returns_manifest(self, empty_plugins_dir: Path):
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        manifest = mgr.get_ui_manifest()
+        assert "plugins" in manifest
+        assert manifest["plugins"] == []

--- a/backend/tests/services/test_cloud_dev_adapter.py
+++ b/backend/tests/services/test_cloud_dev_adapter.py
@@ -1,0 +1,114 @@
+"""Tests for services/cloud/adapters/dev.py — DevCloudAdapter (async, no external deps)."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from app.services.cloud.adapters.dev import DevCloudAdapter, _MOCK_FS
+
+
+@pytest.fixture
+def adapter() -> DevCloudAdapter:
+    return DevCloudAdapter(provider="google_drive")
+
+
+@pytest.mark.asyncio
+class TestListFiles:
+    async def test_root_returns_files(self, adapter: DevCloudAdapter):
+        files = await adapter.list_files("/")
+        assert len(files) > 0
+        names = {f.name for f in files}
+        assert "Documents" in names
+        assert "readme.txt" in names
+
+    async def test_subdirectory(self, adapter: DevCloudAdapter):
+        files = await adapter.list_files("/Documents")
+        names = {f.name for f in files}
+        assert "report.pdf" in names
+        assert "Projects" in names
+
+    async def test_nonexistent_path_returns_empty(self, adapter: DevCloudAdapter):
+        files = await adapter.list_files("/nonexistent")
+        assert files == []
+
+    async def test_trailing_slash_normalized(self, adapter: DevCloudAdapter):
+        files = await adapter.list_files("/Documents/")
+        assert len(files) > 0
+
+    async def test_returns_copies_not_references(self, adapter: DevCloudAdapter):
+        """Modifying returned list should not affect mock filesystem."""
+        files = await adapter.list_files("/")
+        original_len = len(_MOCK_FS["/"])
+        files.clear()
+        assert len(_MOCK_FS["/"]) == original_len
+
+
+@pytest.mark.asyncio
+class TestDownloadFile:
+    async def test_creates_local_file(self, adapter: DevCloudAdapter, tmp_path: Path):
+        dest = tmp_path / "readme.txt"
+        await adapter.download_file("/readme.txt", dest)
+        assert dest.exists()
+        assert dest.stat().st_size > 0
+
+    async def test_creates_parent_dirs(self, adapter: DevCloudAdapter, tmp_path: Path):
+        dest = tmp_path / "sub" / "dir" / "file.txt"
+        await adapter.download_file("/readme.txt", dest)
+        assert dest.exists()
+
+    async def test_progress_callback_called(self, adapter: DevCloudAdapter, tmp_path: Path):
+        calls = []
+        dest = tmp_path / "report.pdf"
+        await adapter.download_file("/Documents/report.pdf", dest, progress_callback=calls.append)
+        assert len(calls) > 0
+        # Last call should equal total size
+        assert calls[-1] >= 1024
+
+
+@pytest.mark.asyncio
+class TestDownloadFolder:
+    async def test_downloads_folder_files(self, adapter: DevCloudAdapter, tmp_path: Path):
+        result = await adapter.download_folder("/Music", tmp_path / "Music")
+        assert result.files_transferred >= 2
+        assert result.bytes_transferred > 0
+        assert (tmp_path / "Music" / "playlist.m3u").exists()
+
+    async def test_recursive_download(self, adapter: DevCloudAdapter, tmp_path: Path):
+        result = await adapter.download_folder("/Documents", tmp_path / "Documents")
+        # Should include files from /Documents and /Documents/Projects
+        assert result.files_transferred >= 4
+
+
+@pytest.mark.asyncio
+class TestGetFileCount:
+    async def test_root_count(self, adapter: DevCloudAdapter):
+        count = await adapter.get_file_count("/")
+        # All non-directory files across entire mock FS
+        assert count is not None
+        assert count >= 10
+
+    async def test_leaf_directory(self, adapter: DevCloudAdapter):
+        count = await adapter.get_file_count("/Music")
+        assert count == 2
+
+    async def test_empty_path(self, adapter: DevCloudAdapter):
+        count = await adapter.get_file_count("/nonexistent")
+        assert count == 0
+
+
+@pytest.mark.asyncio
+class TestGetTotalSize:
+    async def test_root_size(self, adapter: DevCloudAdapter):
+        size = await adapter.get_total_size("/")
+        assert size is not None
+        assert size > 0
+
+    async def test_music_folder_size(self, adapter: DevCloudAdapter):
+        size = await adapter.get_total_size("/Music")
+        # playlist.m3u (2048) + song01.mp3 (8000000)
+        assert size == 2048 + 8_000_000
+
+    async def test_empty_path_returns_zero(self, adapter: DevCloudAdapter):
+        size = await adapter.get_total_size("/nonexistent")
+        assert size == 0

--- a/backend/tests/services/test_cloud_scheduler.py
+++ b/backend/tests/services/test_cloud_scheduler.py
@@ -1,0 +1,149 @@
+"""Tests for services/cloud/scheduler.py — CloudSyncScheduler."""
+
+from unittest.mock import MagicMock, patch, AsyncMock
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.cloud import CloudConnection, CloudImportJob
+from app.services.cloud.scheduler import CloudSyncScheduler
+
+
+def _create_connection(db: Session, user_id: int = 1) -> CloudConnection:
+    """Helper to create a cloud connection."""
+    conn = CloudConnection(
+        user_id=user_id,
+        provider="google_drive",
+        display_name="Test Drive",
+        encrypted_config="encrypted-data",
+        is_active=True,
+    )
+    db.add(conn)
+    db.commit()
+    db.refresh(conn)
+    return conn
+
+
+def _create_completed_sync_job(
+    db: Session, connection_id: int, user_id: int = 1
+) -> CloudImportJob:
+    """Helper to create a completed sync job."""
+    job = CloudImportJob(
+        connection_id=connection_id,
+        user_id=user_id,
+        source_path="/Cloud/Documents",
+        destination_path="/NAS/Documents",
+        job_type="sync",
+        status="completed",
+        completed_at=datetime.now(timezone.utc),
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+class TestRunSync:
+    def test_no_sync_jobs_returns_zero(self, db_session: Session):
+        result = CloudSyncScheduler.run_sync(db_session)
+        assert result == {"synced": 0, "errors": 0}
+
+    def test_no_completed_sync_jobs(self, db_session: Session):
+        conn = _create_connection(db_session)
+        # Create a pending job (not completed)
+        job = CloudImportJob(
+            connection_id=conn.id,
+            user_id=1,
+            source_path="/src",
+            destination_path="/dst",
+            job_type="sync",
+            status="pending",
+        )
+        db_session.add(job)
+        db_session.commit()
+
+        result = CloudSyncScheduler.run_sync(db_session)
+        assert result == {"synced": 0, "errors": 0}
+
+    def test_ignores_import_jobs(self, db_session: Session):
+        conn = _create_connection(db_session)
+        # Create a completed import (not sync) job
+        job = CloudImportJob(
+            connection_id=conn.id,
+            user_id=1,
+            source_path="/src",
+            destination_path="/dst",
+            job_type="import",
+            status="completed",
+            completed_at=datetime.now(timezone.utc),
+        )
+        db_session.add(job)
+        db_session.commit()
+
+        result = CloudSyncScheduler.run_sync(db_session)
+        assert result == {"synced": 0, "errors": 0}
+
+    @patch("app.services.cloud.import_job.CloudImportJobService")
+    def test_resyncs_completed_jobs(self, mock_job_service_cls, db_session: Session):
+        conn = _create_connection(db_session)
+        _create_completed_sync_job(db_session, conn.id)
+
+        # Mock the job service
+        mock_service = MagicMock()
+        mock_job_service_cls.return_value = mock_service
+
+        # start_import returns a new job
+        new_job = MagicMock()
+        new_job.id = 999
+        new_job.status = "completed"
+        mock_service.start_import.return_value = new_job
+
+        # execute_import is async, we need to mock the event loop
+        mock_service.execute_import = AsyncMock()
+
+        # db.refresh(new_job) would fail on a MagicMock, so patch it
+        original_refresh = db_session.refresh
+
+        def _safe_refresh(obj, *args, **kwargs):
+            if isinstance(obj, MagicMock):
+                return
+            original_refresh(obj, *args, **kwargs)
+
+        with patch.object(db_session, "refresh", side_effect=_safe_refresh):
+            result = CloudSyncScheduler.run_sync(db_session)
+        assert result["synced"] == 1
+        assert result["errors"] == 0
+        mock_service.start_import.assert_called_once()
+
+    @patch("app.services.cloud.import_job.CloudImportJobService")
+    def test_handles_sync_errors(self, mock_job_service_cls, db_session: Session):
+        conn = _create_connection(db_session)
+        _create_completed_sync_job(db_session, conn.id)
+
+        mock_service = MagicMock()
+        mock_job_service_cls.return_value = mock_service
+        mock_service.start_import.side_effect = Exception("Cloud API error")
+
+        result = CloudSyncScheduler.run_sync(db_session)
+        assert result["synced"] == 0
+        assert result["errors"] == 1
+
+    def test_deduplicates_by_connection(self, db_session: Session):
+        """Multiple completed sync jobs for same connection should only resync once."""
+        conn = _create_connection(db_session)
+        _create_completed_sync_job(db_session, conn.id)
+        _create_completed_sync_job(db_session, conn.id)
+
+        with patch("app.services.cloud.import_job.CloudImportJobService") as mock_cls:
+            mock_service = MagicMock()
+            mock_cls.return_value = mock_service
+            new_job = MagicMock()
+            new_job.id = 1
+            new_job.status = "completed"
+            mock_service.start_import.return_value = new_job
+            mock_service.execute_import = AsyncMock()
+
+            result = CloudSyncScheduler.run_sync(db_session)
+            # Should only call start_import once despite two completed jobs
+            assert mock_service.start_import.call_count == 1

--- a/backend/tests/services/test_log_buffer.py
+++ b/backend/tests/services/test_log_buffer.py
@@ -1,0 +1,205 @@
+"""Tests for services/log_buffer.py — LogBufferHandler, redaction, query API."""
+
+import asyncio
+import logging
+
+import pytest
+
+from app.services.log_buffer import LogBufferHandler, _redact, get_log_buffer_handler
+
+
+class TestRedact:
+    def test_redacts_password(self):
+        assert "password=***REDACTED***" in _redact("password=secret123")
+
+    def test_redacts_token(self):
+        assert "token=***REDACTED***" in _redact("token=abc.def.ghi")
+
+    def test_redacts_api_key(self):
+        assert "api_key=***REDACTED***" in _redact("api_key=sk-12345")
+
+    def test_redacts_authorization(self):
+        assert "authorization=***REDACTED***" in _redact("authorization=Bearer xyz")
+
+    def test_preserves_non_sensitive(self):
+        msg = "User logged in from 10.0.0.1"
+        assert _redact(msg) == msg
+
+    def test_redacts_multiple_patterns(self):
+        msg = "password=abc token=def"
+        result = _redact(msg)
+        assert "password=***REDACTED***" in result
+        assert "token=***REDACTED***" in result
+
+    def test_case_insensitive(self):
+        assert "PASSWORD=***REDACTED***" in _redact("PASSWORD=secret")
+
+
+class TestLogBufferHandler:
+    def _make_handler(self, maxlen: int = 100) -> LogBufferHandler:
+        return LogBufferHandler(maxlen=maxlen)
+
+    def _emit_record(self, handler: LogBufferHandler, message: str, level: int = logging.INFO):
+        record = logging.LogRecord(
+            name="test.logger",
+            level=level,
+            pathname="test.py",
+            lineno=1,
+            msg=message,
+            args=(),
+            exc_info=None,
+        )
+        handler.emit(record)
+
+    def test_emit_stores_entry(self):
+        h = self._make_handler()
+        self._emit_record(h, "Hello world")
+
+        assert h.get_total_buffered() == 1
+        logs = h.get_logs()
+        assert len(logs) == 1
+        assert logs[0]["message"] == "Hello world"
+        assert logs[0]["level"] == "INFO"
+
+    def test_emit_increments_id(self):
+        h = self._make_handler()
+        self._emit_record(h, "first")
+        self._emit_record(h, "second")
+
+        logs = h.get_logs()
+        assert logs[0]["id"] == 1
+        assert logs[1]["id"] == 2
+
+    def test_ring_buffer_maxlen(self):
+        h = self._make_handler(maxlen=3)
+        for i in range(5):
+            self._emit_record(h, f"msg-{i}")
+
+        assert h.get_total_buffered() == 3
+        logs = h.get_logs()
+        messages = [e["message"] for e in logs]
+        assert messages == ["msg-2", "msg-3", "msg-4"]
+
+    def test_emit_redacts_sensitive_data(self):
+        h = self._make_handler()
+        self._emit_record(h, "login password=hunter2")
+
+        logs = h.get_logs()
+        assert "hunter2" not in logs[0]["message"]
+        assert "***REDACTED***" in logs[0]["message"]
+
+    def test_get_latest_id_empty(self):
+        h = self._make_handler()
+        assert h.get_latest_id() == 0
+
+    def test_get_latest_id(self):
+        h = self._make_handler()
+        self._emit_record(h, "a")
+        self._emit_record(h, "b")
+        assert h.get_latest_id() == 2
+
+    def test_clear(self):
+        h = self._make_handler()
+        self._emit_record(h, "hello")
+        h.clear()
+        assert h.get_total_buffered() == 0
+        assert h.get_latest_id() == 0
+
+
+class TestLogBufferGetLogs:
+    def _setup_handler(self) -> LogBufferHandler:
+        h = LogBufferHandler(maxlen=100)
+        levels = [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL]
+        for i, level in enumerate(levels):
+            record = logging.LogRecord(
+                name=f"test.mod{i}",
+                level=level,
+                pathname="test.py",
+                lineno=1,
+                msg=f"message-{i}",
+                args=(),
+                exc_info=None,
+            )
+            h.emit(record)
+        return h
+
+    def test_since_id_filter(self):
+        h = self._setup_handler()
+        logs = h.get_logs(since_id=3)
+        assert all(e["id"] > 3 for e in logs)
+
+    def test_level_filter(self):
+        h = self._setup_handler()
+        logs = h.get_logs(level="WARNING")
+        assert all(e["level"] in ("WARNING", "ERROR", "CRITICAL") for e in logs)
+        assert len(logs) == 3
+
+    def test_search_filter_message(self):
+        h = self._setup_handler()
+        logs = h.get_logs(search="message-2")
+        assert len(logs) == 1
+        assert logs[0]["message"] == "message-2"
+
+    def test_search_filter_logger_name(self):
+        h = self._setup_handler()
+        logs = h.get_logs(search="mod3")
+        assert len(logs) == 1
+
+    def test_search_case_insensitive(self):
+        h = self._setup_handler()
+        logs = h.get_logs(search="MESSAGE-0")
+        assert len(logs) == 1
+
+    def test_limit(self):
+        h = self._setup_handler()
+        logs = h.get_logs(limit=2)
+        assert len(logs) == 2
+
+    def test_combined_filters(self):
+        h = self._setup_handler()
+        # Only WARNING+ and containing "message"
+        logs = h.get_logs(level="ERROR", search="message", limit=10)
+        assert all(e["level"] in ("ERROR", "CRITICAL") for e in logs)
+
+
+class TestLogBufferSubscribers:
+    def test_subscribe_unsubscribe(self):
+        h = LogBufferHandler(maxlen=100)
+        queue = h.subscribe()
+        assert queue in h._subscribers
+        h.unsubscribe(queue)
+        assert queue not in h._subscribers
+
+    def test_emit_fans_out_to_subscriber(self):
+        h = LogBufferHandler(maxlen=100)
+        queue = h.subscribe()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="fan-out", args=(), exc_info=None,
+        )
+        h.emit(record)
+
+        assert not queue.empty()
+        entry = queue.get_nowait()
+        assert entry["message"] == "fan-out"
+
+
+class TestFormatEntry:
+    def test_entry_has_expected_keys(self):
+        h = LogBufferHandler(maxlen=100)
+        record = logging.LogRecord(
+            name="mylogger", level=logging.ERROR, pathname="file.py", lineno=42,
+            msg="an error", args=(), exc_info=None,
+        )
+        h.emit(record)
+        entry = h.get_logs()[0]
+        assert set(entry.keys()) == {"id", "timestamp", "level", "logger_name", "message", "exc_info"}
+        assert entry["logger_name"] == "mylogger"
+        assert entry["exc_info"] is None
+
+
+class TestGetLogBufferHandlerSingleton:
+    def test_returns_same_instance(self):
+        a = get_log_buffer_handler()
+        b = get_log_buffer_handler()
+        assert a is b

--- a/backend/tests/services/test_plugin_service.py
+++ b/backend/tests/services/test_plugin_service.py
@@ -1,0 +1,146 @@
+"""Tests for services/plugin_service.py — DB CRUD for InstalledPlugin."""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.plugin import InstalledPlugin
+from app.services.plugin_service import (
+    disable_plugin_record,
+    enable_plugin,
+    get_enabled_plugin,
+    get_installed_plugin,
+    rollback_enable,
+    uninstall_plugin,
+    update_config,
+)
+
+
+def _enable_test_plugin(db: Session, name: str = "test-plugin") -> InstalledPlugin:
+    """Helper to create and enable a plugin."""
+    return enable_plugin(
+        db,
+        name=name,
+        version="1.0.0",
+        display_name="Test Plugin",
+        permissions=["read", "write"],
+        default_config={"key": "value"},
+        installed_by="admin",
+    )
+
+
+class TestGetInstalledPlugin:
+    def test_returns_none_when_not_found(self, db_session: Session):
+        assert get_installed_plugin(db_session, "nonexistent") is None
+
+    def test_returns_plugin_after_enable(self, db_session: Session):
+        _enable_test_plugin(db_session)
+        result = get_installed_plugin(db_session, "test-plugin")
+        assert result is not None
+        assert result.name == "test-plugin"
+
+
+class TestGetEnabledPlugin:
+    def test_returns_none_when_not_found(self, db_session: Session):
+        assert get_enabled_plugin(db_session, "nonexistent") is None
+
+    def test_returns_enabled_plugin(self, db_session: Session):
+        _enable_test_plugin(db_session)
+        result = get_enabled_plugin(db_session, "test-plugin")
+        assert result is not None
+        assert result.is_enabled is True
+
+    def test_returns_none_when_disabled(self, db_session: Session):
+        _enable_test_plugin(db_session)
+        disable_plugin_record(db_session, "test-plugin")
+        assert get_enabled_plugin(db_session, "test-plugin") is None
+
+
+class TestEnablePlugin:
+    def test_creates_new_record(self, db_session: Session):
+        record = _enable_test_plugin(db_session)
+        assert record.name == "test-plugin"
+        assert record.version == "1.0.0"
+        assert record.is_enabled is True
+        assert record.granted_permissions == ["read", "write"]
+        assert record.config == {"key": "value"}
+        assert record.installed_by == "admin"
+        assert record.enabled_at is not None
+
+    def test_re_enables_existing_disabled_record(self, db_session: Session):
+        _enable_test_plugin(db_session)
+        disable_plugin_record(db_session, "test-plugin")
+
+        record = enable_plugin(
+            db_session,
+            name="test-plugin",
+            version="2.0.0",
+            display_name="Test Plugin v2",
+            permissions=["admin"],
+            default_config={},
+            installed_by="admin",
+        )
+        assert record.is_enabled is True
+        assert record.granted_permissions == ["admin"]
+        assert record.disabled_at is None
+
+
+class TestDisablePluginRecord:
+    def test_disables_existing_plugin(self, db_session: Session):
+        _enable_test_plugin(db_session)
+        disable_plugin_record(db_session, "test-plugin")
+
+        record = get_installed_plugin(db_session, "test-plugin")
+        assert record is not None
+        assert record.is_enabled is False
+        assert record.disabled_at is not None
+
+    def test_noop_when_not_found(self, db_session: Session):
+        # Should not raise
+        disable_plugin_record(db_session, "nonexistent")
+
+
+class TestRollbackEnable:
+    def test_sets_enabled_to_false(self, db_session: Session):
+        _enable_test_plugin(db_session)
+        rollback_enable(db_session, "test-plugin")
+
+        record = get_installed_plugin(db_session, "test-plugin")
+        assert record is not None
+        assert record.is_enabled is False
+
+    def test_noop_when_not_found(self, db_session: Session):
+        rollback_enable(db_session, "nonexistent")
+
+
+class TestUpdateConfig:
+    def test_updates_existing_config(self, db_session: Session):
+        _enable_test_plugin(db_session)
+        record = update_config(
+            db_session,
+            name="test-plugin",
+            validated_config={"new_key": "new_value"},
+        )
+        assert record.config == {"new_key": "new_value"}
+
+    def test_creates_new_record_if_not_found(self, db_session: Session):
+        record = update_config(
+            db_session,
+            name="new-plugin",
+            validated_config={"a": 1},
+            version="0.1.0",
+            display_name="New",
+            installed_by="admin",
+        )
+        assert record.name == "new-plugin"
+        assert record.is_enabled is False
+        assert record.config == {"a": 1}
+
+
+class TestUninstallPlugin:
+    def test_deletes_existing_plugin(self, db_session: Session):
+        _enable_test_plugin(db_session)
+        assert uninstall_plugin(db_session, "test-plugin") is True
+        assert get_installed_plugin(db_session, "test-plugin") is None
+
+    def test_returns_false_when_not_found(self, db_session: Session):
+        assert uninstall_plugin(db_session, "nonexistent") is False

--- a/backend/tests/services/test_rate_limit_config.py
+++ b/backend/tests/services/test_rate_limit_config.py
@@ -1,0 +1,141 @@
+"""Tests for services/rate_limit_config.py — RateLimitConfig CRUD."""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.rate_limit_config import RateLimitConfig
+from app.schemas.rate_limit_config import RateLimitConfigCreate, RateLimitConfigUpdate
+from app.services.rate_limit_config import RateLimitConfigService
+
+
+def _create_config(
+    db: Session,
+    endpoint_type: str = "auth_login",
+    limit_string: str = "5/minute",
+    description: str = "Login limit",
+    enabled: bool = True,
+    user_id: int = 1,
+) -> RateLimitConfig:
+    schema = RateLimitConfigCreate(
+        endpoint_type=endpoint_type,
+        limit_string=limit_string,
+        description=description,
+        enabled=enabled,
+    )
+    return RateLimitConfigService.create(db, schema, user_id)
+
+
+class TestGetAll:
+    def test_empty_initially(self, db_session: Session):
+        assert list(RateLimitConfigService.get_all(db_session)) == []
+
+    def test_returns_all_configs(self, db_session: Session):
+        _create_config(db_session, endpoint_type="a", limit_string="1/minute")
+        _create_config(db_session, endpoint_type="b", limit_string="2/minute")
+        result = RateLimitConfigService.get_all(db_session)
+        assert len(list(result)) == 2
+
+
+class TestGetByEndpointType:
+    def test_returns_none_when_not_found(self, db_session: Session):
+        assert RateLimitConfigService.get_by_endpoint_type(db_session, "nope") is None
+
+    def test_returns_matching_config(self, db_session: Session):
+        _create_config(db_session, endpoint_type="file_upload", limit_string="20/minute")
+        result = RateLimitConfigService.get_by_endpoint_type(db_session, "file_upload")
+        assert result is not None
+        assert result.limit_string == "20/minute"
+
+
+class TestGetEnabledConfigs:
+    def test_returns_only_enabled(self, db_session: Session):
+        _create_config(db_session, endpoint_type="a", limit_string="1/minute", enabled=True)
+        _create_config(db_session, endpoint_type="b", limit_string="2/minute", enabled=False)
+
+        result = RateLimitConfigService.get_enabled_configs(db_session)
+        assert result == {"a": "1/minute"}
+
+    def test_empty_when_none_enabled(self, db_session: Session):
+        _create_config(db_session, endpoint_type="x", limit_string="1/minute", enabled=False)
+        assert RateLimitConfigService.get_enabled_configs(db_session) == {}
+
+
+class TestCreate:
+    def test_creates_config(self, db_session: Session):
+        config = _create_config(db_session)
+        assert config.id is not None
+        assert config.endpoint_type == "auth_login"
+        assert config.limit_string == "5/minute"
+        assert config.enabled is True
+        assert config.updated_by == 1
+
+    def test_creates_disabled_config(self, db_session: Session):
+        config = _create_config(db_session, enabled=False)
+        assert config.enabled is False
+
+
+class TestUpdate:
+    def test_updates_limit_string(self, db_session: Session):
+        _create_config(db_session, endpoint_type="auth_login")
+        update = RateLimitConfigUpdate(limit_string="10/minute")
+        result = RateLimitConfigService.update(db_session, "auth_login", update, user_id=2)
+        assert result is not None
+        assert result.limit_string == "10/minute"
+        assert result.updated_by == 2
+
+    def test_updates_description(self, db_session: Session):
+        _create_config(db_session, endpoint_type="auth_login")
+        update = RateLimitConfigUpdate(description="Updated desc")
+        result = RateLimitConfigService.update(db_session, "auth_login", update, user_id=1)
+        assert result.description == "Updated desc"
+
+    def test_updates_enabled_flag(self, db_session: Session):
+        _create_config(db_session, endpoint_type="auth_login", enabled=True)
+        update = RateLimitConfigUpdate(enabled=False)
+        result = RateLimitConfigService.update(db_session, "auth_login", update, user_id=1)
+        assert result.enabled is False
+
+    def test_returns_none_when_not_found(self, db_session: Session):
+        update = RateLimitConfigUpdate(limit_string="1/minute")
+        assert RateLimitConfigService.update(db_session, "nope", update, user_id=1) is None
+
+    def test_partial_update_preserves_other_fields(self, db_session: Session):
+        _create_config(
+            db_session,
+            endpoint_type="auth_login",
+            limit_string="5/minute",
+            description="Original",
+        )
+        update = RateLimitConfigUpdate(description="New desc")
+        result = RateLimitConfigService.update(db_session, "auth_login", update, user_id=1)
+        assert result.limit_string == "5/minute"
+        assert result.description == "New desc"
+
+
+class TestDelete:
+    def test_deletes_existing(self, db_session: Session):
+        _create_config(db_session, endpoint_type="auth_login")
+        assert RateLimitConfigService.delete(db_session, "auth_login") is True
+        assert RateLimitConfigService.get_by_endpoint_type(db_session, "auth_login") is None
+
+    def test_returns_false_when_not_found(self, db_session: Session):
+        assert RateLimitConfigService.delete(db_session, "nope") is False
+
+
+class TestSeedDefaults:
+    def test_seeds_when_empty(self, db_session: Session):
+        RateLimitConfigService.seed_defaults(db_session)
+        configs = list(RateLimitConfigService.get_all(db_session))
+        assert len(configs) >= 10  # At least the default entries
+
+    def test_does_not_seed_twice(self, db_session: Session):
+        RateLimitConfigService.seed_defaults(db_session)
+        count_first = len(list(RateLimitConfigService.get_all(db_session)))
+        RateLimitConfigService.seed_defaults(db_session)
+        count_second = len(list(RateLimitConfigService.get_all(db_session)))
+        assert count_first == count_second
+
+    def test_all_seeded_configs_are_enabled(self, db_session: Session):
+        RateLimitConfigService.seed_defaults(db_session)
+        configs = list(RateLimitConfigService.get_all(db_session))
+        assert all(c.enabled for c in configs)

--- a/backend/tests/services/test_samba_service.py
+++ b/backend/tests/services/test_samba_service.py
@@ -1,0 +1,58 @@
+"""Tests for services/samba_service.py — dev-mode stubs return True."""
+
+import pytest
+
+from app.services import samba_service
+
+
+@pytest.mark.asyncio
+class TestSyncSmbPassword:
+    async def test_dev_mode_returns_true(self):
+        result = await samba_service.sync_smb_password("testuser", "Password123")
+        assert result is True
+
+
+@pytest.mark.asyncio
+class TestRemoveSmbUser:
+    async def test_dev_mode_returns_true(self):
+        result = await samba_service.remove_smb_user("testuser")
+        assert result is True
+
+
+@pytest.mark.asyncio
+class TestEnableSmbUser:
+    async def test_dev_mode_returns_true(self):
+        result = await samba_service.enable_smb_user("testuser")
+        assert result is True
+
+
+@pytest.mark.asyncio
+class TestDisableSmbUser:
+    async def test_dev_mode_returns_true(self):
+        result = await samba_service.disable_smb_user("testuser")
+        assert result is True
+
+
+@pytest.mark.asyncio
+class TestRegenerateSharesConfig:
+    async def test_dev_mode_returns_true(self):
+        result = await samba_service.regenerate_shares_config()
+        assert result is True
+
+
+@pytest.mark.asyncio
+class TestReloadSamba:
+    async def test_dev_mode_returns_true(self):
+        result = await samba_service.reload_samba()
+        assert result is True
+
+
+@pytest.mark.asyncio
+class TestGetSambaStatus:
+    async def test_dev_mode_returns_status_dict(self):
+        status = await samba_service.get_samba_status()
+        assert isinstance(status, dict)
+        assert status["is_running"] is False
+        assert status["version"] == "dev-mode"
+        assert status["active_connections"] == []
+        assert isinstance(status["smb_users_count"], int)

--- a/backend/tests/services/test_token_service.py
+++ b/backend/tests/services/test_token_service.py
@@ -1,0 +1,224 @@
+"""Tests for services/token_service.py — RefreshToken CRUD and revocation."""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from app.services.token_service import TokenService
+
+
+def _make_jti() -> str:
+    return str(uuid.uuid4())
+
+
+def _future(hours: int = 24) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(hours=hours)
+
+
+def _past(days: int = 10) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=days)
+
+
+def _store_token(db: Session, user_id: int, **kwargs) -> str:
+    """Helper that stores a token and returns the jti."""
+    jti = kwargs.pop("jti", _make_jti())
+    TokenService.store_refresh_token(
+        db,
+        jti=jti,
+        user_id=user_id,
+        token=f"token-{jti}",
+        expires_at=kwargs.pop("expires_at", _future()),
+        **kwargs,
+    )
+    return jti
+
+
+class TestStoreRefreshToken:
+    def test_stores_and_retrieves(self, db_session: Session, regular_user: User):
+        jti = _make_jti()
+        token = TokenService.store_refresh_token(
+            db_session,
+            jti=jti,
+            user_id=regular_user.id,
+            token="my-secret-token",
+            expires_at=_future(),
+            device_id="phone-1",
+            ip_address="127.0.0.1",
+            user_agent="TestAgent/1.0",
+        )
+        assert token.jti == jti
+        assert token.user_id == regular_user.id
+        assert token.revoked is False
+        assert token.device_id == "phone-1"
+        assert token.created_ip == "127.0.0.1"
+
+    def test_token_hash_not_plaintext(self, db_session: Session, regular_user: User):
+        jti = _make_jti()
+        token = TokenService.store_refresh_token(
+            db_session,
+            jti=jti,
+            user_id=regular_user.id,
+            token="plaintext-value",
+            expires_at=_future(),
+        )
+        assert token.token_hash != "plaintext-value"
+        assert len(token.token_hash) == 64  # SHA-256 hex
+
+
+class TestGetTokenByJti:
+    def test_returns_none_for_unknown(self, db_session: Session):
+        assert TokenService.get_token_by_jti(db_session, "no-such-jti") is None
+
+    def test_returns_token(self, db_session: Session, regular_user: User):
+        jti = _store_token(db_session, regular_user.id)
+        found = TokenService.get_token_by_jti(db_session, jti)
+        assert found is not None
+        assert found.jti == jti
+
+
+class TestIsTokenRevoked:
+    def test_unknown_token_is_revoked(self, db_session: Session):
+        assert TokenService.is_token_revoked(db_session, "unknown") is True
+
+    def test_valid_token_not_revoked(self, db_session: Session, regular_user: User):
+        jti = _store_token(db_session, regular_user.id)
+        assert TokenService.is_token_revoked(db_session, jti) is False
+
+    def test_revoked_token_is_revoked(self, db_session: Session, regular_user: User):
+        jti = _store_token(db_session, regular_user.id)
+        TokenService.revoke_token(db_session, jti)
+        assert TokenService.is_token_revoked(db_session, jti) is True
+
+    def test_expired_token_is_revoked(self, db_session: Session, regular_user: User):
+        jti = _store_token(db_session, regular_user.id, expires_at=_past())
+        assert TokenService.is_token_revoked(db_session, jti) is True
+
+
+class TestRevokeToken:
+    def test_revokes_existing_token(self, db_session: Session, regular_user: User):
+        jti = _store_token(db_session, regular_user.id)
+        assert TokenService.revoke_token(db_session, jti, reason="logout") is True
+
+        token = TokenService.get_token_by_jti(db_session, jti)
+        assert token.revoked is True
+        assert token.revocation_reason == "logout"
+
+    def test_returns_false_for_unknown(self, db_session: Session):
+        assert TokenService.revoke_token(db_session, "unknown") is False
+
+
+class TestRevokeAllUserTokens:
+    def test_revokes_all_active_tokens(self, db_session: Session, regular_user: User):
+        jti1 = _store_token(db_session, regular_user.id)
+        jti2 = _store_token(db_session, regular_user.id)
+
+        count = TokenService.revoke_all_user_tokens(
+            db_session, regular_user.id, reason="password_change"
+        )
+        assert count == 2
+
+        assert TokenService.is_token_revoked(db_session, jti1) is True
+        assert TokenService.is_token_revoked(db_session, jti2) is True
+
+    def test_returns_zero_when_no_tokens(self, db_session: Session, regular_user: User):
+        assert TokenService.revoke_all_user_tokens(db_session, regular_user.id) == 0
+
+    def test_does_not_double_revoke(self, db_session: Session, regular_user: User):
+        jti = _store_token(db_session, regular_user.id)
+        TokenService.revoke_token(db_session, jti)
+        # Already revoked, should not be counted again
+        count = TokenService.revoke_all_user_tokens(db_session, regular_user.id)
+        assert count == 0
+
+
+class TestRevokeDeviceTokens:
+    def test_revokes_by_device(self, db_session: Session, regular_user: User):
+        _store_token(db_session, regular_user.id, device_id="device-A")
+        _store_token(db_session, regular_user.id, device_id="device-A")
+        _store_token(db_session, regular_user.id, device_id="device-B")
+
+        count = TokenService.revoke_device_tokens(db_session, "device-A")
+        assert count == 2
+
+    def test_returns_zero_for_unknown_device(self, db_session: Session):
+        assert TokenService.revoke_device_tokens(db_session, "no-device") == 0
+
+
+class TestUpdateTokenUsage:
+    def test_updates_timestamp_and_ip(self, db_session: Session, regular_user: User):
+        jti = _store_token(db_session, regular_user.id)
+        assert TokenService.update_token_usage(db_session, jti, ip_address="10.0.0.1") is True
+
+        token = TokenService.get_token_by_jti(db_session, jti)
+        assert token.last_used_at is not None
+        assert token.last_used_ip == "10.0.0.1"
+
+    def test_updates_without_ip(self, db_session: Session, regular_user: User):
+        jti = _store_token(db_session, regular_user.id)
+        assert TokenService.update_token_usage(db_session, jti) is True
+
+    def test_returns_false_for_unknown(self, db_session: Session):
+        assert TokenService.update_token_usage(db_session, "nope") is False
+
+
+class TestCleanupExpiredTokens:
+    def test_deletes_old_expired_tokens(self, db_session: Session, regular_user: User):
+        # Expired 10 days ago — beyond the 7-day cutoff
+        _store_token(db_session, regular_user.id, expires_at=_past(days=10))
+        # Still valid
+        jti_valid = _store_token(db_session, regular_user.id, expires_at=_future())
+
+        deleted = TokenService.cleanup_expired_tokens(db_session)
+        assert deleted == 1
+        # Valid token should still exist
+        assert TokenService.get_token_by_jti(db_session, jti_valid) is not None
+
+    def test_keeps_recently_expired_tokens(self, db_session: Session, regular_user: User):
+        # Expired 2 days ago — within 7-day grace period
+        _store_token(
+            db_session,
+            regular_user.id,
+            expires_at=datetime.now(timezone.utc) - timedelta(days=2),
+        )
+        deleted = TokenService.cleanup_expired_tokens(db_session)
+        assert deleted == 0
+
+
+class TestGetUserActiveTokens:
+    def test_returns_active_tokens(self, db_session: Session, regular_user: User):
+        _store_token(db_session, regular_user.id)
+        _store_token(db_session, regular_user.id)
+
+        tokens = TokenService.get_user_active_tokens(db_session, regular_user.id)
+        assert len(tokens) == 2
+
+    def test_excludes_revoked(self, db_session: Session, regular_user: User):
+        jti = _store_token(db_session, regular_user.id)
+        _store_token(db_session, regular_user.id)
+        TokenService.revoke_token(db_session, jti)
+
+        tokens = TokenService.get_user_active_tokens(db_session, regular_user.id)
+        assert len(tokens) == 1
+
+    def test_excludes_expired(self, db_session: Session, regular_user: User):
+        _store_token(db_session, regular_user.id, expires_at=_past())
+        _store_token(db_session, regular_user.id, expires_at=_future())
+
+        tokens = TokenService.get_user_active_tokens(db_session, regular_user.id)
+        assert len(tokens) == 1
+
+
+class TestVerifyTokenOwnership:
+    def test_returns_true_for_owner(self, db_session: Session, regular_user: User):
+        jti = _store_token(db_session, regular_user.id)
+        assert TokenService.verify_token_ownership(db_session, jti, regular_user.id) is True
+
+    def test_returns_false_for_wrong_user(self, db_session: Session, regular_user: User):
+        jti = _store_token(db_session, regular_user.id)
+        assert TokenService.verify_token_ownership(db_session, jti, 99999) is False
+
+    def test_returns_false_for_unknown_token(self, db_session: Session):
+        assert TokenService.verify_token_ownership(db_session, "unknown", 1) is False

--- a/backend/tests/services/test_user_metadata_cache.py
+++ b/backend/tests/services/test_user_metadata_cache.py
@@ -1,0 +1,38 @@
+"""Tests for services/user_metadata_cache.py — pure logic, no DB needed."""
+
+from app.services.user_metadata_cache import fetch_metadata_from_db, get_user_metadata
+
+
+class TestFetchMetadataFromDb:
+    def test_returns_dict_with_expected_keys(self):
+        result = fetch_metadata_from_db(1)
+        assert result == {"user_id": 1, "name": "User1", "role": "user"}
+
+    def test_different_user_ids(self):
+        for uid in (0, 42, 9999):
+            result = fetch_metadata_from_db(uid)
+            assert result["user_id"] == uid
+            assert result["name"] == f"User{uid}"
+
+
+class TestGetUserMetadata:
+    def test_returns_correct_metadata(self):
+        get_user_metadata.cache_clear()
+        result = get_user_metadata(10)
+        assert result["user_id"] == 10
+        assert result["role"] == "user"
+
+    def test_caching_returns_same_object(self):
+        get_user_metadata.cache_clear()
+        first = get_user_metadata(5)
+        second = get_user_metadata(5)
+        # lru_cache should return the exact same object
+        assert first is second
+
+    def test_cache_info_shows_hits(self):
+        get_user_metadata.cache_clear()
+        get_user_metadata(7)
+        get_user_metadata(7)
+        info = get_user_metadata.cache_info()
+        assert info.hits >= 1
+        assert info.misses >= 1

--- a/backend/tests/services/test_websocket_manager.py
+++ b/backend/tests/services/test_websocket_manager.py
@@ -1,0 +1,174 @@
+"""Tests for services/websocket_manager.py — WebSocketManager with mock WebSockets."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.websocket_manager import Connection, WebSocketManager, get_websocket_manager
+
+
+def _make_ws(send_json_side_effect=None) -> MagicMock:
+    """Create a mock WebSocket object."""
+    ws = MagicMock()
+    ws.send_json = AsyncMock(side_effect=send_json_side_effect)
+    return ws
+
+
+@pytest.fixture
+def manager() -> WebSocketManager:
+    return WebSocketManager()
+
+
+@pytest.mark.asyncio
+class TestConnect:
+    async def test_registers_connection(self, manager: WebSocketManager):
+        ws = _make_ws()
+        conn = await manager.connect(ws, user_id=1)
+        assert isinstance(conn, Connection)
+        assert conn.user_id == 1
+        assert manager.is_user_connected(1)
+        assert manager.get_connection_count(1) == 1
+
+    async def test_multiple_connections_same_user(self, manager: WebSocketManager):
+        ws1, ws2 = _make_ws(), _make_ws()
+        await manager.connect(ws1, user_id=1)
+        await manager.connect(ws2, user_id=1)
+        assert manager.get_connection_count(1) == 2
+
+    async def test_admin_tracked(self, manager: WebSocketManager):
+        ws = _make_ws()
+        await manager.connect(ws, user_id=1, is_admin=True)
+        assert 1 in manager._admin_users
+
+
+@pytest.mark.asyncio
+class TestDisconnect:
+    async def test_removes_connection(self, manager: WebSocketManager):
+        ws = _make_ws()
+        await manager.connect(ws, user_id=1)
+        await manager.disconnect(ws)
+        assert not manager.is_user_connected(1)
+
+    async def test_disconnect_one_of_many(self, manager: WebSocketManager):
+        ws1, ws2 = _make_ws(), _make_ws()
+        await manager.connect(ws1, user_id=1)
+        await manager.connect(ws2, user_id=1)
+        await manager.disconnect(ws1)
+        assert manager.get_connection_count(1) == 1
+
+    async def test_disconnect_unknown_ws_is_noop(self, manager: WebSocketManager):
+        ws = _make_ws()
+        await manager.disconnect(ws)  # Should not raise
+
+    async def test_admin_removed_when_last_connection_drops(self, manager: WebSocketManager):
+        ws = _make_ws()
+        await manager.connect(ws, user_id=1, is_admin=True)
+        await manager.disconnect(ws)
+        assert 1 not in manager._admin_users
+
+
+@pytest.mark.asyncio
+class TestBroadcastToUser:
+    async def test_sends_to_user(self, manager: WebSocketManager):
+        ws = _make_ws()
+        await manager.connect(ws, user_id=1)
+        count = await manager.broadcast_to_user(1, {"msg": "hello"})
+        assert count == 1
+        ws.send_json.assert_called_once()
+        payload = ws.send_json.call_args[0][0]
+        assert payload["type"] == "notification"
+        assert payload["payload"] == {"msg": "hello"}
+
+    async def test_returns_zero_for_disconnected_user(self, manager: WebSocketManager):
+        count = await manager.broadcast_to_user(999, {"msg": "hello"})
+        assert count == 0
+
+    async def test_cleans_up_failed_connection(self, manager: WebSocketManager):
+        ws = _make_ws(send_json_side_effect=Exception("connection lost"))
+        await manager.connect(ws, user_id=1)
+        count = await manager.broadcast_to_user(1, {"msg": "hello"})
+        assert count == 0
+        assert not manager.is_user_connected(1)
+
+
+@pytest.mark.asyncio
+class TestBroadcastToAdmins:
+    async def test_sends_only_to_admins(self, manager: WebSocketManager):
+        ws_admin = _make_ws()
+        ws_user = _make_ws()
+        await manager.connect(ws_admin, user_id=1, is_admin=True)
+        await manager.connect(ws_user, user_id=2, is_admin=False)
+
+        count = await manager.broadcast_to_admins({"alert": "disk full"})
+        assert count == 1
+        ws_admin.send_json.assert_called_once()
+        ws_user.send_json.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestBroadcastToAll:
+    async def test_sends_to_all_users(self, manager: WebSocketManager):
+        ws1, ws2 = _make_ws(), _make_ws()
+        await manager.connect(ws1, user_id=1)
+        await manager.connect(ws2, user_id=2)
+
+        count = await manager.broadcast_to_all({"event": "update"})
+        assert count == 2
+
+    async def test_empty_when_no_connections(self, manager: WebSocketManager):
+        count = await manager.broadcast_to_all({"event": "update"})
+        assert count == 0
+
+
+@pytest.mark.asyncio
+class TestSendUnreadCount:
+    async def test_sends_unread_count(self, manager: WebSocketManager):
+        ws = _make_ws()
+        await manager.connect(ws, user_id=1)
+        count = await manager.send_unread_count(1, 5)
+        assert count == 1
+        payload = ws.send_json.call_args[0][0]
+        assert payload["type"] == "unread_count"
+        assert payload["payload"]["count"] == 5
+
+
+class TestGetConnectedUserIds:
+    @pytest.mark.asyncio
+    async def test_returns_connected_ids(self, manager: WebSocketManager):
+        await manager.connect(_make_ws(), user_id=10)
+        await manager.connect(_make_ws(), user_id=20)
+        ids = manager.get_connected_user_ids()
+        assert set(ids) == {10, 20}
+
+
+class TestGetConnectionCount:
+    @pytest.mark.asyncio
+    async def test_total_count(self, manager: WebSocketManager):
+        await manager.connect(_make_ws(), user_id=1)
+        await manager.connect(_make_ws(), user_id=1)
+        await manager.connect(_make_ws(), user_id=2)
+        assert manager.get_connection_count() == 3
+
+    @pytest.mark.asyncio
+    async def test_per_user_count(self, manager: WebSocketManager):
+        await manager.connect(_make_ws(), user_id=1)
+        await manager.connect(_make_ws(), user_id=1)
+        assert manager.get_connection_count(user_id=1) == 2
+        assert manager.get_connection_count(user_id=99) == 0
+
+
+class TestIsUserConnected:
+    @pytest.mark.asyncio
+    async def test_connected(self, manager: WebSocketManager):
+        await manager.connect(_make_ws(), user_id=1)
+        assert manager.is_user_connected(1) is True
+
+    def test_not_connected(self, manager: WebSocketManager):
+        assert manager.is_user_connected(999) is False
+
+
+class TestGetWebSocketManagerSingleton:
+    def test_returns_same_instance(self):
+        a = get_websocket_manager()
+        b = get_websocket_manager()
+        assert a is b

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baluhost-client",
   "private": true,
-  "version": "1.16.1",
+  "version": "1.16.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/components/system-monitor/UptimeStatusBar.tsx
+++ b/client/src/components/system-monitor/UptimeStatusBar.tsx
@@ -64,15 +64,23 @@ export function UptimeStatusBar({ samples, timeRange, label, uptimeField }: Upti
   const config = SEGMENT_CONFIG[timeRange];
 
   const timeslots = useMemo<UptimeTimeslot[]>(() => {
-    const now = Date.now();
-    const rangeStart = now - config.durationMs;
+    const clientNow = Date.now();
     const bucketDuration = config.durationMs / config.segments;
 
-    // Parse and sort samples by time
-    const parsed = samples
+    // Parse all samples
+    const allParsed = samples
       .map(s => ({ ...s, _time: parseUtcTimestamp(s.timestamp).getTime() }))
-      .filter(s => s._time >= rangeStart && s._time <= now)
       .sort((a, b) => a._time - b._time);
+
+    // Use the latest sample timestamp as reference for "now" if available.
+    // This prevents clock/timezone differences between server and client
+    // from causing all samples to be filtered out.
+    const now = allParsed.length > 0
+      ? Math.max(clientNow, allParsed[allParsed.length - 1]._time)
+      : clientNow;
+    const rangeStart = now - config.durationMs;
+
+    const parsed = allParsed.filter(s => s._time >= rangeStart && s._time <= now);
 
     const slots: UptimeTimeslot[] = [];
 


### PR DESCRIPTION
## Summary

- **fix(monitoring):** Resolve uptime bars showing no data for short time ranges
- **fix(updates):** Use actual version in changelog instead of literal "latest"
- **test:** Add coverage for pure-logic/DB-CRUD services, async services/dev-mode stubs, plugin manager/cloud scheduler (Batches 1-3)

## Changelog

See [CHANGELOG.md](./CHANGELOG.md) for full details.

## Test plan

- [ ] Verify uptime bars render correctly for short time ranges
- [ ] Verify update changelog shows actual version number
- [ ] Confirm all new tests pass (`python -m pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)