### PR TITLE
fix(sleep): block third-party suspend during core operating hours

### DIFF
--- a/backend/app/services/power/core_uptime_inhibitor.py
+++ b/backend/app/services/power/core_uptime_inhibitor.py
@@ -1,0 +1,141 @@
+"""
+Logind sleep inhibitor for Core Operating Hours.
+
+While inside an active core-uptime window, BaluHost holds a `systemd-inhibit`
+block lock on `sleep` so that ANY suspend attempt — kernel, logind idle,
+desktop session daemons (mate-screensaver, gnome-power-manager, KDE), or a
+direct `systemctl suspend` invocation — is refused by logind.
+
+Implementation: spawns `/usr/bin/systemd-inhibit --what=sleep --mode=block
+--who=BaluHost --why=<reason> sleep infinity` as a long-lived subprocess. The
+inhibitor is released as soon as the subprocess exits, so we just kill it on
+window end.
+
+Notes:
+- `--mode=block` requires the polkit action
+  `org.freedesktop.login1.inhibit-block-sleep`. Default Debian 13 polkit
+  policy allows this for any local active session and (via implicit-active)
+  for system services that present a valid PID — i.e. the BaluHost systemd
+  unit. If polkit denies, acquire() logs a warning and returns False; window
+  protection then degrades to BaluHost's own per-loop guards (which catch
+  BaluHost-initiated suspends but not third-party desktop daemons).
+- Dev mode / Windows / missing binary → no-op (returns False, logs once).
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_SYSTEMD_INHIBIT = "systemd-inhibit"
+
+
+class CoreUptimeInhibitor:
+    """Holds a logind block-sleep inhibitor while a core-uptime window is active."""
+
+    def __init__(self) -> None:
+        self._proc: Optional[subprocess.Popen] = None
+        self._binary_missing_logged = False
+
+    def is_held(self) -> bool:
+        """True iff the inhibitor subprocess is currently alive."""
+        return self._proc is not None and self._proc.poll() is None
+
+    def acquire(self, reason: str) -> bool:
+        """Acquire the block-sleep inhibitor. Idempotent — no-op if already held.
+
+        Returns True on success (or already held), False if acquisition failed
+        (binary missing, polkit denied, etc.). Failures are logged but do not
+        raise so the caller can degrade gracefully.
+        """
+        if self.is_held():
+            return True
+
+        # Drop a dead subprocess handle so we re-spawn cleanly.
+        if self._proc is not None and self._proc.poll() is not None:
+            logger.info(
+                "Core uptime inhibitor subprocess exited unexpectedly (rc=%s) — re-acquiring",
+                self._proc.returncode,
+            )
+            self._proc = None
+
+        binary = shutil.which(_SYSTEMD_INHIBIT)
+        if binary is None:
+            if not self._binary_missing_logged:
+                logger.warning(
+                    "%s not found — core uptime inhibitor disabled. "
+                    "Third-party suspend (desktop daemons, manual systemctl) "
+                    "will NOT be blocked during core uptime windows.",
+                    _SYSTEMD_INHIBIT,
+                )
+                self._binary_missing_logged = True
+            return False
+
+        try:
+            self._proc = subprocess.Popen(
+                [
+                    binary,
+                    "--what=sleep",
+                    "--mode=block",
+                    "--who=BaluHost",
+                    f"--why={reason}",
+                    "sleep", "infinity",
+                ],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+        except OSError as exc:
+            logger.warning("Failed to spawn %s: %s", _SYSTEMD_INHIBIT, exc)
+            return False
+
+        # Brief settle window — if polkit denies (e.g. missing rules.d entry
+        # for a system service without an active session), systemd-inhibit
+        # exits immediately. Detect that here so the caller knows acquisition
+        # actually failed instead of silently looping every loop tick.
+        time.sleep(0.2)
+        if self._proc.poll() is not None:
+            stderr_output = ""
+            if self._proc.stderr is not None:
+                try:
+                    stderr_output = self._proc.stderr.read().decode("utf-8", errors="replace").strip()
+                except Exception:
+                    pass
+            logger.warning(
+                "%s exited immediately (rc=%s) — likely polkit denial. "
+                "Install /etc/polkit-1/rules.d/50-baluhost-inhibit-sleep.rules. stderr=%r",
+                _SYSTEMD_INHIBIT, self._proc.returncode, stderr_output,
+            )
+            self._proc = None
+            return False
+
+        logger.info(
+            "Core uptime sleep inhibitor acquired (pid=%s, reason=%s)",
+            self._proc.pid, reason,
+        )
+        return True
+
+    def release(self) -> None:
+        """Release the inhibitor by terminating the subprocess. Idempotent."""
+        if self._proc is None:
+            return
+        if self._proc.poll() is None:
+            try:
+                self._proc.terminate()
+                try:
+                    self._proc.wait(timeout=3.0)
+                except subprocess.TimeoutExpired:
+                    logger.warning(
+                        "Core uptime inhibitor pid=%s did not terminate in 3s — killing",
+                        self._proc.pid,
+                    )
+                    self._proc.kill()
+                    self._proc.wait(timeout=1.0)
+            except OSError as exc:
+                logger.warning("Error releasing core uptime inhibitor: %s", exc)
+        logger.info("Core uptime sleep inhibitor released")
+        self._proc = None

--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -28,6 +28,7 @@ from app.core.config import settings
 from app.core.database import SessionLocal
 from app.models.sleep import SleepConfig as SleepConfigModel, SleepStateLog, CoreUptimeWindow as CoreUptimeWindowModel
 from app.services.power import core_uptime as core_uptime_helpers
+from app.services.power.core_uptime_inhibitor import CoreUptimeInhibitor
 from app.schemas.sleep import (
     SleepState,
     SleepTrigger,
@@ -146,6 +147,10 @@ class SleepManagerService:
         self._error_count: int = 0
         self._last_error: Optional[str] = None
         self._last_error_at: Optional[datetime] = None
+        # Logind block-sleep inhibitor — held while inside an active core-uptime
+        # window so third-party suspend (mate-screensaver, gnome-power-manager,
+        # logind idle, manual `systemctl suspend`) is refused by logind.
+        self._core_uptime_inhibitor = CoreUptimeInhibitor()
 
     @classmethod
     async def get_instance(cls, backend: Optional[SleepBackend] = None) -> "SleepManagerService":
@@ -182,6 +187,19 @@ class SleepManagerService:
             # Start schedule check loop
             self._schedule_task = asyncio.create_task(self._schedule_check_loop())
 
+            # If service starts INSIDE a core-uptime window, immediately acquire
+            # the logind inhibitor — the schedule loop only fires in 60s and an
+            # idle desktop daemon could suspend us before the first tick.
+            try:
+                master, windows = self._load_core_uptime()
+                if master:
+                    in_core, _ = core_uptime_helpers.is_in_core_uptime(datetime.now(), windows)
+                    if in_core:
+                        self._core_uptime_inhibitor.acquire("startup_in_core_uptime")
+                        self._was_in_core_uptime = True
+            except Exception as exc:
+                logger.warning("Initial core-uptime inhibitor check failed: %s", exc)
+
         logger.info("Sleep manager started (monitoring=%s, auto_idle=%s, schedule=%s)",
                      monitoring,
                      config.auto_idle_enabled if config else False,
@@ -203,6 +221,10 @@ class SleepManagerService:
         # If in soft sleep, wake up before stopping
         if self._current_state == SleepState.SOFT_SLEEP:
             await self._exit_soft_sleep("service_shutdown")
+
+        # Always release the logind inhibitor on shutdown so suspend works
+        # again after BaluHost goes down (e.g. system shutdown / reboot).
+        self._core_uptime_inhibitor.release()
 
         self._idle_task = None
         self._schedule_task = None
@@ -401,6 +423,16 @@ class SleepManagerService:
                         and self._current_state == SleepState.SOFT_SLEEP:
                     logger.info("Core uptime started while in soft sleep — auto-waking")
                     await self.exit_soft_sleep("core_uptime_started")
+
+                # Logind inhibitor management — converged to the desired state
+                # every tick so a crashed inhibitor subprocess gets re-acquired
+                # and a master-toggle-off promptly releases.
+                should_hold = master and in_core
+                if should_hold and not self._core_uptime_inhibitor.is_held():
+                    self._core_uptime_inhibitor.acquire("core_uptime_active")
+                elif not should_hold and self._core_uptime_inhibitor.is_held():
+                    self._core_uptime_inhibitor.release()
+
                 # Track edge state regardless. When master is off we force False so
                 # that re-enabling the toggle while inside an active window registers
                 # as a fresh rising edge on the next tick and triggers auto-wake.
@@ -779,9 +811,22 @@ class SleepManagerService:
         """
         prev_state = self._current_state
 
