### PR TITLE
fix(deploy): use @@-token in polkit inhibit-sleep rule template

### DIFF
--- a/deploy/install/templates/50-baluhost-inhibit-sleep.rules
+++ b/deploy/install/templates/50-baluhost-inhibit-sleep.rules
@@ -14,7 +14,7 @@
 // This rule grants the BaluHost service user permission for that single action.
 polkit.addRule(function(action, subject) {
     if (action.id == "org.freedesktop.login1.inhibit-block-sleep" &&
-        subject.user == "${BALUHOST_USER}") {
+        subject.user == "@@BALUHOST_USER@@") {
         return polkit.Result.YES;
     }
 });


### PR DESCRIPTION
## Summary

- `templates/50-baluhost-inhibit-sleep.rules` referenced `${BALUHOST_USER}`, but `process_template()` in `lib/common.sh` only replaces `@@KEY@@` tokens.
- A re-deploy would have written the literal string `"${BALUHOST_USER}"` into `/etc/polkit-1/rules.d/50-baluhost-inhibit-sleep.rules`, so polkit's `subject.user` check would never match → core-uptime sleep inhibitor silently broken (`systemd-inhibit` exits with rc=1, `Failed to inhibit: Interactive authentication required`).
- Discovered on BaluNode after suspend kept firing during configured Kernbetriebszeit; manual install of the rendered rule restored the inhibitor. This patch makes the deploy itself produce a correct rule on next run.

The two `${BALUHOST_USER}` occurrences in `//` comments (lines 10/14) are narrative documentation and are intentionally left as-is.

## Test plan

- [ ] Re-run `deploy/install/modules/10-systemd-services.sh` (or full installer) and confirm `/etc/polkit-1/rules.d/50-baluhost-inhibit-sleep.rules` contains `subject.user == "<actual-user>"` instead of the literal `${BALUHOST_USER}`
- [ ] After deploy, restart `baluhost-backend.service` and verify `journalctl -u baluhost-backend | grep -i inhibitor` shows `Core uptime sleep inhibitor acquired` (not `polkit denial`)
- [ ] `systemd-inhibit --list` shows BaluHost as holder with `what=sleep mode=block` during an active core-uptime window

🤖 Generated with [Claude Code](https://claude.com/claude-code)