### PR TITLE
Release (patch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.27.3] - 2026-04-03
+
+### Fixed
+- Notifications: normalize timezone-naive `expires_at` from PostgreSQL to
+  UTC-aware before datetime comparison in device expiration check
+
+---
+
 ## [1.27.2] - 2026-04-03
 
 ### Added

--- a/backend/app/services/notifications/scheduler.py
+++ b/backend/app/services/notifications/scheduler.py
@@ -67,9 +67,13 @@ class NotificationScheduler:
                 try:
                     if device.expires_at is None:
                         continue
+                    # Ensure expires_at is timezone-aware (PostgreSQL may store naive)
+                    expires_at = device.expires_at
+                    if expires_at.tzinfo is None:
+                        expires_at = expires_at.replace(tzinfo=timezone.utc)
                     # Check each warning threshold
                     for warning_type, threshold in cls.WARNING_THRESHOLDS.items():
-                        warning_time = device.expires_at - threshold
+                        warning_time = expires_at - threshold
                         
                         # Check if we should send this warning
                         should_send, reason = cls._should_send_warning(


### PR DESCRIPTION
## Release

### Changes

#### Fixed
- Notifications: normalize timezone-naive `expires_at` from PostgreSQL to
  UTC-aware before datetime comparison in device expiration check

---
Release type: `patch` — version bump happens automatically after merge via `release:patch` label