-        # Clamp wake_at to next core-uptime start, if any
+        # Defense-in-depth: block all non-MANUAL suspend paths during an active
+        # core-uptime window. Per-loop guards (idle/schedule/escalation) already
+        # check this, but they can race or fail open on a transient DB error
+        # (_load_core_uptime returns (False, []) on exception). This guard
+        # ensures no automatic path can suspend regardless of caller. Manual
+        # admin trigger (spec F8) remains allowed; wake_at is still clamped.
         master, windows = self._load_core_uptime()
         if master:
+            in_core, _ = core_uptime_helpers.is_in_core_uptime(datetime.now(), windows)
+            if in_core and trigger != SleepTrigger.MANUAL:
+                logger.info(
+                    "enter_true_suspend blocked: inside active core uptime window "
+                    "(trigger=%s, reason=%s)",
+                    trigger.value, reason,
+                )
+                return False
             next_core = core_uptime_helpers.next_core_uptime_start(datetime.now(), windows)
             if next_core is not None and (wake_at is None or next_core < wake_at):
                 logger.info(

--- a/backend/tests/services/test_core_uptime_inhibitor.py
+++ b/backend/tests/services/test_core_uptime_inhibitor.py
@@ -1,0 +1,179 @@
+"""Unit tests for CoreUptimeInhibitor — the logind block-sleep wrapper."""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.power.core_uptime_inhibitor import CoreUptimeInhibitor
+
+
+def _alive_proc(pid: int = 4242) -> MagicMock:
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = pid
+    proc.poll.return_value = None  # alive
+    return proc
+
+
+def _dead_proc(rc: int = 0) -> MagicMock:
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = 9999
+    proc.poll.return_value = rc
+    proc.returncode = rc
+    return proc
+
+
+def test_acquire_spawns_systemd_inhibit_with_correct_args():
+    inh = CoreUptimeInhibitor()
+    fake_proc = _alive_proc()
+
+    with patch("app.services.power.core_uptime_inhibitor.shutil.which",
+               return_value="/usr/bin/systemd-inhibit"), \
+         patch("app.services.power.core_uptime_inhibitor.time.sleep"), \
+         patch("app.services.power.core_uptime_inhibitor.subprocess.Popen",
+               return_value=fake_proc) as mock_popen:
+        ok = inh.acquire("test_reason")
+
+    assert ok is True
+    assert inh.is_held() is True
+    args, _kwargs = mock_popen.call_args
+    cmd = args[0]
+    assert cmd[0] == "/usr/bin/systemd-inhibit"
+    assert "--what=sleep" in cmd
+    assert "--mode=block" in cmd
+    assert "--who=BaluHost" in cmd
+    assert "--why=test_reason" in cmd
+    # Must hold the lock with a long-lived child so logind doesn't release it.
+    assert cmd[-2:] == ["sleep", "infinity"]
+
+
+def test_acquire_is_idempotent_when_already_held():
+    inh = CoreUptimeInhibitor()
+    inh._proc = _alive_proc()
+
+    with patch("app.services.power.core_uptime_inhibitor.shutil.which",
+               return_value="/usr/bin/systemd-inhibit"), \
+         patch("app.services.power.core_uptime_inhibitor.subprocess.Popen") as mock_popen:
+        ok = inh.acquire("again")
+
+    assert ok is True
+    mock_popen.assert_not_called()
+
+
+def test_acquire_returns_false_when_binary_missing():
+    inh = CoreUptimeInhibitor()
+    with patch("app.services.power.core_uptime_inhibitor.shutil.which", return_value=None), \
+         patch("app.services.power.core_uptime_inhibitor.subprocess.Popen") as mock_popen:
+        ok = inh.acquire("dev")
+
+    assert ok is False
+    assert inh.is_held() is False
+    mock_popen.assert_not_called()
+
+
+def test_missing_binary_warning_emitted_once_only():
+    inh = CoreUptimeInhibitor()
+    with patch("app.services.power.core_uptime_inhibitor.shutil.which", return_value=None), \
+         patch("app.services.power.core_uptime_inhibitor.logger.warning") as mock_warn:
+        inh.acquire("first")
+        inh.acquire("second")
+        inh.acquire("third")
+
+    assert mock_warn.call_count == 1
+
+
+def test_acquire_re_acquires_after_subprocess_died():
+    inh = CoreUptimeInhibitor()
+    inh._proc = _dead_proc(rc=1)  # held a dead subprocess
+    new_proc = _alive_proc(pid=5555)
+
+    with patch("app.services.power.core_uptime_inhibitor.shutil.which",
+               return_value="/usr/bin/systemd-inhibit"), \
+         patch("app.services.power.core_uptime_inhibitor.time.sleep"), \
+         patch("app.services.power.core_uptime_inhibitor.subprocess.Popen",
+               return_value=new_proc) as mock_popen:
+        ok = inh.acquire("recover")
+
+    assert ok is True
+    assert inh._proc is new_proc
+    mock_popen.assert_called_once()
+
+
+def test_release_terminates_running_subprocess():
+    inh = CoreUptimeInhibitor()
+    fake_proc = _alive_proc()
+    inh._proc = fake_proc
+
+    inh.release()
+
+    fake_proc.terminate.assert_called_once()
+    fake_proc.wait.assert_called_once_with(timeout=3.0)
+    assert inh._proc is None
+    assert inh.is_held() is False
+
+
+def test_release_kills_when_terminate_times_out():
+    inh = CoreUptimeInhibitor()
+    fake_proc = _alive_proc()
+    fake_proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="x", timeout=3.0), None]
+    inh._proc = fake_proc
+
+    inh.release()
+
+    fake_proc.terminate.assert_called_once()
+    fake_proc.kill.assert_called_once()
+    assert inh._proc is None
+
+
+def test_release_is_idempotent_when_not_held():
+    inh = CoreUptimeInhibitor()
+    inh.release()  # never acquired
+    assert inh._proc is None
+
+
+def test_release_clears_handle_even_if_subprocess_already_exited():
+    inh = CoreUptimeInhibitor()
+    fake_proc = _dead_proc(rc=0)
+    inh._proc = fake_proc
+
+    inh.release()
+
+    fake_proc.terminate.assert_not_called()
+    assert inh._proc is None
+
+
+def test_acquire_returns_false_when_popen_raises():
+    inh = CoreUptimeInhibitor()
+    with patch("app.services.power.core_uptime_inhibitor.shutil.which",
+               return_value="/usr/bin/systemd-inhibit"), \
+         patch("app.services.power.core_uptime_inhibitor.subprocess.Popen",
+               side_effect=OSError("permission denied")):
+        ok = inh.acquire("denied")
+
+    assert ok is False
+    assert inh.is_held() is False
+
+
+def test_acquire_detects_immediate_polkit_denial():
+    """If systemd-inhibit exits during the 0.2s settle window (polkit denied),
+    acquire returns False and clears the handle so we don't pretend we're held."""
+    inh = CoreUptimeInhibitor()
+    # Process appears 'dead' immediately after spawn — simulates polkit denial.
+    denied_proc = MagicMock(spec=subprocess.Popen)
+    denied_proc.pid = 1234
+    denied_proc.poll.return_value = 1  # exited
+    denied_proc.returncode = 1
+    denied_proc.stderr = MagicMock()
+    denied_proc.stderr.read.return_value = b"Failed to inhibit: Access denied\n"
+
+    with patch("app.services.power.core_uptime_inhibitor.shutil.which",
+               return_value="/usr/bin/systemd-inhibit"), \
+         patch("app.services.power.core_uptime_inhibitor.time.sleep"), \
+         patch("app.services.power.core_uptime_inhibitor.subprocess.Popen",
+               return_value=denied_proc):
+        ok = inh.acquire("polkit_denied")
+
+    assert ok is False
+    assert inh._proc is None
+    assert inh.is_held() is False

