### PR TITLE
fix(quick-settings): open 2FA modal from user menu

### DIFF
--- a/client/src/__tests__/components/UserMenuQuickSettings.test.tsx
+++ b/client/src/__tests__/components/UserMenuQuickSettings.test.tsx
@@ -53,7 +53,7 @@ describe('UserMenuQuickSettings', () => {
     vi.spyOn(twoFactorApi, 'get2FAStatus').mockImplementation(
       () => new Promise(() => {})
     );
-    const { container } = render(<UserMenuQuickSettings onCloseDropdown={vi.fn()} />);
+    const { container } = render(<UserMenuQuickSettings onOpenSetup={vi.fn()} />);
     // The 2FA section should not appear; only Language + ByteUnit sections
     // The container should have exactly 3 children: LanguageSection, divider, ByteUnitSection
     const sections = container.querySelectorAll('section');

--- a/client/src/__tests__/components/UserMenuQuickSettings.test.tsx
+++ b/client/src/__tests__/components/UserMenuQuickSettings.test.tsx
@@ -33,7 +33,7 @@ describe('UserMenuQuickSettings', () => {
     vi.spyOn(twoFactorApi, 'get2FAStatus').mockImplementation(
       () => new Promise(() => {})
     );
-    render(<UserMenuQuickSettings onCloseDropdown={vi.fn()} />);
+    render(<UserMenuQuickSettings onOpenSetup={vi.fn()} />);
     expect(screen.getByText('Deutsch')).toBeInTheDocument();
     expect(screen.getByText('English')).toBeInTheDocument();
   });
@@ -43,7 +43,7 @@ describe('UserMenuQuickSettings', () => {
     vi.spyOn(twoFactorApi, 'get2FAStatus').mockImplementation(
       () => new Promise(() => {})
     );
-    render(<UserMenuQuickSettings onCloseDropdown={vi.fn()} />);
+    render(<UserMenuQuickSettings onOpenSetup={vi.fn()} />);
     expect(screen.getByText('GiB')).toBeInTheDocument();
     expect(screen.getByText('GB')).toBeInTheDocument();
   });
@@ -60,15 +60,15 @@ describe('UserMenuQuickSettings', () => {
     expect(sections.length).toBe(2);
   });
 
-  it('clicking the 2FA setup prompt closes the dropdown via onCloseDropdown', async () => {
+  it('clicking the 2FA setup prompt invokes onOpenSetup', async () => {
     refreshStatus();
     vi.spyOn(twoFactorApi, 'get2FAStatus').mockResolvedValue({
       enabled: false,
       enabled_at: null,
       backup_codes_remaining: 0,
     });
-    const onCloseDropdown = vi.fn();
-    render(<UserMenuQuickSettings onCloseDropdown={onCloseDropdown} />);
+    const onOpenSetup = vi.fn();
+    render(<UserMenuQuickSettings onOpenSetup={onOpenSetup} />);
     // Wait specifically for the 2FA prompt button to appear after the async status resolves.
     // Language (2) + ByteUnit (2) buttons are always present; the 5th button is the prompt.
     // We wait until 5 buttons exist rather than using findAllByRole which resolves on the
@@ -80,6 +80,6 @@ describe('UserMenuQuickSettings', () => {
       promptButton = buttons[buttons.length - 1];
     });
     fireEvent.click(promptButton);
-    expect(onCloseDropdown).toHaveBeenCalledOnce();
+    expect(onOpenSetup).toHaveBeenCalledOnce();
   });
 });

--- a/client/src/components/UserMenu.tsx
+++ b/client/src/components/UserMenu.tsx
@@ -6,6 +6,12 @@ import { useAuth } from '../contexts/AuthContext';
 import { useSystemMode } from '../hooks/useSystemMode';
 import { apiClient } from '../lib/api';
 import UserMenuQuickSettings from './UserMenuQuickSettings';
+import { Modal } from './ui/Modal';
+import {
+  TwoFactorSetupFlow,
+  type TwoFactorSetupStep,
+} from './quickSettings/TwoFactorSetupFlow';
+import { refreshStatus } from './quickSettings/twoFactorStatusStore';
 
 interface UserPublic {
   id: number;
@@ -25,7 +31,21 @@ export default function UserMenu() {
   const [submenuOpen, setSubmenuOpen] = useState(false);
   const [users, setUsers] = useState<UserPublic[] | null>(null);
   const [loadingUsers, setLoadingUsers] = useState(false);
+  const [setupOpen, setSetupOpen] = useState(false);
+  const [setupStep, setSetupStep] = useState<TwoFactorSetupStep>('loading');
   const rootRef = useRef<HTMLDivElement>(null);
+
+  const handleOpenSetup = () => {
+    setOpen(false);
+    setSetupOpen(true);
+  };
+
+  const handleSetupComplete = () => {
+    refreshStatus();
+    setSetupOpen(false);
+  };
+
+  const lockClose = setupStep === 'backup-codes';
 
   const canSwitchUser = systemMode?.dev_mode === true && isAdmin && !isImpersonating;
 
@@ -152,9 +172,24 @@ export default function UserMenu() {
               <div className="border-t border-slate-800/70 my-1" />
             </>
           )}
-          <UserMenuQuickSettings onCloseDropdown={() => setOpen(false)} />
+          <UserMenuQuickSettings onOpenSetup={handleOpenSetup} />
         </div>
       )}
+
+      <Modal
+        isOpen={setupOpen}
+        onClose={() => setSetupOpen(false)}
+        title={t('userMenu.quickSettings.twoFactor.modalTitle')}
+        size="lg"
+        closeOnOverlayClick={!lockClose}
+        closeOnEscape={!lockClose}
+      >
+        <TwoFactorSetupFlow
+          onComplete={handleSetupComplete}
+          onCancel={() => setSetupOpen(false)}
+          onStepChange={setSetupStep}
+        />
+      </Modal>
     </div>
   );
 }

