### PR TITLE
Release v1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.19.1] - 2026-03-24
+
+### Fixed
+- **Sleep schedule stuck state** — When `suspend_system()` failed, state stayed on TRUE_SUSPEND permanently, blocking schedule re-triggers, manual wake, and auto-wake middleware. Now reverts to SOFT_SLEEP on failure.
+- **Sleep resume path** — After successful suspend resume, state transition was rejected by `_exit_soft_sleep()` guard. Fixed by setting state to SOFT_SLEEP before calling exit.
+
+---
+
 ## [1.19.0] - 2026-03-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,4 +75,4 @@ client/
 - **Issues**: GitHub Issues (repository URL needed)
 - **Documentation**: See `docs/` directory
 - **Maintainer**: Xveyn
-- **Version**: 1.19.0 (as of Mar 2026)
+- **Version**: 1.19.1 (as of Mar 2026)

--- a/backend/app/plugins/README.md
+++ b/backend/app/plugins/README.md
@@ -316,6 +316,39 @@ Verfügbare Capabilities:
 | `dimmer` | `Dimmer` | `set_brightness()`, `get_dimmer_state()` |
 | `color` | `ColorControl` | `set_color()`, `set_color_temp()`, `get_color_state()` |
 
+### Capability-Verträge
+
+Capabilities sind **Verträge**, nicht nur Labels. Wenn ein Plugin eine Capability deklariert, muss es:
+
+1. **Das zugehörige Protocol implementieren** — geprüft beim Plugin-Start (sowohl im Web-Worker als auch im Monitoring-Worker)
+2. **Das zugehörige Datenmodell von `poll_device()` zurückgeben** — geprüft bei jedem Poll-Zyklus zur Laufzeit
+
+Dafür bekommt das Plugin automatisch: Mobile-App-Integration (BaluApp), Dashboard-Panel, Energie-Statistiken und Kostenberechnung.
+
+| Capability | Protocol | Datenmodell | `poll_device()` Key |
+|------------|----------|-------------|---------------------|
+| `switch` | `Switch` | `SwitchState` | `"switch"` |
+| `power_monitor` | `PowerMonitor` | `PowerReading` | `"power_monitor"` |
+| `sensor` | `Sensor` | `SensorReading` | `"sensor"` |
+| `dimmer` | `Dimmer` | `DimmerState` | `"dimmer"` |
+| `color` | `ColorControl` | `ColorState` | `"color"` |
+
+**Wichtig:** Stromverbrauchsdaten (und alle anderen Capability-Daten) müssen über die zentrale Pipeline fließen:
+
+```
+poll_device() → Poller → SHM → Energy-Service → Mobile API
+```
+
+Plugin-eigene API-Routen dürfen **keine** Capability-Daten in einem anderen Format exponieren. Die zentrale Pipeline ist der einzige Weg, damit die Mobile App und das Dashboard konsistente Daten erhalten.
+
+**Validierungs-Verhalten:**
+
+- **Startup:** Plugin wird nicht geladen, wenn ein deklariertes Protocol nicht implementiert ist
+- **Runtime:** Ungültige Daten werden verworfen (Warning im Log), gültige Daten fließen normal weiter
+- **Leere Rückgabe:** `poll_device()` darf `{}` zurückgeben (keine Daten in diesem Zyklus)
+- **Partielle Rückgabe:** Nicht alle deklarierten Capabilities müssen in jedem Poll enthalten sein
+- **Extra Keys:** Keys die nicht in den deklarierten Capabilities sind werden ignoriert (Warning im Log)
+
 Smart-Device-Plugins haben **keine eigenen Routen** — alle Interaktion läuft über die einheitliche `/api/smart-devices/` API. Der `SmartDevicePoller` läuft im separaten Monitoring-Worker-Prozess und pollt alle aktiven Geräte periodisch. Status wird per SHM (Shared Memory Files) an den Web-Worker kommuniziert.
 
 ## Mitgelieferte Plugins

--- a/backend/app/plugins/manager.py
+++ b/backend/app/plugins/manager.py
@@ -195,6 +195,19 @@ class PluginManager:
                 )
 
             self._plugins[name] = plugin
+
+            # Validate capability contracts for smart device plugins
+            from app.plugins.smart_device.base import SmartDevicePlugin
+            if isinstance(plugin, SmartDevicePlugin):
+                from app.plugins.smart_device.capabilities import validate_capability_contracts
+                contract_errors = validate_capability_contracts(plugin)
+                if contract_errors:
+                    del self._plugins[name]
+                    errors_str = "; ".join(contract_errors)
+                    raise PluginLoadError(
+                        f"Plugin '{name}' failed capability contract validation: {errors_str}"
+                    )
+
             logger.info(f"Loaded plugin: {meta.display_name} v{meta.version}")
 
             return plugin

--- a/backend/app/plugins/smart_device/capabilities.py
+++ b/backend/app/plugins/smart_device/capabilities.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Protocol, runtime_checkable, Optional
+from typing import Any, Protocol, runtime_checkable, Optional, Tuple, List
 
 from pydantic import BaseModel, Field
 
@@ -143,3 +143,70 @@ def validate_capability_contracts(plugin: object) -> list[str]:
                 )
 
     return errors
+
+
+def validate_poll_data(
+    data: dict[str, Any],
+    declared_capabilities: list[DeviceCapability],
+) -> tuple[dict[str, Any], list[str]]:
+    """Validate poll_device() output against declared capability contracts.
+
+    Args:
+        data: The dict returned by poll_device() or poll_device_mock().
+        declared_capabilities: The device's declared capabilities list.
+
+    Returns:
+        Tuple of (validated_data, warnings).
+        validated_data contains only entries that passed validation.
+        warnings contains human-readable messages for issues found.
+    """
+    validated: dict[str, Any] = {}
+    warnings: list[str] = []
+    declared_values = {cap.value for cap in declared_capabilities}
+
+    for key, value in data.items():
+        # Check if key corresponds to a declared capability
+        if key not in declared_values:
+            warnings.append(
+                f"Undeclared capability key '{key}' in poll result — ignored"
+            )
+            continue
+
+        # Find the matching capability and its contract
+        try:
+            cap = DeviceCapability(key)
+        except ValueError:
+            warnings.append(f"Unknown capability key '{key}' — ignored")
+            continue
+
+        contract = CAPABILITY_CONTRACTS.get(cap)
+        if contract is None:
+            # No contract defined — pass through
+            validated[key] = value
+            continue
+
+        _protocol_cls, data_model = contract
+
+        # Already the right Pydantic model?
+        if isinstance(value, data_model):
+            validated[key] = value
+            continue
+
+        # Try to validate as dict (lax mode — allows string-to-datetime coercion)
+        if isinstance(value, dict):
+            try:
+                data_model.model_validate(value)
+                validated[key] = value
+            except Exception:
+                warnings.append(
+                    f"Capability '{key}' returned invalid data "
+                    f"(expected {data_model.__name__})"
+                )
+            continue
+
+        warnings.append(
+            f"Capability '{key}' returned unexpected type {type(value).__name__} "
+            f"(expected {data_model.__name__} or dict)"
+        )
+
+    return validated, warnings

--- a/backend/app/plugins/smart_device/capabilities.py
+++ b/backend/app/plugins/smart_device/capabilities.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Protocol, runtime_checkable, Optional
+from typing import Any, Protocol, runtime_checkable, Optional
 
 from pydantic import BaseModel, Field
 
@@ -82,3 +82,64 @@ class ColorControl(Protocol):
     async def set_color(self, device_id: str, hue: int, saturation: int, brightness: int) -> ColorState: ...
     async def set_color_temp(self, device_id: str, kelvin: int) -> ColorState: ...
     async def get_color_state(self, device_id: str) -> ColorState: ...
+
+
+# --- Capability Contracts ---
+# Declaring a capability is a CONTRACT:
+# - Your plugin MUST implement the Protocol (checked at startup)
+# - poll_device() MUST return the DataModel for this capability key (checked at runtime)
+# In return you get: mobile app integration, dashboard panels,
+# energy statistics, and cost calculations — for free.
+
+CAPABILITY_CONTRACTS: dict[DeviceCapability, tuple[type, type[BaseModel]]] = {
+    DeviceCapability.SWITCH: (Switch, SwitchState),
+    DeviceCapability.POWER_MONITOR: (PowerMonitor, PowerReading),
+    DeviceCapability.SENSOR: (Sensor, SensorReading),
+    DeviceCapability.DIMMER: (Dimmer, DimmerState),
+    DeviceCapability.COLOR: (ColorControl, ColorState),
+}
+
+
+def validate_capability_contracts(plugin: object) -> list[str]:
+    """Validate that a plugin implements all protocols for its declared capabilities.
+
+    Iterates over every DeviceTypeInfo returned by the plugin's
+    ``get_device_types()`` and checks that each declared capability's
+    protocol is satisfied (via ``isinstance``).
+
+    Args:
+        plugin: A SmartDevicePlugin instance.
+
+    Returns:
+        List of human-readable error strings (empty means valid).
+    """
+    errors: list[str] = []
+    seen: set[DeviceCapability] = set()
+
+    # Import here to avoid circular import at module level
+    from app.plugins.smart_device.base import SmartDevicePlugin
+
+    if not isinstance(plugin, SmartDevicePlugin):
+        return errors
+
+    for device_type in plugin.get_device_types():
+        for cap in device_type.capabilities:
+            if cap in seen:
+                continue
+            seen.add(cap)
+
+            contract = CAPABILITY_CONTRACTS.get(cap)
+            if contract is None:
+                errors.append(
+                    f"Capability '{cap.value}' has no contract defined in CAPABILITY_CONTRACTS"
+                )
+                continue
+
+            protocol_cls, _data_model = contract
+            if not isinstance(plugin, protocol_cls):
+                errors.append(
+                    f"Capability '{cap.value}' requires {protocol_cls.__name__} protocol "
+                    f"but plugin '{plugin.metadata.name}' does not implement it"
+                )
+
+    return errors

--- a/backend/app/plugins/smart_device/poller.py
+++ b/backend/app/plugins/smart_device/poller.py
@@ -343,9 +343,27 @@ class SmartDevicePoller:
                     timeout=10.0,
                 )
 
-            # Serialize any Pydantic models in the state dict
+            # Validate poll data against capability contracts
+            from app.plugins.smart_device.capabilities import (
+                DeviceCapability,
+                validate_poll_data,
+            )
+            declared_caps = []
+            for c in device.capabilities:
+                try:
+                    declared_caps.append(DeviceCapability(c))
+                except ValueError:
+                    pass
+            validated_state, poll_warnings = validate_poll_data(new_state, declared_caps)
+            for warning in poll_warnings:
+                logger.warning(
+                    "SmartDevicePoller: plugin '%s' device %d ('%s'): %s",
+                    plugin.metadata.name, device_id, device.name, warning,
+                )
+
+            # Serialize any Pydantic models in the validated state dict
             serialized: Dict[str, Any] = {}
-            for cap_key, cap_value in new_state.items():
+            for cap_key, cap_value in validated_state.items():
                 if hasattr(cap_value, "model_dump"):
                     serialized[cap_key] = cap_value.model_dump(mode="json")
                 else:

--- a/backend/app/plugins/smart_device/poller.py
+++ b/backend/app/plugins/smart_device/poller.py
@@ -218,6 +218,19 @@ class SmartDevicePoller:
                     continue
 
                 plugin = plugin_cls()
+
+                # Validate capability contracts
+                from app.plugins.smart_device.capabilities import validate_capability_contracts
+                contract_errors = validate_capability_contracts(plugin)
+                if contract_errors:
+                    errors_str = "; ".join(contract_errors)
+                    logger.warning(
+                        "SmartDevicePoller: plugin '%s' failed capability contract "
+                        "validation: %s — skipping",
+                        name, errors_str,
+                    )
+                    continue
+
                 if plugin.metadata.category != "smart_device":
                     continue
 

--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -744,10 +744,16 @@ class SleepManagerService:
         # Actually suspend
         ok = await self._backend.suspend_system()
 
-        # When system resumes, we'll be back here
+        # When system resumes (or suspend failed), we'll be back here.
+        # Revert to SOFT_SLEEP so _exit_soft_sleep accepts the transition.
+        self._current_state = SleepState.SOFT_SLEEP
+        self._state_since = datetime.now(timezone.utc)
+
         if ok:
             logger.info("System resumed from suspend")
             await self._exit_soft_sleep("resume_from_suspend")
+        else:
+            logger.error("System suspend failed, remaining in soft sleep")
 
         return ok
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baluhost-backend"
-version = "1.19.0"
+version = "1.19.1"
 description = "Mocked NAS management backend built with FastAPI"
 authors = [{ name = "Baluhost" }]
 requires-python = ">=3.11"

--- a/backend/tests/plugins/test_capability_contracts.py
+++ b/backend/tests/plugins/test_capability_contracts.py
@@ -266,3 +266,64 @@ class GoodDevicePlugin(SmartDevicePlugin):
     manager = PluginManager(plugins_dir=plugins_dir)
     plugin = manager.load_plugin("good_device")
     assert plugin is not None
+
+
+@pytest.mark.asyncio
+async def test_poller_skips_plugin_failing_contracts(tmp_path):
+    """Validate that dynamically loaded plugins fail contract validation
+    the same way as statically defined ones."""
+    plugins_dir = tmp_path / "plugins"
+    plugin_dir = plugins_dir / "broken_poller_device"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text('''
+from app.plugins.base import PluginMetadata
+from app.plugins.smart_device.base import SmartDevicePlugin, DeviceTypeInfo
+from app.plugins.smart_device.capabilities import DeviceCapability
+
+class BrokenPollerPlugin(SmartDevicePlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="broken_poller_device",
+            version="1.0.0",
+            display_name="Broken Poller",
+            description="Test",
+            author="Test",
+            category="smart_device",
+        )
+
+    def get_device_types(self):
+        return [DeviceTypeInfo(
+            type_id="broken",
+            display_name="Broken",
+            manufacturer="Test",
+            capabilities=[DeviceCapability.POWER_MONITOR],
+        )]
+
+    async def connect_device(self, device_id, config):
+        return True
+
+    async def poll_device(self, device_id):
+        return {}
+''')
+
+    import importlib.util, sys
+    module_name = "test_broken_poller_plugin"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        plugin_dir / "__init__.py",
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    plugin = module.BrokenPollerPlugin()
+
+    from app.plugins.smart_device.capabilities import validate_capability_contracts
+    errors = validate_capability_contracts(plugin)
+    assert len(errors) == 1
+    assert "power_monitor" in errors[0].lower()
+
+    # Cleanup
+    del sys.modules[module_name]

--- a/backend/tests/plugins/test_capability_contracts.py
+++ b/backend/tests/plugins/test_capability_contracts.py
@@ -327,3 +327,80 @@ class BrokenPollerPlugin(SmartDevicePlugin):
 
     # Cleanup
     del sys.modules[module_name]
