### PR TITLE
Release v1.20.5 — Sync Folder Update & File Checksums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.20.5] - 2026-03-29
+
+### Added
+- **Sync Folder Update** — PUT endpoint for updating sync folder configuration (remote path, sync type, auto-sync, status)
+- **File Checksum** — Expose file checksum in directory listing response for client-side change detection
+
+### Fixed
+- **Smart Device** — Use `anyio.from_thread.run` for async calls from sync worker threads, preventing event-loop errors
+
+---
+
 ## [1.20.4] - 2026-03-28
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,4 +75,4 @@ client/
 - **Issues**: GitHub Issues (repository URL needed)
 - **Documentation**: See `docs/` directory
 - **Maintainer**: Xveyn
-- **Version**: 1.20.4 (as of Mar 2026)
+- **Version**: 1.20.5 (as of Mar 2026)

--- a/backend/app/api/routes/mobile.py
+++ b/backend/app/api/routes/mobile.py
@@ -22,6 +22,7 @@ from app.schemas.mobile import (
     CameraBackupStatus,
     SyncFolder as SyncFolderSchema,
     SyncFolderCreate,
+    SyncFolderUpdate,
     UploadQueueListResponse,
 )
 from app.models.mobile import MobileRegistrationToken as MobileRegistrationTokenModel
@@ -466,6 +467,26 @@ async def create_sync_folder(
         db=db,
         device_id=device_id,
         folder_data=folder_data
+    )
+
+
+@router.put("/sync/folders/{folder_id}", response_model=SyncFolderSchema)
+@user_limiter.limit(get_limit("mobile_sync"))
+async def update_sync_folder(
+    request: Request,
+    response: Response,
+    folder_id: str,
+    update_data: SyncFolderUpdate,
+    db: Session = Depends(get_db),
+    current_user: UserPublic = Depends(get_current_user)
+):
+    """
+    Update a sync folder configuration. Also refreshes last_sync timestamp.
+    """
+    return MobileService.update_sync_folder(
+        db=db,
+        folder_id=folder_id,
+        update_data=update_data
     )
 
 

--- a/backend/app/plugins/smart_device/manager.py
+++ b/backend/app/plugins/smart_device/manager.py
@@ -147,15 +147,13 @@ class SmartDeviceManager:
         db.commit()
         db.refresh(device)
 
-        # Notify the plugin about the new device (best-effort)
+        # Notify the plugin about the new device (best-effort).
+        # This method is sync and runs in an AnyIO worker thread (via FastAPI),
+        # so we use anyio.from_thread.run() to call back into the event loop.
         if data.config:
             try:
