### PR TITLE
feat(sleep): OS-Sleep banner + always-awake custom datetime (7d)

### DIFF
--- a/backend/app/api/routes/sleep.py
+++ b/backend/app/api/routes/sleep.py
@@ -35,6 +35,8 @@ from app.schemas.sleep import (
 )
 from app.models.sleep import CoreUptimeWindow as CoreUptimeWindowModel
 from app.services.power.sleep import get_sleep_manager
+from app.services.power import os_sleep_inspector
+from app.schemas.sleep import OsSleepReportResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -239,6 +241,29 @@ async def get_sleep_capabilities(
     """Check system capabilities for sleep features (admin only)."""
     manager = _get_manager()
     return await manager.get_capabilities()
+
+
+@router.get("/os-settings", response_model=OsSleepReportResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def get_os_sleep_settings(
+    request: Request, response: Response,
+    force: bool = False,
+    current_user: User = Depends(get_current_admin),
+) -> OsSleepReportResponse:
+    """Read-only snapshot of OS-level sleep configuration (admin only)."""
+    report = os_sleep_inspector.inspect_os_sleep(force_refresh=force)
+    return OsSleepReportResponse(
+        platform_supported=report.platform_supported,
+        logind=report.logind,
+        sleep_conf=report.sleep_conf,
+        targets=report.targets,
+        issues=[
+            {"severity": i.severity, "key": i.key, "message": i.message, "detail": i.detail}
+            for i in report.issues
+        ],
+        sources=report.sources,
+        collected_at=report.collected_at,
+    )
 
 
 @router.get("/my-permissions", response_model=MyPowerPermissionsResponse)

--- a/backend/app/schemas/sleep.py
+++ b/backend/app/schemas/sleep.py
@@ -4,12 +4,14 @@ Pydantic schemas for Sleep Mode feature.
 Defines the state machine, request/response models, and configuration
 for the two-stage sleep system (Soft Sleep + True Suspend).
 """
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 from app.schemas.validators import validate_mac_address
+
+_MAX_ALWAYS_AWAKE_HORIZON = timedelta(days=7)
 
 
 class SleepState(str, Enum):
@@ -82,6 +84,29 @@ class AlwaysAwakeStatus(BaseModel):
     expires_in_seconds: Optional[float] = Field(
         default=None, description="Seconds until expiry (for live UI countdown)"
     )
+
+
+# ---------------------------------------------------------------------------
+# OS Sleep Inspector
+# ---------------------------------------------------------------------------
+
+class OsSleepIssueModel(BaseModel):
+    """One issue surfaced by the OS sleep inspector."""
+    severity: Literal["info", "warning", "error"]
+    key: str = Field(..., description="Stable identifier, used for i18n lookup")
+    message: str = Field(..., description="Fallback human-readable message")
+    detail: Optional[str] = Field(default=None)
+
+
+class OsSleepReportResponse(BaseModel):
+    """Snapshot of OS sleep configuration (read-only)."""
+    platform_supported: bool = Field(..., description="False on Windows / when /etc/systemd is missing")
+    logind: dict[str, str] = Field(default_factory=dict)
+    sleep_conf: dict[str, str] = Field(default_factory=dict)
+    targets: dict[str, str] = Field(default_factory=dict)
+    issues: list[OsSleepIssueModel] = Field(default_factory=list)
+    sources: list[str] = Field(default_factory=list)
+    collected_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class SleepStatusResponse(BaseModel):
@@ -198,9 +223,13 @@ class SleepConfigUpdate(BaseModel):
         # Normalize naive datetimes to UTC
         if v.tzinfo is None:
             v = v.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
         # Reject "now" as well: a non-future timestamp is meaningless for an override
-        if v <= datetime.now(timezone.utc):
+        if v <= now:
             raise ValueError("always_awake_until must be in the future (UTC)")
+        # Reject far-future values: max 7 days horizon
+        if v > now + _MAX_ALWAYS_AWAKE_HORIZON:
+            raise ValueError("always_awake_until must be at most 7 days in the future")
         return v
 
     @field_validator("wol_mac_address", mode="before")

--- a/backend/app/services/power/os_sleep_inspector.py
+++ b/backend/app/services/power/os_sleep_inspector.py
@@ -219,11 +219,98 @@ def _classify(
 
 
 # ---------------------------------------------------------------------------
-# Public entry point — minimal version for Task 1
-# Full implementation lands in Task 3.
+# Subprocess helpers
+# ---------------------------------------------------------------------------
+def _systemctl_is_enabled(target_names: tuple[str, ...]) -> dict[str, str]:
+    """
+    Run `systemctl is-enabled <name1> <name2> …`. Returns a {name: status} dict.
+    On any failure (FileNotFoundError, TimeoutExpired, non-zero exit) returns {}.
+    """
+    try:
+        proc = subprocess.run(
+            ["systemctl", "is-enabled", *target_names],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.warning("systemctl is-enabled failed: %s", exc)
+        return {}
+    lines = [ln.strip() for ln in proc.stdout.splitlines() if ln.strip()]
+    if len(lines) != len(target_names):
+        logger.warning(
+            "Unexpected systemctl line count: got %d, expected %d",
+            len(lines), len(target_names),
+        )
+    return {name: status for name, status in zip(target_names, lines)}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
 # ---------------------------------------------------------------------------
 def inspect_os_sleep(force_refresh: bool = False) -> OsSleepReport:
+    """
+    Inspect OS sleep settings. Returns a report suitable for read-only display.
+    Cached for 60s; pass force_refresh=True to bypass.
+    """
     if sys.platform != "linux" or not _SYSTEMD_DIR.is_dir():
         return OsSleepReport(platform_supported=False)
-    # Real implementation arrives in Task 3.
-    return OsSleepReport(platform_supported=True)
+
+    if not force_refresh:
+        cached = _cache_get()
+        if cached is not None:
+            return cached
+
+    try:
+        sources: list[str] = []
+
+        logind: dict[str, str] = _parse_systemd_ini(_LOGIND_CONF, section="Login")
+        if _LOGIND_CONF.is_file():
+            sources.append(str(_LOGIND_CONF))
+        for d in _LOGIND_DROPIN_DIRS:
+            if d.is_dir():
+                logind = _merge_drop_ins(logind, d, section="Login")
+                for f in sorted(d.glob("*.conf")):
+                    if f.is_file():
+                        sources.append(str(f))
+
+        sleep_conf: dict[str, str] = _parse_systemd_ini(_SLEEP_CONF, section="Sleep")
+        if _SLEEP_CONF.is_file():
+            sources.append(str(_SLEEP_CONF))
+        for d in _SLEEP_DROPIN_DIRS:
+            if d.is_dir():
+                sleep_conf = _merge_drop_ins(sleep_conf, d, section="Sleep")
+                for f in sorted(d.glob("*.conf")):
+                    if f.is_file():
+                        sources.append(str(f))
+
+        targets = _systemctl_is_enabled(_TARGET_NAMES)
+        has_lid = _LID_SENSOR.is_dir()
+
+        issues = _classify(
+            logind=logind, sleep_conf=sleep_conf, targets=targets, has_lid=has_lid,
+        )
+
+        report = OsSleepReport(
+            platform_supported=True,
+            logind=logind,
+            sleep_conf=sleep_conf,
+            targets=targets,
+            issues=issues,
+            sources=sources,
+        )
+    except Exception as exc:
+        logger.exception("os_sleep_inspector failed: %s", exc)
+        report = OsSleepReport(
+            platform_supported=True,
+            issues=[OsSleepIssue(
+                severity="error",
+                key="inspector.failed",
+                message="OS-Sleep-Detection fehlgeschlagen",
+                detail=str(exc),
+            )],
+        )
+
+    _cache_put(report)
+    return report

--- a/backend/app/services/power/os_sleep_inspector.py
+++ b/backend/app/services/power/os_sleep_inspector.py
@@ -239,10 +239,14 @@ def _systemctl_is_enabled(target_names: tuple[str, ...]) -> dict[str, str]:
         return {}
     lines = [ln.strip() for ln in proc.stdout.splitlines() if ln.strip()]
     if len(lines) != len(target_names):
+        # Positional zip would silently misalign names → statuses (e.g. masking
+        # a real "suspend.target=masked" by mapping it to "hibernate.target").
+        # Drop the whole result rather than report half-truths.
         logger.warning(
-            "Unexpected systemctl line count: got %d, expected %d",
+            "Unexpected systemctl line count: got %d, expected %d — discarding result",
             len(lines), len(target_names),
         )
+        return {}
     return {name: status for name, status in zip(target_names, lines)}
 
 

--- a/backend/app/services/power/os_sleep_inspector.py
+++ b/backend/app/services/power/os_sleep_inspector.py
@@ -158,6 +158,67 @@ def _merge_drop_ins(base: dict[str, str], drop_in_dir: Path, section: str) -> di
 
 
 # ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+_IDLE_ACTION_KEYS = {
+    "suspend": "logind.idle_action.suspend",
+    "hibernate": "logind.idle_action.hibernate",
+    "hybrid-sleep": "logind.idle_action.hybrid_sleep",
+}
+_LID_KEYS = {
+    "suspend": "logind.lid_switch.suspend",
+    "hibernate": "logind.lid_switch.hibernate",
+}
+
+
+def _classify(
+    *,
+    logind: dict[str, str],
+    sleep_conf: dict[str, str],
+    targets: dict[str, str],
+    has_lid: bool,
+) -> list[OsSleepIssue]:
+    issues: list[OsSleepIssue] = []
+
+    idle_action = logind.get("IdleAction", "").strip().lower()
+    if idle_action in _IDLE_ACTION_KEYS:
+        idle_after = logind.get("IdleActionSec", "").strip() or None
+        issues.append(OsSleepIssue(
+            severity="warning",
+            key=_IDLE_ACTION_KEYS[idle_action],
+            message=f"logind: IdleAction={idle_action} (außerhalb von BaluHost)",
+            detail=(f"Wird nach {idle_after} Idle ausgelöst" if idle_after else None),
+        ))
+
+    lid_switch = logind.get("HandleLidSwitch", "").strip().lower()
+    if has_lid and lid_switch in _LID_KEYS:
+        issues.append(OsSleepIssue(
+            severity="info",
+            key=_LID_KEYS[lid_switch],
+            message=f"logind: HandleLidSwitch={lid_switch}",
+            detail="Lid-Sensor erkannt — manueller Deckel-Schluss löst OS-Sleep aus",
+        ))
+
+    if sleep_conf.get("AllowSuspend", "").strip().lower() == "no":
+        issues.append(OsSleepIssue(
+            severity="info",
+            key="sleep_conf.suspend_disabled",
+            message="OS hat Suspend deaktiviert (AllowSuspend=no)",
+            detail="BaluHost-Suspend wird fehlschlagen, solange diese Einstellung aktiv ist",
+        ))
+
+    if targets.get("suspend.target") == "masked":
+        issues.append(OsSleepIssue(
+            severity="error",
+            key="targets.suspend.masked",
+            message="suspend.target ist maskiert",
+            detail="BaluHost kann das System nicht in Suspend versetzen",
+        ))
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
 # Public entry point — minimal version for Task 1
 # Full implementation lands in Task 3.
 # ---------------------------------------------------------------------------

--- a/backend/app/services/power/os_sleep_inspector.py
+++ b/backend/app/services/power/os_sleep_inspector.py
@@ -1,0 +1,168 @@
+"""
+OS sleep settings inspector.
+
+Read-only inspection of systemd's logind/sleep configuration plus
+sleep-related target enablement, classified into severity-tagged issues
+for display on the Sleep page banner.
+
+No subprocess sudo, no writes — purely defensive observation.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from time import monotonic
+from typing import Literal, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants — overridable in tests via monkeypatch
+# ---------------------------------------------------------------------------
+_SYSTEMD_DIR = Path("/etc/systemd")
+
+_LOGIND_CONF = Path("/etc/systemd/logind.conf")
+_LOGIND_DROPIN_DIRS = (
+    Path("/etc/systemd/logind.conf.d"),
+    Path("/run/systemd/logind.conf.d"),
+)
+_SLEEP_CONF = Path("/etc/systemd/sleep.conf")
+_SLEEP_DROPIN_DIRS = (
+    Path("/etc/systemd/sleep.conf.d"),
+    Path("/run/systemd/sleep.conf.d"),
+)
+_TARGET_NAMES = (
+    "sleep.target",
+    "suspend.target",
+    "hibernate.target",
+    "hybrid-sleep.target",
+    "suspend-then-hibernate.target",
+)
+_LID_SENSOR = Path("/proc/acpi/button/lid")
+
+_CACHE_TTL_SECONDS = 60.0
+_SUBPROCESS_TIMEOUT_SECONDS = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+Severity = Literal["info", "warning", "error"]
+
+
+@dataclass(frozen=True)
+class OsSleepIssue:
+    severity: Severity
+    key: str
+    message: str
+    detail: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class OsSleepReport:
+    platform_supported: bool
+    logind: dict[str, str] = field(default_factory=dict)
+    sleep_conf: dict[str, str] = field(default_factory=dict)
+    targets: dict[str, str] = field(default_factory=dict)
+    issues: list[OsSleepIssue] = field(default_factory=list)
+    sources: list[str] = field(default_factory=list)
+    collected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+_cache_lock = threading.Lock()
+_cached: tuple[OsSleepReport, float] | None = None
+
+
+def _cache_get() -> Optional[OsSleepReport]:
+    with _cache_lock:
+        if _cached is None:
+            return None
+        report, stored_at = _cached
+        if monotonic() - stored_at > _CACHE_TTL_SECONDS:
+            return None
+        return report
+
+
+def _cache_put(report: OsSleepReport) -> None:
+    global _cached
+    with _cache_lock:
+        _cached = (report, monotonic())
+
+
+def _cache_clear() -> None:
+    """Test helper: invalidate the cache."""
+    global _cached
+    with _cache_lock:
+        _cached = None
+
+
+# ---------------------------------------------------------------------------
+# INI parsing helpers
+# ---------------------------------------------------------------------------
+def _parse_systemd_ini(path: Path, section: str) -> dict[str, str]:
+    """
+    Minimal systemd-style INI reader. Returns a flat dict for the given section.
+    Missing files yield {}. Malformed lines are skipped (logged at WARNING).
+    """
+    result: dict[str, str] = {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return result
+    except OSError as exc:
+        logger.warning("Could not read %s: %s", path, exc)
+        return result
+
+    in_section = False
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith(";"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_section = line[1:-1] == section
+            continue
+        if not in_section:
+            continue
+        if "=" not in line:
+            logger.warning("Skipping malformed line in %s: %r", path, raw)
+            continue
+        key, _, value = line.partition("=")
+        result[key.strip()] = value.strip()
+    return result
+
+
+def _merge_drop_ins(base: dict[str, str], drop_in_dir: Path, section: str) -> dict[str, str]:
+    """
+    Apply drop-in overrides from drop_in_dir, filename-sorted (systemd's behaviour).
+    Returns a new dict; does not mutate `base`.
+    """
+    merged = dict(base)
+    try:
+        files = sorted(p for p in drop_in_dir.iterdir() if p.is_file() and p.suffix == ".conf")
+    except FileNotFoundError:
+        return merged
+    except OSError as exc:
+        logger.warning("Could not list drop-ins in %s: %s", drop_in_dir, exc)
+        return merged
+    for f in files:
+        merged.update(_parse_systemd_ini(f, section=section))
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Public entry point — minimal version for Task 1
+# Full implementation lands in Task 3.
+# ---------------------------------------------------------------------------
+def inspect_os_sleep(force_refresh: bool = False) -> OsSleepReport:
+    if sys.platform != "linux" or not _SYSTEMD_DIR.is_dir():
+        return OsSleepReport(platform_supported=False)
+    # Real implementation arrives in Task 3.
+    return OsSleepReport(platform_supported=True)

--- a/backend/app/services/power/os_sleep_inspector.py
+++ b/backend/app/services/power/os_sleep_inspector.py
@@ -63,7 +63,7 @@ class OsSleepIssue:
     detail: Optional[str] = None
 
 
-@dataclass(frozen=True)
+@dataclass
 class OsSleepReport:
     platform_supported: bool
     logind: dict[str, str] = field(default_factory=dict)

--- a/backend/tests/api/test_sleep_always_awake_routes.py
+++ b/backend/tests/api/test_sleep_always_awake_routes.py
@@ -137,3 +137,27 @@ def test_status_surfaces_always_awake(client, admin_headers, mock_sleep_manager)
     aa = r.json()["always_awake"]
     assert aa["enabled"] is True
     assert aa["until"] is None
+
+
+def test_until_rejected_when_more_than_7_days(client, admin_headers, mock_sleep_manager):
+    """Test that always_awake_until is rejected if more than 7 days in the future."""
+    eight_days = (datetime.now(timezone.utc) + timedelta(days=8)).isoformat()
+    r = client.put(CONFIG_URL, headers=admin_headers, json={
+        "always_awake_enabled": True,
+        "always_awake_until": eight_days,
+    })
+    assert r.status_code == 422
+    assert "7 days" in r.text or "7 Tagen" in r.text
+
+
+def test_until_accepted_at_6_days_23h(client, admin_headers, mock_sleep_manager):
+    """Test that always_awake_until is accepted at exactly 6 days + 23 hours (within 7-day cap)."""
+    target = (datetime.now(timezone.utc) + timedelta(days=6, hours=23)).isoformat()
+    r = client.put(CONFIG_URL, headers=admin_headers, json={
+        "always_awake_enabled": True,
+        "always_awake_until": target,
+    })
+    assert r.status_code == 200
+    body = r.json()
+    assert body["always_awake_enabled"] is True
+    assert body["always_awake_until"] is not None

--- a/backend/tests/api/test_sleep_os_settings_route.py
+++ b/backend/tests/api/test_sleep_os_settings_route.py
@@ -1,0 +1,82 @@
+"""Tests for GET /api/system/sleep/os-settings."""
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.conftest import get_auth_headers
+from app.core.config import settings
+from app.services.power.os_sleep_inspector import OsSleepIssue, OsSleepReport
+
+
+OS_SETTINGS_URL = f"{settings.api_prefix}/system/sleep/os-settings"
+
+
+@pytest.fixture
+def admin_headers(client: TestClient, admin_user) -> dict[str, str]:
+    return get_auth_headers(client, settings.admin_username, settings.admin_password)
+
+
+@pytest.fixture
+def user_headers(client: TestClient, regular_user) -> dict[str, str]:
+    return get_auth_headers(client, "testuser", "Testpass123!")
+
+
+@pytest.fixture
+def stub_report():
+    return OsSleepReport(
+        platform_supported=True,
+        logind={"IdleAction": "suspend"},
+        sleep_conf={"AllowSuspend": "yes"},
+        targets={"suspend.target": "enabled"},
+        issues=[OsSleepIssue(
+            severity="warning",
+            key="logind.idle_action.suspend",
+            message="logind suspends after idle",
+            detail="30min",
+        )],
+        sources=["/etc/systemd/logind.conf"],
+        collected_at=datetime(2026, 5, 9, 12, 0, tzinfo=timezone.utc),
+    )
+
+
+def test_requires_admin(client, user_headers):
+    """Non-admin users get 403."""
+    res = client.get(OS_SETTINGS_URL, headers=user_headers)
+    assert res.status_code == 403
+
+
+def test_returns_report_for_admin(client, admin_headers, stub_report):
+    with patch(
+        "app.api.routes.sleep.os_sleep_inspector.inspect_os_sleep",
+        return_value=stub_report,
+    ):
+        res = client.get(OS_SETTINGS_URL, headers=admin_headers)
+    assert res.status_code == 200
+    body = res.json()
+    assert body["platform_supported"] is True
+    assert body["logind"]["IdleAction"] == "suspend"
+    assert body["issues"][0]["key"] == "logind.idle_action.suspend"
+
+
+def test_force_param_bypasses_cache(client, admin_headers, stub_report):
+    with patch(
+        "app.api.routes.sleep.os_sleep_inspector.inspect_os_sleep",
+        return_value=stub_report,
+    ) as inspect_mock:
+        res = client.get(
+            f"{OS_SETTINGS_URL}?force=true",
+            headers=admin_headers,
+        )
+    assert res.status_code == 200
+    inspect_mock.assert_called_once_with(force_refresh=True)
+
+
+def test_default_does_not_force_refresh(client, admin_headers, stub_report):
+    with patch(
+        "app.api.routes.sleep.os_sleep_inspector.inspect_os_sleep",
+        return_value=stub_report,
+    ) as inspect_mock:
+        client.get(OS_SETTINGS_URL, headers=admin_headers)
+    inspect_mock.assert_called_once_with(force_refresh=False)

--- a/backend/tests/services/power/test_os_sleep_inspector_classifier.py
+++ b/backend/tests/services/power/test_os_sleep_inspector_classifier.py
@@ -1,0 +1,70 @@
+"""Tests for the os_sleep_inspector issue classifier."""
+import pytest
+
+from app.services.power import os_sleep_inspector as ins
+
+
+def _classify(
+    *,
+    logind: dict[str, str] | None = None,
+    sleep_conf: dict[str, str] | None = None,
+    targets: dict[str, str] | None = None,
+    has_lid: bool = False,
+) -> list[ins.OsSleepIssue]:
+    return ins._classify(
+        logind=logind or {},
+        sleep_conf=sleep_conf or {},
+        targets=targets or {},
+        has_lid=has_lid,
+    )
+
+
+class TestClassifier:
+    def test_idle_action_suspend_warns(self):
+        issues = _classify(logind={"IdleAction": "suspend", "IdleActionSec": "30min"})
+        keys = {i.key for i in issues}
+        assert "logind.idle_action.suspend" in keys
+        suspend = next(i for i in issues if i.key == "logind.idle_action.suspend")
+        assert suspend.severity == "warning"
+        assert suspend.detail is not None and "30min" in suspend.detail
+
+    def test_idle_action_hibernate_warns_with_distinct_key(self):
+        issues = _classify(logind={"IdleAction": "hibernate"})
+        assert any(i.key == "logind.idle_action.hibernate" and i.severity == "warning" for i in issues)
+
+    def test_idle_action_hybrid_sleep_warns(self):
+        issues = _classify(logind={"IdleAction": "hybrid-sleep"})
+        assert any(i.key == "logind.idle_action.hybrid_sleep" and i.severity == "warning" for i in issues)
+
+    def test_idle_action_ignore_does_not_warn(self):
+        issues = _classify(logind={"IdleAction": "ignore"})
+        assert not any(i.key.startswith("logind.idle_action.") for i in issues)
+
+    def test_lid_switch_suspend_with_lid_emits_info(self):
+        issues = _classify(logind={"HandleLidSwitch": "suspend"}, has_lid=True)
+        assert any(i.key == "logind.lid_switch.suspend" and i.severity == "info" for i in issues)
+
+    def test_lid_switch_suspend_without_lid_silent(self):
+        issues = _classify(logind={"HandleLidSwitch": "suspend"}, has_lid=False)
+        assert not any(i.key.startswith("logind.lid_switch.") for i in issues)
+
+    def test_lid_switch_hibernate_emits_info_with_distinct_key(self):
+        issues = _classify(logind={"HandleLidSwitch": "hibernate"}, has_lid=True)
+        assert any(i.key == "logind.lid_switch.hibernate" for i in issues)
+
+    def test_sleep_conf_suspend_disabled_emits_info(self):
+        issues = _classify(sleep_conf={"AllowSuspend": "no"})
+        assert any(i.key == "sleep_conf.suspend_disabled" and i.severity == "info" for i in issues)
+
+    def test_suspend_target_masked_is_error(self):
+        issues = _classify(targets={"suspend.target": "masked"})
+        assert any(i.key == "targets.suspend.masked" and i.severity == "error" for i in issues)
+
+    def test_clean_config_emits_no_issues(self):
+        issues = _classify(
+            logind={"IdleAction": "ignore", "HandleLidSwitch": "ignore"},
+            sleep_conf={"AllowSuspend": "yes"},
+            targets={"suspend.target": "enabled"},
+            has_lid=True,
+        )
+        assert issues == []

--- a/backend/tests/services/power/test_os_sleep_inspector_helpers.py
+++ b/backend/tests/services/power/test_os_sleep_inspector_helpers.py
@@ -1,0 +1,89 @@
+"""Tests for os_sleep_inspector low-level helpers."""
+import sys
+from pathlib import Path
+
+import pytest
+
+from app.services.power import os_sleep_inspector as ins
+
+
+class TestParseSystemdIni:
+    def test_parses_simple_key_value(self, tmp_path: Path):
+        f = tmp_path / "logind.conf"
+        f.write_text("[Login]\nIdleAction=suspend\nIdleActionSec=30min\n")
+        result = ins._parse_systemd_ini(f, section="Login")
+        assert result == {"IdleAction": "suspend", "IdleActionSec": "30min"}
+
+    def test_skips_comments_and_blanks(self, tmp_path: Path):
+        f = tmp_path / "sleep.conf"
+        f.write_text(
+            "# top comment\n"
+            "; semicolon comment\n"
+            "\n"
+            "[Sleep]\n"
+            "AllowSuspend=yes\n"
+            "  # inline indented comment\n"
+            "AllowHibernation=no\n"
+        )
+        result = ins._parse_systemd_ini(f, section="Sleep")
+        assert result == {"AllowSuspend": "yes", "AllowHibernation": "no"}
+
+    def test_only_returns_requested_section(self, tmp_path: Path):
+        f = tmp_path / "logind.conf"
+        f.write_text(
+            "[Login]\nIdleAction=ignore\n"
+            "[Other]\nFoo=bar\n"
+        )
+        assert ins._parse_systemd_ini(f, section="Login") == {"IdleAction": "ignore"}
+        assert ins._parse_systemd_ini(f, section="Other") == {"Foo": "bar"}
+
+    def test_missing_file_returns_empty(self, tmp_path: Path):
+        assert ins._parse_systemd_ini(tmp_path / "nope.conf", section="Login") == {}
+
+    def test_malformed_lines_are_skipped(self, tmp_path: Path):
+        f = tmp_path / "logind.conf"
+        f.write_text("[Login]\nIdleAction=suspend\nthis line has no equals\nIdleActionSec=30min\n")
+        result = ins._parse_systemd_ini(f, section="Login")
+        assert result == {"IdleAction": "suspend", "IdleActionSec": "30min"}
+
+
+class TestMergeDropIns:
+    def test_drop_in_overrides_base(self, tmp_path: Path):
+        base = {"IdleAction": "ignore", "HandleLidSwitch": "suspend"}
+        drop_dir = tmp_path / "logind.conf.d"
+        drop_dir.mkdir()
+        (drop_dir / "30-baluhost.conf").write_text("[Login]\nIdleAction=suspend\n")
+        merged = ins._merge_drop_ins(base, drop_dir, section="Login")
+        assert merged["IdleAction"] == "suspend"
+        assert merged["HandleLidSwitch"] == "suspend"  # untouched
+
+    def test_drop_ins_applied_in_filename_order(self, tmp_path: Path):
+        base: dict[str, str] = {}
+        drop_dir = tmp_path / "logind.conf.d"
+        drop_dir.mkdir()
+        (drop_dir / "10-first.conf").write_text("[Login]\nIdleAction=ignore\n")
+        (drop_dir / "20-second.conf").write_text("[Login]\nIdleAction=suspend\n")
+        merged = ins._merge_drop_ins(base, drop_dir, section="Login")
+        assert merged["IdleAction"] == "suspend"  # later filename wins
+
+    def test_missing_directory_returns_base_unchanged(self, tmp_path: Path):
+        base = {"IdleAction": "ignore"}
+        merged = ins._merge_drop_ins(base, tmp_path / "nope.d", section="Login")
+        assert merged == base
+
+
+class TestPlatformGuard:
+    def test_unsupported_platform_short_circuits(self, monkeypatch):
+        monkeypatch.setattr(ins.sys, "platform", "win32")
+        report = ins.inspect_os_sleep(force_refresh=True)
+        assert report.platform_supported is False
+        assert report.logind == {}
+        assert report.sleep_conf == {}
+        assert report.targets == {}
+        assert report.issues == []
+
+    def test_no_systemd_dir_short_circuits(self, monkeypatch, tmp_path: Path):
+        monkeypatch.setattr(ins.sys, "platform", "linux")
+        monkeypatch.setattr(ins, "_SYSTEMD_DIR", tmp_path / "absent")
+        report = ins.inspect_os_sleep(force_refresh=True)
+        assert report.platform_supported is False

--- a/backend/tests/services/power/test_os_sleep_inspector_integration.py
+++ b/backend/tests/services/power/test_os_sleep_inspector_integration.py
@@ -119,3 +119,25 @@ def test_unexpected_exception_yields_inspector_failed(linux_fs: Path):
         report = ins.inspect_os_sleep(force_refresh=True)
     assert report.platform_supported is True
     assert any(i.key == "inspector.failed" and i.severity == "error" for i in report.issues)
+
+
+def test_systemctl_line_count_mismatch_discards_targets(linux_fs: Path):
+    """If systemctl returns fewer lines than queried (alias collapse on some
+    systemd versions), positional zip would silently misalign — drop the dict."""
+    (linux_fs / "logind.conf").write_text("[Login]\nIdleAction=ignore\n")
+    (linux_fs / "sleep.conf").write_text("[Sleep]\nAllowSuspend=yes\n")
+
+    def short_runner(cmd, *args, **kwargs):
+        # Returns 4 lines for 5 queried targets — would misalign suspend.target=masked
+        # to hibernate.target if positional zipping continued.
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0,
+            stdout="enabled\nmasked\ndisabled\ndisabled\n", stderr="",
+        )
+
+    with patch.object(ins.subprocess, "run", side_effect=short_runner):
+        report = ins.inspect_os_sleep(force_refresh=True)
+    assert report.platform_supported is True
+    assert report.targets == {}
+    # Critically: classifier must not see a phantom "suspend.target": "masked"
+    assert not any(i.key == "targets.suspend.masked" for i in report.issues)

--- a/backend/tests/services/power/test_os_sleep_inspector_integration.py
+++ b/backend/tests/services/power/test_os_sleep_inspector_integration.py
@@ -1,0 +1,121 @@
+"""Integration tests for inspect_os_sleep — file resolution, subprocess, cache, resilience."""
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.services.power import os_sleep_inspector as ins
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    ins._cache_clear()
+    yield
+    ins._cache_clear()
+
+
+@pytest.fixture
+def linux_fs(tmp_path: Path, monkeypatch):
+    """Layout a fake /etc/systemd tree under tmp_path and point the module at it."""
+    systemd = tmp_path / "etc" / "systemd"
+    systemd.mkdir(parents=True)
+    (systemd / "logind.conf.d").mkdir()
+    (systemd / "sleep.conf.d").mkdir()
+    monkeypatch.setattr(ins, "_SYSTEMD_DIR", systemd)
+    monkeypatch.setattr(ins, "_LOGIND_CONF", systemd / "logind.conf")
+    monkeypatch.setattr(ins, "_LOGIND_DROPIN_DIRS", (systemd / "logind.conf.d",))
+    monkeypatch.setattr(ins, "_SLEEP_CONF", systemd / "sleep.conf")
+    monkeypatch.setattr(ins, "_SLEEP_DROPIN_DIRS", (systemd / "sleep.conf.d",))
+    monkeypatch.setattr(ins, "_LID_SENSOR", tmp_path / "no-lid")
+    monkeypatch.setattr(ins.sys, "platform", "linux")
+    return systemd
+
+
+def _fake_systemctl(targets: dict[str, str]):
+    """Build a subprocess.run replacement that emits one status per target."""
+    def runner(cmd, *args, **kwargs):
+        # Return order matches argv order after the leading systemctl args.
+        names = cmd[2:]  # ["systemctl", "is-enabled", *names]
+        out = "\n".join(targets.get(n, "disabled") for n in names) + "\n"
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=out, stderr="")
+    return runner
+
+
+def test_full_report_resolves_drop_ins_and_targets(linux_fs: Path):
+    (linux_fs / "logind.conf").write_text("[Login]\nIdleAction=ignore\n")
+    (linux_fs / "logind.conf.d" / "30-baluhost.conf").write_text("[Login]\nIdleAction=suspend\nIdleActionSec=30min\n")
+    (linux_fs / "sleep.conf").write_text("[Sleep]\nAllowSuspend=yes\n")
+
+    with patch.object(ins.subprocess, "run", side_effect=_fake_systemctl({
+        "sleep.target": "enabled",
+        "suspend.target": "masked",
+        "hibernate.target": "disabled",
+        "hybrid-sleep.target": "disabled",
+        "suspend-then-hibernate.target": "disabled",
+    })):
+        report = ins.inspect_os_sleep(force_refresh=True)
+
+    assert report.platform_supported is True
+    assert report.logind["IdleAction"] == "suspend"
+    assert report.sleep_conf["AllowSuspend"] == "yes"
+    assert report.targets["suspend.target"] == "masked"
+    keys = {i.key for i in report.issues}
+    assert "logind.idle_action.suspend" in keys
+    assert "targets.suspend.masked" in keys
+    # logind.conf and the drop-in were both read; sleep.conf too.
+    assert any("logind.conf" in s for s in report.sources)
+    assert any("30-baluhost.conf" in s for s in report.sources)
+    assert any("sleep.conf" in s for s in report.sources)
+
+
+def test_cache_hit_skips_subprocess(linux_fs: Path):
+    (linux_fs / "logind.conf").write_text("[Login]\nIdleAction=ignore\n")
+    (linux_fs / "sleep.conf").write_text("[Sleep]\nAllowSuspend=yes\n")
+
+    with patch.object(ins.subprocess, "run", side_effect=_fake_systemctl({})) as run_mock:
+        ins.inspect_os_sleep(force_refresh=False)
+        ins.inspect_os_sleep(force_refresh=False)
+    assert run_mock.call_count == 1
+
+
+def test_force_refresh_bypasses_cache(linux_fs: Path):
+    (linux_fs / "logind.conf").write_text("[Login]\nIdleAction=ignore\n")
+    (linux_fs / "sleep.conf").write_text("[Sleep]\nAllowSuspend=yes\n")
+
+    with patch.object(ins.subprocess, "run", side_effect=_fake_systemctl({})) as run_mock:
+        ins.inspect_os_sleep(force_refresh=True)
+        ins.inspect_os_sleep(force_refresh=True)
+    assert run_mock.call_count == 2
+
+
+def test_subprocess_timeout_does_not_raise(linux_fs: Path):
+    (linux_fs / "logind.conf").write_text("[Login]\nIdleAction=ignore\n")
+    (linux_fs / "sleep.conf").write_text("[Sleep]\nAllowSuspend=yes\n")
+
+    def boom(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=5)
+    with patch.object(ins.subprocess, "run", side_effect=boom):
+        report = ins.inspect_os_sleep(force_refresh=True)
+    assert report.platform_supported is True
+    assert report.targets == {}
+
+
+def test_subprocess_failure_does_not_raise(linux_fs: Path):
+    (linux_fs / "logind.conf").write_text("[Login]\nIdleAction=ignore\n")
+    (linux_fs / "sleep.conf").write_text("[Sleep]\nAllowSuspend=yes\n")
+
+    def boom(*args, **kwargs):
+        raise FileNotFoundError("systemctl not found")
+    with patch.object(ins.subprocess, "run", side_effect=boom):
+        report = ins.inspect_os_sleep(force_refresh=True)
+    assert report.platform_supported is True
+    assert report.targets == {}
+
+
+def test_unexpected_exception_yields_inspector_failed(linux_fs: Path):
+    """If a helper raises unexpectedly, return a report with an inspector.failed issue."""
+    with patch.object(ins, "_parse_systemd_ini", side_effect=RuntimeError("kaboom")):
+        report = ins.inspect_os_sleep(force_refresh=True)
+    assert report.platform_supported is True
+    assert any(i.key == "inspector.failed" and i.severity == "error" for i in report.issues)

--- a/backend/tests/test_sleep_schemas.py
+++ b/backend/tests/test_sleep_schemas.py
@@ -1,0 +1,69 @@
+"""Schema-level tests for OsSleepReportResponse and the 7-day cap."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.sleep import (
+    OsSleepIssueModel,
+    OsSleepReportResponse,
+    SleepConfigUpdate,
+)
+
+
+class TestOsSleepReportResponse:
+    def test_minimal_payload_validates(self):
+        payload = {"platform_supported": False}
+        m = OsSleepReportResponse(**payload)
+        assert m.platform_supported is False
+        assert m.logind == {}
+        assert m.issues == []
+        assert m.sources == []
+
+    def test_full_payload_round_trip(self):
+        payload = {
+            "platform_supported": True,
+            "logind": {"IdleAction": "suspend"},
+            "sleep_conf": {"AllowSuspend": "yes"},
+            "targets": {"suspend.target": "enabled"},
+            "issues": [
+                {"severity": "warning", "key": "logind.idle_action.suspend",
+                 "message": "logind suspends after idle", "detail": "30min"}
+            ],
+            "sources": ["/etc/systemd/logind.conf"],
+            "collected_at": "2026-05-09T12:00:00+00:00",
+        }
+        m = OsSleepReportResponse(**payload)
+        assert m.issues[0].severity == "warning"
+        assert m.issues[0].key == "logind.idle_action.suspend"
+
+    def test_severity_must_be_known(self):
+        bad = {
+            "platform_supported": True,
+            "issues": [{"severity": "purple", "key": "x", "message": "y"}],
+        }
+        with pytest.raises(ValidationError):
+            OsSleepReportResponse(**bad)
+
+
+class TestAlwaysAwake7DayCap:
+    def test_until_at_7_days_minus_5min_accepted(self):
+        v = datetime.now(timezone.utc) + timedelta(days=7) - timedelta(minutes=5)
+        SleepConfigUpdate(always_awake_until=v)  # must not raise
+
+    def test_until_8_days_in_future_rejected(self):
+        v = datetime.now(timezone.utc) + timedelta(days=8)
+        with pytest.raises(ValidationError) as exc:
+            SleepConfigUpdate(always_awake_until=v)
+        assert "7 days" in str(exc.value) or "7 Tagen" in str(exc.value)
+
+    def test_until_naive_datetime_normalized_then_capped(self):
+        # Naive value 8 days out — should be normalized to UTC and rejected.
+        v = (datetime.utcnow() + timedelta(days=8)).replace(tzinfo=None)
+        with pytest.raises(ValidationError):
+            SleepConfigUpdate(always_awake_until=v)
+
+    def test_until_in_past_still_rejected(self):
+        v = datetime.now(timezone.utc) - timedelta(minutes=1)
+        with pytest.raises(ValidationError):
+            SleepConfigUpdate(always_awake_until=v)

--- a/client/src/api/sleep.ts
+++ b/client/src/api/sleep.ts
@@ -53,6 +53,25 @@ export interface AlwaysAwakeStatus {
   expires_in_seconds: number | null;
 }
 
+export type OsSleepSeverity = 'info' | 'warning' | 'error';
+
+export interface OsSleepIssue {
+  severity: OsSleepSeverity;
+  key: string;
+  message: string;
+  detail: string | null;
+}
+
+export interface OsSleepReport {
+  platform_supported: boolean;
+  logind: Record<string, string>;
+  sleep_conf: Record<string, string>;
+  targets: Record<string, string>;
+  issues: OsSleepIssue[];
+  sources: string[];
+  collected_at: string;
+}
+
 export interface SleepStatusResponse {
   current_state: SleepState;
   state_since: string | null;
@@ -233,5 +252,12 @@ export async function getSleepHistory(
 
 export async function getSleepCapabilities(): Promise<SleepCapabilities> {
   const response = await apiClient.get<SleepCapabilities>('/api/system/sleep/capabilities');
+  return response.data;
+}
+
+export async function getOsSleepSettings(force = false): Promise<OsSleepReport> {
+  const response = await apiClient.get<OsSleepReport>('/api/system/sleep/os-settings', {
+    params: force ? { force: true } : undefined,
+  });
   return response.data;
 }

--- a/client/src/components/power/AlwaysAwakePanel.tsx
+++ b/client/src/components/power/AlwaysAwakePanel.tsx
@@ -1,7 +1,8 @@
 /**
  * Always-Awake panel.
  *
- * Master toggle + optional expiry presets (1h/4h/8h/permanent).
+ * Master toggle + optional expiry presets (1h/4h/8h/permanent) plus a
+ * custom datetime picker capped at 7 days.
  * Auto-saves all changes; manual Sleep/Suspend on the server side
  * automatically clears the override.
  */
@@ -15,24 +16,47 @@ import {
   updateSleepConfig,
 } from '../../api/sleep';
 
-type Preset = '1h' | '4h' | '8h' | 'permanent';
+type Preset = '1h' | '4h' | '8h' | 'permanent' | 'custom';
 
-const PRESET_HOURS: Record<Exclude<Preset, 'permanent'>, number> = {
+const PRESET_HOURS: Record<Exclude<Preset, 'permanent' | 'custom'>, number> = {
   '1h': 1,
   '4h': 4,
   '8h': 8,
 };
 
+const MIN_HORIZON_MS = 5 * 60 * 1000;        // 5 minutes
+const MAX_HORIZON_MS = 7 * 24 * 3600 * 1000; // 7 days
+
 function formatTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  // Within the next 7 days: "DD.MM. HH:mm". Beyond (shouldn't happen with the cap)
+  // we still render the full date.
+  const ddmm = d.toLocaleDateString([], { day: '2-digit', month: '2-digit' });
+  const hhmm = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  return `${ddmm} ${hhmm}`;
+}
+
 function formatRemaining(seconds: number): string {
   if (seconds < 0) return '0m';
-  const h = Math.floor(seconds / 3600);
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
   const m = Math.floor((seconds % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h`;
   if (h > 0) return `${h}h ${m}m`;
   return `${m}m`;
+}
+
+/** Convert a Date into the value format expected by <input type="datetime-local"> in the user's local TZ. */
+function toLocalInputValue(date: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  );
 }
 
 export function AlwaysAwakePanel() {
@@ -44,7 +68,11 @@ export function AlwaysAwakePanel() {
   const [coreUptimeEnabled, setCoreUptimeEnabled] = useState(false);
   const [activePreset, setActivePreset] = useState<Preset | null>(null);
   const [loading, setLoading] = useState(true);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerValue, setPickerValue] = useState<string>('');
+  const [pickerError, setPickerError] = useState<string | null>(null);
   const tickRef = useRef<number | null>(null);
+  const pickerRef = useRef<HTMLDivElement | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -55,7 +83,6 @@ export function AlwaysAwakePanel() {
       setScheduleEnabled(cfg.schedule_enabled);
       setCoreUptimeEnabled(cfg.core_uptime_enabled ?? false);
 
-      // Infer active preset from loaded state (e.g. after page refresh)
       if (!cfg.always_awake_enabled) {
         setActivePreset(null);
       } else if (cfg.always_awake_until == null) {
@@ -67,7 +94,6 @@ export function AlwaysAwakePanel() {
           ['4h', 4 * 3600],
           ['8h', 8 * 3600],
         ];
-        // Pick the closest preset within 5 minutes; otherwise null (custom).
         let best: Preset | null = null;
         let bestDiff = 5 * 60;
         for (const [p, sec] of candidates) {
@@ -77,7 +103,7 @@ export function AlwaysAwakePanel() {
             best = p;
           }
         }
-        setActivePreset(best);
+        setActivePreset(best ?? 'custom');
       }
     } catch {
       toast.error(t('sleep.alwaysAwake.loadFailed'));
@@ -90,7 +116,6 @@ export function AlwaysAwakePanel() {
     refresh();
   }, [refresh]);
 
-  // Live countdown — decrement every second when until is set
   useEffect(() => {
     if (expiresIn === null) {
       if (tickRef.current) window.clearInterval(tickRef.current);
@@ -104,8 +129,6 @@ export function AlwaysAwakePanel() {
     };
   }, [expiresIn !== null]);
 
-  // Auto-refresh when expired — null out expiresIn first so the countdown effect's
-  // cleanup runs immediately even if the refresh request is slow/fails.
   useEffect(() => {
     if (expiresIn === 0) {
       setExpiresIn(null);
@@ -113,7 +136,26 @@ export function AlwaysAwakePanel() {
     }
   }, [expiresIn, refresh]);
 
-  const setPreset = async (preset: Preset) => {
+  // Close popover on outside click / Escape.
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setPickerOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setPickerOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [pickerOpen]);
+
+  const setPreset = async (preset: Exclude<Preset, 'custom'>) => {
     const newUntil =
       preset === 'permanent'
         ? null
@@ -138,6 +180,57 @@ export function AlwaysAwakePanel() {
       setActivePreset(previousActivePreset);
       toast.error(err instanceof Error ? err.message : t('sleep.alwaysAwake.saveFailed'));
     }
+  };
+
+  const setCustomPreset = async (localValue: string) => {
+    const target = new Date(localValue);
+    if (Number.isNaN(target.getTime())) {
+      setPickerError(t('sleep.alwaysAwake.pickerErrorPast'));
+      return;
+    }
+    const delta = target.getTime() - Date.now();
+    if (delta < MIN_HORIZON_MS) {
+      setPickerError(t('sleep.alwaysAwake.pickerErrorPast'));
+      return;
+    }
+    if (delta > MAX_HORIZON_MS) {
+      setPickerError(t('sleep.alwaysAwake.pickerErrorMax'));
+      return;
+    }
+
+    const newUntil = target.toISOString();
+    const previousEnabled = enabled;
+    const previousUntil = until;
+    const previousExpiresIn = expiresIn;
+    const previousActivePreset = activePreset;
+    setEnabled(true);
+    setUntil(newUntil);
+    setExpiresIn(Math.floor(delta / 1000));
+    setActivePreset('custom');
+    setPickerOpen(false);
+    setPickerError(null);
+    try {
+      await updateSleepConfig({
+        always_awake_enabled: true,
+        always_awake_until: newUntil,
+      });
+    } catch (err) {
+      setEnabled(previousEnabled);
+      setUntil(previousUntil);
+      setExpiresIn(previousExpiresIn);
+      setActivePreset(previousActivePreset);
+      toast.error(err instanceof Error ? err.message : t('sleep.alwaysAwake.saveFailed'));
+    }
+  };
+
+  const openPicker = () => {
+    const seed =
+      activePreset === 'custom' && until
+        ? new Date(until)
+        : new Date(Date.now() + 4 * 3600 * 1000); // default seed: now+4h
+    setPickerValue(toLocalInputValue(seed));
+    setPickerError(null);
+    setPickerOpen(true);
   };
 
   const handleCancel = async () => {
@@ -175,6 +268,9 @@ export function AlwaysAwakePanel() {
       </div>
     );
   }
+
+  const minLocal = toLocalInputValue(new Date(Date.now() + MIN_HORIZON_MS));
+  const maxLocal = toLocalInputValue(new Date(Date.now() + MAX_HORIZON_MS));
 
   return (
     <div className="card border-slate-700/50 p-4 sm:p-6 space-y-4">
@@ -238,12 +334,12 @@ export function AlwaysAwakePanel() {
       )}
 
       <div className="flex flex-wrap gap-2 pt-1">
-        {(['1h', '4h', '8h', 'permanent'] as Preset[]).map((p) => {
+        {(['1h', '4h', '8h', 'permanent'] as const).map((p) => {
           const isActive = enabled && activePreset === p;
           const labelKey =
             p === 'permanent'
               ? 'sleep.alwaysAwake.presetPermanent'
-              : `sleep.alwaysAwake.preset${p}` as const;
+              : (`sleep.alwaysAwake.preset${p}` as const);
           return (
             <button
               key={p}
@@ -259,6 +355,60 @@ export function AlwaysAwakePanel() {
             </button>
           );
         })}
+
+        <div className="relative" ref={pickerRef}>
+          <button
+            type="button"
+            onClick={openPicker}
+            className={`min-w-[3.5rem] rounded px-3 py-1.5 text-xs font-medium transition-colors ${
+              enabled && activePreset === 'custom'
+                ? 'bg-amber-500/30 text-amber-200 border border-amber-500/50'
+                : 'bg-slate-800/40 text-slate-400 border border-slate-700/40 hover:text-amber-300 hover:border-amber-500/30'
+            }`}
+          >
+            {enabled && activePreset === 'custom' && until
+              ? t('sleep.alwaysAwake.activeCustom', { datetime: formatDateTime(until) })
+              : t('sleep.alwaysAwake.presetCustom')}
+          </button>
+
+          {pickerOpen && (
+            <div className="absolute z-10 mt-2 right-0 sm:right-auto sm:left-0 w-72 rounded-md border border-slate-700/60 bg-slate-900 p-3 shadow-xl space-y-2">
+              <label className="block text-xs text-slate-300">
+                {t('sleep.alwaysAwake.pickerLabel')}
+                <input
+                  type="datetime-local"
+                  className="mt-1 block w-full rounded border border-slate-700/60 bg-slate-800 px-2 py-1 text-sm text-slate-100"
+                  min={minLocal}
+                  max={maxLocal}
+                  value={pickerValue}
+                  onChange={(e) => {
+                    setPickerValue(e.target.value);
+                    setPickerError(null);
+                  }}
+                />
+              </label>
+              {pickerError && (
+                <p className="text-xs text-red-400">{pickerError}</p>
+              )}
+              <div className="flex justify-end gap-2 pt-1">
+                <button
+                  type="button"
+                  onClick={() => setPickerOpen(false)}
+                  className="rounded px-2 py-1 text-xs text-slate-400 hover:text-slate-200"
+                >
+                  {t('sleep.alwaysAwake.pickerCancel')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setCustomPreset(pickerValue)}
+                  className="rounded px-2 py-1 text-xs font-medium bg-amber-500/30 text-amber-200 border border-amber-500/50 hover:bg-amber-500/40"
+                >
+                  {t('sleep.alwaysAwake.pickerApply')}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/power/OsSleepSettingsBanner.tsx
+++ b/client/src/components/power/OsSleepSettingsBanner.tsx
@@ -1,0 +1,160 @@
+/**
+ * OS Sleep Settings Banner
+ *
+ * Read-only card at the top of the Sleep page. Surfaces OS-level sleep
+ * triggers (logind, sleep.conf, masked targets) so users understand which
+ * sleep behaviour BaluHost actually owns. No edit functionality.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, CheckCircle2, Info, RefreshCw, ShieldAlert } from 'lucide-react';
+
+import {
+  getOsSleepSettings,
+  type OsSleepIssue,
+  type OsSleepReport,
+  type OsSleepSeverity,
+} from '../../api/sleep';
+
+const ICON_FOR: Record<OsSleepSeverity, typeof AlertTriangle> = {
+  info: Info,
+  warning: AlertTriangle,
+  error: ShieldAlert,
+};
+
+const COLOR_FOR: Record<OsSleepSeverity, string> = {
+  info: 'text-slate-300',
+  warning: 'text-amber-400',
+  error: 'text-red-400',
+};
+
+function IssueLine({ issue }: { issue: OsSleepIssue }) {
+  const { t } = useTranslation('system');
+  const Icon = ICON_FOR[issue.severity];
+  const colorClass = COLOR_FOR[issue.severity];
+  const text = t(`sleep.osSettings.issue.${issue.key}`, { defaultValue: issue.message });
+  return (
+    <div className="flex items-start gap-2 text-sm">
+      <Icon className={`h-4 w-4 shrink-0 mt-0.5 ${colorClass}`} />
+      <div>
+        <span className="text-slate-200">{text}</span>
+        {issue.detail && (
+          <p className="mt-0.5 text-xs text-slate-400">{issue.detail}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DetailsTable({ report }: { report: OsSleepReport }) {
+  const { t } = useTranslation('system');
+  const rows: Array<[string, string]> = [];
+  for (const [k, v] of Object.entries(report.logind)) rows.push([`logind.${k}`, v]);
+  for (const [k, v] of Object.entries(report.sleep_conf)) rows.push([`sleep.${k}`, v]);
+  for (const [k, v] of Object.entries(report.targets)) rows.push([`targets.${k}`, v]);
+  return (
+    <details className="mt-3 group">
+      <summary className="cursor-pointer text-xs text-slate-400 hover:text-slate-200 select-none">
+        {t('sleep.osSettings.detailsToggle')}
+      </summary>
+      <div className="mt-2 space-y-1 pl-4 text-xs">
+        {rows.map(([k, v]) => (
+          <div key={k} className="flex gap-2">
+            <span className="text-slate-500 font-mono">{k}</span>
+            <span className="text-slate-300 font-mono">= {v}</span>
+          </div>
+        ))}
+        {report.sources.length > 0 && (
+          <div className="pt-2 text-slate-500">
+            {t('sleep.osSettings.sources')}: {report.sources.join(', ')}
+          </div>
+        )}
+      </div>
+    </details>
+  );
+}
+
+export function OsSleepSettingsBanner() {
+  const { t } = useTranslation('system');
+  const [report, setReport] = useState<OsSleepReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async (force = false) => {
+    if (force) setRefreshing(true);
+    setError(null);
+    try {
+      const data = await getOsSleepSettings(force);
+      setReport(data);
+    } catch {
+      setError(t('sleep.osSettings.loadFailed'));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    load(false);
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="card border-slate-700/50 p-4 sm:p-6">
+        <div className="animate-pulse space-y-3">
+          <div className="h-5 w-1/3 bg-slate-700/50 rounded" />
+          <div className="h-4 w-2/3 bg-slate-700/40 rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  // Hide entirely on unsupported platforms (no banner, no placeholder).
+  if (report && !report.platform_supported && !error) {
+    return null;
+  }
+
+  return (
+    <div className="card border-slate-700/50 p-4 sm:p-6 space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <h4 className="text-sm font-medium text-white">{t('sleep.osSettings.title')}</h4>
+        <button
+          type="button"
+          onClick={() => load(true)}
+          disabled={refreshing}
+          className="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs text-slate-400 hover:text-slate-200 hover:bg-slate-700/40 transition-colors disabled:opacity-60"
+          aria-label={t('sleep.osSettings.refresh')}
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`} />
+          {t('sleep.osSettings.refresh')}
+        </button>
+      </div>
+
+      {error && (
+        <div className="flex items-start gap-2 text-sm">
+          <ShieldAlert className="h-4 w-4 shrink-0 mt-0.5 text-red-400" />
+          <span className="text-slate-200">{error}</span>
+        </div>
+      )}
+
+      {report && !error && (
+        <>
+          {report.issues.length === 0 ? (
+            <div className="flex items-start gap-2 text-sm">
+              <CheckCircle2 className="h-4 w-4 shrink-0 mt-0.5 text-emerald-400" />
+              <span className="text-slate-200">{t('sleep.osSettings.allClear')}</span>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {report.issues.map((issue) => (
+                <IssueLine key={issue.key} issue={issue} />
+              ))}
+            </div>
+          )}
+          <DetailsTable report={report} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/i18n/locales/de/system.json
+++ b/client/src/i18n/locales/de/system.json
@@ -659,9 +659,16 @@
       "preset4h": "4h",
       "preset8h": "8h",
       "presetPermanent": "Dauerhaft",
+      "presetCustom": "Bis Datum…",
       "activeUntil": "Aktiv bis: {{time}} (in {{remaining}})",
+      "activeCustom": "Bis {{datetime}}",
       "activePermanent": "Dauerhaft aktiv",
       "cancel": "Aufheben",
+      "pickerLabel": "Datum & Uhrzeit",
+      "pickerApply": "Übernehmen",
+      "pickerCancel": "Abbrechen",
+      "pickerErrorPast": "Zeitpunkt muss in der Zukunft liegen (mind. 5 Min)",
+      "pickerErrorMax": "Maximal 7 Tage in der Zukunft",
       "loadFailed": "Konnte Always-Awake nicht laden",
       "saveFailed": "Speichern fehlgeschlagen",
       "hintScheduleResumes": "Geplante Kernbetriebszeit / Sleep-Schedule wird ab {{time}} wieder berücksichtigt.",
@@ -669,6 +676,25 @@
       "bannerActiveWithUntil": "Immer wach aktiv bis {{time}} — Auto-Sleep blockiert.",
       "bannerActivePermanent": "Immer wach aktiv (dauerhaft) — Auto-Sleep blockiert.",
       "scheduleHint": "ℹ Always-Awake hat Vorrang. Sleep-Schedule-Trigger werden ignoriert."
+    },
+    "osSettings": {
+      "title": "OS-Sleep-Einstellungen",
+      "refresh": "Aktualisieren",
+      "detailsToggle": "Details",
+      "allClear": "Keine OS-Sleep-Trigger aktiv. BaluHost steuert Sleep allein.",
+      "sources": "Quellen",
+      "loading": "Wird geladen…",
+      "loadFailed": "OS-Sleep-Einstellungen konnten nicht geladen werden",
+      "issue": {
+        "logind.idle_action.suspend": "logind: IdleAction=suspend (außerhalb von BaluHost)",
+        "logind.idle_action.hibernate": "logind: IdleAction=hibernate (außerhalb von BaluHost)",
+        "logind.idle_action.hybrid_sleep": "logind: IdleAction=hybrid-sleep (außerhalb von BaluHost)",
+        "logind.lid_switch.suspend": "logind: HandleLidSwitch=suspend",
+        "logind.lid_switch.hibernate": "logind: HandleLidSwitch=hibernate",
+        "sleep_conf.suspend_disabled": "OS hat Suspend deaktiviert (AllowSuspend=no)",
+        "targets.suspend.masked": "suspend.target ist maskiert",
+        "inspector.failed": "OS-Sleep-Detection fehlgeschlagen"
+      }
     }
   },
   "fanControl": {

--- a/client/src/i18n/locales/en/system.json
+++ b/client/src/i18n/locales/en/system.json
@@ -664,9 +664,16 @@
       "preset4h": "4h",
       "preset8h": "8h",
       "presetPermanent": "Permanent",
+      "presetCustom": "Until date…",
       "activeUntil": "Active until: {{time}} (in {{remaining}})",
+      "activeCustom": "Until {{datetime}}",
       "activePermanent": "Permanently active",
       "cancel": "Cancel",
+      "pickerLabel": "Date & time",
+      "pickerApply": "Apply",
+      "pickerCancel": "Cancel",
+      "pickerErrorPast": "Must be in the future (at least 5 min)",
+      "pickerErrorMax": "At most 7 days in the future",
       "loadFailed": "Failed to load always-awake state",
       "saveFailed": "Save failed",
       "hintScheduleResumes": "Sleep schedule / core operating hours will resume at {{time}}.",
@@ -674,6 +681,25 @@
       "bannerActiveWithUntil": "Always-awake active until {{time}} — auto-sleep blocked.",
       "bannerActivePermanent": "Always-awake active (permanent) — auto-sleep blocked.",
       "scheduleHint": "ℹ Always-awake takes precedence. Sleep-schedule triggers are ignored."
+    },
+    "osSettings": {
+      "title": "OS sleep settings",
+      "refresh": "Refresh",
+      "detailsToggle": "Details",
+      "allClear": "No OS-level sleep triggers active. BaluHost is in sole control.",
+      "sources": "Sources",
+      "loading": "Loading…",
+      "loadFailed": "Failed to load OS sleep settings",
+      "issue": {
+        "logind.idle_action.suspend": "logind: IdleAction=suspend (outside BaluHost)",
+        "logind.idle_action.hibernate": "logind: IdleAction=hibernate (outside BaluHost)",
+        "logind.idle_action.hybrid_sleep": "logind: IdleAction=hybrid-sleep (outside BaluHost)",
+        "logind.lid_switch.suspend": "logind: HandleLidSwitch=suspend",
+        "logind.lid_switch.hibernate": "logind: HandleLidSwitch=hibernate",
+        "sleep_conf.suspend_disabled": "OS has suspend disabled (AllowSuspend=no)",
+        "targets.suspend.masked": "suspend.target is masked",
+        "inspector.failed": "OS sleep detection failed"
+      }
     }
   },
   "fanControl": {

--- a/client/src/pages/SleepMode.tsx
+++ b/client/src/pages/SleepMode.tsx
@@ -6,6 +6,7 @@
  * SystemControlPage.
  */
 
+import { OsSleepSettingsBanner } from '../components/power/OsSleepSettingsBanner';
 import { SleepModePanel } from '../components/power/SleepModePanel';
 import { AlwaysAwakePanel } from '../components/power/AlwaysAwakePanel';
 import { CoreUptimePanel } from '../components/power/CoreUptimePanel';
@@ -15,6 +16,7 @@ import { SleepHistoryTable } from '../components/power/SleepHistoryTable';
 export default function SleepMode() {
   return (
     <div className="space-y-6">
+      <OsSleepSettingsBanner />
       <SleepModePanel />
       <AlwaysAwakePanel />
       <CoreUptimePanel />

--- a/docs/superpowers/plans/2026-05-09-sleep-page-os-detection-and-custom-datetime.md
+++ b/docs/superpowers/plans/2026-05-09-sleep-page-os-detection-and-custom-datetime.md
@@ -1,0 +1,2067 @@
+# Sleep Page: OS-Sleep-Settings banner + Always-Awake custom datetime — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only OS-sleep-settings card at the top of `/sleep`, and extend the AlwaysAwakePanel preset row with a fifth custom datetime button capped at 7 days.
+
+**Architecture:** A new backend service `os_sleep_inspector` parses `/etc/systemd/{logind,sleep}.conf{,.d}/*` and runs one `systemctl is-enabled` call. Cached 60s, admin-only endpoint at `GET /api/system/sleep/os-settings`. Frontend renders the banner above the existing panels and adds a popover-style datetime picker (`<input type="datetime-local">`, no new deps) to `AlwaysAwakePanel`. Backend `SleepConfigUpdate` validator gains a 7-day horizon cap.
+
+**Tech Stack:** Python 3.11, FastAPI, Pydantic v2, pytest. React 18, TypeScript strict, Tailwind, react-i18next. Native HTML inputs (no date-picker library).
+
+**Spec:** `docs/superpowers/specs/2026-05-09-sleep-page-os-detection-and-custom-datetime-design.md`
+
+---
+
+## Task 1: Backend — `os_sleep_inspector` pure helpers
+
+**Files:**
+- Create: `backend/app/services/power/os_sleep_inspector.py`
+- Test: `backend/tests/services/power/test_os_sleep_inspector_helpers.py`
+
+This task delivers the file/INI parsing helpers and the platform guard. The endpoint and cache come in later tasks.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/services/power/test_os_sleep_inspector_helpers.py`:
+
+```python
+"""Tests for os_sleep_inspector low-level helpers."""
+import sys
+from pathlib import Path
+
+import pytest
+
+from app.services.power import os_sleep_inspector as ins
+
+
+class TestParseSystemdIni:
+    def test_parses_simple_key_value(self, tmp_path: Path):
+        f = tmp_path / "logind.conf"
+        f.write_text("[Login]\nIdleAction=suspend\nIdleActionSec=30min\n")
+        result = ins._parse_systemd_ini(f, section="Login")
+        assert result == {"IdleAction": "suspend", "IdleActionSec": "30min"}
+
+    def test_skips_comments_and_blanks(self, tmp_path: Path):
+        f = tmp_path / "sleep.conf"
+        f.write_text(
+            "# top comment\n"
+            "; semicolon comment\n"
+            "\n"
+            "[Sleep]\n"
+            "AllowSuspend=yes\n"
+            "  # inline indented comment\n"
+            "AllowHibernation=no\n"
+        )
+        result = ins._parse_systemd_ini(f, section="Sleep")
+        assert result == {"AllowSuspend": "yes", "AllowHibernation": "no"}
+
+    def test_only_returns_requested_section(self, tmp_path: Path):
+        f = tmp_path / "logind.conf"
+        f.write_text(
+            "[Login]\nIdleAction=ignore\n"
+            "[Other]\nFoo=bar\n"
+        )
+        assert ins._parse_systemd_ini(f, section="Login") == {"IdleAction": "ignore"}
+        assert ins._parse_systemd_ini(f, section="Other") == {"Foo": "bar"}
+
+    def test_missing_file_returns_empty(self, tmp_path: Path):
+        assert ins._parse_systemd_ini(tmp_path / "nope.conf", section="Login") == {}
+
+    def test_malformed_lines_are_skipped(self, tmp_path: Path):
+        f = tmp_path / "logind.conf"
+        f.write_text("[Login]\nIdleAction=suspend\nthis line has no equals\nIdleActionSec=30min\n")
+        result = ins._parse_systemd_ini(f, section="Login")
+        assert result == {"IdleAction": "suspend", "IdleActionSec": "30min"}
+
+
+class TestMergeDropIns:
+    def test_drop_in_overrides_base(self, tmp_path: Path):
+        base = {"IdleAction": "ignore", "HandleLidSwitch": "suspend"}
+        drop_dir = tmp_path / "logind.conf.d"
+        drop_dir.mkdir()
+        (drop_dir / "30-baluhost.conf").write_text("[Login]\nIdleAction=suspend\n")
+        merged = ins._merge_drop_ins(base, drop_dir, section="Login")
+        assert merged["IdleAction"] == "suspend"
+        assert merged["HandleLidSwitch"] == "suspend"  # untouched
+
+    def test_drop_ins_applied_in_filename_order(self, tmp_path: Path):
+        base: dict[str, str] = {}
+        drop_dir = tmp_path / "logind.conf.d"
+        drop_dir.mkdir()
+        (drop_dir / "10-first.conf").write_text("[Login]\nIdleAction=ignore\n")
+        (drop_dir / "20-second.conf").write_text("[Login]\nIdleAction=suspend\n")
+        merged = ins._merge_drop_ins(base, drop_dir, section="Login")
+        assert merged["IdleAction"] == "suspend"  # later filename wins
+
+    def test_missing_directory_returns_base_unchanged(self, tmp_path: Path):
+        base = {"IdleAction": "ignore"}
+        merged = ins._merge_drop_ins(base, tmp_path / "nope.d", section="Login")
+        assert merged == base
+
+
+class TestPlatformGuard:
+    def test_unsupported_platform_short_circuits(self, monkeypatch):
+        monkeypatch.setattr(ins.sys, "platform", "win32")
+        report = ins.inspect_os_sleep(force_refresh=True)
+        assert report.platform_supported is False
+        assert report.logind == {}
+        assert report.sleep_conf == {}
+        assert report.targets == {}
+        assert report.issues == []
+
+    def test_no_systemd_dir_short_circuits(self, monkeypatch, tmp_path: Path):
+        monkeypatch.setattr(ins.sys, "platform", "linux")
+        monkeypatch.setattr(ins, "_SYSTEMD_DIR", tmp_path / "absent")
+        report = ins.inspect_os_sleep(force_refresh=True)
+        assert report.platform_supported is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/services/power/test_os_sleep_inspector_helpers.py -v`
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.power.os_sleep_inspector'`.
+
+- [ ] **Step 3: Create the module skeleton**
+
+Create `backend/app/services/power/os_sleep_inspector.py`:
+
+```python
+"""
+OS sleep settings inspector.
+
+Read-only inspection of systemd's logind/sleep configuration plus
+sleep-related target enablement, classified into severity-tagged issues
+for display on the Sleep page banner.
+
+No subprocess sudo, no writes — purely defensive observation.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from time import monotonic
+from typing import Literal, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants — overridable in tests via monkeypatch
+# ---------------------------------------------------------------------------
+_SYSTEMD_DIR = Path("/etc/systemd")
+
+_LOGIND_CONF = Path("/etc/systemd/logind.conf")
+_LOGIND_DROPIN_DIRS = (
+    Path("/etc/systemd/logind.conf.d"),
+    Path("/run/systemd/logind.conf.d"),
+)
+_SLEEP_CONF = Path("/etc/systemd/sleep.conf")
+_SLEEP_DROPIN_DIRS = (
+    Path("/etc/systemd/sleep.conf.d"),
+    Path("/run/systemd/sleep.conf.d"),
+)
+_TARGET_NAMES = (
+    "sleep.target",
+    "suspend.target",
+    "hibernate.target",
+    "hybrid-sleep.target",
+    "suspend-then-hibernate.target",
+)
+_LID_SENSOR = Path("/proc/acpi/button/lid")
+
+_CACHE_TTL_SECONDS = 60.0
+_SUBPROCESS_TIMEOUT_SECONDS = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+Severity = Literal["info", "warning", "error"]
+
+
+@dataclass(frozen=True)
+class OsSleepIssue:
+    severity: Severity
+    key: str
+    message: str
+    detail: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class OsSleepReport:
+    platform_supported: bool
+    logind: dict[str, str] = field(default_factory=dict)
+    sleep_conf: dict[str, str] = field(default_factory=dict)
+    targets: dict[str, str] = field(default_factory=dict)
+    issues: list[OsSleepIssue] = field(default_factory=list)
+    sources: list[str] = field(default_factory=list)
+    collected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+_cache_lock = threading.Lock()
+_cached: tuple[OsSleepReport, float] | None = None
+
+
+def _cache_get() -> Optional[OsSleepReport]:
+    with _cache_lock:
+        if _cached is None:
+            return None
+        report, stored_at = _cached
+        if monotonic() - stored_at > _CACHE_TTL_SECONDS:
+            return None
+        return report
+
+
+def _cache_put(report: OsSleepReport) -> None:
+    global _cached
+    with _cache_lock:
+        _cached = (report, monotonic())
+
+
+def _cache_clear() -> None:
+    """Test helper: invalidate the cache."""
+    global _cached
+    with _cache_lock:
+        _cached = None
+
+
+# ---------------------------------------------------------------------------
+# INI parsing helpers
+# ---------------------------------------------------------------------------
+def _parse_systemd_ini(path: Path, section: str) -> dict[str, str]:
+    """
+    Minimal systemd-style INI reader. Returns a flat dict for the given section.
+    Missing files yield {}. Malformed lines are skipped (logged at WARNING).
+    """
+    result: dict[str, str] = {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return result
+    except OSError as exc:
+        logger.warning("Could not read %s: %s", path, exc)
+        return result
+
+    in_section = False
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith(";"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_section = line[1:-1] == section
+            continue
+        if not in_section:
+            continue
+        if "=" not in line:
+            logger.warning("Skipping malformed line in %s: %r", path, raw)
+            continue
+        key, _, value = line.partition("=")
+        result[key.strip()] = value.strip()
+    return result
+
+
+def _merge_drop_ins(base: dict[str, str], drop_in_dir: Path, section: str) -> dict[str, str]:
+    """
+    Apply drop-in overrides from drop_in_dir, filename-sorted (systemd's behaviour).
+    Returns a new dict; does not mutate `base`.
+    """
+    merged = dict(base)
+    try:
+        files = sorted(p for p in drop_in_dir.iterdir() if p.is_file() and p.suffix == ".conf")
+    except FileNotFoundError:
+        return merged
+    except OSError as exc:
+        logger.warning("Could not list drop-ins in %s: %s", drop_in_dir, exc)
+        return merged
+    for f in files:
+        merged.update(_parse_systemd_ini(f, section=section))
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Public entry point — minimal version for Task 1
+# Full implementation lands in Task 3.
+# ---------------------------------------------------------------------------
+def inspect_os_sleep(force_refresh: bool = False) -> OsSleepReport:
+    if sys.platform != "linux" or not _SYSTEMD_DIR.is_dir():
+        return OsSleepReport(platform_supported=False)
+    # Real implementation arrives in Task 3.
+    return OsSleepReport(platform_supported=True)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/power/test_os_sleep_inspector_helpers.py -v`
+
+Expected: PASS for all 11 tests in this file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/power/os_sleep_inspector.py backend/tests/services/power/test_os_sleep_inspector_helpers.py
+git commit -m "feat(sleep): add os_sleep_inspector INI parser and platform guard"
+```
+
+---
+
+## Task 2: Backend — classifier rules
+
+**Files:**
+- Modify: `backend/app/services/power/os_sleep_inspector.py`
+- Test: `backend/tests/services/power/test_os_sleep_inspector_classifier.py` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/services/power/test_os_sleep_inspector_classifier.py`:
+
+```python
+"""Tests for the os_sleep_inspector issue classifier."""
+import pytest
+
+from app.services.power import os_sleep_inspector as ins
+
+
+def _classify(
+    *,
+    logind: dict[str, str] | None = None,
+    sleep_conf: dict[str, str] | None = None,
+    targets: dict[str, str] | None = None,
+    has_lid: bool = False,
+) -> list[ins.OsSleepIssue]:
+    return ins._classify(
+        logind=logind or {},
+        sleep_conf=sleep_conf or {},
+        targets=targets or {},
+        has_lid=has_lid,
+    )
+
+
+class TestClassifier:
+    def test_idle_action_suspend_warns(self):
+        issues = _classify(logind={"IdleAction": "suspend", "IdleActionSec": "30min"})
+        keys = {i.key for i in issues}
+        assert "logind.idle_action.suspend" in keys
+        suspend = next(i for i in issues if i.key == "logind.idle_action.suspend")
+        assert suspend.severity == "warning"
+        assert suspend.detail is not None and "30min" in suspend.detail
+
+    def test_idle_action_hibernate_warns_with_distinct_key(self):
+        issues = _classify(logind={"IdleAction": "hibernate"})
+        assert any(i.key == "logind.idle_action.hibernate" and i.severity == "warning" for i in issues)
+
+    def test_idle_action_hybrid_sleep_warns(self):
+        issues = _classify(logind={"IdleAction": "hybrid-sleep"})
+        assert any(i.key == "logind.idle_action.hybrid_sleep" and i.severity == "warning" for i in issues)
+
+    def test_idle_action_ignore_does_not_warn(self):
+        issues = _classify(logind={"IdleAction": "ignore"})
+        assert not any(i.key.startswith("logind.idle_action.") for i in issues)
+
+    def test_lid_switch_suspend_with_lid_emits_info(self):
+        issues = _classify(logind={"HandleLidSwitch": "suspend"}, has_lid=True)
+        assert any(i.key == "logind.lid_switch.suspend" and i.severity == "info" for i in issues)
+
+    def test_lid_switch_suspend_without_lid_silent(self):
+        issues = _classify(logind={"HandleLidSwitch": "suspend"}, has_lid=False)
+        assert not any(i.key.startswith("logind.lid_switch.") for i in issues)
+
+    def test_lid_switch_hibernate_emits_info_with_distinct_key(self):
+        issues = _classify(logind={"HandleLidSwitch": "hibernate"}, has_lid=True)
+        assert any(i.key == "logind.lid_switch.hibernate" for i in issues)
+
+    def test_sleep_conf_suspend_disabled_emits_info(self):
+        issues = _classify(sleep_conf={"AllowSuspend": "no"})
+        assert any(i.key == "sleep_conf.suspend_disabled" and i.severity == "info" for i in issues)
+
+    def test_suspend_target_masked_is_error(self):
+        issues = _classify(targets={"suspend.target": "masked"})
+        assert any(i.key == "targets.suspend.masked" and i.severity == "error" for i in issues)
+
+    def test_clean_config_emits_no_issues(self):
+        issues = _classify(
+            logind={"IdleAction": "ignore", "HandleLidSwitch": "ignore"},
+            sleep_conf={"AllowSuspend": "yes"},
+            targets={"suspend.target": "enabled"},
+            has_lid=True,
+        )
+        assert issues == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/services/power/test_os_sleep_inspector_classifier.py -v`
+
+Expected: FAIL — `AttributeError: module 'app.services.power.os_sleep_inspector' has no attribute '_classify'`.
+
+- [ ] **Step 3: Add `_classify` to the module**
+
+Append to `backend/app/services/power/os_sleep_inspector.py` (above the `inspect_os_sleep` function):
+
+```python
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+_IDLE_ACTION_KEYS = {
+    "suspend": "logind.idle_action.suspend",
+    "hibernate": "logind.idle_action.hibernate",
+    "hybrid-sleep": "logind.idle_action.hybrid_sleep",
+}
+_LID_KEYS = {
+    "suspend": "logind.lid_switch.suspend",
+    "hibernate": "logind.lid_switch.hibernate",
+}
+
+
+def _classify(
+    *,
+    logind: dict[str, str],
+    sleep_conf: dict[str, str],
+    targets: dict[str, str],
+    has_lid: bool,
+) -> list[OsSleepIssue]:
+    issues: list[OsSleepIssue] = []
+
+    idle_action = logind.get("IdleAction", "").strip().lower()
+    if idle_action in _IDLE_ACTION_KEYS:
+        idle_after = logind.get("IdleActionSec", "").strip() or None
+        issues.append(OsSleepIssue(
+            severity="warning",
+            key=_IDLE_ACTION_KEYS[idle_action],
+            message=f"logind: IdleAction={idle_action} (außerhalb von BaluHost)",
+            detail=(f"Wird nach {idle_after} Idle ausgelöst" if idle_after else None),
+        ))
+
+    lid_switch = logind.get("HandleLidSwitch", "").strip().lower()
+    if has_lid and lid_switch in _LID_KEYS:
+        issues.append(OsSleepIssue(
+            severity="info",
+            key=_LID_KEYS[lid_switch],
+            message=f"logind: HandleLidSwitch={lid_switch}",
+            detail="Lid-Sensor erkannt — manueller Deckel-Schluss löst OS-Sleep aus",
+        ))
+
+    if sleep_conf.get("AllowSuspend", "").strip().lower() == "no":
+        issues.append(OsSleepIssue(
+            severity="info",
+            key="sleep_conf.suspend_disabled",
+            message="OS hat Suspend deaktiviert (AllowSuspend=no)",
+            detail="BaluHost-Suspend wird fehlschlagen, solange diese Einstellung aktiv ist",
+        ))
+
+    if targets.get("suspend.target") == "masked":
+        issues.append(OsSleepIssue(
+            severity="error",
+            key="targets.suspend.masked",
+            message="suspend.target ist maskiert",
+            detail="BaluHost kann das System nicht in Suspend versetzen",
+        ))
+
+    return issues
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/power/test_os_sleep_inspector_classifier.py -v`
+
+Expected: PASS for all 10 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/power/os_sleep_inspector.py backend/tests/services/power/test_os_sleep_inspector_classifier.py
+git commit -m "feat(sleep): add os_sleep_inspector classifier rules"
+```
+
+---
+
+## Task 3: Backend — full `inspect_os_sleep` integration + cache + resilience
+
+**Files:**
+- Modify: `backend/app/services/power/os_sleep_inspector.py`
+- Test: `backend/tests/services/power/test_os_sleep_inspector_integration.py` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/services/power/test_os_sleep_inspector_integration.py`:
+
+```python
+"""Integration tests for inspect_os_sleep — file resolution, subprocess, cache, resilience."""
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.services.power import os_sleep_inspector as ins
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    ins._cache_clear()
+    yield
+    ins._cache_clear()
+
+
+@pytest.fixture
+def linux_fs(tmp_path: Path, monkeypatch):
+    """Layout a fake /etc/systemd tree under tmp_path and point the module at it."""
+    systemd = tmp_path / "etc" / "systemd"
+    systemd.mkdir(parents=True)
+    (systemd / "logind.conf.d").mkdir()
+    (systemd / "sleep.conf.d").mkdir()
+    monkeypatch.setattr(ins, "_SYSTEMD_DIR", systemd)
+    monkeypatch.setattr(ins, "_LOGIND_CONF", systemd / "logind.conf")
+    monkeypatch.setattr(ins, "_LOGIND_DROPIN_DIRS", (systemd / "logind.conf.d",))
+    monkeypatch.setattr(ins, "_SLEEP_CONF", systemd / "sleep.conf")
+    monkeypatch.setattr(ins, "_SLEEP_DROPIN_DIRS", (systemd / "sleep.conf.d",))
+    monkeypatch.setattr(ins, "_LID_SENSOR", tmp_path / "no-lid")
+    monkeypatch.setattr(ins.sys, "platform", "linux")
+    return systemd
+
+
+def _fake_systemctl(targets: dict[str, str]):
+    """Build a subprocess.run replacement that emits one status per target."""
+    def runner(cmd, *args, **kwargs):
+        # Return order matches argv order after the leading systemctl args.
+        names = cmd[2:]  # ["systemctl", "is-enabled", *names]
+        out = "\n".join(targets.get(n, "disabled") for n in names) + "\n"
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=out, stderr="")
+    return runner
+
+
+def test_full_report_resolves_drop_ins_and_targets(linux_fs: Path):
+    (linux_fs / "logind.conf").write_text("[Login]\nIdleAction=ignore\n")
+    (linux_fs / "logind.conf.d" / "30-baluhost.conf").write_text("[Login]\nIdleAction=suspend\nIdleActionSec=30min\n")
+    (linux_fs / "sleep.conf").write_text("[Sleep]\nAllowSuspend=yes\n")
+
+    with patch.object(ins.subprocess, "run", side_effect=_fake_systemctl({
+        "sleep.target": "enabled",
+        "suspend.target": "masked",
+        "hibernate.target": "disabled",
+        "hybrid-sleep.target": "disabled",
+        "suspend-then-hibernate.target": "disabled",
+    })):
+        report = ins.inspect_os_sleep(force_refresh=True)
+
+    assert report.platform_supported is True
+    assert report.logind["IdleAction"] == "suspend"
+    assert report.sleep_conf["AllowSuspend"] == "yes"
+    assert report.targets["suspend.target"] == "masked"
+    keys = {i.key for i in report.issues}
+    assert "logind.idle_action.suspend" in keys
+    assert "targets.suspend.masked" in keys
+    # logind.conf and the drop-in were both read; sleep.conf too.
+    assert any("logind.conf" in s for s in report.sources)
+    assert any("30-baluhost.conf" in s for s in report.sources)
+    assert any("sleep.conf" in s for s in report.sources)
+
+
+def test_cache_hit_skips_subprocess(linux_fs: Path):
+    (linux_fs / "logind.conf").write_text("[Login]\nIdleAction=ignore\n")
+    (linux_fs / "sleep.conf").write_text("[Sleep]\nAllowSuspend=yes\n")
+
+    with patch.object(ins.subprocess, "run", side_effect=_fake_systemctl({})) as run_mock:
+        ins.inspect_os_sleep(force_refresh=False)
+        ins.inspect_os_sleep(force_refresh=False)
+    assert run_mock.call_count == 1
+
+
+def test_force_refresh_bypasses_cache(linux_fs: Path):
+    (linux_fs / "logind.conf").write_text("[Login]\nIdleAction=ignore\n")
+    (linux_fs / "sleep.conf").write_text("[Sleep]\nAllowSuspend=yes\n")
+
+    with patch.object(ins.subprocess, "run", side_effect=_fake_systemctl({})) as run_mock:
+        ins.inspect_os_sleep(force_refresh=True)
+        ins.inspect_os_sleep(force_refresh=True)
+    assert run_mock.call_count == 2
+
+
+def test_subprocess_timeout_does_not_raise(linux_fs: Path):
+    (linux_fs / "logind.conf").write_text("[Login]\nIdleAction=ignore\n")
+    (linux_fs / "sleep.conf").write_text("[Sleep]\nAllowSuspend=yes\n")
+
+    def boom(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=5)
+    with patch.object(ins.subprocess, "run", side_effect=boom):
+        report = ins.inspect_os_sleep(force_refresh=True)
+    assert report.platform_supported is True
+    assert report.targets == {}
+
+
+def test_subprocess_failure_does_not_raise(linux_fs: Path):
+    (linux_fs / "logind.conf").write_text("[Login]\nIdleAction=ignore\n")
+    (linux_fs / "sleep.conf").write_text("[Sleep]\nAllowSuspend=yes\n")
+
+    def boom(*args, **kwargs):
+        raise FileNotFoundError("systemctl not found")
+    with patch.object(ins.subprocess, "run", side_effect=boom):
+        report = ins.inspect_os_sleep(force_refresh=True)
+    assert report.platform_supported is True
+    assert report.targets == {}
+
+
+def test_unexpected_exception_yields_inspector_failed(linux_fs: Path):
+    """If a helper raises unexpectedly, return a report with an inspector.failed issue."""
+    with patch.object(ins, "_parse_systemd_ini", side_effect=RuntimeError("kaboom")):
+        report = ins.inspect_os_sleep(force_refresh=True)
+    assert report.platform_supported is True
+    assert any(i.key == "inspector.failed" and i.severity == "error" for i in report.issues)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/services/power/test_os_sleep_inspector_integration.py -v`
+
+Expected: FAIL — most tests fail because `inspect_os_sleep` is still the stub from Task 1.
+
+- [ ] **Step 3: Replace `inspect_os_sleep` with the full implementation**
+
+In `backend/app/services/power/os_sleep_inspector.py`, replace the stub `inspect_os_sleep` at the bottom with:
+
+```python
+# ---------------------------------------------------------------------------
+# Subprocess helpers
+# ---------------------------------------------------------------------------
+def _systemctl_is_enabled(target_names: tuple[str, ...]) -> dict[str, str]:
+    """
+    Run `systemctl is-enabled <name1> <name2> …`. Returns a {name: status} dict.
+    On any failure (FileNotFoundError, TimeoutExpired, non-zero exit) returns {}.
+    """
+    try:
+        proc = subprocess.run(
+            ["systemctl", "is-enabled", *target_names],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.warning("systemctl is-enabled failed: %s", exc)
+        return {}
+    lines = [ln.strip() for ln in proc.stdout.splitlines() if ln.strip()]
+    if len(lines) != len(target_names):
+        logger.warning(
+            "Unexpected systemctl line count: got %d, expected %d",
+            len(lines), len(target_names),
+        )
+    return {name: status for name, status in zip(target_names, lines)}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+def inspect_os_sleep(force_refresh: bool = False) -> OsSleepReport:
+    """
+    Inspect OS sleep settings. Returns a report suitable for read-only display.
+    Cached for 60s; pass force_refresh=True to bypass.
+    """
+    if sys.platform != "linux" or not _SYSTEMD_DIR.is_dir():
+        return OsSleepReport(platform_supported=False)
+
+    if not force_refresh:
+        cached = _cache_get()
+        if cached is not None:
+            return cached
+
+    try:
+        logind: dict[str, str] = {}
+        sources: list[str] = []
+        if _LOGIND_CONF.is_file():
+            logind = _parse_systemd_ini(_LOGIND_CONF, section="Login")
+            sources.append(str(_LOGIND_CONF))
+        for d in _LOGIND_DROPIN_DIRS:
+            if d.is_dir():
+                before = dict(logind)
+                logind = _merge_drop_ins(logind, d, section="Login")
+                # Track only files we actually read.
+                for f in sorted(d.glob("*.conf")):
+                    if f.is_file() and (f.read_text(encoding="utf-8", errors="replace") or before != logind):
+                        sources.append(str(f))
+
+        sleep_conf: dict[str, str] = {}
+        if _SLEEP_CONF.is_file():
+            sleep_conf = _parse_systemd_ini(_SLEEP_CONF, section="Sleep")
+            sources.append(str(_SLEEP_CONF))
+        for d in _SLEEP_DROPIN_DIRS:
+            if d.is_dir():
+                sleep_conf = _merge_drop_ins(sleep_conf, d, section="Sleep")
+                for f in sorted(d.glob("*.conf")):
+                    if f.is_file():
+                        sources.append(str(f))
+
+        targets = _systemctl_is_enabled(_TARGET_NAMES)
+        has_lid = _LID_SENSOR.is_dir()
+
+        issues = _classify(
+            logind=logind, sleep_conf=sleep_conf, targets=targets, has_lid=has_lid,
+        )
+
+        report = OsSleepReport(
+            platform_supported=True,
+            logind=logind,
+            sleep_conf=sleep_conf,
+            targets=targets,
+            issues=issues,
+            sources=sources,
+        )
+    except Exception as exc:
+        logger.exception("os_sleep_inspector failed: %s", exc)
+        report = OsSleepReport(
+            platform_supported=True,
+            issues=[OsSleepIssue(
+                severity="error",
+                key="inspector.failed",
+                message="OS-Sleep-Detection fehlgeschlagen",
+                detail=str(exc),
+            )],
+        )
+
+    _cache_put(report)
+    return report
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/power/test_os_sleep_inspector_integration.py -v`
+
+Expected: PASS for all 6 tests.
+
+- [ ] **Step 5: Run the full inspector test suite to confirm no regression**
+
+Run: `cd backend && python -m pytest tests/services/power/test_os_sleep_inspector_helpers.py tests/services/power/test_os_sleep_inspector_classifier.py tests/services/power/test_os_sleep_inspector_integration.py -v`
+
+Expected: PASS for all 27 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/power/os_sleep_inspector.py backend/tests/services/power/test_os_sleep_inspector_integration.py
+git commit -m "feat(sleep): wire os_sleep_inspector with systemctl + cache + resilience"
+```
+
+---
+
+## Task 4: Backend — Pydantic schemas + 7-day cap
+
+**Files:**
+- Modify: `backend/app/schemas/sleep.py`
+- Test: `backend/tests/test_sleep_schemas.py` (new)
+
+This task adds the response schema for the OS-settings endpoint and tightens the always-awake validator.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/test_sleep_schemas.py`:
+
+```python
+"""Schema-level tests for OsSleepReportResponse and the 7-day cap."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.sleep import (
+    OsSleepIssueModel,
+    OsSleepReportResponse,
+    SleepConfigUpdate,
+)
+
+
+class TestOsSleepReportResponse:
+    def test_minimal_payload_validates(self):
+        payload = {"platform_supported": False}
+        m = OsSleepReportResponse(**payload)
+        assert m.platform_supported is False
+        assert m.logind == {}
+        assert m.issues == []
+        assert m.sources == []
+
+    def test_full_payload_round_trip(self):
+        payload = {
+            "platform_supported": True,
+            "logind": {"IdleAction": "suspend"},
+            "sleep_conf": {"AllowSuspend": "yes"},
+            "targets": {"suspend.target": "enabled"},
+            "issues": [
+                {"severity": "warning", "key": "logind.idle_action.suspend",
+                 "message": "logind suspends after idle", "detail": "30min"}
+            ],
+            "sources": ["/etc/systemd/logind.conf"],
+            "collected_at": "2026-05-09T12:00:00+00:00",
+        }
+        m = OsSleepReportResponse(**payload)
+        assert m.issues[0].severity == "warning"
+        assert m.issues[0].key == "logind.idle_action.suspend"
+
+    def test_severity_must_be_known(self):
+        bad = {
+            "platform_supported": True,
+            "issues": [{"severity": "purple", "key": "x", "message": "y"}],
+        }
+        with pytest.raises(ValidationError):
+            OsSleepReportResponse(**bad)
+
+
+class TestAlwaysAwake7DayCap:
+    def test_until_at_7_days_minus_5min_accepted(self):
+        v = datetime.now(timezone.utc) + timedelta(days=7) - timedelta(minutes=5)
+        SleepConfigUpdate(always_awake_until=v)  # must not raise
+
+    def test_until_8_days_in_future_rejected(self):
+        v = datetime.now(timezone.utc) + timedelta(days=8)
+        with pytest.raises(ValidationError) as exc:
+            SleepConfigUpdate(always_awake_until=v)
+        assert "7 days" in str(exc.value) or "7 Tagen" in str(exc.value)
+
+    def test_until_naive_datetime_normalized_then_capped(self):
+        # Naive value 8 days out — should be normalized to UTC and rejected.
+        v = (datetime.utcnow() + timedelta(days=8)).replace(tzinfo=None)
+        with pytest.raises(ValidationError):
+            SleepConfigUpdate(always_awake_until=v)
+
+    def test_until_in_past_still_rejected(self):
+        v = datetime.now(timezone.utc) - timedelta(minutes=1)
+        with pytest.raises(ValidationError):
+            SleepConfigUpdate(always_awake_until=v)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_sleep_schemas.py -v`
+
+Expected: FAIL — `ImportError` on `OsSleepIssueModel`/`OsSleepReportResponse`, plus the 7-day cap tests fail because the validator doesn't enforce a max yet.
+
+- [ ] **Step 3: Add response schemas to `backend/app/schemas/sleep.py`**
+
+Add after the existing `AlwaysAwakeStatus` class (after line 84):
+
+```python
+# ---------------------------------------------------------------------------
+# OS Sleep Inspector
+# ---------------------------------------------------------------------------
+
+class OsSleepIssueModel(BaseModel):
+    """One issue surfaced by the OS sleep inspector."""
+    severity: Literal["info", "warning", "error"]
+    key: str = Field(..., description="Stable identifier, used for i18n lookup")
+    message: str = Field(..., description="Fallback human-readable message")
+    detail: Optional[str] = Field(default=None)
+
+
+class OsSleepReportResponse(BaseModel):
+    """Snapshot of OS sleep configuration (read-only)."""
+    platform_supported: bool = Field(..., description="False on Windows / when /etc/systemd is missing")
+    logind: dict[str, str] = Field(default_factory=dict)
+    sleep_conf: dict[str, str] = Field(default_factory=dict)
+    targets: dict[str, str] = Field(default_factory=dict)
+    issues: list[OsSleepIssueModel] = Field(default_factory=list)
+    sources: list[str] = Field(default_factory=list)
+    collected_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+```
+
+- [ ] **Step 4: Tighten the 7-day cap in `_validate_until_future`**
+
+Replace the `_validate_until_future` validator on `SleepConfigUpdate` (currently at lines 193-204) with:
+
+```python
+    @field_validator("always_awake_until")
+    @classmethod
+    def _validate_until_future(cls, v: Optional[datetime]) -> Optional[datetime]:
+        if v is None:
+            return v
+        # Normalize naive datetimes to UTC
+        if v.tzinfo is None:
+            v = v.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        # Reject "now" as well: a non-future timestamp is meaningless for an override
+        if v <= now:
+            raise ValueError("always_awake_until must be in the future (UTC)")
+        # Reject far-future values: max 7 days horizon
+        if v > now + _MAX_ALWAYS_AWAKE_HORIZON:
+            raise ValueError("always_awake_until must be at most 7 days in the future")
+        return v
+```
+
+Just above the `class SleepConfigUpdate` definition (above line 168), add the constant:
+
+```python
+from datetime import timedelta as _timedelta  # local alias to avoid touching the existing import
+_MAX_ALWAYS_AWAKE_HORIZON = _timedelta(days=7)
+```
+
+If `timedelta` is already imported via `from datetime import …` at the top, simplify to `_MAX_ALWAYS_AWAKE_HORIZON = timedelta(days=7)` and skip the local alias. (Check the top of the file before adding the import.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/test_sleep_schemas.py -v`
+
+Expected: PASS for all 7 tests.
+
+- [ ] **Step 6: Run the existing always-awake test suites to confirm no regression**
+
+Run: `cd backend && python -m pytest tests/services/test_sleep_always_awake.py tests/api/test_sleep_always_awake_routes.py tests/test_sleep.py -v`
+
+Expected: PASS for all existing tests (existing presets stay well under 7 days).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/schemas/sleep.py backend/tests/test_sleep_schemas.py
+git commit -m "feat(sleep): add OsSleepReportResponse + 7-day always-awake cap"
+```
+
+---
+
+## Task 5: Backend — `GET /os-settings` endpoint
+
+**Files:**
+- Modify: `backend/app/api/routes/sleep.py`
+- Test: `backend/tests/api/test_sleep_os_settings_route.py` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/api/test_sleep_os_settings_route.py`:
+
+```python
+"""Tests for GET /api/system/sleep/os-settings."""
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from app.services.power.os_sleep_inspector import OsSleepIssue, OsSleepReport
+
+
+@pytest.fixture
+def stub_report():
+    return OsSleepReport(
+        platform_supported=True,
+        logind={"IdleAction": "suspend"},
+        sleep_conf={"AllowSuspend": "yes"},
+        targets={"suspend.target": "enabled"},
+        issues=[OsSleepIssue(
+            severity="warning",
+            key="logind.idle_action.suspend",
+            message="logind suspends after idle",
+            detail="30min",
+        )],
+        sources=["/etc/systemd/logind.conf"],
+        collected_at=datetime(2026, 5, 9, 12, 0, tzinfo=timezone.utc),
+    )
+
+
+def test_requires_admin(client, regular_user_token):
+    """Non-admin users get 403."""
+    res = client.get(
+        "/api/system/sleep/os-settings",
+        headers={"Authorization": f"Bearer {regular_user_token}"},
+    )
+    assert res.status_code == 403
+
+
+def test_returns_report_for_admin(client, admin_token, stub_report):
+    with patch(
+        "app.api.routes.sleep.os_sleep_inspector.inspect_os_sleep",
+        return_value=stub_report,
+    ):
+        res = client.get(
+            "/api/system/sleep/os-settings",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["platform_supported"] is True
+    assert body["logind"]["IdleAction"] == "suspend"
+    assert body["issues"][0]["key"] == "logind.idle_action.suspend"
+
+
+def test_force_param_bypasses_cache(client, admin_token, stub_report):
+    with patch(
+        "app.api.routes.sleep.os_sleep_inspector.inspect_os_sleep",
+        return_value=stub_report,
+    ) as inspect_mock:
+        res = client.get(
+            "/api/system/sleep/os-settings?force=true",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert res.status_code == 200
+    inspect_mock.assert_called_once_with(force_refresh=True)
+
+
+def test_default_does_not_force_refresh(client, admin_token, stub_report):
+    with patch(
+        "app.api.routes.sleep.os_sleep_inspector.inspect_os_sleep",
+        return_value=stub_report,
+    ) as inspect_mock:
+        client.get(
+            "/api/system/sleep/os-settings",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    inspect_mock.assert_called_once_with(force_refresh=False)
+```
+
+If the existing `client` / `admin_token` / `regular_user_token` fixtures don't exist under that exact name, look at one of the existing route tests in `backend/tests/api/test_sleep_*` (e.g. `test_sleep_always_awake_routes.py`) for the project's fixture conventions, and adopt the same names — do NOT invent new fixtures.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/api/test_sleep_os_settings_route.py -v`
+
+Expected: FAIL — endpoint returns 404 (not yet defined).
+
+- [ ] **Step 3: Add the endpoint**
+
+In `backend/app/api/routes/sleep.py`, add the import near the other service imports (around line 37):
+
+```python
+from app.services.power import os_sleep_inspector
+from app.schemas.sleep import OsSleepReportResponse
+```
+
+Add the endpoint between the existing `/capabilities` route (ends ~line 241) and `/my-permissions` (starts ~line 244):
+
+```python
+@router.get("/os-settings", response_model=OsSleepReportResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def get_os_sleep_settings(
+    request: Request, response: Response,
+    force: bool = False,
+    current_user: User = Depends(get_current_admin),
+) -> OsSleepReportResponse:
+    """Read-only snapshot of OS-level sleep configuration (admin only)."""
+    report = os_sleep_inspector.inspect_os_sleep(force_refresh=force)
+    return OsSleepReportResponse(
+        platform_supported=report.platform_supported,
+        logind=report.logind,
+        sleep_conf=report.sleep_conf,
+        targets=report.targets,
+        issues=[
+            {"severity": i.severity, "key": i.key, "message": i.message, "detail": i.detail}
+            for i in report.issues
+        ],
+        sources=report.sources,
+        collected_at=report.collected_at,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/api/test_sleep_os_settings_route.py -v`
+
+Expected: PASS for all 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes/sleep.py backend/tests/api/test_sleep_os_settings_route.py
+git commit -m "feat(sleep): GET /api/system/sleep/os-settings (admin)"
+```
+
+---
+
+## Task 6: Backend — extend always-awake route tests for the 7-day cap
+
+**Files:**
+- Modify: `backend/tests/api/test_sleep_always_awake_routes.py`
+
+- [ ] **Step 1: Add new tests**
+
+Append to `backend/tests/api/test_sleep_always_awake_routes.py` (the file structure / fixtures are already established — match the conventions of the existing tests in this file):
+
+```python
+def test_until_rejected_when_more_than_7_days(client, admin_token):
+    from datetime import datetime, timedelta, timezone
+    eight_days = (datetime.now(timezone.utc) + timedelta(days=8)).isoformat()
+    res = client.put(
+        "/api/system/sleep/config",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"always_awake_enabled": True, "always_awake_until": eight_days},
+    )
+    assert res.status_code == 422
+    assert "7 days" in res.text or "7 Tagen" in res.text
+
+
+def test_until_accepted_at_6_days_23h(client, admin_token):
+    from datetime import datetime, timedelta, timezone
+    target = (datetime.now(timezone.utc) + timedelta(days=6, hours=23)).isoformat()
+    res = client.put(
+        "/api/system/sleep/config",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"always_awake_enabled": True, "always_awake_until": target},
+    )
+    assert res.status_code == 200
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/api/test_sleep_always_awake_routes.py -v`
+
+Expected: PASS — all existing tests still pass and the two new ones validate the cap.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/tests/api/test_sleep_always_awake_routes.py
+git commit -m "test(sleep): cover 7-day always-awake cap on PUT /config"
+```
+
+---
+
+## Task 7: Backend — full sleep test suite sweep
+
+**Files:** none new (verification step)
+
+- [ ] **Step 1: Run sleep-scoped pytest**
+
+Run: `cd backend && python -m pytest -v -k "sleep or os_sleep"`
+
+Expected: all tests pass — none should regress from Tasks 1-6.
+
+- [ ] **Step 2: Run the full backend test suite**
+
+Run: `cd backend && python -m pytest -q`
+
+Expected: same pass/fail surface as before this branch (per memory `feedback_run_tests_before_pr`). Any *new* failures in unrelated tests need investigation before continuing.
+
+If the run is clean, no commit is needed. If a fix-up is required, commit it as `fix(sleep): …` referencing the underlying cause.
+
+---
+
+## Task 8: Frontend — API client types and `getOsSleepSettings`
+
+**Files:**
+- Modify: `client/src/api/sleep.ts`
+
+- [ ] **Step 1: Add types and the API function**
+
+In `client/src/api/sleep.ts`, add after the existing `AlwaysAwakeStatus` interface (after line 54), inside the "Types" section:
+
+```typescript
+export type OsSleepSeverity = 'info' | 'warning' | 'error';
+
+export interface OsSleepIssue {
+  severity: OsSleepSeverity;
+  key: string;
+  message: string;
+  detail: string | null;
+}
+
+export interface OsSleepReport {
+  platform_supported: boolean;
+  logind: Record<string, string>;
+  sleep_conf: Record<string, string>;
+  targets: Record<string, string>;
+  issues: OsSleepIssue[];
+  sources: string[];
+  collected_at: string;
+}
+```
+
+Add the API function at the end of the file (after `getSleepCapabilities`, line 237):
+
+```typescript
+export async function getOsSleepSettings(force = false): Promise<OsSleepReport> {
+  const response = await apiClient.get<OsSleepReport>('/api/system/sleep/os-settings', {
+    params: force ? { force: true } : undefined,
+  });
+  return response.data;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd client && npx tsc --noEmit`
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/api/sleep.ts
+git commit -m "feat(sleep): frontend api client for os-settings"
+```
+
+---
+
+## Task 9: Frontend — i18n keys
+
+**Files:**
+- Modify: `client/src/i18n/locales/de/system.json`
+- Modify: `client/src/i18n/locales/en/system.json`
+
+- [ ] **Step 1: Add the German keys**
+
+In `client/src/i18n/locales/de/system.json`, locate the `sleep` object. Add a new `osSettings` block (sibling of `alwaysAwake` and the other sleep blocks):
+
+```json
+"osSettings": {
+  "title": "OS-Sleep-Einstellungen",
+  "refresh": "Aktualisieren",
+  "detailsToggle": "Details",
+  "allClear": "Keine OS-Sleep-Trigger aktiv. BaluHost steuert Sleep allein.",
+  "sources": "Quellen",
+  "loading": "Wird geladen…",
+  "loadFailed": "OS-Sleep-Einstellungen konnten nicht geladen werden",
+  "issue": {
+    "logind.idle_action.suspend": "logind: IdleAction=suspend (außerhalb von BaluHost)",
+    "logind.idle_action.hibernate": "logind: IdleAction=hibernate (außerhalb von BaluHost)",
+    "logind.idle_action.hybrid_sleep": "logind: IdleAction=hybrid-sleep (außerhalb von BaluHost)",
+    "logind.lid_switch.suspend": "logind: HandleLidSwitch=suspend",
+    "logind.lid_switch.hibernate": "logind: HandleLidSwitch=hibernate",
+    "sleep_conf.suspend_disabled": "OS hat Suspend deaktiviert (AllowSuspend=no)",
+    "targets.suspend.masked": "suspend.target ist maskiert",
+    "inspector.failed": "OS-Sleep-Detection fehlgeschlagen"
+  }
+}
+```
+
+In the same `sleep.alwaysAwake` block, add these new keys (siblings of the existing `preset1h`, `presetPermanent`, etc.):
+
+```json
+"presetCustom": "Bis Datum…",
+"activeCustom": "Bis {{datetime}}",
+"pickerLabel": "Datum & Uhrzeit",
+"pickerApply": "Übernehmen",
+"pickerCancel": "Abbrechen",
+"pickerErrorPast": "Zeitpunkt muss in der Zukunft liegen (mind. 5 Min)",
+"pickerErrorMax": "Maximal 7 Tage in der Zukunft"
+```
+
+- [ ] **Step 2: Add the English keys**
+
+Mirror in `client/src/i18n/locales/en/system.json`:
+
+```json
+"osSettings": {
+  "title": "OS sleep settings",
+  "refresh": "Refresh",
+  "detailsToggle": "Details",
+  "allClear": "No OS-level sleep triggers active. BaluHost is in sole control.",
+  "sources": "Sources",
+  "loading": "Loading…",
+  "loadFailed": "Failed to load OS sleep settings",
+  "issue": {
+    "logind.idle_action.suspend": "logind: IdleAction=suspend (outside BaluHost)",
+    "logind.idle_action.hibernate": "logind: IdleAction=hibernate (outside BaluHost)",
+    "logind.idle_action.hybrid_sleep": "logind: IdleAction=hybrid-sleep (outside BaluHost)",
+    "logind.lid_switch.suspend": "logind: HandleLidSwitch=suspend",
+    "logind.lid_switch.hibernate": "logind: HandleLidSwitch=hibernate",
+    "sleep_conf.suspend_disabled": "OS has suspend disabled (AllowSuspend=no)",
+    "targets.suspend.masked": "suspend.target is masked",
+    "inspector.failed": "OS sleep detection failed"
+  }
+}
+```
+
+For `sleep.alwaysAwake`:
+
+```json
+"presetCustom": "Until date…",
+"activeCustom": "Until {{datetime}}",
+"pickerLabel": "Date & time",
+"pickerApply": "Apply",
+"pickerCancel": "Cancel",
+"pickerErrorPast": "Must be in the future (at least 5 min)",
+"pickerErrorMax": "At most 7 days in the future"
+```
+
+- [ ] **Step 3: Type-check + lint the JSON**
+
+Run: `cd client && npx tsc --noEmit`
+
+Expected: no errors. Also visually scan both files for trailing commas / missing commas.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/i18n/locales/de/system.json client/src/i18n/locales/en/system.json
+git commit -m "feat(sleep): i18n strings for os-settings banner + custom datetime"
+```
+
+---
+
+## Task 10: Frontend — `OsSleepSettingsBanner` component
+
+**Files:**
+- Create: `client/src/components/power/OsSleepSettingsBanner.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `client/src/components/power/OsSleepSettingsBanner.tsx`:
+
+```tsx
+/**
+ * OS Sleep Settings Banner
+ *
+ * Read-only card at the top of the Sleep page. Surfaces OS-level sleep
+ * triggers (logind, sleep.conf, masked targets) so users understand which
+ * sleep behaviour BaluHost actually owns. No edit functionality.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, CheckCircle2, Info, RefreshCw, ShieldAlert } from 'lucide-react';
+
+import {
+  getOsSleepSettings,
+  type OsSleepIssue,
+  type OsSleepReport,
+  type OsSleepSeverity,
+} from '../../api/sleep';
+
+const ICON_FOR: Record<OsSleepSeverity, typeof AlertTriangle> = {
+  info: Info,
+  warning: AlertTriangle,
+  error: ShieldAlert,
+};
+
+const COLOR_FOR: Record<OsSleepSeverity, string> = {
+  info: 'text-slate-300',
+  warning: 'text-amber-400',
+  error: 'text-red-400',
+};
+
+function IssueLine({ issue }: { issue: OsSleepIssue }) {
+  const { t } = useTranslation('system');
+  const Icon = ICON_FOR[issue.severity];
+  const colorClass = COLOR_FOR[issue.severity];
+  const text = t(`sleep.osSettings.issue.${issue.key}`, { defaultValue: issue.message });
+  return (
+    <div className="flex items-start gap-2 text-sm">
+      <Icon className={`h-4 w-4 shrink-0 mt-0.5 ${colorClass}`} />
+      <div>
+        <span className="text-slate-200">{text}</span>
+        {issue.detail && (
+          <p className="mt-0.5 text-xs text-slate-400">{issue.detail}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DetailsTable({ report }: { report: OsSleepReport }) {
+  const { t } = useTranslation('system');
+  const rows: Array<[string, string]> = [];
+  for (const [k, v] of Object.entries(report.logind)) rows.push([`logind.${k}`, v]);
+  for (const [k, v] of Object.entries(report.sleep_conf)) rows.push([`sleep.${k}`, v]);
+  for (const [k, v] of Object.entries(report.targets)) rows.push([`targets.${k}`, v]);
+  return (
+    <details className="mt-3 group">
+      <summary className="cursor-pointer text-xs text-slate-400 hover:text-slate-200 select-none">
+        {t('sleep.osSettings.detailsToggle')}
+      </summary>
+      <div className="mt-2 space-y-1 pl-4 text-xs">
+        {rows.map(([k, v]) => (
+          <div key={k} className="flex gap-2">
+            <span className="text-slate-500 font-mono">{k}</span>
+            <span className="text-slate-300 font-mono">= {v}</span>
+          </div>
+        ))}
+        {report.sources.length > 0 && (
+          <div className="pt-2 text-slate-500">
+            {t('sleep.osSettings.sources')}: {report.sources.join(', ')}
+          </div>
+        )}
+      </div>
+    </details>
+  );
+}
+
+export function OsSleepSettingsBanner() {
+  const { t } = useTranslation('system');
+  const [report, setReport] = useState<OsSleepReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async (force = false) => {
+    if (force) setRefreshing(true);
+    setError(null);
+    try {
+      const data = await getOsSleepSettings(force);
+      setReport(data);
+    } catch {
+      setError(t('sleep.osSettings.loadFailed'));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    load(false);
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="card border-slate-700/50 p-4 sm:p-6">
+        <div className="animate-pulse space-y-3">
+          <div className="h-5 w-1/3 bg-slate-700/50 rounded" />
+          <div className="h-4 w-2/3 bg-slate-700/40 rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  // Hide entirely on unsupported platforms (no banner, no placeholder).
+  if (report && !report.platform_supported && !error) {
+    return null;
+  }
+
+  return (
+    <div className="card border-slate-700/50 p-4 sm:p-6 space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <h4 className="text-sm font-medium text-white">{t('sleep.osSettings.title')}</h4>
+        <button
+          type="button"
+          onClick={() => load(true)}
+          disabled={refreshing}
+          className="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs text-slate-400 hover:text-slate-200 hover:bg-slate-700/40 transition-colors disabled:opacity-60"
+          aria-label={t('sleep.osSettings.refresh')}
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`} />
+          {t('sleep.osSettings.refresh')}
+        </button>
+      </div>
+
+      {error && (
+        <div className="flex items-start gap-2 text-sm">
+          <ShieldAlert className="h-4 w-4 shrink-0 mt-0.5 text-red-400" />
+          <span className="text-slate-200">{error}</span>
+        </div>
+      )}
+
+      {report && !error && (
+        <>
+          {report.issues.length === 0 ? (
+            <div className="flex items-start gap-2 text-sm">
+              <CheckCircle2 className="h-4 w-4 shrink-0 mt-0.5 text-emerald-400" />
+              <span className="text-slate-200">{t('sleep.osSettings.allClear')}</span>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {report.issues.map((issue) => (
+                <IssueLine key={issue.key} issue={issue} />
+              ))}
+            </div>
+          )}
+          <DetailsTable report={report} />
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd client && npx tsc --noEmit`
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/components/power/OsSleepSettingsBanner.tsx
+git commit -m "feat(sleep): OsSleepSettingsBanner component"
+```
+
+---
+
+## Task 11: Frontend — mount the banner on the Sleep page
+
+**Files:**
+- Modify: `client/src/pages/SleepMode.tsx`
+
+- [ ] **Step 1: Add the component as the first child**
+
+Replace the contents of `client/src/pages/SleepMode.tsx` with:
+
+```tsx
+/**
+ * Sleep Mode Page
+ *
+ * Combines the sleep mode control panel, core operating hours configuration,
+ * legacy sleep config, and history into a single page rendered as a tab in
+ * SystemControlPage.
+ */
+
+import { OsSleepSettingsBanner } from '../components/power/OsSleepSettingsBanner';
+import { SleepModePanel } from '../components/power/SleepModePanel';
+import { AlwaysAwakePanel } from '../components/power/AlwaysAwakePanel';
+import { CoreUptimePanel } from '../components/power/CoreUptimePanel';
+import { SleepConfigPanel } from '../components/power/SleepConfigPanel';
+import { SleepHistoryTable } from '../components/power/SleepHistoryTable';
+
+export default function SleepMode() {
+  return (
+    <div className="space-y-6">
+      <OsSleepSettingsBanner />
+      <SleepModePanel />
+      <AlwaysAwakePanel />
+      <CoreUptimePanel />
+      <SleepConfigPanel />
+      <SleepHistoryTable />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd client && npx tsc --noEmit`
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/pages/SleepMode.tsx
+git commit -m "feat(sleep): mount OsSleepSettingsBanner at top of Sleep page"
+```
+
+---
+
+## Task 12: Frontend — `AlwaysAwakePanel` custom datetime button + popover
+
+**Files:**
+- Modify: `client/src/components/power/AlwaysAwakePanel.tsx`
+
+This is the largest single edit. Read the file end-to-end before editing.
+
+- [ ] **Step 1: Read the current `AlwaysAwakePanel`**
+
+Open `client/src/components/power/AlwaysAwakePanel.tsx` to understand the existing optimistic-update pattern (`setPreset` lines 116-141) and the preset inference block (lines 58-81). Match those patterns when extending.
+
+- [ ] **Step 2: Replace the file contents**
+
+Replace `client/src/components/power/AlwaysAwakePanel.tsx` with:
+
+```tsx
+/**
+ * Always-Awake panel.
+ *
+ * Master toggle + optional expiry presets (1h/4h/8h/permanent) plus a
+ * custom datetime picker capped at 7 days.
+ * Auto-saves all changes; manual Sleep/Suspend on the server side
+ * automatically clears the override.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { Coffee, Clock, X } from 'lucide-react';
+import {
+  getSleepConfig,
+  getSleepStatus,
+  updateSleepConfig,
+} from '../../api/sleep';
+
+type Preset = '1h' | '4h' | '8h' | 'permanent' | 'custom';
+
+const PRESET_HOURS: Record<Exclude<Preset, 'permanent' | 'custom'>, number> = {
+  '1h': 1,
+  '4h': 4,
+  '8h': 8,
+};
+
+const MIN_HORIZON_MS = 5 * 60 * 1000;        // 5 minutes
+const MAX_HORIZON_MS = 7 * 24 * 3600 * 1000; // 7 days
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  // Within the next 7 days: "DD.MM. HH:mm". Beyond (shouldn't happen with the cap)
+  // we still render the full date.
+  const ddmm = d.toLocaleDateString([], { day: '2-digit', month: '2-digit' });
+  const hhmm = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  return `${ddmm} ${hhmm}`;
+}
+
+function formatRemaining(seconds: number): string {
+  if (seconds < 0) return '0m';
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+/** Convert a Date into the value format expected by <input type="datetime-local"> in the user's local TZ. */
+function toLocalInputValue(date: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  );
+}
+
+export function AlwaysAwakePanel() {
+  const { t } = useTranslation('system');
+  const [enabled, setEnabled] = useState(false);
+  const [until, setUntil] = useState<string | null>(null);
+  const [expiresIn, setExpiresIn] = useState<number | null>(null);
+  const [scheduleEnabled, setScheduleEnabled] = useState(false);
+  const [coreUptimeEnabled, setCoreUptimeEnabled] = useState(false);
+  const [activePreset, setActivePreset] = useState<Preset | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerValue, setPickerValue] = useState<string>('');
+  const [pickerError, setPickerError] = useState<string | null>(null);
+  const tickRef = useRef<number | null>(null);
+  const pickerRef = useRef<HTMLDivElement | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [cfg, status] = await Promise.all([getSleepConfig(), getSleepStatus()]);
+      setEnabled(cfg.always_awake_enabled ?? false);
+      setUntil(cfg.always_awake_until ?? null);
+      setExpiresIn(status.always_awake?.expires_in_seconds ?? null);
+      setScheduleEnabled(cfg.schedule_enabled);
+      setCoreUptimeEnabled(cfg.core_uptime_enabled ?? false);
+
+      if (!cfg.always_awake_enabled) {
+        setActivePreset(null);
+      } else if (cfg.always_awake_until == null) {
+        setActivePreset('permanent');
+      } else {
+        const remaining = status.always_awake?.expires_in_seconds ?? 0;
+        const candidates: Array<[Preset, number]> = [
+          ['1h', 1 * 3600],
+          ['4h', 4 * 3600],
+          ['8h', 8 * 3600],
+        ];
+        let best: Preset | null = null;
+        let bestDiff = 5 * 60;
+        for (const [p, sec] of candidates) {
+          const diff = Math.abs(remaining - sec);
+          if (diff <= bestDiff) {
+            bestDiff = diff;
+            best = p;
+          }
+        }
+        setActivePreset(best ?? 'custom');
+      }
+    } catch {
+      toast.error(t('sleep.alwaysAwake.loadFailed'));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (expiresIn === null) {
+      if (tickRef.current) window.clearInterval(tickRef.current);
+      return;
+    }
+    tickRef.current = window.setInterval(() => {
+      setExpiresIn((prev) => (prev === null ? null : Math.max(0, prev - 1)));
+    }, 1000);
+    return () => {
+      if (tickRef.current) window.clearInterval(tickRef.current);
+    };
+  }, [expiresIn !== null]);
+
+  useEffect(() => {
+    if (expiresIn === 0) {
+      setExpiresIn(null);
+      refresh();
+    }
+  }, [expiresIn, refresh]);
+
+  // Close popover on outside click / Escape.
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setPickerOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setPickerOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [pickerOpen]);
+
+  const setPreset = async (preset: Exclude<Preset, 'custom'>) => {
+    const newUntil =
+      preset === 'permanent'
+        ? null
+        : new Date(Date.now() + PRESET_HOURS[preset] * 3600 * 1000).toISOString();
+    const previousEnabled = enabled;
+    const previousUntil = until;
+    const previousExpiresIn = expiresIn;
+    const previousActivePreset = activePreset;
+    setEnabled(true);
+    setUntil(newUntil);
+    setExpiresIn(newUntil ? PRESET_HOURS[preset as keyof typeof PRESET_HOURS] * 3600 : null);
+    setActivePreset(preset);
+    try {
+      await updateSleepConfig({
+        always_awake_enabled: true,
+        always_awake_until: newUntil,
+      });
+    } catch (err) {
+      setEnabled(previousEnabled);
+      setUntil(previousUntil);
+      setExpiresIn(previousExpiresIn);
+      setActivePreset(previousActivePreset);
+      toast.error(err instanceof Error ? err.message : t('sleep.alwaysAwake.saveFailed'));
+    }
+  };
+
+  const setCustomPreset = async (localValue: string) => {
+    const target = new Date(localValue);
+    if (Number.isNaN(target.getTime())) {
+      setPickerError(t('sleep.alwaysAwake.pickerErrorPast'));
+      return;
+    }
+    const delta = target.getTime() - Date.now();
+    if (delta < MIN_HORIZON_MS) {
+      setPickerError(t('sleep.alwaysAwake.pickerErrorPast'));
+      return;
+    }
+    if (delta > MAX_HORIZON_MS) {
+      setPickerError(t('sleep.alwaysAwake.pickerErrorMax'));
+      return;
+    }
+
+    const newUntil = target.toISOString();
+    const previousEnabled = enabled;
+    const previousUntil = until;
+    const previousExpiresIn = expiresIn;
+    const previousActivePreset = activePreset;
+    setEnabled(true);
+    setUntil(newUntil);
+    setExpiresIn(Math.floor(delta / 1000));
+    setActivePreset('custom');
+    setPickerOpen(false);
+    setPickerError(null);
+    try {
+      await updateSleepConfig({
+        always_awake_enabled: true,
+        always_awake_until: newUntil,
+      });
+    } catch (err) {
+      setEnabled(previousEnabled);
+      setUntil(previousUntil);
+      setExpiresIn(previousExpiresIn);
+      setActivePreset(previousActivePreset);
+      toast.error(err instanceof Error ? err.message : t('sleep.alwaysAwake.saveFailed'));
+    }
+  };
+
+  const openPicker = () => {
+    const seed =
+      activePreset === 'custom' && until
+        ? new Date(until)
+        : new Date(Date.now() + 4 * 3600 * 1000); // default seed: now+4h
+    setPickerValue(toLocalInputValue(seed));
+    setPickerError(null);
+    setPickerOpen(true);
+  };
+
+  const handleCancel = async () => {
+    const prev = { enabled, until, expiresIn, activePreset };
+    setEnabled(false);
+    setUntil(null);
+    setExpiresIn(null);
+    setActivePreset(null);
+    try {
+      await updateSleepConfig({ always_awake_enabled: false });
+    } catch (err) {
+      setEnabled(prev.enabled);
+      setUntil(prev.until);
+      setExpiresIn(prev.expiresIn);
+      setActivePreset(prev.activePreset);
+      toast.error(err instanceof Error ? err.message : t('sleep.alwaysAwake.saveFailed'));
+    }
+  };
+
+  const handleMasterToggle = async () => {
+    if (enabled) {
+      await handleCancel();
+    } else {
+      await setPreset('permanent');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="card border-slate-700/50 p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-6 bg-slate-700/50 rounded w-1/3" />
+          <div className="h-24 bg-slate-700/50 rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  const minLocal = toLocalInputValue(new Date(Date.now() + MIN_HORIZON_MS));
+  const maxLocal = toLocalInputValue(new Date(Date.now() + MAX_HORIZON_MS));
+
+  return (
+    <div className="card border-slate-700/50 p-4 sm:p-6 space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Coffee className="h-4 w-4 text-amber-400" />
+          <div>
+            <h4 className="text-sm font-medium text-white">{t('sleep.alwaysAwake.title')}</h4>
+            <p className="mt-0.5 text-xs text-slate-400">{t('sleep.alwaysAwake.description')}</p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={handleMasterToggle}
+          className={`relative inline-flex h-6 w-11 shrink-0 rounded-full transition-colors ${
+            enabled ? 'bg-amber-500' : 'bg-slate-600'
+          }`}
+          aria-label={t('sleep.alwaysAwake.masterToggle')}
+        >
+          <span
+            className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform transition-transform ${
+              enabled ? 'translate-x-5.5 ml-0.5' : 'translate-x-0.5'
+            } mt-0.5`}
+          />
+        </button>
+      </div>
+
+      {enabled && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 text-xs text-amber-200">
+            <Clock className="h-4 w-4 shrink-0" />
+            {until && expiresIn !== null ? (
+              <span>{t('sleep.alwaysAwake.activeUntil', {
+                time: formatTime(until),
+                remaining: formatRemaining(expiresIn),
+              })}</span>
+            ) : (
+              <span>{t('sleep.alwaysAwake.activePermanent')}</span>
+            )}
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="ml-auto inline-flex items-center gap-1 rounded px-2 py-0.5 text-slate-400 hover:text-red-300 hover:bg-red-500/10 transition-colors"
+            >
+              <X className="h-3.5 w-3.5" />
+              {t('sleep.alwaysAwake.cancel')}
+            </button>
+          </div>
+
+          {(scheduleEnabled || coreUptimeEnabled) && until && (
+            <div className="rounded border border-amber-500/20 bg-amber-500/10 p-2 text-xs text-amber-300">
+              {t('sleep.alwaysAwake.hintScheduleResumes', { time: formatTime(until) })}
+            </div>
+          )}
+          {(scheduleEnabled || coreUptimeEnabled) && !until && (
+            <div className="rounded border border-blue-500/20 bg-blue-500/10 p-2 text-xs text-blue-300">
+              {t('sleep.alwaysAwake.hintPermanentClearToResume')}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2 pt-1">
+        {(['1h', '4h', '8h', 'permanent'] as const).map((p) => {
+          const isActive = enabled && activePreset === p;
+          const labelKey =
+            p === 'permanent'
+              ? 'sleep.alwaysAwake.presetPermanent'
+              : (`sleep.alwaysAwake.preset${p}` as const);
+          return (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setPreset(p)}
+              className={`min-w-[3.5rem] rounded px-3 py-1.5 text-xs font-medium transition-colors ${
+                isActive
+                  ? 'bg-amber-500/30 text-amber-200 border border-amber-500/50'
+                  : 'bg-slate-800/40 text-slate-400 border border-slate-700/40 hover:text-amber-300 hover:border-amber-500/30'
+              }`}
+            >
+              {t(labelKey)}
+            </button>
+          );
+        })}
+
+        <div className="relative" ref={pickerRef}>
+          <button
+            type="button"
+            onClick={openPicker}
+            className={`min-w-[3.5rem] rounded px-3 py-1.5 text-xs font-medium transition-colors ${
+              enabled && activePreset === 'custom'
+                ? 'bg-amber-500/30 text-amber-200 border border-amber-500/50'
+                : 'bg-slate-800/40 text-slate-400 border border-slate-700/40 hover:text-amber-300 hover:border-amber-500/30'
+            }`}
+          >
+            {enabled && activePreset === 'custom' && until
+              ? t('sleep.alwaysAwake.activeCustom', { datetime: formatDateTime(until) })
+              : t('sleep.alwaysAwake.presetCustom')}
+          </button>
+
+          {pickerOpen && (
+            <div className="absolute z-10 mt-2 right-0 sm:right-auto sm:left-0 w-72 rounded-md border border-slate-700/60 bg-slate-900 p-3 shadow-xl space-y-2">
+              <label className="block text-xs text-slate-300">
+                {t('sleep.alwaysAwake.pickerLabel')}
+                <input
+                  type="datetime-local"
+                  className="mt-1 block w-full rounded border border-slate-700/60 bg-slate-800 px-2 py-1 text-sm text-slate-100"
+                  min={minLocal}
+                  max={maxLocal}
+                  value={pickerValue}
+                  onChange={(e) => {
+                    setPickerValue(e.target.value);
+                    setPickerError(null);
+                  }}
+                />
+              </label>
+              {pickerError && (
+                <p className="text-xs text-red-400">{pickerError}</p>
+              )}
+              <div className="flex justify-end gap-2 pt-1">
+                <button
+                  type="button"
+                  onClick={() => setPickerOpen(false)}
+                  className="rounded px-2 py-1 text-xs text-slate-400 hover:text-slate-200"
+                >
+                  {t('sleep.alwaysAwake.pickerCancel')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setCustomPreset(pickerValue)}
+                  className="rounded px-2 py-1 text-xs font-medium bg-amber-500/30 text-amber-200 border border-amber-500/50 hover:bg-amber-500/40"
+                >
+                  {t('sleep.alwaysAwake.pickerApply')}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd client && npx tsc --noEmit`
+
+Expected: no errors.
+
+- [ ] **Step 4: Build the frontend**
+
+Run: `cd client && npm run build`
+
+Expected: successful build with no warnings about missing icons or unresolved imports.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/power/AlwaysAwakePanel.tsx
+git commit -m "feat(sleep): always-awake custom datetime button (capped 7d)"
+```
+
+---
+
+## Task 13: End-to-end verification (manual smoke)
+
+**Files:** none new
+
+This is the manual smoke gate — type checks and build are not enough.
+
+- [ ] **Step 1: Start dev mode**
+
+Run (from project root):
+
+```bash
+python start_dev.py
+```
+
+Open `http://localhost:5173`, log in as `admin` / `DevMode2024`. Navigate to **System Control → Hardware → Sleep**.
+
+- [ ] **Step 2: Verify the OS-Sleep banner**
+
+On Windows dev mode the banner should NOT appear. The page should show the existing 5 panels in their current order. Inspect the browser console — no errors.
+
+If running on a Linux dev environment with `/etc/systemd` present, the banner should appear above `SleepModePanel` with at least the "all clear" line, and `[Refresh ⟳]` should reload the report.
+
+- [ ] **Step 3: Verify the custom datetime button**
+
+In the AlwaysAwakePanel preset row, the 5th button labelled "Bis Datum…" should appear after `Dauerhaft`. Click it:
+
+1. A popover opens below/beside the button containing a datetime input with `min` ≈ now+5min, `max` ≈ now+7d.
+2. Pick a datetime ~2 days in the future, click **Übernehmen**.
+3. The popover closes, the button switches to "Bis DD.MM. HH:mm" with active styling, and the activity row shows "Aktiv bis HH:mm (in 1d 23h)".
+4. Reload the page. The button still shows the custom value with active styling.
+5. Re-open the popover, change the value to "1 hour from now", click **Übernehmen**. The chip should switch from `custom` back to `1h` (the inference promotes the closest matching preset within 5min).
+6. Click the master toggle off, then on. State resets to `Dauerhaft` as before.
+
+- [ ] **Step 4: Verify the 7-day cap**
+
+Open the popover, manually type a date 8 days in the future. Click **Übernehmen** — the inline error "Maximal 7 Tage in der Zukunft" appears, the popover stays open, no API call fires. (Inspect the Network tab to confirm.)
+
+If you hit `Übernehmen` very fast and still get to the API: backend returns 422 and the optimistic state reverts with a toast. Either path is acceptable.
+
+- [ ] **Step 5: Run the full backend test suite (final gate)**
+
+Run: `cd backend && python -m pytest -q`
+
+Expected: same pass/fail surface as before the branch (per memory `feedback_run_tests_before_pr`).
+
+- [ ] **Step 6: Final commit (if any fix-ups were needed)**
+
+If steps 1-5 pass without changes, no commit needed. If you found a bug:
+
+```bash
+git add -A
+git commit -m "fix(sleep): smoke fixes for os-settings banner / custom datetime"
+```
+
+---
+
+## Self-Review
+
+Spec coverage:
+- §3 page layout ordering: Task 11.
+- §4.2 inspector helpers + platform guard: Task 1.
+- §4.2 classifier rules table: Task 2 (one key per `IdleAction` variant — verified in tests).
+- §4.2 cache + resilience: Task 3.
+- §4.3 endpoint: Task 5.
+- §4.4 banner UI: Task 10.
+- §4.5 API client types: Task 8.
+- §5 backend 7-day cap: Task 4 (validator) and Task 6 (route-level integration test).
+- §5.3 frontend custom button + popover: Task 12.
+- §5.4 native popover (no Radix): Task 12 (uses `mousedown` listener + Escape).
+- §6 i18n keys: Task 9.
+- §7 data flow: covered implicitly by Tasks 3, 5, 12 (test traces match spec).
+- §8 error handling: Tasks 3, 10, 12.
+- §9 testing strategy: Tasks 1-7 cover all listed backend tests; Task 13 covers frontend manual smoke.
+
+Placeholder scan: no `TBD`/`TODO`. Two locations call out conditional handling that the engineer must adapt:
+- Task 4 step 4 mentions "if `timedelta` is already imported, drop the alias" — this is a real choice the engineer must make, not a placeholder.
+- Task 5 step 1 instructs adopting the project's existing fixture names — necessary because the writer of this plan can't see those fixtures from the task summary.
+
+Type/name consistency:
+- `OsSleepIssue` (dataclass) vs `OsSleepIssueModel` (Pydantic) — distinct on purpose; they cross at the route handler in Task 5 step 3.
+- `inspect_os_sleep(force_refresh=...)` keyword used consistently in Tasks 1, 3, 5.
+- Cache helpers `_cache_get` / `_cache_put` / `_cache_clear` referenced consistently across Tasks 1 and 3.
+- Frontend `Preset` union evolves from `'1h' | '4h' | '8h' | 'permanent'` to add `'custom'` in Task 12; `setPreset` is narrowed via `Exclude<Preset, 'custom'>` to preserve type safety.

--- a/docs/superpowers/specs/2026-05-09-sleep-page-os-detection-and-custom-datetime-design.md
+++ b/docs/superpowers/specs/2026-05-09-sleep-page-os-detection-and-custom-datetime-design.md
@@ -1,0 +1,375 @@
+# Sleep Page: OS-Sleep-Settings banner + Always-Awake custom datetime
+
+**Date:** 2026-05-09
+**Page:** System Control → Hardware → Sleep (`/sleep`)
+**Status:** Design accepted, plan pending
+
+## 1. Goals
+
+Two independent additions to the existing Sleep page:
+
+1. **OS-Sleep-Settings banner** — a read-only card at the top of the page showing whether the operating system has its own sleep/suspend triggers configured (logind `IdleAction`, lid switch handling, `sleep.conf` flags, masked targets, etc.). Read-only: no editing, no writing to OS config files.
+
+2. **Custom datetime in the "Immer wach" panel** — alongside the existing `1h / 4h / 8h / Dauerhaft` presets, a fifth option that lets the user pick an arbitrary date+time in the future (capped at 7 days) for the always-awake override.
+
+## 2. Non-goals
+
+- No edit/write capability for OS sleep settings (no buttons that mask targets, no `systemctl mask` from the UI). Pure read.
+- No new third-party dependencies, frontend or backend. Native HTML inputs only (`<input type="datetime-local">`, `<details>` for the expandable section).
+- No D-Bus integration. Reading systemd config files + cheap `systemctl is-enabled` is sufficient.
+- No changes to the `CoreUptimePanel` ("Kernbetriebszeit") — the user-facing terminology was clarified upfront: this work targets the `AlwaysAwakePanel` ("Immer wach").
+
+## 3. Page layout
+
+`client/src/pages/SleepMode.tsx` gains one new component as the very first child:
+
+```
+SleepMode
+├── OsSleepSettingsBanner   ← NEW (Feature 1)
+├── SleepModePanel
+├── AlwaysAwakePanel        ← extended with custom datetime button (Feature 2)
+├── CoreUptimePanel
+├── SleepConfigPanel
+└── SleepHistoryTable
+```
+
+When the OS-sleep banner has nothing to display (e.g. Windows dev mode), it returns `null` and the page falls back to its current order without a placeholder.
+
+## 4. Feature 1 — OS-Sleep-Settings banner
+
+### 4.1 User-facing contract
+
+Three render states:
+
+1. **Loading** — skeleton card.
+2. **Unsupported platform** (`platform_supported: false`) — component returns `null`. No "not available" message.
+3. **Linux** — header line, one line per detected issue with severity icon (⚠ warning / ✓ ok / ✗ error / ℹ info), an expandable `[Details ⌄]` section with a flat key/value table, and a `[Refresh ⟳]` button. When `issues` is empty: a single "alles okay" line so users can see the panel did its job.
+
+### 4.2 Backend service: `backend/app/services/power/os_sleep_inspector.py` (new)
+
+```python
+@dataclass(frozen=True)
+class OsSleepIssue:
+    severity: Literal["info", "warning", "error"]
+    key: str                      # stable id, e.g. "logind.idle_action.suspend"
+    message: str                  # fallback text if frontend has no i18n entry for `key`
+    detail: Optional[str]
+
+@dataclass(frozen=True)
+class OsSleepReport:
+    platform_supported: bool
+    logind: dict[str, str]        # resolved values: HandleLidSwitch, IdleAction, IdleActionSec, …
+    sleep_conf: dict[str, str]    # AllowSuspend, AllowHibernation, HibernateMode, …
+    targets: dict[str, str]       # {"sleep.target": "enabled", "suspend.target": "masked", …}
+    issues: list[OsSleepIssue]
+    sources: list[str]            # config file paths actually read
+    collected_at: datetime
+
+def inspect_os_sleep(force_refresh: bool = False) -> OsSleepReport: ...
+```
+
+**Inputs read** (last-write-wins, mirroring how systemd resolves drop-ins):
+
+1. `/etc/systemd/logind.conf` then drop-ins under `/etc/systemd/logind.conf.d/*.conf` and `/run/systemd/logind.conf.d/*.conf`.
+2. `/etc/systemd/sleep.conf` then drop-ins under `/etc/systemd/sleep.conf.d/*.conf` and `/run/systemd/sleep.conf.d/*.conf`.
+3. One `systemctl is-enabled sleep.target suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target` call (no sudo, list-args, 5s timeout). Output parsed line-by-line into `targets`.
+
+**Helpers:**
+
+- `_parse_systemd_ini(path: Path, section: str) -> dict[str, str]` — minimal INI reader: skips blank lines and `#`/`;` comments, recognises `[Section]` headers, splits `KEY=VALUE` and trims. Malformed lines are logged at WARNING and skipped.
+- `_merge_drop_ins(base: dict, drop_in_dir: Path, section: str) -> dict` — sorts drop-in files alphabetically (systemd's behaviour) and overlays.
+- `_classify(report) -> list[OsSleepIssue]` — initial rule set:
+
+| Rule | Severity | `key` |
+|---|---|---|
+| `logind.IdleAction == "suspend"` | warning | `logind.idle_action.suspend` |
+| `logind.IdleAction == "hibernate"` | warning | `logind.idle_action.hibernate` |
+| `logind.IdleAction == "hybrid-sleep"` | warning | `logind.idle_action.hybrid_sleep` |
+| `logind.HandleLidSwitch in {suspend, hibernate}` AND lid sensor present | info | `logind.lid_switch.suspend` (or `.hibernate`) |
+| `sleep.AllowSuspend == no` | info | `sleep_conf.suspend_disabled` |
+| `targets["suspend.target"] == "masked"` | error | `targets.suspend.masked` |
+
+One distinct `key` per variant, so the frontend can attach precise i18n strings. Backend `message` field is a German fallback if no i18n entry matches.
+
+Lid sensor probe: `Path("/proc/acpi/button/lid").is_dir()` — keeps the laptop-only rule from firing on desktops.
+
+**Platform guard:** if `sys.platform != "linux"` OR `Path("/etc/systemd").is_dir() is False`, return `OsSleepReport(platform_supported=False, logind={}, sleep_conf={}, targets={}, issues=[], sources=[], collected_at=now())`. No subprocess calls made on Windows/macOS.
+
+**Caching:** module-level `_CACHE: tuple[OsSleepReport, float] | None`, TTL 60s. The endpoint forwards `?force=true` to bypass.
+
+**Resilience:** the entire body of `inspect_os_sleep` is wrapped in try/except. Any unexpected error produces a report with `platform_supported=True` and a single `OsSleepIssue(severity="error", key="inspector.failed", …)` so the endpoint always returns 200 and the banner renders something meaningful.
+
+### 4.3 Backend endpoint
+
+In `backend/app/api/routes/sleep.py` (existing file):
+
+```python
+@router.get("/os-settings", response_model=OsSleepReportResponse)
+@limiter.limit(get_limit("default"))
+async def get_os_sleep_settings(
+    request: Request,
+    force: bool = False,
+    current_user: User = Depends(deps.get_current_admin),
+) -> OsSleepReportResponse:
+    return os_sleep_inspector.inspect_os_sleep(force_refresh=force)
+```
+
+- Admin-only (matches the rest of `/api/system/sleep/`).
+- Default rate limit; the call is cheap when cached.
+- Pydantic schema `OsSleepReportResponse` mirrors the dataclass (lives in `backend/app/schemas/sleep.py`).
+
+### 4.4 Frontend component: `client/src/components/power/OsSleepSettingsBanner.tsx` (new)
+
+```
+┌────────────────────────────────────────────┐
+│ [icon] OS-Sleep-Einstellungen   [Refresh ⟳]│
+│ ⚠ logind: IdleAction=suspend nach 30min   │
+│ ✓ suspend.target nicht maskiert            │
+│ ─────────────────────────────────────────  │
+│ [Details ⌄]                                │
+│   ▸ logind.HandleLidSwitch = suspend       │
+│   ▸ logind.IdleAction      = suspend       │
+│   ▸ sleep.AllowSuspend     = yes           │
+│   ▸ targets.suspend.target = enabled       │
+│   ▸ Quellen: /etc/systemd/logind.conf, …  │
+└────────────────────────────────────────────┘
+```
+
+- Same shell as siblings: `card border-slate-700/50 p-4 sm:p-6 space-y-4`.
+- `useEffect` loads on mount; refresh button calls `getOsSleepSettings(true)`.
+- `report.platform_supported === false` → component returns `null`.
+- Severity colors from existing palette: `error` red-400, `warning` amber-400, `info` slate-300, `ok` emerald-400.
+- Details section is a plain `<details><summary>` (native HTML).
+- All visible strings via `useTranslation('system')` under `sleep.osSettings.*`. Issue strings use the backend's `key` for i18n lookup with `defaultValue: issue.message`, so unknown keys still show the backend's fallback text.
+
+### 4.5 API client addition
+
+`client/src/api/sleep.ts`:
+
+```typescript
+export type OsSleepSeverity = 'info' | 'warning' | 'error';
+
+export interface OsSleepIssue {
+  severity: OsSleepSeverity;
+  key: string;
+  message: string;
+  detail: string | null;
+}
+
+export interface OsSleepReport {
+  platform_supported: boolean;
+  logind: Record<string, string>;
+  sleep_conf: Record<string, string>;
+  targets: Record<string, string>;
+  issues: OsSleepIssue[];
+  sources: string[];
+  collected_at: string;
+}
+
+export async function getOsSleepSettings(force = false): Promise<OsSleepReport> {
+  const res = await apiClient.get('/api/system/sleep/os-settings', {
+    params: force ? { force: true } : undefined,
+  });
+  return res.data;
+}
+```
+
+## 5. Feature 2 — Custom datetime in AlwaysAwakePanel
+
+### 5.1 User-facing contract
+
+The preset row gains a fifth chip alongside `1h / 4h / 8h / Dauerhaft`:
+
+- **No custom value set:** `[ Bis Datum… ]` — clicking opens a popover.
+- **Custom value set + active:** `[ Bis 14.05. 18:30  ⌄ ]` — the chip is the active preset, clicking reopens the popover for editing.
+
+The popover contains a single `<input type="datetime-local">` with `min` = now+5min, `max` = now+7d, plus `[Übernehmen]` / `[Abbrechen]` buttons. Inline error text appears below the input on validation failure.
+
+### 5.2 Backend tweak
+
+Existing validator `backend/app/schemas/sleep.py:SleepConfigUpdate._validate_until_future` is extended to enforce a 7-day cap:
+
+```python
+MAX_ALWAYS_AWAKE_HORIZON = timedelta(days=7)
+…
+if v > datetime.now(timezone.utc) + MAX_ALWAYS_AWAKE_HORIZON:
+    raise ValueError("always_awake_until must be at most 7 days in the future")
+```
+
+The 1h/4h/8h presets stay well under the cap; the change is invisible to existing callers.
+
+### 5.3 Frontend changes: `client/src/components/power/AlwaysAwakePanel.tsx`
+
+1. Extend the `Preset` union with `'custom'` and add constants:
+
+   ```typescript
+   type Preset = '1h' | '4h' | '8h' | 'permanent' | 'custom';
+   const MAX_HORIZON_MS = 7 * 24 * 3600 * 1000;
+   const MIN_HORIZON_MS = 5 * 60 * 1000;
+   ```
+
+2. New picker state:
+
+   ```typescript
+   const [pickerOpen, setPickerOpen] = useState(false);
+   const [pickerValue, setPickerValue] = useState<string>(''); // datetime-local string
+   const [pickerError, setPickerError] = useState<string | null>(null);
+   ```
+
+3. Extend the preset-inference block (currently lines 58-81): if `enabled && always_awake_until != null` and remaining seconds doesn't match `1h/4h/8h` within ±5min, set `activePreset = 'custom'`.
+
+4. Render the fifth chip conditionally on `activePreset`. Active label is the chosen datetime formatted as `Bis DD.MM. HH:mm` (or full date if more than 6 days out).
+
+5. New `setCustomPreset(value: string)` handler: validates locally (`MIN_HORIZON_MS ≤ delta ≤ MAX_HORIZON_MS`), then `updateSleepConfig({ always_awake_enabled: true, always_awake_until: new Date(value).toISOString() })` with the same optimistic-update + revert-on-error pattern the existing presets use (see lines 116-141).
+
+6. **`<input type="datetime-local">` quirks:** value format is local time `YYYY-MM-DDTHH:mm`, no timezone. Conversion: `new Date(value).toISOString()` for the API call (browser interprets the local string in the user's TZ). Helper `toLocalInputValue(date: Date): string` for prefilling and for `min`/`max` attributes.
+
+### 5.4 Popover implementation
+
+A plain absolutely-positioned `<div>` anchored to the chip, with a click-outside listener (`useEffect` on `document.mousedown`). No Radix/Headless UI. The popover closes on Escape, on click outside, on Übernehmen success, and on Abbrechen.
+
+## 6. i18n keys (new)
+
+In `client/src/i18n/locales/{de,en}/system.json`:
+
+```
+sleep.osSettings.title
+sleep.osSettings.refresh
+sleep.osSettings.detailsToggle
+sleep.osSettings.allClear
+sleep.osSettings.sources
+sleep.osSettings.issue.<key>            (one per backend issue.key)
+
+sleep.alwaysAwake.presetCustom          "Bis Datum…"
+sleep.alwaysAwake.activeCustom          "Bis {{datetime}}"
+sleep.alwaysAwake.pickerLabel           "Datum & Uhrzeit"
+sleep.alwaysAwake.pickerApply           "Übernehmen"
+sleep.alwaysAwake.pickerCancel          "Abbrechen"
+sleep.alwaysAwake.pickerErrorPast       "Zeitpunkt muss in der Zukunft liegen (mind. 5 Min)"
+sleep.alwaysAwake.pickerErrorMax        "Maximal 7 Tage in der Zukunft"
+```
+
+EN strings are direct translations (e.g. `presetCustom: "Until date…"`).
+
+## 7. Data flow
+
+### 7.1 Page load
+
+```
+SleepMode mounts
+  └─ OsSleepSettingsBanner.useEffect
+       └─ GET /api/system/sleep/os-settings
+            └─ os_sleep_inspector.inspect_os_sleep()
+                 ├─ cache hit (≤60s old) → return cached report
+                 └─ cache miss
+                      ├─ platform check (sys.platform != "linux" → unsupported report)
+                      ├─ parse logind.conf + drop-ins
+                      ├─ parse sleep.conf + drop-ins
+                      ├─ subprocess `systemctl is-enabled …` (5s timeout)
+                      ├─ _classify(report) → issues[]
+                      └─ cache + return
+```
+
+Refresh button takes the same path with `force=True`, bypassing the cache.
+
+### 7.2 Custom datetime save
+
+```
+User picks 2026-05-14T18:30 → "Übernehmen"
+  └─ AlwaysAwakePanel.setCustomPreset
+       ├─ local validation (≥now+5min, ≤now+7d)
+       ├─ optimistic update: enabled=true, until=ISO, expiresIn=secs, activePreset='custom'
+       ├─ PUT /api/system/sleep/config
+       │   { always_awake_enabled: true, always_awake_until: "2026-05-14T16:30:00Z" }
+       │     └─ backend SleepConfigUpdate validator (future + ≤7d guard)
+       └─ on success: keep state; on error: revert + toast.error
+```
+
+## 8. Error handling
+
+**`os_sleep_inspector`:**
+- `FileNotFoundError` on a config file → that section is empty in the report; no exception propagates. `sources` only lists files actually opened.
+- `subprocess.TimeoutExpired` / non-zero exit on `systemctl is-enabled` → `targets` is empty `{}`; no exception. The classifier doesn't flag missing target data.
+- INI parser sees a malformed line → log at WARNING, skip the line, continue.
+- Unexpected exception → wrapped at the top of `inspect_os_sleep`, returns a report with a single `inspector.failed` error issue.
+
+**Endpoint:** standard 401/403 from auth dep → handled by existing axios interceptor. No special UI.
+
+**`OsSleepSettingsBanner`:**
+- Network failure → render a single `error` issue tile inline; `[Refresh]` stays enabled. No toast (passive panel; toasts on every failed page mount would be noisy).
+- `platform_supported: false` → returns `null` silently.
+
+**`AlwaysAwakePanel`:**
+- Backend rejects datetime (past or >7d) → revert optimistic state, `toast.error(err.message)`. Existing pattern at lines 134-140 already does this.
+- Reopening popover with custom set → prefill `pickerValue` from `until` converted to local input format.
+
+## 9. Testing strategy
+
+### Backend
+
+`tests/services/power/test_os_sleep_inspector.py` (new):
+
+- `test_parse_logind_simple` — fixture `tmp_path/logind.conf` with `[Login]\nIdleAction=suspend\n`, assert dict.
+- `test_drop_in_overrides_base` — base says `IdleAction=ignore`, drop-in `30-baluhost.conf` says `IdleAction=suspend` → effective value is `suspend`.
+- `test_classifier_flags_idle_suspend` — fed a mock dict with `IdleAction=suspend`, expect a warning issue with key `logind.idle_action.suspend`.
+- `test_classifier_flags_masked_target` — `targets={"suspend.target": "masked"}` → error issue.
+- `test_unsupported_platform` — monkeypatch `sys.platform = "win32"` → `platform_supported is False`, no subprocess called.
+- `test_cache_hit_skips_subprocess` — call twice within TTL, assert `subprocess.run` called once.
+- `test_force_refresh_bypasses_cache` — `inspect_os_sleep(force_refresh=True)` calls subprocess on every call.
+- `test_subprocess_timeout_does_not_raise` — patch `subprocess.run` to raise `TimeoutExpired` → report still returned, `targets` is `{}`.
+- `test_inspector_catches_unexpected_exception` — patch `_parse_systemd_ini` to raise → report has `inspector.failed` issue, no exception escapes.
+
+`tests/api/test_sleep_os_settings_route.py` (new):
+
+- `test_requires_admin` — non-admin user → 403.
+- `test_returns_report_for_admin` — admin → 200, body matches `OsSleepReportResponse`.
+- `test_force_param_bypasses_cache` — patch the inspector, assert `force_refresh=True` propagated.
+
+`tests/api/test_sleep_always_awake_routes.py` (existing, extend):
+
+- `test_until_rejected_when_more_than_7_days` — PUT with `always_awake_until` 8 days out → 422.
+- `test_until_accepted_at_6_days_23h` — PUT with 6d 23h → 200.
+
+Full backend `pytest` run before PR (per existing memory `feedback_run_tests_before_pr`).
+
+### Frontend
+
+Type-check + manual smoke (project doesn't ship vitest tests for these panels, matching the established pattern from `2026-05-07-always-awake.md`):
+
+1. `cd client && npx tsc --noEmit` clean.
+2. `cd client && npm run build` succeeds.
+3. `python start_dev.py`, navigate to System Control → Hardware → Sleep:
+   - Banner: appears in Linux, returns `null` in Windows dev mode (no console error).
+   - Custom button: `[Bis Datum…]` opens popover; picker enforces min/max; Übernehmen triggers `updateSleepConfig`.
+   - Custom value persists across page reload (chip becomes `Bis 14.05. 18:30`).
+   - Picking >7 days: backend 422, optimistic state reverts, toast appears.
+
+## 10. Files touched
+
+### Backend
+
+| File | Change |
+|---|---|
+| `backend/app/services/power/os_sleep_inspector.py` | **new** — service module |
+| `backend/app/schemas/sleep.py` | **add** `OsSleepIssue`, `OsSleepReportResponse`; **extend** `SleepConfigUpdate._validate_until_future` with 7-day cap |
+| `backend/app/api/routes/sleep.py` | **add** `GET /os-settings` endpoint |
+| `backend/tests/services/power/test_os_sleep_inspector.py` | **new** |
+| `backend/tests/api/test_sleep_os_settings_route.py` | **new** |
+| `backend/tests/api/test_sleep_always_awake_routes.py` | **extend** — 7-day cap tests |
+
+### Frontend
+
+| File | Change |
+|---|---|
+| `client/src/api/sleep.ts` | **add** `OsSleepReport`/`OsSleepIssue`/`getOsSleepSettings` |
+| `client/src/components/power/OsSleepSettingsBanner.tsx` | **new** |
+| `client/src/components/power/AlwaysAwakePanel.tsx` | extend with custom datetime button + popover |
+| `client/src/pages/SleepMode.tsx` | mount `<OsSleepSettingsBanner />` as first child |
+| `client/src/i18n/locales/de/system.json` | new keys under `sleep.osSettings.*` and `sleep.alwaysAwake.*` |
+| `client/src/i18n/locales/en/system.json` | mirror DE keys |
+
+## 11. Open questions / future work
+
+- **Edit functionality** — masking targets / writing logind drop-ins from the UI was rejected for this iteration (YAGNI risk + sudo/polkit complexity). Could be a follow-up if users actually want it.
+- **D-Bus integration** — also rejected for this iteration; file-parsing is sufficient and avoids a new dep. Could be revisited if file-resolved values diverge from runtime values often enough to be worth the cost.
+- **Issue rule expansion** — initial classifier rules are intentionally narrow. Add rules incrementally as we hit real-world OS configurations that surprise users.


### PR DESCRIPTION
## Summary

Two read-only/UX additions to **System Control → Hardware → Sleep**:

- **OS-Sleep-Settings banner** at the top of the page — read-only inspection of systemd's `logind.conf` + `sleep.conf` (with drop-ins) plus `systemctl is-enabled` for sleep-related targets, classified into severity-tagged issues. Hidden entirely on Windows / non-systemd hosts. Cached 60s, refreshable. New admin endpoint `GET /api/system/sleep/os-settings`.
- **Custom datetime preset** in `AlwaysAwakePanel` — 5th option alongside `1h/4h/8h/Dauerhaft` letting admins pick an arbitrary expiry up to 7 days out via a popover with a native `<input type="datetime-local">` (no new deps). Backend `SleepConfigUpdate` validator now caps `always_awake_until` at 7 days.

Spec: `docs/superpowers/specs/2026-05-09-sleep-page-os-detection-and-custom-datetime-design.md`
Plan: `docs/superpowers/plans/2026-05-09-sleep-page-os-detection-and-custom-datetime.md`

## What's in the diff

**Backend**
- `app/services/power/os_sleep_inspector.py` (new, ~310 lines) — INI parser, drop-in merger, classifier, `_systemctl_is_enabled` helper, cached `inspect_os_sleep`, fail-closed resilience.
- `app/schemas/sleep.py` — `OsSleepIssueModel` + `OsSleepReportResponse`; tightened `_validate_until_future` with 7-day horizon.
- `app/api/routes/sleep.py` — `GET /os-settings` (admin-only, rate-limited).
- 4 new test files (helpers / classifier / integration / route) + 2 cap tests appended to `test_sleep_always_awake_routes.py`.

**Frontend**
- `client/src/api/sleep.ts` — `OsSleepReport`/`OsSleepIssue` types + `getOsSleepSettings`.
- `client/src/components/power/OsSleepSettingsBanner.tsx` (new) — loading skeleton, hidden on unsupported platform, all-clear / per-issue rows, `<details>` for raw values, refresh button.
- `client/src/components/power/AlwaysAwakePanel.tsx` — extended with custom-datetime button + popover (native input, click-outside + Escape close, optimistic save with revert).
- `client/src/pages/SleepMode.tsx` — mounts banner as first child.
- `i18n/locales/{de,en}/system.json` — `sleep.osSettings.*` + new keys for `sleep.alwaysAwake.{presetCustom,activeCustom,picker*}`.

## Test plan

- [x] Backend sleep-scoped: `pytest -k 'sleep or os_sleep'` — **176 passed, 0 failed**.
- [x] Full backend `pytest` — 2715 passed, 3 pre-existing Windows-only failures (`test_owner_can_delete_own_file`, `test_admin_can_delete_any_file`, `test_start_acquires_inhibitor_and_subscribes`), same 3 documented in #78. None in code paths this branch touches.
- [x] Frontend `npx tsc --noEmit` — clean.
- [x] Frontend `npm run build` — clean (2958 modules).
- [ ] Manual smoke in dev mode (`python start_dev.py`):
  - [ ] Windows: banner does NOT render, no console errors.
  - [ ] Custom-datetime button: opens popover, enforces `min`/`max`, Übernehmen saves, chip shows `Bis DD.MM. HH:mm`, persists across reload.
  - [ ] Picking >7 days: backend returns 422, optimistic state reverts, toast appears.
- [ ] Linux smoke (production / staging): banner renders with at least the all-clear line; refresh works; classifier emits expected issues for a contrived `IdleAction=suspend` drop-in.

## Notable design choices

- **Read-only by design.** No UI to mask targets or write `/etc/systemd/*.conf` — keeps the security surface minimal. Future iteration can add edit if real demand surfaces.
- **No new dependencies.** Native `<input type="datetime-local">` instead of a date-picker library; native `<details>` instead of a popover lib. Per saved feedback `feedback_no_new_deps_for_small_features`.
- **Fail-closed inspector.** Any unexpected exception surfaces as one `inspector.failed` issue; the banner still renders something. Subprocess failures yield `targets={}`. A line-count mismatch on `systemctl is-enabled` (alias collapse on some systemd versions) discards the whole result rather than misalign names → statuses (could otherwise mask a real `suspend.target=masked`).
- **`OsSleepReport.detail` carries German prose for known issues.** Acceptable for a German-primary deployment; English `message` is i18n'd via the issue `key` lookup. Moving `detail` behind i18n is a known minor follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)