### PR TITLE
Release (minor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.27.0] - 2026-04-03
+
+### Added
+- **Notification Routing** — Admin-configurable notification categories for non-admin users
+  - Admins can assign notification categories (RAID, SMART, Backup, Scheduler, System, Security, Sync, VPN) per user
+  - New `user_notification_routing` database table with per-category boolean flags
+  - Admin endpoints on `/api/users/{id}/notification-routing` for viewing and updating
+  - `GET /api/notifications/my-routing` read-only endpoint for users to see assigned categories
+  - Routed users receive both push (Firebase) and in-app (WebSocket) notifications
+  - User's own NotificationPreferences (quiet hours, channel opt-out) respected after routing
+  - Per-user notification copies created for routed users so they appear in notification list
+  - Frontend toggle UI in user edit modal with category icons and descriptions
+  - Read-only badge display in user's notification settings showing assigned categories
+  - Audit logging for routing changes
+- **Dependencies** — Audit logger added as FastAPI dependency for cleaner injection
+
+### Fixed
+- Sleep: use atomic rtcwake suspend to fix scheduled wake-up failure
+- Security: add defense-in-depth username validation for Samba
+- Security: harden config defaults and add production validators
+
+### Changed
+- Refactor: add `ensure_db()` context manager to deduplicate session boilerplate
+- Refactor: remove legacy `sys.modules` backward-compat shims
+
+---
+
 ## [1.26.0] - 2026-04-03
 
 ### Added

--- a/backend/alembic/versions/1a72b07a9a99_add_user_notification_routing_table.py
+++ b/backend/alembic/versions/1a72b07a9a99_add_user_notification_routing_table.py
@@ -1,0 +1,49 @@
+"""add user_notification_routing table
+
+Revision ID: 1a72b07a9a99
+Revises: 049_recreate_sync_tables
+Create Date: 2026-04-03 14:49:01.017766
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1a72b07a9a99'
+down_revision: Union[str, Sequence[str], None] = '049_recreate_sync_tables'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('user_notification_routing',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('user_id', sa.Integer(), nullable=False),
+    sa.Column('receive_raid', sa.Boolean(), server_default='0', nullable=False),
+    sa.Column('receive_smart', sa.Boolean(), server_default='0', nullable=False),
+    sa.Column('receive_backup', sa.Boolean(), server_default='0', nullable=False),
+    sa.Column('receive_scheduler', sa.Boolean(), server_default='0', nullable=False),
+    sa.Column('receive_system', sa.Boolean(), server_default='0', nullable=False),
+    sa.Column('receive_security', sa.Boolean(), server_default='0', nullable=False),
+    sa.Column('receive_sync', sa.Boolean(), server_default='0', nullable=False),
+    sa.Column('receive_vpn', sa.Boolean(), server_default='0', nullable=False),
+    sa.Column('granted_by', sa.Integer(), nullable=True),
+    sa.Column('granted_at', sa.DateTime(timezone=True), server_default=sa.text('(CURRENT_TIMESTAMP)'), nullable=False),
+    sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('(CURRENT_TIMESTAMP)'), nullable=False),
+    sa.ForeignKeyConstraint(['granted_by'], ['users.id'], ondelete='SET NULL'),
+    sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_user_notification_routing_id'), 'user_notification_routing', ['id'], unique=False)
+    op.create_index(op.f('ix_user_notification_routing_user_id'), 'user_notification_routing', ['user_id'], unique=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_user_notification_routing_user_id'), table_name='user_notification_routing')
+    op.drop_index(op.f('ix_user_notification_routing_id'), table_name='user_notification_routing')
+    op.drop_table('user_notification_routing')

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -19,6 +19,14 @@ logger = logging.getLogger(__name__)
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f"{settings.api_prefix}/auth/login", auto_error=False)
 
 
+def get_audit_logger():
+    """FastAPI dependency that provides the database-backed audit logger.
+
+    Use as: audit_logger: AuditLoggerDB = Depends(deps.get_audit_logger)
+    """
+    return get_audit_logger_db()
+
+
 async def get_current_user(
     request: Request,
     token: Optional[str] = Depends(oauth2_scheme),

--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -281,6 +281,30 @@ async def update_notification_preferences(
     return NotificationPreferencesResponse.from_db(prefs)
 
 
+@router.get("/my-routing")
+@user_limiter.limit(get_limit("admin_operations"))
+async def get_my_notification_routing(
+    request: Request, response: Response,
+    current_user: UserPublic = Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get the current user's notification routing (read-only)."""
+    from app.services.notification_routing import get_routing
+    from app.schemas.notification_routing import MyNotificationRoutingResponse
+
+    routing = get_routing(db, current_user.id)
+    return MyNotificationRoutingResponse(
+        receive_raid=routing.receive_raid,
+        receive_smart=routing.receive_smart,
+        receive_backup=routing.receive_backup,
+        receive_scheduler=routing.receive_scheduler,
+        receive_system=routing.receive_system,
+        receive_security=routing.receive_security,
+        receive_sync=routing.receive_sync,
+        receive_vpn=routing.receive_vpn,
+    )
+
+
 # Admin endpoints for creating notifications
 @router.post("", response_model=NotificationResponse, status_code=status.HTTP_201_CREATED)
 @user_limiter.limit(get_limit("admin_operations"))

--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -20,6 +20,7 @@ from app.schemas.notification import (
     NotificationPreferencesResponse,
     NotificationCategoryEnum,
 )
+from app.schemas.notification_routing import MyNotificationRoutingResponse
 from app.services.notifications import get_notification_service
 from app.services import auth as auth_service
 from app.services.permissions import is_privileged
