### PR TITLE
fix(migration): patch metrictype enum for GPU before seed (hotfix)

### DIFF
--- a/backend/alembic/versions/e828c7b306d5_add_gpu_samples_table.py
+++ b/backend/alembic/versions/e828c7b306d5_add_gpu_samples_table.py
@@ -51,6 +51,14 @@ def upgrade() -> None:
     # NOTE: SQLAlchemy's SQLEnum stores by enum NAME, not value, so we use "GPU"
     # (uppercase) to match how MonitoringConfig(metric_type=MetricType.GPU) serializes.
     conn = op.get_bind()
+
+    # On PostgreSQL the metrictype enum type pre-exists from earlier migrations
+    # and does not yet contain 'GPU'. ALTER TYPE ... ADD VALUE must run outside
+    # a transaction block, so commit first and use AUTOCOMMIT for the DDL.
+    if conn.dialect.name == "postgresql":
+        with op.get_context().autocommit_block():
+            conn.execute(sa.text("ALTER TYPE metrictype ADD VALUE IF NOT EXISTS 'GPU'"))
+
     existing = conn.execute(
         sa.text("SELECT 1 FROM monitoring_config WHERE metric_type = :mt"),
         {"mt": "GPU"},


### PR DESCRIPTION
## Summary
- Fixes Deploy Production failure introduced in v1.31.0 — alembic migration `e828c7b306d5_add_gpu_samples_table` crashed with `psycopg2.errors.InvalidTextRepresentation: ungültiger Eingabewert für Enum metrictype: »GPU«` because the existing PostgreSQL `metrictype` enum did not yet contain `'GPU'`.
- Adds `ALTER TYPE metrictype ADD VALUE IF NOT EXISTS 'GPU'` inside an `autocommit_block` (PG requires the new enum value to be committed before it can be used). SQLite (dev) skipped via `dialect.name == "postgresql"` check.

## Test plan
- [x] `pytest tests/services/power/gpu/` — 62 passed locally
- [ ] CI Check passes
- [ ] Deploy Production runner re-runs migration successfully on PG 17.7

## Why patch to main
Production deploy is blocked until this lands; cannot wait for the next release train.