### PR TITLE
Release (patch) - v1.30.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,113 @@
+name: 🐛 Bug Report
+description: Report a reproducible bug in BaluHost
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill out the fields below so we can reproduce and fix the issue quickly.
+
+        **Security issues:** Do not report vulnerabilities here. See [SECURITY.md](../blob/main/SECURITY.md).
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checks
+      options:
+        - label: I searched existing issues and did not find a duplicate
+          required: true
+        - label: I can reproduce this on the latest version
+          required: true
+        - label: This is not a security vulnerability (those go via SECURITY.md)
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: BaluHost version
+      description: Output of the About page or `backend/pyproject.toml` version
+      placeholder: "1.30.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      multiple: true
+      options:
+        - Backend (FastAPI)
+        - Frontend (Web UI)
+        - TUI (Terminal UI)
+        - RAID / Disk management
+        - Authentication
+        - File operations
+        - Monitoring / Telemetry
+        - Power / Fan control
+        - VPN / Networking
+        - Plugin system
+        - Scheduler
+        - Setup / Installation
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Runtime mode
+      options:
+        - Production (NAS_MODE=prod)
+        - Development (NAS_MODE=dev)
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "Debian 13 / Windows 11 / Ubuntu 24.04"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps so we can replicate the issue.
+      placeholder: |
+        1. Log in as admin
+        2. Navigate to …
+        3. Click …
+        4. Observe …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Backend log output (`journalctl -u baluhost-backend` or terminal), browser console, or stack traces. Redact any secrets.
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, configuration snippets, anything else that might help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Security Vulnerability
+    url: https://github.com/Xveyn/BaluHost/security/advisories/new
+    about: Please report security vulnerabilities privately via GitHub Security Advisories. Do not open a public issue.
+  - name: 💬 Questions & Discussions
+    url: https://github.com/Xveyn/BaluHost/discussions
+    about: Ask questions, share ideas, or discuss usage in GitHub Discussions instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,81 @@
+name: ✨ Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Before submitting, please check existing issues and discussions to avoid duplicates.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checks
+      options:
+        - label: I searched existing issues and discussions for similar requests
+          required: true
+        - label: This is a feature request, not a bug report
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? What is the current workflow or limitation?
+      placeholder: "Today I have to … which is painful because …"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe how you imagine the feature working. Include API shape, UI mockups, or CLI examples if helpful.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why they are less ideal.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      multiple: true
+      options:
+        - Backend (FastAPI)
+        - Frontend (Web UI)
+        - TUI (Terminal UI)
+        - RAID / Disk management
+        - Authentication
+        - File operations
+        - Monitoring / Telemetry
+        - Power / Fan control
+        - VPN / Networking
+        - Plugin system
+        - Scheduler
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: willingness
+    attributes:
+      label: Would you be willing to implement this?
+      options:
+        - "Yes, I can open a PR"
+        - "Yes, with guidance"
+        - "No, just suggesting"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links, screenshots, related issues, anything else.

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -99,5 +99,8 @@ jobs:
         run: |
           git fetch origin main development
           git checkout development
-          git merge origin/main --no-edit
-          git push origin development
+          if git merge origin/main --ff-only; then
+            git push origin development
+          else
+            echo "::warning::development has diverged from main — skipping sync to avoid merge commit. Next release will reconcile."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.30.1] - 2026-04-15
+
+### Fixed
+- Plugins: return 503 instead of 500 when marketplace setup fails
+- CI: use fast-forward-only merge when syncing main → development to avoid merge commits
+
+### Added
+- Security policy (SECURITY.md) with private reporting channels and coordinated disclosure process
+- GitHub issue templates (bug report, feature request) with structured forms
+
+### Changed
+- Contributing guide: clarify that all PRs must target `development`; `main` is release-only
+
+---
+
 ## [1.30.0] - 2026-04-14
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,13 @@ npm run test
 
 ## 🔀 Git Workflow
 
+> **Important:** All contributions must go through Pull Requests targeting the `development` branch. Direct pushes to `main` or `development` are not accepted — `main` is updated exclusively by the release workflow (PR from `development` → `main` with a `release:*` label). PRs opened against `main` will be closed with a request to re-open them against `development`.
+
+**Branch hierarchy:**
+- `main` — Production. Read-only for contributors. Updated automatically by the release workflow.
+- `development` — Integration branch. **Target for all PRs.**
+- `feature/*`, `fix/*`, etc. — Working branches, created from `development`.
+
 ### Branch Naming
 - `feature/description` - New features
 - `fix/description` - Bug fixes
@@ -252,8 +259,10 @@ Fixes #456
 
 ### Pull Request Process
 
-1. **Create a feature branch**
+1. **Create a feature branch from `development`**
    ```bash
+   git checkout development
+   git pull origin development
    git checkout -b feature/my-feature
    ```
 