-                import asyncio
-                loop = asyncio.get_event_loop()
-                if loop.is_running():
-                    asyncio.ensure_future(
-                        plugin.connect_device(str(device.id), data.config)
-                    )
+                from anyio.from_thread import run as _anyio_run
+                _anyio_run(plugin.connect_device, str(device.id), data.config)
             except Exception as exc:
                 logger.warning(
                     "Could not schedule connect_device for device %d: %s",
@@ -237,10 +235,8 @@ class SmartDeviceManager:
         plugin = self._plugins.get(device.plugin_name)
         if plugin is not None:
             try:
-                import asyncio
-                loop = asyncio.get_event_loop()
-                if loop.is_running():
-                    asyncio.ensure_future(plugin.disconnect_device(str(device.id)))
+                from anyio.from_thread import run as _anyio_run
+                _anyio_run(plugin.disconnect_device, str(device.id))
             except Exception as exc:
                 logger.debug("disconnect_device for %d failed: %s", device.id, exc)
 

--- a/backend/app/schemas/files.py
+++ b/backend/app/schemas/files.py
@@ -33,6 +33,7 @@ class FileItem(BaseModel):
     owner_id: str | None = None
     mime_type: str | None = None
     file_id: int | None = None
+    checksum: str | None = None
     sync_info: list[SyncDeviceInfo] | None = None
     can_read: bool | None = None
     can_write: bool | None = None

--- a/backend/app/schemas/mobile.py
+++ b/backend/app/schemas/mobile.py
@@ -109,6 +109,14 @@ class SyncFolderCreate(BaseModel):
     auto_sync: bool = True
 
 
+class SyncFolderUpdate(BaseModel):
+    """Schema for updating a sync folder."""
+    remote_path: Optional[str] = None
+    sync_type: Optional[str] = None
+    auto_sync: Optional[bool] = None
+    status: Optional[str] = None
+
+
 class SyncFolder(SyncFolderCreate):
     """Schema for sync folder in responses."""
     id: str

--- a/backend/app/services/files/operations.py
+++ b/backend/app/services/files/operations.py
@@ -236,6 +236,12 @@ def list_directory(relative_path: str = "", user: UserPublic | None = None, db: 
             if meta:
                 file_id = meta.id
 
+        checksum = None
+        if not is_dir and db:
+            meta = metadata_map.get(relative_entry)
+            if meta:
+                checksum = meta.checksum
+
         item = FileItem(
             name=entry.name,
             path=relative_entry,
@@ -245,6 +251,7 @@ def list_directory(relative_path: str = "", user: UserPublic | None = None, db: 
             owner_id=entry_owner,
             mime_type=mime_type,
             file_id=file_id,
+            checksum=checksum,
         )
         # Attach share permissions for non-owner shared files
         if db and entry_owner and not can_view(user, entry_owner) and not path_utils.is_in_shared_dir(relative_entry):

--- a/backend/app/services/mobile.py
+++ b/backend/app/services/mobile.py
@@ -23,6 +23,7 @@ from app.schemas.mobile import (
     MobileRegistrationToken as MobileRegistrationTokenSchema,
     CameraBackupSettings,
     SyncFolderCreate,
+    SyncFolderUpdate,
 )
 from app.services import auth as auth_service
 from app.core import security
@@ -458,6 +459,24 @@ class MobileService:
         db.commit()
         db.refresh(sync_folder)
         return sync_folder
+
+    @staticmethod
+    def update_sync_folder(
+        db: Session,
+        folder_id: str,
+        update_data: SyncFolderUpdate
+    ) -> SyncFolder:
+        """Update a sync folder configuration and refresh last_sync."""
+        folder = db.query(SyncFolder).filter(SyncFolder.id == folder_id).first()
+        if not folder:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=404, detail="Sync folder not found")
+        for field, value in update_data.model_dump(exclude_unset=True).items():
+            setattr(folder, field, value)
+        folder.last_sync = datetime.now(timezone.utc)
+        db.commit()
+        db.refresh(folder)
+        return folder
 
     @staticmethod
     def delete_sync_folder(db: Session, folder_id: str) -> None:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baluhost-backend"
-version = "1.20.4"
+version = "1.20.5"
 description = "Mocked NAS management backend built with FastAPI"
 authors = [{ name = "Baluhost" }]
 requires-python = ">=3.11"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baluhost-client",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baluhost-client",
-      "version": "1.20.4",
+      "version": "1.20.5",
       "dependencies": {
         "axios": "^1.13.1",
         "i18next": "^25.8.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baluhost-client",
   "private": true,
-  "version": "1.20.4",
+  "version": "1.20.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- **Sync folder update endpoint** — PUT `/api/mobile/sync/folders/{folder_id}` for updating sync folder config (remote path, sync type, auto-sync, status)
- **File checksum in listings** — `checksum` field exposed in directory listing response for client-side change detection
- **Smart device fix** — Use `anyio.from_thread.run` for async calls from sync worker threads

## Changelog
See [CHANGELOG.md](./CHANGELOG.md) for full details.

## Test plan
- [ ] Verify PUT sync folder endpoint updates fields and refreshes `last_sync`
- [ ] Verify directory listing includes `checksum` for files with metadata
- [ ] Verify smart device async calls work without event-loop errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)