### PR TITLE
feat(stats): auto-update README Project Stats on every release

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -70,7 +70,10 @@ jobs:
           echo "New version: $NEW_VERSION"
           echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
 
-          git add backend/pyproject.toml client/package.json CLAUDE.md
+          # Regenerate README stats (counts only tracked files via git ls-files)
+          python3 scripts/generate_readme_stats.py --write
+
+          git add backend/pyproject.toml client/package.json CLAUDE.md README.md
           git commit -m "chore: bump version to v${NEW_VERSION}"
           git push origin main
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.31.7] - 2026-05-04
+
+### Fixed
+- Sleep: capability badges correctly detect Suspend and Wake-on-LAN — `systemctl can-suspend` and `ethtool` now run via sudo so polkit/CAP_NET_ADMIN restrictions don't make working features look unavailable (#70)
+
+---
+
 ## [1.31.6] - 2026-05-04
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,4 +98,4 @@ Each major directory has its own CLAUDE.md with structure, conventions, and patt
 - **Issues**: GitHub Issues (repository URL needed)
 - **Documentation**: See `docs/` directory
 - **Maintainer**: Xveyn
-- **Version**: 1.31.6 (as of Mar 2026)
+- **Version**: 1.31.7 (as of Mar 2026)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Deployed since January 25, 2026 on Debian 13 (Ryzen 5 5600GT, 16GB RAM).
 | **Database** | PostgreSQL 17.7 | With Alembic migrations |
 | **Proxy** | Nginx | Port 80, rate limiting, security headers |
 | **Backend** | Systemd | 4 Uvicorn workers, auto-restart |
-| **Testing** | 1465 tests | 82 test files, CI/CD via GitHub Actions |
+| **Testing** | <!-- STATS:TEST_COUNT:START -->2578 tests<!-- STATS:TEST_COUNT:END --> | <!-- STATS:TEST_FILES:START -->181 test files<!-- STATS:TEST_FILES:END -->, CI/CD via GitHub Actions |
 | **Monitoring** | Prometheus/Grafana | Ready |
 
 ---