--- a/backend/tests/services/test_sleep_core_uptime_integration.py
+++ b/backend/tests/services/test_sleep_core_uptime_integration.py
@@ -233,6 +233,174 @@ async def test_escalation_aborts_during_core_uptime():
 
 
 @pytest.mark.asyncio
+async def test_schedule_loop_acquires_inhibitor_when_entering_window():
+    """Edge OFF→ON in the schedule loop must acquire the logind inhibitor."""
+    svc = _build_service()
+    cfg = _config(core_enabled=True)
+    in_core_sequence = iter([(False, None), (True, _window_workdays_8_22())])
+
+    with patch.object(svc, "_load_config", return_value=cfg), \
+         patch.object(svc, "_load_core_uptime", return_value=(True, [_window_workdays_8_22()])), \
+         patch("app.services.power.sleep.core_uptime_helpers.is_in_core_uptime",
+               side_effect=lambda *a, **k: next(in_core_sequence)), \
+         patch.object(svc._core_uptime_inhibitor, "acquire") as mock_acquire, \
+         patch.object(svc._core_uptime_inhibitor, "release") as mock_release, \
+         patch.object(svc._core_uptime_inhibitor, "is_held", side_effect=[False, False, True, True]):
+        svc._is_running = True
+        svc._current_state = SleepState.AWAKE
+        svc._was_in_core_uptime = False
+
+        ticks = [0]
+
+        async def two_ticks(*_a, **_k):
+            ticks[0] += 1
+            if ticks[0] >= 3:
+                svc._is_running = False
+
+        with patch("app.services.power.sleep.asyncio.sleep", side_effect=two_ticks):
+            await svc._schedule_check_loop()
+
+    mock_acquire.assert_called_once_with("core_uptime_active")
+    mock_release.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schedule_loop_releases_inhibitor_when_leaving_window():
+    """Edge ON→OFF must release the logind inhibitor."""
+    svc = _build_service()
+    cfg = _config(core_enabled=True)
+    in_core_sequence = iter([(True, _window_workdays_8_22()), (False, None)])
+
+    with patch.object(svc, "_load_config", return_value=cfg), \
+         patch.object(svc, "_load_core_uptime", return_value=(True, [_window_workdays_8_22()])), \
+         patch("app.services.power.sleep.core_uptime_helpers.is_in_core_uptime",
+               side_effect=lambda *a, **k: next(in_core_sequence)), \
+         patch.object(svc._core_uptime_inhibitor, "acquire") as mock_acquire, \
+         patch.object(svc._core_uptime_inhibitor, "release") as mock_release, \
+         patch.object(svc._core_uptime_inhibitor, "is_held", side_effect=[True, True, False, False]):
+        svc._is_running = True
+        svc._current_state = SleepState.AWAKE
+        svc._was_in_core_uptime = True
+
+        ticks = [0]
+
+        async def two_ticks(*_a, **_k):
+            ticks[0] += 1
+            if ticks[0] >= 3:
+                svc._is_running = False
+
+        with patch("app.services.power.sleep.asyncio.sleep", side_effect=two_ticks):
+            await svc._schedule_check_loop()
+
+    mock_release.assert_called_once_with()
+    mock_acquire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schedule_loop_releases_inhibitor_when_master_toggle_off():
+    """Master toggle off mid-flight must release the inhibitor even if windows match."""
+    svc = _build_service()
+    cfg_off = _config(core_enabled=False)
+
+    with patch.object(svc, "_load_config", return_value=cfg_off), \
+         patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
+         patch.object(svc._core_uptime_inhibitor, "acquire") as mock_acquire, \
+         patch.object(svc._core_uptime_inhibitor, "release") as mock_release, \
+         patch.object(svc._core_uptime_inhibitor, "is_held", return_value=True):
+        svc._is_running = True
+        svc._current_state = SleepState.AWAKE
+        svc._was_in_core_uptime = True
+
+        ticks = [0]
+
+        async def one_tick(*_a, **_k):
+            ticks[0] += 1
+            if ticks[0] >= 2:
+                svc._is_running = False
+
+        with patch("app.services.power.sleep.asyncio.sleep", side_effect=one_tick):
+            await svc._schedule_check_loop()
+
+    mock_release.assert_called()
+    mock_acquire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stop_releases_inhibitor():
+    """SleepManagerService.stop() must release the logind inhibitor."""
+    svc = _build_service()
+
+    with patch.object(svc._core_uptime_inhibitor, "release") as mock_release:
+        svc._is_running = True
+        await svc.stop()
+
+    mock_release.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("trigger", [
+    SleepTrigger.SCHEDULE,
+    SleepTrigger.AUTO_IDLE,
+    SleepTrigger.AUTO_ESCALATION,
+    SleepTrigger.RTC_WAKE,
+])
+async def test_enter_true_suspend_blocks_non_manual_during_active_window(trigger):
+    """Defense-in-depth: any automatic trigger must be blocked while in a
+    core-uptime window, even if a per-loop guard somehow let it through."""
+    svc = _build_service()
+    cfg = _config(core_enabled=True)
+
+    suspend_called = []
+
+    async def fake_suspend_system(wake_at=None):
+        suspend_called.append(wake_at)
+        return True
+
+    with patch.object(svc, "_load_config", return_value=cfg), \
+         patch.object(svc, "_load_core_uptime", return_value=(True, [_window_workdays_8_22()])), \
+         patch("app.services.power.sleep.core_uptime_helpers.is_in_core_uptime",
+               return_value=(True, _window_workdays_8_22())), \
+         patch.object(svc._backend, "suspend_system", side_effect=fake_suspend_system), \
+         patch("app.services.power.sleep.SessionLocal"), \
+         patch("app.services.notifications.events.emit_system_suspend", new=AsyncMock(return_value=None)):
+        svc._current_state = SleepState.SOFT_SLEEP
+        ok = await svc.enter_true_suspend("auto", trigger)
+
+    assert ok is False
+    assert suspend_called == []
+
+
+@pytest.mark.asyncio
+async def test_enter_true_suspend_allows_manual_during_active_window():
+    """Manual admin trigger must still suspend during core uptime (spec F8) —
+    the only exception to the defense-in-depth block."""
+    svc = _build_service()
+    cfg = _config(core_enabled=True)
+    next_start = datetime(2026, 5, 7, 8, 0)
+
+    suspend_called = []
+
+    async def fake_suspend_system(wake_at=None):
+        suspend_called.append(wake_at)
+        return True
+
+    with patch.object(svc, "_load_config", return_value=cfg), \
+         patch.object(svc, "_load_core_uptime", return_value=(True, [_window_workdays_8_22()])), \
+         patch("app.services.power.sleep.core_uptime_helpers.is_in_core_uptime",
+               return_value=(True, _window_workdays_8_22())), \
+         patch("app.services.power.sleep.core_uptime_helpers.next_core_uptime_start",
+               return_value=next_start), \
+         patch.object(svc._backend, "suspend_system", side_effect=fake_suspend_system), \
+         patch("app.services.power.sleep.SessionLocal"), \
+         patch("app.services.notifications.events.emit_system_suspend", new=AsyncMock(return_value=None)):
+        svc._current_state = SleepState.SOFT_SLEEP
+        ok = await svc.enter_true_suspend("manual", SleepTrigger.MANUAL)
+
+    assert ok is True
+    assert suspend_called == [next_start]  # wake_at clamped to next_start
+
+
+@pytest.mark.asyncio
 async def test_enter_true_suspend_clamps_wake_at_to_next_core_start():
     """If wake_at is after next core uptime start, it is clamped to that start."""
     svc = _build_service()

