### PR TITLE
docs(rules): retire development branch from git workflow rule

### DIFF
--- a/.claude/rules/production.md
+++ b/.claude/rules/production.md
@@ -58,5 +58,5 @@ python kill_prod.py     # Stop all BaluHost processes
 ## Git Workflow
 
 - **Main branch**: `main` (production deployments)
-- **Development branch**: `development` (active development)
-- Features branch off from `development`, PRs merge to `main`
+- Feature/fix branches branch off from `main` and PR directly back into `main`. Merging the PR creates a Pre-Release tag and deploys to production. Stable releases are cut by the manual `release-stable.yml` workflow_dispatch.
+- The `development` branch was retired 2026-05-06; do not push to it or target it as a PR base.


### PR DESCRIPTION
## Summary

`.claude/rules/production.md` still instructed contributors to branch off `development` and PR into `main`. The `development` branch is retired — feature/fix branches now PR directly to `main` and merging triggers the Pre-Release tag/deploy.

## Changes

- Replaced the three-line \"Git Workflow\" section with the new flow.
- Documented the retirement date so the reason is discoverable in the future.

## Notes

- Local `development` was deleted 2026-05-06.
- Remote `origin/development` deletion is blocked by a GitHub repository rule (branch protection / deletion rule). It can stay until the rule is updated; nothing should target it.

## Test plan

- [x] No code change — docs only.
- [x] `production.md` rendered manually to verify the section is coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)