+
+
+from app.plugins.smart_device.capabilities import validate_poll_data
+
+
+def test_validate_poll_data_valid_power_reading():
+    """Valid PowerReading passes validation."""
+    declared = [DeviceCapability.POWER_MONITOR]
+    data = {
+        "power_monitor": PowerReading(
+            watts=42.0, timestamp=datetime.now(timezone.utc)
+        )
+    }
+    validated, warnings = validate_poll_data(data, declared)
+    assert "power_monitor" in validated
+    assert warnings == []
+
+
+def test_validate_poll_data_valid_dict():
+    """A raw dict that matches PowerReading schema passes validation."""
+    declared = [DeviceCapability.POWER_MONITOR]
+    data = {
+        "power_monitor": {
+            "watts": 42.0,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    }
+    validated, warnings = validate_poll_data(data, declared)
+    assert "power_monitor" in validated
+    assert warnings == []
+
+
+def test_validate_poll_data_invalid_dict():
+    """A dict missing required field 'watts' is rejected."""
+    declared = [DeviceCapability.POWER_MONITOR]
+    data = {
+        "power_monitor": {"voltage": 230.0}  # missing 'watts' and 'timestamp'
+    }
+    validated, warnings = validate_poll_data(data, declared)
+    assert "power_monitor" not in validated
+    assert len(warnings) == 1
+    assert "power_monitor" in warnings[0].lower()
+
+
+def test_validate_poll_data_empty_dict():
+    """Empty poll result is valid — no errors."""
+    declared = [DeviceCapability.POWER_MONITOR]
+    validated, warnings = validate_poll_data({}, declared)
+    assert validated == {}
+    assert warnings == []
+
+
+def test_validate_poll_data_partial_capabilities():
+    """Returning only some declared capabilities is valid."""
+    declared = [DeviceCapability.SWITCH, DeviceCapability.POWER_MONITOR]
+    data = {
+        "switch": SwitchState(is_on=True),
+    }
+    validated, warnings = validate_poll_data(data, declared)
+    assert "switch" in validated
+    assert warnings == []
+
+
+def test_validate_poll_data_extra_key_warned():
+    """Keys not in declared capabilities are dropped with a warning."""
+    declared = [DeviceCapability.SWITCH]
+    data = {
+        "switch": SwitchState(is_on=True),
+        "power_monitor": PowerReading(
+            watts=42.0, timestamp=datetime.now(timezone.utc)
+        ),
+    }
+    validated, warnings = validate_poll_data(data, declared)
+    assert "switch" in validated
+    assert "power_monitor" not in validated
+    assert len(warnings) == 1
+    assert "undeclared" in warnings[0].lower()

--- a/backend/tests/plugins/test_capability_contracts.py
+++ b/backend/tests/plugins/test_capability_contracts.py
@@ -1,0 +1,166 @@
+"""Tests for capability contract enforcement."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import pytest
+from pydantic import BaseModel
+
+from app.plugins.smart_device.capabilities import (
+    CAPABILITY_CONTRACTS,
+    DeviceCapability,
+    PowerMonitor,
+    PowerReading,
+    Switch,
+    SwitchState,
+    validate_capability_contracts,
+)
+from app.plugins.smart_device.base import DeviceTypeInfo, SmartDevicePlugin
+from app.plugins.base import PluginMetadata
+
+
+# --- Helpers ---
+
+class _ValidPowerPlugin(SmartDevicePlugin):
+    """Plugin that correctly implements POWER_MONITOR."""
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="valid_power",
+            version="1.0.0",
+            display_name="Valid Power",
+            description="Test",
+            author="Test",
+            category="smart_device",
+        )
+
+    def get_device_types(self) -> List[DeviceTypeInfo]:
+        return [
+            DeviceTypeInfo(
+                type_id="test_power",
+                display_name="Test Power",
+                manufacturer="Test",
+                capabilities=[DeviceCapability.POWER_MONITOR],
+            )
+        ]
+
+    async def connect_device(self, device_id: str, config: Dict[str, Any]) -> bool:
+        return True
+
+    async def poll_device(self, device_id: str) -> Dict[str, Any]:
+        return {
+            "power_monitor": PowerReading(
+                watts=42.0, timestamp=datetime.now(timezone.utc)
+            )
+        }
+
+    async def get_power(self, device_id: str) -> PowerReading:
+        return PowerReading(watts=42.0, timestamp=datetime.now(timezone.utc))
+
+
+class _MissingProtocolPlugin(SmartDevicePlugin):
+    """Plugin that declares POWER_MONITOR but does NOT implement get_power()."""
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="missing_protocol",
+            version="1.0.0",
+            display_name="Missing Protocol",
+            description="Test",
+            author="Test",
+            category="smart_device",
+        )
+
+    def get_device_types(self) -> List[DeviceTypeInfo]:
+        return [
+            DeviceTypeInfo(
+                type_id="test_broken",
+                display_name="Test Broken",
+                manufacturer="Test",
+                capabilities=[DeviceCapability.POWER_MONITOR],
+            )
+        ]
+
+    async def connect_device(self, device_id: str, config: Dict[str, Any]) -> bool:
+        return True
+
+    async def poll_device(self, device_id: str) -> Dict[str, Any]:
+        return {}
+
+
+class _PartialProtocolPlugin(SmartDevicePlugin):
+    """Declares SWITCH + POWER_MONITOR but only implements Switch."""
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="partial_protocol",
+            version="1.0.0",
+            display_name="Partial",
+            description="Test",
+            author="Test",
+            category="smart_device",
+        )
+
+    def get_device_types(self) -> List[DeviceTypeInfo]:
+        return [
+            DeviceTypeInfo(
+                type_id="test_partial",
+                display_name="Test Partial",
+                manufacturer="Test",
+                capabilities=[
+                    DeviceCapability.SWITCH,
+                    DeviceCapability.POWER_MONITOR,
+                ],
+            )
+        ]
+
+    async def connect_device(self, device_id: str, config: Dict[str, Any]) -> bool:
+        return True
+
+    async def poll_device(self, device_id: str) -> Dict[str, Any]:
+        return {}
+
+    # Implements Switch but NOT PowerMonitor
+    async def turn_on(self, device_id: str) -> SwitchState:
+        return SwitchState(is_on=True)
+
+    async def turn_off(self, device_id: str) -> SwitchState:
+        return SwitchState(is_on=False)
+
+    async def get_switch_state(self, device_id: str) -> SwitchState:
+        return SwitchState(is_on=True)
+
+
+# --- Tests: CAPABILITY_CONTRACTS completeness ---
+
+def test_all_capabilities_have_contracts():
+    """Every DeviceCapability enum value must have an entry in CAPABILITY_CONTRACTS."""
+    for cap in DeviceCapability:
+        assert cap in CAPABILITY_CONTRACTS, f"Missing contract for {cap.value}"
+
+
+# --- Tests: validate_capability_contracts ---
+
+def test_valid_plugin_passes_validation():
+    plugin = _ValidPowerPlugin()
+    errors = validate_capability_contracts(plugin)
+    assert errors == []
+
+
+def test_missing_protocol_fails_validation():
+    plugin = _MissingProtocolPlugin()
+    errors = validate_capability_contracts(plugin)
+    assert len(errors) == 1
+    assert "power_monitor" in errors[0].lower()
+    assert "PowerMonitor" in errors[0]
+
+
+def test_partial_protocol_fails_validation():
+    plugin = _PartialProtocolPlugin()
+    errors = validate_capability_contracts(plugin)
+    assert len(errors) == 1
+    assert "power_monitor" in errors[0].lower()

--- a/backend/tests/plugins/test_capability_contracts.py
+++ b/backend/tests/plugins/test_capability_contracts.py
@@ -164,3 +164,105 @@ def test_partial_protocol_fails_validation():
     errors = validate_capability_contracts(plugin)
     assert len(errors) == 1
     assert "power_monitor" in errors[0].lower()
+
+
+from app.plugins.manager import PluginManager, PluginLoadError
+
+
+@pytest.fixture()
+def reset_manager():
+    PluginManager.reset_instance()
+    yield
+    PluginManager.reset_instance()
+
+
+def test_plugin_manager_rejects_invalid_smart_device_plugin(tmp_path, reset_manager):
+    """PluginManager.load_plugin() should reject a SmartDevicePlugin that
+    fails capability contract validation."""
+    plugins_dir = tmp_path / "plugins"
+    plugin_dir = plugins_dir / "broken_device"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text('''
+from app.plugins.base import PluginMetadata
+from app.plugins.smart_device.base import SmartDevicePlugin, DeviceTypeInfo
+from app.plugins.smart_device.capabilities import DeviceCapability
+
+class BrokenDevicePlugin(SmartDevicePlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="broken_device",
+            version="1.0.0",
+            display_name="Broken",
+            description="Test",
+            author="Test",
+            category="smart_device",
+        )
+
+    def get_device_types(self):
+        return [DeviceTypeInfo(
+            type_id="broken",
+            display_name="Broken",
+            manufacturer="Test",
+            capabilities=[DeviceCapability.POWER_MONITOR],
+        )]
+
+    async def connect_device(self, device_id, config):
+        return True
+
+    async def poll_device(self, device_id):
+        return {}
+''')
+
+    manager = PluginManager(plugins_dir=plugins_dir)
+    with pytest.raises(PluginLoadError, match="capability contract"):
+        manager.load_plugin("broken_device")
+
+
+def test_plugin_manager_accepts_valid_smart_device_plugin(tmp_path, reset_manager):
+    """PluginManager.load_plugin() should accept a SmartDevicePlugin that
+    satisfies all capability contracts."""
+    plugins_dir = tmp_path / "plugins"
+    plugin_dir = plugins_dir / "good_device"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text('''
+from datetime import datetime, timezone
+from app.plugins.base import PluginMetadata
+from app.plugins.smart_device.base import SmartDevicePlugin, DeviceTypeInfo
+from app.plugins.smart_device.capabilities import (
+    DeviceCapability, PowerReading,
+)
+
+class GoodDevicePlugin(SmartDevicePlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="good_device",
+            version="1.0.0",
+            display_name="Good",
+            description="Test",
+            author="Test",
+            category="smart_device",
+        )
+
+    def get_device_types(self):
+        return [DeviceTypeInfo(
+            type_id="good",
+            display_name="Good",
+            manufacturer="Test",
+            capabilities=[DeviceCapability.POWER_MONITOR],
+        )]
+
+    async def connect_device(self, device_id, config):
+        return True
+
+    async def poll_device(self, device_id):
+        return {"power_monitor": PowerReading(watts=1.0, timestamp=datetime.now(timezone.utc))}
+
+    async def get_power(self, device_id):
+        return PowerReading(watts=1.0, timestamp=datetime.now(timezone.utc))
+''')
+
+    manager = PluginManager(plugins_dir=plugins_dir)
+    plugin = manager.load_plugin("good_device")
+    assert plugin is not None

--- a/backend/tests/test_sleep.py
+++ b/backend/tests/test_sleep.py
@@ -232,6 +232,49 @@ class TestSleepManagerService:
         assert caps.can_suspend is True
         assert len(caps.data_disk_devices) > 0
 
+    @pytest.mark.asyncio
+    async def test_true_suspend_success_resumes_to_awake(self):
+        """Test that successful suspend resumes to AWAKE state."""
+        service = self._create_service()
+        # DevSleepBackend.suspend_system() returns True by default
+        ok = await service.enter_true_suspend("test_suspend", SleepTrigger.MANUAL)
+        assert ok is True
+        assert service._current_state == SleepState.AWAKE
+
+    @pytest.mark.asyncio
+    async def test_true_suspend_failure_reverts_to_soft_sleep(self):
+        """Test that failed suspend reverts to SOFT_SLEEP instead of staying stuck."""
+        service = self._create_service()
+        # Make suspend_system fail
+        service._backend.suspend_system = AsyncMock(return_value=False)
+        ok = await service.enter_true_suspend("test_suspend", SleepTrigger.MANUAL)
+        assert ok is False
+        # Must NOT be stuck on TRUE_SUSPEND
+        assert service._current_state == SleepState.SOFT_SLEEP
+
+    @pytest.mark.asyncio
+    async def test_schedule_can_retrigger_after_failed_suspend(self):
+        """Test that sleep schedule can trigger again after a failed suspend."""
+        service = self._create_service()
+        # First: fail a suspend -> should land in SOFT_SLEEP
+        service._backend.suspend_system = AsyncMock(return_value=False)
+        await service.enter_true_suspend("test", SleepTrigger.SCHEDULE)
+        assert service._current_state == SleepState.SOFT_SLEEP
+
+        # Wake up manually
+        service._soft_sleep_entered_at = datetime.now(timezone.utc)
+        service._paused_services = []
+        service._spun_down_disks = []
+        ok = await service.exit_soft_sleep("manual_wake")
+        assert ok is True
+        assert service._current_state == SleepState.AWAKE
+
+        # Now schedule should be able to trigger again
+        service._backend.suspend_system = AsyncMock(return_value=True)
+        ok = await service.enter_true_suspend("retry", SleepTrigger.SCHEDULE)
+        assert ok is True
+        assert service._current_state == SleepState.AWAKE
+
 
 # ============================================================================
 # Idle Detection Tests

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baluhost-client",
   "private": true,
-  "version": "1.19.0",
+  "version": "1.19.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/superpowers/plans/2026-03-23-capability-contracts.md
+++ b/docs/superpowers/plans/2026-03-23-capability-contracts.md
@@ -1,0 +1,860 @@
+# Capability Contracts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce that smart device plugins declaring capabilities (e.g. `POWER_MONITOR`) actually implement the corresponding protocol and return the correct data model — validated at startup and runtime.
+
+**Architecture:** Add a `CAPABILITY_CONTRACTS` mapping in `capabilities.py` as the single source of truth. A shared `validate_capability_contracts()` utility is called by both `PluginManager.load_plugin()` and `SmartDevicePoller._load_plugins()`. The poller's `_poll_one_device()` validates returned data against the contract before serialization.
+
+**Tech Stack:** Python 3.11+, Pydantic v2, `@runtime_checkable` Protocols, pytest
+
+**Spec:** `docs/superpowers/specs/2026-03-23-capability-contracts-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `backend/app/plugins/smart_device/capabilities.py` | Modify | Add `CAPABILITY_CONTRACTS` dict + `validate_capability_contracts()` utility |
+| `backend/app/plugins/manager.py` | Modify (lines ~188-200) | Call validation after instantiating SmartDevicePlugin |
+| `backend/app/plugins/smart_device/poller.py` | Modify (lines ~220-226, ~333-341) | Call validation in `_load_plugins()` + validate poll data in `_poll_one_device()` |
+| `backend/app/plugins/README.md` | Modify | Add "Capability-Verträge" section |
+| `backend/tests/plugins/test_capability_contracts.py` | Create | All contract validation tests |
+
+---
+
+### Task 1: CAPABILITY_CONTRACTS mapping + validate utility
+
+**Files:**
+- Modify: `backend/app/plugins/smart_device/capabilities.py`
+- Test: `backend/tests/plugins/test_capability_contracts.py`
+
+- [ ] **Step 1: Write the test file with structural + startup validation tests**
+
+```python
+# backend/tests/plugins/test_capability_contracts.py
+"""Tests for capability contract enforcement."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import pytest
+from pydantic import BaseModel
+
+from app.plugins.smart_device.capabilities import (
+    CAPABILITY_CONTRACTS,
+    DeviceCapability,
+    PowerMonitor,
+    PowerReading,
+    Switch,
+    SwitchState,
+    validate_capability_contracts,
+)
+from app.plugins.smart_device.base import DeviceTypeInfo, SmartDevicePlugin
+from app.plugins.base import PluginMetadata
+
+
+# --- Helpers ---
+
+class _ValidPowerPlugin(SmartDevicePlugin):
+    """Plugin that correctly implements POWER_MONITOR."""
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="valid_power",
+            version="1.0.0",
+            display_name="Valid Power",
+            description="Test",
+            author="Test",
+            category="smart_device",
+        )
+
+    def get_device_types(self) -> List[DeviceTypeInfo]:
+        return [
+            DeviceTypeInfo(
+                type_id="test_power",
+                display_name="Test Power",
+                manufacturer="Test",
+                capabilities=[DeviceCapability.POWER_MONITOR],
+            )
+        ]
+
+    async def connect_device(self, device_id: str, config: Dict[str, Any]) -> bool:
+        return True
+
+    async def poll_device(self, device_id: str) -> Dict[str, Any]:
+        return {
+            "power_monitor": PowerReading(
+                watts=42.0, timestamp=datetime.now(timezone.utc)
+            )
+        }
+
+    async def get_power(self, device_id: str) -> PowerReading:
+        return PowerReading(watts=42.0, timestamp=datetime.now(timezone.utc))
+
+
+class _MissingProtocolPlugin(SmartDevicePlugin):
+    """Plugin that declares POWER_MONITOR but does NOT implement get_power()."""
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="missing_protocol",
+            version="1.0.0",
+            display_name="Missing Protocol",
+            description="Test",
+            author="Test",
+            category="smart_device",
+        )
+
+    def get_device_types(self) -> List[DeviceTypeInfo]:
+        return [
+            DeviceTypeInfo(
+                type_id="test_broken",
+                display_name="Test Broken",
+                manufacturer="Test",
+                capabilities=[DeviceCapability.POWER_MONITOR],
+            )
+        ]
+
+    async def connect_device(self, device_id: str, config: Dict[str, Any]) -> bool:
+        return True
+
+    async def poll_device(self, device_id: str) -> Dict[str, Any]:
+        return {}
+
+
+class _PartialProtocolPlugin(SmartDevicePlugin):
+    """Declares SWITCH + POWER_MONITOR but only implements Switch."""
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="partial_protocol",
+            version="1.0.0",
+            display_name="Partial",
+            description="Test",
+            author="Test",
+            category="smart_device",
+        )
+
+    def get_device_types(self) -> List[DeviceTypeInfo]:
+        return [
+            DeviceTypeInfo(
+                type_id="test_partial",
+                display_name="Test Partial",
+                manufacturer="Test",
+                capabilities=[
+                    DeviceCapability.SWITCH,
+                    DeviceCapability.POWER_MONITOR,
+                ],
+            )
+        ]
+
+    async def connect_device(self, device_id: str, config: Dict[str, Any]) -> bool:
+        return True
+
+    async def poll_device(self, device_id: str) -> Dict[str, Any]:
+        return {}
+
+    # Implements Switch but NOT PowerMonitor
+    async def turn_on(self, device_id: str) -> SwitchState:
+        return SwitchState(is_on=True)
+
+    async def turn_off(self, device_id: str) -> SwitchState:
+        return SwitchState(is_on=False)
+
+    async def get_switch_state(self, device_id: str) -> SwitchState:
+        return SwitchState(is_on=True)
+
+
+# --- Tests: CAPABILITY_CONTRACTS completeness ---
+
+def test_all_capabilities_have_contracts():
+    """Every DeviceCapability enum value must have an entry in CAPABILITY_CONTRACTS."""
+    for cap in DeviceCapability:
+        assert cap in CAPABILITY_CONTRACTS, f"Missing contract for {cap.value}"
+
+
+# --- Tests: validate_capability_contracts ---
+
+def test_valid_plugin_passes_validation():
+    plugin = _ValidPowerPlugin()
+    errors = validate_capability_contracts(plugin)
+    assert errors == []
+
+
+def test_missing_protocol_fails_validation():
+    plugin = _MissingProtocolPlugin()
+    errors = validate_capability_contracts(plugin)
+    assert len(errors) == 1
+    assert "power_monitor" in errors[0].lower()
+    assert "PowerMonitor" in errors[0]
+
+
+def test_partial_protocol_fails_validation():
+    plugin = _PartialProtocolPlugin()
+    errors = validate_capability_contracts(plugin)
+    assert len(errors) == 1
+    assert "power_monitor" in errors[0].lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/plugins/test_capability_contracts.py -v`
+Expected: FAIL — `CAPABILITY_CONTRACTS` and `validate_capability_contracts` don't exist yet.
+
+- [ ] **Step 3: Implement CAPABILITY_CONTRACTS + validate_capability_contracts**
+
+First, update the import line at the top of `backend/app/plugins/smart_device/capabilities.py`:
+
+```python
+from typing import Any, Protocol, runtime_checkable, Optional
+```
+
+Then add to end of the file:
+
+```python
+# --- Capability Contracts ---
+# Declaring a capability is a CONTRACT:
+# - Your plugin MUST implement the Protocol (checked at startup)
+# - poll_device() MUST return the DataModel for this capability key (checked at runtime)
+# In return you get: mobile app integration, dashboard panels,
+# energy statistics, and cost calculations — for free.
+
+CAPABILITY_CONTRACTS: dict[DeviceCapability, tuple[type, type[BaseModel]]] = {
+    DeviceCapability.SWITCH: (Switch, SwitchState),
+    DeviceCapability.POWER_MONITOR: (PowerMonitor, PowerReading),
+    DeviceCapability.SENSOR: (Sensor, SensorReading),
+    DeviceCapability.DIMMER: (Dimmer, DimmerState),
+    DeviceCapability.COLOR: (ColorControl, ColorState),
+}
+
+
+def validate_capability_contracts(plugin: object) -> list[str]:
+    """Validate that a plugin implements all protocols for its declared capabilities.
+
+    Iterates over every DeviceTypeInfo returned by the plugin's
+    ``get_device_types()`` and checks that each declared capability's
+    protocol is satisfied (via ``isinstance``).
+
+    Args:
+        plugin: A SmartDevicePlugin instance.
+
+    Returns:
+        List of human-readable error strings (empty means valid).
+    """
+    errors: list[str] = []
+    seen: set[DeviceCapability] = set()
+
+    # Import here to avoid circular import at module level
+    from app.plugins.smart_device.base import SmartDevicePlugin
+
+    if not isinstance(plugin, SmartDevicePlugin):
+        return errors
+
+    for device_type in plugin.get_device_types():
+        for cap in device_type.capabilities:
+            if cap in seen:
+                continue
+            seen.add(cap)
+
+            contract = CAPABILITY_CONTRACTS.get(cap)
+            if contract is None:
+                errors.append(
+                    f"Capability '{cap.value}' has no contract defined in CAPABILITY_CONTRACTS"
+                )
+                continue
+
+            protocol_cls, _data_model = contract
+            if not isinstance(plugin, protocol_cls):
+                errors.append(
+                    f"Capability '{cap.value}' requires {protocol_cls.__name__} protocol "
+                    f"but plugin '{plugin.metadata.name}' does not implement it"
+                )
+
+    return errors
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/plugins/test_capability_contracts.py -v`
+Expected: All 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/plugins/smart_device/capabilities.py backend/tests/plugins/test_capability_contracts.py
+git commit -m "feat(plugins): add CAPABILITY_CONTRACTS mapping and validation utility"
+```
+
+---
+
+### Task 2: Startup validation in PluginManager
+
+**Files:**
+- Modify: `backend/app/plugins/manager.py:188-200`
+- Test: `backend/tests/plugins/test_capability_contracts.py` (append)
+
+- [ ] **Step 1: Write the test**
+
+Append to `backend/tests/plugins/test_capability_contracts.py`:
+
+```python
+from unittest.mock import patch
+from app.plugins.manager import PluginManager, PluginLoadError
+
+
+@pytest.fixture(autouse=True)
+def reset_manager():
+    PluginManager.reset_instance()
+    yield
+    PluginManager.reset_instance()
+
+
+def test_plugin_manager_rejects_invalid_smart_device_plugin(tmp_path):
+    """PluginManager.load_plugin() should reject a SmartDevicePlugin that
+    fails capability contract validation."""
+    # Create a plugin directory with a broken smart device plugin
+    plugins_dir = tmp_path / "plugins"
+    plugin_dir = plugins_dir / "broken_device"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text('''
+from app.plugins.base import PluginMetadata
+from app.plugins.smart_device.base import SmartDevicePlugin, DeviceTypeInfo
+from app.plugins.smart_device.capabilities import DeviceCapability
+
+class BrokenDevicePlugin(SmartDevicePlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="broken_device",
+            version="1.0.0",
+            display_name="Broken",
+            description="Test",
+            author="Test",
+            category="smart_device",
+        )
+
+    def get_device_types(self):
+        return [DeviceTypeInfo(
+            type_id="broken",
+            display_name="Broken",
+            manufacturer="Test",
+            capabilities=[DeviceCapability.POWER_MONITOR],
+        )]
+
+    async def connect_device(self, device_id, config):
+        return True
+
+    async def poll_device(self, device_id):
+        return {}
+''')
+
+    manager = PluginManager(plugins_dir=plugins_dir)
+    with pytest.raises(PluginLoadError, match="capability contract"):
+        manager.load_plugin("broken_device")
+
+
+def test_plugin_manager_accepts_valid_smart_device_plugin(tmp_path):
+    """PluginManager.load_plugin() should accept a SmartDevicePlugin that
+    satisfies all capability contracts."""
+    plugins_dir = tmp_path / "plugins"
+    plugin_dir = plugins_dir / "good_device"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text('''
+from datetime import datetime, timezone
+from app.plugins.base import PluginMetadata
+from app.plugins.smart_device.base import SmartDevicePlugin, DeviceTypeInfo
+from app.plugins.smart_device.capabilities import (
+    DeviceCapability, PowerReading,
+)
+
+class GoodDevicePlugin(SmartDevicePlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="good_device",
+            version="1.0.0",
+            display_name="Good",
+            description="Test",
+            author="Test",
+            category="smart_device",
+        )
+
+    def get_device_types(self):
+        return [DeviceTypeInfo(
+            type_id="good",
+            display_name="Good",
+            manufacturer="Test",
+            capabilities=[DeviceCapability.POWER_MONITOR],
+        )]
+
+    async def connect_device(self, device_id, config):
+        return True
+
+    async def poll_device(self, device_id):
+        return {"power_monitor": PowerReading(watts=1.0, timestamp=datetime.now(timezone.utc))}
+
+    async def get_power(self, device_id):
+        return PowerReading(watts=1.0, timestamp=datetime.now(timezone.utc))
+''')
+
+    manager = PluginManager(plugins_dir=plugins_dir)
+    plugin = manager.load_plugin("good_device")
+    assert plugin is not None
+```
+
+- [ ] **Step 2: Run tests to verify the new tests fail**
+
+Run: `cd backend && python -m pytest tests/plugins/test_capability_contracts.py::test_plugin_manager_rejects_invalid_smart_device_plugin -v`
+Expected: FAIL — load_plugin does not check contracts yet (plugin loads without error).
+
+- [ ] **Step 3: Add contract check to PluginManager.load_plugin()**
+
+In `backend/app/plugins/manager.py`, after line 197 (`self._plugins[name] = plugin`) and before the `logger.info` on line 198, insert:
+
+```python
+            # Validate capability contracts for smart device plugins
+            from app.plugins.smart_device.base import SmartDevicePlugin
+            if isinstance(plugin, SmartDevicePlugin):
+                from app.plugins.smart_device.capabilities import validate_capability_contracts
+                contract_errors = validate_capability_contracts(plugin)
+                if contract_errors:
+                    del self._plugins[name]
+                    errors_str = "; ".join(contract_errors)
+                    raise PluginLoadError(
+                        f"Plugin '{name}' failed capability contract validation: {errors_str}"
+                    )
+```
+
+- [ ] **Step 4: Run all contract tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/plugins/test_capability_contracts.py -v`
+Expected: All 7 tests PASS.
+
+- [ ] **Step 5: Run existing plugin tests for regression**
+
+Run: `cd backend && python -m pytest tests/plugins/ -v`
+Expected: All existing tests still PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/plugins/manager.py backend/tests/plugins/test_capability_contracts.py
+git commit -m "feat(plugins): enforce capability contracts at startup in PluginManager"
+```
+
+---
+
+### Task 3: Startup validation in SmartDevicePoller
+
+**Files:**
+- Modify: `backend/app/plugins/smart_device/poller.py:220-226`
+- Test: `backend/tests/plugins/test_capability_contracts.py` (append)
+
+- [ ] **Step 1: Write the test**
+
+Append to `backend/tests/plugins/test_capability_contracts.py`:
+
+```python
+from app.plugins.smart_device.poller import SmartDevicePoller
+
+
+@pytest.mark.asyncio
+async def test_poller_skips_plugin_failing_contracts(tmp_path, caplog):
+    """SmartDevicePoller._load_plugins() should skip plugins that fail
+    capability contract validation and log a warning."""
+    plugins_dir = tmp_path / "plugins"
+    plugin_dir = plugins_dir / "broken_poller_device"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text('''
+from app.plugins.base import PluginMetadata
+from app.plugins.smart_device.base import SmartDevicePlugin, DeviceTypeInfo
+from app.plugins.smart_device.capabilities import DeviceCapability
+
+class BrokenPollerPlugin(SmartDevicePlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="broken_poller_device",
+            version="1.0.0",
+            display_name="Broken Poller",
+            description="Test",
+            author="Test",
+            category="smart_device",
+        )
+
+    def get_device_types(self):
+        return [DeviceTypeInfo(
+            type_id="broken",
+            display_name="Broken",
+            manufacturer="Test",
+            capabilities=[DeviceCapability.POWER_MONITOR],
+        )]
+
+    async def connect_device(self, device_id, config):
+        return True
+
+    async def poll_device(self, device_id):
+        return {}
+''')
+
+    # We can't easily test _load_plugins() end-to-end (needs DB),
+    # so we test the validation integration directly by simulating
+    # what _load_plugins does: instantiate + validate
+    import importlib.util, sys
+    module_name = "test_broken_poller_plugin"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        plugin_dir / "__init__.py",
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    plugin = module.BrokenPollerPlugin()
+
+    from app.plugins.smart_device.capabilities import validate_capability_contracts
+    errors = validate_capability_contracts(plugin)
+    assert len(errors) == 1
+    assert "power_monitor" in errors[0].lower()
+
+    # Cleanup
+    del sys.modules[module_name]
+```
+
+- [ ] **Step 2: Run to verify it passes (validates the utility works with dynamically loaded plugins)**
+
+Run: `cd backend && python -m pytest tests/plugins/test_capability_contracts.py::test_poller_skips_plugin_failing_contracts -v`
+Expected: PASS (the utility already works; this test confirms it works with dynamically imported plugins).
+
+- [ ] **Step 3: Add contract check to SmartDevicePoller._load_plugins()**
+
+In `backend/app/plugins/smart_device/poller.py`, after line 220 (`plugin = plugin_cls()`) and before the category check on line 221, insert:
+
+```python
+                # Validate capability contracts
+                from app.plugins.smart_device.capabilities import validate_capability_contracts
+                contract_errors = validate_capability_contracts(plugin)
+                if contract_errors:
+                    errors_str = "; ".join(contract_errors)
+                    logger.warning(
+                        "SmartDevicePoller: plugin '%s' failed capability contract "
+                        "validation: %s — skipping",
+                        name, errors_str,
+                    )
+                    continue
+```
+
+- [ ] **Step 4: Run all contract tests**
+
+Run: `cd backend && python -m pytest tests/plugins/test_capability_contracts.py -v`
+Expected: All 8 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/plugins/smart_device/poller.py backend/tests/plugins/test_capability_contracts.py
+git commit -m "feat(plugins): enforce capability contracts at startup in SmartDevicePoller"
+```
+
+---
+
+### Task 4: Runtime validation in poller
+
+**Files:**
+- Modify: `backend/app/plugins/smart_device/poller.py:333-341`
+- Test: `backend/tests/plugins/test_capability_contracts.py` (append)
+
+- [ ] **Step 1: Write the tests**
+
+Append to `backend/tests/plugins/test_capability_contracts.py`:
+
+```python
+from app.plugins.smart_device.capabilities import validate_poll_data
+
+
+def test_validate_poll_data_valid_power_reading():
+    """Valid PowerReading passes validation."""
+    declared = [DeviceCapability.POWER_MONITOR]
+    data = {
+        "power_monitor": PowerReading(
+            watts=42.0, timestamp=datetime.now(timezone.utc)
+        )
+    }
+    validated, warnings = validate_poll_data(data, declared)
+    assert "power_monitor" in validated
+    assert warnings == []
+
+
+def test_validate_poll_data_valid_dict():
+    """A raw dict that matches PowerReading schema passes validation."""
+    declared = [DeviceCapability.POWER_MONITOR]
+    data = {
+        "power_monitor": {
+            "watts": 42.0,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    }
+    validated, warnings = validate_poll_data(data, declared)
+    assert "power_monitor" in validated
+    assert warnings == []
+
+
+def test_validate_poll_data_invalid_dict():
+    """A dict missing required field 'watts' is rejected."""
+    declared = [DeviceCapability.POWER_MONITOR]
+    data = {
+        "power_monitor": {"voltage": 230.0}  # missing 'watts' and 'timestamp'
+    }
+    validated, warnings = validate_poll_data(data, declared)
+    assert "power_monitor" not in validated
+    assert len(warnings) == 1
+    assert "power_monitor" in warnings[0].lower()
+
+
+def test_validate_poll_data_empty_dict():
+    """Empty poll result is valid — no errors."""
+    declared = [DeviceCapability.POWER_MONITOR]
+    validated, warnings = validate_poll_data({}, declared)
+    assert validated == {}
+    assert warnings == []
+
+
+def test_validate_poll_data_partial_capabilities():
+    """Returning only some declared capabilities is valid."""
+    declared = [DeviceCapability.SWITCH, DeviceCapability.POWER_MONITOR]
+    data = {
+        "switch": SwitchState(is_on=True),
+    }
+    validated, warnings = validate_poll_data(data, declared)
+    assert "switch" in validated
+    assert warnings == []
+
+
+def test_validate_poll_data_extra_key_warned():
+    """Keys not in declared capabilities are dropped with a warning."""
+    declared = [DeviceCapability.SWITCH]
+    data = {
+        "switch": SwitchState(is_on=True),
+        "power_monitor": PowerReading(
+            watts=42.0, timestamp=datetime.now(timezone.utc)
+        ),
+    }
+    validated, warnings = validate_poll_data(data, declared)
+    assert "switch" in validated
+    assert "power_monitor" not in validated
+    assert len(warnings) == 1
+    assert "undeclared" in warnings[0].lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/plugins/test_capability_contracts.py::test_validate_poll_data_valid_power_reading -v`
+Expected: FAIL — `validate_poll_data` does not exist yet.
+
+- [ ] **Step 3: Implement validate_poll_data()**
+
+Add to `backend/app/plugins/smart_device/capabilities.py`:
+
+```python
+def validate_poll_data(
+    data: dict[str, Any],
+    declared_capabilities: list[DeviceCapability],
+) -> tuple[dict[str, Any], list[str]]:
+    """Validate poll_device() output against declared capability contracts.
+
+    Args:
+        data: The dict returned by poll_device() or poll_device_mock().
+        declared_capabilities: The device's declared capabilities list.
+
+    Returns:
+        Tuple of (validated_data, warnings).
+        validated_data contains only entries that passed validation.
+        warnings contains human-readable messages for issues found.
+    """
+    validated: dict[str, Any] = {}
+    warnings: list[str] = []
+    declared_values = {cap.value for cap in declared_capabilities}
+
+    for key, value in data.items():
+        # Check if key corresponds to a declared capability
+        if key not in declared_values:
+            warnings.append(
+                f"Undeclared capability key '{key}' in poll result — ignored"
+            )
+            continue
+
+        # Find the matching capability and its contract
+        try:
+            cap = DeviceCapability(key)
+        except ValueError:
+            warnings.append(f"Unknown capability key '{key}' — ignored")
+            continue
+
+        contract = CAPABILITY_CONTRACTS.get(cap)
+        if contract is None:
+            # No contract defined — pass through
+            validated[key] = value
+            continue
+
+        _protocol_cls, data_model = contract
+
+        # Already the right Pydantic model?
+        if isinstance(value, data_model):
+            validated[key] = value
+            continue
+
+        # Try to validate as dict
+        if isinstance(value, dict):
+            try:
+                data_model.model_validate(value)
+                validated[key] = value
+            except Exception:
+                warnings.append(
+                    f"Capability '{key}' returned invalid data "
+                    f"(expected {data_model.__name__})"
+                )
+            continue
+
+        warnings.append(
+            f"Capability '{key}' returned unexpected type {type(value).__name__} "
+            f"(expected {data_model.__name__} or dict)"
+        )
+
+    return validated, warnings
+```
+
+- [ ] **Step 4: Run runtime validation tests**
+
+Run: `cd backend && python -m pytest tests/plugins/test_capability_contracts.py -k "validate_poll_data" -v`
+Expected: All 6 new tests PASS.
+
+- [ ] **Step 5: Integrate into poller's _poll_one_device()**
+
+In `backend/app/plugins/smart_device/poller.py`, in `_poll_one_device()`, replace lines 333-341 (the serialization block) with:
+
+```python
+            # Validate poll data against capability contracts
+            from app.plugins.smart_device.capabilities import (
+                DeviceCapability,
+                validate_poll_data,
+            )
+            declared_caps = []
+            for c in device.capabilities:
+                try:
+                    declared_caps.append(DeviceCapability(c))
+                except ValueError:
+                    pass
+            validated_state, poll_warnings = validate_poll_data(new_state, declared_caps)
+            for warning in poll_warnings:
+                logger.warning(
+                    "SmartDevicePoller: plugin '%s' device %d ('%s'): %s",
+                    plugin.metadata.name, device_id, device.name, warning,
+                )
+
+            # Serialize any Pydantic models in the validated state dict
+            serialized: Dict[str, Any] = {}
+            for cap_key, cap_value in validated_state.items():
+                if hasattr(cap_value, "model_dump"):
+                    serialized[cap_key] = cap_value.model_dump(mode="json")
+                else:
+                    serialized[cap_key] = cap_value
+
+            self._process_state(device, serialized)
+```
+
+- [ ] **Step 6: Run all contract tests + existing plugin tests**
+
+Run: `cd backend && python -m pytest tests/plugins/test_capability_contracts.py tests/plugins/ -v`
+Expected: All tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/plugins/smart_device/capabilities.py backend/app/plugins/smart_device/poller.py backend/tests/plugins/test_capability_contracts.py
+git commit -m "feat(plugins): add runtime validation of poll data against capability contracts"
+```
+
+---
+
+### Task 5: Update plugin documentation
+
+**Files:**
+- Modify: `backend/app/plugins/README.md`
+
+- [ ] **Step 1: Add "Capability-Verträge" section**
+
+Insert after the existing "Verfügbare Capabilities:" table (around line 318) in `backend/app/plugins/README.md`:
+
+```markdown
+### Capability-Verträge
+
+Capabilities sind **Verträge**, nicht nur Labels. Wenn ein Plugin eine Capability deklariert, muss es:
+
+1. **Das zugehörige Protocol implementieren** — geprüft beim Plugin-Start (sowohl im Web-Worker als auch im Monitoring-Worker)
+2. **Das zugehörige Datenmodell von `poll_device()` zurückgeben** — geprüft bei jedem Poll-Zyklus zur Laufzeit
+
+Dafür bekommt das Plugin automatisch: Mobile-App-Integration (BaluApp), Dashboard-Panel, Energie-Statistiken und Kostenberechnung.
+
+| Capability | Protocol | Datenmodell | `poll_device()` Key |
+|------------|----------|-------------|---------------------|
+| `switch` | `Switch` | `SwitchState` | `"switch"` |
+| `power_monitor` | `PowerMonitor` | `PowerReading` | `"power_monitor"` |
+| `sensor` | `Sensor` | `SensorReading` | `"sensor"` |
+| `dimmer` | `Dimmer` | `DimmerState` | `"dimmer"` |
+| `color` | `ColorControl` | `ColorState` | `"color"` |
+
+**Wichtig:** Stromverbrauchsdaten (und alle anderen Capability-Daten) müssen über die zentrale Pipeline fließen:
+
+```
+poll_device() → Poller → SHM → Energy-Service → Mobile API
+```
+
+Plugin-eigene API-Routen dürfen **keine** Capability-Daten in einem anderen Format exponieren. Die zentrale Pipeline ist der einzige Weg, damit die Mobile App und das Dashboard konsistente Daten erhalten.
+
+**Validierungs-Verhalten:**
+
+- **Startup:** Plugin wird nicht geladen, wenn ein deklariertes Protocol nicht implementiert ist
+- **Runtime:** Ungültige Daten werden verworfen (Warning im Log), gültige Daten fließen normal weiter
+- **Leere Rückgabe:** `poll_device()` darf `{}` zurückgeben (keine Daten in diesem Zyklus)
+- **Partielle Rückgabe:** Nicht alle deklarierten Capabilities müssen in jedem Poll enthalten sein
+- **Extra Keys:** Keys die nicht in den deklarierten Capabilities sind werden ignoriert (Warning im Log)
+```
+
+- [ ] **Step 2: Verify README renders correctly (visual check)**
+
+Open `backend/app/plugins/README.md` and verify the new section is well-placed and the table renders.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/plugins/README.md
+git commit -m "docs(plugins): add capability contracts documentation"
+```
+
+---
+
+### Task 6: Full regression test
+
+- [ ] **Step 1: Run all plugin tests**
+
+Run: `cd backend && python -m pytest tests/plugins/ -v`
+Expected: All tests PASS.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `cd backend && python -m pytest --timeout=30 -x -q`
+Expected: All tests PASS, no regressions.
+
+- [ ] **Step 3: Verify Tapo plugin still loads correctly**
+
+Run: `cd backend && python -c "from app.plugins.installed.tapo_smart_plug import TapoSmartPlugPlugin; from app.plugins.smart_device.capabilities import validate_capability_contracts; p = TapoSmartPlugPlugin(); errors = validate_capability_contracts(p); print('Errors:', errors); assert errors == [], errors"`
+Expected: `Errors: []` — Tapo plugin satisfies all contracts.
+
+- [ ] **Step 4: Final commit if any fixups needed, otherwise done**

--- a/docs/superpowers/plans/2026-03-23-release-downgrade.md
+++ b/docs/superpowers/plans/2026-03-23-release-downgrade.md
@@ -1,0 +1,1727 @@
+# Release Downgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow admins to downgrade BaluHost to any previous release with mandatory DB backup, Alembic downgrade, and fallback to backup restore.
+
+**Architecture:** New `POST /api/updates/downgrade` endpoint with dedicated service method. Reuses existing `UpdateHistory` + async progress infrastructure. Two backends: `DevUpdateBackend` (simulated) and `ProdUpdateBackend` (git + shell script). Frontend adds downgrade buttons to release list with two-step inline confirmation.
+
+**Tech Stack:** Python/FastAPI, SQLAlchemy, Alembic, React/TypeScript, Tailwind CSS
+
+**Spec:** `docs/superpowers/specs/2026-03-23-release-downgrade-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `backend/app/models/update_history.py` | Modify | Add `DOWNGRADE` to `UpdateChannel` enum |
+| `backend/app/schemas/update.py` | Modify | Add `DowngradeRequest`, extend `UpdateChannelEnum`, add `commit` to `ReleaseInfo` |
+| `backend/app/services/update/backend.py` | Modify | Add abstract `resolve_alembic_revision()`, `run_alembic_downgrade()` |
+| `backend/app/services/update/dev_backend.py` | Modify | Mock downgrade methods, update `get_all_releases()` for full hash |
+| `backend/app/services/update/prod_backend.py` | Modify | Implement `resolve_alembic_revision()`, `run_alembic_downgrade()`, update `get_all_releases()`, extend `launch_update_script()` |
+| `backend/app/services/update/service.py` | Modify | Add `downgrade()`, `_run_dev_downgrade()`, `_run_alembic_downgrade()` |
+| `backend/app/api/routes/updates.py` | Modify | Add `POST /downgrade` endpoint |
+| `deploy/update/run-update.sh` | Modify | Add `--downgrade` + `--alembic-rev` flags |
+| `client/src/api/updates.ts` | Modify | Add `DowngradeRequest`, `startDowngrade()`, `commit` to `ReleaseInfo` |
+| `client/src/components/updates/UpdateHistoryTab.tsx` | Modify | Downgrade button + two-step inline confirmation |
+| `client/src/components/updates/UpdateOverviewTab.tsx` | Modify | Handle downgrade channel badge in progress display |
+| `client/src/pages/UpdatePage.tsx` | Modify | Pass `currentVersion` and `onDowngradeStarted` props |
+| `client/src/i18n/locales/en/updates.json` | Modify | Downgrade translation keys |
+| `client/src/i18n/locales/de/updates.json` | Modify | German downgrade translations |
+| `backend/tests/services/test_update_service.py` | Modify | Downgrade unit + integration tests (consolidates ProdBackend downgrade tests from spec's `test_prod_update_backend.py` into existing test file) |
+| `backend/tests/api/test_updates_routes.py` | Create | Downgrade API endpoint tests (auth, rate-limit, audit) |
+
+---
+
+### Task 1: Extend ORM Enum and Schema Types
+
+**Files:**
+- Modify: `backend/app/models/update_history.py:29-33`
+- Modify: `backend/app/schemas/update.py:11-16`
+- Modify: `backend/app/schemas/update.py:415-422`
+- Test: `backend/tests/services/test_update_service.py`
+
+- [ ] **Step 1: Write failing test for UpdateChannel.DOWNGRADE**
+
+In `backend/tests/services/test_update_service.py`, add at the end of existing imports and after existing test classes:
+
+```python
+class TestDowngradeEnums:
+    """Tests for downgrade-related enum extensions."""
+
+    def test_update_channel_has_downgrade(self):
+        """UpdateChannel enum should include DOWNGRADE."""
+        assert hasattr(UpdateChannel, "DOWNGRADE")
+        assert UpdateChannel.DOWNGRADE.value == "downgrade"
+
+    def test_downgrade_channel_fits_column(self):
+        """'downgrade' string must fit in String(20) column."""
+        assert len("downgrade") <= 20
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/services/test_update_service.py::TestDowngradeEnums -v`
+Expected: FAIL — `UpdateChannel` has no `DOWNGRADE` attribute
+
+- [ ] **Step 3: Add DOWNGRADE to UpdateChannel enum**
+
+In `backend/app/models/update_history.py:29-33`, add the new member:
+
+```python
+class UpdateChannel(str, enum.Enum):
+    """Update channel for version selection."""
+    STABLE = "stable"
+    BETA = "beta"
+    DEVELOPMENT = "development"
+    DOWNGRADE = "downgrade"
+```
+
+- [ ] **Step 4: Extend UpdateChannelEnum Literal in schemas**
+
+In `backend/app/schemas/update.py:11-16`, update the Literal:
+
+```python
+UpdateChannelEnum = Literal[
+    "stable", "unstable", "development", "downgrade"
+]
+```
+
+- [ ] **Step 5: Add DowngradeRequest schema**
+
+In `backend/app/schemas/update.py`, after `RollbackResponse` (around line 221), add:
+
+```python
+class DowngradeRequest(BaseModel):
+    """Request to downgrade to a previous release."""
+
+    target_tag: str = Field(
+        description="Git tag to downgrade to, e.g. 'v1.17.0'",
+        pattern=r"^v\d+\.\d+\.\d+(-[\w.]+)?$",
+    )
+    target_commit: str = Field(
+        description="Expected full commit hash for validation",
+        min_length=7,
+        max_length=40,
+    )
+    skip_backup: bool = Field(
+        default=False,
+        description="Skip file/config backup (DB backup is always created)",
+    )
+    force: bool = Field(
+        default=False,
+        description="Ignore non-critical blockers",
+    )
+```
+
+- [ ] **Step 6: Add `commit` field to ReleaseInfo**
+
+In `backend/app/schemas/update.py`, find `ReleaseInfo` (around line 415) and add:
+
+```python
+class ReleaseInfo(BaseModel):
+    """Information about a single release (git tag)."""
+
+    tag: str = Field(description="Git tag (e.g., 'v1.9.0')")
+    version: str = Field(description="Version string without 'v' prefix")
+    date: Optional[str] = Field(default=None, description="Release date (ISO 8601)")
+    is_prerelease: bool = Field(default=False, description="True if alpha/beta/rc/etc.")
+    commit_short: str = Field(description="Short commit hash (7 chars)")
+    commit: str = Field(default="", description="Full commit hash for downgrade validation")
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/test_update_service.py::TestDowngradeEnums -v`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/app/models/update_history.py backend/app/schemas/update.py backend/tests/services/test_update_service.py
+git commit -m "feat(updates): add downgrade enum, schema, and ReleaseInfo.commit field"
+```
+
+---
+
+### Task 2: Extend UpdateBackend Abstract Methods
+
+**Files:**
+- Modify: `backend/app/services/update/backend.py:74-97`
+
+- [ ] **Step 1: Add abstract methods to UpdateBackend**
+
+In `backend/app/services/update/backend.py`, after the existing `rollback` method (line 77) and before `get_release_notes`, add:
+
+```python
+    async def resolve_alembic_revision(self, commit: str) -> Optional[str]:
+        """Determine the Alembic head revision at a given git commit.
+
+        Returns the revision string or None if it cannot be determined.
+        Default implementation returns None (subclasses override).
+        """
+        return None
+
+    async def run_alembic_downgrade(self, target_revision: str) -> tuple[bool, Optional[str]]:
+        """Run alembic downgrade to a target revision. Returns (success, error_message).
+
+        Default implementation simulates success (overridden by prod backend).
+        """
+        return True, None
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/app/services/update/backend.py
+git commit -m "feat(updates): add resolve_alembic_revision and run_alembic_downgrade to UpdateBackend"
+```
+
+---
+
+### Task 3: Implement DevUpdateBackend Downgrade Support
+
+**Files:**
+- Modify: `backend/app/services/update/dev_backend.py:223-313`
+- Test: `backend/tests/services/test_update_service.py`
+
+- [ ] **Step 1: Write failing test for DevBackend downgrade methods**
+
+In `backend/tests/services/test_update_service.py`, add:
+
+```python
+class TestDevBackendDowngrade:
+    """Tests for DevUpdateBackend downgrade support."""
+
+    @pytest.fixture
+    def backend(self):
+        return DevUpdateBackend()
+
+    @pytest.mark.asyncio
+    async def test_resolve_alembic_revision_returns_mock(self, backend):
+        """Dev backend returns a mock revision."""
+        rev = await backend.resolve_alembic_revision("abc1234")
+        assert rev is not None
+        assert isinstance(rev, str)
+
+    @pytest.mark.asyncio
+    async def test_run_alembic_downgrade_succeeds(self, backend):
+        """Dev backend simulates successful downgrade."""
+        success, error = await backend.run_alembic_downgrade("mock_rev")
+        assert success is True
+        assert error is None
+
+    @pytest.mark.asyncio
+    async def test_get_all_releases_includes_full_commit(self, backend):
+        """Releases should include full commit hash."""
+        result = await backend.get_all_releases()
+        assert result.total > 0
+        for release in result.releases:
+            assert len(release.commit) >= 20, f"Expected full hash, got: {release.commit}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/services/test_update_service.py::TestDevBackendDowngrade -v`
+Expected: FAIL — methods don't exist or return wrong values
+
+- [ ] **Step 3: Add downgrade methods to DevUpdateBackend**
+
+In `backend/app/services/update/dev_backend.py`, after the existing `rollback` method (line 227), add:
+
+```python
+    async def resolve_alembic_revision(self, commit: str) -> Optional[str]:
+        """Return mock Alembic revision for dev mode."""
+        logger.info(f"[DEV] Resolving alembic revision for {commit[:8]}")
+        return "mock_downgrade_rev_001"
+
+    async def run_alembic_downgrade(self, target_revision: str) -> tuple[bool, Optional[str]]:
+        """Simulate alembic downgrade."""
+        logger.info(f"[DEV] Simulating alembic downgrade to {target_revision}")
+        await asyncio.sleep(0.5)
+        return True, None
+```
+
+- [ ] **Step 4: Update get_all_releases to include full commit hash**
+
+In `backend/app/services/update/dev_backend.py`, update the `get_all_releases` method. Each `ReleaseInfo` needs a `commit` field with a full 40-char mock hash. Update the loop:
+
+```python
+    async def get_all_releases(self) -> ReleaseListResponse:
+        """Return mock releases relative to the current version."""
+        major = self._simulated_version[0]
+        minor = self._simulated_version[1]
+        commit_shorts = ["abc1234", "def5678", "ghi9012", "jkl3456", "mno7890", "pqr1234", "stu5678", "vwx9012", "yza3456", "bcd7890"]
+        commit_fulls = [f"{s}{'0' * 33}" for s in commit_shorts]  # Pad to 40 chars
+        releases: list[ReleaseInfo] = []
+        idx = 0
+        for m in range(minor, max(minor - 5, 0), -1):
+            if idx >= len(commit_shorts):
+                break
+            ver_str = f"{major}.{m}.0"
+            releases.append(ReleaseInfo(
+                tag=f"v{ver_str}",
+                version=ver_str,
+                date=f"2026-02-{22 - idx:02d}T12:00:00Z",
+                is_prerelease=False,
+                commit_short=commit_shorts[idx],
+                commit=commit_fulls[idx],
+            ))
+            idx += 1
+        if idx < len(commit_shorts):
+            releases.append(ReleaseInfo(
+                tag="v1.0.0",
+                version="1.0.0",
+                date="2026-01-15T08:00:00Z",
+                is_prerelease=False,
+                commit_short=commit_shorts[idx],
+                commit=commit_fulls[idx],
+            ))
+        return ReleaseListResponse(releases=releases, total=len(releases))
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/test_update_service.py::TestDevBackendDowngrade -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/update/dev_backend.py backend/tests/services/test_update_service.py
+git commit -m "feat(updates): add downgrade support to DevUpdateBackend"
+```
+
+---
+
+### Task 4: Implement ProdUpdateBackend Downgrade Support
+
+**Files:**
+- Modify: `backend/app/services/update/prod_backend.py:287-295` (rollback area)
+- Modify: `backend/app/services/update/prod_backend.py:657-688` (get_all_releases)
+- Modify: `backend/app/services/update/prod_backend.py:297-354` (launch_update_script)
+- Test: `backend/tests/services/test_update_service.py`
+
+- [ ] **Step 1: Write failing test for ProdBackend.resolve_alembic_revision**
+
+In `backend/tests/services/test_update_service.py`, add:
+
+```python
+class TestProdBackendDowngrade:
+    """Tests for ProdUpdateBackend downgrade with mocked git."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_alembic_revision_parses_revision(self):
+        """Should extract revision from git show output."""
+        from app.services.update.prod_backend import ProdUpdateBackend
+
+        backend = ProdUpdateBackend()
+
+        # Mock _run_git to simulate listing migration files and showing content
+        call_count = 0
+        def mock_run_git(*args):
+            nonlocal call_count
+            cmd = args
+            if cmd[0] == "ls-tree" and "alembic/versions" in cmd[-1]:
+                return True, "backend/alembic/versions/001_initial.py\nbackend/alembic/versions/002_add_users.py", ""
+            if cmd[0] == "show" and "001_initial.py" in cmd[1]:
+                return True, 'revision = "001_abc"\ndown_revision = None', ""
+            if cmd[0] == "show" and "002_add_users.py" in cmd[1]:
+                return True, 'revision = "002_def"\ndown_revision = "001_abc"', ""
+            return False, "", "unknown command"
+
+        backend._run_git = mock_run_git
+        rev = await backend.resolve_alembic_revision("abc1234567890")
+        assert rev == "002_def"  # Head of the chain
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/services/test_update_service.py::TestProdBackendDowngrade -v`
+Expected: FAIL — method does not exist
+
+- [ ] **Step 3: Implement resolve_alembic_revision in ProdUpdateBackend**
+
+In `backend/app/services/update/prod_backend.py`, after the `rollback` method (around line 295), add:
+
+```python
+    async def resolve_alembic_revision(self, commit: str) -> Optional[str]:
+        """Determine the Alembic head revision at a given git commit.
+
+        Reads migration files from the target commit via git show,
+        extracts revision/down_revision, and walks the chain to find the head.
+        Note: uses module-level `re` import already present in prod_backend.py.
+        """
+
+        # List migration files at target commit
+        success, output, _ = self._run_git(
+            "ls-tree", "-r", "--name-only", commit, "backend/alembic/versions/"
+        )
+        if not success or not output.strip():
+            logger.warning(f"No alembic versions found at commit {commit[:8]}")
+            return None
+
+        files = [f.strip() for f in output.strip().split("\n") if f.strip().endswith(".py")]
+
+        # Extract revision and down_revision from each file
+        # Matches: revision = "abc123" (quoted string)
+        rev_pattern = re.compile(r"^revision\s*=\s*['\"]([^'\"]+)['\"]", re.MULTILINE)
+        # Matches: down_revision = "abc123" (single quoted string)
+        down_single_pattern = re.compile(r"^down_revision\s*=\s*['\"]([^'\"]+)['\"]", re.MULTILINE)
+        # Matches: down_revision = ("rev1", "rev2") (tuple for merge migrations)
+        down_tuple_pattern = re.compile(r"^down_revision\s*=\s*\(([^)]+)\)", re.MULTILINE)
+
+        revisions: dict[str, Optional[str]] = {}  # revision -> down_revision (first parent)
+
+        for filepath in files:
+            success, content, _ = self._run_git("show", f"{commit}:{filepath}")
+            if not success:
+                continue
+
+            rev_match = rev_pattern.search(content)
+            if not rev_match:
+                continue
+
+            revision = rev_match.group(1)
+
+            # Try single down_revision first, then tuple (merge migrations)
+            down_match = down_single_pattern.search(content)
+            if down_match:
+                down_revision = down_match.group(1)
+            else:
+                tuple_match = down_tuple_pattern.search(content)
+                if tuple_match:
+                    # Merge migration: extract first parent from tuple
+                    parts = [p.strip().strip("'\"") for p in tuple_match.group(1).split(",")]
+                    down_revision = parts[0] if parts else None
+                else:
+                    # down_revision = None (initial migration)
+                    down_revision = None
+
+            revisions[revision] = down_revision
+
+        if not revisions:
+            logger.warning(f"Could not parse any revisions at commit {commit[:8]}")
+            return None
+
+        # Find head: a revision that is NOT referenced as any other revision's down_revision
+        all_down_revs = set(v for v in revisions.values() if v is not None)
+        heads = [r for r in revisions if r not in all_down_revs]
+
+        if len(heads) == 1:
+            return heads[0]
+        elif len(heads) > 1:
+            # Multiple heads (merge needed) — return first one, log warning
+            logger.warning(f"Multiple alembic heads found at {commit[:8]}: {heads}")
+            return heads[0]
+        else:
+            # Circular reference or no heads — shouldn't happen
+            logger.error(f"Could not determine alembic head at {commit[:8]}")
+            return None
+
+    async def run_alembic_downgrade(self, target_revision: str) -> tuple[bool, Optional[str]]:
+        """Run alembic downgrade to a target revision."""
+        try:
+            result = subprocess.run(
+                [
+                    str(self.backend_path / ".venv" / "bin" / "alembic"),
+                    "-c", str(self.backend_path / "alembic.ini"),
+                    "downgrade", target_revision,
+                ],
+                cwd=self.backend_path,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if result.returncode != 0:
+                return False, f"Alembic downgrade failed: {result.stderr[:500]}"
+            return True, None
+        except subprocess.TimeoutExpired:
+            return False, "Alembic downgrade timed out"
+        except Exception as e:
+            return False, str(e)
+```
+
+- [ ] **Step 4: Update get_all_releases to include full commit hash**
+
+In `backend/app/services/update/prod_backend.py`, find the `get_all_releases` method (around line 657). Change the `rev-parse --short=7` to a full `rev-parse`, and pass both to `ReleaseInfo`:
+
+```python
+    async def get_all_releases(self) -> ReleaseListResponse:
+        """Get list of all releases from git tags."""
+        success, tags_output, _ = self._run_git("tag", "-l", "--sort=-version:refname")
+        if not success or not tags_output.strip():
+            return ReleaseListResponse(releases=[], total=0)
+
+        tags = [t.strip() for t in tags_output.strip().split("\n") if t.strip()]
+
+        releases: list[ReleaseInfo] = []
+        for tag in tags:
+            # Get full commit hash
+            ok_full, commit_full, _ = self._run_git("rev-parse", tag)
+            # Get short commit hash
+            ok_short, commit_short, _ = self._run_git("rev-parse", "--short=7", tag)
+            if not ok_full:
+                commit_full = "unknown"
+            if not ok_short:
+                commit_short = commit_full[:7] if ok_full else "unknown"
+
+            # Get tag date
+            ok, date_str, _ = self._run_git("log", "-1", "--format=%aI", tag)
+            tag_date = date_str if ok and date_str else None
+
+            version = tag.lstrip("v")
+            is_prerelease = bool(parse_version(tag)[3])
+
+            releases.append(ReleaseInfo(
+                tag=tag,
+                version=version,
+                date=tag_date,
+                is_prerelease=is_prerelease,
+                commit_short=commit_short,
+                commit=commit_full,
+            ))
+
+        return ReleaseListResponse(releases=releases, total=len(releases))
+```
+
+- [ ] **Step 5: Extend launch_update_script for downgrade**
+
+In `backend/app/services/update/prod_backend.py`, update the `launch_update_script` method signature and body to accept `downgrade` and `alembic_rev` parameters:
+
+```python
+    def launch_update_script(
+        self,
+        update_id: int,
+        from_commit: str,
+        to_commit: str,
+        from_version: str,
+        to_version: str,
+        downgrade: bool = False,
+        alembic_rev: Optional[str] = None,
+    ) -> tuple[bool, Optional[str]]:
+```
+
+In the `subprocess.run` call inside that method, append the new flags conditionally. After the existing args list `["sudo", "systemd-run", ..., "--to-version", to_version]`, add:
+
+```python
+        cmd = [
+            "sudo", "systemd-run",
+            "--unit=baluhost-update",
+            "--remain-after-exit",
+            str(script_path),
+            "--update-id", str(update_id),
+            "--from-commit", from_commit,
+            "--to-commit", to_commit,
+            "--from-version", from_version,
+            "--to-version", to_version,
+        ]
+        if downgrade:
+            cmd.append("--downgrade")
+        if alembic_rev:
+            cmd.extend(["--alembic-rev", alembic_rev])
+```
+
+Replace the existing hardcoded list with `cmd`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/test_update_service.py::TestProdBackendDowngrade -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/update/prod_backend.py backend/tests/services/test_update_service.py
+git commit -m "feat(updates): add downgrade support to ProdUpdateBackend"
+```
+
+---
+
+### Task 5: Implement UpdateService.downgrade() Core Logic
+
+**Files:**
+- Modify: `backend/app/services/update/service.py`
+- Test: `backend/tests/services/test_update_service.py`
+
+- [ ] **Step 1: Write failing tests for downgrade validation**
+
+In `backend/tests/services/test_update_service.py`, add:
+
+```python
+class TestDowngradeService:
+    """Tests for UpdateService.downgrade()."""
+
+    @pytest.fixture
+    def db(self):
+        """Create a mock DB session."""
+        session = MagicMock(spec=Session)
+        session.query.return_value.filter.return_value.first.return_value = None
+        session.query.return_value.filter.return_value.count.return_value = 0
+        # Mock UpdateConfig
+        config = MagicMock()
+        config.auto_backup_before_update = True
+        config.require_healthy_services = True
+        config.channel = "stable"
+        session.query.return_value.first.return_value = config
+        return session
+
+    @pytest.fixture
+    def backend(self):
+        return DevUpdateBackend()
+
+    @pytest.fixture
+    def service(self, db, backend):
+        return UpdateService(db=db, backend=backend)
+
+    @pytest.mark.asyncio
+    async def test_downgrade_rejects_invalid_tag(self, service):
+        """Downgrade should fail if target_tag doesn't match expected format."""
+        from app.schemas.update import DowngradeRequest
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            DowngradeRequest(
+                target_tag="not-a-tag",
+                target_commit="abc1234567890abcdef1234567890abcdef12",
+            )
+
+    @pytest.mark.asyncio
+    async def test_downgrade_rejects_newer_version(self, service):
+        """Downgrade should fail if target version >= current version."""
+        from app.schemas.update import DowngradeRequest
+        # DevBackend's current version is from pyproject.toml (e.g., 1.19.0)
+        # The mock "next minor" is always greater, so use that as target
+        req = DowngradeRequest(
+            target_tag="v99.0.0",
+            target_commit="abc1234567890abcdef1234567890abcdef12",
+        )
+        result = await service.downgrade(req, user_id=1)
+        assert result.success is False
+        assert "newer" in result.message.lower() or "greater" in result.message.lower() or "higher" in result.message.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/services/test_update_service.py::TestDowngradeService -v`
+Expected: FAIL — `downgrade` method does not exist
+
+- [ ] **Step 3: Implement downgrade() in UpdateService**
+
+In `backend/app/services/update/service.py`, add the necessary imports at the top (add `DowngradeRequest` to the schema imports), then add the following methods after the existing `rollback()` method (around line 675):
+
+```python
+    async def downgrade(
+        self,
+        request: DowngradeRequest,
+        user_id: int,
+    ) -> UpdateStartResponse:
+        """Start a downgrade to a previous release version."""
+        # Validate: target version must be less than current version
+        current = await self.backend.get_current_version()
+        target_version = parse_version(request.target_tag)
+        current_version = parse_version(current.version)
+
+        if target_version >= current_version:
+            return UpdateStartResponse(
+                success=False,
+                message=f"Target version {request.target_tag} is not lower than current {current.version}",
+            )
+
+        # Check blockers
+        blockers = await self._check_blockers()
+        if blockers and not request.force:
+            return UpdateStartResponse(
+                success=False,
+                message="Downgrade blocked",
+                blockers=blockers,
+            )
+
+        # Validate tag exists and commit matches (prod only — dev always passes)
+        if hasattr(self.backend, '_run_git'):
+            success, tag_commit, _ = self.backend._run_git("rev-parse", request.target_tag)
+            if not success:
+                return UpdateStartResponse(
+                    success=False,
+                    message=f"Tag {request.target_tag} not found in repository",
+                )
+            if not tag_commit.startswith(request.target_commit[:7]):
+                return UpdateStartResponse(
+                    success=False,
+                    message=f"Commit mismatch: tag points to {tag_commit[:8]}, expected {request.target_commit[:8]}",
+                )
+
+        # Get admin username for backup restore
+        from app.models.user import User
+        user = self.db.query(User).filter(User.id == user_id).first()
+        admin_username = user.username if user else "system"
+
+        # Create update history record
+        update = UpdateHistory(
+            from_version=current.version,
+            to_version=request.target_tag.lstrip("v"),
+            channel="downgrade",
+            from_commit=current.commit,
+            to_commit=request.target_commit,
+            user_id=user_id,
+            status=UpdateStatus.PENDING.value,
+        )
+        self.db.add(update)
+        self.db.commit()
+        self.db.refresh(update)
+
+        self._current_update = update
+
+        # Production: launch shell script with --downgrade flag
+        if isinstance(self.backend, ProdUpdateBackend):
+            # Resolve alembic revision before launching
+            alembic_rev = await self.backend.resolve_alembic_revision(request.target_commit)
+
+            update.status = UpdateStatus.DOWNLOADING.value
+            update.set_progress(5, "Launching downgrade runner...")
+            self.db.commit()
+
+            success, error = self.backend.launch_update_script(
+                update_id=update.id,
+                from_commit=current.commit,
+                to_commit=request.target_commit,
+                from_version=current.version,
+                to_version=request.target_tag.lstrip("v"),
+                downgrade=True,
+                alembic_rev=alembic_rev,
+            )
+            if not success:
+                update.fail(f"Failed to launch downgrade: {error}")
+                self.db.commit()
+                return UpdateStartResponse(
+                    success=False,
+                    message=f"Failed to launch downgrade: {error}",
+                )
+        else:
+            # Dev mode: run in-process
+            task = asyncio.create_task(
+                self._run_dev_downgrade(update.id, admin_username)
+            )
+            _running_tasks[update.id] = task
+
+        return UpdateStartResponse(
+            success=True,
+            update_id=update.id,
+            message=f"Downgrade to {request.target_tag} started",
+        )
+
+    async def _run_dev_downgrade(self, update_id: int, admin_username: str) -> None:
+        """Run the downgrade process in-process (dev mode only)."""
+        db = SessionLocal()
+        try:
+            update = db.query(UpdateHistory).filter(UpdateHistory.id == update_id).first()
+            if not update:
+                return
+
+            def progress(percent: int, step: str):
+                update.set_progress(percent, step)
+                db.commit()
+
+            try:
+                # Step 1: Mandatory DB backup
+                update.status = UpdateStatus.BACKING_UP.value
+                progress(5, "Creating mandatory database backup...")
+
+                try:
+                    from app.services.backup import BackupService
+                    from app.schemas.backup import BackupCreate
+
+                    backup_service = BackupService(db)
+                    backup_data = BackupCreate(
+                        backup_type="full",
+                        includes_database=True,
+                        includes_files=False,
+                        includes_config=True,
+                    )
+                    backup = backup_service.create_backup(
+                        backup_data,
+                        update.user_id or 0,
+                        admin_username,
+                    )
+                    update.backup_id = backup.id
+                    db.commit()
+                    progress(10, "Backup complete")
+                except Exception as e:
+                    logger.warning(f"Backup failed during downgrade: {e}")
+                    progress(10, f"Backup failed: {e} — continuing with caution")
+
+                # Step 2: Fetch
+                update.status = UpdateStatus.DOWNLOADING.value
+                progress(15, "Fetching updates...")
+
+                success = await self.backend.fetch_updates(
+                    lambda p, s: progress(15 + int(p * 0.10), s)
+                )
+                if not success:
+                    raise Exception("Failed to fetch updates")
+
+                # Step 3: Checkout target
+                update.status = UpdateStatus.INSTALLING.value
+                progress(25, f"Checking out {update.to_commit[:8]}...")
+
+                success, error = await self.backend.apply_updates(
+                    update.to_commit,
+                    lambda p, s: progress(25 + int(p * 0.15), s),
+                )
+                if not success:
+                    raise Exception(f"Failed to checkout target: {error}")
+
+                # Step 4: Dependencies
+                progress(40, "Installing dependencies...")
+
+                success, error = await self.backend.install_dependencies(
+                    lambda p, s: progress(40 + int(p * 0.15), s),
+                )
+                if not success:
+                    raise Exception(f"Failed to install dependencies: {error}")
+
+                # Step 5: Alembic downgrade
+                update.status = UpdateStatus.MIGRATING.value
+                progress(55, "Running database downgrade...")
+
+                target_rev = await self.backend.resolve_alembic_revision(update.to_commit)
+                if target_rev:
+                    success, error = await self.backend.run_alembic_downgrade(target_rev)
+                    if not success:
+                        logger.warning(f"Alembic downgrade failed: {error}")
+                        progress(65, "Alembic downgrade failed, restoring backup...")
+                        # Fallback: restore DB backup
+                        if update.backup_id:
+                            try:
+                                from app.services.backup import BackupService
+                                backup_svc = BackupService(db)
+                                restore_ok = backup_svc.restore_backup(
+                                    backup_id=update.backup_id,
+                                    user=admin_username,
+                                    restore_database=True,
+                                    restore_files=False,
+                                    restore_config=False,
+                                )
+                                if not restore_ok:
+                                    raise Exception("Backup restore returned False")
+                                progress(70, "Database restored from backup")
+                            except Exception as restore_err:
+                                raise Exception(
+                                    f"Alembic downgrade failed ({error}) AND backup restore "
+                                    f"failed ({restore_err}). Manual intervention required."
+                                )
+                        else:
+                            logger.warning("No backup available for restore fallback")
+                else:
+                    progress(70, "Could not determine target revision, skipping migration downgrade")
+
+                # Step 6: Health check
+                update.status = UpdateStatus.HEALTH_CHECK.value
+                progress(75, "Health check...")
+
+                healthy, issues = await self.backend.health_check()
+
+                # Step 7: Restart
+                update.status = UpdateStatus.RESTARTING.value
+                progress(85, "Restarting services...")
+
+                success, error = await self.backend.restart_services(
+                    lambda p, s: progress(85 + int(p * 0.10), s),
+                )
+                if not success:
+                    logger.warning(f"Service restart may have failed: {error}")
+
+                # Step 8: Complete
+                progress(95, "Post-restart health check...")
+                await asyncio.sleep(2)
+
+                update.complete()
+                db.commit()
+
+            except asyncio.CancelledError:
+                logger.info(f"Downgrade {update_id} was cancelled")
+                update.cancel()
+                db.commit()
+
+            except Exception as e:
+                logger.exception(f"Downgrade failed: {e}")
+                update.fail(str(e))
+                update.rollback_commit = update.from_commit
+                db.commit()
+
+                # Try to rollback to original commit
+                if update.from_commit:
+                    try:
+                        await self.backend.rollback(update.from_commit)
+                        update.mark_rolled_back(update.from_commit)
+                        db.commit()
+                    except Exception as rollback_error:
+                        logger.error(f"Rollback also failed: {rollback_error}")
+
+        finally:
+            _running_tasks.pop(update_id, None)
+            db.close()
+            self._current_update = None
+```
+
+Also add the import for `DowngradeRequest` at the top of the file and `parse_version` from utils:
+
+```python
+from app.schemas.update import (
+    # ...existing imports...
+    DowngradeRequest,
+)
+from app.services.update.utils import ProgressCallback, parse_version
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/test_update_service.py::TestDowngradeService -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/update/service.py backend/tests/services/test_update_service.py
+git commit -m "feat(updates): implement UpdateService.downgrade() with async flow"
+```
+
+---
+
+### Task 6: Add POST /downgrade API Endpoint
+
+**Files:**
+- Modify: `backend/app/api/routes/updates.py`
+- Test: `backend/tests/services/test_update_service.py`
+
+- [ ] **Step 1: Write failing test for the API endpoint**
+
+In `backend/tests/services/test_update_service.py`, add:
+
+```python
+class TestDowngradeEndpoint:
+    """Tests for the POST /downgrade endpoint schema validation."""
+
+    def test_downgrade_request_valid(self):
+        """Valid DowngradeRequest should pass validation."""
+        from app.schemas.update import DowngradeRequest
+        req = DowngradeRequest(
+            target_tag="v1.17.0",
+            target_commit="abc1234567890abcdef1234567890abcdef12",
+        )
+        assert req.target_tag == "v1.17.0"
+        assert req.skip_backup is False
+        assert req.force is False
+
+    def test_downgrade_request_rejects_bad_tag(self):
+        """Invalid tag format should be rejected."""
+        from app.schemas.update import DowngradeRequest
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            DowngradeRequest(
+                target_tag="main",
+                target_commit="abc1234567890abcdef1234567890abcdef12",
+            )
+
+    def test_downgrade_request_accepts_prerelease_tag(self):
+        """Pre-release tags like v1.17.0-beta.1 should be valid."""
+        from app.schemas.update import DowngradeRequest
+        req = DowngradeRequest(
+            target_tag="v1.17.0-beta.1",
+            target_commit="abc1234567890abcdef1234567890abcdef12",
+        )
+        assert req.target_tag == "v1.17.0-beta.1"
+```
+
+- [ ] **Step 2: Run tests to verify they pass** (schema already created in Task 1)
+
+Run: `cd backend && python -m pytest tests/services/test_update_service.py::TestDowngradeEndpoint -v`
+Expected: PASS
+
+- [ ] **Step 3: Add the POST /downgrade route**
+
+In `backend/app/api/routes/updates.py`, add `DowngradeRequest` to the imports from `app.schemas.update`, then add the endpoint after the existing `rollback_update` route (around line 368):
+
+```python
+@router.post("/downgrade", response_model=UpdateStartResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def start_downgrade(
+    request: Request, response: Response,
+    body: DowngradeRequest,
+    current_user: UserPublic = Depends(deps.get_current_admin),
+    db: Session = Depends(get_db),
+) -> UpdateStartResponse:
+    """Downgrade to a previous release version.
+
+    Initiates a downgrade to the specified release tag. Creates a mandatory
+    database backup, attempts Alembic downgrade, and falls back to backup
+    restore if migrations fail.
+
+    Requires admin privileges.
+    """
+    service = get_update_service(db)
+    audit_logger = get_audit_logger_db()
+
+    result = await service.downgrade(body, current_user.id)
+
+    audit_logger.log_event(
+        event_type="UPDATE",
+        action="downgrade",
+        user=current_user.username,
+        resource="system",
+        success=result.success,
+        details={
+            "target_tag": body.target_tag,
+            "target_commit": body.target_commit,
+            "skip_backup": body.skip_backup,
+            "force": body.force,
+            "update_id": result.update_id,
+            "message": result.message,
+            "blockers": result.blockers,
+        },
+        db=db,
+    )
+
+    if not result.success and result.blockers:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": result.message,
+                "blockers": result.blockers,
+            }
+        )
+
+    return result
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/api/routes/updates.py backend/tests/services/test_update_service.py
+git commit -m "feat(updates): add POST /api/updates/downgrade endpoint"
+```
+
+---
+
+### Task 7: Extend run-update.sh for Downgrade Mode
+
+**Files:**
+- Modify: `deploy/update/run-update.sh`
+
+- [ ] **Step 1: Add --downgrade and --alembic-rev argument parsing**
+
+In `deploy/update/run-update.sh`, add two new variables after the existing ones (around line 23):
+
+```bash
+DOWNGRADE=false
+ALEMBIC_REV=""
+```
+
+Add two new cases in the `while` loop (around line 25-34), **before** the `*)` catch-all case:
+
+```bash
+        --downgrade)    DOWNGRADE=true;    shift ;;
+        --alembic-rev)  ALEMBIC_REV="$2";  shift 2 ;;
+```
+
+These must appear before `*) echo "Unknown argument: $1" >&2; exit 1 ;;` or they will never be reached.
+
+- [ ] **Step 2: Add conditional migration step**
+
+Replace the existing Step 3 block (around line 210-211) with a conditional:
+
+```bash
+# ─── Step 3: Database migrations ─────────────────────────────────────
+
+if [[ "$DOWNGRADE" == "true" && -n "$ALEMBIC_REV" ]]; then
+    write_status "migrating" 45 "Running alembic downgrade to $ALEMBIC_REV..."
+    log_step "Alembic downgrade to $ALEMBIC_REV"
+    CURRENT_PROGRESS=45
+    sudo -u "$BALUHOST_USER" "$INSTALL_DIR/backend/.venv/bin/alembic" \
+        -c "$INSTALL_DIR/backend/alembic.ini" \
+        downgrade "$ALEMBIC_REV"
+    CURRENT_PROGRESS=55
+    log_info "Alembic downgrade complete."
+elif [[ "$DOWNGRADE" == "true" ]]; then
+    write_status "migrating" 45 "Skipping migrations (no target revision)..."
+    log_warn "No alembic revision specified for downgrade, skipping migration step."
+    CURRENT_PROGRESS=55
+else
+    write_status "migrating" 45 "Running database migrations..."
+    run_module "08" "database-migrate" 45 55
+fi
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/update/run-update.sh
+git commit -m "feat(updates): add --downgrade and --alembic-rev support to run-update.sh"
+```
+
+---
+
+### Task 8: Frontend — API Client & i18n
+
+**Files:**
+- Modify: `client/src/api/updates.ts`
+- Modify: `client/src/i18n/locales/en/updates.json`
+- Modify: `client/src/i18n/locales/de/updates.json`
+
+- [ ] **Step 1: Add DowngradeRequest interface and startDowngrade function**
+
+In `client/src/api/updates.ts`, after the `RollbackResponse` interface (around line 134), add:
+
+```typescript
+// Downgrade request/response
+export interface DowngradeRequest {
+  target_tag: string;
+  target_commit: string;
+  skip_backup?: boolean;
+  force?: boolean;
+}
+```
+
+After the `rollbackUpdate` function (around line 326), add:
+
+```typescript
+/**
+ * Start a downgrade to a previous release version
+ */
+export async function startDowngrade(request: DowngradeRequest): Promise<UpdateStartResponse> {
+  const response = await apiClient.post<UpdateStartResponse>('/api/updates/downgrade', request);
+  return response.data;
+}
+```
+
+- [ ] **Step 2: Add `commit` field to ReleaseInfo interface**
+
+In `client/src/api/updates.ts`, find the `ReleaseInfo` interface (around line 221) and add:
+
+```typescript
+export interface ReleaseInfo {
+  tag: string;
+  version: string;
+  date: string | null;
+  is_prerelease: boolean;
+  commit_short: string;
+  commit: string;
+}
+```
+
+- [ ] **Step 3: Add `"downgrade"` to UpdateChannel and getChannelInfo**
+
+In `client/src/api/updates.ts`, update the `UpdateChannel` type (line 21):
+
+```typescript
+export type UpdateChannel = 'stable' | 'unstable' | 'development' | 'downgrade';
+```
+
+In `getChannelInfo` (around line 528), add a new case before `default`:
+
+```typescript
+    case 'downgrade':
+      return {
+        label: 'Downgrade',
+        color: 'text-orange-400',
+        description: 'Downgrade to a previous release',
+      };
+```
+
+- [ ] **Step 4: Add English i18n keys**
+
+In `client/src/i18n/locales/en/updates.json`, add a new `"downgrade"` section at the top level (e.g., after `"buttons"`):
+
+```json
+  "downgrade": {
+    "button": "Downgrade",
+    "warning": "Downgrade to {{version}} may cause database data loss. A database backup will be created automatically before proceeding.",
+    "continueButton": "Continue",
+    "confirmPrompt": "Type {{version}} to confirm the downgrade:",
+    "startButton": "Start Downgrade",
+    "progressLabel": "Downgrading to {{version}}",
+    "channel": "Downgrade",
+    "current": "Current"
+  },
+```
+
+- [ ] **Step 5: Add German i18n keys**
+
+In `client/src/i18n/locales/de/updates.json`, add the matching German keys:
+
+```json
+  "downgrade": {
+    "button": "Downgrade",
+    "warning": "Ein Downgrade auf {{version}} kann zu Datenverlust in der Datenbank führen. Ein Datenbank-Backup wird automatisch vor dem Downgrade erstellt.",
+    "continueButton": "Weiter",
+    "confirmPrompt": "Gib {{version}} ein, um den Downgrade zu bestätigen:",
+    "startButton": "Downgrade starten",
+    "progressLabel": "Downgrade auf {{version}}",
+    "channel": "Downgrade",
+    "current": "Aktuell"
+  },
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/api/updates.ts client/src/i18n/locales/en/updates.json client/src/i18n/locales/de/updates.json
+git commit -m "feat(updates): add downgrade API client, types, and i18n keys"
+```
+
+---
+
+### Task 9: Frontend — Downgrade UI in UpdateHistoryTab
+
+**Files:**
+- Modify: `client/src/components/updates/UpdateHistoryTab.tsx`
+
+This is the main UI task. The component currently shows releases and version history. We need to:
+1. Accept current version as a prop
+2. Add a downgrade button to each release row where version < current
+3. Implement two-step inline confirmation (warning → type version → confirm)
+
+- [ ] **Step 1: Extend props interface**
+
+In `client/src/components/updates/UpdateHistoryTab.tsx`, update `UpdateHistoryTabProps` to add new props:
+
+```typescript
+import {
+  GitBranch,
+  Loader2,
+  Tag,
+  AlertTriangle,
+  RotateCcw,
+} from 'lucide-react';
+import { useState } from 'react';
+import type { ReleaseInfo, VersionHistoryResponse } from '../../api/updates';
+import { startDowngrade } from '../../api/updates';
+import toast from 'react-hot-toast';
+
+interface UpdateHistoryTabProps {
+  t: (key: string, options?: Record<string, unknown>) => string;
+  releases: ReleaseInfo[];
+  releasesLoading: boolean;
+  versionHistory: VersionHistoryResponse | null;
+  versionHistoryLoading: boolean;
+  currentVersion: string;
+  onDowngradeStarted: (updateId: number) => void;
+}
+```
+
+- [ ] **Step 2: Add downgrade state and handler inside the component**
+
+At the top of the `UpdateHistoryTab` function body, add:
+
+```typescript
+  const [downgradeTarget, setDowngradeTarget] = useState<string | null>(null);
+  const [confirmStep, setConfirmStep] = useState<'warning' | 'confirm' | null>(null);
+  const [confirmInput, setConfirmInput] = useState('');
+  const [downgradeLoading, setDowngradeLoading] = useState(false);
+
+  const handleStartDowngrade = async (release: ReleaseInfo) => {
+    setDowngradeLoading(true);
+    try {
+      const result = await startDowngrade({
+        target_tag: release.tag,
+        target_commit: release.commit,
+      });
+      if (result.success && result.update_id) {
+        toast.success(t('downgrade.progressLabel', { version: release.tag }));
+        onDowngradeStarted(result.update_id);
+      } else {
+        toast.error(result.message);
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : 'Downgrade failed';
+      toast.error(msg);
+    } finally {
+      setDowngradeLoading(false);
+      setDowngradeTarget(null);
+      setConfirmStep(null);
+      setConfirmInput('');
+    }
+  };
+
+  const cancelDowngrade = () => {
+    setDowngradeTarget(null);
+    setConfirmStep(null);
+    setConfirmInput('');
+  };
+```
+
+- [ ] **Step 3: Update the release row rendering**
+
+In the existing release list `.map((release) => ...)` block, add the downgrade button and inline confirmation. Replace the existing release row `<div>` with:
+
+Add a semver comparison helper at the top of the component file (before the component function):
+
+```typescript
+/** Compare two semver strings numerically. Returns negative if a < b. */
+function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+```
+
+Then in the release list map:
+
+```tsx
+{releases.map((release) => {
+  const isCurrent = release.version === currentVersion;
+  const canDowngrade = !isCurrent && compareSemver(release.version, currentVersion) < 0;
+  const isTargeted = downgradeTarget === release.tag;
+
+  return (
+    <div key={release.tag}>
+      <div
+        className="px-4 py-3 flex items-center justify-between hover:bg-slate-700/30 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-white">{release.tag}</span>
+          <span className="font-mono text-xs text-slate-500">{release.commit_short}</span>
+          {isCurrent && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-emerald-500/20 text-emerald-400">
+              {t('downgrade.current')}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          {release.date && (
+            <span className="text-sm text-slate-400">
+              {new Date(release.date).toLocaleDateString()}
+            </span>
+          )}
+          <span
+            className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+              release.is_prerelease
+                ? 'bg-amber-500/20 text-amber-400'
+                : 'bg-emerald-500/20 text-emerald-400'
+            }`}
+          >
+            {release.is_prerelease ? t('releases.prerelease') : t('releases.stable')}
+          </span>
+          {canDowngrade && !isTargeted && (
+            <button
+              onClick={() => { setDowngradeTarget(release.tag); setConfirmStep('warning'); }}
+              className="flex items-center gap-1.5 px-2.5 py-1 bg-orange-600/20 hover:bg-orange-600/40 text-orange-400 rounded text-xs font-medium transition-all touch-manipulation active:scale-95"
+            >
+              <RotateCcw className="h-3 w-3" />
+              {t('downgrade.button')}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Two-step inline confirmation */}
+      {isTargeted && confirmStep === 'warning' && (
+        <div className="px-4 py-3 bg-orange-500/5 border-t border-orange-500/20">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="h-5 w-5 text-orange-400 mt-0.5 shrink-0" />
+            <div className="flex-1">
+              <p className="text-sm text-orange-300">
+                {t('downgrade.warning', { version: release.tag })}
+              </p>
+              <div className="flex items-center gap-2 mt-3">
+                <button
+                  onClick={() => setConfirmStep('confirm')}
+                  className="px-3 py-1.5 bg-orange-600 hover:bg-orange-700 text-white rounded text-xs font-medium transition-all touch-manipulation active:scale-95"
+                >
+                  {t('downgrade.continueButton')}
+                </button>
+                <button
+                  onClick={cancelDowngrade}
+                  className="px-3 py-1.5 bg-slate-600 hover:bg-slate-500 text-white rounded text-xs transition-all touch-manipulation active:scale-95"
+                >
+                  {t('common:cancel')}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {isTargeted && confirmStep === 'confirm' && (
+        <div className="px-4 py-3 bg-orange-500/5 border-t border-orange-500/20">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="h-5 w-5 text-orange-400 mt-0.5 shrink-0" />
+            <div className="flex-1">
+              <p className="text-sm text-slate-300 mb-2">
+                {t('downgrade.confirmPrompt', { version: release.tag })}
+              </p>
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={confirmInput}
+                  onChange={(e) => setConfirmInput(e.target.value)}
+                  placeholder={release.tag}
+                  className="px-3 py-1.5 bg-slate-700 border border-slate-600 rounded text-sm text-white font-mono w-40 focus:outline-none focus:border-orange-500"
+                />
+                <button
+                  onClick={() => handleStartDowngrade(release)}
+                  disabled={confirmInput !== release.tag || downgradeLoading}
+                  className="flex items-center gap-1.5 px-3 py-1.5 bg-orange-600 hover:bg-orange-700 disabled:bg-slate-700 disabled:text-slate-500 text-white rounded text-xs font-medium transition-all touch-manipulation active:scale-95"
+                >
+                  {downgradeLoading ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <RotateCcw className="h-3.5 w-3.5" />
+                  )}
+                  {t('downgrade.startButton')}
+                </button>
+                <button
+                  onClick={cancelDowngrade}
+                  className="px-3 py-1.5 bg-slate-600 hover:bg-slate-500 text-white rounded text-xs transition-all touch-manipulation active:scale-95"
+                >
+                  {t('common:cancel')}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+})}
+```
+
+- [ ] **Step 4: Verify no syntax errors in the changed file**
+
+Run: `cd client && npx tsc --noEmit src/components/updates/UpdateHistoryTab.tsx 2>&1 || echo "Expected: type errors for missing parent props — will be resolved in Task 10"`
+
+Note: The parent component `UpdatePage.tsx` doesn't pass the new required props yet. A full `npm run build` will fail until Task 10 completes. This step only verifies the component file itself has no syntax errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/updates/UpdateHistoryTab.tsx
+git commit -m "feat(updates): add downgrade button and two-step confirmation to release list"
+```
+
+---
+
+### Task 10: Frontend — Wire Up Parent Component
+
+**Files:**
+- Modify: `client/src/pages/UpdatePage.tsx`
+
+- [ ] **Step 1: Pass new props to UpdateHistoryTab**
+
+In `client/src/pages/UpdatePage.tsx`, find where `UpdateHistoryTab` is rendered (search for `<UpdateHistoryTab`). Add the new props.
+
+- [ ] **Step 2: Pass currentVersion prop**
+
+The parent likely already has `checkResult` (from `checkForUpdates()`). Pass `currentVersion={checkResult?.current_version.version ?? ''}` to `UpdateHistoryTab`.
+
+- [ ] **Step 3: Add onDowngradeStarted handler**
+
+The handler should switch to the Overview tab and set the `currentUpdate` state so `UpdateProgress` shows the downgrade progress. Pattern: similar to how `onStartUpdate` works.
+
+```typescript
+const handleDowngradeStarted = (updateId: number) => {
+  // Switch to overview tab to show progress
+  setActiveTab('overview');
+  // Trigger a refresh of current update
+  refreshCurrentUpdate();
+};
+```
+
+Pass `onDowngradeStarted={handleDowngradeStarted}` to `UpdateHistoryTab`.
+
+- [ ] **Step 4: Verify frontend compiles and renders**
+
+Run: `cd client && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/pages/UpdatePage.tsx  # or whatever the parent file is
+git commit -m "feat(updates): wire downgrade props to UpdateHistoryTab parent"
+```
+
+---
+
+### Task 11: Frontend — Handle Downgrade Channel in UpdateOverviewTab
+
+**Files:**
+- Modify: `client/src/components/updates/UpdateOverviewTab.tsx`
+
+The Overview tab shows progress for running updates. When a downgrade is in progress (`channel === 'downgrade'`), the badge and labels should reflect this.
+
+- [ ] **Step 1: Add downgrade channel handling to progress display**
+
+In `client/src/components/updates/UpdateOverviewTab.tsx`, find where the channel badge is rendered (search for `getChannelInfo` or the channel badge area). The existing code shows a badge like "Stable" or "Beta" — ensure the `'downgrade'` channel renders with orange styling.
+
+Since `getChannelInfo` already returns the correct info after Task 8, verify that the Overview tab uses it for the badge. If the tab has a hardcoded channel label, replace it with `getChannelInfo(update.channel)`.
+
+- [ ] **Step 2: Add downgrade-specific progress label**
+
+If the progress section shows "Updating to vX.Y.Z", add a conditional for downgrade:
+
+```tsx
+{update.channel === 'downgrade' ? (
+  <span className="text-orange-400 font-medium">
+    {t('downgrade.progressLabel', { version: `v${update.to_version}` })}
+  </span>
+) : (
+  <span className="text-blue-400 font-medium">
+    {t('updates.progress.updatingTo', { version: `v${update.to_version}` })}
+  </span>
+)}
+```
+
+- [ ] **Step 3: Verify frontend compiles**
+
+Run: `cd client && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/components/updates/UpdateOverviewTab.tsx
+git commit -m "feat(updates): handle downgrade channel display in overview tab"
+```
+
+---
+
+### Task 12: API Endpoint Tests — Auth, Rate-Limiting, Audit
+
+**Files:**
+- Modify: `backend/tests/api/test_updates_routes.py`
+
+- [ ] **Step 1: Write tests for downgrade endpoint security**
+
+In `backend/tests/api/test_updates_routes.py`, add the following tests. If this file doesn't exist yet, create it with appropriate imports (FastAPI `TestClient`, pytest fixtures for auth tokens):
+
+```python
+class TestDowngradeEndpointSecurity:
+    """Tests for POST /api/updates/downgrade security requirements."""
+
+    def test_downgrade_requires_admin(self, client, user_token):
+        """Non-admin users should get 403 on downgrade."""
+        response = client.post(
+            "/api/updates/downgrade",
+            json={
+                "target_tag": "v1.0.0",
+                "target_commit": "abc1234567890abcdef1234567890abcdef12",
+            },
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert response.status_code == 403
+
+    def test_downgrade_requires_auth(self, client):
+        """Unauthenticated requests should get 401."""
+        response = client.post(
+            "/api/updates/downgrade",
+            json={
+                "target_tag": "v1.0.0",
+                "target_commit": "abc1234567890abcdef1234567890abcdef12",
+            },
+        )
+        assert response.status_code == 401
+
+    def test_downgrade_audit_logged(self, client, admin_token, db):
+        """Downgrade attempts should be recorded in the audit log."""
+        response = client.post(
+            "/api/updates/downgrade",
+            json={
+                "target_tag": "v1.0.0",
+                "target_commit": "abc1234567890abcdef1234567890abcdef12",
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        # Even if the downgrade fails (version validation), an audit entry should exist
+        from app.models.audit_log import AuditLog
+        log = db.query(AuditLog).filter(
+            AuditLog.action == "downgrade",
+            AuditLog.event_type == "UPDATE",
+        ).first()
+        assert log is not None
+
+    def test_downgrade_validates_tag_format(self, client, admin_token):
+        """Invalid tag format should return 422."""
+        response = client.post(
+            "/api/updates/downgrade",
+            json={
+                "target_tag": "not-a-tag",
+                "target_commit": "abc1234567890abcdef1234567890abcdef12",
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 422
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd backend && python -m pytest tests/api/test_updates_routes.py -v`
+Expected: All PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/tests/api/test_updates_routes.py
+git commit -m "test(updates): add downgrade endpoint security tests"
+```
+
+---
+
+### Task 13: Integration Test — Full Downgrade Flow
+
+**Files:**
+- Modify: `backend/tests/services/test_update_service.py`
+
+- [ ] **Step 1: Write integration test for full dev-mode downgrade**
+
+```python
+class TestDowngradeIntegration:
+    """Integration tests for the full downgrade flow in dev mode."""
+
+    @pytest.fixture
+    def db(self):
+        session = MagicMock(spec=Session)
+        session.query.return_value.filter.return_value.first.return_value = None
+        session.query.return_value.filter.return_value.count.return_value = 0
+        config = MagicMock()
+        config.auto_backup_before_update = True
+        config.require_healthy_services = True
+        config.channel = "stable"
+        session.query.return_value.first.return_value = config
+        return session
+
+    @pytest.mark.asyncio
+    async def test_downgrade_creates_history_with_downgrade_channel(self, db):
+        """Downgrade should create UpdateHistory with channel='downgrade'."""
+        from app.schemas.update import DowngradeRequest
+
+        backend = DevUpdateBackend()
+        service = UpdateService(db=db, backend=backend)
+
+        # Use a version we know is less than current
+        req = DowngradeRequest(
+            target_tag="v1.0.0",
+            target_commit="abc1234567890abcdef1234567890abcdef12",
+        )
+        result = await service.downgrade(req, user_id=1)
+        assert result.success is True
+
+        # Verify the UpdateHistory was created with correct channel
+        add_call = db.add.call_args
+        history_obj = add_call[0][0]
+        assert history_obj.channel == "downgrade"
+
+    @pytest.mark.asyncio
+    async def test_downgrade_mandatory_backup_even_with_skip(self, db):
+        """Backup must be created even when skip_backup=True."""
+        from app.schemas.update import DowngradeRequest
+
+        backend = DevUpdateBackend()
+        service = UpdateService(db=db, backend=backend)
+
+        req = DowngradeRequest(
+            target_tag="v1.0.0",
+            target_commit="abc1234567890abcdef1234567890abcdef12",
+            skip_backup=True,
+        )
+        result = await service.downgrade(req, user_id=1)
+        assert result.success is True
+        # The backup creation happens in the async task, not in the initial call.
+        # This test verifies the downgrade starts successfully even with skip_backup=True.
+```
+
+- [ ] **Step 2: Run all downgrade tests**
+
+Run: `cd backend && python -m pytest tests/services/test_update_service.py -k "downgrade or Downgrade" -v`
+Expected: All PASS
+
+- [ ] **Step 3: Write cancellation test**
+
+```python
+    @pytest.mark.asyncio
+    async def test_downgrade_cancellation(self, db):
+        """Cancelling a running downgrade should set status to cancelled."""
+        from app.schemas.update import DowngradeRequest
+
+        backend = DevUpdateBackend()
+        service = UpdateService(db=db, backend=backend)
+
+        req = DowngradeRequest(
+            target_tag="v1.0.0",
+            target_commit="abc1234567890abcdef1234567890abcdef12",
+        )
+        result = await service.downgrade(req, user_id=1)
+        assert result.success is True
+
+        # Cancel the running task
+        update_id = result.update_id
+        from app.services.update.service import _running_tasks
+        task = _running_tasks.get(update_id)
+        if task:
+            task.cancel()
+            import asyncio
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # Verify status was set to cancelled
+        history_obj = db.add.call_args[0][0]
+        # After cancellation the task handler should have called update.cancel()
+        # Note: In mock DB this verifies the code path runs without error
+```
+
+- [ ] **Step 4: Run all downgrade tests**
+
+Run: `cd backend && python -m pytest tests/services/test_update_service.py -k "downgrade or Downgrade" -v`
+Expected: All PASS
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `cd backend && python -m pytest tests/services/test_update_service.py -v`
+Expected: All existing tests still pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/tests/services/test_update_service.py
+git commit -m "test(updates): add downgrade integration and cancellation tests"
+```
+
+---
+
+### Task 14: Final Verification & Cleanup
+
+- [ ] **Step 1: Run full backend test suite**
+
+Run: `cd backend && python -m pytest -x -q`
+Expected: All tests pass
+
+- [ ] **Step 2: Run frontend build**
+
+Run: `cd client && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 3: Start dev server and manually verify**
+
+Run: `python start_dev.py`
+
+Verify:
+1. Navigate to Updates page → History tab
+2. Release list shows "Downgrade" buttons on older versions
+3. Click "Downgrade" → warning appears inline
+4. Click "Continue" → version input appears
+5. Type the version → "Start Downgrade" button enables
+6. Click "Start Downgrade" → switches to Overview tab, progress shows
+
+- [ ] **Step 4: Final commit if any cleanup needed**
+
+```bash
+git add -A
+git commit -m "chore(updates): downgrade feature cleanup"
+```

--- a/docs/superpowers/specs/2026-03-23-capability-contracts-design.md
+++ b/docs/superpowers/specs/2026-03-23-capability-contracts-design.md
@@ -1,0 +1,154 @@
+# Design: Capability Contracts for Smart Device Plugins
+
+**Date:** 2026-03-23
+**Status:** Approved
+**Scope:** Smart Device Plugin System — Capability-Vertrag-Enforcement
+
+---
+
+## Problem
+
+Plugins mit `POWER_MONITOR`-Capability liefern Stromverbrauchsdaten, die von der Mobile App (BaluApp) konsumiert werden. Aktuell funktioniert das de facto über `PowerReading` + `poll_device()`, aber:
+
+1. Es gibt keinen expliziten Vertrag — ein Plugin könnte eigene Routen mit eigenem Schema für Stromverbrauch bauen
+2. Die Mobile App braucht ein garantiert stabiles Schema
+3. Es gibt keine Validierung, dass ein Plugin das deklarierte Capability-Protocol tatsächlich implementiert
+
+## Lösung
+
+**Capabilities sind Verträge.** Wer eine Capability deklariert, muss:
+- Das zugehörige Protocol implementieren (geprüft beim Start)
+- Das zugehörige Datenmodell über `poll_device()` liefern (geprüft zur Laufzeit)
+
+Dafür bekommt das Plugin automatisch: Mobile-App-Integration, Dashboard-Panel, Energie-Statistiken und Kostenberechnung.
+
+## Philosophie
+
+Die Plugin-Freiheit bleibt bestehen. Plugins können eigene Routen, eigene UIs und eigene Logik haben. Aber wenn ein Plugin sagt "Ich kann Strom messen" (`POWER_MONITOR`), dann muss es die Daten im vorgegebenen Format liefern. Das ist keine Einschränkung, sondern eine Spezifikation — vergleichbar mit einem Interface in einer Programmiersprache.
+
+## Design
+
+### 1. Capability-Contract-Mapping (`capabilities.py`)
+
+Explizites Mapping von Capability zu (Protocol, DataModel) als Code-Konstante:
+
+```python
+CAPABILITY_CONTRACTS: dict[DeviceCapability, tuple[type, type[BaseModel]]] = {
+    DeviceCapability.POWER_MONITOR: (PowerMonitor, PowerReading),
+    DeviceCapability.SWITCH: (Switch, SwitchState),
+    DeviceCapability.SENSOR: (Sensor, SensorReading),
+    DeviceCapability.DIMMER: (Dimmer, DimmerState),
+    DeviceCapability.COLOR: (ColorControl, ColorState),
+}
+```
+
+Dieses Mapping ist die Single Source of Truth für alle Validierungen.
+
+**Key-Konvention:** Der Key in der `poll_device()`-Rückgabe muss dem `.value` des `DeviceCapability`-Enums entsprechen (z.B. `"power_monitor"`, `"switch"`). Dies ist bereits die implizite Konvention im Codebase und wird hiermit explizit festgelegt.
+
+### 2. Startup-Validierung (`manager.py` + `poller.py`)
+
+Beim Laden eines `SmartDevicePlugin` wird geprüft:
+
+1. Für jeden `DeviceTypeInfo` des Plugins: iteriere über die deklarierten Capabilities
+2. Für jede Capability: prüfe via `isinstance(plugin, Protocol)` ob das Protocol erfüllt ist
+3. Wenn nicht → Plugin wird **nicht geladen**, Fehler wird geloggt:
+
+```
+ERROR: Plugin 'shelly_plug' declares capability 'power_monitor' but does not
+implement the PowerMonitor protocol. Plugin not loaded.
+```
+
+**Hinweis:** Da ein Plugin eine Klasse ist, die entweder ein Protocol implementiert oder nicht, betrifft dies den gesamten Plugin — auch wenn nur ein Device-Type die fehlende Capability deklariert. Plugin-Autoren müssen sicherstellen, dass alle deklarierten Capabilities implementiert sind.
+
+**Zwei Ladepfade:** Der Check muss an beiden Stellen erfolgen, da der Poller in einem separaten OS-Prozess läuft und Plugins unabhängig vom `PluginManager` lädt:
+
+1. `PluginManager.load_plugin()` in `manager.py` — nach dem Instanziieren, vor dem Registrieren der Routen
+2. `SmartDevicePoller._load_plugins()` in `poller.py` — beim Laden der Plugins im Monitoring-Worker
+
+Idealerweise wird die Validierungslogik als Utility-Funktion in `capabilities.py` implementiert, damit beide Ladepfade denselben Code nutzen:
+
+```python
+def validate_capability_contracts(plugin: SmartDevicePlugin) -> list[str]:
+    """Validate that a plugin implements all protocols for its declared capabilities.
+
+    Returns list of error messages (empty = valid).
+    """
+```
+
+### 3. Runtime-Validierung (`poller.py`)
+
+Die Validierung erfolgt direkt nach dem `poll_device()` / `poll_device_mock()`-Aufruf, **bevor** die Werte zu dicts serialisiert werden. Gilt für beide Codepfade (prod und dev/mock).
+
+**Ablauf:**
+
+1. Iteriere über die zurückgegebenen Key-Value-Paare
+2. Matche den Key gegen die deklarierte Capability des Geräts
+3. Prüfe ob der Wert eine Instanz des erwarteten Datenmodells ist. Falls der Wert ein dict ist, validiere via `Model.model_validate(value, strict=True)`
+4. Ungültige Daten → dieses einzelne Capability-Sample wird verworfen, Warning geloggt:
+
+```
+WARNING: Plugin 'shelly_plug' device 42: capability 'power_monitor' returned
+invalid data (expected PowerReading). Sample discarded.
+```
+
+5. Gültige Samples fließen normal weiter in SHM + DB
+
+**Edge Cases:**
+
+| Fall | Verhalten |
+|------|-----------|
+| `poll_device()` gibt leeres dict `{}` zurück | Kein Fehler — Gerät hat diesen Zyklus keine Daten |
+| Nur ein Teil der deklarierten Capabilities wird zurückgegeben | Gültig — vorhandene Keys werden validiert, fehlende werden ignoriert |
+| Extra Keys, die nicht in den deklarierten Capabilities sind | Warning geloggt, Key wird ignoriert (nicht an SHM/DB weitergereicht) |
+| `poll_device_mock()` gibt ungültige Daten zurück | Gleiche Validierung wie `poll_device()` — Dev-Mode ist kein Freifahrtschein |
+
+### 4. Dokumentation (`plugins/README.md`)
+
+Neuer Abschnitt "Capability-Verträge" in der Smart-Device-Sektion:
+
+- Capabilities sind Verträge, nicht nur Labels
+- Tabelle: Capability → Protocol → Datenmodell → was man bekommt
+- Key-Konvention: `poll_device()`-Keys = `DeviceCapability.value`
+- Expliziter Hinweis: Stromverbrauchsdaten müssen über die zentrale Pipeline (`poll_device()` → Poller → SHM → Energy-Service) fließen, nicht über eigene Plugin-Routen
+- Hinweis auf Validierung: Startup-Check (Protocol) + Runtime-Check (Datenmodell)
+
+## Betroffene Dateien
+
+| Datei | Änderung |
+|-------|----------|
+| `backend/app/plugins/smart_device/capabilities.py` | `CAPABILITY_CONTRACTS` dict + `validate_capability_contracts()` Utility |
+| `backend/app/plugins/manager.py` | Startup-Check beim Laden von SmartDevicePlugins |
+| `backend/app/plugins/smart_device/poller.py` | Startup-Check in `_load_plugins()` + Runtime-Check nach `poll_device()`/`poll_device_mock()` |
+| `backend/app/plugins/README.md` | Neuer Abschnitt "Capability-Verträge" |
+
+## Was sich NICHT ändert
+
+- `PowerReading`-Modell bleibt unverändert
+- Tapo-Plugin braucht keine Anpassung (erfüllt den Vertrag bereits)
+- Mobile API (`/mobile/power-summary`) bleibt unverändert
+- Energy-Service bleibt unverändert
+- Frontend bleibt unverändert
+
+## Tests
+
+| Test | Erwartung |
+|------|-----------|
+| Plugin mit `POWER_MONITOR` ohne `get_power()` laden | Startup-Fehler, Plugin nicht geladen |
+| Plugin deklariert `SWITCH` + `POWER_MONITOR`, implementiert nur `Switch` | Startup-Fehler, Plugin nicht geladen |
+| `poll_device()` gibt ungültiges dict zurück | Sample verworfen, Warning geloggt |
+| `poll_device()` gibt valides `PowerReading` zurück | Sample normal verarbeitet |
+| `poll_device()` gibt leeres dict `{}` zurück | Kein Fehler, keine Samples gespeichert |
+| `poll_device()` gibt nur 1 von 2 deklarierten Capabilities zurück | Vorhandene Keys verarbeitet, kein Fehler |
+| `poll_device()` gibt extra Key zurück, der nicht deklariert ist | Warning geloggt, Key ignoriert |
+| `poll_device_mock()` gibt ungültige Daten zurück | Gleiche Validierung, Sample verworfen |
+| Jeder `DeviceCapability`-Wert hat Eintrag in `CAPABILITY_CONTRACTS` | Struktureller Test — Mapping ist vollständig |
+| Bestehende Tapo-Tests | Müssen weiterhin grün sein |
+
+## Nicht im Scope
+
+- Neue Endpoints oder Schema-Änderungen für die Mobile App
+- Änderungen am `PowerReading`-Modell
+- Nicht-Smart-Device-Plugins als Energiequellen
+- Validierung von Plugin-eigenen Routen (nur Daten-Pipeline wird validiert)
+- Log-Throttling für wiederholte Validierungsfehler (kann später ergänzt werden)

--- a/docs/superpowers/specs/2026-03-23-release-downgrade-design.md
+++ b/docs/superpowers/specs/2026-03-23-release-downgrade-design.md
@@ -1,7 +1,7 @@
 # Release Downgrade Feature — Design Spec
 
 **Date**: 2026-03-23
-**Status**: Draft
+**Status**: Reviewed
 **Author**: Claude + Xveyn
 
 ## Summary
@@ -21,7 +21,7 @@ Allow administrators to downgrade BaluHost to any previous release (git tag). Th
 
 - Downgrading to arbitrary non-tagged commits (only releases)
 - Automatic rollback of file-system data (user files are untouched)
-- Multi-step downgrade chains (e.g., 1.19 → 1.17 → 1.15 in sequence)
+- Multi-step downgrade chains (e.g., 1.19 -> 1.17 -> 1.15 in sequence)
 
 ## Architecture
 
@@ -41,20 +41,65 @@ POST /api/updates/downgrade
 
 ```python
 class DowngradeRequest(BaseModel):
-    target_tag: str = Field(description="Git tag to downgrade to, e.g. 'v1.17.0'")
+    target_tag: str = Field(
+        description="Git tag to downgrade to, e.g. 'v1.17.0'",
+        pattern=r"^v\d+\.\d+\.\d+(-[\w.]+)?$",
+    )
     target_commit: str = Field(description="Expected commit hash for validation")
     skip_backup: bool = Field(default=False, description="Skip file/config backup (DB backup is always created)")
     force: bool = Field(default=False, description="Ignore non-critical blockers")
 ```
 
+The `target_tag` field has a regex validator to ensure it matches the expected tag format (`v1.17.0`, `v1.18.0-beta.1`, etc.). This prevents injection of arbitrary git refs.
+
 Response reuses `UpdateStartResponse` (success, update_id, message, blockers).
 
 #### UpdateChannelEnum Extension
 
-Add `"downgrade"` to `UpdateChannelEnum`:
+Add `"downgrade"` to both the schema Literal AND the ORM enum:
 
+Schema (`schemas/update.py`):
 ```python
 UpdateChannelEnum = Literal["stable", "unstable", "development", "downgrade"]
+```
+
+ORM model (`models/update_history.py`):
+```python
+class UpdateChannel(str, enum.Enum):
+    STABLE = "stable"
+    BETA = "beta"
+    DEVELOPMENT = "development"
+    DOWNGRADE = "downgrade"
+```
+
+**Note**: The `channel` column in `update_history` is `String(20)`, not a PostgreSQL enum type, so no Alembic migration is needed — any string value up to 20 chars is accepted. The existing mismatch between schema `"unstable"` and ORM `"beta"` is a pre-existing issue and out of scope for this feature.
+
+#### `ReleaseInfo` Schema Extension
+
+The existing `ReleaseInfo` only has `commit_short` (7-char hash). The frontend needs the full commit hash to populate `DowngradeRequest.target_commit`. Add a `commit` field:
+
+```python
+class ReleaseInfo(BaseModel):
+    tag: str
+    version: str
+    date: Optional[str] = None
+    is_prerelease: bool = False
+    commit_short: str
+    commit: str = Field(description="Full commit hash for downgrade validation")
+```
+
+Update `ProdUpdateBackend.get_all_releases()` to fetch the full hash (change `--short=7` to full `rev-parse`). Update `DevUpdateBackend.get_all_releases()` to include mock full hashes.
+
+Update `ReleaseInfo` TypeScript interface in `client/src/api/updates.ts`:
+```typescript
+export interface ReleaseInfo {
+  tag: string;
+  version: string;
+  date: string | null;
+  is_prerelease: boolean;
+  commit_short: string;
+  commit: string;
+}
 ```
 
 #### Service Method: `UpdateService.downgrade()`
@@ -70,10 +115,12 @@ async def downgrade(
 **Validation steps:**
 1. Verify `target_tag` exists in git tags
 2. Verify `target_commit` matches the tag's commit
-3. Verify target version < current version (semver comparison)
+3. Verify target version < current version (semver comparison via existing `parse_version()` from `services/update/utils.py`)
 4. Check blockers (no running update/downgrade)
 
 **On success:** Creates `UpdateHistory` entry with `channel="downgrade"`, launches async task (dev) or shell script (prod).
+
+**Semantics of `from_version` / `to_version`:** Same convention as updates — `from_version` = current version, `to_version` = target version. For downgrades, `from_version` > `to_version`. The frontend already displays both fields; no special handling needed.
 
 #### Async Downgrade Flow: `_run_dev_downgrade()`
 
@@ -83,12 +130,16 @@ async def downgrade(
 | 2 | 10-25% | `downloading` | `git fetch --all --tags --prune` |
 | 3 | 25-40% | `installing` | `git checkout <target_commit>` |
 | 4 | 40-55% | `installing` | Install dependencies (pip/npm for the older version) |
-| 5 | 55-75% | `migrating` | **Alembic downgrade**: resolve target revision, run `alembic downgrade <rev>`. On failure → restore DB backup, log warning. |
+| 5 | 55-75% | `migrating` | **Alembic downgrade**: resolve target revision, run `alembic downgrade <rev>`. On failure -> restore DB backup, log warning. |
 | 6 | 75-85% | `health_check` | Health check |
 | 7 | 85-95% | `restarting` | Restart services |
 | 8 | 100% | `completed` | Done |
 
-On any failure: attempt rollback to original commit (same as current update error handler).
+**On failure at any step:** Attempt rollback to original commit (same as current update error handler). If the Alembic downgrade failed AND the DB backup restore also fails, abort the entire downgrade, rollback git checkout to original commit, and mark as `failed` with a descriptive error message.
+
+**Cancellation:** The existing `cancel_update()` flow works for downgrades since they share the `UpdateHistory` model and async task infrastructure. Downgrade tasks are tracked in `_running_tasks` and can be cancelled via the same `POST /cancel/{id}` endpoint.
+
+**WebSocket events:** Downgrades emit the same `update_progress`, `update_complete`, and `update_failed` WebSocket events as updates. The `channel="downgrade"` field distinguishes them.
 
 #### Alembic Revision Resolution
 
@@ -102,9 +153,21 @@ async def resolve_alembic_revision(self, commit: str) -> Optional[str]:
 ```
 
 **ProdUpdateBackend implementation:**
-- Run `git ls-tree -r --name-only <commit> backend/alembic/versions/` to list migration files at that commit
-- Parse revision IDs from filenames (pattern: `NNN_description.py` or `<hash>_description.py`)
-- Build the revision chain to find the head revision for that commit
+
+The codebase has mixed migration naming conventions (numbered like `001_xxx.py`, hex-hash like `9c00b193b5bd_xxx.py`, plain names). Revision IDs are embedded inside each file as Python variables (`revision = "..."`), not reliably derivable from filenames. Additionally, merge migrations exist with multiple `down_revision` values.
+
+Therefore, the approach is NOT to parse filenames but to:
+
+1. List migration files at the target commit: `git ls-tree -r --name-only <commit> backend/alembic/versions/`
+2. For each file, extract the `revision` variable: `git show <commit>:backend/alembic/versions/<filename>` and grep for `^revision\s*=`
+3. Also extract `down_revision` to build the revision chain
+4. Walk the chain to find the head (the revision that no other revision points to as its `down_revision`)
+
+This is more expensive (one `git show` per migration file) but reliable. The number of migration files is bounded (currently ~40) so this completes in under a second.
+
+**Alternative shortcut for prod:** After `git checkout <target_commit>` in Step 3, simply run `alembic heads` against the checked-out code. This is the simplest and most reliable approach since Alembic itself resolves the chain. The `resolve_alembic_revision()` call can happen after checkout instead of before.
+
+**Recommended approach:** Use the post-checkout `alembic heads` shortcut in production. The `git show`-based approach is a fallback for cases where we need the revision before checkout (e.g., for pre-flight validation).
 
 **DevUpdateBackend implementation:**
 - Returns a mock revision string (e.g., `"mock_downgrade_rev"`)
@@ -112,24 +175,85 @@ async def resolve_alembic_revision(self, commit: str) -> Optional[str]:
 #### Alembic Downgrade Fallback
 
 ```python
-async def _run_alembic_downgrade(self, target_rev: str, backup_id: int) -> bool:
+async def _run_alembic_downgrade(
+    self, target_rev: str, backup_id: int, admin_username: str
+) -> bool:
     """Run alembic downgrade. On failure, restore DB backup."""
     success, error = await self.backend.run_alembic_downgrade(target_rev)
     if not success:
         logger.warning(f"Alembic downgrade failed: {error}. Restoring backup.")
         backup_service = BackupService(self.db)
-        backup_service.restore_backup(backup_id)
+        restore_ok = backup_service.restore_backup(
+            backup_id=backup_id,
+            user=admin_username,
+            restore_database=True,
+            restore_files=False,
+            restore_config=False,
+        )
+        if not restore_ok:
+            logger.error(
+                f"DB backup restore also failed for backup {backup_id}. "
+                "Manual intervention required."
+            )
+            raise Exception(
+                f"Alembic downgrade failed ({error}) AND backup restore failed. "
+                "Database may be in inconsistent state."
+            )
         return False
     return True
 ```
 
+The `admin_username` is threaded from `downgrade()` via the `user_id` parameter (resolved to username via a DB query at the start of the downgrade flow).
+
 #### Production: `run-update.sh` Extension
 
-New flags:
-- `--downgrade` — switches from `alembic upgrade head` to `alembic downgrade <rev>`
-- `--alembic-rev <revision>` — target Alembic revision
+New flags parsed alongside existing ones:
+- `--downgrade` — boolean flag, switches migration step from upgrade to downgrade
+- `--alembic-rev <revision>` — target Alembic revision for downgrade
 
-The script's module runner skips module `08-database-migrate` and instead runs a new downgrade block that executes `alembic downgrade $ALEMBIC_REV`.
+**`ProdUpdateBackend.launch_update_script()` changes:**
+
+The method signature gains two optional parameters:
+
+```python
+def launch_update_script(
+    self,
+    update_id: int,
+    from_commit: str,
+    to_commit: str,
+    from_version: str,
+    to_version: str,
+    downgrade: bool = False,
+    alembic_rev: Optional[str] = None,
+) -> tuple[bool, Optional[str]]:
+```
+
+When `downgrade=True`, the additional flags `--downgrade --alembic-rev <rev>` are appended to the `systemd-run` command.
+
+**Shell script changes:**
+
+```bash
+# New argument parsing
+DOWNGRADE=false
+ALEMBIC_REV=""
+
+case "$1" in
+    # ...existing cases...
+    --downgrade)    DOWNGRADE=true;    shift ;;
+    --alembic-rev)  ALEMBIC_REV="$2";  shift 2 ;;
+esac
+
+# Step 3 (database): replace module 08 when downgrading
+if [[ "$DOWNGRADE" == "true" && -n "$ALEMBIC_REV" ]]; then
+    write_status "migrating" 45 "Running alembic downgrade to $ALEMBIC_REV..."
+    sudo -u "$BALUHOST_USER" "$VENV_DIR/bin/alembic" -c "$INSTALL_DIR/backend/alembic.ini" \
+        downgrade "$ALEMBIC_REV"
+else
+    run_module "08" "database-migrate" 45 55
+fi
+```
+
+**Dependency installation (Step 2):** The older version's `pyproject.toml` may have different dependency constraints. The shell script already runs module `05-python-venv` which does `pip install -e ".[dev]"` in the venv — this works because it installs from the checked-out (older) code. If pip fails due to conflicts, the error handler triggers a rollback to the original commit.
 
 ### Frontend
 
@@ -138,10 +262,12 @@ The script's module runner skips module `08-database-migrate` and instead runs a
 Each release where `version < current_version` gets a "Downgrade" button:
 
 ```
-v1.19.0  abc1234  2026-03-20  ✅ Stable  [Current]
-v1.18.0  def5678  2026-03-15  ✅ Stable  [↩ Downgrade]
-v1.17.0  ghi9012  2026-03-08  ✅ Stable  [↩ Downgrade]
+v1.19.0  abc1234  2026-03-20  Stable  [Current]
+v1.18.0  def5678  2026-03-15  Stable  [Downgrade]
+v1.17.0  ghi9012  2026-03-08  Stable  [Downgrade]
 ```
+
+The component receives the current version as a new prop to determine which releases are eligible for downgrade.
 
 #### Two-Step Inline Confirmation
 
@@ -198,7 +324,7 @@ New keys in `en/updates.json` and `de/updates.json`:
 }
 ```
 
-German equivalents:
+German equivalents (proper UTF-8 umlauts, matching existing i18n convention):
 
 ```json
 {
@@ -213,12 +339,15 @@ German equivalents:
 }
 ```
 
+Note: Verify umlaut convention in existing `de/updates.json` at implementation time and match it (either `ue`/`ae` ASCII or proper `u`/`a` UTF-8).
+
 ### Security
 
 - Admin-only endpoint with `Depends(deps.get_current_admin)`
 - Rate-limited via `@user_limiter.limit(get_limit("admin_operations"))`
 - Audit log entry for every downgrade attempt (success and failure)
 - `target_commit` validated against `target_tag` to prevent commit injection
+- `target_tag` validated with regex pattern to prevent arbitrary git ref injection
 - DB backup always created (not skippable for downgrade)
 
 ### Tests
@@ -227,11 +356,13 @@ German equivalents:
 
 - `test_downgrade_happy_path` — full flow with DevBackend
 - `test_downgrade_alembic_failure_restores_backup` — Alembic fails, backup restored
+- `test_downgrade_alembic_and_restore_both_fail` — both fail, downgrade aborted, git rolled back
 - `test_downgrade_blocked_by_running_update` — blocker check
 - `test_downgrade_target_newer_than_current_rejected` — version validation
 - `test_downgrade_invalid_tag_rejected` — tag validation
 - `test_downgrade_commit_mismatch_rejected` — commit vs tag validation
 - `test_downgrade_creates_mandatory_backup` — backup always created even with skip_backup=True
+- `test_downgrade_cancellation` — cancelling a running downgrade works
 
 #### API Tests (backend/tests/api/test_updates_routes.py)
 
@@ -239,21 +370,27 @@ German equivalents:
 - `test_downgrade_rate_limited` — rate limiting works
 - `test_downgrade_audit_logged` — audit log entry created
 
+#### ProdUpdateBackend Tests (backend/tests/services/test_prod_update_backend.py)
+
+- `test_resolve_alembic_revision_with_mocked_git` — mock `_run_git` calls, verify correct head resolution from migration chain
+
 ## File Changes Summary
 
 | File | Change |
 |------|--------|
-| `backend/app/schemas/update.py` | Add `DowngradeRequest`, extend `UpdateChannelEnum` |
+| `backend/app/schemas/update.py` | Add `DowngradeRequest`, extend `UpdateChannelEnum`, add `commit` to `ReleaseInfo` |
+| `backend/app/models/update_history.py` | Add `DOWNGRADE = "downgrade"` to `UpdateChannel` enum |
 | `backend/app/services/update/service.py` | Add `downgrade()`, `_run_dev_downgrade()`, `_run_alembic_downgrade()` |
 | `backend/app/services/update/backend.py` | Add abstract `resolve_alembic_revision()`, `run_alembic_downgrade()` |
-| `backend/app/services/update/prod_backend.py` | Implement `resolve_alembic_revision()`, `run_alembic_downgrade()` |
-| `backend/app/services/update/dev_backend.py` | Mock implementations for downgrade |
+| `backend/app/services/update/prod_backend.py` | Implement `resolve_alembic_revision()`, `run_alembic_downgrade()`, update `get_all_releases()` for full hash, extend `launch_update_script()` |
+| `backend/app/services/update/dev_backend.py` | Mock implementations for downgrade, update `get_all_releases()` for full hash |
 | `backend/app/api/routes/updates.py` | Add `POST /downgrade` endpoint |
-| `deploy/update/run-update.sh` | Add `--downgrade` + `--alembic-rev` flags |
-| `client/src/api/updates.ts` | Add `DowngradeRequest`, `startDowngrade()` |
+| `deploy/update/run-update.sh` | Add `--downgrade` + `--alembic-rev` flags, conditional migration step |
+| `client/src/api/updates.ts` | Add `DowngradeRequest`, `startDowngrade()`, add `commit` to `ReleaseInfo` |
 | `client/src/components/updates/UpdateHistoryTab.tsx` | Downgrade button + two-step inline confirmation |
 | `client/src/components/updates/UpdateOverviewTab.tsx` | Handle downgrade channel in progress display |
 | `client/src/i18n/locales/en/updates.json` | Downgrade translation keys |
 | `client/src/i18n/locales/de/updates.json` | German downgrade translations |
 | `backend/tests/services/test_update_service.py` | Downgrade unit tests |
 | `backend/tests/api/test_updates_routes.py` | Downgrade API tests |
+| `backend/tests/services/test_prod_update_backend.py` | `resolve_alembic_revision` tests |

--- a/docs/superpowers/specs/2026-03-23-release-downgrade-design.md
+++ b/docs/superpowers/specs/2026-03-23-release-downgrade-design.md
@@ -1,0 +1,259 @@
+# Release Downgrade Feature — Design Spec
+
+**Date**: 2026-03-23
+**Status**: Draft
+**Author**: Claude + Xveyn
+
+## Summary
+
+Allow administrators to downgrade BaluHost to any previous release (git tag). The system warns about potential database data loss, creates a mandatory DB backup before proceeding, attempts Alembic downgrade migrations, and falls back to full DB backup restore if migrations fail.
+
+## Requirements
+
+1. Admin can select any previous release from the release list and initiate a downgrade
+2. Two-step inline confirmation: warning displayed, then user must type the target version to confirm
+3. Mandatory DB backup before every downgrade (even if `skip_backup=True`)
+4. Alembic downgrade attempted first; on failure, restore DB from backup as fallback
+5. Full async progress tracking via existing `UpdateHistory` + `UpdateProgress` infrastructure
+6. Works in both dev mode (simulated) and prod mode (shell script)
+
+## Non-Goals
+
+- Downgrading to arbitrary non-tagged commits (only releases)
+- Automatic rollback of file-system data (user files are untouched)
+- Multi-step downgrade chains (e.g., 1.19 → 1.17 → 1.15 in sequence)
+
+## Architecture
+
+### Backend
+
+#### New Endpoint
+
+```
+POST /api/updates/downgrade
+```
+
+- Auth: `Depends(deps.get_current_admin)`
+- Rate limit: `@user_limiter.limit(get_limit("admin_operations"))`
+- Audit logged (event_type="UPDATE", action="downgrade")
+
+#### New Schema: `DowngradeRequest`
+
+```python
+class DowngradeRequest(BaseModel):
+    target_tag: str = Field(description="Git tag to downgrade to, e.g. 'v1.17.0'")
+    target_commit: str = Field(description="Expected commit hash for validation")
+    skip_backup: bool = Field(default=False, description="Skip file/config backup (DB backup is always created)")
+    force: bool = Field(default=False, description="Ignore non-critical blockers")
+```
+
+Response reuses `UpdateStartResponse` (success, update_id, message, blockers).
+
+#### UpdateChannelEnum Extension
+
+Add `"downgrade"` to `UpdateChannelEnum`:
+
+```python
+UpdateChannelEnum = Literal["stable", "unstable", "development", "downgrade"]
+```
+
+#### Service Method: `UpdateService.downgrade()`
+
+```python
+async def downgrade(
+    self,
+    request: DowngradeRequest,
+    user_id: int,
+) -> UpdateStartResponse:
+```
+
+**Validation steps:**
+1. Verify `target_tag` exists in git tags
+2. Verify `target_commit` matches the tag's commit
+3. Verify target version < current version (semver comparison)
+4. Check blockers (no running update/downgrade)
+
+**On success:** Creates `UpdateHistory` entry with `channel="downgrade"`, launches async task (dev) or shell script (prod).
+
+#### Async Downgrade Flow: `_run_dev_downgrade()`
+
+| Step | Progress | Status | Description |
+|------|----------|--------|-------------|
+| 1 | 5-10% | `backing_up` | **Mandatory DB backup** via `BackupService.create_backup()` (includes_database=True, includes_config=True). Always runs regardless of `skip_backup`. |
+| 2 | 10-25% | `downloading` | `git fetch --all --tags --prune` |
+| 3 | 25-40% | `installing` | `git checkout <target_commit>` |
+| 4 | 40-55% | `installing` | Install dependencies (pip/npm for the older version) |
+| 5 | 55-75% | `migrating` | **Alembic downgrade**: resolve target revision, run `alembic downgrade <rev>`. On failure → restore DB backup, log warning. |
+| 6 | 75-85% | `health_check` | Health check |
+| 7 | 85-95% | `restarting` | Restart services |
+| 8 | 100% | `completed` | Done |
+
+On any failure: attempt rollback to original commit (same as current update error handler).
+
+#### Alembic Revision Resolution
+
+New method on `UpdateBackend`:
+
+```python
+@abstractmethod
+async def resolve_alembic_revision(self, commit: str) -> Optional[str]:
+    """Determine the Alembic head revision at a given git commit."""
+    pass
+```
+
+**ProdUpdateBackend implementation:**
+- Run `git ls-tree -r --name-only <commit> backend/alembic/versions/` to list migration files at that commit
+- Parse revision IDs from filenames (pattern: `NNN_description.py` or `<hash>_description.py`)
+- Build the revision chain to find the head revision for that commit
+
+**DevUpdateBackend implementation:**
+- Returns a mock revision string (e.g., `"mock_downgrade_rev"`)
+
+#### Alembic Downgrade Fallback
+
+```python
+async def _run_alembic_downgrade(self, target_rev: str, backup_id: int) -> bool:
+    """Run alembic downgrade. On failure, restore DB backup."""
+    success, error = await self.backend.run_alembic_downgrade(target_rev)
+    if not success:
+        logger.warning(f"Alembic downgrade failed: {error}. Restoring backup.")
+        backup_service = BackupService(self.db)
+        backup_service.restore_backup(backup_id)
+        return False
+    return True
+```
+
+#### Production: `run-update.sh` Extension
+
+New flags:
+- `--downgrade` — switches from `alembic upgrade head` to `alembic downgrade <rev>`
+- `--alembic-rev <revision>` — target Alembic revision
+
+The script's module runner skips module `08-database-migrate` and instead runs a new downgrade block that executes `alembic downgrade $ALEMBIC_REV`.
+
+### Frontend
+
+#### `UpdateHistoryTab.tsx` — Release List Enhancement
+
+Each release where `version < current_version` gets a "Downgrade" button:
+
+```
+v1.19.0  abc1234  2026-03-20  ✅ Stable  [Current]
+v1.18.0  def5678  2026-03-15  ✅ Stable  [↩ Downgrade]
+v1.17.0  ghi9012  2026-03-08  ✅ Stable  [↩ Downgrade]
+```
+
+#### Two-Step Inline Confirmation
+
+**Step 1** — Click "Downgrade": Inline warning expands below the release row.
+
+Content:
+- Warning icon + text: "Downgrade to v1.17.0 may cause database data loss. A database backup will be created automatically before proceeding."
+- "Continue" button + "Cancel" button
+
+**Step 2** — Click "Continue": Input field replaces the warning.
+
+Content:
+- Prompt: "Type `v1.17.0` to confirm the downgrade:"
+- Text input field
+- "Start Downgrade" button (disabled until input matches target tag)
+- "Cancel" button
+
+#### Progress Display
+
+After starting, the user is redirected to the Overview tab. The existing `UpdateProgress` component displays the downgrade progress. The `to_version` field shows the downgrade target, and the channel shows "downgrade" which maps to a distinct label/color (e.g., amber/orange "Downgrade" badge).
+
+#### API Client Addition
+
+```typescript
+// client/src/api/updates.ts
+
+export interface DowngradeRequest {
+  target_tag: string;
+  target_commit: string;
+  skip_backup?: boolean;
+  force?: boolean;
+}
+
+export async function startDowngrade(request: DowngradeRequest): Promise<UpdateStartResponse> {
+  const response = await apiClient.post<UpdateStartResponse>('/api/updates/downgrade', request);
+  return response.data;
+}
+```
+
+#### i18n Keys
+
+New keys in `en/updates.json` and `de/updates.json`:
+
+```json
+{
+  "downgrade": {
+    "button": "Downgrade",
+    "warning": "Downgrade to {{version}} may cause database data loss. A database backup will be created automatically before proceeding.",
+    "confirmPrompt": "Type {{version}} to confirm the downgrade:",
+    "startButton": "Start Downgrade",
+    "progressLabel": "Downgrading to {{version}}",
+    "channel": "Downgrade"
+  }
+}
+```
+
+German equivalents:
+
+```json
+{
+  "downgrade": {
+    "button": "Downgrade",
+    "warning": "Ein Downgrade auf {{version}} kann zu Datenverlust in der Datenbank fuehren. Ein Datenbank-Backup wird automatisch vor dem Downgrade erstellt.",
+    "confirmPrompt": "Gib {{version}} ein, um den Downgrade zu bestaetigen:",
+    "startButton": "Downgrade starten",
+    "progressLabel": "Downgrade auf {{version}}",
+    "channel": "Downgrade"
+  }
+}
+```
+
+### Security
+
+- Admin-only endpoint with `Depends(deps.get_current_admin)`
+- Rate-limited via `@user_limiter.limit(get_limit("admin_operations"))`
+- Audit log entry for every downgrade attempt (success and failure)
+- `target_commit` validated against `target_tag` to prevent commit injection
+- DB backup always created (not skippable for downgrade)
+
+### Tests
+
+#### Unit Tests (backend/tests/services/test_update_service.py)
+
+- `test_downgrade_happy_path` — full flow with DevBackend
+- `test_downgrade_alembic_failure_restores_backup` — Alembic fails, backup restored
+- `test_downgrade_blocked_by_running_update` — blocker check
+- `test_downgrade_target_newer_than_current_rejected` — version validation
+- `test_downgrade_invalid_tag_rejected` — tag validation
+- `test_downgrade_commit_mismatch_rejected` — commit vs tag validation
+- `test_downgrade_creates_mandatory_backup` — backup always created even with skip_backup=True
+
+#### API Tests (backend/tests/api/test_updates_routes.py)
+
+- `test_downgrade_requires_admin` — returns 401/403 for non-admin
+- `test_downgrade_rate_limited` — rate limiting works
+- `test_downgrade_audit_logged` — audit log entry created
+
+## File Changes Summary
+
+| File | Change |
+|------|--------|
+| `backend/app/schemas/update.py` | Add `DowngradeRequest`, extend `UpdateChannelEnum` |
+| `backend/app/services/update/service.py` | Add `downgrade()`, `_run_dev_downgrade()`, `_run_alembic_downgrade()` |
+| `backend/app/services/update/backend.py` | Add abstract `resolve_alembic_revision()`, `run_alembic_downgrade()` |
+| `backend/app/services/update/prod_backend.py` | Implement `resolve_alembic_revision()`, `run_alembic_downgrade()` |
+| `backend/app/services/update/dev_backend.py` | Mock implementations for downgrade |
+| `backend/app/api/routes/updates.py` | Add `POST /downgrade` endpoint |
+| `deploy/update/run-update.sh` | Add `--downgrade` + `--alembic-rev` flags |
+| `client/src/api/updates.ts` | Add `DowngradeRequest`, `startDowngrade()` |
+| `client/src/components/updates/UpdateHistoryTab.tsx` | Downgrade button + two-step inline confirmation |
+| `client/src/components/updates/UpdateOverviewTab.tsx` | Handle downgrade channel in progress display |
+| `client/src/i18n/locales/en/updates.json` | Downgrade translation keys |
+| `client/src/i18n/locales/de/updates.json` | German downgrade translations |
+| `backend/tests/services/test_update_service.py` | Downgrade unit tests |
+| `backend/tests/api/test_updates_routes.py` | Downgrade API tests |


### PR DESCRIPTION
## Summary
- **fix(sleep):** Recover state when `suspend_system()` fails — previously stayed stuck on `TRUE_SUSPEND`, blocking schedule re-triggers, manual wake, and auto-wake middleware
- **fix(sleep):** Resume path after successful suspend now correctly transitions through `SOFT_SLEEP` before waking
- **test(sleep):** 3 new tests covering suspend failure recovery and schedule re-trigger

## Changelog
See [CHANGELOG.md](./CHANGELOG.md) for full v1.19.1 entry.