--- a/deploy/install/modules/10-systemd-services.sh
+++ b/deploy/install/modules/10-systemd-services.sh
@@ -91,6 +91,24 @@ else
     log_warn "Deploy sudoers template not found: $DEPLOY_SUDOERS_TEMPLATE (skipping)"
 fi
 
+# --- Install polkit rule for core-uptime sleep inhibitor ---
+log_step "Polkit Rule (Core Uptime Inhibitor)"
+
+POLKIT_TEMPLATE="$TEMPLATE_DIR/50-baluhost-inhibit-sleep.rules"
+POLKIT_OUTPUT="/etc/polkit-1/rules.d/50-baluhost-inhibit-sleep.rules"
+
+if [[ -f "$POLKIT_TEMPLATE" ]]; then
+    process_template "$POLKIT_TEMPLATE" "$POLKIT_OUTPUT" \
+        "BALUHOST_USER=$BALUHOST_USER"
+    chmod 644 "$POLKIT_OUTPUT"
+    log_info "Installed polkit rule: $POLKIT_OUTPUT"
+
+    # polkit reloads rules.d files on next request — no daemon-reload needed.
+else
+    log_warn "Polkit rule template not found: $POLKIT_TEMPLATE (skipping)"
+    log_warn "Core uptime inhibitor will degrade to BaluHost-internal guards only."
+fi
+
 # --- Reload systemd ---
 log_step "Reloading Systemd"
 

