### PR TITLE
fix(gpu-power): publish capabilities for followers + unblock body routes

### DIFF
--- a/backend/alembic/versions/gpu_caps_mw_2026_05_06.py
+++ b/backend/alembic/versions/gpu_caps_mw_2026_05_06.py
@@ -1,0 +1,53 @@
+"""add capabilities_json to gpu_power_runtime_state
+
+Revision ID: gpu_caps_mw_2026_05_06
+Revises: gpu_power_mw_2026_05_03
+Create Date: 2026-05-06
+
+Adds the ``capabilities_json`` column to ``gpu_power_runtime_state`` so the
+primary worker can publish hardware-reported GPU capabilities for followers
+to read. Without this, ``GpuPowerManagerService.get_capabilities()`` on a
+secondary worker returns ``vendor=None`` because its ``_backend`` is ``None``,
+and the UI's Hardware Overrides section flickers between "AMD detected" and
+"no GPU detected" depending on which worker handled the request.
+
+NB: revision ID kept short (22 chars). ``alembic_version.version_num`` is
+VARCHAR(32) and an earlier migration in this series (originally
+``2026_05_03_gpu_power_multi_worker``, 34 chars) failed in prod with
+``StringDataRightTruncation``.
+
+See docs/superpowers/plans/2026-05-02-gpu-power-manager-multi-worker-fix.md
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'gpu_caps_mw_2026_05_06'
+down_revision: Union[str, Sequence[str], None] = 'gpu_power_mw_2026_05_03'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _column_exists(bind, table: str, column: str) -> bool:
+    insp = sa.inspect(bind)
+    if not insp.has_table(table):
+        return False
+    return any(c["name"] == column for c in insp.get_columns(table))
+
+
+def upgrade() -> None:
+    """Idempotent: skip if the column already exists from a prior partial run."""
+    bind = op.get_bind()
+    if not _column_exists(bind, 'gpu_power_runtime_state', 'capabilities_json'):
+        op.add_column(
+            'gpu_power_runtime_state',
+            sa.Column('capabilities_json', sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if _column_exists(bind, 'gpu_power_runtime_state', 'capabilities_json'):
+        op.drop_column('gpu_power_runtime_state', 'capabilities_json')

--- a/backend/app/api/routes/gpu_power.py
+++ b/backend/app/api/routes/gpu_power.py
@@ -1,6 +1,9 @@
 """GPU power management API routes."""
-from __future__ import annotations
-
+# NB: do not add ``from __future__ import annotations`` here. Combined with
+# Pydantic v2 + FastAPI's body detection through slowapi's ``@limiter.limit``
+# wrapper, deferred annotations turn body params into ForwardRefs that
+# FastAPI can no longer resolve as Pydantic models — the request body would
+# be misinterpreted as a query parameter and every PUT/POST returns 422.
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
 from app.api import deps

--- a/backend/app/models/gpu_power.py
+++ b/backend/app/models/gpu_power.py
@@ -77,6 +77,7 @@ class GpuPowerRuntimeState(Base):
         DateTime(timezone=True), nullable=True
     )
     last_reason: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    capabilities_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/backend/app/services/power/gpu/manager.py
+++ b/backend/app/services/power/gpu/manager.py
@@ -145,11 +145,22 @@ class GpuPowerManagerService:
             has_write = await self._backend.has_write_permission() if self._backend else False
         except Exception:
             has_write = False
+
+        # Serialize hardware capabilities so followers can answer
+        # /api/gpu-power/capabilities without their own backend instance.
+        capabilities_json: Optional[str] = None
+        if self._backend is not None and self._backend.detected:
+            try:
+                capabilities_json = self._backend.capabilities().model_dump_json()
+            except Exception as exc:
+                logger.warning("Could not serialize GPU capabilities: %s", exc)
+
         update_runtime_state(
             current_state=self._state.value,
             detected=bool(self._backend.detected) if self._backend else False,
             vendor=self._backend.vendor if (self._backend and self._backend.detected) else None,
             has_write_permission=bool(has_write),
+            capabilities_json=capabilities_json,
         )
 
         self._monitor_task = asyncio.create_task(self._monitor_loop())
@@ -510,9 +521,20 @@ class GpuPowerManagerService:
         return True, None
 
     def get_capabilities(self) -> GpuPowerCapabilities:
-        if self._backend is None:
-            return GpuPowerCapabilities(vendor=None)
-        return self._backend.capabilities()
+        # Primary worker has the live backend; ask it directly.
+        if self._primary and self._backend is not None:
+            return self._backend.capabilities()
+        # Follower: read what the primary published to the runtime-state row.
+        # Without this, every request landing on a secondary worker reports
+        # vendor=None — and the UI's Hardware Overrides section flips between
+        # "AMD detected" and "no GPU detected" round-robin across workers.
+        raw = load_runtime_state().get("capabilities_json")
+        if raw:
+            try:
+                return GpuPowerCapabilities.model_validate_json(raw)
+            except Exception as exc:
+                logger.warning("Could not parse stored GPU capabilities: %s", exc)
+        return GpuPowerCapabilities(vendor=None)
 
     def get_history(self, limit: int = 100) -> Tuple[List[GpuPowerHistoryEntry], int]:
         try:

--- a/backend/app/services/power/gpu/runtime_state_store.py
+++ b/backend/app/services/power/gpu/runtime_state_store.py
@@ -30,8 +30,8 @@ def load_runtime_state() -> dict[str, Any]:
     Load the singleton ``gpu_power_runtime_state`` row.
 
     Returns a dict with keys: current_state, detected, vendor,
-    has_write_permission, last_transition, last_reason. Falls back to
-    safe defaults if the row is missing.
+    has_write_permission, last_transition, last_reason, capabilities_json.
+    Falls back to safe defaults if the row is missing.
     """
     defaults: dict[str, Any] = {
         "current_state": "active",
@@ -40,6 +40,7 @@ def load_runtime_state() -> dict[str, Any]:
         "has_write_permission": False,
         "last_transition": None,
         "last_reason": None,
+        "capabilities_json": None,
     }
     try:
         db = SessionLocal()