@@ -282,11 +291,13 @@ Fixes #456
    git push origin feature/my-feature
    ```
 
-6. **Open a Pull Request**
-   - Use a clear, descriptive title
-   - Reference related issues
+6. **Open a Pull Request against `development`**
+   - **Base branch: `development`** (not `main`!)
+   - Use a clear, descriptive title following Conventional Commits
+   - Reference related issues (`Closes #123`)
    - Describe what changed and why
    - Include screenshots for UI changes
+   - Wait for CI to pass — auto-merge runs only on green CI
 
 ### PR Template
 
@@ -514,7 +525,7 @@ Any other relevant information.
 
 ### Reporting Security Issues
 **DO NOT** open public issues for security vulnerabilities.
-Email security concerns to: [security@baluhost.example] (TODO)
+See [SECURITY.md](SECURITY.md) for the private reporting process (GitHub Security Advisories preferred).
 
 ## 📜 Code of Conduct
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest minor release line receives security updates. BaluHost follows semantic versioning — patch releases (`1.30.x`) carry security fixes for the current minor.
+
+| Version | Supported |
+| ------- | --------- |
+| 1.30.x  | ✅        |
+| < 1.30  | ❌        |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Instead, report them privately via one of these channels:
+
+- **GitHub Security Advisories** (preferred): Open a draft advisory at
+  <https://github.com/Xveyn/BaluHost/security/advisories/new>
+- **Email**: Contact the maintainer via the address listed on the [Xveyn GitHub profile](https://github.com/Xveyn)
+
+Please include as much of the following as possible:
+
+- Type of issue (e.g. path traversal, auth bypass, RCE, SSRF, information disclosure)
+- Affected component (backend route, frontend page, service module, version)
+- Full paths of source files related to the issue
+- Step-by-step reproduction instructions
+- Proof-of-concept or exploit code (if available)
+- Impact assessment — what can an attacker achieve?
+
+This information helps triage and fix the issue faster.
+
+## Response Timeline
+
+BaluHost is maintained by a single developer in spare time. Best-effort targets:
+
+| Stage               | Target     |
+| ------------------- | ---------- |
+| Initial response    | 72 hours   |
+| Triage & severity   | 7 days     |
+| Fix for high/critical | 14 days  |
+| Coordinated disclosure | after fix is released |
+
+If you do not receive a response within 7 days, please send a reminder — the report may have been missed.
+
+## Disclosure Policy
+
+BaluHost follows **coordinated disclosure**:
+
+1. You report the vulnerability privately.
+2. We confirm the issue and develop a fix on a private branch.
+3. A patched release is published.
+4. After users have had reasonable time to update (typically 14 days), the advisory is made public.
+5. Reporters are credited in the advisory unless they prefer to remain anonymous.
+
+## Scope
+
+In scope:
+
+- `backend/app/` — FastAPI application, auth, file operations, services
+- `client/src/` — React frontend
+- Default configuration shipped with the project
+- GitHub Actions workflows in `.github/workflows/`
+
+Out of scope:
+
+- Vulnerabilities in third-party dependencies — report those upstream first; we will bump affected dependencies as fixes land
+- Social engineering or physical attacks
+- Denial-of-service attacks that require abnormal traffic volume
+- Issues in development/dev-mode (`NAS_MODE=dev`) that do not affect production
+- Self-XSS or attacks requiring an already-compromised victim account
+
+## Security Posture
+
+For context on BaluHost's current security invariants, accepted risks, and threat model, see `.claude/rules/security-agent.md` in this repository. Known gaps are documented there and in `PRODUCTION_READINESS.md`.

--- a/backend/app/services/plugin_marketplace.py
+++ b/backend/app/services/plugin_marketplace.py
@@ -16,6 +16,7 @@ things together.
 from __future__ import annotations
 
 import json
+import logging
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -23,7 +24,7 @@ from typing import Callable, Optional, Sequence
 
 from pydantic import ValidationError
 
-from app.plugins.core_versions import CoreVersions, load_core_versions
+from app.plugins.core_versions import CoreVersions, CoreVersionsError, load_core_versions
 from app.plugins.installer import (
     InstalledArtifact,
     PluginInstaller,
@@ -35,6 +36,8 @@ from app.plugins.marketplace import (
     MarketplaceVersionEntry,
 )
 from app.plugins.resolver import InstalledPluginRequirement
+
+logger = logging.getLogger(__name__)
 
 IndexFetcher = Callable[[str], bytes]
 
@@ -207,23 +210,57 @@ def get_marketplace_service() -> MarketplaceService:
     Uses ``settings.plugins_marketplace_index_url`` and the configured
     external plugins directory. Tests should override this via
     ``app.dependency_overrides``.
-    """
-    global _instance
-    if _instance is None:
-        from app.core.config import settings
 
-        plugins_dir = Path(settings.plugins_external_dir)
+    Raises a 503 ``HTTPException`` if the plugins directory cannot be
+    created (permission denied, read-only FS, …) or the Core versions
+    snapshot cannot be loaded — so operators see a clear reason instead
+    of a bare 500 traceback.
+    """
+    from fastapi import HTTPException, status
+
+    global _instance
+    if _instance is not None:
+        return _instance
+
+    from app.core.config import settings
+
+    plugins_dir = Path(settings.plugins_external_dir)
+    try:
         plugins_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.error(
+            "plugin marketplace disabled: cannot create plugins dir %s: %s",
+            plugins_dir,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                f"plugin marketplace unavailable: plugins directory "
+                f"{plugins_dir} is not writable by the backend service user "
+                f"({exc.strerror or exc}). Create the directory and chown it "
+                f"to the service user."
+            ),
+        ) from exc
+
+    try:
         core_versions = load_core_versions()
-        installer = PluginInstaller(
-            plugins_dir=plugins_dir,
-            core_versions=core_versions,
-        )
-        _instance = MarketplaceService(
-            index_url=settings.plugins_marketplace_index_url,
-            installer=installer,
-            cache_ttl=settings.plugins_marketplace_cache_ttl,
-        )
+    except CoreVersionsError as exc:
+        logger.error("plugin marketplace disabled: cannot load core_versions.json: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"plugin marketplace unavailable: core_versions.json could not be loaded ({exc})",
+        ) from exc
+
+    installer = PluginInstaller(
+        plugins_dir=plugins_dir,
+        core_versions=core_versions,
+    )
+    _instance = MarketplaceService(
+        index_url=settings.plugins_marketplace_index_url,
+        installer=installer,
+        cache_ttl=settings.plugins_marketplace_cache_ttl,
+    )
     return _instance
 
 

--- a/backend/tests/plugins/test_plugin_marketplace_service.py
+++ b/backend/tests/plugins/test_plugin_marketplace_service.py
@@ -16,13 +16,15 @@ from typing import Dict
 
 import pytest
 
-from app.plugins.core_versions import CoreVersions
+from app.plugins.core_versions import CoreVersions, CoreVersionsError
 from app.plugins.installer import PluginInstaller
 from app.services.plugin_marketplace import (
     IndexFetchError,
     IndexParseError,
     MarketplaceService,
     PluginNotFoundError,
+    get_marketplace_service,
+    reset_marketplace_service,
 )
 
 
@@ -326,3 +328,64 @@ class TestInstallDelegate:
         svc.install("demo")
         # Same cached index used for lookup on both installs.
         assert fake.index_calls == 1
+
+
+class TestGetMarketplaceServiceDependency:
+    """The FastAPI dependency must degrade gracefully on setup failures.
+
+    In production the plugins directory is ``/var/lib/baluhost/plugins`` and
+    the service user may not have write access to it. The dependency used
+    to raise a bare ``PermissionError`` which bubbled up as an unhandled
+    500; it should now raise a 503 ``HTTPException`` with a diagnostic
+    message instead.
+    """
+
+    def setup_method(self) -> None:
+        reset_marketplace_service()
+
+    def teardown_method(self) -> None:
+        reset_marketplace_service()
+
+    def test_permission_error_on_mkdir_becomes_503(self, monkeypatch, tmp_path):
+        from app.core.config import settings
+        from fastapi import HTTPException
+
+        monkeypatch.setattr(settings, "plugins_external_dir", str(tmp_path / "nope"))
+
+        def _deny(self, *args, **kwargs):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(Path, "mkdir", _deny)
+
+        with pytest.raises(HTTPException) as excinfo:
+            get_marketplace_service()
+        assert excinfo.value.status_code == 503
+        assert "plugin marketplace unavailable" in excinfo.value.detail.lower()
+        assert "not writable" in excinfo.value.detail
+
+    def test_core_versions_error_becomes_503(self, monkeypatch, tmp_path):
+        from app.core.config import settings
+        from app.services import plugin_marketplace as svc_mod
+        from fastapi import HTTPException
+
+        monkeypatch.setattr(settings, "plugins_external_dir", str(tmp_path / "plugins"))
+
+        def _boom(path=None):
+            raise CoreVersionsError("missing file")
+
+        monkeypatch.setattr(svc_mod, "load_core_versions", _boom)
+
+        with pytest.raises(HTTPException) as excinfo:
+            get_marketplace_service()
+        assert excinfo.value.status_code == 503
+        assert "core_versions.json" in excinfo.value.detail
+
+    def test_successful_build_caches_singleton(self, monkeypatch, tmp_path):
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "plugins_external_dir", str(tmp_path / "plugins"))
+
+        svc = get_marketplace_service()
+        svc2 = get_marketplace_service()
+        assert svc is svc2
+        assert (tmp_path / "plugins").is_dir()


### PR DESCRIPTION
## Release v1.30.1

### Fixed
- Plugins: return 503 instead of 500 when marketplace setup fails
- CI: use fast-forward-only merge when syncing main → development to avoid merge commits

### Added
- Security policy (SECURITY.md) with private reporting channels and coordinated disclosure process
- GitHub issue templates (bug report, feature request) with structured forms

### Changed
- Contributing guide: clarify that all PRs must target `development`; `main` is release-only

---
Release type: `patch` — version bump happens automatically after merge via `release:patch` label