### PR TITLE
fix(alembic): re-parent always_awake migration onto gpu_caps head

### DIFF
--- a/backend/alembic/versions/d45e605bfc4d_add_always_awake_to_sleep_config.py
+++ b/backend/alembic/versions/d45e605bfc4d_add_always_awake_to_sleep_config.py
@@ -1,7 +1,7 @@
 """add always_awake to sleep_config
 
 Revision ID: d45e605bfc4d
-Revises: gpu_power_mw_2026_05_03
+Revises: gpu_caps_mw_2026_05_06
 Create Date: 2026-05-07 22:07:28.588818
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = 'd45e605bfc4d'
-down_revision: Union[str, Sequence[str], None] = 'gpu_power_mw_2026_05_03'
+down_revision: Union[str, Sequence[str], None] = 'gpu_caps_mw_2026_05_06'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
Production deploy of #78 failed with **Multiple head revisions are present**, auto-rolled back to commit 4a5f8ae. Both `d45e605bfc4d` (always_awake) and `gpu_caps_mw_2026_05_06` were parented on `gpu_power_mw_2026_05_03` because PR #78 missed the rebase after `gpu_caps` landed on 2026-05-06.

This PR re-parents `d45e605bfc4d` onto `gpu_caps_mw_2026_05_06` for a single, linear head.

## Why re-parent (not merge revision)
- The two migrations touch unrelated tables (`sleep_config` vs `gpu_power_runtime_state`) — no ordering constraint.
- `d45e605bfc4d` had never been applied to a real database (PR tests use `Base.metadata.create_all`, not alembic).
- Linear history avoids the merge-revision noise.

## Verification
- ` python -m alembic heads ` → single head `d45e605bfc4d`
- ` python -m alembic history --rev-range gpu_power_mw_2026_05_03:d45e605bfc4d ` → clean linear chain
- 83 sleep-related tests green locally

## Failed deploy reference
- https://github.com/Xveyn/BaluHost/actions/runs/25568920136

🤖 Generated with [Claude Code](https://claude.com/claude-code)