@@ -54,6 +55,7 @@ def load_runtime_state() -> dict[str, Any]:
                 "has_write_permission": bool(row.has_write_permission),
                 "last_transition": row.last_transition,
                 "last_reason": row.last_reason,
+                "capabilities_json": row.capabilities_json,
             }
         finally:
             db.close()

--- a/backend/tests/services/power/gpu/test_manager_multi_worker.py
+++ b/backend/tests/services/power/gpu/test_manager_multi_worker.py
@@ -29,8 +29,15 @@ def _gpu_power_tables_in_global_db():
     ]
     inspector = inspect(engine)
     for table in tables:
-        if not inspector.has_table(table.name):
-            table.create(bind=engine, checkfirst=True)
+        # Drop tables whose schema is out of sync with the model so a stale
+        # dev DB (e.g. left over from before a column was added) is upgraded
+        # transparently for the test run.
+        if inspector.has_table(table.name):
+            existing_cols = {c["name"] for c in inspector.get_columns(table.name)}
+            expected_cols = {col.name for col in table.columns}
+            if expected_cols - existing_cols:
+                table.drop(bind=engine, checkfirst=True)
+        table.create(bind=engine, checkfirst=True)
 
     Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     db = Session()
@@ -147,6 +154,37 @@ class TestFollowerRouting:
         assert status.vendor == "amd"
         assert status.has_write_permission is True
         assert status.current_state == GpuPowerState.ACTIVE
+
+    def test_follower_get_capabilities_reads_from_runtime_state(self):
+        """A follower's get_capabilities must reflect the primary's published caps.
+
+        Without this, the Hardware Overrides section in the UI flickers between
+        the primary's correct answer and the followers' "no GPU detected" empty
+        capabilities, depending on which Uvicorn worker handled the request.
+        """
+        from app.schemas.gpu_power import GpuPowerCapabilities
+        from app.services.power.gpu.runtime_state_store import update_runtime_state
+
+        published = GpuPowerCapabilities(
+            vendor="amd",
+            amd_performance_levels=["auto", "low", "high"],
+            amd_profile_modes=["BOOTUP_DEFAULT", "POWER_SAVING"],
+        )
+        update_runtime_state(
+            detected=True,
+            vendor="amd",
+            capabilities_json=published.model_dump_json(),
+        )
+
+        follower = GpuPowerManagerService()
+        follower._is_running = True
+        follower._primary = False
+        follower._backend = None
+
+        caps = follower.get_capabilities()
+        assert caps.vendor == "amd"
+        assert caps.amd_performance_levels == ["auto", "low", "high"]
+        assert caps.amd_profile_modes == ["BOOTUP_DEFAULT", "POWER_SAVING"]
 
 
 class TestPrimaryDemandPath:


### PR DESCRIPTION
## Summary

Two production bugs in `/api/gpu-power/*` that both manifested as flickering UI on multi-worker prod (4 Uvicorn workers).

- **Bug 1 — \"no GPU detected\" 3-of-4 times**: `GpuPowerManagerService.get_capabilities()` was not primary/follower-aware. Followers had `_backend=None`, so they always returned `vendor=None`. The Hardware Overrides section in PowerManagement rendered \"no GPU detected\" round-robin across workers. Fixed by serializing the primary's capabilities into a new `gpu_power_runtime_state.capabilities_json` column during `start()` and deserializing on followers — same pattern as the existing `detected`/`vendor`/`has_write_permission` fields.
- **Bug 2 — `PUT /config` and `POST /demand` always 422**: `from __future__ import annotations` in `routes/gpu_power.py` defers type resolution. Combined with Pydantic v2 and slowapi's `@limiter.limit` wrapper, FastAPI no longer recognized body params as `BaseModel` and parsed them as query params (`loc: [\"query\", \"body\"]`). Removed the future-import with a comment explaining why it must not come back.

## Migration

`gpu_caps_mw_2026_05_06` adds `gpu_power_runtime_state.capabilities_json` (TEXT, nullable). Idempotent, short revision ID (22 chars) per the prior truncation lesson documented in `gpu_power_mw_2026_05_03`.

## Test plan

- [x] `pytest tests/services/power/gpu/` → 68 passed
- [x] `pytest tests/api/test_gpu_power_routes.py` → 11 passed (was 8 passed / 3 failed on main)
- [x] New test `test_follower_get_capabilities_reads_from_runtime_state` confirms follower deserializes capabilities from the DB row
- [ ] Manual prod verification (after deploy): Hardware Overrides section stays on \"AMD detected\" across 10 consecutive page reloads
- [ ] Manual prod verification: `PUT /api/gpu-power/config` from the UI saves successfully (200 instead of 422)

🤖 Generated with [Claude Code](https://claude.com/claude-code)