--- a/deploy/install/templates/50-baluhost-inhibit-sleep.rules
+++ b/deploy/install/templates/50-baluhost-inhibit-sleep.rules
@@ -1,0 +1,20 @@
+// BaluHost — allow the service user to acquire logind block-sleep inhibitors.
+//
+// Background: BaluHost's "Core Operating Hours" feature holds a logind
+// `Inhibit(what=sleep, mode=block)` lock during active windows so third-party
+// suspend (mate-screensaver, gnome-power-manager, KDE, manual `systemctl
+// suspend`) is refused while the window is open.
+//
+// The default polkit policy on Debian 13 for
+// `org.freedesktop.login1.inhibit-block-sleep` is `allow_active=yes` only.
+// A systemd service running as ${BALUHOST_USER} has no active session, so
+// without this rule polkit asks for admin auth and the service silently fails
+// to acquire the inhibitor.
+//
+// This rule grants the BaluHost service user permission for that single action.
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.login1.inhibit-block-sleep" &&
+        subject.user == "${BALUHOST_USER}") {
+        return polkit.Result.YES;
+    }
+});


### PR DESCRIPTION
## Summary

Production server suspended during a configured Core Operating Hours window because `mate-screensaver` / `mate-power-manager` initiated `systemctl suspend` via D-Bus completely outside BaluHost — the per-loop guards added in #64 only catch BaluHost-initiated suspend paths. Logs:

```
Mai 02 11:35:37 ... Sleep config updated: ['core_uptime_enabled']     ← master toggle ON
Mai 02 11:45:48 systemd-logind[1602]: Delay lock is active (UID 1000/sven, PID 107636/mate-screensave) but inhibitor timeout is reached.
Mai 02 11:45:48 systemd[1]: Reached target sleep.target - Sleep.       ← suspended despite active window
```

No BaluHost backend log entry for the 11:45:48 suspend → not BaluHost-initiated.

## Fix

1. **`CoreUptimeInhibitor`** — holds an `org.freedesktop.login1.Inhibit(what=sleep, mode=block)` lock via a `systemd-inhibit` subprocess (`backend/app/services/power/core_uptime_inhibitor.py`). logind then refuses ANY suspend attempt regardless of initiator.
2. **Wired into `SleepManagerService`**: schedule loop converges acquire/release every 60s tick; service start acquires immediately if booted inside a window; service stop releases.
3. **Defense-in-depth in `enter_true_suspend`**: blocks all non-`MANUAL` triggers during active windows so any internal future caller is also caught (the loop guards already do this; this is a safety net).
4. **Polkit rule** (`/etc/polkit-1/rules.d/50-baluhost-inhibit-sleep.rules`): grants the BaluHost service user permission for the `org.freedesktop.login1.inhibit-block-sleep` action. Default Debian 13 policy is `allow_active=yes` only — a systemd service has no active session and would be silently denied.

## Test plan

- [x] `pytest tests/services/test_core_uptime_inhibitor.py tests/services/test_sleep_core_uptime_integration.py tests/services/test_core_uptime_helpers.py tests/api/test_core_uptime_routes.py tests/test_sleep.py` → 124/124 passed
- [x] New tests cover: spawn args, idempotent acquire, missing binary no-op, polkit-denial detection, subprocess-died re-acquire, terminate+kill paths, schedule-loop wiring (acquire on edge in, release on edge out, release on master-toggle-off, release on stop), defense-in-depth `enter_true_suspend` block for SCHEDULE/AUTO_IDLE/AUTO_ESCALATION/RTC_WAKE, MANUAL still allowed
- [ ] Post-merge on prod: re-enable Core Operating Hours, confirm `loginctl show-session` lists a `block:sleep` inhibitor with `who=BaluHost`, attempt manual `systemctl suspend` and confirm it's refused
- [ ] Post-merge: verify `mate-power-manager` cannot suspend during active window

🤖 Generated with [Claude Code](https://claude.com/claude-code)