@@ -281,7 +282,7 @@ async def update_notification_preferences(
     return NotificationPreferencesResponse.from_db(prefs)
 
 
-@router.get("/my-routing")
+@router.get("/my-routing", response_model=MyNotificationRoutingResponse)
 @user_limiter.limit(get_limit("admin_operations"))
 async def get_my_notification_routing(
     request: Request, response: Response,
@@ -290,7 +291,6 @@ async def get_my_notification_routing(
 ):
     """Get the current user's notification routing (read-only)."""
     from app.services.notification_routing import get_routing
-    from app.schemas.notification_routing import MyNotificationRoutingResponse
 
     routing = get_routing(db, current_user.id)
     return MyNotificationRoutingResponse(

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -370,3 +370,45 @@ async def update_user_power_permissions(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
     return update_permissions(db, user_id, body, granted_by=current_admin.id)
+
+
+from app.schemas.notification_routing import NotificationRoutingResponse, NotificationRoutingUpdate
+
+
+@router.get("/{user_id}/notification-routing", response_model=NotificationRoutingResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def get_user_notification_routing(
+    request: Request,
+    response: Response,
+    user_id: int,
+    current_admin: UserPublic = Depends(deps.get_current_admin),
+    db: Session = Depends(get_db),
+) -> NotificationRoutingResponse:
+    """Get notification routing for a user (admin only)."""
+    from app.services.notification_routing import get_routing
+
+    user = user_service.get_user(user_id, db=db)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    return get_routing(db, user_id)
+
+
+@router.put("/{user_id}/notification-routing", response_model=NotificationRoutingResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def update_user_notification_routing(
+    request: Request,
+    response: Response,
+    user_id: int,
+    body: NotificationRoutingUpdate,
+    current_admin: UserPublic = Depends(deps.get_current_admin),
+    db: Session = Depends(get_db),
+) -> NotificationRoutingResponse:
+    """Update notification routing for a user (admin only)."""
+    from app.services.notification_routing import update_routing
+
+    user = user_service.get_user(user_id, db=db)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    return update_routing(db, user_id, body, granted_by=current_admin.id)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -39,8 +39,8 @@ class Settings(BaseSettings):
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7  # Refresh token TTL (long)
     privileged_roles: list[str] = ["admin"]
     
-    # Registration control
-    registration_enabled: bool = True  # Set False in production (via REGISTRATION_ENABLED env var) to require admin-created accounts
+    # Registration control — defaults to False for security (production requires admin-created accounts)
+    registration_enabled: bool = False
 
     # Local-only access enforcement (Option B security)
     enforce_local_only: bool = False  # Set True to restrict sensitive endpoints to localhost
@@ -232,6 +232,9 @@ class Settings(BaseSettings):
                 self.sleep_mode_enabled = False
             if self.pihole_enabled:
                 self.pihole_enabled = False
+            # Enable registration in dev mode for convenience
+            if not self.registration_enabled:
+                self.registration_enabled = True
             # Auto-generate VPN encryption key for dev mode
             if not self.vpn_encryption_key:
                 from cryptography.fernet import Fernet
@@ -286,6 +289,36 @@ class Settings(BaseSettings):
                 )
             if len(v) < 32:
                 raise ValueError("token_secret must be at least 32 characters for security")
+        return v
+
+    @field_validator("registration_enabled")
+    @classmethod
+    def validate_registration(cls, v: bool, info) -> bool:
+        """Warn when open registration is enabled in production."""
+        import os
+        is_dev = os.getenv("NAS_MODE", "dev").lower() == "dev"
+        is_test = os.getenv("SKIP_APP_INIT") == "1" or os.getenv("PYTEST_CURRENT_TEST")
+
+        if not (is_dev or is_test) and v:
+            logging.warning(
+                "REGISTRATION_ENABLED=true in production — anyone can create accounts. "
+                "Set REGISTRATION_ENABLED=false to require admin-created accounts."
+            )
+        return v
+
+    @field_validator("totp_encryption_key")
+    @classmethod
+    def validate_totp_key(cls, v: str, info) -> str:
+        """Warn when TOTP encryption key is not set in production."""
+        import os
+        is_dev = os.getenv("NAS_MODE", "dev").lower() == "dev"
+        is_test = os.getenv("SKIP_APP_INIT") == "1" or os.getenv("PYTEST_CURRENT_TEST")
+
+        if not (is_dev or is_test) and not v:
+            logging.warning(
+                "TOTP_ENCRYPTION_KEY not set — TOTP secrets will use VPN_ENCRYPTION_KEY as fallback. "
+                "Set a dedicated TOTP_ENCRYPTION_KEY for proper key isolation."
+            )
         return v
 
     @field_validator("balupi_handshake_secret")

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,5 +1,6 @@
 """Database configuration and session management."""
-from typing import Generator
+from contextlib import contextmanager
+from typing import Generator, Optional
 from pathlib import Path
 import os
 import logging
@@ -155,7 +156,7 @@ def commit_with_retry(db: Session, *, retries: int = 3, delay_seconds: float = 0
 def get_db() -> Generator[Session, None, None]:
     """
     Dependency to get database session.
-    
+
     Usage in FastAPI:
         @router.get("/users")
         def get_users(db: Session = Depends(get_db)):
@@ -166,6 +167,28 @@ def get_db() -> Generator[Session, None, None]:
         yield db
     finally:
         db.close()
+
+
+@contextmanager
+def ensure_db(db: Optional[Session] = None) -> Generator[Session, None, None]:
+    """Context manager that reuses an existing session or creates a temporary one.
+
+    Replaces the 'should_close = db is None' boilerplate pattern.
+
+    Usage::
+
+        def my_service_func(db: Optional[Session] = None):
+            with ensure_db(db) as session:
+                session.query(...)
+    """
+    if db is not None:
+        yield db
+    else:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
 
 
 def init_db() -> None:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -83,6 +83,7 @@ from app.models.ad_discovery import (
 from app.models.file_activity import FileActivity
 from app.models.fritzbox import FritzBoxConfig
 from app.models.power_permissions import UserPowerPermission
+from app.models.notification_routing import UserNotificationRouting
 from app.models.sync_progress import ChunkedUpload, SyncBandwidthLimit, SyncSchedule, SelectiveSync
 from app.models.sync_state import SyncState, SyncMetadata, SyncFileVersion
 
@@ -171,6 +172,7 @@ __all__ = [
     "FileActivity",
     "FritzBoxConfig",
     "UserPowerPermission",
+    "UserNotificationRouting",
     "ChunkedUpload",
     "SyncBandwidthLimit",
     "SyncSchedule",

--- a/backend/app/models/notification_routing.py
+++ b/backend/app/models/notification_routing.py
@@ -1,0 +1,44 @@
+"""Database model for user notification routing."""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Boolean, DateTime, Integer, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+
+
+class UserNotificationRouting(Base):
+    """Per-user notification category routing, granted by an admin."""
+
+    __tablename__ = "user_notification_routing"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False, index=True
+    )
+
+    receive_raid: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+    receive_smart: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+    receive_backup: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+    receive_scheduler: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+    receive_system: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+    receive_security: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+    receive_sync: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+    receive_vpn: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+
+    granted_by: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    granted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    # Relationships
+    user = relationship("User", foreign_keys=[user_id])
+    granted_by_user = relationship("User", foreign_keys=[granted_by])

--- a/backend/app/schemas/notification_routing.py
+++ b/backend/app/schemas/notification_routing.py
@@ -1,0 +1,51 @@
+"""Pydantic schemas for user notification routing."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class NotificationRoutingResponse(BaseModel):
+    """Response schema for notification routing (admin view)."""
+
+    user_id: int
+    receive_raid: bool = False
+    receive_smart: bool = False
+    receive_backup: bool = False
+    receive_scheduler: bool = False
+    receive_system: bool = False
+    receive_security: bool = False
+    receive_sync: bool = False
+    receive_vpn: bool = False
+    granted_by: Optional[int] = None
+    granted_by_username: Optional[str] = None
+    granted_at: Optional[datetime] = None
+
+    model_config = {"from_attributes": True}
+
+
+class NotificationRoutingUpdate(BaseModel):
+    """Request schema for updating notification routing."""
+
+    receive_raid: Optional[bool] = Field(default=None, description="Receive RAID notifications")
+    receive_smart: Optional[bool] = Field(default=None, description="Receive SMART notifications")
+    receive_backup: Optional[bool] = Field(default=None, description="Receive Backup notifications")
+    receive_scheduler: Optional[bool] = Field(default=None, description="Receive Scheduler notifications")
+    receive_system: Optional[bool] = Field(default=None, description="Receive System notifications")
+    receive_security: Optional[bool] = Field(default=None, description="Receive Security notifications")
+    receive_sync: Optional[bool] = Field(default=None, description="Receive Sync notifications")
+    receive_vpn: Optional[bool] = Field(default=None, description="Receive VPN notifications")
+
+
+class MyNotificationRoutingResponse(BaseModel):
+    """Response for the user's own routing (read-only, no admin metadata)."""
+
+    receive_raid: bool = False
+    receive_smart: bool = False
+    receive_backup: bool = False
+    receive_scheduler: bool = False
+    receive_system: bool = False
+    receive_security: bool = False
+    receive_sync: bool = False
+    receive_vpn: bool = False

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,164 +1,19 @@
 """
 Services package.
 
-This module provides backward-compatible re-exports for all services
-that have been moved to subdirectories. Old import paths continue to work.
+Public re-exports for commonly used service classes.
 """
-import sys
-
-# ============================================================
-# Versioning services (moved to versioning/)
-# ============================================================
 from app.services.versioning.vcl import VCLService
 from app.services.versioning.cache import VCLCache, VCLCacheSync, PendingVersion
 from app.services.versioning.priority import VCLPriorityMode, VCLMonitor
 
-# Import actual modules for aliasing
-from app.services.versioning import vcl as _vcl
-from app.services.versioning import cache as _vcl_cache
-from app.services.versioning import priority as _vcl_priority
-
-# Register backward-compatible module paths in sys.modules
-sys.modules["app.services.vcl"] = _vcl
-sys.modules["app.services.vcl_cache"] = _vcl_cache
-sys.modules["app.services.vcl_priority"] = _vcl_priority
-
-# ============================================================
-# VPN services (moved to vpn/)
-# ============================================================
 from app.services.vpn.service import VPNService
 from app.services.vpn.profiles import VPNService as VPNProfileService
 from app.services.vpn.encryption import VPNEncryption
 
-# Import actual modules for aliasing
-from app.services.vpn import service as _vpn_service_module
-from app.services.vpn import profiles as _vpn_profiles_module
-from app.services.vpn import encryption as _vpn_encryption_module
-
-# Register backward-compatible module paths in sys.modules
-# Note: app.services.vpn is a package, so it's handled by its own __init__.py
-sys.modules["app.services.vpn_service"] = _vpn_profiles_module
-sys.modules["app.services.vpn_encryption"] = _vpn_encryption_module
-
-# ============================================================
-# Audit services (moved to audit/)
-# ============================================================
 from app.services.audit.logger import AuditLogger, get_audit_logger
 from app.services.audit.logger_db import AuditLoggerDB, get_audit_logger_db
 from app.services.audit.admin_db import AdminDBService
-
-# Import actual modules for aliasing
-from app.services.audit import logger as _audit_logger
-from app.services.audit import logger_db as _audit_logger_db
-from app.services.audit import admin_db as _admin_db
-
-# Register backward-compatible module paths in sys.modules
-sys.modules["app.services.audit_logger"] = _audit_logger
-sys.modules["app.services.audit_logger_db"] = _audit_logger_db
-sys.modules["app.services.admin_db"] = _admin_db
-
-# ============================================================
-# Hardware services (moved to hardware/)
-# ============================================================
-from app.services.hardware import raid as _raid
-from app.services.hardware import smart as _smart
-from app.services.hardware import sensors as _sensors
-
-# Register backward-compatible module paths in sys.modules
-sys.modules["app.services.raid"] = _raid
-sys.modules["app.services.smart"] = _smart
-sys.modules["app.services.sensors"] = _sensors
-
-# ============================================================
-# Backup services (moved to backup/)
-# ============================================================
-from app.services.backup import service as _backup_service
-from app.services.backup import scheduler as _backup_scheduler_mod
-
-# Register backward-compatible module paths in sys.modules
-# NOTE: Do NOT override "app.services.backup" — it is a real package with __init__.py
-sys.modules["app.services.backup_service"] = _backup_service
-sys.modules["app.services.backup_scheduler"] = _backup_scheduler_mod
-
-# ============================================================
-# Files services (moved to files/)
-# ============================================================
-from app.services.files import operations as _files
-from app.services.files import metadata as _file_metadata
-from app.services.files import metadata_db as _file_metadata_db
-from app.services.files import shares as _shares
-
-# Register backward-compatible module paths in sys.modules
-# NOTE: Do NOT override "app.services.files" — it is a real package with __init__.py
-sys.modules["app.services.files_operations"] = _files
-sys.modules["app.services.file_metadata"] = _file_metadata
-sys.modules["app.services.file_metadata_db"] = _file_metadata_db
-sys.modules["app.services.shares"] = _shares
-
-# ============================================================
-# Notifications services (moved to notifications/)
-# ============================================================
-from app.services.notifications import service as _notification_service
-from app.services.notifications import scheduler as _notification_scheduler_mod
-from app.services.notifications import events as _event_emitter
-from app.services.notifications import firebase as _firebase_service
-
-# Register backward-compatible module paths in sys.modules
-# NOTE: Do NOT override "app.services.notifications" — it is a real package with __init__.py
-sys.modules["app.services.notification_service"] = _notification_service
-sys.modules["app.services.notification_scheduler"] = _notification_scheduler_mod
-sys.modules["app.services.event_emitter"] = _event_emitter
-sys.modules["app.services.firebase_service"] = _firebase_service
-
-# ============================================================
-# Power services (moved to power/)
-# ============================================================
-from app.services.power import manager as _power_manager
-from app.services.power import presets as _power_preset_service
-from app.services.power import energy as _energy_stats
-from app.services.power import fan_control as _fan_control
-
-# Register backward-compatible module paths in sys.modules
-sys.modules["app.services.power_manager"] = _power_manager
-sys.modules["app.services.power_preset_service"] = _power_preset_service
-sys.modules["app.services.energy_stats"] = _energy_stats
-sys.modules["app.services.fan_control"] = _fan_control
-
-# ============================================================
-# Sync services (moved to sync/)
-# ============================================================
-from app.services.sync import file_sync as _file_sync
-from app.services.sync import progressive as _progressive_sync
-from app.services.sync import background as _sync_background
-from app.services.sync import scheduler as _sync_scheduler
-
-# Register backward-compatible module paths in sys.modules
-sys.modules["app.services.file_sync"] = _file_sync
-sys.modules["app.services.progressive_sync"] = _progressive_sync
-sys.modules["app.services.sync_background"] = _sync_background
-sys.modules["app.services.sync_scheduler"] = _sync_scheduler
-
-# ============================================================
-# Benchmark services (moved to benchmark/)
-# ============================================================
-from app.services import benchmark as _benchmark_service
-
-# Register backward-compatible module path in sys.modules
-# NOTE: Do NOT override "app.services.benchmark" — it is a real package with __init__.py
-sys.modules["app.services.benchmark_service"] = _benchmark_service
-
-# ============================================================
-# Scheduler services (moved to scheduler/)
-# ============================================================
-from app.services.scheduler import execution as _scheduler_execution
-from app.services.scheduler import service as _scheduler_service_mod
-from app.services.scheduler import worker as _scheduler_worker_mod
-from app.services import scheduler as _scheduler_pkg
-
-# Register backward-compatible module paths in sys.modules
-# NOTE: Do NOT override "app.services.scheduler" — it is a real package with __init__.py
-sys.modules["app.services.scheduler_service"] = _scheduler_pkg
-sys.modules["app.services.scheduler_worker_service"] = _scheduler_worker_mod
 
 __all__ = [
     # Versioning

--- a/backend/app/services/audit/logger_db.py
+++ b/backend/app/services/audit/logger_db.py
@@ -87,23 +87,17 @@ class AuditLoggerDB:
         )
         
         # Use provided session or create a new one
-        should_close = False
-        if db is None:
-            db = next(get_db())
-            should_close = True
-        
+        from app.core.database import ensure_db
+
         try:
-            db.add(audit_entry)
-            db.commit()
-            db.refresh(audit_entry)
-            return audit_entry
+            with ensure_db(db) as session:
+                session.add(audit_entry)
+                session.commit()
+                session.refresh(audit_entry)
+                return audit_entry
         except Exception as e:
-            logger.error(f"Failed to write audit log to database: {e}")
-            db.rollback()
+            logger.error("Failed to write audit log to database: %s", e)
             return None
-        finally:
-            if should_close:
-                db.close()
     
     def log_file_access(
         self,

--- a/backend/app/services/benchmark/__init__.py
+++ b/backend/app/services/benchmark/__init__.py
@@ -3,10 +3,6 @@ Disk Benchmark Service.
 
 Provides CrystalDiskMark-style disk performance benchmarks using fio.
 Supports both production (real fio) and development (simulated) modes.
-
-This package re-exports all public symbols so that existing imports
-like ``from app.services.benchmark_service import X`` continue to work
-(via the sys.modules alias registered in ``app.services.__init__``).
 """
 
 from app.services.benchmark.api import (

--- a/backend/app/services/hardware/smart/enrichment.py
+++ b/backend/app/services/hardware/smart/enrichment.py
@@ -58,7 +58,7 @@ def _enrich_with_filesystem_usage(devices: list[SmartDevice]) -> None:
         # RAID-aware: Erstelle Mapping member_base_name -> (used, total, mountpoint, array_name)
         raid_member_map: dict[str, tuple[int, int, str | None, str]] = {}
         try:
-            from app.services import raid as raid_service
+            from app.services.hardware import raid as raid_service
             from app.services.hardware.raid import find_raid_mountpoint
             raid_data = raid_service.get_status()
             if raid_data and raid_data.arrays:

--- a/backend/app/services/notification_routing.py
+++ b/backend/app/services/notification_routing.py
@@ -1,0 +1,149 @@
+"""Service for managing per-user notification routing."""
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from app.models.notification_routing import UserNotificationRouting
+from app.schemas.notification_routing import (
+    NotificationRoutingResponse,
+    NotificationRoutingUpdate,
+)
+from app.services.audit.logger_db import get_audit_logger_db
+
+logger = logging.getLogger(__name__)
+
+# Maps category string to model field name
+_CATEGORY_FIELD_MAP = {
+    "raid": "receive_raid",
+    "smart": "receive_smart",
+    "backup": "receive_backup",
+    "scheduler": "receive_scheduler",
+    "system": "receive_system",
+    "security": "receive_security",
+    "sync": "receive_sync",
+    "vpn": "receive_vpn",
+}
+
+
+def get_routing(db: Session, user_id: int) -> NotificationRoutingResponse:
+    """Get notification routing for a user. Returns defaults if no entry exists."""
+    routing = db.query(UserNotificationRouting).filter(
+        UserNotificationRouting.user_id == user_id
+    ).first()
+
+    if not routing:
+        return NotificationRoutingResponse(user_id=user_id)
+
+    granted_by_username = None
+    if routing.granted_by:
+        from app.models.user import User
+        admin = db.query(User).filter(User.id == routing.granted_by).first()
+        if admin:
+            granted_by_username = admin.username
+
+    return NotificationRoutingResponse(
+        user_id=routing.user_id,
+        receive_raid=routing.receive_raid,
+        receive_smart=routing.receive_smart,
+        receive_backup=routing.receive_backup,
+        receive_scheduler=routing.receive_scheduler,
+        receive_system=routing.receive_system,
+        receive_security=routing.receive_security,
+        receive_sync=routing.receive_sync,
+        receive_vpn=routing.receive_vpn,
+        granted_by=routing.granted_by,
+        granted_by_username=granted_by_username,
+        granted_at=routing.granted_at,
+    )
+
+
+def update_routing(
+    db: Session,
+    user_id: int,
+    update: NotificationRoutingUpdate,
+    granted_by: int,
+) -> NotificationRoutingResponse:
+    """Create or update notification routing for a user."""
+    audit_logger = get_audit_logger_db()
+
+    routing = db.query(UserNotificationRouting).filter(
+        UserNotificationRouting.user_id == user_id
+    ).first()
+
+    if not routing:
+        routing = UserNotificationRouting(user_id=user_id, granted_by=granted_by)
+        db.add(routing)
+
+    old_values = {field: getattr(routing, field) for field in _CATEGORY_FIELD_MAP.values()}
+
+    for category, field in _CATEGORY_FIELD_MAP.items():
+        value = getattr(update, field)
+        if value is not None:
+            setattr(routing, field, value)
+
+    routing.granted_by = granted_by
+
+    db.commit()
+    db.refresh(routing)
+
+    new_values = {field: getattr(routing, field) for field in _CATEGORY_FIELD_MAP.values()}
+
+    # Audit log
+    from app.models.user import User
+    admin = db.query(User).filter(User.id == granted_by).first()
+    target = db.query(User).filter(User.id == user_id).first()
+
+    audit_logger.log_security_event(
+        action="notification_routing_changed",
+        user=admin.username if admin else str(granted_by),
+        resource=f"user:{target.username if target else user_id}",
+        details={"old": old_values, "new": new_values},
+        success=True,
+        db=db,
+    )
+
+    return get_routing(db, user_id)
+
+
+def check_routing(db: Session, user_id: int, category: str) -> bool:
+    """Check if a user has routing enabled for a specific category."""
+    field = _CATEGORY_FIELD_MAP.get(category)
+    if not field:
+        return False
+
+    routing = db.query(UserNotificationRouting).filter(
+        UserNotificationRouting.user_id == user_id
+    ).first()
+
+    if not routing:
+        return False
+
+    return bool(getattr(routing, field, False))
+
+
+def get_routed_user_ids(db: Session, category: str) -> list[int]:
+    """Get all non-admin user IDs with routing enabled for a category.
+
+    Args:
+        db: Database session
+        category: Notification category (raid, smart, etc.)
+
+    Returns:
+        List of user IDs with routing enabled for this category
+    """
+    field = _CATEGORY_FIELD_MAP.get(category)
+    if not field:
+        return []
+
+    from app.models.user import User
+
+    routing_rows = db.query(UserNotificationRouting.user_id).join(
+        User, UserNotificationRouting.user_id == User.id
+    ).filter(
+        getattr(UserNotificationRouting, field) == True,
+        User.role != "admin",
+        User.is_active == True,
+    ).all()
+
+    return [uid for (uid,) in routing_rows]

--- a/backend/app/services/notifications/events.py
+++ b/backend/app/services/notifications/events.py
@@ -579,14 +579,22 @@ class EventEmitter:
                         User.is_active == True,
                     ).all()
                 ]
-                if not admin_ids:
+
+                # Also include non-admin users with routing for this category
+                from app.services.notification_routing import get_routed_user_ids
+                routed_ids = get_routed_user_ids(db, category)
+
+                all_recipient_ids = list(set(admin_ids + routed_ids))
+                if not all_recipient_ids:
                     return
+
                 devices = db.query(MobileDevice).filter(
-                    MobileDevice.user_id.in_(admin_ids),
+                    MobileDevice.user_id.in_(all_recipient_ids),
                     MobileDevice.is_active == True,
                     MobileDevice.push_token.isnot(None),
                 ).all()
             else:
+                admin_ids = []
                 devices = db.query(MobileDevice).filter(
                     MobileDevice.user_id == user_id,
                     MobileDevice.is_active == True,
@@ -594,6 +602,17 @@ class EventEmitter:
                 ).all()
 
             for device in devices:
+                # For routed non-admin users, check their preferences
+                if user_id is None and device.user_id not in admin_ids:
+                    from app.services.notifications.service import get_notification_service
+                    svc = get_notification_service()
+                    prefs = svc.get_user_preferences(db, device.user_id)
+                    if prefs:
+                        if svc._is_quiet_hours(prefs) and priority < 3:
+                            continue
+                        if not svc._should_send_to_channel(prefs, category, "push"):
+                            continue
+
                 result = FirebaseService.send_notification(
                     device_token=device.push_token,
                     title=title,

--- a/backend/app/services/notifications/events.py
+++ b/backend/app/services/notifications/events.py
@@ -512,6 +512,31 @@ class EventEmitter:
                     priority=config.priority,
                     action_url=config.action_url,
                 )
+
+                # Create per-user notification copies for routed non-admin users
+                # so they appear in the user's notification list
+                if user_id is None:
+                    from app.services.notification_routing import get_routed_user_ids
+                    from app.services.notifications.service import get_notification_service
+                    svc = get_notification_service()
+                    routed_ids = get_routed_user_ids(db, config.category)
+                    for uid in routed_ids:
+                        prefs = svc.get_user_preferences(db, uid)
+                        if prefs:
+                            if svc._is_quiet_hours(prefs) and config.priority < 3:
+                                continue
+                        user_copy = Notification(
+                            user_id=uid,
+                            category=config.category,
+                            notification_type=config.notification_type,
+                            title=title,
+                            message=message,
+                            action_url=config.action_url,
+                            extra_data={"event_type": event_type, **kwargs},
+                            priority=config.priority,
+                        )
+                        db.add(user_copy)
+                    db.commit()
             except Exception as e:
                 db.rollback()
                 logger.error(f"Failed to create notification for {event_type}: {e}")

--- a/backend/app/services/notifications/service.py
+++ b/backend/app/services/notifications/service.py
@@ -126,6 +126,28 @@ class NotificationService:
             # System notification - broadcast to all admins via WebSocket + Push
             await self._broadcast_to_recipients(db, notification)
             await self._send_push_to_recipients(db, notification)
+
+            # Create per-user notification copies for routed non-admin users
+            # so they appear in the user's notification list
+            from app.services.notification_routing import get_routed_user_ids
+            routed_ids = get_routed_user_ids(db, notification.category)
+            for uid in routed_ids:
+                prefs = self.get_user_preferences(db, uid)
+                if prefs:
+                    if self._is_quiet_hours(prefs) and notification.priority < 3:
+                        continue
+                user_copy = Notification(
+                    user_id=uid,
+                    category=notification.category,
+                    notification_type=notification.notification_type,
+                    title=notification.title,
+                    message=notification.message,
+                    action_url=notification.action_url,
+                    extra_data=notification.extra_data,
+                    priority=notification.priority,
+                )
+                db.add(user_copy)
+            db.commit()
             return
 
         # Get user preferences
@@ -163,10 +185,16 @@ class NotificationService:
             # Broadcast to all admins
             await self._websocket_manager.broadcast_to_admins(notification.to_dict())
 
-            # Also broadcast to routed non-admin users
+            # Also broadcast to routed non-admin users (respecting preferences)
             from app.services.notification_routing import get_routed_user_ids
             routed_ids = get_routed_user_ids(db, notification.category)
             for uid in routed_ids:
+                prefs = self.get_user_preferences(db, uid)
+                if prefs:
+                    if self._is_quiet_hours(prefs) and notification.priority < 3:
+                        continue
+                    if not self._should_send_to_channel(prefs, notification.category, "in_app"):
+                        continue
                 await self._websocket_manager.broadcast_to_user(uid, notification.to_dict())
         except Exception as e:
             logger.error(f"Failed to broadcast notification: {e}")

--- a/backend/app/services/notifications/service.py
+++ b/backend/app/services/notifications/service.py
@@ -124,8 +124,8 @@ class NotificationService:
         """
         if notification.user_id is None:
             # System notification - broadcast to all admins via WebSocket + Push
-            await self._broadcast_to_admins(notification)
-            await self._send_push_to_admins(db, notification)
+            await self._broadcast_to_recipients(db, notification)
+            await self._send_push_to_recipients(db, notification)
             return
 
         # Get user preferences
@@ -152,27 +152,29 @@ class NotificationService:
         if self._should_send_to_channel(prefs, notification.category, "push"):
             await self._send_push(db, notification)
 
-    async def _broadcast_to_admins(self, notification: Notification) -> None:
-        """Broadcast notification to all admin users via WebSocket.
-
-        Args:
-            notification: Notification to broadcast
-        """
-        if self._websocket_manager:
-            try:
-                await self._websocket_manager.broadcast_to_admins(notification.to_dict())
-            except Exception as e:
-                logger.error(f"Failed to broadcast to admins: {e}")
-
-    async def _send_push_to_admins(
+    async def _broadcast_to_recipients(
         self, db: Session, notification: Notification
     ) -> None:
-        """Send push notification to all admin users' mobile devices.
+        """Broadcast notification to admin users and routed non-admin users via WebSocket."""
+        if not self._websocket_manager:
+            return
 
-        Args:
-            db: Database session
-            notification: Notification to send
-        """
+        try:
+            # Broadcast to all admins
+            await self._websocket_manager.broadcast_to_admins(notification.to_dict())
+
+            # Also broadcast to routed non-admin users
+            from app.services.notification_routing import get_routed_user_ids
+            routed_ids = get_routed_user_ids(db, notification.category)
+            for uid in routed_ids:
+                await self._websocket_manager.broadcast_to_user(uid, notification.to_dict())
+        except Exception as e:
+            logger.error(f"Failed to broadcast notification: {e}")
+
+    async def _send_push_to_recipients(
+        self, db: Session, notification: Notification
+    ) -> None:
+        """Send push notification to admin users and routed non-admin users."""
         from app.services.notifications.firebase import FirebaseService
         from app.models.mobile import MobileDevice
 
@@ -180,17 +182,24 @@ class NotificationService:
             return
 
         try:
+            # 1. Always include all admin users
             admin_ids = [
                 uid for (uid,) in db.query(User.id).filter(
                     User.role == "admin",
                     User.is_active == True,
                 ).all()
             ]
-            if not admin_ids:
+
+            # 2. Include non-admin users with routing for this category
+            from app.services.notification_routing import get_routed_user_ids
+            routed_ids = get_routed_user_ids(db, notification.category)
+
+            all_recipient_ids = list(set(admin_ids + routed_ids))
+            if not all_recipient_ids:
                 return
 
             devices = db.query(MobileDevice).filter(
-                MobileDevice.user_id.in_(admin_ids),
+                MobileDevice.user_id.in_(all_recipient_ids),
                 MobileDevice.is_active == True,
                 MobileDevice.push_token.isnot(None),
             ).all()
@@ -198,6 +207,16 @@ class NotificationService:
             for device in devices:
                 if not device.push_token:
                     continue
+
+                # For routed non-admin users, check their preferences
+                if device.user_id not in admin_ids:
+                    prefs = self.get_user_preferences(db, device.user_id)
+                    if prefs:
+                        if self._is_quiet_hours(prefs) and notification.priority < 3:
+                            continue
+                        if not self._should_send_to_channel(prefs, notification.category, "push"):
+                            continue
+
                 result = FirebaseService.send_notification(
                     device_token=device.push_token,
                     title=notification.title,
@@ -209,7 +228,7 @@ class NotificationService:
                     notification_type=notification.notification_type,
                 )
                 if result["success"]:
-                    logger.debug(f"Admin push sent to device {device.id}")
+                    logger.debug(f"Push sent to device {device.id}")
                 elif result["error"] == "unregistered":
                     logger.warning(
                         f"Device {device.id} token unregistered, clearing"
@@ -218,10 +237,10 @@ class NotificationService:
                     db.commit()
                 else:
                     logger.error(
-                        f"Admin push to device {device.id} failed: {result['error']}"
+                        f"Push to device {device.id} failed: {result['error']}"
                     )
         except Exception as e:
-            logger.error(f"Failed to send admin push notifications: {e}")
+            logger.error(f"Failed to send push notifications: {e}")
 
     async def _send_in_app(self, notification: Notification) -> None:
         """Send notification via WebSocket for in-app display.

--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -59,8 +59,10 @@ class SleepBackend(abc.ABC):
         """Spin up given disk devices. Returns list of successfully spun-up devices."""
 
     @abc.abstractmethod
-    async def suspend_system(self) -> bool:
-        """Suspend the system. Returns True on success."""
+    async def suspend_system(self, wake_at: Optional[datetime] = None) -> bool:
+        """Suspend the system. If *wake_at* is given, schedule an RTC alarm
+        atomically (i.e. ``rtcwake -m mem``) so the system wakes at that time.
+        Returns True on success."""
 
     @abc.abstractmethod
     async def schedule_rtc_wake(self, wake_at: datetime) -> bool:
@@ -725,14 +727,6 @@ class SleepManagerService:
 
         self._current_state = SleepState.ENTERING_SUSPEND
 
-        # Schedule RTC wake if requested
-        if wake_at:
-            try:
-                await self._backend.schedule_rtc_wake(wake_at)
-                logger.info("RTC wake scheduled for %s", wake_at.isoformat())
-            except Exception as e:
-                logger.warning("Could not schedule RTC wake: %s", e)
-
         self._log_state_change(
             SleepState.SOFT_SLEEP, SleepState.TRUE_SUSPEND, reason, trigger,
             details={"wake_at": wake_at.isoformat() if wake_at else None},
@@ -741,8 +735,9 @@ class SleepManagerService:
         self._current_state = SleepState.TRUE_SUSPEND
         self._state_since = datetime.now(timezone.utc)
 
-        # Actually suspend
-        ok = await self._backend.suspend_system()
+        # Suspend the system.  When *wake_at* is given the backend uses
+        # ``rtcwake -m mem`` which sets the RTC alarm and suspends atomically.
+        ok = await self._backend.suspend_system(wake_at=wake_at)
 
         # When system resumes (or suspend failed), we'll be back here.
         # Revert to SOFT_SLEEP so _exit_soft_sleep accepts the transition.

--- a/backend/app/services/power/sleep_backend_dev.py
+++ b/backend/app/services/power/sleep_backend_dev.py
@@ -3,6 +3,7 @@ Development backend for sleep mode that simulates all operations in-memory.
 """
 import asyncio
 import logging
+from datetime import datetime
 from typing import Optional
 
 from app.services.power.sleep import SleepBackend
@@ -27,9 +28,12 @@ class DevSleepBackend(SleepBackend):
         logger.info("[DEV] Simulated disk spinup: %s", devices)
         return devices
 
-    async def suspend_system(self) -> bool:
+    async def suspend_system(self, wake_at: Optional[datetime] = None) -> bool:
         self._suspended = True
-        logger.info("[DEV] Simulated system suspend")
+        if wake_at:
+            logger.info("[DEV] Simulated system suspend with RTC wake at %s", wake_at.isoformat())
+        else:
+            logger.info("[DEV] Simulated system suspend")
         # Simulate waking up after a short delay
         await asyncio.sleep(2)
         self._suspended = False

--- a/backend/app/services/power/sleep_backend_linux.py
+++ b/backend/app/services/power/sleep_backend_linux.py
@@ -57,15 +57,27 @@ class LinuxSleepBackend(SleepBackend):
                 logger.warning("Failed to spin up %s: %s", device, output)
         return spun_up
 
-    async def suspend_system(self) -> bool:
-        ok, output = await self._run_cmd(["sudo", "systemctl", "suspend"], timeout=30)
+    async def suspend_system(self, wake_at: Optional[datetime] = None) -> bool:
+        if wake_at:
+            # Use rtcwake -m mem to set the RTC alarm and suspend atomically.
+            # This is more reliable than setting the alarm separately and then
+            # calling systemctl suspend, because the kernel may clear a
+            # previously-set wakealarm during its own suspend path.
+            timestamp = str(int(wake_at.timestamp()))
+            # Let rtcwake auto-detect UTC/local from /etc/adjtime (no -l/-u).
+            cmd = ["sudo", "rtcwake", "-m", "mem", "-t", timestamp]
+            logger.info("Suspending with RTC wake at %s (ts=%s)", wake_at.isoformat(), timestamp)
+            ok, output = await self._run_cmd(cmd, timeout=30)
+        else:
+            ok, output = await self._run_cmd(["sudo", "systemctl", "suspend"], timeout=30)
         if not ok:
             logger.error("System suspend failed: %s", output)
         return ok
 
     async def schedule_rtc_wake(self, wake_at: datetime) -> bool:
         timestamp = str(int(wake_at.timestamp()))
-        ok, output = await self._run_cmd(["sudo", "rtcwake", "-m", "no", "-l", "-t", timestamp])
+        # Let rtcwake auto-detect UTC/local from /etc/adjtime (no -l/-u).
+        ok, output = await self._run_cmd(["sudo", "rtcwake", "-m", "no", "-t", timestamp])
         if not ok:
             logger.error("RTC wake schedule failed: %s", output)
         return ok

--- a/backend/app/services/samba_service.py
+++ b/backend/app/services/samba_service.py
@@ -10,6 +10,7 @@ In dev mode all system commands are no-ops.
 import asyncio
 import logging
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Optional
@@ -19,6 +20,21 @@ from app.core.database import SessionLocal
 from app.models.user import User
 
 logger = logging.getLogger(__name__)
+
+# Defense-in-depth: validate usernames before passing to system commands.
+# Only allow lowercase alphanumeric, hyphens, and underscores (standard Linux username rules).
+_USERNAME_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
+
+
+def _validate_username(username: str) -> None:
+    """Validate username before use in subprocess commands.
+
+    Raises ValueError if username contains unexpected characters.
+    This is defense-in-depth — Pydantic validates at registration,
+    but service functions must not trust callers blindly.
+    """
+    if not _USERNAME_RE.match(username):
+        raise ValueError(f"Invalid username for Samba operation: {username!r}")
 
 SAMBA_SHARES_CONF = "/etc/samba/baluhost-shares.conf"
 
@@ -55,6 +71,7 @@ async def _ensure_system_user(username: str) -> None:
     The user is added to the same group as the BaluHost service user
     so Samba can access files owned by that group.
     """
+    _validate_username(username)
     if settings.is_dev_mode:
         logger.info("[DEV] Mock _ensure_system_user('%s')", username)
         return
@@ -84,6 +101,7 @@ async def sync_smb_password(username: str, plaintext_password: str) -> bool:
 
     This creates the Samba account if it doesn't exist yet (smbpasswd -a).
     """
+    _validate_username(username)
     if settings.is_dev_mode:
         logger.info("[DEV] Mock sync_smb_password('%s')", username)
         return True
@@ -106,6 +124,7 @@ async def sync_smb_password(username: str, plaintext_password: str) -> bool:
 
 async def remove_smb_user(username: str) -> bool:
     """Remove a user from the Samba password database."""
+    _validate_username(username)
     if settings.is_dev_mode:
         logger.info("[DEV] Mock remove_smb_user('%s')", username)
         return True
@@ -121,6 +140,7 @@ async def remove_smb_user(username: str) -> bool:
 
 async def enable_smb_user(username: str) -> bool:
     """Enable a Samba user account."""
+    _validate_username(username)
     if settings.is_dev_mode:
         logger.info("[DEV] Mock enable_smb_user('%s')", username)
         return True
@@ -136,6 +156,7 @@ async def enable_smb_user(username: str) -> bool:
 
 async def disable_smb_user(username: str) -> bool:
     """Disable a Samba user account."""
+    _validate_username(username)
     if settings.is_dev_mode:
         logger.info("[DEV] Mock disable_smb_user('%s')", username)
         return True

--- a/backend/app/services/totp_service.py
+++ b/backend/app/services/totp_service.py
@@ -28,9 +28,16 @@ ISSUER_NAME = "BaluHost"
 
 
 def _get_totp_fernet() -> Fernet:
-    """Get Fernet instance for TOTP encryption, using dedicated key or VPN key fallback."""
+    """Get Fernet instance for TOTP encryption, using dedicated key."""
     from app.core.config import settings
-    key = settings.totp_encryption_key or settings.vpn_encryption_key
+    key = settings.totp_encryption_key
+    if not key:
+        if not settings.is_dev_mode:
+            logger.warning(
+                "TOTP_ENCRYPTION_KEY not set — falling back to VPN_ENCRYPTION_KEY. "
+                "Set a dedicated TOTP_ENCRYPTION_KEY in production for key isolation."
+            )
+        key = settings.vpn_encryption_key
     if not key:
         raise ValueError(
             "No encryption key configured for TOTP "

--- a/backend/app/services/users.py
+++ b/backend/app/services/users.py
@@ -9,7 +9,7 @@ from passlib.context import CryptContext
 from sqlalchemy.orm import Session
 
 from app.core.config import Settings, settings
-from app.core.database import SessionLocal
+from app.core.database import SessionLocal, ensure_db
 from app.models.user import User
 from app.schemas.user import UserCreate, UserPublic, UserUpdate
 from app.services.files.storage_permissions import set_storage_dir_permissions
@@ -59,21 +59,17 @@ def ensure_user_home_directories(db: Optional[Session] = None) -> None:
     """Ensure home directories exist for all non-admin users and create the Shared folder."""
     from app.services.files.metadata_db import get_metadata, create_metadata
 
-    should_close = db is None
-    if db is None:
-        db = _get_db()
-
-    try:
+    with ensure_db(db) as session:
         storage_root = _get_storage_root()
 
         # Ensure Shared folder
         shared_dir = storage_root / SHARED_DIR_NAME
         shared_dir.mkdir(parents=True, exist_ok=True)
         set_storage_dir_permissions(shared_dir)
-        existing_shared = get_metadata(SHARED_DIR_NAME, db=db)
+        existing_shared = get_metadata(SHARED_DIR_NAME, db=session)
         if not existing_shared:
             # Shared folder owned by admin (owner_id is NOT NULL in DB)
-            admin_user = db.query(User).filter(User.role == "admin").first()
+            admin_user = session.query(User).filter(User.role == "admin").first()
             if admin_user:
                 create_metadata(
                     relative_path=SHARED_DIR_NAME,
@@ -81,17 +77,14 @@ def ensure_user_home_directories(db: Optional[Session] = None) -> None:
                     owner_id=admin_user.id,
                     size_bytes=0,
                     is_directory=True,
-                    db=db,
+                    db=session,
                 )
                 logger.info("Shared directory created at %s", shared_dir)
 
         # Ensure home dirs for all non-admin users
-        users = db.query(User).filter(User.role != "admin").all()
+        users = session.query(User).filter(User.role != "admin").all()
         for user in users:
-            _create_home_directory(user.username, user.id, db=db)
-    finally:
-        if should_close:
-            db.close()
+            _create_home_directory(user.username, user.id, db=session)
 
 
 def _rename_home_directory(old_username: str, new_username: str, db: Optional[Session] = None) -> None:
@@ -99,11 +92,7 @@ def _rename_home_directory(old_username: str, new_username: str, db: Optional[Se
     from app.services.files.metadata_db import rename_metadata
     from app.models.file_metadata import FileMetadata
 
-    should_close = db is None
-    if db is None:
-        db = _get_db()
-
-    try:
+    with ensure_db(db) as session:
         storage_root = _get_storage_root()
         old_dir = storage_root / old_username
         new_dir = storage_root / new_username
@@ -116,13 +105,13 @@ def _rename_home_directory(old_username: str, new_username: str, db: Optional[Se
             old_path=old_username,
             new_path=new_username,
             new_name=new_username,
-            db=db,
+            db=session,
         )
 
         # Update all child metadata paths with the old prefix
         old_prefix = f"{old_username}/"
         new_prefix = f"{new_username}/"
-        children = db.query(FileMetadata).filter(
+        children = session.query(FileMetadata).filter(
             FileMetadata.path.startswith(old_prefix)
         ).all()
         for child in children:
@@ -131,11 +120,8 @@ def _rename_home_directory(old_username: str, new_username: str, db: Optional[Se
                 child.parent_path = new_prefix + child.parent_path[len(old_prefix):]
             elif child.parent_path == old_username:
                 child.parent_path = new_username
-        db.commit()
+        session.commit()
         logger.info("Renamed home directory from '%s' to '%s'", old_username, new_username)
-    finally:
-        if should_close:
-            db.close()
 
 
 def ensure_admin_user(settings: Settings) -> None:
@@ -159,56 +145,31 @@ def ensure_admin_user(settings: Settings) -> None:
 
 def list_users(db: Optional[Session] = None) -> Iterable[User]:
     """List all users from database."""
-    should_close = db is None
-    if db is None:
-        db = _get_db()
-    
-    try:
-        return db.query(User).all()
-    finally:
-        if should_close:
-            db.close()
+    with ensure_db(db) as session:
+        return session.query(User).all()
 
 
 def get_user(user_id: int | str, db: Optional[Session] = None) -> Optional[User]:
     """Get user by ID from database."""
-    should_close = db is None
-    if db is None:
-        db = _get_db()
-    
-    try:
+    with ensure_db(db) as session:
         # Support both int and string IDs for backward compatibility
         if isinstance(user_id, str):
             try:
                 user_id = int(user_id)
             except ValueError:
                 return None
-        return db.query(User).filter(User.id == user_id).first()
-    finally:
-        if should_close:
-            db.close()
+        return session.query(User).filter(User.id == user_id).first()
 
 
 def get_user_by_username(username: str, db: Optional[Session] = None) -> Optional[User]:
     """Get user by username from database."""
-    should_close = db is None
-    if db is None:
-        db = _get_db()
-    
-    try:
-        return db.query(User).filter(User.username == username).first()
-    finally:
-        if should_close:
-            db.close()
+    with ensure_db(db) as session:
+        return session.query(User).filter(User.username == username).first()
 
 
 def create_user(payload: UserCreate, db: Optional[Session] = None) -> User:
     """Create new user in database."""
-    should_close = db is None
-    if db is None:
-        db = _get_db()
-
-    try:
+    with ensure_db(db) as session:
         password_hash = pwd_context.hash(payload.password)
         # Convert empty string to None for email (database nullable field)
         email = payload.email if payload.email and payload.email.strip() else None
@@ -218,31 +179,24 @@ def create_user(payload: UserCreate, db: Optional[Session] = None) -> User:
             role=(getattr(payload, "role", None) or "user"),
             hashed_password=password_hash,
         )
-        db.add(user)
-        db.commit()
-        db.refresh(user)
+        session.add(user)
+        session.commit()
+        session.refresh(user)
 
         # Create home directory for non-admin users
         if user.role != "admin":
             try:
-                _create_home_directory(user.username, user.id, db=db)
+                _create_home_directory(user.username, user.id, db=session)
             except Exception:
                 logger.warning("Failed to create home directory for user '%s'", user.username, exc_info=True)
 
         return user
-    finally:
-        if should_close:
-            db.close()
 
 
 def update_user(user_id: int | str, payload: UserUpdate, db: Optional[Session] = None) -> Optional[User]:
     """Update user in database."""
-    should_close = db is None
-    if db is None:
-        db = _get_db()
-    
-    try:
-        user = get_user(user_id, db=db)
+    with ensure_db(db) as session:
+        user = get_user(user_id, db=session)
         if not user:
             return None
 
@@ -260,13 +214,13 @@ def update_user(user_id: int | str, payload: UserUpdate, db: Optional[Session] =
         if payload.is_active is not None:
             user.is_active = payload.is_active
 
-        db.commit()
-        db.refresh(user)
+        session.commit()
+        session.refresh(user)
 
         # Rename home directory if username changed and user is not admin
         if payload.username and payload.username != old_username and user.role != "admin":
             try:
-                _rename_home_directory(old_username, payload.username, db=db)
+                _rename_home_directory(old_username, payload.username, db=session)
             except Exception:
                 logger.warning(
                     "Failed to rename home directory from '%s' to '%s'",
@@ -274,27 +228,20 @@ def update_user(user_id: int | str, payload: UserUpdate, db: Optional[Session] =
                 )
 
         return user
-    finally:
-        if should_close:
-            db.close()
 
 
 def delete_user(user_id: int | str, db: Optional[Session] = None) -> bool:
     """Delete user from database."""
-    should_close = db is None
-    if db is None:
-        db = _get_db()
-    
-    try:
-        user = get_user(user_id, db=db)
+    with ensure_db(db) as session:
+        user = get_user(user_id, db=session)
         if not user:
             return False
 
         username = user.username
         is_admin = user.role == "admin"
 
-        db.delete(user)
-        db.commit()
+        session.delete(user)
+        session.commit()
 
         # Remove home directory for non-admin users
         if not is_admin:
@@ -308,9 +255,6 @@ def delete_user(user_id: int | str, db: Optional[Session] = None) -> bool:
                 logger.warning("Failed to delete home directory for user '%s'", username, exc_info=True)
 
         return True
-    finally:
-        if should_close:
-            db.close()
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
@@ -320,21 +264,14 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 
 def update_user_password(user_id: int | str, new_password: str, db: Optional[Session] = None) -> bool:
     """Update user password in database."""
-    should_close = db is None
-    if db is None:
-        db = _get_db()
-    
-    try:
-        user = get_user(user_id, db=db)
+    with ensure_db(db) as session:
+        user = get_user(user_id, db=session)
         if not user:
             return False
-        
+
         user.hashed_password = pwd_context.hash(new_password)
-        db.commit()
+        session.commit()
         return True
-    finally:
-        if should_close:
-            db.close()
 
 
 def list_users_filtered(

--- a/backend/baluhost_tui/screens/dashboard.py
+++ b/backend/baluhost_tui/screens/dashboard.py
@@ -13,7 +13,7 @@ from textual.reactive import reactive
 from rich.text import Text
 
 from app.services.telemetry import get_history, get_latest_cpu_usage, get_latest_memory_sample
-from app.services.raid import get_status as get_raid_status
+from app.services.hardware.raid import get_status as get_raid_status
 from app.services.users import list_users
 from app.services.audit.logger_db import get_audit_logger_db
 from app.core.config import settings

--- a/backend/baluhost_tui/screens/raid.py
+++ b/backend/baluhost_tui/screens/raid.py
@@ -54,7 +54,7 @@ class RaidControlScreen(Screen):
                     arrays = data.get("arrays", [])
                 else:
                     # local import
-                    from app.services import raid as raid_service
+                    from app.services.hardware import raid as raid_service
                     st = raid_service.get_status()
                     arrays = [a.__dict__ for a in st.arrays]
 
@@ -90,7 +90,7 @@ class RaidControlScreen(Screen):
                     token = data.get("token")
                     expires = data.get("expires_at")
                 else:
-                    from app.services.raid import request_confirmation
+                    from app.services.hardware.raid import request_confirmation
                     data = request_confirmation("delete_array", {"array": array})
                     token = data["token"]
                     expires = data["expires_at"]
@@ -113,7 +113,7 @@ class RaidControlScreen(Screen):
                     res.raise_for_status()
                     data = res.json()
                 else:
-                    from app.services.raid import execute_confirmation
+                    from app.services.hardware.raid import execute_confirmation
                     data = execute_confirmation(self.last_token)
 
             self.notify(f"Execute result: {data}", severity="information")

--- a/backend/scripts/test/test_raid_backend.py
+++ b/backend/scripts/test/test_raid_backend.py
@@ -9,7 +9,7 @@ import os
 # Add backend to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from app.services.raid import DevRaidBackend
+from app.services.hardware.raid import DevRaidBackend
 from app.schemas.system import CreateArrayRequest
 
 def test_raid_backend():

--- a/backend/tests/integration/test_remote_server_start.py
+++ b/backend/tests/integration/test_remote_server_start.py
@@ -8,7 +8,7 @@ from unittest.mock import patch, MagicMock
 from app.models import ServerProfile, VPNProfile, VPNType
 from app.main import app
 from app.core.config import settings
-from app.services.vpn_encryption import VPNEncryption
+from app.services.vpn.encryption import VPNEncryption
 
 
 @pytest.fixture

--- a/backend/tests/logging/test_audit_logging.py
+++ b/backend/tests/logging/test_audit_logging.py
@@ -21,7 +21,7 @@ class TestAuditLogger:
     @pytest.fixture
     def audit_logger_enabled(self, temp_audit_dir):
         """Create audit logger with logging enabled."""
-        with patch('app.services.audit_logger.settings') as mock_settings:
+        with patch('app.services.audit.logger.settings') as mock_settings:
             mock_settings.is_dev_mode = False
             mock_settings.audit_logging_enabled = True
             mock_settings.nas_temp_path = str(temp_audit_dir)
@@ -31,7 +31,7 @@ class TestAuditLogger:
     @pytest.fixture
     def audit_logger_disabled(self, temp_audit_dir):
         """Create audit logger with logging disabled (dev mode)."""
-        with patch('app.services.audit_logger.settings') as mock_settings:
+        with patch('app.services.audit.logger.settings') as mock_settings:
             mock_settings.is_dev_mode = True
             mock_settings.audit_logging_enabled = False
             mock_settings.nas_temp_path = str(temp_audit_dir)

--- a/backend/tests/logging/test_file_logging.py
+++ b/backend/tests/logging/test_file_logging.py
@@ -56,8 +56,8 @@ class TestFileOperationLogging:
     async def test_upload_logs_audit_event(self, temp_storage, mock_user):
         """Test that file upload creates audit log entry."""
         with patch('app.services.files.operations.get_audit_logger_db') as mock_audit, \
-             patch('app.services.file_metadata_db.create_metadata') as mock_create, \
-             patch('app.services.file_metadata_db.update_metadata') as mock_update:
+             patch('app.services.files.metadata_db.create_metadata') as mock_create, \
+             patch('app.services.files.metadata_db.update_metadata') as mock_update:
             mock_logger = MagicMock()
             mock_audit.return_value = mock_logger
             
@@ -87,8 +87,8 @@ class TestFileOperationLogging:
     def test_delete_file_logs_audit_event(self, temp_storage, mock_user):
         """Test that file deletion creates audit log entry."""
         with patch('app.services.files.operations.get_audit_logger_db') as mock_audit, \
-             patch('app.services.file_metadata_db.create_metadata') as mock_create, \
-             patch('app.services.file_metadata_db.update_metadata') as mock_update:
+             patch('app.services.files.metadata_db.create_metadata') as mock_create, \
+             patch('app.services.files.metadata_db.update_metadata') as mock_update:
             mock_logger = MagicMock()
             mock_audit.return_value = mock_logger
             
@@ -114,8 +114,8 @@ class TestFileOperationLogging:
     def test_delete_directory_logs_audit_event(self, temp_storage, mock_user):
         """Test that directory deletion creates audit log entry."""
         with patch('app.services.files.operations.get_audit_logger_db') as mock_audit, \
-             patch('app.services.file_metadata_db.create_metadata') as mock_create, \
-             patch('app.services.file_metadata_db.update_metadata') as mock_update, \
+             patch('app.services.files.metadata_db.create_metadata') as mock_create, \
+             patch('app.services.files.metadata_db.update_metadata') as mock_update, \
              patch('app.services.files.operations.file_metadata_db.delete_metadata') as mock_delete_meta:
             mock_logger = MagicMock()
             mock_audit.return_value = mock_logger
@@ -136,8 +136,8 @@ class TestFileOperationLogging:
     def test_create_folder_logs_audit_event(self, temp_storage, mock_user):
         """Test that folder creation creates audit log entry."""
         with patch('app.services.files.operations.get_audit_logger_db') as mock_audit, \
-             patch('app.services.file_metadata_db.create_metadata') as mock_create, \
-             patch('app.services.file_metadata_db.update_metadata') as mock_update:
+             patch('app.services.files.metadata_db.create_metadata') as mock_create, \
+             patch('app.services.files.metadata_db.update_metadata') as mock_update:
             mock_logger = MagicMock()
             mock_audit.return_value = mock_logger
             
@@ -156,8 +156,8 @@ class TestFileOperationLogging:
     def test_move_path_logs_audit_event(self, temp_storage, mock_user):
         """Test that moving files/folders creates audit log entry."""
         with patch('app.services.files.operations.get_audit_logger_db') as mock_audit, \
-             patch('app.services.file_metadata_db.create_metadata') as mock_create, \
-             patch('app.services.file_metadata_db.update_metadata') as mock_update, \
+             patch('app.services.files.metadata_db.create_metadata') as mock_create, \
+             patch('app.services.files.metadata_db.update_metadata') as mock_update, \
              patch('app.services.files.operations.file_metadata_db') as mock_metadata_db:
             mock_logger = MagicMock()
             mock_audit.return_value = mock_logger
@@ -184,8 +184,8 @@ class TestFileOperationLogging:
     def test_system_operations_log_as_system_user(self, temp_storage):
         """Test that operations without user log as system."""
         with patch('app.services.files.operations.get_audit_logger_db') as mock_audit, \
-             patch('app.services.file_metadata_db.create_metadata') as mock_create, \
-             patch('app.services.file_metadata_db.update_metadata') as mock_update:
+             patch('app.services.files.metadata_db.create_metadata') as mock_create, \
+             patch('app.services.files.metadata_db.update_metadata') as mock_update:
             mock_logger = MagicMock()
             mock_audit.return_value = mock_logger
             
@@ -200,8 +200,8 @@ class TestFileOperationLogging:
     async def test_multiple_uploads_log_multiple_entries(self, temp_storage, mock_user):
         """Test that multiple file uploads create multiple audit entries."""
         with patch('app.services.files.operations.get_audit_logger_db') as mock_audit, \
-             patch('app.services.file_metadata_db.create_metadata') as mock_create, \
-             patch('app.services.file_metadata_db.update_metadata') as mock_update:
+             patch('app.services.files.metadata_db.create_metadata') as mock_create, \
+             patch('app.services.files.metadata_db.update_metadata') as mock_update:
             mock_logger = MagicMock()
             mock_audit.return_value = mock_logger
             
@@ -227,8 +227,8 @@ class TestFileOperationLogging:
         """Test that audit logging respects dev mode setting."""
         # In dev mode, audit logger should still be called but won't write to disk
         with patch('app.services.files.operations.get_audit_logger_db') as mock_audit, \
-             patch('app.services.file_metadata_db.create_metadata') as mock_create, \
-             patch('app.services.file_metadata_db.update_metadata') as mock_update:
+             patch('app.services.files.metadata_db.create_metadata') as mock_create, \
+             patch('app.services.files.metadata_db.update_metadata') as mock_update:
             mock_logger = MagicMock()
             mock_logger.is_enabled.return_value = False
             mock_audit.return_value = mock_logger

--- a/backend/tests/raid/test_mdadm_integration.py
+++ b/backend/tests/raid/test_mdadm_integration.py
@@ -2,7 +2,7 @@ import json
 import subprocess
 from types import SimpleNamespace
 
-from app.services.raid import MdadmRaidBackend, MdstatInfo
+from app.services.hardware.raid import MdadmRaidBackend, MdstatInfo
 from app.schemas.system import RaidSpeedLimits, RaidStatusResponse, RaidArray, RaidDevice
 
 

--- a/backend/tests/raid/test_mdadm_integration_local.py
+++ b/backend/tests/raid/test_mdadm_integration_local.py
@@ -3,7 +3,7 @@ import subprocess
 from types import SimpleNamespace
 import pytest
 
-from app.services.raid import MdadmRaidBackend, MdstatInfo
+from app.services.hardware.raid import MdadmRaidBackend, MdstatInfo
 from app.schemas.system import RaidSpeedLimits, RaidStatusResponse, RaidArray, RaidDevice
 
 

--- a/backend/tests/raid/test_mdadm_parsing.py
+++ b/backend/tests/raid/test_mdadm_parsing.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 
-from app.services.raid import MdadmRaidBackend, MdstatInfo
+from app.services.hardware.raid import MdadmRaidBackend, MdstatInfo
 
 
 def _mk_backend():

--- a/backend/tests/raid/test_mdstat_parse.py
+++ b/backend/tests/raid/test_mdstat_parse.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.services.raid import _parse_mdstat
+from app.services.hardware.raid import _parse_mdstat
 
 
 def test_parse_simple_resync():

--- a/backend/tests/raid/test_raid_extended.py
+++ b/backend/tests/raid/test_raid_extended.py
@@ -1,8 +1,8 @@
 import math
 import pytest
 
-from app.services import raid
-from app.services.raid import DevRaidBackend
+from app.services.hardware import raid
+from app.services.hardware.raid import DevRaidBackend
 from app.core import config
 from app.schemas.system import CreateArrayRequest, RaidDevice
 

--- a/backend/tests/raid/test_raid_parsing.py
+++ b/backend/tests/raid/test_raid_parsing.py
@@ -1,5 +1,5 @@
 from app.schemas.system import RaidDevice
-from app.services.raid import MdstatInfo, _derive_array_status, _map_device_state, _parse_mdstat
+from app.services.hardware.raid import MdstatInfo, _derive_array_status, _map_device_state, _parse_mdstat
 
 
 def test_parse_mdstat_with_progress() -> None:

--- a/backend/tests/raid/test_raid_scheduler.py
+++ b/backend/tests/raid/test_raid_scheduler.py
@@ -1,7 +1,7 @@
 import pytest
 
 from app.core.config import settings
-from app.services import raid as raid_service
+from app.services.hardware import raid as raid_service
 
 
 def test_trigger_raid_scrub_api(client, admin_headers):

--- a/backend/tests/raid/test_raid_scrub.py
+++ b/backend/tests/raid/test_raid_scrub.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.services import raid as raid_service
+from app.services.hardware import raid as raid_service
 
 
 @pytest.mark.skipif(not isinstance(raid_service._backend, raid_service.DevRaidBackend), reason="Dev backend not active")

--- a/backend/tests/raid/test_smart_scheduler.py
+++ b/backend/tests/raid/test_smart_scheduler.py
@@ -1,7 +1,7 @@
 import pytest
 
 from app.core.config import settings
-from app.services import smart as smart_service
+from app.services.hardware import smart as smart_service
 
 
 def test_trigger_smart_test_api_admin(client, admin_headers):

--- a/backend/tests/services/test_scheduler_service.py
+++ b/backend/tests/services/test_scheduler_service.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from sqlalchemy.orm import Session
 
-from app.services.scheduler_service import SchedulerService, _format_interval
+from app.services.scheduler.service import SchedulerService, _format_interval
 from app.models.scheduler_history import (
     SchedulerExecution,
     SchedulerConfig,

--- a/backend/tests/services/test_vcl_service.py
+++ b/backend/tests/services/test_vcl_service.py
@@ -5,7 +5,7 @@ import pytest
 from pathlib import Path
 from sqlalchemy.orm import Session
 
-from app.services.vcl import VCLService
+from app.services.versioning.vcl import VCLService
 from app.models.vcl import FileVersion, VersionBlob, VCLSettings, VCLStats
 from app.models.file_metadata import FileMetadata
 from app.models.user import User

--- a/backend/tests/services/test_vcl_storage_path.py
+++ b/backend/tests/services/test_vcl_storage_path.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from unittest.mock import patch
 from sqlalchemy.orm import Session
 
-from app.services.vcl import VCLService
+from app.services.versioning.vcl import VCLService
 from app.models.user import User
 from app.models.file_metadata import FileMetadata
 

--- a/backend/tests/test_notification_routing.py
+++ b/backend/tests/test_notification_routing.py
@@ -1,0 +1,154 @@
+"""Tests for notification routing feature."""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.notification_routing import UserNotificationRouting
+from app.schemas.notification_routing import NotificationRoutingUpdate
+
+
+class TestNotificationRoutingModel:
+    """Tests for the UserNotificationRouting model."""
+
+    def test_create_routing(self, db, admin_user):
+        """New routing row has all categories disabled by default."""
+        routing = UserNotificationRouting(user_id=admin_user.id)
+        db.add(routing)
+        db.commit()
+        db.refresh(routing)
+
+        assert routing.receive_raid is False
+        assert routing.receive_smart is False
+        assert routing.receive_backup is False
+        assert routing.receive_scheduler is False
+        assert routing.receive_system is False
+        assert routing.receive_security is False
+        assert routing.receive_sync is False
+        assert routing.receive_vpn is False
+
+    def test_unique_user_id(self, db, regular_user):
+        """Only one routing row per user."""
+        db.add(UserNotificationRouting(user_id=regular_user.id))
+        db.commit()
+        db.add(UserNotificationRouting(user_id=regular_user.id))
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+
+class TestNotificationRoutingService:
+    """Tests for the notification routing service."""
+
+    def test_get_routing_no_row(self, db, regular_user):
+        """Returns defaults when no row exists for the user."""
+        from app.services.notification_routing import get_routing
+
+        result = get_routing(db, user_id=regular_user.id)
+        assert result.user_id == regular_user.id
+        assert result.receive_raid is False
+        assert result.granted_by is None
+
+    def test_update_routing_creates_row(self, db, admin_user, regular_user):
+        """Update creates a new row if none exists."""
+        from app.services.notification_routing import update_routing
+
+        update = NotificationRoutingUpdate(receive_raid=True, receive_security=True)
+        result = update_routing(
+            db, user_id=regular_user.id, update=update, granted_by=admin_user.id
+        )
+
+        assert result.receive_raid is True
+        assert result.receive_security is True
+        assert result.receive_smart is False
+        assert result.granted_by == admin_user.id
+
+    def test_update_routing_partial(self, db, admin_user, regular_user):
+        """Partial update only changes specified fields, leaving others intact."""
+        from app.services.notification_routing import update_routing
+
+        # Create with raid=True
+        update1 = NotificationRoutingUpdate(receive_raid=True)
+        update_routing(db, user_id=regular_user.id, update=update1, granted_by=admin_user.id)
+
+        # Update only smart; raid should remain True
+        update2 = NotificationRoutingUpdate(receive_smart=True)
+        result = update_routing(
+            db, user_id=regular_user.id, update=update2, granted_by=admin_user.id
+        )
+
+        assert result.receive_raid is True
+        assert result.receive_smart is True
+
+    def test_check_routing(self, db, admin_user, regular_user):
+        """check_routing returns the correct boolean for each category."""
+        from app.services.notification_routing import check_routing, update_routing
+
+        update = NotificationRoutingUpdate(receive_raid=True)
+        update_routing(db, user_id=regular_user.id, update=update, granted_by=admin_user.id)
+
+        assert check_routing(db, regular_user.id, "raid") is True
+        assert check_routing(db, regular_user.id, "smart") is False
+        assert check_routing(db, regular_user.id, "nonexistent") is False
+
+    def test_get_routed_user_ids(self, db, admin_user, regular_user):
+        """get_routed_user_ids returns only non-admin users with routing enabled."""
+        from app.services.notification_routing import get_routed_user_ids, update_routing
+
+        # Give regular user raid routing
+        update = NotificationRoutingUpdate(receive_raid=True)
+        update_routing(db, user_id=regular_user.id, update=update, granted_by=admin_user.id)
+
+        routed = get_routed_user_ids(db, "raid")
+        assert regular_user.id in routed
+        # Admin should not appear even if they happen to have a routing row
+        assert admin_user.id not in routed
+
+        # A category with no routing enabled should return empty
+        assert get_routed_user_ids(db, "smart") == []
+
+
+class TestNotificationRoutingAPI:
+    """Tests for notification routing API endpoints."""
+
+    def test_get_routing_requires_admin(self, client, user_headers, regular_user):
+        """Non-admin cannot read another user's routing via the admin endpoint."""
+        resp = client.get(
+            f"/api/users/{regular_user.id}/notification-routing",
+            headers=user_headers,
+        )
+        assert resp.status_code in (401, 403)
+
+    def test_get_routing_admin(self, client, admin_headers, regular_user):
+        """Admin can read a user's routing; defaults are all False."""
+        resp = client.get(
+            f"/api/users/{regular_user.id}/notification-routing",
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["receive_raid"] is False
+
+    def test_update_routing_admin(self, client, admin_headers, regular_user):
+        """Admin can update routing; response reflects new and unchanged values."""
+        resp = client.put(
+            f"/api/users/{regular_user.id}/notification-routing",
+            headers=admin_headers,
+            json={"receive_raid": True, "receive_system": True},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["receive_raid"] is True
+        assert data["receive_system"] is True
+        assert data["receive_smart"] is False
+
+    def test_my_routing(self, client, user_headers):
+        """User can read their own routing via the my-routing endpoint."""
+        resp = client.get(
+            "/api/notifications/my-routing",
+            headers=user_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "receive_raid" in data
+        # MyNotificationRoutingResponse should not expose admin metadata
+        assert "granted_by" not in data

--- a/backend/tests/test_pihole.py
+++ b/backend/tests/test_pihole.py
@@ -341,7 +341,7 @@ class TestPiholeService:
     def test_deploy_container_persists_password(self, db_session: Session):
         """After deploy_container(), the generated password is saved encrypted in the DB."""
         from app.services.pihole.service import PiholeService
-        from app.services.vpn_encryption import VPNEncryption
+        from app.services.vpn.encryption import VPNEncryption
 
         svc = PiholeService(db_session)
 
@@ -390,7 +390,7 @@ class TestPiholeService:
         13-60s window while wait_for_ready polls Pi-hole.
         """
         from app.services.pihole.service import PiholeService
-        from app.services.vpn_encryption import VPNEncryption
+        from app.services.vpn.encryption import VPNEncryption
         import app.services.pihole.service as svc_mod
 
         svc = PiholeService(db_session)

--- a/client/src/api/notificationRouting.ts
+++ b/client/src/api/notificationRouting.ts
@@ -1,0 +1,76 @@
+/**
+ * API client for user notification routing management.
+ */
+
+import { apiClient } from '../lib/api';
+
+export interface UserNotificationRouting {
+  user_id: number;
+  receive_raid: boolean;
+  receive_smart: boolean;
+  receive_backup: boolean;
+  receive_scheduler: boolean;
+  receive_system: boolean;
+  receive_security: boolean;
+  receive_sync: boolean;
+  receive_vpn: boolean;
+  granted_by: number | null;
+  granted_by_username: string | null;
+  granted_at: string | null;
+}
+
+export interface UserNotificationRoutingUpdate {
+  receive_raid?: boolean;
+  receive_smart?: boolean;
+  receive_backup?: boolean;
+  receive_scheduler?: boolean;
+  receive_system?: boolean;
+  receive_security?: boolean;
+  receive_sync?: boolean;
+  receive_vpn?: boolean;
+}
+
+export interface MyNotificationRouting {
+  receive_raid: boolean;
+  receive_smart: boolean;
+  receive_backup: boolean;
+  receive_scheduler: boolean;
+  receive_system: boolean;
+  receive_security: boolean;
+  receive_sync: boolean;
+  receive_vpn: boolean;
+}
+
+/**
+ * Get notification routing for a user (admin only).
+ */
+export async function getUserNotificationRouting(userId: number): Promise<UserNotificationRouting> {
+  const { data } = await apiClient.get<UserNotificationRouting>(
+    `/api/users/${userId}/notification-routing`,
+  );
+  return data;
+}
+
+/**
+ * Update notification routing for a user (admin only).
+ */
+export async function updateUserNotificationRouting(
+  userId: number,
+  update: UserNotificationRoutingUpdate,
+): Promise<UserNotificationRouting> {
+  const { data } = await apiClient.put<UserNotificationRouting>(
+    `/api/users/${userId}/notification-routing`,
+    update,
+  );
+  return data;
+}
+
+/**
+ * Get own notification routing (read-only).
+ */
+export async function getMyNotificationRouting(): Promise<MyNotificationRouting> {
+  const { data } = await apiClient.get<MyNotificationRouting>(
+    '/api/notifications/my-routing',
+  );
+  return data;
+}

--- a/client/src/components/user-management/NotificationRoutingSection.tsx
+++ b/client/src/components/user-management/NotificationRoutingSection.tsx
@@ -1,0 +1,178 @@
+import { useState, useEffect } from 'react';
+import {
+  HardDrive,
+  Activity,
+  Archive,
+  Clock,
+  Server,
+  Shield,
+  RefreshCw,
+  Globe,
+  Bell,
+  Loader2,
+} from 'lucide-react';
+import {
+  getUserNotificationRouting,
+  updateUserNotificationRouting,
+  type UserNotificationRouting,
+  type UserNotificationRoutingUpdate,
+} from '../../api/notificationRouting';
+import { handleApiError } from '../../lib/errorHandling';
+import toast from 'react-hot-toast';
+
+interface NotificationRoutingSectionProps {
+  userId: number;
+  userRole: string;
+}
+
+interface RoutingToggle {
+  key: keyof UserNotificationRoutingUpdate;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+}
+
+const ROUTING_TOGGLES: RoutingToggle[] = [
+  {
+    key: 'receive_raid',
+    label: 'RAID',
+    description: 'RAID-Statusaenderungen und Warnungen',
+    icon: <HardDrive className="h-4 w-4" />,
+  },
+  {
+    key: 'receive_smart',
+    label: 'SMART',
+    description: 'Festplatten-Gesundheitswarnungen',
+    icon: <Activity className="h-4 w-4" />,
+  },
+  {
+    key: 'receive_backup',
+    label: 'Backup',
+    description: 'Backup-Erfolge und -Fehler',
+    icon: <Archive className="h-4 w-4" />,
+  },
+  {
+    key: 'receive_scheduler',
+    label: 'Scheduler',
+    description: 'Geplante Aufgaben Statusmeldungen',
+    icon: <Clock className="h-4 w-4" />,
+  },
+  {
+    key: 'receive_system',
+    label: 'System',
+    description: 'Speicherplatz, Temperatur, Services',
+    icon: <Server className="h-4 w-4" />,
+  },
+  {
+    key: 'receive_security',
+    label: 'Sicherheit',
+    description: 'Fehlgeschlagene Logins, Brute-Force',
+    icon: <Shield className="h-4 w-4" />,
+  },
+  {
+    key: 'receive_sync',
+    label: 'Sync',
+    description: 'Sync-Konflikte und -Fehler',
+    icon: <RefreshCw className="h-4 w-4" />,
+  },
+  {
+    key: 'receive_vpn',
+    label: 'VPN',
+    description: 'VPN-Client-Ablaufwarnungen',
+    icon: <Globe className="h-4 w-4" />,
+  },
+];
+
+export function NotificationRoutingSection({ userId, userRole }: NotificationRoutingSectionProps) {
+  const [routing, setRouting] = useState<UserNotificationRouting | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (userRole === 'admin') return;
+    setLoading(true);
+    getUserNotificationRouting(userId)
+      .then(setRouting)
+      .catch(() => setRouting(null))
+      .finally(() => setLoading(false));
+  }, [userId, userRole]);
+
+  if (userRole === 'admin') return null;
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 py-3 text-sm text-slate-400">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Lade Benachrichtigungs-Routing...
+      </div>
+    );
+  }
+
+  const handleToggle = async (key: keyof UserNotificationRoutingUpdate, newValue: boolean) => {
+    setSaving(true);
+    try {
+      const update: UserNotificationRoutingUpdate = { [key]: newValue };
+      const result = await updateUserNotificationRouting(userId, update);
+      setRouting(result);
+      toast.success('Benachrichtigungs-Routing aktualisiert');
+    } catch (error) {
+      handleApiError(error, 'Fehler beim Speichern');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="border-t border-slate-800 pt-3 mt-3">
+      <div className="flex items-center gap-2 mb-1">
+        <Bell className="h-4 w-4 text-slate-400" />
+        <h3 className="text-sm font-medium text-slate-300">System-Benachrichtigungen</h3>
+      </div>
+      <p className="text-xs text-slate-500 mb-3">
+        Legt fest, welche System-Benachrichtigungen dieser User erhaelt.
+      </p>
+
+      <div className="space-y-2">
+        {ROUTING_TOGGLES.map((toggle) => {
+          const value = routing?.[toggle.key] ?? false;
+
+          return (
+            <div key={toggle.key} className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-slate-400">{toggle.icon}</span>
+                <div>
+                  <span className="text-sm text-slate-200">{toggle.label}</span>
+                  <span className="text-xs text-slate-500 ml-2">{toggle.description}</span>
+                </div>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={value}
+                disabled={saving}
+                onClick={() => handleToggle(toggle.key, !value)}
+                className={`relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors
+                  ${value ? 'bg-sky-500' : 'bg-slate-700'}
+                  ${saving ? 'opacity-50' : 'cursor-pointer'}
+                `}
+              >
+                <span
+                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform
+                    ${value ? 'translate-x-4' : 'translate-x-0.5'}
+                  `}
+                />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {routing?.granted_by_username && (
+        <p className="text-xs text-slate-500 mt-2">
+          Zuletzt geaendert von {routing.granted_by_username}
+          {routing.granted_at && ` am ${new Date(routing.granted_at).toLocaleDateString('de-DE')}`}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/user-management/UserFormModal.tsx
+++ b/client/src/components/user-management/UserFormModal.tsx
@@ -4,6 +4,7 @@ import { X } from 'lucide-react';
 import type { UserPublic } from '../../api/users';
 import type { UserFormData } from '../../hooks/useUserManagement';
 import { PowerPermissionsSection } from './PowerPermissionsSection';
+import { NotificationRoutingSection } from './NotificationRoutingSection';
 
 interface UserFormModalProps {
   open: boolean;
@@ -126,6 +127,13 @@ export function UserFormModal({ open, editingUser, onClose, onSubmit }: UserForm
 
           {editingUser && (
             <PowerPermissionsSection
+              userId={editingUser.id}
+              userRole={editingUser.role}
+            />
+          )}
+
+          {editingUser && (
+            <NotificationRoutingSection
               userId={editingUser.id}
               userRole={editingUser.role}
             />

--- a/client/src/pages/NotificationPreferencesPage.tsx
+++ b/client/src/pages/NotificationPreferencesPage.tsx
@@ -26,6 +26,7 @@ import {
   type NotificationCategory,
   type CategoryPreference,
 } from '../api/notifications';
+import { getMyNotificationRouting, type MyNotificationRouting } from '../api/notificationRouting';
 
 const ALL_CATEGORIES: NotificationCategory[] = [
   'raid',
@@ -60,9 +61,16 @@ export default function NotificationPreferencesPage({ embedded = false }: { embe
   const [quietHoursEnd, setQuietHoursEnd] = useState('07:00');
   const [minPriority, setMinPriority] = useState(0);
   const [categoryPrefs, setCategoryPrefs] = useState<Record<string, CategoryPreference>>({});
+  const [routing, setRouting] = useState<MyNotificationRouting | null>(null);
 
   useEffect(() => {
     loadPreferences();
+  }, []);
+
+  useEffect(() => {
+    getMyNotificationRouting()
+      .then(setRouting)
+      .catch(() => setRouting(null));
   }, []);
 
   const loadPreferences = async () => {
@@ -305,6 +313,33 @@ export default function NotificationPreferencesPage({ embedded = false }: { embe
           </div>
         )}
       </div>
+
+      {/* Admin-assigned routing (read-only) */}
+      {routing && Object.values(routing).some((v) => v === true) && (
+        <div className="border border-slate-700 rounded-lg p-4 mb-6">
+          <h3 className="text-sm font-medium text-slate-300 mb-2">
+            Zugewiesene System-Benachrichtigungen
+          </h3>
+          <p className="text-xs text-slate-500 mb-3">
+            Diese Kategorien wurden dir von einem Administrator zugewiesen.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {(Object.entries(routing) as [string, boolean][])
+              .filter(([_, enabled]) => enabled)
+              .map(([key]) => {
+                const category = key.replace('receive_', '') as NotificationCategory;
+                return (
+                  <span
+                    key={key}
+                    className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-sky-500/10 text-sky-400 border border-sky-500/20"
+                  >
+                    {getCategoryName(category)}
+                  </span>
+                );
+              })}
+          </div>
+        </div>
+      )}
 
       {/* Category Settings */}
       <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">


### PR DESCRIPTION
## Release

### Changes

#### Added
- **Notification Routing** — Admin-configurable notification categories for non-admin users
  - Admins can assign notification categories (RAID, SMART, Backup, Scheduler, System, Security, Sync, VPN) per user
  - New `user_notification_routing` database table with per-category boolean flags
  - Admin endpoints on `/api/users/{id}/notification-routing` for viewing and updating
  - `GET /api/notifications/my-routing` read-only endpoint for users to see assigned categories
  - Routed users receive both push (Firebase) and in-app (WebSocket) notifications
  - User's own NotificationPreferences (quiet hours, channel opt-out) respected after routing
  - Per-user notification copies created for routed users so they appear in notification list
  - Frontend toggle UI in user edit modal with category icons and descriptions
  - Read-only badge display in user's notification settings showing assigned categories
  - Audit logging for routing changes
- **Dependencies** — Audit logger added as FastAPI dependency for cleaner injection

#### Fixed
- Sleep: use atomic rtcwake suspend to fix scheduled wake-up failure
- Security: add defense-in-depth username validation for Samba
- Security: harden config defaults and add production validators

#### Changed
- Refactor: add `ensure_db()` context manager to deduplicate session boilerplate
- Refactor: remove legacy `sys.modules` backward-compat shims

---
Release type: `minor` — version bump happens automatically after merge via `release:minor` label