@@ -167,19 +167,19 @@ See [Infrastructure](docs/deployment/infrastructure.md) and [Emergency Runbook](
 BaluHost/
 ├── backend/                 # Python FastAPI
 │   ├── app/
-│   │   ├── api/routes/      # 51 API route modules
-│   │   ├── services/        # 143 service modules
-│   │   ├── models/          # 42 SQLAlchemy ORM models
-│   │   ├── schemas/         # 41 Pydantic schemas
+│   │   ├── api/routes/      # API route modules
+│   │   ├── services/        # Service modules
+│   │   ├── models/          # SQLAlchemy ORM models
+│   │   ├── schemas/         # Pydantic schemas
 │   │   ├── core/            # Config, security, database
 │   │   └── middleware/      # Security headers, rate limiting
 │   ├── baluhost_tui/        # Terminal UI (Textual)
-│   ├── tests/               # 82 test files
-│   └── alembic/             # 74 database migrations
+│   ├── tests/               # Pytest suite
+│   └── alembic/             # Database migrations
 ├── client/                  # React + TypeScript + Vite
 │   └── src/
-│       ├── pages/           # 31 page components
-│       ├── components/      # 30+ component directories
+│       ├── pages/           # Page components
+│       ├── components/      # Reusable components
 │       ├── api/             # Typed API clients
 │       ├── hooks/           # Custom React hooks
 │       ├── contexts/        # Auth context
@@ -308,25 +308,27 @@ docs/
 
 ## Project Stats
 
+<!-- STATS:PROJECT:START -->
 | Metric | Count |
 |--------|-------|
 | **Version** | ![Latest Release](https://img.shields.io/github/v/release/Xveyn/BaluHost?label=) |
-| **Backend code** | 150,685 lines across 735 Python files |
-| &nbsp;&nbsp;↳ Application (`app/`) | 97,186 lines / 411 files |
-| &nbsp;&nbsp;↳ Tests (`tests/`) | 38,309 lines / 166 files |
+| **Backend code** | 156,943 lines across 766 Python files |
+| &nbsp;&nbsp;↳ Application (`app/`) | 100,507 lines / 422 files |
+| &nbsp;&nbsp;↳ Tests (`tests/`) | 40,895 lines / 181 files |
 | &nbsp;&nbsp;↳ Scripts (`scripts/`) | 6,291 lines / 48 files |
-| &nbsp;&nbsp;↳ Alembic migrations | 5,989 lines / 92 files |
+| &nbsp;&nbsp;↳ Alembic migrations | 6,340 lines / 97 files |
 | &nbsp;&nbsp;↳ Terminal UI (`baluhost_tui/`) | 2,910 lines / 18 files |
-| **Frontend code** | 78,107 lines across 427 source files (`client/src/`, .ts/.tsx/.js/.jsx/.css) |
-| **Test functions** | 1465 |
-| **API route modules** | 51 |
-| **Service modules** | 143 |
-| **Database models** | 42 |
-| **Database migrations** | 74 |
-| **Frontend pages** | 31 |
+| **Frontend code** | 79,258 lines across 435 source files (`client/src/`, .ts/.tsx/.js/.jsx/.css) |
+| **Test functions** | 2578 |
+| **API route modules** | 61 |
+| **Service modules** | 178 |
+| **Database models** | 48 |
+| **Database migrations** | 96 |
+| **Frontend pages** | 33 |
 | **CI/CD workflows** | 7 |
 
-<sub>LOC counted via `git ls-files` (respects `.gitignore`, excludes virtualenvs, `node_modules/`, `dist/`, caches, dev-storage). Last measured 2026-04-30.</sub>
+<sub>LOC counted via `git ls-files` (respects `.gitignore`, excludes virtualenvs, `node_modules/`, `dist/`, caches, dev-storage). Last measured 2026-05-06.</sub>
+<!-- STATS:PROJECT:END -->
 
 ---
 

--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -1102,11 +1102,14 @@ class SleepManagerService:
 
         can_suspend = systemctl
         if not settings.is_dev_mode:
-            # Check if suspend is actually supported
+            # The service user has no active logind session, so polkit returns
+            # "challenge" without sudo even though `sudo systemctl suspend`
+            # itself is allowed via NOPASSWD. Run the check via sudo too so the
+            # capability badge reflects reality.
             try:
                 import subprocess
                 result = subprocess.run(
-                    ["systemctl", "can-suspend"],
+                    ["sudo", "systemctl", "can-suspend"],
                     capture_output=True, text=True, timeout=5,
                 )
                 can_suspend = result.returncode == 0 and "yes" in result.stdout.lower()

--- a/backend/app/services/power/sleep_backend_linux.py
+++ b/backend/app/services/power/sleep_backend_linux.py
@@ -112,9 +112,11 @@ class LinuxSleepBackend(SleepBackend):
                     if len(parts) >= 2:
                         iface = parts[1].strip()
                         if iface != "lo":
-                            # Check WoL support
+                            # Check WoL support. Reading WoL settings via
+                            # ethtool requires CAP_NET_ADMIN, so use sudo
+                            # (NOPASSWD via baluhost-hardware-sudoers).
                             wol_result = subprocess.run(
-                                ["ethtool", iface],
+                                ["sudo", "ethtool", iface],
                                 capture_output=True, text=True, timeout=5,
                             )
                             if wol_result.returncode == 0 and "Wake-on:" in wol_result.stdout:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baluhost-backend"
-version = "1.31.6"
+version = "1.31.7"
 description = "Mocked NAS management backend built with FastAPI"
 authors = [{ name = "Baluhost" }]
 requires-python = ">=3.11"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baluhost-client",
   "private": true,
-  "version": "1.31.6",
+  "version": "1.31.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/api/updates.ts
+++ b/client/src/api/updates.ts
@@ -28,6 +28,7 @@ export interface VersionInfo {
   tag: string | null;
   date: string | null;
   is_dev_build: boolean;
+  is_prerelease: boolean;
 }
 
 // Changelog entry

--- a/client/src/contexts/VersionContext.tsx
+++ b/client/src/contexts/VersionContext.tsx
@@ -90,3 +90,27 @@ export function useFormattedVersion(prefix: string = 'BaluHost OS'): string {
 
   return `${prefix} v${version}`;
 }
+
+/**
+ * Hook to get formatted version string + is_prerelease flag for badge display.
+ * Returns "v..." while loading, "v?.?.?" on error.
+ */
+export function useVersionDisplay(prefix: string = 'BaluHost OS'): {
+  text: string;
+  isPrerelease: boolean;
+} {
+  const { fullVersion, loading, error } = useVersion();
+
+  if (loading) {
+    return { text: `${prefix} v...`, isPrerelease: false };
+  }
+
+  if (error || !fullVersion) {
+    return { text: `${prefix} v?.?.?`, isPrerelease: false };
+  }
+
+  return {
+    text: `${prefix} v${fullVersion.version}`,
+    isPrerelease: fullVersion.is_prerelease,
+  };
+}

--- a/deploy/install/templates/baluhost-hardware-sudoers
+++ b/deploy/install/templates/baluhost-hardware-sudoers
@@ -19,4 +19,9 @@
 
 # Power management
 @@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/systemctl suspend
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/systemctl can-suspend
 @@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/sbin/rtcwake
+
+# Capability detection (Wake-on-LAN settings read requires CAP_NET_ADMIN)
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/sbin/ethtool
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /sbin/ethtool

--- a/docs/superpowers/plans/2026-05-06-readme-stats-automation.md
+++ b/docs/superpowers/plans/2026-05-06-readme-stats-automation.md
@@ -1,0 +1,1200 @@
+# README Stats Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-update the Project Stats table and Production Status test counts in `README.md` on every release, using a stdlib-only Python script driven by `git ls-files` (no third-party deps, no gitignored files counted).
+
+**Architecture:** A single script `scripts/generate_readme_stats.py` enumerates tracked files via `git ls-files`, categorizes them by path/extension, computes counts and LOC, and splices the result into `README.md` between named HTML-comment markers. The script runs inside the existing `auto-merge.yml` workflow as part of the version-bump commit, so stats changes ride along with the release on `main` (no separate auto-commit). Tests live in `scripts/test_generate_readme_stats.py` next to the script and run via pytest.
+
+**Tech Stack:** Python 3.11 stdlib only (`subprocess`, `pathlib`, `ast`, `re`, `dataclasses`, `argparse`). Pytest for tests (already a dev dep). YAML edit to `auto-merge.yml`.
+
+---
+
+## File Structure
+
+- **Create:** `scripts/generate_readme_stats.py` — the script (CLI entry + library functions)
+- **Create:** `scripts/test_generate_readme_stats.py` — pytest tests for the script
+- **Create:** `scripts/conftest.py` — adds `scripts/` to `sys.path` so tests can `import generate_readme_stats`
+- **Modify:** `README.md` — add `<!-- STATS:* -->` markers around dynamic content, remove inline file/module counts from the architecture tree (single source of truth = Project Stats table)
+- **Modify:** `.github/workflows/auto-merge.yml:57-75` — add `python3 scripts/generate_readme_stats.py --write` before the version-bump commit; include `README.md` in the staged paths
+
+**Responsibilities:**
+- `generate_readme_stats.py` does all logic (collect → compute → render → splice). Single file, no submodules.
+- `test_generate_readme_stats.py` tests pure functions in isolation (no git invocation, no real README writes).
+- `conftest.py` is a 2-line shim — nothing else.
+
+---
+
+## Design Decisions (locked in)
+
+1. **Source of truth for "tracked files":** `git ls-files`. This automatically respects `.gitignore`, excludes `node_modules/`, `.venv/`, `dist/`, `dev-storage/`, etc. — no manual ignore list needed.
+2. **Architecture tree (README.md:170–186):** the inline counts (`51 API route modules`, `143 service modules`, etc.) get **stripped**. Tree stays as a pure structural diagram. All counts live in the Project Stats table — one source of truth.
+3. **Test-function counting:** AST-parse each tracked test file (`backend/tests/**/*.py` matching `test_*.py` or `*_test.py`) and count top-level + class-method functions named `test_*` or `async test_*`. No reliance on `pytest --collect-only` (would require importable backend with all deps).
+4. **Markers:** `<!-- STATS:<NAME>:START -->` ... `<!-- STATS:<NAME>:END -->`. Block-level markers for the Project Stats table; inline markers for the testing row. The script raises a clear error if any expected marker is missing.
+5. **CLI modes:**
+   - `--check` (default in CI verification, optional): exits non-zero if README would change.
+   - `--write` (used in auto-merge.yml): rewrites README in place.
+   - No flags = `--check` (safer default).
+6. **Categories counted** (matches current README Project Stats table):
+   - Backend total LOC + file count (Python files anywhere under `backend/` excluding tests is **not** the split — current README sums *all* Python files including tests; we preserve that)
+   - Per-subdir splits: `backend/app/`, `backend/tests/`, `backend/scripts/`, `backend/alembic/`, `backend/baluhost_tui/`
+   - Frontend: `client/src/**/*.{ts,tsx,js,jsx,css}`
+   - Test functions (count of `def test_*` in tracked test files)
+   - API route modules: `backend/app/api/routes/*.py` excluding `__init__.py`
+   - Service modules: `backend/app/services/**/*.py` excluding `__init__.py`
+   - Database models: `backend/app/models/*.py` excluding `__init__.py`
+   - Database migrations: `backend/alembic/versions/*.py` (no `__init__.py` exclusion needed there)
+   - Frontend pages: `client/src/pages/**/*.tsx`
+   - CI/CD workflows: `.github/workflows/*.{yml,yaml}`
+
+---
+
+## Task 1: Project Skeleton
+
+**Files:**
+- Create: `scripts/generate_readme_stats.py`
+- Create: `scripts/conftest.py`
+- Create: `scripts/test_generate_readme_stats.py`
+
+- [ ] **Step 1: Create the conftest shim**
+
+Write `scripts/conftest.py`:
+
+```python
+"""Add scripts/ to sys.path so sibling test modules can import the script."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+```
+
+- [ ] **Step 2: Create the script with a placeholder main**
+
+Write `scripts/generate_readme_stats.py`:
+
+```python
+#!/usr/bin/env python3
+"""Generate and splice BaluHost README stats from tracked git files.
+
+Counts only files reported by `git ls-files` — automatically respects
+.gitignore. No third-party dependencies.
+
+Usage:
+    python scripts/generate_readme_stats.py            # check mode (exit 1 if drift)
+    python scripts/generate_readme_stats.py --check    # explicit check mode
+    python scripts/generate_readme_stats.py --write    # rewrite README.md in place
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write", action="store_true", help="Rewrite README.md")
+    parser.add_argument("--check", action="store_true", help="Exit 1 if drift")
+    args = parser.parse_args()
+
+    if not args.write and not args.check:
+        args.check = True
+
+    raise NotImplementedError("filled in by later tasks")
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 3: Create the test file with a smoke import test**
+
+Write `scripts/test_generate_readme_stats.py`:
+
+```python
+"""Tests for scripts/generate_readme_stats.py — stdlib + pytest only."""
+from __future__ import annotations
+
+import generate_readme_stats as grs
+
+
+def test_module_imports():
+    assert hasattr(grs, "main")
+```
+
+- [ ] **Step 4: Run the smoke test**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: PASS (1 test)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/generate_readme_stats.py scripts/conftest.py scripts/test_generate_readme_stats.py
+git commit -m "chore(stats): scaffold readme stats generator"
+```
+
+---
+
+## Task 2: `count_lines()` for LOC
+
+**Files:**
+- Modify: `scripts/generate_readme_stats.py`
+- Modify: `scripts/test_generate_readme_stats.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/test_generate_readme_stats.py`:
+
+```python
+def test_count_lines_simple(tmp_path):
+    f = tmp_path / "a.py"
+    f.write_text("a\nb\nc\n", encoding="utf-8")
+    assert grs.count_lines([f]) == 3
+
+
+def test_count_lines_no_trailing_newline(tmp_path):
+    f = tmp_path / "a.py"
+    f.write_text("a\nb\nc", encoding="utf-8")  # no final \n
+    # Newline count: \n appears twice → 3 lines logically. We define count as
+    # number of \n bytes, matching `wc -l` semantics (which under-counts the
+    # last unterminated line). Document this in the test.
+    assert grs.count_lines([f]) == 2
+
+
+def test_count_lines_handles_binary_and_missing(tmp_path):
+    binary = tmp_path / "blob.bin"
+    binary.write_bytes(b"\x00\x01\n\x02")  # 1 newline byte
+    missing = tmp_path / "does-not-exist.py"
+    assert grs.count_lines([binary, missing]) == 1
+
+
+def test_count_lines_multiple_files(tmp_path):
+    a = tmp_path / "a.py"
+    a.write_text("x\ny\n", encoding="utf-8")
+    b = tmp_path / "b.py"
+    b.write_text("p\nq\nr\n", encoding="utf-8")
+    assert grs.count_lines([a, b]) == 5
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 4 failures (`AttributeError: module ... has no attribute 'count_lines'`)
+
+- [ ] **Step 3: Implement `count_lines`**
+
+Add to `scripts/generate_readme_stats.py` (above `main`):
+
+```python
+from typing import Iterable
+
+
+def count_lines(files: Iterable[Path]) -> int:
+    """Count newline bytes across files. Matches `wc -l` semantics.
+
+    Skips files that are unreadable (missing, permission error). We count
+    newlines rather than lines to keep behavior simple and binary-safe.
+    """
+    total = 0
+    for f in files:
+        try:
+            with open(f, "rb") as fh:
+                while chunk := fh.read(65536):
+                    total += chunk.count(b"\n")
+        except OSError:
+            continue
+    return total
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 5 PASS (smoke test + 4 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/generate_readme_stats.py scripts/test_generate_readme_stats.py
+git commit -m "feat(stats): add count_lines() with wc -l semantics"
+```
+
+---
+
+## Task 3: `count_test_functions()`
+
+**Files:**
+- Modify: `scripts/generate_readme_stats.py`
+- Modify: `scripts/test_generate_readme_stats.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to test file:
+
+```python
+def test_count_test_functions_module_level(tmp_path):
+    f = tmp_path / "test_x.py"
+    f.write_text(
+        "def test_one():\n    pass\n\n"
+        "def test_two():\n    pass\n\n"
+        "def helper():\n    pass\n",
+        encoding="utf-8",
+    )
+    assert grs.count_test_functions([f]) == 2
+
+
+def test_count_test_functions_async(tmp_path):
+    f = tmp_path / "test_async.py"
+    f.write_text(
+        "async def test_a():\n    pass\n\n"
+        "def test_b():\n    pass\n",
+        encoding="utf-8",
+    )
+    assert grs.count_test_functions([f]) == 2
+
+
+def test_count_test_functions_in_class(tmp_path):
+    f = tmp_path / "test_class.py"
+    f.write_text(
+        "class TestThing:\n"
+        "    def test_inside(self):\n        pass\n"
+        "    def helper(self):\n        pass\n"
+        "    async def test_async_inside(self):\n        pass\n",
+        encoding="utf-8",
+    )
+    assert grs.count_test_functions([f]) == 2
+
+
+def test_count_test_functions_skips_syntax_errors(tmp_path):
+    bad = tmp_path / "test_bad.py"
+    bad.write_text("def test_x(:\n    broken syntax", encoding="utf-8")
+    good = tmp_path / "test_good.py"
+    good.write_text("def test_y():\n    pass\n", encoding="utf-8")
+    assert grs.count_test_functions([bad, good]) == 1
+
+
+def test_count_test_functions_empty_list():
+    assert grs.count_test_functions([]) == 0
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 5 failures (no `count_test_functions`)
+
+- [ ] **Step 3: Implement `count_test_functions`**
+
+Add to `scripts/generate_readme_stats.py`:
+
+```python
+import ast
+
+
+def count_test_functions(files: Iterable[Path]) -> int:
+    """Count def/async def whose name starts with 'test_' across files.
+
+    Uses AST so it works without importing the project. Walks the whole
+    tree to catch class methods. Files that fail to parse are skipped.
+    """
+    total = 0
+    for f in files:
+        try:
+            tree = ast.parse(f.read_text(encoding="utf-8"))
+        except (SyntaxError, OSError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name.startswith("test_"):
+                    total += 1
+    return total
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 10 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/generate_readme_stats.py scripts/test_generate_readme_stats.py
+git commit -m "feat(stats): add count_test_functions() via AST"
+```
+
+---
+
+## Task 4: `tracked_files()` + `under()` filter
+
+**Files:**
+- Modify: `scripts/generate_readme_stats.py`
+- Modify: `scripts/test_generate_readme_stats.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to test file:
+
+```python
+def test_under_unix_paths():
+    files = [Path("backend/app/main.py"), Path("client/src/App.tsx"), Path("README.md")]
+    result = grs.under(files, "backend/app/")
+    assert result == [Path("backend/app/main.py")]
+
+
+def test_under_normalizes_windows_paths():
+    # git ls-files always emits forward slashes on Windows too — but defensively
+    # we normalize, so a Path with backslashes still matches.
+    files = [Path("backend\\app\\main.py")]
+    result = grs.under(files, "backend/app/")
+    assert result == files
+
+
+def test_under_multiple_prefixes():
+    files = [
+        Path("backend/app/main.py"),
+        Path("backend/tests/test_x.py"),
+        Path("client/src/App.tsx"),
+    ]
+    result = grs.under(files, "backend/app/", "backend/tests/")
+    assert len(result) == 2
+
+
+def test_under_excludes_init_when_requested():
+    files = [
+        Path("backend/app/models/user.py"),
+        Path("backend/app/models/__init__.py"),
+    ]
+    result = grs.under(files, "backend/app/models/", exclude_init=True)
+    assert result == [Path("backend/app/models/user.py")]
+
+
+def test_with_ext_filter():
+    files = [Path("a.py"), Path("a.tsx"), Path("a.md")]
+    assert grs.with_ext(files, ".py", ".tsx") == [Path("a.py"), Path("a.tsx")]
+
+
+def test_tracked_files_parses_git_output(monkeypatch):
+    def fake_check_output(cmd, **kw):
+        assert cmd[:2] == ["git", "ls-files"]
+        return "backend/app/main.py\nREADME.md\n\n"
+
+    monkeypatch.setattr(grs.subprocess, "check_output", fake_check_output)
+    files = grs.tracked_files()
+    assert Path("backend/app/main.py") in files
+    assert Path("README.md") in files
+    assert len(files) == 2  # blank line dropped
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 6 failures
+
+- [ ] **Step 3: Implement helpers**
+
+Add to `scripts/generate_readme_stats.py`:
+
+```python
+import subprocess
+
+
+def tracked_files(cwd: Path | None = None) -> list[Path]:
+    """List repo files tracked by git. Respects .gitignore by definition."""
+    out = subprocess.check_output(
+        ["git", "ls-files"],
+        cwd=cwd or ROOT,
+        text=True,
+        encoding="utf-8",
+    )
+    return [Path(line) for line in out.splitlines() if line.strip()]
+
+
+def _normalize(p: Path) -> str:
+    return str(p).replace("\\", "/")
+
+
+def under(
+    files: Iterable[Path],
+    *prefixes: str,
+    exclude_init: bool = False,
+) -> list[Path]:
+    """Return files whose normalized path starts with any of the prefixes."""
+    out: list[Path] = []
+    for f in files:
+        norm = _normalize(f)
+        if not any(norm.startswith(p) for p in prefixes):
+            continue
+        if exclude_init and f.name == "__init__.py":
+            continue
+        out.append(f)
+    return out
+
+
+def with_ext(files: Iterable[Path], *exts: str) -> list[Path]:
+    """Return files whose suffix is in exts (suffixes include the dot)."""
+    return [f for f in files if f.suffix in exts]
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 16 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/generate_readme_stats.py scripts/test_generate_readme_stats.py
+git commit -m "feat(stats): add tracked_files() and path filters"
+```
+
+---
+
+## Task 5: `compute_stats()` aggregator
+
+**Files:**
+- Modify: `scripts/generate_readme_stats.py`
+- Modify: `scripts/test_generate_readme_stats.py`
+
+- [ ] **Step 1: Write the failing test using a fixture file tree**
+
+Append to test file:
+
+```python
+def _make_repo(tmp_path: Path) -> Path:
+    """Create a fixture file tree mimicking BaluHost layout."""
+    tree = {
+        "backend/app/main.py": "x = 1\n",
+        "backend/app/api/routes/auth.py": "def f():\n    pass\n",
+        "backend/app/api/routes/files.py": "def g():\n    pass\n",
+        "backend/app/api/routes/__init__.py": "",
+        "backend/app/services/auth.py": "def h():\n    pass\n",
+        "backend/app/services/files/upload.py": "def i():\n    pass\n",
+        "backend/app/services/__init__.py": "",
+        "backend/app/services/files/__init__.py": "",
+        "backend/app/models/user.py": "class User: ...\n",
+        "backend/app/models/__init__.py": "",
+        "backend/tests/test_one.py": "def test_a():\n    pass\n",
+        "backend/tests/test_two.py": "def test_b():\n    pass\n\ndef test_c():\n    pass\n",
+        "backend/scripts/foo.py": "print('hi')\n",
+        "backend/alembic/versions/0001_init.py": "# rev\n",
+        "backend/alembic/versions/0002_add.py": "# rev\n",
+        "backend/baluhost_tui/main.py": "pass\n",
+        "client/src/App.tsx": "export const X = 1;\n",
+        "client/src/pages/Dashboard.tsx": "export default 1;\n",
+        "client/src/pages/Settings.tsx": "export default 2;\n",
+        "client/src/lib/api.ts": "export {};\n",
+        "client/src/styles.css": "body{}\n",
+        ".github/workflows/ci.yml": "name: ci\n",
+        ".github/workflows/release.yml": "name: rel\n",
+    }
+    for rel, content in tree.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    return tmp_path
+
+
+def test_compute_stats_counts_match_fixture(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr(grs, "ROOT", repo)
+    files = [Path(rel) for rel in [
+        "backend/app/main.py",
+        "backend/app/api/routes/auth.py",
+        "backend/app/api/routes/files.py",
+        "backend/app/api/routes/__init__.py",
+        "backend/app/services/auth.py",
+        "backend/app/services/files/upload.py",
+        "backend/app/services/__init__.py",
+        "backend/app/services/files/__init__.py",
+        "backend/app/models/user.py",
+        "backend/app/models/__init__.py",
+        "backend/tests/test_one.py",
+        "backend/tests/test_two.py",
+        "backend/scripts/foo.py",
+        "backend/alembic/versions/0001_init.py",
+        "backend/alembic/versions/0002_add.py",
+        "backend/baluhost_tui/main.py",
+        "client/src/App.tsx",
+        "client/src/pages/Dashboard.tsx",
+        "client/src/pages/Settings.tsx",
+        "client/src/lib/api.ts",
+        "client/src/styles.css",
+        ".github/workflows/ci.yml",
+        ".github/workflows/release.yml",
+    ]]
+
+    s = grs.compute_stats(files)
+
+    assert s.api_route_modules == 2  # __init__ excluded
+    assert s.service_modules == 2    # __init__ excluded, both auth.py + upload.py
+    assert s.db_models == 1          # __init__ excluded
+    assert s.db_migrations == 2
+    assert s.frontend_pages == 2
+    assert s.workflows == 2
+    assert s.test_functions == 3     # 1 + 2
+
+    assert s.backend_app.files == 10  # all .py under backend/app/
+    assert s.backend_tests.files == 2
+    assert s.backend_scripts.files == 1
+    assert s.backend_alembic.files == 2
+    assert s.backend_tui.files == 1
+    assert s.backend_total.files == 16  # sum of subdirs
+
+    assert s.frontend.files == 5  # .tsx, .ts, .css under client/src/
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py::test_compute_stats_counts_match_fixture -v`
+Expected: FAIL — `compute_stats` not defined
+
+- [ ] **Step 3: Implement dataclasses + compute_stats**
+
+Add to `scripts/generate_readme_stats.py`:
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Bucket:
+    files: int
+    lines: int
+
+
+@dataclass(frozen=True)
+class Stats:
+    backend_total: Bucket
+    backend_app: Bucket
+    backend_tests: Bucket
+    backend_scripts: Bucket
+    backend_alembic: Bucket
+    backend_tui: Bucket
+    frontend: Bucket
+    test_functions: int
+    api_route_modules: int
+    service_modules: int
+    db_models: int
+    db_migrations: int
+    frontend_pages: int
+    workflows: int
+
+
+def _bucket(files: list[Path]) -> Bucket:
+    return Bucket(files=len(files), lines=count_lines(files))
+
+
+def compute_stats(files: list[Path]) -> Stats:
+    """Compute the full stats payload from a list of tracked file paths."""
+    py = with_ext(files, ".py")
+
+    app = under(py, "backend/app/")
+    tests = under(py, "backend/tests/")
+    scripts = under(py, "backend/scripts/")
+    alembic = under(py, "backend/alembic/")
+    tui = under(py, "backend/baluhost_tui/")
+
+    backend_total_files = app + tests + scripts + alembic + tui
+    frontend = under(
+        with_ext(files, ".ts", ".tsx", ".js", ".jsx", ".css"),
+        "client/src/",
+    )
+
+    return Stats(
+        backend_total=_bucket(backend_total_files),
+        backend_app=_bucket(app),
+        backend_tests=_bucket(tests),
+        backend_scripts=_bucket(scripts),
+        backend_alembic=_bucket(alembic),
+        backend_tui=_bucket(tui),
+        frontend=_bucket(frontend),
+        test_functions=count_test_functions(tests),
+        api_route_modules=len(under(py, "backend/app/api/routes/", exclude_init=True)),
+        service_modules=len(under(py, "backend/app/services/", exclude_init=True)),
+        db_models=len(under(py, "backend/app/models/", exclude_init=True)),
+        db_migrations=len(under(py, "backend/alembic/versions/", exclude_init=True)),
+        frontend_pages=len(under(with_ext(files, ".tsx"), "client/src/pages/")),
+        workflows=len(under(
+            with_ext(files, ".yml", ".yaml"),
+            ".github/workflows/",
+        )),
+    )
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 17 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/generate_readme_stats.py scripts/test_generate_readme_stats.py
+git commit -m "feat(stats): add compute_stats() aggregator"
+```
+
+---
+
+## Task 6: `render_project_stats_block()` and `render_test_count()` / `render_test_files()`
+
+**Files:**
+- Modify: `scripts/generate_readme_stats.py`
+- Modify: `scripts/test_generate_readme_stats.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to test file:
+
+```python
+def _stub_stats() -> grs.Stats:
+    return grs.Stats(
+        backend_total=grs.Bucket(files=735, lines=150_685),
+        backend_app=grs.Bucket(files=411, lines=97_186),
+        backend_tests=grs.Bucket(files=166, lines=38_309),
+        backend_scripts=grs.Bucket(files=48, lines=6_291),
+        backend_alembic=grs.Bucket(files=92, lines=5_989),
+        backend_tui=grs.Bucket(files=18, lines=2_910),
+        frontend=grs.Bucket(files=427, lines=78_107),
+        test_functions=1465,
+        api_route_modules=51,
+        service_modules=143,
+        db_models=42,
+        db_migrations=74,
+        frontend_pages=31,
+        workflows=7,
+    )
+
+
+def test_render_project_stats_block_contains_all_rows():
+    md = grs.render_project_stats_block(_stub_stats())
+    assert "150,685 lines across 735 Python files" in md
+    assert "97,186 lines / 411 files" in md
+    assert "38,309 lines / 166 files" in md
+    assert "78,107 lines across 427 source files" in md
+    assert "| **Test functions** | 1465 |" in md
+    assert "| **API route modules** | 51 |" in md
+    assert "| **Service modules** | 143 |" in md
+    assert "| **Database models** | 42 |" in md
+    assert "| **Database migrations** | 74 |" in md
+    assert "| **Frontend pages** | 31 |" in md
+    assert "| **CI/CD workflows** | 7 |" in md
+
+
+def test_render_project_stats_block_includes_measured_date():
+    md = grs.render_project_stats_block(_stub_stats(), measured="2026-05-06")
+    assert "Last measured 2026-05-06" in md
+
+
+def test_render_test_count():
+    assert grs.render_test_count(_stub_stats()) == "1465 tests"
+
+
+def test_render_test_files():
+    assert grs.render_test_files(_stub_stats()) == "166 test files"
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 4 failures
+
+- [ ] **Step 3: Implement render functions**
+
+Add to `scripts/generate_readme_stats.py`:
+
+```python
+from datetime import date
+
+
+def _fmt(n: int) -> str:
+    return f"{n:,}"
+
+
+def render_project_stats_block(s: Stats, measured: str | None = None) -> str:
+    """Render the Project Stats markdown block (between STATS markers)."""
+    measured = measured or date.today().isoformat()
+    return (
+        "| Metric | Count |\n"
+        "|--------|-------|\n"
+        "| **Version** | "
+        "![Latest Release]"
+        "(https://img.shields.io/github/v/release/Xveyn/BaluHost?label=) |\n"
+        f"| **Backend code** | {_fmt(s.backend_total.lines)} lines across "
+        f"{_fmt(s.backend_total.files)} Python files |\n"
+        f"| &nbsp;&nbsp;↳ Application (`app/`) | {_fmt(s.backend_app.lines)} lines / "
+        f"{_fmt(s.backend_app.files)} files |\n"
+        f"| &nbsp;&nbsp;↳ Tests (`tests/`) | {_fmt(s.backend_tests.lines)} lines / "
+        f"{_fmt(s.backend_tests.files)} files |\n"
+        f"| &nbsp;&nbsp;↳ Scripts (`scripts/`) | {_fmt(s.backend_scripts.lines)} lines / "
+        f"{_fmt(s.backend_scripts.files)} files |\n"
+        f"| &nbsp;&nbsp;↳ Alembic migrations | {_fmt(s.backend_alembic.lines)} lines / "
+        f"{_fmt(s.backend_alembic.files)} files |\n"
+        f"| &nbsp;&nbsp;↳ Terminal UI (`baluhost_tui/`) | {_fmt(s.backend_tui.lines)} lines / "
+        f"{_fmt(s.backend_tui.files)} files |\n"
+        f"| **Frontend code** | {_fmt(s.frontend.lines)} lines across "
+        f"{_fmt(s.frontend.files)} source files (`client/src/`, .ts/.tsx/.js/.jsx/.css) |\n"
+        f"| **Test functions** | {s.test_functions} |\n"
+        f"| **API route modules** | {s.api_route_modules} |\n"
+        f"| **Service modules** | {s.service_modules} |\n"
+        f"| **Database models** | {s.db_models} |\n"
+        f"| **Database migrations** | {s.db_migrations} |\n"
+        f"| **Frontend pages** | {s.frontend_pages} |\n"
+        f"| **CI/CD workflows** | {s.workflows} |\n"
+        "\n"
+        "<sub>LOC counted via `git ls-files` (respects `.gitignore`, "
+        "excludes virtualenvs, `node_modules/`, `dist/`, caches, dev-storage). "
+        f"Last measured {measured}.</sub>"
+    )
+
+
+def render_test_count(s: Stats) -> str:
+    return f"{s.test_functions} tests"
+
+
+def render_test_files(s: Stats) -> str:
+    return f"{s.backend_tests.files} test files"
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 21 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/generate_readme_stats.py scripts/test_generate_readme_stats.py
+git commit -m "feat(stats): render markdown for project stats and inline test counts"
+```
+
+---
+
+## Task 7: `replace_between_markers()`
+
+**Files:**
+- Modify: `scripts/generate_readme_stats.py`
+- Modify: `scripts/test_generate_readme_stats.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to test file:
+
+```python
+def test_replace_between_markers_block():
+    text = (
+        "intro\n"
+        "<!-- STATS:PROJECT:START -->\n"
+        "old content here\n"
+        "more old\n"
+        "<!-- STATS:PROJECT:END -->\n"
+        "outro\n"
+    )
+    out = grs.replace_between_markers(text, "PROJECT", "NEW BLOCK")
+    assert (
+        "<!-- STATS:PROJECT:START -->\nNEW BLOCK\n<!-- STATS:PROJECT:END -->" in out
+    )
+    assert "old content" not in out
+    assert "intro\n" in out and "outro\n" in out
+
+
+def test_replace_between_markers_inline():
+    text = "Row | <!-- STATS:TC:START -->old<!-- STATS:TC:END --> | rest"
+    out = grs.replace_between_markers(text, "TC", "new", inline=True)
+    assert "<!-- STATS:TC:START -->new<!-- STATS:TC:END -->" in out
+    assert "old" not in out
+
+
+def test_replace_between_markers_idempotent():
+    text = (
+        "<!-- STATS:X:START -->\nfoo\n<!-- STATS:X:END -->"
+    )
+    once = grs.replace_between_markers(text, "X", "bar")
+    twice = grs.replace_between_markers(once, "X", "bar")
+    assert once == twice
+
+
+def test_replace_between_markers_missing_raises():
+    text = "no markers here"
+    try:
+        grs.replace_between_markers(text, "MISSING", "x")
+    except ValueError as e:
+        assert "MISSING" in str(e)
+    else:
+        raise AssertionError("expected ValueError")
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 4 failures
+
+- [ ] **Step 3: Implement `replace_between_markers`**
+
+Add to `scripts/generate_readme_stats.py`:
+
+```python
+import re
+
+
+def replace_between_markers(
+    text: str, name: str, content: str, *, inline: bool = False
+) -> str:
+    """Replace the content between <!-- STATS:NAME:START --> and ...:END -->.
+
+    Block mode (default): expects markers on their own lines, replaces the
+    lines in between. Inline mode: marker pair appears on a single line and
+    only the inner span is replaced.
+
+    Raises ValueError if either marker is missing.
+    """
+    start = f"<!-- STATS:{name}:START -->"
+    end = f"<!-- STATS:{name}:END -->"
+    if start not in text or end not in text:
+        raise ValueError(f"Marker pair STATS:{name} not found in text")
+
+    if inline:
+        pattern = re.escape(start) + r".*?" + re.escape(end)
+        return re.sub(pattern, f"{start}{content}{end}", text, count=1, flags=re.S)
+
+    # Block mode: keep marker lines, replace everything strictly between.
+    pattern = (
+        re.escape(start) + r"\n.*?\n" + re.escape(end)
+    )
+    return re.sub(pattern, f"{start}\n{content}\n{end}", text, count=1, flags=re.S)
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 25 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/generate_readme_stats.py scripts/test_generate_readme_stats.py
+git commit -m "feat(stats): add idempotent marker-based text splice"
+```
+
+---
+
+## Task 8: Wire CLI `main()` + end-to-end smoke test
+
+**Files:**
+- Modify: `scripts/generate_readme_stats.py`
+- Modify: `scripts/test_generate_readme_stats.py`
+
+- [ ] **Step 1: Write the failing end-to-end test**
+
+Append to test file:
+
+```python
+def test_apply_to_text_replaces_three_marker_pairs():
+    template = (
+        "before\n"
+        "<!-- STATS:PROJECT:START -->\n"
+        "OLD TABLE\n"
+        "<!-- STATS:PROJECT:END -->\n"
+        "row | <!-- STATS:TEST_COUNT:START -->old<!-- STATS:TEST_COUNT:END --> | "
+        "<!-- STATS:TEST_FILES:START -->old<!-- STATS:TEST_FILES:END -->,\n"
+        "after\n"
+    )
+    s = _stub_stats()
+    out = grs.apply_to_text(template, s, measured="2026-05-06")
+
+    assert "OLD TABLE" not in out
+    assert "150,685 lines across 735" in out
+    assert "1465 tests" in out
+    assert "166 test files" in out
+    assert "Last measured 2026-05-06" in out
+
+
+def test_apply_to_text_idempotent():
+    template = (
+        "<!-- STATS:PROJECT:START -->\nx\n<!-- STATS:PROJECT:END -->\n"
+        "<!-- STATS:TEST_COUNT:START -->x<!-- STATS:TEST_COUNT:END -->\n"
+        "<!-- STATS:TEST_FILES:START -->x<!-- STATS:TEST_FILES:END -->\n"
+    )
+    once = grs.apply_to_text(template, _stub_stats(), measured="2026-05-06")
+    twice = grs.apply_to_text(once, _stub_stats(), measured="2026-05-06")
+    assert once == twice
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 2 failures (no `apply_to_text`)
+
+- [ ] **Step 3: Implement `apply_to_text` and complete `main`**
+
+Add to `scripts/generate_readme_stats.py`:
+
+```python
+def apply_to_text(readme_text: str, stats: Stats, *, measured: str | None = None) -> str:
+    """Apply all three marker replacements to a README body."""
+    out = replace_between_markers(
+        readme_text, "PROJECT", render_project_stats_block(stats, measured=measured)
+    )
+    out = replace_between_markers(
+        out, "TEST_COUNT", render_test_count(stats), inline=True
+    )
+    out = replace_between_markers(
+        out, "TEST_FILES", render_test_files(stats), inline=True
+    )
+    return out
+```
+
+Replace the placeholder `main()` with:
+
+```python
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--write", action="store_true", help="Rewrite README.md in place")
+    mode.add_argument("--check", action="store_true", help="Exit 1 if README would change")
+    args = parser.parse_args()
+
+    if not args.write and not args.check:
+        args.check = True
+
+    files = tracked_files()
+    stats = compute_stats(files)
+    current = README.read_text(encoding="utf-8")
+    new = apply_to_text(current, stats)
+
+    if new == current:
+        print("README stats up to date.")
+        return 0
+
+    if args.write:
+        README.write_text(new, encoding="utf-8")
+        print("README.md updated.")
+        return 0
+
+    # check mode
+    print("README stats are out of date. Run with --write to update.", file=sys.stderr)
+    return 1
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 27 PASS
+
+- [ ] **Step 5: Run script in --check mode against the current README (will fail until Task 9 adds markers)**
+
+Run: `python scripts/generate_readme_stats.py --check`
+Expected: exit code 1 with `ValueError: Marker pair STATS:PROJECT not found` — confirms the script is wired but the README has no markers yet. This is the expected state at this point in the plan.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/generate_readme_stats.py scripts/test_generate_readme_stats.py
+git commit -m "feat(stats): wire CLI main with --check and --write modes"
+```
+
+---
+
+## Task 9: Add markers to README and remove inline architecture counts
+
+**Files:**
+- Modify: `README.md` (add 3 marker pairs, strip 7 inline numbers from architecture tree, drop the obsolete `Last measured 2026-04-30` sub-note since it now lives inside the generated block)
+
+- [ ] **Step 1: Add inline markers around the test count and test files in the Production Status row**
+
+In `README.md` line 32, replace:
+```markdown
+| **Testing** | 1465 tests | 82 test files, CI/CD via GitHub Actions |
+```
+with:
+```markdown
+| **Testing** | <!-- STATS:TEST_COUNT:START -->1465 tests<!-- STATS:TEST_COUNT:END --> | <!-- STATS:TEST_FILES:START -->82 test files<!-- STATS:TEST_FILES:END -->, CI/CD via GitHub Actions |
+```
+
+- [ ] **Step 2: Strip inline counts from the Architecture tree (lines 167–197)**
+
+In `README.md`, replace:
+```markdown
+│   │   ├── api/routes/      # 51 API route modules
+│   │   ├── services/        # 143 service modules
+│   │   ├── models/          # 42 SQLAlchemy ORM models
+│   │   ├── schemas/         # 41 Pydantic schemas
+```
+with:
+```markdown
+│   │   ├── api/routes/      # API route modules
+│   │   ├── services/        # Service modules
+│   │   ├── models/          # SQLAlchemy ORM models
+│   │   ├── schemas/         # Pydantic schemas
+```
+
+Replace:
+```markdown
+│   ├── tests/               # 82 test files
+│   └── alembic/             # 74 database migrations
+```
+with:
+```markdown
+│   ├── tests/               # Pytest suite
+│   └── alembic/             # Database migrations
+```
+
+Replace:
+```markdown
+│       ├── pages/           # 31 page components
+│       ├── components/      # 30+ component directories
+```
+with:
+```markdown
+│       ├── pages/           # Page components
+│       ├── components/      # Reusable components
+```
+
+(The `30+ component directories` line was already approximate; we drop it because we are not generating that count. If we want to add it later, extend `compute_stats`.)
+
+- [ ] **Step 3: Wrap the Project Stats block with markers and remove the standalone "Last measured" sub-note**
+
+In `README.md`, replace lines 309–329 (the `## Project Stats` section through the `<sub>` line) with:
+
+```markdown
+## Project Stats
+
+<!-- STATS:PROJECT:START -->
+| Metric | Count |
+|--------|-------|
+| **Version** | ![Latest Release](https://img.shields.io/github/v/release/Xveyn/BaluHost?label=) |
+| **Backend code** | (regenerated by scripts/generate_readme_stats.py) |
+<!-- STATS:PROJECT:END -->
+```
+
+The placeholder line will be overwritten by the script in Step 4 — we just need valid marker structure for the script to splice into.
+
+- [ ] **Step 4: Regenerate the README**
+
+Run: `python scripts/generate_readme_stats.py --write`
+Expected stdout: `README.md updated.`
+
+- [ ] **Step 5: Verify the result**
+
+Run: `python scripts/generate_readme_stats.py --check`
+Expected stdout: `README stats up to date.` (exit 0)
+
+Run: `git diff README.md` and visually verify:
+- Project Stats table has real numbers
+- Production Status testing row has real numbers wrapped in markers
+- Architecture tree has no inline numbers
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): wire stats markers and remove inline counts from architecture tree"
+```
+
+---
+
+## Task 10: Wire script into auto-merge.yml release workflow
+
+**Files:**
+- Modify: `.github/workflows/auto-merge.yml:57-75` (the "Bump version from release label" step)
+
+- [ ] **Step 1: Read current step body**
+
+Open `.github/workflows/auto-merge.yml`. Locate the step beginning at line 57:
+
+```yaml
+      - name: Bump version from release label
+        if: env.RELEASE_LABEL != ''
+        working-directory: /tmp/repo
+        run: |
+          BUMP_TYPE="${RELEASE_LABEL#release:}"
+          echo "Release label: $RELEASE_LABEL → bump type: $BUMP_TYPE"
+
+          CURRENT_VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' backend/pyproject.toml)
+          echo "Current version: $CURRENT_VERSION"
+
+          python3 scripts/bump_version.py "$BUMP_TYPE"
+
+          NEW_VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' backend/pyproject.toml)
+          echo "New version: $NEW_VERSION"
+          echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
+
+          git add backend/pyproject.toml client/package.json CLAUDE.md
+          git commit -m "chore: bump version to v${NEW_VERSION}"
+          git push origin main
+```
+
+- [ ] **Step 2: Modify the step to regenerate stats and include README in the commit**
+
+Replace the step body with:
+
+```yaml
+      - name: Bump version from release label
+        if: env.RELEASE_LABEL != ''
+        working-directory: /tmp/repo
+        run: |
+          BUMP_TYPE="${RELEASE_LABEL#release:}"
+          echo "Release label: $RELEASE_LABEL → bump type: $BUMP_TYPE"
+
+          CURRENT_VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' backend/pyproject.toml)
+          echo "Current version: $CURRENT_VERSION"
+
+          python3 scripts/bump_version.py "$BUMP_TYPE"
+
+          NEW_VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' backend/pyproject.toml)
+          echo "New version: $NEW_VERSION"
+          echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
+
+          # Regenerate README stats (counts only tracked files via git ls-files)
+          python3 scripts/generate_readme_stats.py --write
+
+          git add backend/pyproject.toml client/package.json CLAUDE.md README.md
+          git commit -m "chore: bump version to v${NEW_VERSION}"
+          git push origin main
+```
+
+The change is two lines: one comment + the script invocation, and adding `README.md` to the `git add` list. If stats didn't change, `git add README.md` is a no-op and the commit still works.
+
+- [ ] **Step 3: Verify the YAML is well-formed**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/auto-merge.yml'))"`
+Expected: no output (success). If `yaml` is not installed, fall back to:
+Run: `python -c "import json,subprocess; subprocess.check_call(['python','-c','open(\".github/workflows/auto-merge.yml\").read()'])"`
+
+- [ ] **Step 4: Run the full test suite once more**
+
+Run: `python -m pytest scripts/test_generate_readme_stats.py -v`
+Expected: 27 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/auto-merge.yml
+git commit -m "ci(release): regenerate README stats during version bump"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- "Don't track gitignored files" → Task 4 uses `git ls-files` exclusively. ✓
+- "No dependencies" → script imports only stdlib (`argparse`, `ast`, `dataclasses`, `datetime`, `pathlib`, `re`, `subprocess`, `sys`, `typing`). Tests use only pytest (existing dev dep). ✓
+- "Bei zukünftigen releases (und pre-releases)" → Task 10 wires into `auto-merge.yml` which fires on every release-label PR merge to `main`, including pre-release versions (`-alpha`/`-beta`/`-rc` suffixes). ✓
+- "Sauber" → tasks remove inline architecture counts (single source of truth), add idempotent marker splice, full TDD coverage. ✓
+
+**Type consistency:** all functions use names introduced earlier — `count_lines`, `count_test_functions`, `tracked_files`, `under`, `with_ext`, `compute_stats`, `Bucket`, `Stats`, `render_project_stats_block`, `render_test_count`, `render_test_files`, `replace_between_markers`, `apply_to_text`, `main`. No drift.
+
+**Placeholder scan:** No TBDs. Each step has full code or full command. The README placeholder line in Task 9 Step 3 is intentional — it gets overwritten by Step 4 in the same task.
+
+**Skip list confirmed:**
+- We do NOT count `dependencies` (e.g., `node_modules/`, `.venv/`, vendored libs) — `git ls-files` excludes them.
+- We do NOT count `.metadata.json`, `dev-storage/`, `dist/`, `htmlcov/` — all gitignored.
+- We do NOT touch `CLAUDE.md` Version line — that's already handled by `bump_version.py`.
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-06-readme-stats-automation.md`.

--- a/docs/superpowers/plans/2026-05-06-release-flow-prerelease-default.md
+++ b/docs/superpowers/plans/2026-05-06-release-flow-prerelease-default.md
@@ -1,0 +1,1860 @@
+# Release Flow Pre-Release Default Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch PR-merges-to-main from auto-stable-releases to pre-releases by default, with a manual `workflow_dispatch` trigger for stable promotions and auto-CHANGELOG generation from Conventional Commits.
+
+**Architecture:** Two-phase atomic switch. Phase 1 ships backend+frontend infrastructure (new schema field, tag-based version detection, pre-release badge, CHANGELOG helper scripts) under the existing flow. Phase 2 atomically replaces auto-merge bumping with pre-release tagging and adds the new `release-stable.yml` workflow.
+
+**Tech Stack:** GitHub Actions (YAML), Python 3.11, FastAPI, Pydantic, React 18, TypeScript, Tailwind, pytest, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-05-06-release-flow-prerelease-default-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `scripts/bump_version.py` | Modify | Add `--dry-run` flag |
+| `scripts/generate_changelog_section.py` | Create | Group conventional commits into Keep-a-Changelog sections |
+| `scripts/insert_changelog_section.py` | Create | Insert new section after H1 in `CHANGELOG.md` |
+| `tests/scripts/test_bump_version.py` | Create | Tests for `--dry-run` |
+| `tests/scripts/test_generate_changelog_section.py` | Create | Tests for grouping/parsing logic |
+| `tests/scripts/test_insert_changelog_section.py` | Create | Tests for insertion |
+| `backend/app/schemas/update.py` | Modify | Add `is_prerelease: bool` to `VersionInfo` |
+| `backend/app/services/update/prod_backend.py` | Modify | Tag-based version detection, set `is_prerelease` |
+| `backend/app/services/update/dev_backend.py` | Modify | Set `is_prerelease=False` |
+| `backend/tests/services/test_update_service.py` | Modify | Tests for tag-based detection + `is_prerelease` |
+| `client/src/api/updates.ts` | Modify | Add `is_prerelease` to TS `VersionInfo` |
+| `client/src/contexts/VersionContext.tsx` | Modify | Add `useVersionDisplay()` hook |
+| `client/src/i18n/locales/en/updates.json` | Modify | `preRelease.badge` key |
+| `client/src/i18n/locales/de/updates.json` | Modify | `preRelease.badge` key |
+| `client/src/components/updates/UpdateOverviewTab.tsx` | Modify | Render pre-release badge |
+| `.github/workflows/release-stable.yml` | Create | `workflow_dispatch` for stable promotion |
+| `.github/workflows/auto-merge.yml` | Modify | Remove bump steps, switch to pre-release tagging |
+| `.github/workflows/deploy-production.yml` | Modify | Extend skip filter for `chore: release v` |
+| `.github/workflows/create-release.yml` | Modify | Recognize `-pre.` as prerelease |
+| `.github/workflows/ci-check.yml` | Modify | Remove `changelog-guard` job |
+| `.claude/commands/release/_release.md` | Modify | Simplify (drop label/CHANGELOG steps) |
+| `.claude/commands/release/_release-stable.md` | Create | Trigger `release-stable.yml` via `gh workflow run` |
+| `C:\Users\SvenB\.claude\projects\D--Programme--x86--Baluhost\memory\feedback_release_workflow.md` | Modify | Update memory entry |
+
+**Phase 1 (Tasks 1-12):** Backend + frontend infrastructure. Ships via existing release flow (last `release:patch` PR under the old system).
+
+**Phase 2 (Tasks 13-19):** Workflow switch — must be a single atomic PR.
+
+**Phase 3 (Tasks 20-21):** Cleanup + memory update.
+
+---
+
+## Phase 1: Backend & Frontend Infrastructure
+
+### Task 1: Add `--dry-run` flag to `bump_version.py`
+
+**Files:**
+- Modify: `scripts/bump_version.py`
+- Create: `tests/scripts/__init__.py` (empty, may already exist)
+- Create: `tests/scripts/test_bump_version.py`
+
+**Context:** The new `release-stable.yml` workflow needs to compute the next version *before* committing, so it can generate the CHANGELOG section with the correct version heading. `--dry-run` outputs the computed new version on stdout without modifying any files.
+
+- [ ] **Step 1: Create the test file with failing tests**
+
+Path: `tests/scripts/test_bump_version.py`
+
+```python
+"""Tests for scripts/bump_version.py --dry-run flag."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "bump_version.py"
+
+
+def _read_pyproject_version() -> str:
+    text = (REPO_ROOT / "backend" / "pyproject.toml").read_text(encoding="utf-8")
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("version") and "=" in s:
+            return s.split("=", 1)[1].strip().strip('"').strip("'")
+    raise RuntimeError("version not found")
+
+
+def _run_bump(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        check=False,
+    )
+
+
+def test_dry_run_patch_outputs_next_version_without_writing():
+    current = _read_pyproject_version()
+    parts = current.split(".")
+    expected = f"{parts[0]}.{parts[1]}.{int(parts[2]) + 1}"
+
+    result = _run_bump("patch", "--dry-run")
+    assert result.returncode == 0, result.stderr
+    # Expected version must appear on the last non-empty stdout line
+    lines = [ln for ln in result.stdout.strip().splitlines() if ln.strip()]
+    assert lines[-1].strip() == expected
+
+    # Verify pyproject.toml unchanged
+    assert _read_pyproject_version() == current
+
+
+def test_dry_run_minor_outputs_next_version():
+    current = _read_pyproject_version()
+    parts = current.split(".")
+    expected = f"{parts[0]}.{int(parts[1]) + 1}.0"
+
+    result = _run_bump("minor", "--dry-run")
+    assert result.returncode == 0, result.stderr
+    lines = [ln for ln in result.stdout.strip().splitlines() if ln.strip()]
+    assert lines[-1].strip() == expected
+    assert _read_pyproject_version() == current
+
+
+def test_dry_run_major_outputs_next_version():
+    current = _read_pyproject_version()
+    parts = current.split(".")
+    expected = f"{int(parts[0]) + 1}.0.0"
+
+    result = _run_bump("major", "--dry-run")
+    assert result.returncode == 0, result.stderr
+    lines = [ln for ln in result.stdout.strip().splitlines() if ln.strip()]
+    assert lines[-1].strip() == expected
+    assert _read_pyproject_version() == current
+```
+
+If `tests/scripts/__init__.py` does not exist yet, also create it (empty file).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/scripts/test_bump_version.py -v`
+Expected: FAIL — current `bump_version.py` does not support `--dry-run`; it would treat it as an unknown argument and exit 1.
+
+- [ ] **Step 3: Add `--dry-run` to `bump_version.py`**
+
+Replace the body of `main()` in `scripts/bump_version.py` with:
+
+```python
+def main() -> None:
+    args = sys.argv[1:]
+    dry_run = False
+    if "--dry-run" in args:
+        dry_run = True
+        args = [a for a in args if a != "--dry-run"]
+
+    current = read_current_version()
+
+    if not args:
+        new_version = current
+        if not dry_run:
+            print(f"Syncing version {new_version} to all files...")
+    else:
+        arg = args[0]
+        if arg in ("major", "minor", "patch"):
+            new_version = bump(current, arg)
+        elif re.match(r"^\d+\.\d+\.\d+", arg):
+            new_version = arg
+        else:
+            print(f"Usage: {sys.argv[0]} [major|minor|patch|X.Y.Z] [--dry-run]")
+            sys.exit(1)
+        if not dry_run:
+            print(f"Bumping version: {current} -> {new_version}")
+
+    if dry_run:
+        # Emit only the computed version; CI captures stdout
+        print(new_version)
+        return
+
+    if args and args[0] in ("major", "minor", "patch"):
+        update_pyproject(new_version)
+    elif args:
+        update_pyproject(new_version)
+
+    update_package_json(new_version)
+    update_claude_md(new_version)
+
+    print("Updated files:")
+    print(f"  backend/pyproject.toml  -> {new_version}")
+    print(f"  client/package.json     -> {new_version}")
+    print(f"  CLAUDE.md               -> {new_version}")
+    print()
+    print("Note: Run 'cd client && npm install' to sync package-lock.json")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/scripts/test_bump_version.py -v`
+Expected: PASS — all three tests green.
+
+- [ ] **Step 5: Verify normal usage still works (regression)**
+
+Run: `python scripts/bump_version.py patch --dry-run`
+Expected: prints only the computed next version on the last line, no file modifications.
+
+Run: `python scripts/bump_version.py` (no args, no `--dry-run`)
+Expected: syncs current pyproject version to package.json and CLAUDE.md (existing behavior).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/bump_version.py tests/scripts/__init__.py tests/scripts/test_bump_version.py
+git commit -m "feat(scripts): add --dry-run flag to bump_version.py"
+```
+
+---
+
+### Task 2: Create `generate_changelog_section.py`
+
+**Files:**
+- Create: `scripts/generate_changelog_section.py`
+- Create: `tests/scripts/test_generate_changelog_section.py`
+
+**Context:** Reads commits since a given ref via `git log <since>..HEAD --pretty=format:'%H%x1f%s%x1f%b%x1e' --no-merges` and produces a Keep-a-Changelog section grouped by Conventional-Commits type. Used by `release-stable.yml` and previewed by `_release-stable.md` slash command.
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `tests/scripts/test_generate_changelog_section.py`
+
+```python
+"""Tests for scripts/generate_changelog_section.py."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "generate_changelog_section.py"
+
+
+def _run(*args: str, input_text: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        input=input_text,
+        cwd=str(REPO_ROOT),
+        check=False,
+    )
+
+
+def test_groups_feat_under_added():
+    # --stdin reads pre-formatted commit lines, bypassing git for unit tests
+    commits = (
+        "abc1234\x1ffeat: add new dashboard widget\x1f\x1e"
+        "def5678\x1ffix: prevent crash on empty input\x1f\x1e"
+    )
+    result = _run("--version", "1.32.0", "--date", "2026-05-06", "--stdin",
+                  "--output", "-", input_text=commits)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "## [1.32.0] - 2026-05-06" in out
+    assert "### Added" in out
+    assert "- add new dashboard widget" in out
+    assert "### Fixed" in out
+    assert "- prevent crash on empty input" in out
+
+
+def test_scope_renders_as_bold_prefix():
+    commits = "abc1234\x1ffeat(sleep): detect Suspend + WoL capabilities\x1f\x1e"
+    result = _run("--version", "1.32.0", "--date", "2026-05-06", "--stdin",
+                  "--output", "-", input_text=commits)
+    assert result.returncode == 0, result.stderr
+    assert "- **(sleep)** detect Suspend + WoL capabilities" in result.stdout
+
+
+def test_chore_ci_test_style_build_are_ignored():
+    commits = (
+        "a\x1fchore: bump dependencies\x1f\x1e"
+        "b\x1fci: tweak workflow\x1f\x1e"
+        "c\x1ftest: add coverage\x1f\x1e"
+        "d\x1fstyle: reformat\x1f\x1e"
+        "e\x1fbuild: update tooling\x1f\x1e"
+    )
+    result = _run("--version", "1.32.0", "--date", "2026-05-06", "--stdin",
+                  "--output", "-", input_text=commits)
+    assert result.returncode == 0, result.stderr
+    # No bullet lines — only the heading + date + trailing separator
+    assert "- " not in result.stdout
+
+
+def test_non_conventional_commits_are_ignored():
+    commits = "abc\x1fjust a plain commit message\x1f\x1e"
+    result = _run("--version", "1.32.0", "--date", "2026-05-06", "--stdin",
+                  "--output", "-", input_text=commits)
+    assert result.returncode == 0, result.stderr
+    assert "- " not in result.stdout
+
+
+def test_breaking_change_in_subject_creates_breaking_section():
+    commits = "abc1234\x1ffeat!: rewrite auth flow\x1f\x1e"
+    result = _run("--version", "2.0.0", "--date", "2026-05-06", "--stdin",
+                  "--output", "-", input_text=commits)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "### ⚠ BREAKING CHANGES" in out  # ⚠ char
+    assert "- rewrite auth flow" in out
+
+
+def test_breaking_change_in_body_creates_breaking_section():
+    commits = (
+        "abc1234\x1ffeat: rewrite auth flow\x1f"
+        "BREAKING CHANGE: removes /api/legacy/login\x1e"
+    )
+    result = _run("--version", "2.0.0", "--date", "2026-05-06", "--stdin",
+                  "--output", "-", input_text=commits)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "### ⚠ BREAKING CHANGES" in out
+    assert "- rewrite auth flow" in out
+
+
+def test_pr_number_extracted_from_subject_suffix():
+    commits = "abc1234\x1ffix(sleep): detect Suspend + WoL capabilities (#70)\x1f\x1e"
+    result = _run("--version", "1.32.0", "--date", "2026-05-06", "--stdin",
+                  "--output", "-", input_text=commits)
+    assert result.returncode == 0, result.stderr
+    assert "- **(sleep)** detect Suspend + WoL capabilities (#70)" in result.stdout
+
+
+def test_empty_commits_produces_no_bullets_and_exit_zero():
+    # Empty input is allowed; the workflow's emptiness check is its own concern
+    result = _run("--version", "1.32.0", "--date", "2026-05-06", "--stdin",
+                  "--output", "-", input_text="")
+    assert result.returncode == 0, result.stderr
+    assert "## [1.32.0] - 2026-05-06" in result.stdout
+    assert "- " not in result.stdout
+
+
+def test_writes_to_file_when_output_path_given(tmp_path):
+    target = tmp_path / "section.md"
+    commits = "abc\x1ffeat: x\x1f\x1e"
+    result = _run("--version", "1.32.0", "--date", "2026-05-06", "--stdin",
+                  "--output", str(target), input_text=commits)
+    assert result.returncode == 0, result.stderr
+    assert target.read_text(encoding="utf-8").startswith("## [1.32.0] - 2026-05-06")
+    assert "- x" in target.read_text(encoding="utf-8")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/scripts/test_generate_changelog_section.py -v`
+Expected: FAIL — script does not exist.
+
+- [ ] **Step 3: Implement the script**
+
+Path: `scripts/generate_changelog_section.py`
+
+```python
+#!/usr/bin/env python3
+"""Generate a Keep-a-Changelog section from Conventional Commits.
+
+Usage:
+    python scripts/generate_changelog_section.py \\
+        --version 1.32.0 \\
+        --since v1.31.0 \\
+        --output CHANGELOG-section.md
+
+Or with prepared input on stdin (used by tests):
+    python scripts/generate_changelog_section.py \\
+        --version 1.32.0 --date 2026-05-06 --stdin --output - < commits.txt
+
+Stdin format (each commit terminated by 0x1e, fields separated by 0x1f):
+    <sha>\\x1f<subject>\\x1f<body>\\x1e
+
+Conventional Commits mapping:
+    feat:      -> ### Added
+    fix:       -> ### Fixed
+    refactor:  -> ### Changed
+    perf:      -> ### Changed
+    docs:      -> ### Documentation
+    feat!: / BREAKING CHANGE: in body -> ### ⚠ BREAKING CHANGES (top of section)
+    chore:/ci:/test:/style:/build: -> ignored
+    Anything without a recognised prefix -> ignored
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from datetime import date as date_cls
+from pathlib import Path
+
+CC_PATTERN = re.compile(
+    r"^(?P<type>feat|fix|refactor|perf|docs|chore|ci|test|style|build|revert)"
+    r"(?P<bang>!?)"
+    r"(?:\((?P<scope>[^)]+)\))?"
+    r":\s*(?P<desc>.+)$"
+)
+
+GROUP_FOR_TYPE = {
+    "feat": "Added",
+    "fix": "Fixed",
+    "refactor": "Changed",
+    "perf": "Changed",
+    "docs": "Documentation",
+}
+
+IGNORED_TYPES = {"chore", "ci", "test", "style", "build", "revert"}
+
+
+def parse_commits_from_stdin() -> list[tuple[str, str, str]]:
+    raw = sys.stdin.read()
+    if not raw:
+        return []
+    out: list[tuple[str, str, str]] = []
+    for entry in raw.split("\x1e"):
+        if not entry.strip():
+            continue
+        parts = entry.split("\x1f")
+        # Pad to (sha, subject, body)
+        while len(parts) < 3:
+            parts.append("")
+        sha, subject, body = parts[0], parts[1], parts[2]
+        out.append((sha.strip(), subject.strip(), body.strip()))
+    return out
+
+
+def parse_commits_from_git(since: str) -> list[tuple[str, str, str]]:
+    result = subprocess.run(
+        ["git", "log", f"{since}..HEAD",
+         "--pretty=format:%H\x1f%s\x1f%b\x1e",
+         "--no-merges"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(f"git log failed: {result.stderr}\n")
+        sys.exit(2)
+    raw = result.stdout
+    if not raw.strip():
+        return []
+    out: list[tuple[str, str, str]] = []
+    for entry in raw.split("\x1e"):
+        if not entry.strip():
+            continue
+        parts = entry.split("\x1f")
+        while len(parts) < 3:
+            parts.append("")
+        out.append((parts[0].strip(), parts[1].strip(), parts[2].strip()))
+    return out
+
+
+def classify(subject: str, body: str) -> tuple[str | None, str, bool]:
+    """Return (group, formatted_description, is_breaking).
+
+    group is one of: "Added", "Fixed", "Changed", "Documentation", or None (ignore).
+    Breaking commits are also returned with their normal group, plus is_breaking=True.
+    """
+    m = CC_PATTERN.match(subject)
+    if not m:
+        return (None, "", False)
+    cc_type = m.group("type")
+    bang = m.group("bang") == "!"
+    scope = m.group("scope")
+    desc = m.group("desc").strip()
+    is_breaking = bang or "BREAKING CHANGE:" in body
+
+    if cc_type in IGNORED_TYPES and not is_breaking:
+        return (None, "", False)
+    group = GROUP_FOR_TYPE.get(cc_type)
+    if group is None and is_breaking:
+        # A breaking chore/etc. still counts under BREAKING CHANGES
+        group = None
+    formatted = f"**({scope})** {desc}" if scope else desc
+    return (group, formatted, is_breaking)
+
+
+def render_section(version: str, date_iso: str,
+                   commits: list[tuple[str, str, str]]) -> str:
+    breaking: list[str] = []
+    buckets: dict[str, list[str]] = {
+        "Added": [],
+        "Changed": [],
+        "Fixed": [],
+        "Documentation": [],
+    }
+    for _sha, subject, body in commits:
+        group, desc, is_breaking = classify(subject, body)
+        if is_breaking and desc:
+            breaking.append(desc)
+        if group is not None and desc:
+            buckets[group].append(desc)
+
+    lines: list[str] = [f"## [{version}] - {date_iso}", ""]
+    if breaking:
+        lines.append("### ⚠ BREAKING CHANGES")
+        lines.append("")
+        for item in breaking:
+            lines.append(f"- {item}")
+        lines.append("")
+    for group in ("Added", "Changed", "Fixed", "Documentation"):
+        items = buckets[group]
+        if not items:
+            continue
+        lines.append(f"### {group}")
+        lines.append("")
+        for item in items:
+            lines.append(f"- {item}")
+        lines.append("")
+    lines.append("---")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--date", default=date_cls.today().isoformat())
+    parser.add_argument("--since", help="Git ref. Required unless --stdin.")
+    parser.add_argument("--stdin", action="store_true",
+                        help="Read commits from stdin (test mode)")
+    parser.add_argument("--output", required=True,
+                        help="Output file path or '-' for stdout")
+    args = parser.parse_args()
+
+    if args.stdin:
+        commits = parse_commits_from_stdin()
+    else:
+        if not args.since:
+            sys.stderr.write("--since is required (unless --stdin)\n")
+            return 2
+        commits = parse_commits_from_git(args.since)
+
+    section = render_section(args.version, args.date, commits)
+
+    if args.output == "-":
+        sys.stdout.write(section)
+    else:
+        Path(args.output).write_text(section, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/scripts/test_generate_changelog_section.py -v`
+Expected: PASS — all eight tests green.
+
+- [ ] **Step 5: Smoke-test against real git history**
+
+Run: `python scripts/generate_changelog_section.py --version 1.32.0 --since 0e6c6ab --output -`
+Expected: prints a section with `## [1.32.0] - <today>` heading and (likely empty) buckets since 0e6c6ab is the latest commit at plan-write time.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/generate_changelog_section.py tests/scripts/test_generate_changelog_section.py
+git commit -m "feat(scripts): add generate_changelog_section.py"
+```
+
+---
+
+### Task 3: Create `insert_changelog_section.py`
+
+**Files:**
+- Create: `scripts/insert_changelog_section.py`
+- Create: `tests/scripts/test_insert_changelog_section.py`
+
+**Context:** Reads a section from `--section` and prepends it to `--target` (CHANGELOG.md) directly after the H1 heading (`# Changelog`), preserving the existing `---` separator style.
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `tests/scripts/test_insert_changelog_section.py`
+
+```python
+"""Tests for scripts/insert_changelog_section.py."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "insert_changelog_section.py"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        check=False,
+    )
+
+
+def test_inserts_section_after_h1_heading(tmp_path):
+    target = tmp_path / "CHANGELOG.md"
+    target.write_text(
+        "# Changelog\n\n"
+        "All notable changes...\n\n"
+        "---\n\n"
+        "## [1.31.7] - 2026-05-04\n\n"
+        "### Fixed\n\n"
+        "- something\n\n"
+        "---\n",
+        encoding="utf-8",
+    )
+    section = tmp_path / "section.md"
+    section.write_text(
+        "## [1.32.0] - 2026-05-06\n\n"
+        "### Added\n\n"
+        "- new feature\n\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    result = _run("--section", str(section), "--target", str(target))
+    assert result.returncode == 0, result.stderr
+
+    out = target.read_text(encoding="utf-8")
+    # H1 + preamble preserved
+    assert out.startswith("# Changelog\n\nAll notable changes...\n\n---\n\n")
+    # New section sits immediately after the preamble's --- separator
+    assert "---\n\n## [1.32.0] - 2026-05-06" in out
+    # Old section still present
+    assert "## [1.31.7] - 2026-05-04" in out
+    # New section appears before the old one
+    new_idx = out.index("[1.32.0]")
+    old_idx = out.index("[1.31.7]")
+    assert new_idx < old_idx
+
+
+def test_inserts_when_no_existing_sections(tmp_path):
+    target = tmp_path / "CHANGELOG.md"
+    target.write_text(
+        "# Changelog\n\nAll notable changes...\n\n---\n",
+        encoding="utf-8",
+    )
+    section = tmp_path / "section.md"
+    section.write_text(
+        "## [1.0.0] - 2026-05-06\n\n### Added\n\n- first release\n\n---\n",
+        encoding="utf-8",
+    )
+
+    result = _run("--section", str(section), "--target", str(target))
+    assert result.returncode == 0, result.stderr
+
+    out = target.read_text(encoding="utf-8")
+    assert "## [1.0.0] - 2026-05-06" in out
+    assert "- first release" in out
+
+
+def test_fails_when_target_lacks_h1(tmp_path):
+    target = tmp_path / "CHANGELOG.md"
+    target.write_text("Not a real changelog\n", encoding="utf-8")
+    section = tmp_path / "section.md"
+    section.write_text("## [1.0.0]\n", encoding="utf-8")
+
+    result = _run("--section", str(section), "--target", str(target))
+    assert result.returncode != 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/scripts/test_insert_changelog_section.py -v`
+Expected: FAIL — script does not exist.
+
+- [ ] **Step 3: Implement the script**
+
+Path: `scripts/insert_changelog_section.py`
+
+```python
+#!/usr/bin/env python3
+"""Insert a new CHANGELOG section after the H1 heading.
+
+Usage:
+    python scripts/insert_changelog_section.py \\
+        --section /tmp/changelog-section.md \\
+        --target CHANGELOG.md
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+H1_PATTERN = re.compile(r"^# Changelog\s*$", re.MULTILINE)
+# Find the first '---\n' separator after the H1 heading
+SEPARATOR_AFTER_H1 = re.compile(r"^---\s*$", re.MULTILINE)
+
+
+def insert(target: Path, section_text: str) -> None:
+    text = target.read_text(encoding="utf-8")
+
+    h1_match = H1_PATTERN.search(text)
+    if not h1_match:
+        sys.stderr.write(
+            f"Target {target} does not contain '# Changelog' heading\n"
+        )
+        sys.exit(2)
+
+    # Find the first --- separator after the H1
+    sep_match = SEPARATOR_AFTER_H1.search(text, pos=h1_match.end())
+    if sep_match:
+        # Insert directly after the separator, with one blank line before the new section
+        insert_at = sep_match.end()
+        before = text[:insert_at]
+        after = text[insert_at:]
+        if not after.startswith("\n\n"):
+            # Normalise so we always have exactly one blank line separator
+            sep_break = "\n\n"
+            after = after.lstrip("\n")
+            after = sep_break + after
+        new_text = before + "\n\n" + section_text.rstrip() + "\n" + after
+    else:
+        # No separator after H1 — insert directly after the H1 line
+        insert_at = h1_match.end()
+        before = text[:insert_at]
+        after = text[insert_at:]
+        new_text = before + "\n\n" + section_text.rstrip() + "\n" + after
+
+    target.write_text(new_text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--section", required=True, type=Path)
+    parser.add_argument("--target", required=True, type=Path)
+    args = parser.parse_args()
+
+    section_text = args.section.read_text(encoding="utf-8")
+    insert(args.target, section_text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/scripts/test_insert_changelog_section.py -v`
+Expected: PASS — all three tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/insert_changelog_section.py tests/scripts/test_insert_changelog_section.py
+git commit -m "feat(scripts): add insert_changelog_section.py"
+```
+
+---
+
+### Task 4: Add `is_prerelease` field to `VersionInfo` schema
+
+**Files:**
+- Modify: `backend/app/schemas/update.py`
+
+**Context:** Pydantic schema field. Defaults to `False` so existing producers don't break before backends are updated.
+
+- [ ] **Step 1: Find the existing `VersionInfo` definition**
+
+Run: `python -c "from app.schemas.update import VersionInfo; import json; print(json.dumps(VersionInfo.model_json_schema(), indent=2))"` from `backend/`.
+
+Expected: Schema includes `version`, `commit`, `commit_short`, `tag`, `date`, `is_dev_build`. No `is_prerelease` yet.
+
+- [ ] **Step 2: Add the field**
+
+In `backend/app/schemas/update.py`, locate the `VersionInfo` class (search for `class VersionInfo`). Add `is_prerelease: bool = False` directly after the existing `is_dev_build` field. Keep ordering consistent so schema export stays stable.
+
+Final structure should look like:
+
+```python
+class VersionInfo(BaseModel):
+    version: str
+    commit: str
+    commit_short: str
+    tag: Optional[str] = None
+    date: Optional[datetime] = None
+    is_dev_build: bool = False
+    is_prerelease: bool = False
+```
+
+(Existing fields may differ slightly — preserve them; only add `is_prerelease`.)
+
+- [ ] **Step 3: Verify schema export**
+
+Run from `backend/`:
+```bash
+python -c "from app.schemas.update import VersionInfo; v = VersionInfo(version='1.0.0', commit='abc', commit_short='abc', is_dev_build=False); print(v.is_prerelease)"
+```
+Expected: `False`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/schemas/update.py
+git commit -m "feat(schemas): add is_prerelease to VersionInfo"
+```
+
+---
+
+### Task 5: Update `ProdUpdateBackend.get_current_version()` for tag-based detection
+
+**Files:**
+- Modify: `backend/app/services/update/prod_backend.py`
+- Modify: `backend/tests/services/test_update_service.py`
+
+**Context:** The current implementation reads version from `pyproject.toml` and only detects "exact tag" as a boolean (`is_dev_build`). With pre-release tags pushed on every merge, HEAD will normally be exactly on a tag — we want the displayed `version` and `tag` to reflect the actual tag (including the `-pre.N` suffix), and a new `is_prerelease` flag to be derived from the tag name.
+
+- [ ] **Step 1: Write failing tests**
+
+In `backend/tests/services/test_update_service.py`, add a new test class. Find a good insertion point near the existing version-related tests (search for `class TestVersionParsing` or similar). If unsure, append at the end of the file.
+
+```python
+class TestProdBackendGetCurrentVersion:
+    """Tests for tag-based version detection in ProdUpdateBackend.get_current_version."""
+
+    @pytest.fixture
+    def backend(self):
+        from app.services.update.prod_backend import ProdUpdateBackend
+        return ProdUpdateBackend()
+
+    @pytest.mark.asyncio
+    async def test_head_on_prerelease_tag_uses_tag_as_version(self, backend):
+        """When HEAD is on a pre-release tag, version reflects the full tag name."""
+        def fake_run_git(*args):
+            cmd = args
+            if cmd[:3] == ("describe", "--tags", "--exact-match"):
+                return True, "v1.31.7-pre.42", ""
+            if cmd[:2] == ("rev-parse", "HEAD"):
+                return True, "abc1234567890abcdef1234567890abcdef12345678", ""
+            if cmd[:3] == ("log", "-1", "--format=%cI"):
+                return True, "2026-05-06T10:00:00+00:00", ""
+            return False, "", "unexpected"
+
+        backend._run_git = fake_run_git
+        info = await backend.get_current_version()
+        assert info.version == "1.31.7-pre.42"
+        assert info.tag == "v1.31.7-pre.42"
+        assert info.is_prerelease is True
+        assert info.is_dev_build is False
+        assert info.commit_short == "abc1234"
+
+    @pytest.mark.asyncio
+    async def test_head_on_stable_tag_marks_not_prerelease(self, backend):
+        """Stable tags have no -pre/-rc suffix and is_prerelease must be False."""
+        def fake_run_git(*args):
+            cmd = args
+            if cmd[:3] == ("describe", "--tags", "--exact-match"):
+                return True, "v1.32.0", ""
+            if cmd[:2] == ("rev-parse", "HEAD"):
+                return True, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", ""
+            if cmd[:3] == ("log", "-1", "--format=%cI"):
+                return True, "2026-05-06T10:00:00+00:00", ""
+            return False, "", "unexpected"
+
+        backend._run_git = fake_run_git
+        info = await backend.get_current_version()
+        assert info.version == "1.32.0"
+        assert info.tag == "v1.32.0"
+        assert info.is_prerelease is False
+        assert info.is_dev_build is False
+
+    @pytest.mark.asyncio
+    async def test_head_between_tags_falls_back_to_pyproject(self, backend):
+        """When HEAD is not on a tag (local dev), falls back to pyproject + is_dev_build=True."""
+        def fake_run_git(*args):
+            cmd = args
+            if cmd[:3] == ("describe", "--tags", "--exact-match"):
+                return False, "", "fatal: no exact match"
+            if cmd[:2] == ("rev-parse", "HEAD"):
+                return True, "feedfacefeedfacefeedfacefeedfacefeedface", ""
+            if cmd[:3] == ("log", "-1", "--format=%cI"):
+                return True, "2026-05-06T10:00:00+00:00", ""
+            return False, "", "unexpected"
+
+        backend._run_git = fake_run_git
+        info = await backend.get_current_version()
+        # version comes from pyproject.toml (whatever the test repo has)
+        assert info.is_prerelease is False
+        assert info.is_dev_build is True
+        assert info.tag is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tag,expected", [
+        ("v1.0.0-pre.1", True),
+        ("v1.0.0-rc.1", True),
+        ("v1.0.0-alpha", True),
+        ("v1.0.0-beta", True),
+        ("v1.0.0-unstable", True),
+        ("v1.0.0", False),
+        ("v2.5.10", False),
+    ])
+    async def test_prerelease_detection_by_tag_suffix(self, backend, tag, expected):
+        def fake_run_git(*args):
+            cmd = args
+            if cmd[:3] == ("describe", "--tags", "--exact-match"):
+                return True, tag, ""
+            if cmd[:2] == ("rev-parse", "HEAD"):
+                return True, "0" * 40, ""
+            if cmd[:3] == ("log", "-1", "--format=%cI"):
+                return True, "2026-05-06T10:00:00+00:00", ""
+            return False, "", ""
+        backend._run_git = fake_run_git
+        info = await backend.get_current_version()
+        assert info.is_prerelease is expected
+```
+
+(If `pytest` and `pytest_asyncio` are not already imported at the top of the file, ensure they are — most test files in this repo already use `import pytest` and the `asyncio_mode = "auto"` from `pyproject.toml`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run from `backend/`:
+```bash
+python -m pytest tests/services/test_update_service.py::TestProdBackendGetCurrentVersion -v
+```
+Expected: FAIL — current implementation always reads from pyproject and never sets `is_prerelease`.
+
+- [ ] **Step 3: Update `ProdUpdateBackend.get_current_version()`**
+
+In `backend/app/services/update/prod_backend.py`, replace the body of `get_current_version` with:
+
+```python
+    async def get_current_version(self) -> VersionInfo:
+        """Get current version from git tag (preferred) or pyproject.toml (fallback)."""
+        # Try exact tag match first — succeeds for pre-release and stable tags
+        exact_ok, exact_tag, _ = self._run_git("describe", "--tags", "--exact-match")
+        if exact_ok and exact_tag.strip():
+            tag_name = exact_tag.strip()
+            version = tag_name.lstrip("v")
+            is_prerelease = any(
+                marker in tag_name for marker in ("-pre.", "-rc.", "-alpha", "-beta", "-unstable")
+            )
+            is_dev_build = False
+            tag = tag_name
+        else:
+            # Local build between tags — fall back to pyproject.toml
+            version = version_to_string(get_installed_version())
+            tag = None
+            is_prerelease = False
+            is_dev_build = True
+
+        # Commit metadata
+        success, commit, _ = self._run_git("rev-parse", "HEAD")
+        if not success:
+            commit = "unknown"
+
+        success, date_str, _ = self._run_git("log", "-1", "--format=%cI")
+        date = datetime.fromisoformat(date_str) if success and date_str else None
+
+        return VersionInfo(
+            version=version,
+            commit=commit,
+            commit_short=commit[:7] if commit != "unknown" else "unknown",
+            tag=tag,
+            date=date,
+            is_dev_build=is_dev_build,
+            is_prerelease=is_prerelease,
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/services/test_update_service.py::TestProdBackendGetCurrentVersion -v`
+Expected: PASS — all parameterised cases green.
+
+- [ ] **Step 5: Run the full update-service test class to catch regressions**
+
+Run: `python -m pytest tests/services/test_update_service.py -v`
+Expected: PASS — no existing tests broken.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/update/prod_backend.py backend/tests/services/test_update_service.py
+git commit -m "feat(updates): tag-based version detection with is_prerelease"
+```
+
+---
+
+### Task 6: Update `DevUpdateBackend.get_current_version()`
+
+**Files:**
+- Modify: `backend/app/services/update/dev_backend.py`
+
+**Context:** Dev backend is purely simulated. Set `is_prerelease=False` for the mocked stable version so dev-mode UI behaves like production-stable.
+
+- [ ] **Step 1: Modify the dev backend**
+
+In `backend/app/services/update/dev_backend.py`, find `get_current_version()` (around line 46-54). Update the `VersionInfo` constructor call to include `is_prerelease=False`:
+
+```python
+    async def get_current_version(self) -> VersionInfo:
+        return VersionInfo(
+            version=version_to_string(self._simulated_version),
+            commit=self._current_commit,
+            commit_short=self._current_commit[:7],
+            tag=f"v{version_to_string(self._simulated_version)}",
+            date=datetime.now(timezone.utc),
+            is_dev_build=True,
+            is_prerelease=False,
+        )
+```
+
+- [ ] **Step 2: Smoke-test in dev mode**
+
+Run: `cd backend && NAS_MODE=dev python -c "import asyncio; from app.services.update.dev_backend import DevUpdateBackend; b = DevUpdateBackend(); v = asyncio.run(b.get_current_version()); print(v.version, v.is_prerelease)"`
+Expected: prints version like `1.0.0 False`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/services/update/dev_backend.py
+git commit -m "feat(updates): set is_prerelease=False on dev backend"
+```
+
+---
+
+### Task 7: Add `is_prerelease` to TypeScript `VersionInfo` interface
+
+**Files:**
+- Modify: `client/src/api/updates.ts`
+
+**Context:** Mirror the backend schema change.
+
+- [ ] **Step 1: Locate the interface**
+
+Open `client/src/api/updates.ts` and find `interface VersionInfo` (it lives near the top of the file alongside other API types).
+
+- [ ] **Step 2: Add the field**
+
+Add `is_prerelease: boolean;` after `is_dev_build`:
+
+```typescript
+export interface VersionInfo {
+  version: string;
+  commit: string;
+  commit_short: string;
+  tag: string | null;
+  date: string | null;
+  is_dev_build: boolean;
+  is_prerelease: boolean;
+}
+```
+
+(Preserve other existing fields exactly as they are.)
+
+- [ ] **Step 3: Type-check**
+
+Run from `client/`: `npx tsc --noEmit`
+Expected: PASS — no new type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/api/updates.ts
+git commit -m "feat(api): add is_prerelease to VersionInfo TS interface"
+```
+
+---
+
+### Task 8: Add `useVersionDisplay()` hook to `VersionContext`
+
+**Files:**
+- Modify: `client/src/contexts/VersionContext.tsx`
+
+**Context:** Existing `useFormattedVersion()` returns just a string. The new hook returns both the formatted string and `isPrerelease` so consumers can render an optional badge alongside the version text.
+
+- [ ] **Step 1: Add the new hook**
+
+In `client/src/contexts/VersionContext.tsx`, append after the existing `useFormattedVersion` definition:
+
+```typescript
+/**
+ * Hook to get formatted version string + is_prerelease flag for badge display.
+ * Returns "v..." while loading, "v?.?.?" on error.
+ */
+export function useVersionDisplay(prefix: string = 'BaluHost OS'): {
+  text: string;
+  isPrerelease: boolean;
+} {
+  const { fullVersion, loading, error } = useVersion();
+
+  if (loading) {
+    return { text: `${prefix} v...`, isPrerelease: false };
+  }
+
+  if (error || !fullVersion) {
+    return { text: `${prefix} v?.?.?`, isPrerelease: false };
+  }
+
+  return {
+    text: `${prefix} v${fullVersion.version}`,
+    isPrerelease: fullVersion.is_prerelease,
+  };
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run from `client/`: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/contexts/VersionContext.tsx
+git commit -m "feat(version): add useVersionDisplay hook with isPrerelease"
+```
+
+---
+
+### Task 9: Add `preRelease.badge` i18n keys
+
+**Files:**
+- Modify: `client/src/i18n/locales/en/updates.json`
+- Modify: `client/src/i18n/locales/de/updates.json`
+
+**Context:** Existing `updates` namespace has a top-level structure with sub-objects. Add a new top-level key `preRelease`.
+
+- [ ] **Step 1: Update English translations**
+
+In `client/src/i18n/locales/en/updates.json`, add the following at the same level as existing top-level keys (e.g., right before `"version": { ... }`):
+
+```json
+  "preRelease": {
+    "badge": "Pre-Release"
+  },
+```
+
+(Make sure to add the trailing comma if a sibling key follows; remove any trailing comma if it sits at the end of the object.)
+
+- [ ] **Step 2: Update German translations**
+
+In `client/src/i18n/locales/de/updates.json`, add:
+
+```json
+  "preRelease": {
+    "badge": "Pre-Release"
+  },
+```
+
+- [ ] **Step 3: Verify JSON validity**
+
+Run from `client/`:
+```bash
+node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/en/updates.json','utf8'))"
+node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/de/updates.json','utf8'))"
+```
+Expected: no output (= valid JSON).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/i18n/locales/en/updates.json client/src/i18n/locales/de/updates.json
+git commit -m "feat(i18n): add updates.preRelease.badge keys (en/de)"
+```
+
+---
+
+### Task 10: Render Pre-Release badge in `UpdateOverviewTab`
+
+**Files:**
+- Modify: `client/src/components/updates/UpdateOverviewTab.tsx`
+
+**Context:** This is the primary version-display surface (currently uses the `version.current` strings — see `client/src/i18n/locales/en/updates.json:23`). Identify the existing version render and add the badge next to it.
+
+- [ ] **Step 1: Open the file and locate the version rendering**
+
+Open `client/src/components/updates/UpdateOverviewTab.tsx` and find where the current version is shown. Search for either `useVersion` or `currentVersion` or `version.current` (i18n key reference). The component already consumes `VersionContext` — check whether it uses `useVersion()` or `useFormattedVersion()`.
+
+- [ ] **Step 2: Replace `useVersion()`/`useFormattedVersion()` with `useVersionDisplay()` if the version is rendered as plain text**
+
+Adjust the import:
+```typescript
+import { useVersionDisplay } from '../../contexts/VersionContext';
+```
+
+In the component body, replace existing version-text logic with:
+```typescript
+const { text: versionText, isPrerelease } = useVersionDisplay('BaluHost OS');
+```
+(Or use the prefix already in the i18n string — pass an empty prefix if the heading already says "Current Version".)
+
+If the component uses `fullVersion.version` directly (e.g., showing `1.31.7` without the "BaluHost OS v" prefix), keep that pattern but additionally read `fullVersion.is_prerelease`:
+```typescript
+const { fullVersion } = useVersion();
+const isPrerelease = fullVersion?.is_prerelease ?? false;
+```
+
+- [ ] **Step 3: Render the badge next to the version text**
+
+Add the badge JSX directly after the version text element. The exact wrapper depends on the existing layout (likely an inline-flex container). Pattern:
+
+```tsx
+<div className="flex items-center gap-2">
+  <span className="text-2xl font-semibold text-slate-100">{versionText}</span>
+  {isPrerelease && (
+    <span className="inline-flex items-center rounded-md bg-amber-500/20 px-2 py-0.5 text-xs font-medium text-amber-300">
+      {t('preRelease.badge')}
+    </span>
+  )}
+</div>
+```
+
+If the component already uses `useTranslation('updates')` the `t('preRelease.badge')` works directly. Otherwise, ensure the namespace is loaded — search for existing `useTranslation('updates')` usage in the same file and follow that pattern.
+
+- [ ] **Step 4: Verify in dev mode**
+
+Run: `python start_dev.py`
+- Open `http://localhost:5173/updates` (or wherever the Updates page is routed).
+- Expected: version is shown without a badge (dev mode sets `is_prerelease=false`).
+
+For a manual production-style verification: temporarily edit `dev_backend.py` to return `is_prerelease=True` and reload the page. Expected: amber "Pre-Release" badge appears next to the version. Revert the temporary edit before committing.
+
+- [ ] **Step 5: Type-check + build**
+
+Run from `client/`:
+```bash
+npx tsc --noEmit
+npm run build
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/components/updates/UpdateOverviewTab.tsx
+git commit -m "feat(updates): render Pre-Release badge in UpdateOverviewTab"
+```
+
+---
+
+### Task 11: Verify other version consumers don't need updates
+
+**Files:**
+- Read-only inspection of: `client/src/pages/Login.tsx`, `client/src/components/Layout.tsx` (if it shows version), and any sidebar/footer.
+
+**Context:** The badge only matters in places where users care about whether they're on a Pre-Release. Other places (Login footer, etc.) can keep showing just the version text. This task is to **decide intentionally**, not to add badges everywhere.
+
+- [ ] **Step 1: Find all consumers of version data**
+
+Run (from repo root): `python -c "import subprocess; subprocess.run(['git', 'grep', '-n', '-E', 'useFormattedVersion|useVersion\\(|useVersionDisplay|fullVersion|is_dev_build|is_prerelease', 'client/src'])"`
+
+Note each occurrence in a scratch file. Expected hits: `VersionContext.tsx` (definitions), `Login.tsx` (line 14), `UpdateOverviewTab.tsx` (just modified), possibly `Layout.tsx` or similar.
+
+- [ ] **Step 2: Decide per consumer**
+
+For each non-Updates consumer:
+- **Login.tsx**: Only shows version on the login page footer. Decision: do not add badge — login page doesn't need to advertise pre-release status. No changes needed.
+- **Layout.tsx / Footer / Sidebar (if present)**: If shows version, add the badge using `useVersionDisplay()` to be consistent with the Updates page.
+
+If no other prominent consumer requires the badge, this task is complete with no code changes.
+
+- [ ] **Step 3: Commit (only if changes were made)**
+
+If you modified additional files:
+```bash
+git add <files>
+git commit -m "feat(version): show Pre-Release badge in <component>"
+```
+Otherwise: no commit needed.
+
+---
+
+### Task 12: Phase 1 final verification
+
+**Files:** N/A (verification only)
+
+- [ ] **Step 1: Run all backend tests**
+
+Run from `backend/`: `python -m pytest -q`
+Expected: PASS — full suite green.
+
+- [ ] **Step 2: Run all frontend tests**
+
+Run from `client/`:
+```bash
+npx vitest run
+```
+Expected: PASS.
+
+- [ ] **Step 3: Run frontend build**
+
+Run from `client/`: `npm run build`
+Expected: PASS, `dist/` produced.
+
+- [ ] **Step 4: Smoke-test the full app in dev mode**
+
+Run: `python start_dev.py`
+- Login as admin/DevMode2024
+- Navigate to Updates page
+- Verify version is displayed (no badge in dev mode is correct)
+- Stop with Ctrl+C
+
+- [ ] **Step 5: No commit needed** — Phase 1 ends. The changes can be merged via the existing release flow as a `release:patch` or `release:minor` PR.
+
+---
+
+## Phase 2: Workflow Switch (Atomic)
+
+**IMPORTANT:** All tasks in Phase 2 must land in **one** PR. A partial state (e.g., new auto-merge.yml without updated skip-filter) would cause redundant deploys or broken tagging.
+
+### Task 13: Create `release-stable.yml` workflow
+
+**Files:**
+- Create: `.github/workflows/release-stable.yml`
+
+- [ ] **Step 1: Create the workflow file**
+
+```yaml
+name: Release Stable
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Semver bump for the new stable release"
+        type: choice
+        required: true
+        options: [patch, minor, major]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.DEPLOY_PAT }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute next version
+        id: version
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
+        run: |
+          CURRENT=$(grep -oP '^version\s*=\s*"\K[^"]+' backend/pyproject.toml)
+          NEW=$(python scripts/bump_version.py "$BUMP_TYPE" --dry-run | tail -1)
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+          echo "Bumping $CURRENT -> $NEW"
+
+      - name: Find last stable tag
+        id: last_stable
+        run: |
+          LAST=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -Ev -- '-(pre|rc|alpha|beta|unstable)' | sort -V | tail -1 || true)
+          if [ -z "$LAST" ]; then
+            echo "No previous stable tag found; using initial commit"
+            LAST=$(git rev-list --max-parents=0 HEAD)
+          fi
+          echo "ref=$LAST" >> "$GITHUB_OUTPUT"
+          echo "Last stable: $LAST"
+
+      - name: Generate CHANGELOG section
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+          LAST_REF: ${{ steps.last_stable.outputs.ref }}
+        run: |
+          python scripts/generate_changelog_section.py \
+            --version "$NEW_VERSION" \
+            --since "$LAST_REF" \
+            --output /tmp/changelog-section.md
+          echo "--- Generated section ---"
+          cat /tmp/changelog-section.md
+          echo "--- End ---"
+          if ! grep -q '^- ' /tmp/changelog-section.md; then
+            echo "::error::No conventional-commit changes since $LAST_REF -- refusing to create empty release"
+            exit 1
+          fi
+
+      - name: Insert CHANGELOG section
+        run: |
+          python scripts/insert_changelog_section.py \
+            --section /tmp/changelog-section.md \
+            --target CHANGELOG.md
+
+      - name: Bump version files
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
+        run: python scripts/bump_version.py "$BUMP_TYPE"
+
+      - name: Commit + push version bump
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+        run: |
+          git add backend/pyproject.toml client/package.json CLAUDE.md CHANGELOG.md
+          git commit -m "chore: release v${NEW_VERSION}"
+          git push origin main
+
+      - name: Tag + push
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+        run: |
+          TAG="v${NEW_VERSION}"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          echo "Stable release tag $TAG pushed -- create-release.yml will create the GitHub Release"
+```
+
+- [ ] **Step 2: YAML lint**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/release-stable.yml'))"`
+Expected: no output (valid YAML).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release-stable.yml
+git commit -m "feat(ci): add release-stable.yml for manual stable promotion"
+```
+
+---
+
+### Task 14: Modify `auto-merge.yml` to push pre-release tags
+
+**Files:**
+- Modify: `.github/workflows/auto-merge.yml`
+
+- [ ] **Step 1: Replace the bump + tag logic**
+
+Open `.github/workflows/auto-merge.yml`. The current jobs we change:
+
+**(a)** Remove the entire `Read release label before merging` block? — NO. The merge step itself stays. But the `RELEASE_LABEL` env propagation can be removed since we no longer use it. Specifically:
+
+In the `Find and merge PR` step, remove these three lines (currently around lines 36-38):
+```bash
+RELEASE_LABEL=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name | select(startswith("release:"))] | first // empty')
+echo "RELEASE_LABEL=$RELEASE_LABEL" >> "$GITHUB_ENV"
+echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
+```
+
+**(b)** Delete the entire `Bump version from release label` step (currently at lines 57-75 — the step with `if: env.RELEASE_LABEL != ''`).
+
+**(c)** Replace the `Auto-tag from pyproject.toml` step (currently at lines 77-91) with the new pre-release-tag logic:
+
+```yaml
+      - name: Auto-tag pre-release
+        working-directory: /tmp/repo
+        env:
+          RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+        run: |
+          VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' backend/pyproject.toml || true)
+          if [ -z "$VERSION" ]; then
+            echo "Could not read version from pyproject.toml -- skipping pre-release tag"
+            exit 0
+          fi
+          TAG="v${VERSION}-pre.${RUN_NUMBER}"
+          if git tag -l "$TAG" | grep -q .; then
+            echo "Tag $TAG already exists -- skipping"
+          else
+            echo "Creating pre-release tag $TAG"
+            git tag -a "$TAG" -m "Pre-release $TAG"
+            git push origin "$TAG"
+            echo "Tag $TAG pushed -- create-release.yml will create the GitHub pre-release"
+          fi
+```
+
+**(d)** Keep the final `Sync development with main` step exactly as it is.
+
+- [ ] **Step 2: YAML lint**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/auto-merge.yml'))"`
+Expected: valid YAML.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/auto-merge.yml
+git commit -m "feat(ci): switch auto-merge to pre-release tags"
+```
+
+---
+
+### Task 15: Extend skip filter in `deploy-production.yml`
+
+**Files:**
+- Modify: `.github/workflows/deploy-production.yml`
+
+- [ ] **Step 1: Update the skip condition**
+
+In `.github/workflows/deploy-production.yml`, locate the `deploy` job's `if:` condition. Currently:
+
+```yaml
+    if: "!startsWith(github.event.head_commit.message, 'chore: bump version')"
+```
+
+Replace with:
+
+```yaml
+    if: "!startsWith(github.event.head_commit.message, 'chore: bump version') && !startsWith(github.event.head_commit.message, 'chore: release v')"
+```
+
+- [ ] **Step 2: YAML lint**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-production.yml'))"`
+Expected: valid YAML.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/deploy-production.yml
+git commit -m "ci(deploy): skip redundant deploy on stable release commits"
+```
+
+---
+
+### Task 16: Recognize `-pre.` as prerelease in `create-release.yml`
+
+**Files:**
+- Modify: `.github/workflows/create-release.yml`
+
+- [ ] **Step 1: Update the prerelease detection**
+
+In `.github/workflows/create-release.yml`, find the `Determine pre-release` step (around lines 39-48). Replace its `run:` block with:
+
+```bash
+          if [[ "$TAG" == *-pre.* ]] || [[ "$TAG" == *-alpha* ]] || [[ "$TAG" == *-beta* ]] || [[ "$TAG" == *-unstable* ]] || [[ "$TAG" == *-rc* ]]; then
+            echo "flag=--prerelease" >> "$GITHUB_OUTPUT"
+          else
+            echo "flag=" >> "$GITHUB_OUTPUT"
+          fi
+```
+
+(The only addition is the first `[[ "$TAG" == *-pre.* ]]` clause.)
+
+- [ ] **Step 2: YAML lint**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/create-release.yml'))"`
+Expected: valid YAML.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/create-release.yml
+git commit -m "ci(release): recognize -pre. tag suffix as prerelease"
+```
+
+---
+
+### Task 17: Remove `changelog-guard` job from `ci-check.yml`
+
+**Files:**
+- Modify: `.github/workflows/ci-check.yml`
+
+- [ ] **Step 1: Delete the job**
+
+In `.github/workflows/ci-check.yml`, delete the entire `changelog-guard` job (lines 57-100 in the current version). The remaining jobs are `backend-tests` and `frontend-build`.
+
+After deletion, the file ends after the `frontend-build` job's last step.
+
+- [ ] **Step 2: YAML lint**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci-check.yml'))"`
+Expected: valid YAML.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci-check.yml
+git commit -m "ci(check): remove changelog-guard job (no longer needed)"
+```
+
+---
+
+### Task 18: Simplify `_release.md` slash command
+
+**Files:**
+- Modify: `.claude/commands/release/_release.md`
+
+- [ ] **Step 1: Replace the file contents**
+
+Path: `.claude/commands/release/_release.md`
+
+Replace the entire content with:
+
+```markdown
+# Release-PR: development → main
+
+Erstelle einen PR von `development` nach `main`. Jeder Merge erzeugt automatisch ein Pre-Release-Tag und deployt auf Production. Stable-Releases werden separat über `/release-stable` getriggert.
+
+## Workflow
+
+### 1. Branch-Check
+
+Verifiziere `development`-Branch:
+```bash
+git branch --show-current
+```
+Falls nicht `development`: abbrechen mit Hinweis.
+
+### 2. Commits seit letztem Stable anzeigen
+
+```bash
+LAST_STABLE=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -Ev -- '-(pre|rc|alpha|beta|unstable)' | sort -V | tail -1)
+echo "Last stable: $LAST_STABLE"
+git log "$LAST_STABLE"..HEAD --oneline
+```
+
+### 3. PR erstellen
+
+**FRAGE DEN BENUTZER:** PR jetzt erstellen?
+
+```bash
+gh pr create \
+  --base main \
+  --head development \
+  --title "<auto-generated from commit subjects>" \
+  --body "$(cat <<'EOF'
+## Changes
+
+<list of commit subjects>
+
+---
+This PR will trigger a Pre-Release tag (`v<current>-pre.<N>`) and a Production-Deploy after merge.
+For a Stable release, run `/release-stable` separately after the desired Pre-Release has run on production.
+EOF
+)"
+```
+
+**ZEIGE DEM BENUTZER** den PR-Link.
+
+> **Was nach Merge automatisch passiert:**
+> 1. CI Check läuft (Backend-Tests + Frontend-Build)
+> 2. Auto-Merge merged den PR
+> 3. Pre-Release-Tag `v<current>-pre.<run_number>` wird erstellt
+> 4. Push auf main triggert deploy-production.yml → NAS deployt
+> 5. Tag-Push triggert create-release.yml → GitHub Pre-Release
+> 6. Development wird mit main synchronisiert (FF only)
+
+## Regeln
+
+- **NIEMALS** lokal auf main mergen — immer über PR
+- **NIEMALS** lokal die Version bumpen — passiert nur beim Stable-Trigger
+- **NIEMALS** Tags manuell pushen
+- **NIEMALS** ohne Bestätigung des Benutzers committen oder pushen
+- Bei bereits existierendem PR: Benutzer informieren und fragen ob Update gewünscht
+- Commit-Message endet mit: `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/commands/release/_release.md
+git commit -m "docs(commands): simplify release PR slash command"
+```
+
+---
+
+### Task 19: Create `_release-stable.md` slash command
+
+**Files:**
+- Create: `.claude/commands/release/_release-stable.md`
+
+- [ ] **Step 1: Create the file**
+
+Path: `.claude/commands/release/_release-stable.md`
+
+```markdown
+# Release Stable
+
+Triggert den `release-stable.yml` Workflow auf GitHub. Promotet HEAD von `main` zu einem stabilen Release: Bump + CHANGELOG-Sektion + Stable-Tag + GitHub-Release als „Latest".
+
+## Voraussetzung
+
+- HEAD von `main` läuft auf der Production-NAS (Pre-Release wurde getestet)
+- `gh` CLI ist authentifiziert
+
+## Workflow
+
+### 1. Bump-Type vorschlagen
+
+Analysiere Commits seit letztem Stable-Tag:
+```bash
+LAST_STABLE=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -Ev -- '-(pre|rc|alpha|beta|unstable)' | sort -V | tail -1)
+git fetch origin main
+git log "$LAST_STABLE"..origin/main --pretty=format:'%s'
+```
+
+**Vorschlag basierend auf Commits:**
+- Mindestens ein `feat!:` oder `BREAKING CHANGE:` im Body → `major`
+- Mindestens ein `feat:` → `minor`
+- Sonst → `patch`
+
+**FRAGE DEN BENUTZER:** Welcher Bump-Type? (Vorschlag anzeigen)
+
+### 2. CHANGELOG-Vorschau lokal generieren
+
+```bash
+NEW_VERSION=$(python scripts/bump_version.py <bump_type> --dry-run | tail -1)
+python scripts/generate_changelog_section.py \
+  --version "$NEW_VERSION" \
+  --since "$LAST_STABLE" \
+  --output -
+```
+
+(Nur Vorschau — der echte CHANGELOG wird im Workflow geschrieben.)
+
+**FRAGE DEN BENUTZER:** Sieht die Sektion korrekt aus?
+
+### 3. Workflow triggern
+
+**FRAGE DEN BENUTZER:** Trigger ausführen?
+
+```bash
+gh workflow run release-stable.yml --ref main -f bump_type=<type>
+```
+
+### 4. Status-Link
+
+```bash
+sleep 3
+gh run list --workflow=release-stable.yml --limit 1
+```
+
+Zeige dem Benutzer Run-URL.
+
+## Regeln
+
+- Workflow läuft auf `main`, nicht `development`
+- NIEMALS lokal `pyproject.toml` / `package.json` / `CLAUDE.md` bumpen
+- NIEMALS lokal Stable-Tags erstellen oder pushen
+- NIEMALS in `CHANGELOG.md` lokal eine neue Sektion hinzufügen — der Workflow macht das
+- Bei Workflow-Fehler: Run-Logs anzeigen und Benutzer informieren
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/commands/release/_release-stable.md
+git commit -m "docs(commands): add release-stable slash command"
+```
+
+---
+
+## Phase 3: Cleanup
+
+### Task 20: Update memory entry for new release workflow
+
+**Files:**
+- Modify: `C:\Users\SvenB\.claude\projects\D--Programme--x86--Baluhost\memory\feedback_release_workflow.md`
+
+**Context:** The existing memory says "Tags are handled by the create-release workflow" — still true, but now the tag created on PR-merge is a Pre-Release tag, not a Stable tag. The memory should reflect the new two-step flow.
+
+- [ ] **Step 1: Replace the file contents**
+
+```markdown
+---
+name: release-workflow
+description: Release workflow - PR creates Pre-Release, manual workflow_dispatch creates Stable
+type: feedback
+---
+
+Don't merge development into main locally. PR development → main creates a **Pre-Release tag** (`v<current>-pre.<run_number>`) automatically and deploys to production. Stable releases are NEVER created by PR merges.
+
+To create a Stable release, run the `release-stable.yml` workflow manually (GH UI or `/release-stable`). It bumps `pyproject.toml` / `package.json` / `CLAUDE.md`, generates a CHANGELOG section from Conventional Commits, tags HEAD as `vX.Y.Z` (no suffix), and creates a GitHub Release marked as "Latest".
+
+**Why:** PR merges are not always stable enough to be the "Latest" version on the STABLE update channel. The two-step flow lets the production NAS run a Pre-Release first, then promote to Stable only when proven good.
+
+**How to apply:** During release work:
+- For a PR onto main: just push to development and `gh pr create --base main --head development` (no `release:*` label needed — those are obsolete).
+- To promote to Stable: run `gh workflow run release-stable.yml --ref main -f bump_type=patch|minor|major` or use `/release-stable`.
+- Do not `git checkout main && git merge`. Do not `git tag` or bump versions locally.
+```
+
+- [ ] **Step 2: No commit needed** — memory files are local to your machine and not in the repo.
+
+---
+
+### Task 21: Final E2E verification on next release cycle
+
+**Files:** N/A (verification only — to be run after Phase 2 PR is merged into main)
+
+**Context:** The first PR-merge after Phase 2 lands proves the new flow works. This task documents the verification checklist; do NOT execute as part of the implementation PR — execute it after the PR is merged.
+
+- [ ] **Step 1: After Phase 2 merge — verify Pre-Release flow**
+
+After the Phase 2 PR is merged to main:
+- Verify a new tag `v<current>-pre.<run_number>` was pushed: `git fetch --tags && git tag -l | tail`
+- Verify a GitHub Release marked as "Pre-Release" exists for that tag (in the GitHub UI)
+- Verify Production-Deploy ran (`sudo journalctl -u baluhost-backend -n 100`)
+- Verify `pyproject.toml`/`package.json`/`CLAUDE.md` are unchanged (`git diff <previous_main>..main -- backend/pyproject.toml client/package.json CLAUDE.md` should show only the changes from the Phase 2 PR itself, no version bumps)
+- Verify BaluHost UI shows the pre-release version + Pre-Release badge
+
+- [ ] **Step 2: Verify Stable flow (when ready)**
+
+When the next Stable release is desired:
+- Run `gh workflow run release-stable.yml --ref main -f bump_type=patch` (or appropriate type)
+- Watch the run: `gh run watch`
+- Verify a new commit `chore: release vX.Y.Z` exists on main
+- Verify Production-Deploy was **skipped** (skip filter caught the commit) — check Actions UI
+- Verify a new tag `vX.Y.Z` (no suffix) exists
+- Verify a GitHub Release marked as "Latest" exists for that tag
+- Verify CHANGELOG.md has a new section at the top
+- Verify BaluHost UI shows the new stable version, no badge
+
+- [ ] **Step 3: Verify edge case — empty stable trigger**
+
+Immediately after creating a stable release, run the workflow again with the same `bump_type`:
+- Expected: workflow fails with `::error::No conventional-commit changes since v<previous_stable>`
+
+- [ ] **Step 4: Document any issues for follow-up**
+
+If any verification step fails, capture logs in a new GitHub issue tagged `release-workflow`.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:** All sections of the spec are implemented:
+- Pre-release tagging in auto-merge.yml — Task 14
+- Skip-filter — Task 15
+- create-release.yml suffix detection — Task 16
+- ci-check.yml changelog-guard removal — Task 17
+- Backend version endpoint — Tasks 4, 5, 6
+- Frontend pre-release badge — Tasks 7, 8, 9, 10, 11
+- Slash commands — Tasks 18, 19
+- bump_version.py --dry-run — Task 1
+- generate_changelog_section.py — Task 2
+- insert_changelog_section.py — Task 3
+- release-stable.yml — Task 13
+- Memory + final verification — Tasks 20, 21
+
+**Type consistency check:** The `is_prerelease` boolean is consistent across:
+- `VersionInfo` Pydantic schema (Task 4)
+- `ProdUpdateBackend.get_current_version()` return value (Task 5)
+- `DevUpdateBackend.get_current_version()` return value (Task 6)
+- TypeScript `VersionInfo` interface (Task 7)
+- `useVersionDisplay()` hook return type (Task 8)
+- Component consumption (Task 10)
+
+The pre-release marker list is consistent across:
+- Backend detection: `("-pre.", "-rc.", "-alpha", "-beta", "-unstable")` (Task 5)
+- Frontend: derived from backend response — no duplicate logic
+- create-release.yml regex: `*-pre.*`, `*-alpha*`, `*-beta*`, `*-unstable*`, `*-rc*` (Task 16)
+- release-stable.yml exclusion regex when finding last stable: `-(pre|rc|alpha|beta|unstable)` (Task 13)
+
+The skip-filter prefixes in deploy-production.yml are consistent with:
+- The version-bump commit emitted by release-stable.yml: `chore: release v${NEW_VERSION}` (Task 13)
+- The legacy bump prefix `chore: bump version` (kept for backward compatibility with old commits, no harm if obsolete)

--- a/docs/superpowers/specs/2026-05-06-release-flow-prerelease-default-design.md
+++ b/docs/superpowers/specs/2026-05-06-release-flow-prerelease-default-design.md
@@ -1,0 +1,662 @@
+# Release Flow: Pre-Release als Default, manueller Stable-Trigger
+
+**Date:** 2026-05-06
+**Status:** Approved (brainstorming complete, ready for plan)
+**Branch:** `feature/release-flow-prerelease-default` (to be created from `development`)
+
+## Problem
+
+Heute wird bei jedem PR `development → main` mit `release:patch|minor|major` Label automatisch ein Stable-Release erzeugt: Version-Bump in `pyproject.toml` / `package.json` / `CLAUDE.md`, Tag `vX.Y.Z`, GitHub-Release als „Latest", Production-Deploy.
+
+Das passt nicht zur Realität: Features brauchen Zeit auf der echten NAS, bis klar ist, dass sie stabil laufen. Ein PR-Merge ist häufig nicht der Moment für einen offiziellen Stable-Release. Aktuell sind dadurch potenziell instabile Versionen als „Latest" markiert (relevant für den `STABLE`-Update-Channel und das `BaluHost-Plugin-Market`-Repo, das `min_baluhost_version` referenziert).
+
+## Solution (1-Satz)
+
+PR-Merges auf `main` erzeugen **Pre-Release-Tags** statt Stable-Releases (Production-Deploy bleibt unverändert); ein neuer manueller `workflow_dispatch`-Workflow `release-stable.yml` promotet HEAD bei Bedarf zu einem Stable-Release mit Bump + Auto-CHANGELOG.
+
+## Goals
+
+- Jeder PR-Merge auf `main` → Production-Deploy + Pre-Release-Tag `v<last_stable>-pre.<run_number>`
+- `pyproject.toml` / `package.json` / `CLAUDE.md` werden bei Pre-Releases **nicht** verändert
+- Manueller Stable-Trigger (GH UI oder Slash-Command) → Bump + CHANGELOG-Sektion + Stable-Tag + GitHub-Release als „Latest"
+- BaluHost-UI zeigt Pre-Release-Version + Badge an
+- CHANGELOG-Sektionen werden beim Stable-Trigger automatisch aus Conventional Commits generiert (kein manuelles Pflegen mehr)
+
+## Non-Goals
+
+- Keine Änderung am Production-Deploy-Skript (`/opt/baluhost/deploy/scripts/ci-deploy.sh`)
+- Keine zweite Maschine / kein Staging-Setup
+- Keine Änderung am Pi-Frontend-Deploy (`deploy-pi.yml`) — bleibt path-gefiltert wie heute
+- Keine Änderung am Update-Service-Channel-Modell (`STABLE` / `UNSTABLE` / `DEVELOPMENT`) — der bestehende `is_prerelease`-Flag in `ReleaseInfo` wird vom neuen Tag-Schema bereits korrekt gefüllt
+- Keine Anpassung der bestehenden Branch-Protection-Regeln (falls welche existieren — wird im Plan separat geprüft)
+
+## Architecture
+
+```
+Feature-Arbeit                                Manueller Stable-Release
+───────────────                                ────────────────────────
+
+   development                                GitHub UI / gh CLI
+       │  (PR development → main)             "Run workflow"
+       ▼                                        bump_type: patch|minor|major
+   ci-check.yml ──────────────► PASSES              │
+       │                                            ▼
+       ▼                                       release-stable.yml (NEW)
+   auto-merge.yml (modified)                       │
+       │                                           ├─ Read CURRENT_VERSION
+       ├─ Mergt PR                                 │  from pyproject.toml
+       ├─ KEINE Versions-Bumps                     ├─ Compute NEW_VERSION
+       ├─ KEIN release:* Label nötig               ├─ Generate CHANGELOG section
+       ├─ Tag: v${CURRENT}-pre.${RUN}              │  from conventional commits
+       ├─ Push tag                                 ├─ python scripts/bump_version.py
+       │                                           ├─ commit "chore: release v${NEW}"
+       ▼                                           ├─ push origin main
+   Push to main                                    ├─ tag vNEW (no -pre suffix)
+       │                                           └─ push tag
+       ├─► deploy-production.yml ──► NAS deployt
+       │  (skip filter blocks "chore: release v" too)
+       │
+       ├─► deploy-pi.yml (only if client/** changed)
+       │
+       └─► create-release.yml triggert auf Tag-Push
+           - "-pre.*" → marked als "Pre-Release"
+           - sonst → marked als "Latest"
+```
+
+**Key invariants:**
+1. `pyproject.toml` ist single source of truth für **Stable**-Version. Pre-Releases verändern keine Versions-Dateien.
+2. Pre-Release-Tag-Schema: `v<pyproject_version>-pre.<github_run_number>`. Run number ist monoton steigend pro Repo, garantiert eindeutig.
+3. Stable-Trigger schreibt **einen** Commit auf main (`chore: release vX.Y.Z`) + **einen** Tag (`vX.Y.Z`). Beide werden vom Skip-Filter im Production-Deploy gefangen, weil der Code identisch zum letzten Pre-Release ist.
+4. GitHub-Release-Klassifizierung erfolgt automatisch in `create-release.yml` über Tag-Suffix-Pattern.
+
+## Components
+
+### 1. Pre-Release-Tagging in `auto-merge.yml`
+
+**Datei:** `.github/workflows/auto-merge.yml`
+
+**Entfernt:**
+- Job-Step „Bump version from release label" (Zeile ~57-75)
+- Lesen des `release:*` Labels und Berechnen von `BUMP_TYPE`/`NEW_VERSION`
+- `python3 scripts/bump_version.py "$BUMP_TYPE"`
+- Commit `chore: bump version to v${NEW_VERSION}` und Push
+
+**Geändert:**
+- Job-Step „Auto-tag from pyproject.toml" wird umbenannt zu „Auto-tag pre-release" und nutzt:
+  ```yaml
+  - name: Auto-tag pre-release
+    working-directory: /tmp/repo
+    env:
+      RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+    run: |
+      VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' backend/pyproject.toml)
+      TAG="v${VERSION}-pre.${RUN_NUMBER}"
+      if git tag -l "$TAG" | grep -q .; then
+        echo "Tag $TAG already exists — skipping"
+      else
+        echo "Creating pre-release tag $TAG"
+        git tag -a "$TAG" -m "Pre-release $TAG"
+        git push origin "$TAG"
+      fi
+  ```
+- `RUN_NUMBER` kommt aus dem auslösenden CI-Check-Workflow-Run, damit pro PR-Merge eindeutig
+
+**Unverändert:**
+- Job-Step „Find and merge PR" — mergt PR, löscht Branch (außer `development`)
+- Job-Step „Sync development with main" — bleibt wichtig damit `development` Stable-Bumps + CHANGELOG übernimmt
+
+### 2. Neuer Workflow `release-stable.yml`
+
+**Datei:** `.github/workflows/release-stable.yml` (CREATE)
+
+**Trigger:** `workflow_dispatch` mit Input `bump_type` (Choice: `patch` / `minor` / `major`)
+
+**Permissions:** `contents: write`
+
+**Steps:**
+
+```yaml
+name: Release Stable
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Semver bump for the new stable release"
+        type: choice
+        required: true
+        options: [patch, minor, major]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # need full history for git log
+          token: ${{ secrets.DEPLOY_PAT }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute next version
+        id: version
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
+        run: |
+          CURRENT=$(grep -oP '^version\s*=\s*"\K[^"]+' backend/pyproject.toml)
+          NEW=$(python scripts/bump_version.py "$BUMP_TYPE" --dry-run | tail -1)
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+          echo "Bumping $CURRENT → $NEW"
+
+      - name: Find last stable tag
+        id: last_stable
+        run: |
+          # Stable tags match v*.*.* but NOT *-pre.* / *-rc.* / *-alpha* / *-beta*
+          LAST=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -Ev -- '-(pre|rc|alpha|beta|unstable)' | sort -V | tail -1)
+          if [ -z "$LAST" ]; then
+            echo "No previous stable tag found; using initial commit"
+            LAST=$(git rev-list --max-parents=0 HEAD)
+          fi
+          echo "ref=$LAST" >> "$GITHUB_OUTPUT"
+          echo "Last stable: $LAST"
+
+      - name: Generate CHANGELOG section
+        id: changelog
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+          LAST_REF: ${{ steps.last_stable.outputs.ref }}
+        run: |
+          python scripts/generate_changelog_section.py \
+            --version "$NEW_VERSION" \
+            --since "$LAST_REF" \
+            --output /tmp/changelog-section.md
+          # Fail if section is empty (no commits since last stable)
+          if ! grep -q '^- ' /tmp/changelog-section.md; then
+            echo "::error::No conventional-commit changes since $LAST_REF — refusing to create empty release"
+            exit 1
+          fi
+
+      - name: Insert CHANGELOG section
+        run: |
+          # Prepend the new section directly after the file header (line 1: "# Changelog")
+          python scripts/insert_changelog_section.py \
+            --section /tmp/changelog-section.md \
+            --target CHANGELOG.md
+
+      - name: Bump version files
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
+        run: python scripts/bump_version.py "$BUMP_TYPE"
+
+      - name: Commit + push
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+        run: |
+          git add backend/pyproject.toml client/package.json CLAUDE.md CHANGELOG.md
+          git commit -m "chore: release v${NEW_VERSION}"
+          git push origin main
+
+      - name: Tag + push
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+        run: |
+          TAG="v${NEW_VERSION}"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          echo "Stable release tag $TAG pushed — create-release.yml will create the GitHub Release"
+```
+
+**Edge-Cases:**
+- Kein Commit seit letztem Stable → `generate_changelog_section.py` produziert leere Sektion → Workflow bricht ab
+- `--dry-run` Flag in `bump_version.py` muss ergänzt werden (siehe Section 5)
+
+### 3. Skip-Filter erweitern in `deploy-production.yml`
+
+**Datei:** `.github/workflows/deploy-production.yml`
+
+**Geändert:**
+```yaml
+# vorher:
+if: "!startsWith(github.event.head_commit.message, 'chore: bump version')"
+
+# nachher:
+if: "!startsWith(github.event.head_commit.message, 'chore: bump version') && !startsWith(github.event.head_commit.message, 'chore: release v')"
+```
+
+Der Stable-Trigger pusht einen `chore: release vX.Y.Z`-Commit auf main. Production läuft schon auf demselben Code (vom letzten Pre-Release-Deploy), daher überspringt der Filter den redundanten Deploy.
+
+### 4. Pre-Release-Erkennung in `create-release.yml`
+
+**Datei:** `.github/workflows/create-release.yml`
+
+**Geändert:** Step „Determine pre-release" erweitern um `*-pre.*` Pattern:
+
+```bash
+if [[ "$TAG" == *-pre.* ]] || [[ "$TAG" == *-alpha* ]] || [[ "$TAG" == *-beta* ]] || [[ "$TAG" == *-unstable* ]] || [[ "$TAG" == *-rc* ]]; then
+  echo "flag=--prerelease" >> "$GITHUB_OUTPUT"
+else
+  echo "flag=" >> "$GITHUB_OUTPUT"
+fi
+```
+
+**Unverändert:** Auto-Notes aus CHANGELOG (für Stable) bzw. Fallback auf `gh api .../releases/generate-notes` (für Pre-Releases — CHANGELOG enthält keine Pre-Release-Sektionen).
+
+### 5. CHANGELOG-Guard entfernen + Helper-Skripte
+
+**Datei:** `.github/workflows/ci-check.yml`
+
+**Entfernt:** Job `changelog-guard` (Zeilen 57-100). Es gibt keine `release:*` Labels mehr.
+
+**Datei:** `scripts/bump_version.py`
+
+**Geändert:** `--dry-run` Flag hinzufügen, das die berechnete neue Version auf stdout ausgibt ohne Dateien zu verändern. Wird vom `release-stable.yml`-Workflow genutzt.
+
+```python
+# Pseudocode-Erweiterung am Ende von main():
+if "--dry-run" in sys.argv:
+    print(new_version)
+    return
+# (existing) update_pyproject(...) etc.
+```
+
+**Datei:** `scripts/generate_changelog_section.py` (CREATE)
+
+Liest Conventional-Commits-Subjects aus `git log $SINCE..HEAD --pretty=format:'%s|%H'`, gruppiert nach Typ:
+
+| Conventional-Commits-Typ | CHANGELOG-Sektion |
+|--------------------------|-------------------|
+| `feat:` (auch mit Scope) | `### Added` |
+| `fix:` | `### Fixed` |
+| `refactor:`, `perf:`     | `### Changed` |
+| `docs:` | `### Documentation` |
+| `feat!:`, `BREAKING CHANGE:` im Body | `### ⚠ BREAKING CHANGES` (zuoberst) |
+| `chore:`, `ci:`, `test:`, `style:`, `build:` | **ignoriert** |
+| Subjects ohne Conventional-Commits-Präfix | **ignoriert** (sauberer CHANGELOG) |
+
+Format-Beispiel:
+```markdown
+## [1.32.0] - 2026-05-06
+
+### Added
+
+- **(sleep)** detect Suspend + WoL capabilities via sudo (#70)
+- new dashboard widget for power profiles (#73)
+
+### Fixed
+
+- prevent empty release notes — generate-notes fallback + label guard (#68)
+```
+
+Zusatz-Logik:
+- Scope (z.B. `feat(sleep):`) wird als `**(sleep)**` rendered
+- PR-Nummer aus Merge-Commit-Subject extrahieren (`Merge pull request #X` Pattern oder ` (#X)` am Ende des Subjects)
+- BREAKING-Changes im Commit-Body (mehrzeilige `git log --pretty=format:'%s%n%n%b'`) werden gesondert geparst und in eigene Sektion gepackt
+
+**Datei:** `scripts/insert_changelog_section.py` (CREATE)
+
+Klein, ~30 Zeilen: liest `--section` und `--target`, fügt die neue Sektion direkt nach der ersten H1-Zeile (`# Changelog`) ein, mit `---`-Separator dazwischen passend zum bestehenden Stil.
+
+### 6. Backend Version-Endpoint anpassen
+
+**Dateien:**
+- `backend/app/services/update/prod_backend.py:60-91` (`get_current_version`)
+- `backend/app/services/update/dev_backend.py:46-54` (`get_current_version`)
+- `backend/app/schemas/update.py` (`VersionInfo`)
+
+**Schema-Erweiterung in `VersionInfo`:**
+```python
+class VersionInfo(BaseModel):
+    version: str           # "1.31.7-pre.42" oder "1.32.0"
+    commit: str
+    commit_short: str
+    tag: Optional[str]     # "v1.31.7-pre.42" oder "v1.32.0" oder None
+    date: Optional[datetime]
+    is_dev_build: bool     # True nur bei lokalem Build ohne exakten Tag
+    is_prerelease: bool    # NEW — True wenn Tag ein Pre-Release-Suffix hat
+```
+
+**Neue Logik in `ProdUpdateBackend.get_current_version()`:**
+```python
+async def get_current_version(self) -> VersionInfo:
+    # Try exact tag match (will succeed for pre-release and stable tags pushed by CI)
+    exact_ok, exact_tag, _ = self._run_git("describe", "--tags", "--exact-match")
+    if exact_ok and exact_tag.strip():
+        tag = exact_tag.strip()
+        version = tag.lstrip("v")
+        is_prerelease = any(
+            marker in tag for marker in ("-pre.", "-rc.", "-alpha", "-beta", "-unstable")
+        )
+        is_dev_build = False
+    else:
+        # Local build between tags — fall back to pyproject.toml
+        version = version_to_string(get_installed_version())
+        tag = None
+        is_prerelease = False
+        is_dev_build = True
+
+    success, commit, _ = self._run_git("rev-parse", "HEAD")
+    if not success:
+        commit = "unknown"
+
+    success, date_str, _ = self._run_git("log", "-1", "--format=%cI")
+    date = datetime.fromisoformat(date_str) if success and date_str else None
+
+    return VersionInfo(
+        version=version,
+        commit=commit,
+        commit_short=commit[:7] if commit != "unknown" else "unknown",
+        tag=tag,
+        date=date,
+        is_dev_build=is_dev_build,
+        is_prerelease=is_prerelease,
+    )
+```
+
+**`DevUpdateBackend.get_current_version()`:** Setzt `is_prerelease=False`, `is_dev_build=True` (unverändert), liefert simulierte Stable-Version.
+
+**Endpoint:** `GET /api/updates/version` (public, no auth, in `backend/app/api/routes/updates.py:38-49`) bleibt strukturell unverändert — Response-Shape erweitert sich automatisch.
+
+### 7. Frontend — Pre-Release-Anzeige
+
+**Datei:** `client/src/api/updates.ts`
+
+**Geändert:** Interface `VersionInfo` um `is_prerelease: boolean` erweitern.
+
+**Datei:** `client/src/contexts/VersionContext.tsx`
+
+`VersionProvider` lädt `getPublicVersion()` einmal beim Mount und stellt `fullVersion: VersionInfo | null` über `useVersion()` zur Verfügung. Provider-Logik bleibt unverändert — der zusätzliche Boolean steht automatisch in `fullVersion.is_prerelease`.
+
+**Geändert:** Helper `useFormattedVersion()`. Aktuell:
+```typescript
+return `${prefix} v${version}`;
+```
+
+Neu (zusätzliche Hook-Variante für Anzeigen, die auch das Pre-Release-Badge brauchen):
+```typescript
+export function useVersionDisplay(prefix: string = 'BaluHost OS'): {
+  text: string;
+  isPrerelease: boolean;
+} {
+  const { fullVersion, loading, error } = useVersion();
+  if (loading) return { text: `${prefix} v...`, isPrerelease: false };
+  if (error || !fullVersion) return { text: `${prefix} v?.?.?`, isPrerelease: false };
+  return {
+    text: `${prefix} v${fullVersion.version}`,
+    isPrerelease: fullVersion.is_prerelease,
+  };
+}
+```
+
+`useFormattedVersion()` bleibt für Rückwärts-Kompatibilität (rein String-basiert) — Stellen die das Badge brauchen wechseln auf `useVersionDisplay()`.
+
+**Konsumenten** (im Plan zu identifizieren — minimum):
+- `client/src/pages/UpdatePage.tsx` und/oder Tab-Components in `client/src/components/updates/` — primärer Anzeigeort
+- Layout/Footer falls Version dort gerendert wird (`useFormattedVersion()` Aufrufer suchen)
+
+**Pre-Release-Badge:** kleines Tailwind-Span neben dem Versions-Text:
+```tsx
+{isPrerelease && (
+  <span className="ml-2 inline-flex items-center rounded-md bg-amber-500/20 px-2 py-0.5 text-xs font-medium text-amber-300">
+    {t('updates.preRelease.badge')}
+  </span>
+)}
+```
+
+**i18n-Keys:**
+
+`client/src/i18n/locales/en/updates.json`:
+```json
+"preRelease": {
+  "badge": "Pre-Release"
+}
+```
+
+`client/src/i18n/locales/de/updates.json`:
+```json
+"preRelease": {
+  "badge": "Pre-Release"
+}
+```
+
+### 8. Slash-Commands
+
+**Datei:** `.claude/commands/release/_release.md` (MODIFY)
+
+Vereinfachte Version (Label/CHANGELOG-Schreiben raus, da beides nicht mehr gebraucht wird):
+
+```markdown
+# Release-PR: development → main
+
+Erstelle einen PR von `development` nach `main`. Jeder Merge erzeugt automatisch ein Pre-Release-Tag und deployt auf Production. Stable-Releases werden separat über `/release-stable` getriggert.
+
+## Workflow
+
+### 1. Branch-Check
+Verifiziere `development`-Branch. Falls nicht: abbrechen.
+
+### 2. Commits seit letztem Stable anzeigen
+```bash
+git log $(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -Ev -- '-(pre|rc|alpha|beta|unstable)' | sort -V | tail -1)..HEAD --oneline
+```
+
+### 3. PR erstellen
+```bash
+gh pr create --base main --head development \
+  --title "<auto-generated from commit subjects>" \
+  --body "<list of commits>"
+```
+
+### 4. Hinweis auf automatischen Flow
+- CI Check läuft → Auto-Merge → Pre-Release-Tag `v<current>-pre.<run>` → Deploy
+- KEIN Stable-Release, KEIN Bump in pyproject.toml/package.json/CLAUDE.md
+- Für Stable-Release: `/release-stable` separat ausführen
+
+## Regeln
+- NIEMALS lokal auf main mergen
+- NIEMALS lokal Versionen bumpen
+- NIEMALS Tags manuell pushen
+```
+
+**Datei:** `.claude/commands/release/_release-stable.md` (CREATE)
+
+```markdown
+# Release Stable
+
+Triggert den `release-stable.yml` Workflow auf GitHub, der HEAD von `main` zu einem stabilen Release promotet (Bump + CHANGELOG-Sektion + Stable-Tag + GitHub-Release als „Latest").
+
+## Workflow
+
+### 1. Bump-Type bestimmen
+Analysiere Commits seit letztem Stable-Tag:
+```bash
+LAST_STABLE=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -Ev -- '-(pre|rc|alpha|beta|unstable)' | sort -V | tail -1)
+git log "$LAST_STABLE"..origin/main --pretty=format:'%s'
+```
+
+**Vorschlag basierend auf Commits:**
+- Mindestens ein `feat!:` oder `BREAKING CHANGE:` im Body → `major`
+- Mindestens ein `feat:` → `minor`
+- Sonst → `patch`
+
+**Frage Nutzer:** Welcher Bump-Type? (Vorschlag anzeigen)
+
+### 2. CHANGELOG-Vorschau
+Zeige geplante neue Version + Vorschau der CHANGELOG-Sektion (lokal generiert via `python scripts/generate_changelog_section.py --version <NEW> --since "$LAST_STABLE" --output -`). Nur als Vorschau — der echte CHANGELOG wird im Workflow geschrieben.
+
+### 3. Bestätigung + Trigger
+**Frage Nutzer:** Trigger ausführen?
+
+```bash
+gh workflow run release-stable.yml --ref main -f bump_type=<type>
+```
+
+### 4. Status-Link anzeigen
+```bash
+gh run list --workflow=release-stable.yml --limit 1
+```
+
+## Regeln
+- Workflow läuft auf `main` (nicht `development`)
+- Lokale `development`-Branch wird nach Stable-Release vom Auto-Merge-Workflow synchronisiert (existing logic)
+- NIEMALS lokal `pyproject.toml`/`package.json`/`CLAUDE.md` bumpen
+- NIEMALS lokal Stable-Tags erstellen oder pushen
+```
+
+## Data Flow
+
+### Pre-Release Flow (jeder PR-Merge)
+
+1. PR `development → main` wird erstellt
+2. `ci-check.yml` läuft (backend-tests, frontend-build) — kein `changelog-guard` mehr
+3. `auto-merge.yml` triggert auf `workflow_run: completed` von CI Check
+4. Mergt PR via `gh pr merge`
+5. Liest `version` aus `backend/pyproject.toml` (z.B. `1.31.7`)
+6. Erstellt Tag `v1.31.7-pre.${GITHUB_RUN_NUMBER}`, pusht
+7. Push auf main triggert `deploy-production.yml` → ci-deploy.sh → NAS deployt
+8. Tag-Push triggert `create-release.yml` → erkennt `-pre.` → GitHub-Release als „Pre-Release"
+9. `auto-merge.yml` finalen Step: Sync `development` mit `main` (FF only)
+
+### Stable Flow (manuell, selten)
+
+1. User entscheidet: aktueller `main` ist gut, soll Stable werden
+2. User triggert `release-stable.yml` via GH UI oder `/release-stable` Slash-Command
+3. Workflow checkt main aus, liest `CURRENT_VERSION` aus pyproject.toml
+4. Berechnet `NEW_VERSION` via `python scripts/bump_version.py <bump_type> --dry-run`
+5. Findet `LAST_STABLE_TAG` (Tag-Liste filtern auf Stable-Pattern)
+6. Generiert CHANGELOG-Sektion aus Commits seit `LAST_STABLE_TAG` via `scripts/generate_changelog_section.py`
+7. Bricht ab falls Sektion leer
+8. Inserted Sektion in CHANGELOG.md direkt nach der H1-Zeile (`# Changelog`), vor existierenden Sektionen
+9. `python scripts/bump_version.py <bump_type>` → bumpt 3 Dateien
+10. Commit `chore: release v${NEW_VERSION}` mit allen 4 Dateien
+11. Push auf main
+12. Tag `v${NEW_VERSION}` (kein Suffix), Push
+13. Push triggert `deploy-production.yml` — wird durch erweiterten Skip-Filter geblockt (kein redundanter Deploy)
+14. Tag-Push triggert `create-release.yml` — kein `-pre.` → GitHub-Release als „Latest"
+15. `auto-merge.yml`-Sync-Logik triggert nicht (kein PR-Merge), aber: nächster `development → main` PR pickt die neue Stable-Version + CHANGELOG-Aktualisierung mit, weil `auto-merge.yml`-Sync-Step `git merge origin/main --ff-only` macht
+
+### Versions-Anzeige in der UI
+
+1. Frontend lädt beim Mount `getPublicVersion()` (Rate-limited public endpoint)
+2. Backend: `git describe --tags --exact-match` auf HEAD
+   - Auf Production: HEAD ist immer auf einem Tag (Pre-Release oder Stable, ggf. nach Stable-Bump-Commit kurzzeitig nicht — aber dann wird via `is_dev_build` gehandhabt)
+   - Auf Dev: simulierter Wert
+3. `VersionInfo` enthält `version` (z.B. `1.31.7-pre.42`) + `is_prerelease`
+4. `useVersionDisplay()` Hook liefert `{text, isPrerelease}` an Konsumenten
+5. Anzeige: Text + optionales amber-Badge
+
+## Error Handling
+
+| Szenario | Verhalten |
+|----------|-----------|
+| Pre-Release-Tag bereits vorhanden (Run-Number-Kollision, theoretisch) | `auto-merge.yml` loggt Skip, deploy läuft trotzdem |
+| `release-stable.yml` ohne Commits seit letztem Stable | Workflow bricht mit Error ab (`generate_changelog_section.py` exit code) |
+| `release-stable.yml` während laufender Pre-Release-Pipeline | Eigener Run, kein Concurrency-Lock — sein Push triggert wieder `deploy-production.yml` der durch `concurrency: production-deploy` gequeued wird |
+| `bump_version.py --dry-run` neu ergänzt | Falls altes Skript verwendet wird ohne Flag → Workflow scheitert beim ersten Test (TDD im Plan) |
+| `git describe --tags --exact-match` schlägt fehl (lokal/dev) | Fallback auf pyproject.toml → `version=1.31.7`, `is_dev_build=true`, `is_prerelease=false` |
+| Skip-Filter im Production-Deploy fängt Stable-Bump-Commit nicht | Redundanter Deploy mit identischem Code, kein Schaden, aber sichtbar in Run-History — wird im Plan als Test verifiziert |
+| Tag-Push schlägt fehl (Permissions) | `auto-merge.yml`/`release-stable.yml` loggt Error, Tag muss manuell nachgepusht werden — kein automatisches Retry |
+| User mit `release:*` Label auf altem PR mergt nach Rollout | Label hat keinen Effekt mehr — Pre-Release-Tag wird trotzdem korrekt erzeugt |
+
+## Testing
+
+### Manuell (Dev-Mode + Live-Test)
+
+1. **Pre-Release-Flow E2E:**
+   - Branch von `development` → kleine Änderung → PR auf main → mergen
+   - Verify: Tag `v<aktuelle>-pre.<N>` existiert auf GitHub
+   - Verify: GitHub-Release angelegt, markiert als „Pre-Release"
+   - Verify: Production-Deploy läuft (Logs in `journalctl -u baluhost-backend -f`)
+   - Verify: `pyproject.toml`/`package.json`/`CLAUDE.md` unverändert
+   - Verify: BaluHost-UI zeigt `v<aktuelle>-pre.<N>` mit Pre-Release-Badge
+
+2. **Stable-Flow:**
+   - `/release-stable` mit `bump_type=patch` ausführen
+   - Verify: Workflow erfolgreich
+   - Verify: Neuer Stable-Tag, GitHub-Release als „Latest"
+   - Verify: pyproject.toml/package.json/CLAUDE.md gebumpt
+   - Verify: CHANGELOG.md hat neue Sektion mit korrekt gruppierten Conventional-Commits-Einträgen
+   - Verify: Production-Deploy wurde übersprungen (Logs)
+   - Verify: BaluHost-UI zeigt jetzt Stable-Version, kein Badge
+
+3. **Edge: Stable ohne Commits:**
+   - Sofort nach Stable-Trigger nochmal triggern
+   - Verify: Workflow bricht mit Error ab
+
+### Unit-Tests (im Plan zu schreiben)
+
+- `scripts/generate_changelog_section.py`: Tests für Conventional-Commits-Parsing, Scope-Extraktion, BREAKING-Detection, PR-Number-Extraktion, leere Sektion → exit 1
+- `scripts/insert_changelog_section.py`: Test für Insertion an korrekter Stelle, Beibehaltung des Trennzeichens
+- `scripts/bump_version.py`: Test für `--dry-run` Mode (keine Datei-Änderungen, korrekte Ausgabe auf stdout)
+- `backend/app/services/update/prod_backend.py::get_current_version`: Tests mit gemocktem `_run_git` für (a) HEAD auf Pre-Release-Tag, (b) HEAD auf Stable-Tag, (c) HEAD zwischen Tags
+
+### CI-Tests
+
+- Bestehende `ci-check.yml` (backend-tests + frontend-build) bleibt unverändert
+- Manuell verifizieren dass `changelog-guard` weg ist und PRs ohne CHANGELOG-Änderung durchlaufen
+
+## Migration / Rollout
+
+**Reihenfolge der Implementierung** (im Plan zu detaillieren):
+
+1. **Phase 1 — Backend-Änderungen** (deploybar ohne Workflow-Änderungen):
+   - `bump_version.py --dry-run` Flag
+   - `scripts/generate_changelog_section.py` + `scripts/insert_changelog_section.py`
+   - `VersionInfo.is_prerelease` Schema-Feld + Backend-Logik
+   - Frontend `useVersionDisplay()` + Badge + i18n
+   - Tests
+
+2. **Phase 2 — Workflow-Switch** (atomar deployen):
+   - Neuer `release-stable.yml`
+   - `auto-merge.yml` Pre-Release-Tagging statt Stable-Bump
+   - `deploy-production.yml` erweiterter Skip-Filter
+   - `create-release.yml` `-pre.` Pattern
+   - `ci-check.yml` `changelog-guard` entfernen
+   - Slash-Commands `_release.md` umbauen + `_release-stable.md` neu
+
+3. **Phase 3 — Cleanup:**
+   - Memory-Eintrag `feedback_release_workflow.md` aktualisieren (neue Pre-Release-Semantik dokumentieren)
+   - Alte offene PRs mit `release:*` Label prüfen — Label entfernen oder mergen vor Phase-2-Switch
+   - `release:patch|minor|major` Labels im Repo löschen (optional, aber sauber)
+
+**Atomarität:** Phase 2 muss in einem PR/Merge passieren, sonst gibt es zwischen Workflow-Updates inkonsistente Zustände (z.B. neuer `auto-merge.yml` ohne neuen Skip-Filter im Deploy).
+
+## File Changes Summary
+
+| Datei | Aktion | Zweck |
+|-------|--------|-------|
+| `.github/workflows/release-stable.yml` | **Create** | Manuelle Stable-Promotion via workflow_dispatch |
+| `.github/workflows/auto-merge.yml` | Modify | Pre-Release-Tags statt Stable-Bump; Bump-Step entfernen |
+| `.github/workflows/deploy-production.yml` | Modify | Skip-Filter um `chore: release v` erweitern |
+| `.github/workflows/create-release.yml` | Modify | `-pre.` als Prerelease-Suffix erkennen |
+| `.github/workflows/ci-check.yml` | Modify | `changelog-guard` Job entfernen |
+| `backend/app/services/update/prod_backend.py` | Modify | Tag-basierte Version + `is_prerelease` |
+| `backend/app/services/update/dev_backend.py` | Modify | `is_prerelease=False` mocken |
+| `backend/app/schemas/update.py` | Modify | `is_prerelease: bool` zu `VersionInfo` |
+| `backend/tests/services/test_update_service.py` | Modify | Tests für neue Tag-Detection |
+| `client/src/api/updates.ts` | Modify | `is_prerelease` zu `VersionInfo` interface |
+| `client/src/contexts/VersionContext.tsx` | Modify | `useVersionDisplay()` Hook ergänzen |
+| `client/src/pages/UpdatePage.tsx` (oder relevante Tab-Components) | Modify | Pre-Release-Badge anzeigen |
+| `client/src/i18n/locales/de/updates.json` | Modify | `preRelease.badge` Key |
+| `client/src/i18n/locales/en/updates.json` | Modify | `preRelease.badge` Key |
+| `scripts/bump_version.py` | Modify | `--dry-run` Flag |
+| `scripts/generate_changelog_section.py` | **Create** | Conventional-Commits → CHANGELOG-Sektion |
+| `scripts/insert_changelog_section.py` | **Create** | Insert-Helper für CHANGELOG.md |
+| `.claude/commands/release/_release.md` | Modify | Vereinfacht — kein Label, kein CHANGELOG-Schreiben |
+| `.claude/commands/release/_release-stable.md` | **Create** | Stable-Trigger via `gh workflow run` |
+
+## Open Questions / Defer
+
+- **Stable-Release-Channel-Mapping im Update-Service:** Der `services/update/` filtert Releases nach Channel. Aktuell vermutlich `STABLE` = nicht-prerelease, `UNSTABLE` = prerelease. Das passt automatisch zum neuen Schema (`is_prerelease=true` bei `-pre.*`). Verifikation im Plan: existing `ReleaseInfo.is_prerelease` Logic in `prod_backend.py::get_all_releases()` checken.
+- **`release:patch|minor|major` Labels im Repo:** Können nach erfolgreichem Rollout gelöscht werden. Nicht blockierend für die Implementierung — können stehen bleiben (sind dann no-ops).
+- **Branch-Protection auf main:** Falls eingerichtet, ggf. anpassen damit `release-stable.yml` Bot direkt pushen darf (DEPLOY_PAT muss Rechte haben). Im Plan zu verifizieren.

--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -1,0 +1,7 @@
+"""Add scripts/ to sys.path so sibling test modules can import the script."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/scripts/generate_readme_stats.py
+++ b/scripts/generate_readme_stats.py
@@ -227,8 +227,13 @@ def replace_between_markers(
     lines in between. Inline mode: marker pair appears on a single line and
     only the inner span is replaced.
 
+    Input text is normalized to LF line endings; output is LF. Callers on
+    Windows that read the file with `read_text(encoding="utf-8")` will get
+    CRLF, which is converted to LF here so the regex anchors match.
+
     Raises ValueError if either marker is missing.
     """
+    text = text.replace("\r\n", "\n")
     start = f"<!-- STATS:{name}:START -->"
     end = f"<!-- STATS:{name}:END -->"
     if start not in text or end not in text:

--- a/scripts/generate_readme_stats.py
+++ b/scripts/generate_readme_stats.py
@@ -250,16 +250,47 @@ def replace_between_markers(
     return re.sub(pattern, f"{start}\n{content}\n{end}", text, count=1, flags=re.S)
 
 
+def apply_to_text(readme_text: str, stats: Stats, *, measured: str | None = None) -> str:
+    """Apply all three marker replacements to a README body."""
+    out = replace_between_markers(
+        readme_text, "PROJECT", render_project_stats_block(stats, measured=measured)
+    )
+    out = replace_between_markers(
+        out, "TEST_COUNT", render_test_count(stats), inline=True
+    )
+    out = replace_between_markers(
+        out, "TEST_FILES", render_test_files(stats), inline=True
+    )
+    return out
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--write", action="store_true", help="Rewrite README.md")
-    parser.add_argument("--check", action="store_true", help="Exit 1 if drift")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--write", action="store_true", help="Rewrite README.md in place")
+    mode.add_argument("--check", action="store_true", help="Exit 1 if README would change")
     args = parser.parse_args()
 
     if not args.write and not args.check:
         args.check = True
 
-    raise NotImplementedError("filled in by later tasks")
+    files = tracked_files()
+    stats = compute_stats(files)
+    current = README.read_text(encoding="utf-8")
+    new = apply_to_text(current, stats)
+
+    if new == current:
+        print("README stats up to date.")
+        return 0
+
+    if args.write:
+        README.write_text(new, encoding="utf-8")
+        print("README.md updated.")
+        return 0
+
+    # check mode
+    print("README stats are out of date. Run with --write to update.", file=sys.stderr)
+    return 1
 
 
 if __name__ == "__main__":

--- a/scripts/generate_readme_stats.py
+++ b/scripts/generate_readme_stats.py
@@ -16,6 +16,7 @@ import ast
 import subprocess
 import sys
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 from typing import Iterable
 
@@ -165,6 +166,55 @@ def compute_stats(files: list[Path]) -> Stats:
             ".github/workflows/",
         )),
     )
+
+
+def _fmt(n: int) -> str:
+    return f"{n:,}"
+
+
+def render_project_stats_block(s: Stats, measured: str | None = None) -> str:
+    """Render the Project Stats markdown block (between STATS markers)."""
+    measured = measured or date.today().isoformat()
+    return (
+        "| Metric | Count |\n"
+        "|--------|-------|\n"
+        "| **Version** | "
+        "![Latest Release]"
+        "(https://img.shields.io/github/v/release/Xveyn/BaluHost?label=) |\n"
+        f"| **Backend code** | {_fmt(s.backend_total.lines)} lines across "
+        f"{_fmt(s.backend_total.files)} Python files |\n"
+        f"| &nbsp;&nbsp;↳ Application (`app/`) | {_fmt(s.backend_app.lines)} lines / "
+        f"{_fmt(s.backend_app.files)} files |\n"
+        f"| &nbsp;&nbsp;↳ Tests (`tests/`) | {_fmt(s.backend_tests.lines)} lines / "
+        f"{_fmt(s.backend_tests.files)} files |\n"
+        f"| &nbsp;&nbsp;↳ Scripts (`scripts/`) | {_fmt(s.backend_scripts.lines)} lines / "
+        f"{_fmt(s.backend_scripts.files)} files |\n"
+        f"| &nbsp;&nbsp;↳ Alembic migrations | {_fmt(s.backend_alembic.lines)} lines / "
+        f"{_fmt(s.backend_alembic.files)} files |\n"
+        f"| &nbsp;&nbsp;↳ Terminal UI (`baluhost_tui/`) | {_fmt(s.backend_tui.lines)} lines / "
+        f"{_fmt(s.backend_tui.files)} files |\n"
+        f"| **Frontend code** | {_fmt(s.frontend.lines)} lines across "
+        f"{_fmt(s.frontend.files)} source files (`client/src/`, .ts/.tsx/.js/.jsx/.css) |\n"
+        f"| **Test functions** | {s.test_functions} |\n"
+        f"| **API route modules** | {s.api_route_modules} |\n"
+        f"| **Service modules** | {s.service_modules} |\n"
+        f"| **Database models** | {s.db_models} |\n"
+        f"| **Database migrations** | {s.db_migrations} |\n"
+        f"| **Frontend pages** | {s.frontend_pages} |\n"
+        f"| **CI/CD workflows** | {s.workflows} |\n"
+        "\n"
+        "<sub>LOC counted via `git ls-files` (respects `.gitignore`, "
+        "excludes virtualenvs, `node_modules/`, `dist/`, caches, dev-storage). "
+        f"Last measured {measured}.</sub>"
+    )
+
+
+def render_test_count(s: Stats) -> str:
+    return f"{s.test_functions} tests"
+
+
+def render_test_files(s: Stats) -> str:
+    return f"{s.backend_tests.files} test files"
 
 
 def main() -> int:

--- a/scripts/generate_readme_stats.py
+++ b/scripts/generate_readme_stats.py
@@ -276,7 +276,7 @@ def main() -> int:
 
     files = tracked_files()
     stats = compute_stats(files)
-    current = README.read_text(encoding="utf-8")
+    current = README.read_text(encoding="utf-8").replace("\r\n", "\n")
     new = apply_to_text(current, stats)
 
     if new == current:

--- a/scripts/generate_readme_stats.py
+++ b/scripts/generate_readme_stats.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import re
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -215,6 +216,33 @@ def render_test_count(s: Stats) -> str:
 
 def render_test_files(s: Stats) -> str:
     return f"{s.backend_tests.files} test files"
+
+
+def replace_between_markers(
+    text: str, name: str, content: str, *, inline: bool = False
+) -> str:
+    """Replace the content between <!-- STATS:NAME:START --> and ...:END -->.
+
+    Block mode (default): expects markers on their own lines, replaces the
+    lines in between. Inline mode: marker pair appears on a single line and
+    only the inner span is replaced.
+
+    Raises ValueError if either marker is missing.
+    """
+    start = f"<!-- STATS:{name}:START -->"
+    end = f"<!-- STATS:{name}:END -->"
+    if start not in text or end not in text:
+        raise ValueError(f"Marker pair STATS:{name} not found in text")
+
+    if inline:
+        pattern = re.escape(start) + r".*?" + re.escape(end)
+        return re.sub(pattern, f"{start}{content}{end}", text, count=1, flags=re.S)
+
+    # Block mode: keep marker lines, replace everything strictly between.
+    pattern = (
+        re.escape(start) + r"\n.*?\n" + re.escape(end)
+    )
+    return re.sub(pattern, f"{start}\n{content}\n{end}", text, count=1, flags=re.S)
 
 
 def main() -> int:

--- a/scripts/generate_readme_stats.py
+++ b/scripts/generate_readme_stats.py
@@ -12,6 +12,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import ast
 import sys
 from pathlib import Path
 from typing import Iterable
@@ -34,6 +35,25 @@ def count_lines(files: Iterable[Path]) -> int:
                     total += chunk.count(b"\n")
         except OSError:
             continue
+    return total
+
+
+def count_test_functions(files: Iterable[Path]) -> int:
+    """Count def/async def whose name starts with 'test_' across files.
+
+    Uses AST so it works without importing the project. Walks the whole
+    tree to catch class methods. Files that fail to parse are skipped.
+    """
+    total = 0
+    for f in files:
+        try:
+            tree = ast.parse(f.read_text(encoding="utf-8"))
+        except (SyntaxError, OSError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name.startswith("test_"):
+                    total += 1
     return total
 
 

--- a/scripts/generate_readme_stats.py
+++ b/scripts/generate_readme_stats.py
@@ -14,9 +14,27 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
+from typing import Iterable
 
 ROOT = Path(__file__).resolve().parents[1]
 README = ROOT / "README.md"
+
+
+def count_lines(files: Iterable[Path]) -> int:
+    """Count newline bytes across files. Matches `wc -l` semantics.
+
+    Skips files that are unreadable (missing, permission error). We count
+    newlines rather than lines to keep behavior simple and binary-safe.
+    """
+    total = 0
+    for f in files:
+        try:
+            with open(f, "rb") as fh:
+                while chunk := fh.read(65536):
+                    total += chunk.count(b"\n")
+        except OSError:
+            continue
+    return total
 
 
 def main() -> int:

--- a/scripts/generate_readme_stats.py
+++ b/scripts/generate_readme_stats.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Generate and splice BaluHost README stats from tracked git files.
+
+Counts only files reported by `git ls-files` — automatically respects
+.gitignore. No third-party dependencies.
+
+Usage:
+    python scripts/generate_readme_stats.py            # check mode (exit 1 if drift)
+    python scripts/generate_readme_stats.py --check    # explicit check mode
+    python scripts/generate_readme_stats.py --write    # rewrite README.md in place
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write", action="store_true", help="Rewrite README.md")
+    parser.add_argument("--check", action="store_true", help="Exit 1 if drift")
+    args = parser.parse_args()
+
+    if not args.write and not args.check:
+        args.check = True
+
+    raise NotImplementedError("filled in by later tasks")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_readme_stats.py
+++ b/scripts/generate_readme_stats.py
@@ -25,13 +25,16 @@ README = ROOT / "README.md"
 def count_lines(files: Iterable[Path]) -> int:
     """Count newline bytes across files. Matches `wc -l` semantics.
 
-    Skips files that are unreadable (missing, permission error). We count
-    newlines rather than lines to keep behavior simple and binary-safe.
+    Relative paths are resolved against ROOT so the script works regardless
+    of the process's current working directory. Skips files that are
+    unreadable (missing, permission error). Counts newlines rather than
+    lines to keep behavior simple and binary-safe.
     """
     total = 0
     for f in files:
+        path = f if f.is_absolute() else ROOT / f
         try:
-            with open(f, "rb") as fh:
+            with open(path, "rb") as fh:
                 while chunk := fh.read(65536):
                     total += chunk.count(b"\n")
         except OSError:
@@ -42,13 +45,16 @@ def count_lines(files: Iterable[Path]) -> int:
 def count_test_functions(files: Iterable[Path]) -> int:
     """Count def/async def whose name starts with 'test_' across files.
 
-    Uses AST so it works without importing the project. Walks the whole
-    tree to catch class methods. Files that fail to parse are skipped.
+    Relative paths are resolved against ROOT so the script works regardless
+    of the process's current working directory. Uses AST so it works without
+    importing the project. Walks the whole tree to catch class methods.
+    Files that fail to parse are skipped.
     """
     total = 0
     for f in files:
+        path = f if f.is_absolute() else ROOT / f
         try:
-            tree = ast.parse(f.read_text(encoding="utf-8"))
+            tree = ast.parse(path.read_text(encoding="utf-8"))
         except (SyntaxError, OSError, UnicodeDecodeError):
             continue
         for node in ast.walk(tree):

--- a/scripts/generate_readme_stats.py
+++ b/scripts/generate_readme_stats.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import subprocess
 import sys
 from pathlib import Path
 from typing import Iterable
@@ -55,6 +56,43 @@ def count_test_functions(files: Iterable[Path]) -> int:
                 if node.name.startswith("test_"):
                     total += 1
     return total
+
+
+def tracked_files(cwd: Path | None = None) -> list[Path]:
+    """List repo files tracked by git. Respects .gitignore by definition."""
+    out = subprocess.check_output(
+        ["git", "ls-files"],
+        cwd=cwd or ROOT,
+        text=True,
+        encoding="utf-8",
+    )
+    return [Path(line) for line in out.splitlines() if line.strip()]
+
+
+def _normalize(p: Path) -> str:
+    return str(p).replace("\\", "/")
+
+
+def under(
+    files: Iterable[Path],
+    *prefixes: str,
+    exclude_init: bool = False,
+) -> list[Path]:
+    """Return files whose normalized path starts with any of the prefixes."""
+    out: list[Path] = []
+    for f in files:
+        norm = _normalize(f)
+        if not any(norm.startswith(p) for p in prefixes):
+            continue
+        if exclude_init and f.name == "__init__.py":
+            continue
+        out.append(f)
+    return out
+
+
+def with_ext(files: Iterable[Path], *exts: str) -> list[Path]:
+    """Return files whose suffix is in exts (suffixes include the dot)."""
+    return [f for f in files if f.suffix in exts]
 
 
 def main() -> int:

--- a/scripts/generate_readme_stats.py
+++ b/scripts/generate_readme_stats.py
@@ -158,7 +158,7 @@ def compute_stats(files: list[Path]) -> Stats:
         api_route_modules=len(under(py, "backend/app/api/routes/", exclude_init=True)),
         service_modules=len(under(py, "backend/app/services/", exclude_init=True)),
         db_models=len(under(py, "backend/app/models/", exclude_init=True)),
-        db_migrations=len(under(py, "backend/alembic/versions/", exclude_init=True)),
+        db_migrations=len(under(py, "backend/alembic/versions/")),
         frontend_pages=len(under(with_ext(files, ".tsx"), "client/src/pages/")),
         workflows=len(under(
             with_ext(files, ".yml", ".yaml"),

--- a/scripts/generate_readme_stats.py
+++ b/scripts/generate_readme_stats.py
@@ -142,6 +142,8 @@ def compute_stats(files: list[Path]) -> Stats:
     alembic = under(py, "backend/alembic/")
     tui = under(py, "backend/baluhost_tui/")
 
+    # backend_total is the explicit union of the five dirs above. New top-level
+    # backend dirs (e.g. backend/plugins/) must be added there and here to count.
     backend_total_files = app + tests + scripts + alembic + tui
     frontend = under(
         with_ext(files, ".ts", ".tsx", ".js", ".jsx", ".css"),
@@ -277,7 +279,11 @@ def main() -> int:
     files = tracked_files()
     stats = compute_stats(files)
     current = README.read_text(encoding="utf-8").replace("\r\n", "\n")
-    new = apply_to_text(current, stats)
+    try:
+        new = apply_to_text(current, stats)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
 
     if new == current:
         print("README stats up to date.")

--- a/scripts/generate_readme_stats.py
+++ b/scripts/generate_readme_stats.py
@@ -15,6 +15,7 @@ import argparse
 import ast
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
@@ -99,6 +100,71 @@ def under(
 def with_ext(files: Iterable[Path], *exts: str) -> list[Path]:
     """Return files whose suffix is in exts (suffixes include the dot)."""
     return [f for f in files if f.suffix in exts]
+
+
+@dataclass(frozen=True)
+class Bucket:
+    files: int
+    lines: int
+
+
+@dataclass(frozen=True)
+class Stats:
+    backend_total: Bucket
+    backend_app: Bucket
+    backend_tests: Bucket
+    backend_scripts: Bucket
+    backend_alembic: Bucket
+    backend_tui: Bucket
+    frontend: Bucket
+    test_functions: int
+    api_route_modules: int
+    service_modules: int
+    db_models: int
+    db_migrations: int
+    frontend_pages: int
+    workflows: int
+
+
+def _bucket(files: list[Path]) -> Bucket:
+    return Bucket(files=len(files), lines=count_lines(files))
+
+
+def compute_stats(files: list[Path]) -> Stats:
+    """Compute the full stats payload from a list of tracked file paths."""
+    py = with_ext(files, ".py")
+
+    app = under(py, "backend/app/")
+    tests = under(py, "backend/tests/")
+    scripts = under(py, "backend/scripts/")
+    alembic = under(py, "backend/alembic/")
+    tui = under(py, "backend/baluhost_tui/")
+
+    backend_total_files = app + tests + scripts + alembic + tui
+    frontend = under(
+        with_ext(files, ".ts", ".tsx", ".js", ".jsx", ".css"),
+        "client/src/",
+    )
+
+    return Stats(
+        backend_total=_bucket(backend_total_files),
+        backend_app=_bucket(app),
+        backend_tests=_bucket(tests),
+        backend_scripts=_bucket(scripts),
+        backend_alembic=_bucket(alembic),
+        backend_tui=_bucket(tui),
+        frontend=_bucket(frontend),
+        test_functions=count_test_functions(tests),
+        api_route_modules=len(under(py, "backend/app/api/routes/", exclude_init=True)),
+        service_modules=len(under(py, "backend/app/services/", exclude_init=True)),
+        db_models=len(under(py, "backend/app/models/", exclude_init=True)),
+        db_migrations=len(under(py, "backend/alembic/versions/", exclude_init=True)),
+        frontend_pages=len(under(with_ext(files, ".tsx"), "client/src/pages/")),
+        workflows=len(under(
+            with_ext(files, ".yml", ".yaml"),
+            ".github/workflows/",
+        )),
+    )
 
 
 def main() -> int:

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -1,6 +1,8 @@
 """Tests for scripts/generate_readme_stats.py — stdlib + pytest only."""
 from __future__ import annotations
 
+from pathlib import Path
+
 import generate_readme_stats as grs
 
 
@@ -88,3 +90,53 @@ def test_count_test_functions_skips_missing_file(tmp_path):
     good = tmp_path / "test_good.py"
     good.write_text("def test_y():\n    pass\n", encoding="utf-8")
     assert grs.count_test_functions([missing, good]) == 1
+
+
+def test_under_unix_paths():
+    files = [Path("backend/app/main.py"), Path("client/src/App.tsx"), Path("README.md")]
+    result = grs.under(files, "backend/app/")
+    assert result == [Path("backend/app/main.py")]
+
+
+def test_under_normalizes_windows_paths():
+    # git ls-files always emits forward slashes on Windows too — but defensively
+    # we normalize, so a Path with backslashes still matches.
+    files = [Path("backend\\app\\main.py")]
+    result = grs.under(files, "backend/app/")
+    assert result == files
+
+
+def test_under_multiple_prefixes():
+    files = [
+        Path("backend/app/main.py"),
+        Path("backend/tests/test_x.py"),
+        Path("client/src/App.tsx"),
+    ]
+    result = grs.under(files, "backend/app/", "backend/tests/")
+    assert len(result) == 2
+
+
+def test_under_excludes_init_when_requested():
+    files = [
+        Path("backend/app/models/user.py"),
+        Path("backend/app/models/__init__.py"),
+    ]
+    result = grs.under(files, "backend/app/models/", exclude_init=True)
+    assert result == [Path("backend/app/models/user.py")]
+
+
+def test_with_ext_filter():
+    files = [Path("a.py"), Path("a.tsx"), Path("a.md")]
+    assert grs.with_ext(files, ".py", ".tsx") == [Path("a.py"), Path("a.tsx")]
+
+
+def test_tracked_files_parses_git_output(monkeypatch):
+    def fake_check_output(cmd, **kw):
+        assert cmd[:2] == ["git", "ls-files"]
+        return "backend/app/main.py\nREADME.md\n\n"
+
+    monkeypatch.setattr(grs.subprocess, "check_output", fake_check_output)
+    files = grs.tracked_files()
+    assert Path("backend/app/main.py") in files
+    assert Path("README.md") in files
+    assert len(files) == 2  # blank line dropped

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -299,3 +299,46 @@ def test_render_test_count():
 
 def test_render_test_files():
     assert grs.render_test_files(_stub_stats()) == "166 test files"
+
+
+def test_replace_between_markers_block():
+    text = (
+        "intro\n"
+        "<!-- STATS:PROJECT:START -->\n"
+        "old content here\n"
+        "more old\n"
+        "<!-- STATS:PROJECT:END -->\n"
+        "outro\n"
+    )
+    out = grs.replace_between_markers(text, "PROJECT", "NEW BLOCK")
+    assert (
+        "<!-- STATS:PROJECT:START -->\nNEW BLOCK\n<!-- STATS:PROJECT:END -->" in out
+    )
+    assert "old content" not in out
+    assert "intro\n" in out and "outro\n" in out
+
+
+def test_replace_between_markers_inline():
+    text = "Row | <!-- STATS:TC:START -->old<!-- STATS:TC:END --> | rest"
+    out = grs.replace_between_markers(text, "TC", "new", inline=True)
+    assert "<!-- STATS:TC:START -->new<!-- STATS:TC:END -->" in out
+    assert "old" not in out
+
+
+def test_replace_between_markers_idempotent():
+    text = (
+        "<!-- STATS:X:START -->\nfoo\n<!-- STATS:X:END -->"
+    )
+    once = grs.replace_between_markers(text, "X", "bar")
+    twice = grs.replace_between_markers(once, "X", "bar")
+    assert once == twice
+
+
+def test_replace_between_markers_missing_raises():
+    text = "no markers here"
+    try:
+        grs.replace_between_markers(text, "MISSING", "x")
+    except ValueError as e:
+        assert "MISSING" in str(e)
+    else:
+        raise AssertionError("expected ValueError")

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -184,6 +184,7 @@ def _make_repo(tmp_path: Path) -> Path:
         "backend/scripts/foo.py": "print('hi')\n",
         "backend/alembic/versions/0001_init.py": "# rev\n",
         "backend/alembic/versions/0002_add.py": "# rev\n",
+        "backend/alembic/env.py": "# alembic env\n",
         "backend/baluhost_tui/main.py": "pass\n",
         "client/src/App.tsx": "export const X = 1;\n",
         "client/src/pages/Dashboard.tsx": "export default 1;\n",
@@ -219,6 +220,7 @@ def test_compute_stats_counts_match_fixture(tmp_path, monkeypatch):
         "backend/scripts/foo.py",
         "backend/alembic/versions/0001_init.py",
         "backend/alembic/versions/0002_add.py",
+        "backend/alembic/env.py",
         "backend/baluhost_tui/main.py",
         "client/src/App.tsx",
         "client/src/pages/Dashboard.tsx",
@@ -234,7 +236,7 @@ def test_compute_stats_counts_match_fixture(tmp_path, monkeypatch):
     assert s.api_route_modules == 2  # __init__ excluded
     assert s.service_modules == 2    # __init__ excluded, both auth.py + upload.py
     assert s.db_models == 1          # __init__ excluded
-    assert s.db_migrations == 2
+    assert s.db_migrations == 2      # only versions/, env.py excluded
     assert s.frontend_pages == 2
     assert s.workflows == 2
     assert s.test_functions == 3     # 1 + 2
@@ -242,8 +244,8 @@ def test_compute_stats_counts_match_fixture(tmp_path, monkeypatch):
     assert s.backend_app.files == 10  # all .py under backend/app/
     assert s.backend_tests.files == 2
     assert s.backend_scripts.files == 1
-    assert s.backend_alembic.files == 2
+    assert s.backend_alembic.files == 3  # versions/ + env.py — broader than db_migrations
     assert s.backend_tui.files == 1
-    assert s.backend_total.files == 16  # sum of subdirs
+    assert s.backend_total.files == 17  # sum of subdirs
 
     assert s.frontend.files == 5  # .tsx, .ts, .css under client/src/

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -81,3 +81,10 @@ def test_count_test_functions_skips_syntax_errors(tmp_path):
 
 def test_count_test_functions_empty_list():
     assert grs.count_test_functions([]) == 0
+
+
+def test_count_test_functions_skips_missing_file(tmp_path):
+    missing = tmp_path / "does-not-exist.py"
+    good = tmp_path / "test_good.py"
+    good.write_text("def test_y():\n    pass\n", encoding="utf-8")
+    assert grs.count_test_functions([missing, good]) == 1

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -140,3 +140,27 @@ def test_tracked_files_parses_git_output(monkeypatch):
     assert Path("backend/app/main.py") in files
     assert Path("README.md") in files
     assert len(files) == 2  # blank line dropped
+
+
+def test_count_lines_resolves_relative_against_ROOT(tmp_path, monkeypatch):
+    """count_lines should open relative paths against ROOT, not process cwd."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "file.py").write_text("a\nb\n", encoding="utf-8")
+    monkeypatch.setattr(grs, "ROOT", repo)
+    other = tmp_path / "other"
+    other.mkdir()
+    monkeypatch.chdir(other)
+    assert grs.count_lines([Path("file.py")]) == 2
+
+
+def test_count_test_functions_resolves_relative_against_ROOT(tmp_path, monkeypatch):
+    """count_test_functions should open relative paths against ROOT, not process cwd."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "test_x.py").write_text("def test_a():\n    pass\n", encoding="utf-8")
+    monkeypatch.setattr(grs, "ROOT", repo)
+    other = tmp_path / "other"
+    other.mkdir()
+    monkeypatch.chdir(other)
+    assert grs.count_test_functions([Path("test_x.py")]) == 1

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -428,3 +428,21 @@ def test_main_check_mode_handles_crlf_readme(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["generate_readme_stats.py", "--check"])
     rc = grs.main()
     assert rc == 0, capsys.readouterr()
+
+
+def test_main_exits_2_on_missing_markers(tmp_path, monkeypatch, capsys):
+    """Missing markers should produce a clean stderr message and exit code 2."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    readme = repo / "README.md"
+    readme.write_text("no markers here\n", encoding="utf-8")
+
+    monkeypatch.setattr(grs, "README", readme)
+    monkeypatch.setattr(grs, "tracked_files", lambda: [])
+    monkeypatch.setattr(grs, "compute_stats", lambda files: _stub_stats())
+
+    monkeypatch.setattr(sys, "argv", ["generate_readme_stats.py", "--check"])
+    rc = grs.main()
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "STATS:PROJECT" in captured.err

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -36,3 +36,48 @@ def test_count_lines_multiple_files(tmp_path):
     b = tmp_path / "b.py"
     b.write_text("p\nq\nr\n", encoding="utf-8")
     assert grs.count_lines([a, b]) == 5
+
+
+def test_count_test_functions_module_level(tmp_path):
+    f = tmp_path / "test_x.py"
+    f.write_text(
+        "def test_one():\n    pass\n\n"
+        "def test_two():\n    pass\n\n"
+        "def helper():\n    pass\n",
+        encoding="utf-8",
+    )
+    assert grs.count_test_functions([f]) == 2
+
+
+def test_count_test_functions_async(tmp_path):
+    f = tmp_path / "test_async.py"
+    f.write_text(
+        "async def test_a():\n    pass\n\n"
+        "def test_b():\n    pass\n",
+        encoding="utf-8",
+    )
+    assert grs.count_test_functions([f]) == 2
+
+
+def test_count_test_functions_in_class(tmp_path):
+    f = tmp_path / "test_class.py"
+    f.write_text(
+        "class TestThing:\n"
+        "    def test_inside(self):\n        pass\n"
+        "    def helper(self):\n        pass\n"
+        "    async def test_async_inside(self):\n        pass\n",
+        encoding="utf-8",
+    )
+    assert grs.count_test_functions([f]) == 2
+
+
+def test_count_test_functions_skips_syntax_errors(tmp_path):
+    bad = tmp_path / "test_bad.py"
+    bad.write_text("def test_x(:\n    broken syntax", encoding="utf-8")
+    good = tmp_path / "test_good.py"
+    good.write_text("def test_y():\n    pass\n", encoding="utf-8")
+    assert grs.count_test_functions([bad, good]) == 1
+
+
+def test_count_test_functions_empty_list():
+    assert grs.count_test_functions([]) == 0

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -275,6 +275,9 @@ def test_render_project_stats_block_contains_all_rows():
     assert "150,685 lines across 735 Python files" in md
     assert "97,186 lines / 411 files" in md
     assert "38,309 lines / 166 files" in md
+    assert "6,291 lines / 48 files" in md
+    assert "5,989 lines / 92 files" in md
+    assert "2,910 lines / 18 files" in md
     assert "78,107 lines across 427 source files" in md
     assert "| **Test functions** | 1465 |" in md
     assert "| **API route modules** | 51 |" in md

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -249,3 +249,50 @@ def test_compute_stats_counts_match_fixture(tmp_path, monkeypatch):
     assert s.backend_total.files == 17  # sum of subdirs
 
     assert s.frontend.files == 5  # .tsx, .ts, .css under client/src/
+
+
+def _stub_stats() -> grs.Stats:
+    return grs.Stats(
+        backend_total=grs.Bucket(files=735, lines=150_685),
+        backend_app=grs.Bucket(files=411, lines=97_186),
+        backend_tests=grs.Bucket(files=166, lines=38_309),
+        backend_scripts=grs.Bucket(files=48, lines=6_291),
+        backend_alembic=grs.Bucket(files=92, lines=5_989),
+        backend_tui=grs.Bucket(files=18, lines=2_910),
+        frontend=grs.Bucket(files=427, lines=78_107),
+        test_functions=1465,
+        api_route_modules=51,
+        service_modules=143,
+        db_models=42,
+        db_migrations=74,
+        frontend_pages=31,
+        workflows=7,
+    )
+
+
+def test_render_project_stats_block_contains_all_rows():
+    md = grs.render_project_stats_block(_stub_stats())
+    assert "150,685 lines across 735 Python files" in md
+    assert "97,186 lines / 411 files" in md
+    assert "38,309 lines / 166 files" in md
+    assert "78,107 lines across 427 source files" in md
+    assert "| **Test functions** | 1465 |" in md
+    assert "| **API route modules** | 51 |" in md
+    assert "| **Service modules** | 143 |" in md
+    assert "| **Database models** | 42 |" in md
+    assert "| **Database migrations** | 74 |" in md
+    assert "| **Frontend pages** | 31 |" in md
+    assert "| **CI/CD workflows** | 7 |" in md
+
+
+def test_render_project_stats_block_includes_measured_date():
+    md = grs.render_project_stats_block(_stub_stats(), measured="2026-05-06")
+    assert "Last measured 2026-05-06" in md
+
+
+def test_render_test_count():
+    assert grs.render_test_count(_stub_stats()) == "1465 tests"
+
+
+def test_render_test_files():
+    assert grs.render_test_files(_stub_stats()) == "166 test files"

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -164,3 +164,86 @@ def test_count_test_functions_resolves_relative_against_ROOT(tmp_path, monkeypat
     other.mkdir()
     monkeypatch.chdir(other)
     assert grs.count_test_functions([Path("test_x.py")]) == 1
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """Create a fixture file tree mimicking BaluHost layout."""
+    tree = {
+        "backend/app/main.py": "x = 1\n",
+        "backend/app/api/routes/auth.py": "def f():\n    pass\n",
+        "backend/app/api/routes/files.py": "def g():\n    pass\n",
+        "backend/app/api/routes/__init__.py": "",
+        "backend/app/services/auth.py": "def h():\n    pass\n",
+        "backend/app/services/files/upload.py": "def i():\n    pass\n",
+        "backend/app/services/__init__.py": "",
+        "backend/app/services/files/__init__.py": "",
+        "backend/app/models/user.py": "class User: ...\n",
+        "backend/app/models/__init__.py": "",
+        "backend/tests/test_one.py": "def test_a():\n    pass\n",
+        "backend/tests/test_two.py": "def test_b():\n    pass\n\ndef test_c():\n    pass\n",
+        "backend/scripts/foo.py": "print('hi')\n",
+        "backend/alembic/versions/0001_init.py": "# rev\n",
+        "backend/alembic/versions/0002_add.py": "# rev\n",
+        "backend/baluhost_tui/main.py": "pass\n",
+        "client/src/App.tsx": "export const X = 1;\n",
+        "client/src/pages/Dashboard.tsx": "export default 1;\n",
+        "client/src/pages/Settings.tsx": "export default 2;\n",
+        "client/src/lib/api.ts": "export {};\n",
+        "client/src/styles.css": "body{}\n",
+        ".github/workflows/ci.yml": "name: ci\n",
+        ".github/workflows/release.yml": "name: rel\n",
+    }
+    for rel, content in tree.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    return tmp_path
+
+
+def test_compute_stats_counts_match_fixture(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr(grs, "ROOT", repo)
+    files = [Path(rel) for rel in [
+        "backend/app/main.py",
+        "backend/app/api/routes/auth.py",
+        "backend/app/api/routes/files.py",
+        "backend/app/api/routes/__init__.py",
+        "backend/app/services/auth.py",
+        "backend/app/services/files/upload.py",
+        "backend/app/services/__init__.py",
+        "backend/app/services/files/__init__.py",
+        "backend/app/models/user.py",
+        "backend/app/models/__init__.py",
+        "backend/tests/test_one.py",
+        "backend/tests/test_two.py",
+        "backend/scripts/foo.py",
+        "backend/alembic/versions/0001_init.py",
+        "backend/alembic/versions/0002_add.py",
+        "backend/baluhost_tui/main.py",
+        "client/src/App.tsx",
+        "client/src/pages/Dashboard.tsx",
+        "client/src/pages/Settings.tsx",
+        "client/src/lib/api.ts",
+        "client/src/styles.css",
+        ".github/workflows/ci.yml",
+        ".github/workflows/release.yml",
+    ]]
+
+    s = grs.compute_stats(files)
+
+    assert s.api_route_modules == 2  # __init__ excluded
+    assert s.service_modules == 2    # __init__ excluded, both auth.py + upload.py
+    assert s.db_models == 1          # __init__ excluded
+    assert s.db_migrations == 2
+    assert s.frontend_pages == 2
+    assert s.workflows == 2
+    assert s.test_functions == 3     # 1 + 2
+
+    assert s.backend_app.files == 10  # all .py under backend/app/
+    assert s.backend_tests.files == 2
+    assert s.backend_scripts.files == 1
+    assert s.backend_alembic.files == 2
+    assert s.backend_tui.files == 1
+    assert s.backend_total.files == 16  # sum of subdirs
+
+    assert s.frontend.files == 5  # .tsx, .ts, .css under client/src/

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -342,3 +342,19 @@ def test_replace_between_markers_missing_raises():
         assert "MISSING" in str(e)
     else:
         raise AssertionError("expected ValueError")
+
+
+def test_replace_between_markers_normalizes_crlf():
+    """Windows-checked-out READMEs may have CRLF; the splice must still work."""
+    text = (
+        "intro\r\n"
+        "<!-- STATS:X:START -->\r\n"
+        "old\r\n"
+        "<!-- STATS:X:END -->\r\n"
+        "outro\r\n"
+    )
+    out = grs.replace_between_markers(text, "X", "NEW")
+    assert "<!-- STATS:X:START -->\nNEW\n<!-- STATS:X:END -->" in out
+    assert "old" not in out
+    # Output is normalized to LF
+    assert "\r\n" not in out

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -358,3 +358,34 @@ def test_replace_between_markers_normalizes_crlf():
     assert "old" not in out
     # Output is normalized to LF
     assert "\r\n" not in out
+
+
+def test_apply_to_text_replaces_three_marker_pairs():
+    template = (
+        "before\n"
+        "<!-- STATS:PROJECT:START -->\n"
+        "OLD TABLE\n"
+        "<!-- STATS:PROJECT:END -->\n"
+        "row | <!-- STATS:TEST_COUNT:START -->old<!-- STATS:TEST_COUNT:END --> | "
+        "<!-- STATS:TEST_FILES:START -->old<!-- STATS:TEST_FILES:END -->,\n"
+        "after\n"
+    )
+    s = _stub_stats()
+    out = grs.apply_to_text(template, s, measured="2026-05-06")
+
+    assert "OLD TABLE" not in out
+    assert "150,685 lines across 735" in out
+    assert "1465 tests" in out
+    assert "166 test files" in out
+    assert "Last measured 2026-05-06" in out
+
+
+def test_apply_to_text_idempotent():
+    template = (
+        "<!-- STATS:PROJECT:START -->\nx\n<!-- STATS:PROJECT:END -->\n"
+        "<!-- STATS:TEST_COUNT:START -->x<!-- STATS:TEST_COUNT:END -->\n"
+        "<!-- STATS:TEST_FILES:START -->x<!-- STATS:TEST_FILES:END -->\n"
+    )
+    once = grs.apply_to_text(template, _stub_stats(), measured="2026-05-06")
+    twice = grs.apply_to_text(once, _stub_stats(), measured="2026-05-06")
+    assert once == twice

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -1,0 +1,8 @@
+"""Tests for scripts/generate_readme_stats.py — stdlib + pytest only."""
+from __future__ import annotations
+
+import generate_readme_stats as grs
+
+
+def test_module_imports():
+    assert hasattr(grs, "main")

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -6,3 +6,33 @@ import generate_readme_stats as grs
 
 def test_module_imports():
     assert hasattr(grs, "main")
+
+
+def test_count_lines_simple(tmp_path):
+    f = tmp_path / "a.py"
+    f.write_text("a\nb\nc\n", encoding="utf-8")
+    assert grs.count_lines([f]) == 3
+
+
+def test_count_lines_no_trailing_newline(tmp_path):
+    f = tmp_path / "a.py"
+    f.write_text("a\nb\nc", encoding="utf-8")  # no final \n
+    # Newline count: \n appears twice → 3 lines logically. We define count as
+    # number of \n bytes, matching `wc -l` semantics (which under-counts the
+    # last unterminated line). Document this in the test.
+    assert grs.count_lines([f]) == 2
+
+
+def test_count_lines_handles_binary_and_missing(tmp_path):
+    binary = tmp_path / "blob.bin"
+    binary.write_bytes(b"\x00\x01\n\x02")  # 1 newline byte
+    missing = tmp_path / "does-not-exist.py"
+    assert grs.count_lines([binary, missing]) == 1
+
+
+def test_count_lines_multiple_files(tmp_path):
+    a = tmp_path / "a.py"
+    a.write_text("x\ny\n", encoding="utf-8")
+    b = tmp_path / "b.py"
+    b.write_text("p\nq\nr\n", encoding="utf-8")
+    assert grs.count_lines([a, b]) == 5

--- a/scripts/test_generate_readme_stats.py
+++ b/scripts/test_generate_readme_stats.py
@@ -1,6 +1,7 @@
 """Tests for scripts/generate_readme_stats.py — stdlib + pytest only."""
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import generate_readme_stats as grs
@@ -389,3 +390,41 @@ def test_apply_to_text_idempotent():
     once = grs.apply_to_text(template, _stub_stats(), measured="2026-05-06")
     twice = grs.apply_to_text(once, _stub_stats(), measured="2026-05-06")
     assert once == twice
+
+
+def test_main_check_mode_handles_crlf_readme(tmp_path, monkeypatch, capsys):
+    """--check must not report drift just because README on disk has CRLF."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Build a stable README with markers, render once, write back as CRLF.
+    template = (
+        "before\n"
+        "<!-- STATS:PROJECT:START -->\n"
+        "old\n"
+        "<!-- STATS:PROJECT:END -->\n"
+        "row | <!-- STATS:TEST_COUNT:START -->old<!-- STATS:TEST_COUNT:END --> | "
+        "<!-- STATS:TEST_FILES:START -->old<!-- STATS:TEST_FILES:END -->,\n"
+        "after\n"
+    )
+    stats = _stub_stats()
+    populated = grs.apply_to_text(template, stats, measured="2026-05-06")
+
+    readme = repo / "README.md"
+    readme.write_bytes(populated.replace("\n", "\r\n").encode("utf-8"))
+
+    monkeypatch.setattr(grs, "README", readme)
+    monkeypatch.setattr(grs, "tracked_files", lambda: [])
+    monkeypatch.setattr(grs, "compute_stats", lambda files: stats)
+    monkeypatch.setattr(grs, "apply_to_text", lambda text, s: grs.replace_between_markers(
+        grs.replace_between_markers(
+            grs.replace_between_markers(
+                text, "PROJECT", grs.render_project_stats_block(s, measured="2026-05-06")
+            ),
+            "TEST_COUNT", grs.render_test_count(s), inline=True,
+        ),
+        "TEST_FILES", grs.render_test_files(s), inline=True,
+    ))
+
+    monkeypatch.setattr(sys, "argv", ["generate_readme_stats.py", "--check"])
+    rc = grs.main()
+    assert rc == 0, capsys.readouterr()


### PR DESCRIPTION
## Summary
- New `scripts/generate_readme_stats.py` (stdlib-only) computes Project Stats from `git ls-files` — no third-party deps, gitignored files automatically excluded.
- README now has three marker pairs; the script splices the rendered table + the inline `Testing` row counts via `--write` (or fails `--check` on drift).
- Wired into `.github/workflows/auto-merge.yml`: stats refresh in the **same commit** that bumps the version on every release-labeled PR merge to `main`. No separate auto-commit, no extra noise.
- Architecture tree in README stripped of inline counts (`51 API route modules`, `143 service modules`, etc.) → single source of truth lives in the Project Stats table.

Plan: [`docs/superpowers/plans/2026-05-06-readme-stats-automation.md`](docs/superpowers/plans/2026-05-06-readme-stats-automation.md).

## What gets counted
Backend + frontend LOC and file counts (split per subdir), test functions (AST walk over tracked test files), API routes / services / models / migrations / pages / workflows. Only files reported by `git ls-files` — `.gitignore`, `node_modules/`, `.venv/`, `dev-storage/` are excluded for free.

## Test plan
- [x] 33 unit tests in `scripts/test_generate_readme_stats.py` cover each helper, marker splice, idempotence, CWD-independence, CRLF normalization, missing-marker error path, and `main` exit codes
- [x] `python scripts/generate_readme_stats.py --check` returns 0 on this branch
- [x] `python scripts/generate_readme_stats.py --write` is idempotent (running twice produces an empty diff)
- [ ] On the next release: verify the auto-merge step's "Bump version from release label" produces a single commit that updates `pyproject.toml`, `package.json`, `CLAUDE.md`, **and** `README.md`
- [ ] Confirm "Last measured" date in the rendered table flips to the release date

## Notes
- Heads-up: `tests/api/test_gpu_power_routes.py::test_put_config_admin_succeeds` currently fails on `main` (422 vs 200, schema validation) — not introduced by this PR (zero `backend/` changes here), but CI will likely fail until that test is addressed.
- Repo runs with `core.autocrlf=true` on Windows; the script normalizes CRLF→LF defensively in two places (`replace_between_markers` and `main`'s equality check) so local devs don't trigger phantom rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)