--- a/client/src/components/UserMenuQuickSettings.tsx
+++ b/client/src/components/UserMenuQuickSettings.tsx
@@ -1,58 +1,21 @@
-import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { Modal } from './ui/Modal';
 import { LanguageSection } from './quickSettings/LanguageSection';
 import { ByteUnitSection } from './quickSettings/ByteUnitSection';
 import { TwoFactorPromptSection } from './quickSettings/TwoFactorPromptSection';
-import { TwoFactorSetupFlow, type TwoFactorSetupStep } from './quickSettings/TwoFactorSetupFlow';
-import { refreshStatus } from './quickSettings/twoFactorStatusStore';
 
 interface Props {
-  /** Called when an action inside Quick-Settings should also close the parent dropdown
-   * (e.g., before opening the 2FA setup Modal so the dropdown does not remain
-   * mounted behind it). */
-  onCloseDropdown: () => void;
+  /** Open the 2FA setup modal. The parent is responsible for closing the
+   * dropdown before showing the modal — otherwise the modal would be
+   * unmounted along with this component. */
+  onOpenSetup: () => void;
 }
 
-export default function UserMenuQuickSettings({ onCloseDropdown }: Props) {
-  const { t } = useTranslation('common');
-  const [setupOpen, setSetupOpen] = useState(false);
-  const [setupStep, setSetupStep] = useState<TwoFactorSetupStep>('loading');
-
-  const handleOpenSetup = () => {
-    onCloseDropdown();
-    setSetupOpen(true);
-  };
-
-  const handleSetupComplete = () => {
-    refreshStatus();
-    setSetupOpen(false);
-  };
-
-  // Backup-codes step must not be dismissable by accident
-  const lockClose = setupStep === 'backup-codes';
-
+export default function UserMenuQuickSettings({ onOpenSetup }: Props) {
   return (
     <div className="flex flex-col">
       <LanguageSection />
       <div className="border-t border-slate-800/70 my-1" />
       <ByteUnitSection />
-      <TwoFactorPromptSection onOpenSetup={handleOpenSetup} />
-
-      <Modal
-        isOpen={setupOpen}
-        onClose={() => setSetupOpen(false)}
-        title={t('userMenu.quickSettings.twoFactor.modalTitle')}
-        size="lg"
-        closeOnOverlayClick={!lockClose}
-        closeOnEscape={!lockClose}
-      >
-        <TwoFactorSetupFlow
-          onComplete={handleSetupComplete}
-          onCancel={() => setSetupOpen(false)}
-          onStepChange={setSetupStep}
-        />
-      </Modal>
+      <TwoFactorPromptSection onOpenSetup={onOpenSetup} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Clicking "Set up now" in the user-menu Quick-Settings dropdown closed the dropdown but the 2FA setup modal never appeared.

**Cause:** The `<Modal>` and its `setupOpen`/`setupStep` state lived inside `UserMenuQuickSettings`, which itself was rendered inside the `{open && (...)}` conditional of `UserMenu`. Clicking the button ran:

```ts
onCloseDropdown();   // setOpen(false) → unmounts {open && (...)}
setSetupOpen(true);  // setState on already-unmounting component → discarded
```

Both state updates batched in the same render → React unmounted `UserMenuQuickSettings` (and the Modal with it) before `setupOpen=true` could take effect → modal never rendered.

**Fix:** Lift `setupOpen` / `setupStep` state and the `<Modal>` / `<TwoFactorSetupFlow>` JSX up into `UserMenu` so they live **outside** the `{open && (...)}` block and survive the dropdown close. `UserMenuQuickSettings` becomes a presentational component receiving an `onOpenSetup` callback.

## Test plan

- [x] `vitest` — all 9 quick-settings tests green locally (incl. updated `UserMenuQuickSettings.test.tsx` with the renamed prop)
- [x] `tsc --noEmit` clean
- [ ] CI `backend-tests` green
- [ ] CI `frontend-build` green
- [ ] Manual: in prod, open user menu → "Set up now" → 2FA modal opens