### PR TITLE
Release (patch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.27.7] - 2026-04-06
+
+### Added
+- Power menu: sleep and suspend options for admins
+- Notifications: emit sync-completed event when mobile folder sync finishes
+
+### Fixed
+- Notifications: filter out empty notifications and add time_ago for WebSocket-delivered items
+- Cloud: include OAuth credentials in rclone config for token refresh
+
+---
+
 ## [1.27.6] - 2026-04-05
 
 ### Added

--- a/backend/app/api/routes/mobile.py
+++ b/backend/app/api/routes/mobile.py
@@ -25,7 +25,7 @@ from app.schemas.mobile import (
     SyncFolderUpdate,
     UploadQueueListResponse,
 )
-from app.models.mobile import MobileRegistrationToken as MobileRegistrationTokenModel
+from app.models.mobile import MobileRegistrationToken as MobileRegistrationTokenModel, MobileDevice
 from app.services.mobile import MobileService
 
 logger = logging.getLogger(__name__)
@@ -483,11 +483,34 @@ async def update_sync_folder(
     """
     Update a sync folder configuration. Also refreshes last_sync timestamp.
     """
-    return MobileService.update_sync_folder(
+    # Capture previous status to detect sync completion
+    from app.models.mobile import SyncFolder as SyncFolderModel
+    folder_before = db.query(SyncFolderModel).filter(SyncFolderModel.id == folder_id).first()
+    previous_status = folder_before.status if folder_before else None
+
+    result = MobileService.update_sync_folder(
         db=db,
         folder_id=folder_id,
         update_data=update_data
     )
+
+    # Emit notification when sync completes (status changes to "idle" from "syncing")
+    if update_data.status == "idle" and previous_status == "syncing":
+        try:
+            from app.services.notifications.events import get_event_emitter, EventType
+            device = db.query(MobileDevice).filter(MobileDevice.id == result.device_id).first()
+            device_name = device.device_name if device else result.device_id
+            folder_name = result.remote_path or folder_id
+            get_event_emitter().emit_sync(
+                EventType.SYNC_COMPLETED,
+                user_id=current_user.id,
+                folder_name=folder_name,
+                device_name=device_name,
+            )
+        except Exception:
+            logging.getLogger(__name__).warning("Failed to emit sync completed notification", exc_info=True)
+
+    return result
 
 
 @router.delete("/sync/folders/{folder_id}", status_code=204)

--- a/backend/app/services/cloud/adapters/rclone.py
+++ b/backend/app/services/cloud/adapters/rclone.py
@@ -413,13 +413,20 @@ class RcloneAdapter(CloudAdapter):
         await self._run_rclone("delete", remote, timeout=60)
 
     @staticmethod
-    def generate_config(provider: str, token_json: str) -> tuple[str, str]:
+    def generate_config(
+        provider: str,
+        token_json: str,
+        client_id: str = "",
+        client_secret: str = "",
+    ) -> tuple[str, str]:
         """
         Generate rclone config content from OAuth token.
 
         Args:
             provider: "google_drive" or "onedrive"
             token_json: JSON string of the OAuth token
+            client_id: OAuth client ID (required for token refresh)
+            client_secret: OAuth client secret (required for token refresh)
 
         Returns:
             Tuple of (remote_name, config_content)
@@ -432,6 +439,8 @@ class RcloneAdapter(CloudAdapter):
             config = (
                 f"[{remote_name}]\n"
                 f"type = drive\n"
+                f"client_id = {client_id}\n"
+                f"client_secret = {client_secret}\n"
                 f"scope = drive.readonly\n"
                 f"token = {token_json}\n"
             )
@@ -439,6 +448,8 @@ class RcloneAdapter(CloudAdapter):
             config = (
                 f"[{remote_name}]\n"
                 f"type = onedrive\n"
+                f"client_id = {client_id}\n"
+                f"client_secret = {client_secret}\n"
                 f"token = {token_json}\n"
                 f"drive_type = personal\n"
             )

--- a/backend/app/services/cloud/service.py
+++ b/backend/app/services/cloud/service.py
@@ -152,7 +152,9 @@ class CloudService:
         if upgrade_connection_id is not None:
             existing = self.get_connection(upgrade_connection_id, user_id)
             from app.services.cloud.adapters.rclone import RcloneAdapter
-            _remote_name, config_content = RcloneAdapter.generate_config(provider, token_json)
+            _remote_name, config_content = RcloneAdapter.generate_config(
+                provider, token_json, client_id, client_secret,
+            )
             existing.encrypted_config = encrypt_credentials(config_content)
             existing.rclone_remote_name = _remote_name
             self.db.commit()
@@ -162,7 +164,9 @@ class CloudService:
 
         # Generate rclone config
         from app.services.cloud.adapters.rclone import RcloneAdapter
-        remote_name, config_content = RcloneAdapter.generate_config(provider, token_json)
+        remote_name, config_content = RcloneAdapter.generate_config(
+            provider, token_json, client_id, client_secret,
+        )
 
         # Determine display name
         display_name = "Google Drive" if provider == "google_drive" else "OneDrive"

--- a/backend/app/services/notifications/events.py
+++ b/backend/app/services/notifications/events.py
@@ -313,6 +313,14 @@ EVENT_CONFIGS: dict[str, EventConfig] = {
         message_template="Ein Datei-Konflikt wurde bei '{file_path}' erkannt. Manuelle Lösung erforderlich.",
         action_url="/sync",
     ),
+    EventType.SYNC_COMPLETED: EventConfig(
+        priority=0,
+        category="sync",
+        notification_type="info",
+        title_template="Synchronisation abgeschlossen: {folder_name}",
+        message_template="Die Synchronisation für '{folder_name}' ({device_name}) wurde erfolgreich abgeschlossen.",
+        action_url="/settings?tab=sync",
+    ),
     EventType.SYNC_FAILED: EventConfig(
         priority=2,
         category="sync",

--- a/client/src/components/PowerMenu.tsx
+++ b/client/src/components/PowerMenu.tsx
@@ -1,7 +1,9 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Power, PowerOff, RotateCcw, LogOut } from 'lucide-react';
+import { Power, PowerOff, RotateCcw, LogOut, Moon, Pause } from 'lucide-react';
 import { ConfirmDialog } from './ui/ConfirmDialog';
+import { getSleepStatus, enterSoftSleep, enterSuspend } from '../api/sleep';
+import toast from 'react-hot-toast';
 
 interface PowerMenuProps {
   isAdmin: boolean;
@@ -13,8 +15,18 @@ interface PowerMenuProps {
 export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: PowerMenuProps) {
   const { t } = useTranslation('common');
   const [isOpen, setIsOpen] = useState(false);
-  const [confirmAction, setConfirmAction] = useState<'shutdown' | 'restart' | null>(null);
+  const [confirmAction, setConfirmAction] = useState<'shutdown' | 'restart' | 'sleep' | 'suspend' | null>(null);
+  const [sleepAvailable, setSleepAvailable] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Check sleep availability when dropdown opens
+  useEffect(() => {
+    if (isOpen && isAdmin) {
+      getSleepStatus()
+        .then(() => setSleepAvailable(true))
+        .catch(() => setSleepAvailable(false));
+    }
+  }, [isOpen, isAdmin]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -41,6 +53,20 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
       await onShutdown();
     } else if (action === 'restart') {
       await onRestart();
+    } else if (action === 'sleep') {
+      try {
+        await enterSoftSleep();
+        toast.success(t('powerMenu.sleepActivated', 'Sleep mode activated'));
+      } catch {
+        toast.error(t('powerMenu.sleepFailed', 'Failed to enter sleep mode'));
+      }
+    } else if (action === 'suspend') {
+      try {
+        await enterSuspend();
+        toast.success(t('powerMenu.suspendActivated', 'System suspended'));
+      } catch {
+        toast.error(t('powerMenu.suspendFailed', 'Failed to suspend system'));
+      }
     }
   };
 
@@ -88,6 +114,36 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
                       <p className="text-xs text-slate-400">{t('powerMenu.shutdownDesc', 'Shut down server')}</p>
                     </div>
                   </button>
+
+                  {sleepAvailable && (
+                    <>
+                      <button
+                        onClick={() => { setConfirmAction('sleep'); }}
+                        className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-blue-500/10"
+                      >
+                        <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-blue-500/30 bg-blue-500/10">
+                          <Moon className="h-4 w-4 text-blue-400" />
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium text-slate-100">{t('powerMenu.sleep', 'Sleep')}</p>
+                          <p className="text-xs text-slate-400">{t('powerMenu.sleepDesc', 'Enter sleep mode')}</p>
+                        </div>
+                      </button>
+
+                      <button
+                        onClick={() => { setConfirmAction('suspend'); }}
+                        className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-purple-500/10"
+                      >
+                        <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-purple-500/30 bg-purple-500/10">
+                          <Pause className="h-4 w-4 text-purple-400" />
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium text-slate-100">{t('powerMenu.suspend', 'Standby')}</p>
+                          <p className="text-xs text-slate-400">{t('powerMenu.suspendDesc', 'Suspend system')}</p>
+                        </div>
+                      </button>
+                    </>
+                  )}
                 </div>
 
                 <div className="mx-3 border-t border-slate-800" />
@@ -131,6 +187,28 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
         confirmLabel={t('powerMenu.restart', 'Restart')}
         cancelLabel={t('buttons.cancel', 'Cancel')}
         variant="warning"
+        onConfirm={handleConfirm}
+        onCancel={() => setConfirmAction(null)}
+      />
+
+      <ConfirmDialog
+        open={confirmAction === 'sleep'}
+        title={t('powerMenu.sleep', 'Sleep')}
+        message={t('powerMenu.sleepConfirm', 'Enter sleep mode? Services will be paused, but the server remains reachable.')}
+        confirmLabel={t('powerMenu.sleep', 'Sleep')}
+        cancelLabel={t('buttons.cancel', 'Cancel')}
+        variant="warning"
+        onConfirm={handleConfirm}
+        onCancel={() => setConfirmAction(null)}
+      />
+
+      <ConfirmDialog
+        open={confirmAction === 'suspend'}
+        title={t('powerMenu.suspend', 'Standby')}
+        message={t('powerMenu.suspendConfirm', 'Suspend the system? The server will be unreachable until woken up.')}
+        confirmLabel={t('powerMenu.suspend', 'Standby')}
+        cancelLabel={t('buttons.cancel', 'Cancel')}
+        variant="danger"
         onConfirm={handleConfirm}
         onCancel={() => setConfirmAction(null)}
       />

--- a/client/src/contexts/NotificationContext.tsx
+++ b/client/src/contexts/NotificationContext.tsx
@@ -40,7 +40,15 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   const { isConnected } = useNotificationSocket({
     enabled: !!token && !isPi,
     onNotification: (notification) => {
-      setNotifications((prev) => [notification, ...prev.slice(0, 49)]);
+      // Skip notifications with empty or missing title
+      if (!notification.title?.trim()) return;
+
+      // Compute time_ago for WebSocket-delivered notifications (not included in to_dict())
+      const enriched = notification.time_ago
+        ? notification
+        : { ...notification, time_ago: 'just now' };
+
+      setNotifications((prev) => [enriched, ...prev.slice(0, 49)]);
       if (notification.notification_type === 'critical') {
         toast.error(notification.title, { duration: 5000 });
       } else if (notification.notification_type === 'warning') {
@@ -60,7 +68,8 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         getNotifications({ page_size: 20 }),
         getUnreadCount(),
       ]);
-      setNotifications(notifResponse.notifications);
+      // Filter out notifications with empty or missing title
+      setNotifications(notifResponse.notifications.filter((n) => n.title?.trim()));
       setUnreadCount(countResponse.count);
     } catch {
       // Non-critical

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -242,7 +242,17 @@
     "shutdownEta": "Shutdown geplant — beendet in ~{{eta}}s",
     "restarting": "Wird neu gestartet...",
     "restartStarted": "Neustart gestartet...",
-    "restartingWait": "Neustart — warte auf Server..."
+    "restartingWait": "Neustart — warte auf Server...",
+    "sleep": "Schlafmodus",
+    "sleepDesc": "Dienste pausieren",
+    "sleepConfirm": "Schlafmodus aktivieren? Dienste werden pausiert, der Server bleibt erreichbar.",
+    "sleepActivated": "Schlafmodus aktiviert",
+    "sleepFailed": "Schlafmodus konnte nicht aktiviert werden",
+    "suspend": "Standby",
+    "suspendDesc": "System in Standby versetzen",
+    "suspendConfirm": "System in Standby versetzen? Der Server ist nicht erreichbar, bis er aufgeweckt wird.",
+    "suspendActivated": "System wird in Standby versetzt",
+    "suspendFailed": "Standby konnte nicht aktiviert werden"
   },
   "adminOnly": "Nur für Admins",
   "ssdCache": {

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -242,7 +242,17 @@
     "shutdownEta": "Shutdown scheduled — stopping in ~{{eta}}s",
     "restarting": "Restarting...",
     "restartStarted": "Restart initiated...",
-    "restartingWait": "Restarting — waiting for server..."
+    "restartingWait": "Restarting — waiting for server...",
+    "sleep": "Sleep",
+    "sleepDesc": "Enter sleep mode",
+    "sleepConfirm": "Enter sleep mode? Services will be paused, but the server remains reachable.",
+    "sleepActivated": "Sleep mode activated",
+    "sleepFailed": "Failed to enter sleep mode",
+    "suspend": "Standby",
+    "suspendDesc": "Suspend system",
+    "suspendConfirm": "Suspend the system? The server will be unreachable until woken up.",
+    "suspendActivated": "System suspended",
+    "suspendFailed": "Failed to suspend system"
   },
   "adminOnly": "Admin only",
   "ssdCache": {


### PR DESCRIPTION
## Release

### Changes

#### Added
- Power menu: sleep and suspend options for admins
- Notifications: emit sync-completed event when mobile folder sync finishes

#### Fixed
- Notifications: filter out empty notifications and add time_ago for WebSocket-delivered items
- Cloud: include OAuth credentials in rclone config for token refresh

---
Release type: `patch` — version bump happens automatically after merge via `release:patch` label