### PR TITLE
Release v1.20.1 — VPN Mode Clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.20.1] - 2026-03-25
+
+### Added
+- **VPN Mode Clarity** — Clearly distinguish Router-VPN (FritzBox) from NAS-VPN (WireGuard) in the UI
+  - Backend: `vpn_fallback` boolean in mobile token response — `true` when auto-mode silently fell back to NAS-VPN
+  - MobileDevicesPage: VPN type buttons relabeled to "Router-VPN (FritzBox)" / "NAS-VPN (WireGuard)", amber WoL warnings when NAS-VPN is selected or is the only available option, fallback notice in QR dialog
+  - VpnManagement: New NAS-VPN info card with server initialization status, active client count, and permanent WoL warning
+  - i18n: German and English translations for VPN management section
+
+---
+
 ## [1.20.0] - 2026-03-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,4 +75,4 @@ client/
 - **Issues**: GitHub Issues (repository URL needed)
 - **Documentation**: See `docs/` directory
 - **Maintainer**: Xveyn
-- **Version**: 1.20.0 (as of Mar 2026)
+- **Version**: 1.20.1 (as of Mar 2026)

--- a/backend/app/schemas/mobile.py
+++ b/backend/app/schemas/mobile.py
@@ -68,6 +68,7 @@ class MobileRegistrationToken(BaseModel):
     qr_code: str = Field(..., description="Base64 encoded QR code image")
     vpn_config: Optional[str] = Field(default=None, description="Base64 encoded WireGuard config (optional)")
     device_token_validity_days: int = Field(..., description="Device token validity in days (30-180)")
+    vpn_fallback: bool = Field(default=False, description="True when auto mode fell back to NAS-VPN")
 
 
 class MobileRegistrationResponse(BaseModel):

--- a/backend/app/services/mobile.py
+++ b/backend/app/services/mobile.py
@@ -69,6 +69,7 @@ class MobileService:
         # Generate VPN config if requested
         vpn_config_base64 = None
         vpn_config_type = None
+        vpn_did_fallback = False
         if include_vpn:
             try:
                 from app.services.vpn import VPNService
@@ -90,6 +91,7 @@ class MobileService:
                         use_fritzbox = True
                     else:
                         use_wireguard = True
+                        vpn_did_fallback = True
 
                 if use_fritzbox:
                     vpn_config_base64 = VPNService.get_fritzbox_config_base64(db)
@@ -167,7 +169,8 @@ class MobileService:
             expires_at=expires_at,
             qr_code=qr_code_base64,
             vpn_config=vpn_config_base64,
-            device_token_validity_days=token_validity_days
+            device_token_validity_days=token_validity_days,
+            vpn_fallback=vpn_did_fallback and vpn_config_base64 is not None,
         )
     
     @staticmethod

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baluhost-backend"
-version = "1.20.0"
+version = "1.20.1"
 description = "Mocked NAS management backend built with FastAPI"
 authors = [{ name = "Baluhost" }]
 requires-python = ">=3.11"

--- a/backend/tests/integration/test_mobile_token_vpn_flow.py
+++ b/backend/tests/integration/test_mobile_token_vpn_flow.py
@@ -39,6 +39,9 @@ def test_mobile_token_with_vpn_and_revoke(client):
         assert "token" in data
         # When include_vpn is true, vpn_config should be present (base64 string)
         assert data.get("vpn_config") is not None
+        # Default vpn_type is "auto" and no FritzBox config exists in test DB,
+        # so it falls back to NAS-VPN (WireGuard) — vpn_fallback should be True
+        assert data.get("vpn_fallback") is True
 
     # Create an explicit VPN client owned by the authenticated user and revoke it
     with TestClient(app, base_url="http://test") as client3:

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baluhost-client",
   "private": true,
-  "version": "1.20.0",
+  "version": "1.20.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/api/mobile.ts
+++ b/client/src/api/mobile.ts
@@ -10,6 +10,7 @@ export interface MobileRegistrationToken {
   expires_at: string;
   qr_code: string;
   vpn_config?: string;
+  vpn_fallback?: boolean;
   device_token_validity_days: number;
 }
 

--- a/client/src/components/VpnManagement.tsx
+++ b/client/src/components/VpnManagement.tsx
@@ -22,6 +22,7 @@ export default function VpnManagement() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [qrData, setQrData] = useState<string | null>(null);
+  const [nasVpnInfo, setNasVpnInfo] = useState<{ configured: boolean; activeClients: number } | null>(null);
 
   useEffect(() => {
     loadConfig();
@@ -42,6 +43,17 @@ export default function VpnManagement() {
       } catch {
         // QR code generation failed — config is still usable
         setQrData(null);
+      }
+
+      // Load NAS-VPN server status (admin-only endpoint)
+      try {
+        const serverRes = await apiClient.get('/api/vpn/server-config');
+        setNasVpnInfo({
+          configured: true,
+          activeClients: serverRes.data.active_clients ?? 0,
+        });
+      } catch {
+        setNasVpnInfo({ configured: false, activeClients: 0 });
       }
     } catch (err: unknown) {
       const status = err != null && typeof err === 'object' && 'response' in err
@@ -280,6 +292,37 @@ export default function VpnManagement() {
           </div>
         </div>
       )}
+
+      {/* NAS-VPN Info Section */}
+      <div className="card border-slate-800/60 bg-slate-900/55">
+        <h3 className="text-lg font-semibold mb-4 flex items-center text-white">
+          <Wifi className="w-5 h-5 mr-2 text-slate-400" />
+          {t('vpn.nasVpnTitle')}
+        </h3>
+
+        <div className="p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg mb-4">
+          <p className="text-xs text-amber-300">
+            ⚠ {t('vpn.nasVpnWolWarning')}
+          </p>
+        </div>
+
+        {nasVpnInfo && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+            <div>
+              <span className="text-slate-400">{t('vpn.status')}:</span>
+              <p className={`font-medium ${nasVpnInfo.configured ? 'text-green-400' : 'text-slate-400'}`}>
+                {nasVpnInfo.configured ? t('vpn.nasVpnInitialized') : t('vpn.nasVpnNotInitialized')}
+              </p>
+            </div>
+            {nasVpnInfo.configured && (
+              <div>
+                <span className="text-slate-400">{t('vpn.nasVpnActiveClients')}:</span>
+                <p className="text-white font-medium">{nasVpnInfo.activeClients}</p>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -286,7 +286,12 @@
     "deleteConfirm": "VPN-Konfiguration wirklich löschen?",
     "deleteSuccess": "Konfiguration gelöscht",
     "deleteFailed": "Löschen fehlgeschlagen",
-    "downloadFailed": "Download fehlgeschlagen"
+    "downloadFailed": "Download fehlgeschlagen",
+    "nasVpnTitle": "NAS-VPN (WireGuard Server)",
+    "nasVpnWolWarning": "Wenn das NAS per Sleep/WoL in den Ruhezustand versetzt wird, ist der NAS-VPN-Tunnel nicht erreichbar. Fuer unterbrechungsfreien VPN-Zugang wird Router-VPN empfohlen.",
+    "nasVpnInitialized": "Initialisiert",
+    "nasVpnNotInitialized": "Nicht initialisiert",
+    "nasVpnActiveClients": "Aktive Clients"
   },
   "tapo": {
     "loading": "Lade Geräte...",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -286,7 +286,12 @@
     "deleteConfirm": "Really delete VPN configuration?",
     "deleteSuccess": "Configuration deleted",
     "deleteFailed": "Delete failed",
-    "downloadFailed": "Download failed"
+    "downloadFailed": "Download failed",
+    "nasVpnTitle": "NAS-VPN (WireGuard Server)",
+    "nasVpnWolWarning": "When the NAS is suspended via Sleep/WoL, the NAS-VPN tunnel will be unreachable. For uninterrupted VPN access, Router-VPN is recommended.",
+    "nasVpnInitialized": "Initialized",
+    "nasVpnNotInitialized": "Not initialized",
+    "nasVpnActiveClients": "Active clients"
   },
   "tapo": {
     "loading": "Loading devices...",

--- a/client/src/pages/MobileDevicesPage.tsx
+++ b/client/src/pages/MobileDevicesPage.tsx
@@ -219,6 +219,14 @@ export default function MobileDevicesPage() {
               </label>
             </div>
 
+            {includeVpn && availableVpnTypes.length === 1 && availableVpnTypes[0] === 'wireguard' && (
+              <div className="ml-6 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg">
+                <p className="text-xs text-amber-300">
+                  ⚠ Kein Router-VPN konfiguriert. VPN wird direkt ueber das NAS bereitgestellt. Bei Nutzung von Sleep/WoL ist der VPN-Tunnel nicht erreichbar, solange das NAS schlaeft.
+                </p>
+              </div>
+            )}
+
             {includeVpn && availableVpnTypes.length > 1 && (
               <div className="ml-6 space-y-2">
                 <label className="block text-sm font-medium text-slate-300">
@@ -227,8 +235,8 @@ export default function MobileDevicesPage() {
                 <div className="flex flex-wrap gap-2">
                   {[
                     { value: 'auto', label: 'Automatisch' },
-                    ...(availableVpnTypes.includes('fritzbox') ? [{ value: 'fritzbox', label: 'FritzBox VPN' }] : []),
-                    { value: 'wireguard', label: 'WireGuard Server' },
+                    ...(availableVpnTypes.includes('fritzbox') ? [{ value: 'fritzbox', label: 'Router-VPN (FritzBox)' }] : []),
+                    { value: 'wireguard', label: 'NAS-VPN (WireGuard)' },
                   ].map((opt) => (
                     <button
                       key={opt.value}
@@ -245,10 +253,17 @@ export default function MobileDevicesPage() {
                   ))}
                 </div>
                 <p className="text-xs text-slate-500">
-                  {vpnType === 'auto' && 'FritzBox hat Priorität, WireGuard Server als Fallback'}
-                  {vpnType === 'fritzbox' && 'Nutzt die vom Admin hochgeladene FritzBox-Konfiguration'}
-                  {vpnType === 'wireguard' && 'Generiert eine eigene WireGuard-Client-Konfiguration'}
+                  {vpnType === 'auto' && 'Router-VPN bevorzugt, NAS-VPN als Fallback'}
+                  {vpnType === 'fritzbox' && 'Nutzt die vom Admin hochgeladene Router-Konfiguration'}
+                  {vpnType === 'wireguard' && 'VPN laeuft direkt ueber das NAS'}
                 </p>
+                {vpnType === 'wireguard' && (
+                  <div className="p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg">
+                    <p className="text-xs text-amber-300">
+                      ⚠ VPN laeuft direkt ueber das NAS. Bei Nutzung von Sleep/WoL ist der VPN-Tunnel nicht erreichbar, solange das NAS schlaeft.
+                    </p>
+                  </div>
+                )}
               </div>
             )}
           </div>
@@ -472,6 +487,13 @@ export default function MobileDevicesPage() {
                   <p>✓ Geräte-Autorisierung gilt für <strong className="text-sky-400">{qrData.device_token_validity_days} Tage ({Math.round(qrData.device_token_validity_days / 30)} Monate)</strong></p>
                   {qrData.vpn_config && (
                     <p className="text-green-400">✓ VPN-Konfiguration eingeschlossen</p>
+                  )}
+                  {qrData.vpn_fallback && (
+                    <div className="p-2 bg-amber-500/10 border border-amber-500/30 rounded-lg">
+                      <p className="text-xs text-amber-300">
+                        ⚠ Kein Router-VPN konfiguriert — NAS-VPN wird als Fallback verwendet.
+                      </p>
+                    </div>
                   )}
                 </div>
 


### PR DESCRIPTION
## Summary

- **VPN Mode Clarity**: Clearly distinguish Router-VPN (FritzBox) from NAS-VPN (WireGuard) in the UI
  - Backend: `vpn_fallback` boolean in mobile token response when auto-mode falls back to NAS-VPN
  - MobileDevicesPage: Relabeled VPN buttons ("Router-VPN (FritzBox)" / "NAS-VPN (WireGuard)"), amber WoL warnings, fallback notice in QR dialog
  - VpnManagement: New NAS-VPN info card with server status, active clients, and WoL warning
  - i18n: German and English translations for VPN management section
- Version bump to v1.20.1

## Test plan

- [x] Backend tests pass (`pytest -k mobile` — 4 passed)
- [x] Frontend build succeeds (no TypeScript errors)
- [x] `vpn_fallback` correctly set to `true` only when auto-mode falls back to NAS-VPN
- [ ] Visual check: MobileDevicesPage shows new labels and warnings
- [ ] Visual check: VpnManagement shows NAS-VPN info section

🤖 Generated with [Claude Code](https://claude.com/claude-code)