### PR TITLE
feat(notifications): trash + retention

### DIFF
--- a/backend/alembic/versions/87f057d69ce4_notification_trash_retention.py
+++ b/backend/alembic/versions/87f057d69ce4_notification_trash_retention.py
@@ -1,0 +1,72 @@
+"""notification trash retention
+
+Revision ID: 87f057d69ce4
+Revises: d45e605bfc4d
+Create Date: 2026-05-11 22:55:03.462093
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '87f057d69ce4'
+down_revision: Union[str, Sequence[str], None] = 'd45e605bfc4d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.add_column(
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True)
+        )
+        batch_op.create_index("ix_notifications_deleted_at", ["deleted_at"])
+
+    # Backfill: existing soft-dismissed rows start their retention now.
+    op.execute(
+        "UPDATE notifications SET deleted_at = CURRENT_TIMESTAMP "
+        "WHERE is_dismissed"
+    )
+
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.drop_column("is_dismissed")
+
+    with op.batch_alter_table("notification_preferences") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "trash_retention_days",
+                sa.Integer(),
+                nullable=False,
+                server_default="7",
+            )
+        )
+        batch_op.create_check_constraint(
+            "ck_trash_retention_1_7",
+            "trash_retention_days BETWEEN 1 AND 7",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "is_dismissed",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("0"),
+            )
+        )
+    op.execute(
+        "UPDATE notifications SET is_dismissed = "
+        "(CASE WHEN deleted_at IS NOT NULL THEN 1 ELSE 0 END)"
+    )
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.drop_index("ix_notifications_deleted_at")
+        batch_op.drop_column("deleted_at")
+
+    with op.batch_alter_table("notification_preferences") as batch_op:
+        batch_op.drop_constraint("ck_trash_retention_1_7", type_="check")
+        batch_op.drop_column("trash_retention_days")

--- a/backend/alembic/versions/87f057d69ce4_notification_trash_retention.py
+++ b/backend/alembic/versions/87f057d69ce4_notification_trash_retention.py
@@ -56,7 +56,7 @@ def downgrade() -> None:
                 "is_dismissed",
                 sa.Boolean(),
                 nullable=False,
-                server_default=sa.text("0"),
+                server_default=sa.false(),
             )
         )
     op.execute(

--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -353,6 +353,59 @@ async def get_my_notification_routing(
     )
 
 
+@router.get("/trash", response_model=NotificationListResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def get_trash(
+    request: Request, response: Response,
+    category: Optional[NotificationCategoryEnum] = Query(None),
+    notification_type: Optional[str] = Query(None),
+    created_after: Optional[datetime] = Query(None),
+    created_before: Optional[datetime] = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    current_user: UserPublic = Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+) -> NotificationListResponse:
+    """List trashed notifications for the current user, paginated."""
+    service = get_notification_service()
+    offset = (page - 1) * page_size
+    admin = is_privileged(current_user)
+
+    notifications = service.get_user_notifications(
+        db=db,
+        user_id=current_user.id,
+        trashed_only=True,
+        category=category,
+        notification_type=notification_type,
+        created_after=created_after,
+        created_before=created_before,
+        limit=page_size,
+        offset=offset,
+        is_admin=admin,
+    )
+
+    total = service.count_user_notifications(
+        db=db,
+        user_id=current_user.id,
+        trashed_only=True,
+        category=category,
+        notification_type=notification_type,
+        created_after=created_after,
+        created_before=created_before,
+        is_admin=admin,
+    )
+
+    unread_count = service.get_unread_count(db, current_user.id, is_admin=admin)
+
+    return NotificationListResponse(
+        notifications=[NotificationResponse.from_db(n) for n in notifications],
+        total=total,
+        unread_count=unread_count,
+        page=page,
+        page_size=page_size,
+    )
+
+
 # Admin endpoints for creating notifications
 @router.post("", response_model=NotificationResponse, status_code=status.HTTP_201_CREATED)
 @user_limiter.limit(get_limit("admin_operations"))

--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -275,6 +275,44 @@ async def restore_notification(
     return NotificationResponse.from_db(notification)
 
 
+@router.delete("/trash")
+@user_limiter.limit(get_limit("admin_operations"))
+async def empty_trash(
+    request: Request, response: Response,
+    current_user: UserPublic = Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Empty the current user's trash (admins also wipe trashed system notifications)."""
+    service = get_notification_service()
+    count = service.empty_trash(
+        db, current_user.id, is_admin=is_privileged(current_user)
+    )
+    return {"count": count}
+
+
+@router.delete("/{notification_id}", status_code=status.HTTP_204_NO_CONTENT)
+@user_limiter.limit(get_limit("admin_operations"))
+async def delete_notification(
+    request: Request, response: Response,
+    notification_id: int,
+    current_user: UserPublic = Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+) -> Response:
+    """Permanently delete a notification (any state)."""
+    service = get_notification_service()
+    deleted = service.delete_permanently(
+        db, notification_id, current_user.id, is_admin=is_privileged(current_user)
+    )
+
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Notification not found",
+        )
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
 # Preferences endpoints
 @router.get("/preferences", response_model=NotificationPreferencesResponse)
 @user_limiter.limit(get_limit("admin_operations"))

--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -385,6 +385,7 @@ async def update_notification_preferences(
         quiet_hours_start=quiet_start,
         quiet_hours_end=quiet_end,
         min_priority=body.min_priority,
+        trash_retention_days=body.trash_retention_days,
     )
 
     return NotificationPreferencesResponse.from_db(prefs)

--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -35,7 +35,6 @@ router = APIRouter(prefix="/notifications", tags=["notifications"])
 async def get_notifications(
     request: Request, response: Response,
     unread_only: bool = Query(False, description="Only return unread notifications"),
-    include_dismissed: bool = Query(False, description="Include dismissed notifications"),
     category: Optional[NotificationCategoryEnum] = Query(None, description="Filter by category"),
     notification_type: Optional[str] = Query(None, description="Filter by type (info, warning, critical)"),
     created_after: Optional[datetime] = Query(None, description="Only return notifications after this time"),
@@ -57,7 +56,6 @@ async def get_notifications(
         db=db,
         user_id=current_user.id,
         unread_only=unread_only,
-        include_dismissed=include_dismissed,
         category=category,
         notification_type=notification_type,
         created_after=created_after,
@@ -74,7 +72,6 @@ async def get_notifications(
         db=db,
         user_id=current_user.id,
         unread_only=unread_only,
-        include_dismissed=include_dismissed,
         category=category,
         notification_type=notification_type,
         created_after=created_after,
@@ -192,10 +189,11 @@ async def dismiss_all_notifications(
     current_user: UserPublic = Depends(deps.get_current_user),
     db: Session = Depends(get_db),
 ) -> MarkReadResponse:
-    """Dismiss all notifications for the current user.
+    """Move all active notifications for the current user to trash.
 
-    Sets is_dismissed=True and is_read=True on all non-dismissed notifications.
-    Notifications remain in the DB and can be retrieved with include_dismissed=true.
+    Sets deleted_at=NOW() and is_read=True on all active notifications.
+    Items can be restored from the trash view or are auto-purged after the
+    user's configured retention period (default 7 days).
     """
     service = get_notification_service()
     count = service.dismiss_all(db, current_user.id, is_admin=is_privileged(current_user))
@@ -210,9 +208,11 @@ async def dismiss_notification(
     current_user: UserPublic = Depends(deps.get_current_user),
     db: Session = Depends(get_db),
 ) -> NotificationResponse:
-    """Dismiss a notification.
+    """Move a notification to trash.
 
-    Dismissed notifications are hidden from the default list but can be retrieved with include_dismissed=true.
+    The notification is hidden from inbox views and appears in the trash,
+    where it can be restored or permanently deleted. Auto-purged after the
+    user's configured retention period (default 7 days).
     """
     service = get_notification_service()
     notification = service.dismiss(db, notification_id, current_user.id, is_admin=is_privileged(current_user))

--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -252,6 +252,29 @@ async def snooze_notification(
     return NotificationResponse.from_db(notification)
 
 
+@router.post("/{notification_id}/restore", response_model=NotificationResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def restore_notification(
+    request: Request, response: Response,
+    notification_id: int,
+    current_user: UserPublic = Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+) -> NotificationResponse:
+    """Restore a notification from trash."""
+    service = get_notification_service()
+    notification = service.restore(
+        db, notification_id, current_user.id, is_admin=is_privileged(current_user)
+    )
+
+    if not notification:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Notification not found",
+        )
+
+    return NotificationResponse.from_db(notification)
+
+
 # Preferences endpoints
 @router.get("/preferences", response_model=NotificationPreferencesResponse)
 @user_limiter.limit(get_limit("admin_operations"))

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -5,7 +5,7 @@ from datetime import datetime, time
 from enum import Enum
 from typing import TYPE_CHECKING, Optional, Any
 
-from sqlalchemy import String, DateTime, Integer, Boolean, Text, Time, ForeignKey, JSON
+from sqlalchemy import String, DateTime, Integer, Boolean, Text, Time, ForeignKey, JSON, CheckConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
@@ -66,7 +66,9 @@ class Notification(Base):
     message: Mapped[str] = mapped_column(Text, nullable=False)
     action_url: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
     is_read: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    is_dismissed: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None, index=True
+    )
     priority: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     extra_data: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
     snoozed_until: Mapped[Optional[datetime]] = mapped_column(
@@ -91,7 +93,7 @@ class Notification(Base):
             "message": self.message,
             "action_url": self.action_url,
             "is_read": self.is_read,
-            "is_dismissed": self.is_dismissed,
+            "deleted_at": self.deleted_at.isoformat() if self.deleted_at else None,
             "priority": self.priority,
             "metadata": self.extra_data,
             "snoozed_until": self.snoozed_until.isoformat() if self.snoozed_until else None,
@@ -102,6 +104,12 @@ class NotificationPreferences(Base):
     """User notification preferences model."""
 
     __tablename__ = "notification_preferences"
+    __table_args__ = (
+        CheckConstraint(
+            "trash_retention_days BETWEEN 1 AND 7",
+            name="ck_trash_retention_1_7",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     user_id: Mapped[int] = mapped_column(
@@ -125,6 +133,11 @@ class NotificationPreferences(Base):
     # Minimum priority for notifications (0 = all, 1 = warning+, 2 = critical only)
     min_priority: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
 
+    # Trash retention window: 1–7 days (default 7)
+    trash_retention_days: Mapped[int] = mapped_column(
+        Integer, default=7, nullable=False
+    )
+
     # Relationship
     user: Mapped["User"] = relationship("User", back_populates="notification_preferences")
 
@@ -143,6 +156,7 @@ class NotificationPreferences(Base):
             "quiet_hours_start": self.quiet_hours_start.isoformat() if self.quiet_hours_start else None,
             "quiet_hours_end": self.quiet_hours_end.isoformat() if self.quiet_hours_end else None,
             "min_priority": self.min_priority,
+            "trash_retention_days": self.trash_retention_days,
         }
 
     def is_channel_enabled_for_category(

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -135,7 +135,7 @@ class NotificationPreferences(Base):
 
     # Trash retention window: 1–7 days (default 7)
     trash_retention_days: Mapped[int] = mapped_column(
-        Integer, default=7, nullable=False
+        Integer, default=7, server_default="7", nullable=False
     )
 
     # Relationship

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -60,7 +60,10 @@ class NotificationResponse(NotificationBase):
     created_at: datetime
     user_id: Optional[int] = None
     is_read: bool = False
-    is_dismissed: bool = False
+    deleted_at: Optional[datetime] = Field(
+        default=None,
+        description="Timestamp when notification was moved to trash (null = active)"
+    )
     snoozed_until: Optional[datetime] = Field(
         default=None,
         description="Snooze expiry time (null if not snoozed)"
@@ -102,7 +105,7 @@ class NotificationResponse(NotificationBase):
             message=notification.message,
             action_url=notification.action_url,
             is_read=notification.is_read,
-            is_dismissed=notification.is_dismissed,
+            deleted_at=notification.deleted_at,
             priority=notification.priority,
             metadata=notification.extra_data,
             time_ago=time_ago,
@@ -197,6 +200,12 @@ class NotificationPreferencesBase(BaseModel):
         default=None,
         description="Per-category notification settings"
     )
+    trash_retention_days: int = Field(
+        default=7,
+        ge=1,
+        le=7,
+        description="Days to retain notifications in trash before auto-purge"
+    )
 
 
 class NotificationPreferencesUpdate(BaseModel):
@@ -209,6 +218,7 @@ class NotificationPreferencesUpdate(BaseModel):
     quiet_hours_end: Optional[str] = None
     min_priority: Optional[int] = Field(default=None, ge=0, le=3)
     category_preferences: Optional[dict[str, CategoryPreference]] = None
+    trash_retention_days: Optional[int] = Field(default=None, ge=1, le=7)
 
 
 class NotificationPreferencesResponse(NotificationPreferencesBase):
@@ -232,6 +242,7 @@ class NotificationPreferencesResponse(NotificationPreferencesBase):
             quiet_hours_end=prefs.quiet_hours_end.isoformat() if prefs.quiet_hours_end else None,
             min_priority=prefs.min_priority,
             category_preferences=prefs.category_preferences,
+            trash_retention_days=prefs.trash_retention_days,
         )
 
 

--- a/backend/app/services/notifications/scheduler.py
+++ b/backend/app/services/notifications/scheduler.py
@@ -277,28 +277,56 @@ class NotificationScheduler:
             db.close()
 
 
+def _run_trash_cleanup() -> None:
+    """Hourly job: hard-delete notifications past their retention."""
+    db = SessionLocal()
+    try:
+        from app.services.notifications.service import get_notification_service
+        count = get_notification_service().cleanup_expired_trash(db)
+        if count:
+            logger.info("Trash cleanup: deleted %d expired notifications", count)
+    except Exception:
+        logger.exception("Trash cleanup job failed")
+    finally:
+        db.close()
+
+
 def start_notification_scheduler() -> None:
     """Start the notification scheduler background job."""
     global _notification_scheduler
     if _notification_scheduler is not None:
-        return
-    if not FirebaseService.is_available():
-        logger.info("Notification scheduler skipped (Firebase not configured)")
         return
     try:
         from apscheduler.schedulers.background import BackgroundScheduler
     except ImportError:
         logger.warning("APScheduler not installed, notification scheduler disabled")
         return
+
     _notification_scheduler = BackgroundScheduler()
+
+    # Always-on: hourly trash cleanup (independent of Firebase)
     _notification_scheduler.add_job(
-        func=NotificationScheduler.run_periodic_check,
+        func=_run_trash_cleanup,
         trigger="interval",
         hours=1,
-        id="device_expiration_check",
-        name="Check and send device expiration warnings",
+        id="notification_trash_cleanup",
+        name="Hard-delete expired trashed notifications",
         replace_existing=True,
     )
+
+    # Firebase-dependent: device expiration warnings
+    if FirebaseService.is_available():
+        _notification_scheduler.add_job(
+            func=NotificationScheduler.run_periodic_check,
+            trigger="interval",
+            hours=1,
+            id="device_expiration_check",
+            name="Check and send device expiration warnings",
+            replace_existing=True,
+        )
+    else:
+        logger.info("Device expiration check skipped (Firebase not configured)")
+
     _notification_scheduler.start()
     logger.info("Notification scheduler started (running every hour)")
 

--- a/backend/app/services/notifications/service.py
+++ b/backend/app/services/notifications/service.py
@@ -737,6 +737,27 @@ class NotificationService:
         logger.info(f"Moved {count} notifications to trash for user {user_id}")
         return count
 
+    def restore(
+        self,
+        db: Session,
+        notification_id: int,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> Optional[Notification]:
+        """Restore a notification from trash (idempotent on already-active rows)."""
+        notification = db.query(Notification).filter(
+            Notification.id == notification_id,
+            self._user_filter(user_id, is_admin),
+        ).first()
+
+        if notification and notification.deleted_at is not None:
+            notification.deleted_at = None
+            db.commit()
+            db.refresh(notification)
+            logger.debug(f"Restored notification {notification_id} from trash")
+
+        return notification
+
     def snooze(
         self,
         db: Session,

--- a/backend/app/services/notifications/service.py
+++ b/backend/app/services/notifications/service.py
@@ -467,7 +467,7 @@ class NotificationService:
             query = query.filter(Notification.is_read == False)
 
         if not include_dismissed:
-            query = query.filter(Notification.is_dismissed == False)
+            query = query.filter(Notification.deleted_at.is_(None))
 
         if category:
             query = query.filter(Notification.category == category)
@@ -534,7 +534,7 @@ class NotificationService:
             query = query.filter(Notification.is_read == False)
 
         if not include_dismissed:
-            query = query.filter(Notification.is_dismissed == False)
+            query = query.filter(Notification.deleted_at.is_(None))
 
         if category:
             query = query.filter(Notification.category == category)
@@ -575,7 +575,7 @@ class NotificationService:
         ).filter(
             self._user_filter(user_id, is_admin),
             Notification.is_read == False,
-            Notification.is_dismissed == False,
+            Notification.deleted_at.is_(None),
         )
 
         # Exclude snoozed notifications
@@ -614,7 +614,7 @@ class NotificationService:
         query = db.query(Notification).filter(
             self._user_filter(user_id, is_admin),
             Notification.is_read == False,
-            Notification.is_dismissed == False,
+            Notification.deleted_at.is_(None),
         )
 
         # Exclude snoozed notifications
@@ -701,28 +701,18 @@ class NotificationService:
         user_id: int,
         is_admin: bool = False,
     ) -> Optional[Notification]:
-        """Dismiss a notification.
-
-        Args:
-            db: Database session
-            notification_id: Notification ID
-            user_id: User ID (for ownership check)
-            is_admin: Whether the user is an admin (can dismiss system notifications)
-
-        Returns:
-            Updated Notification or None if not found
-        """
+        """Move a notification to trash (idempotent on already-trashed rows)."""
         notification = db.query(Notification).filter(
             Notification.id == notification_id,
             self._user_filter(user_id, is_admin),
         ).first()
 
-        if notification:
-            notification.is_dismissed = True
+        if notification and notification.deleted_at is None:
+            notification.deleted_at = datetime.now(timezone.utc)
             notification.is_read = True
             db.commit()
             db.refresh(notification)
-            logger.debug(f"Dismissed notification {notification_id}")
+            logger.debug(f"Moved notification {notification_id} to trash")
 
         return notification
 
@@ -732,28 +722,19 @@ class NotificationService:
         user_id: int,
         is_admin: bool = False,
     ) -> int:
-        """Dismiss all non-dismissed notifications for a user.
-
-        Args:
-            db: Database session
-            user_id: User ID
-            is_admin: Whether the user is an admin (includes system notifications)
-
-        Returns:
-            Number of notifications dismissed
-        """
+        """Move all active notifications for a user to trash."""
         query = db.query(Notification).filter(
             self._user_filter(user_id, is_admin),
-            Notification.is_dismissed == False,
+            Notification.deleted_at.is_(None),
         )
 
         count = query.update({
-            Notification.is_dismissed: True,
+            Notification.deleted_at: datetime.now(timezone.utc),
             Notification.is_read: True,
         })
         db.commit()
 
-        logger.info(f"Dismissed {count} notifications for user {user_id}")
+        logger.info(f"Moved {count} notifications to trash for user {user_id}")
         return count
 
     def snooze(

--- a/backend/app/services/notifications/service.py
+++ b/backend/app/services/notifications/service.py
@@ -906,31 +906,65 @@ class NotificationService:
         logger.info(f"Updated notification preferences for user {user_id}")
         return prefs
 
-    async def cleanup_old_notifications(
-        self,
-        db: Session,
-        retention_days: int = 90,
-    ) -> int:
-        """Delete notifications older than retention period.
+    def cleanup_expired_trash(self, db: Session) -> int:
+        """Hard-delete trashed notifications past their retention.
+
+        Per-user retention comes from NotificationPreferences.trash_retention_days
+        (default 7 if no prefs row). System notifications (user_id IS NULL) use
+        a fixed 7-day retention.
 
         Args:
             db: Database session
-            retention_days: Number of days to retain notifications
 
         Returns:
             Number of notifications deleted
         """
         from datetime import timedelta
 
-        cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+        now = datetime.now(timezone.utc)
 
-        count = db.query(Notification).filter(
-            Notification.created_at < cutoff
-        ).delete()
+        users_with_trash = (
+            db.query(Notification.user_id)
+            .filter(
+                Notification.deleted_at.is_not(None),
+                Notification.user_id.is_not(None),
+            )
+            .distinct()
+            .all()
+        )
+
+        total = 0
+        for (user_id,) in users_with_trash:
+            prefs = self.get_user_preferences(db, user_id)
+            retention_days = prefs.trash_retention_days if prefs else 7
+            cutoff = now - timedelta(days=retention_days)
+            count = (
+                db.query(Notification)
+                .filter(
+                    Notification.user_id == user_id,
+                    Notification.deleted_at.is_not(None),
+                    Notification.deleted_at < cutoff,
+                )
+                .delete(synchronize_session=False)
+            )
+            total += count
+
+        # System notifications use fixed 7-day retention
+        sys_cutoff = now - timedelta(days=7)
+        total += (
+            db.query(Notification)
+            .filter(
+                Notification.user_id.is_(None),
+                Notification.deleted_at.is_not(None),
+                Notification.deleted_at < sys_cutoff,
+            )
+            .delete(synchronize_session=False)
+        )
 
         db.commit()
-        logger.info(f"Cleaned up {count} old notifications")
-        return count
+        if total:
+            logger.info(f"Expired trash cleanup: deleted {total} notifications")
+        return total
 
 
 # Singleton instance

--- a/backend/app/services/notifications/service.py
+++ b/backend/app/services/notifications/service.py
@@ -779,6 +779,25 @@ class NotificationService:
             logger.debug(f"Hard-deleted notification {notification_id}")
         return count > 0
 
+    def empty_trash(
+        self,
+        db: Session,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> int:
+        """Hard-delete every trashed notification visible to this user."""
+        count = (
+            db.query(Notification)
+            .filter(
+                self._user_filter(user_id, is_admin),
+                Notification.deleted_at.is_not(None),
+            )
+            .delete(synchronize_session=False)
+        )
+        db.commit()
+        logger.info(f"Emptied trash for user {user_id}: {count} rows")
+        return count
+
     def snooze(
         self,
         db: Session,

--- a/backend/app/services/notifications/service.py
+++ b/backend/app/services/notifications/service.py
@@ -425,7 +425,7 @@ class NotificationService:
         db: Session,
         user_id: int,
         unread_only: bool = False,
-        include_dismissed: bool = False,
+        trashed_only: bool = False,
         category: Optional[str] = None,
         notification_type: Optional[str] = None,
         created_after: Optional[datetime] = None,
@@ -440,7 +440,8 @@ class NotificationService:
             db: Database session
             user_id: User ID
             unread_only: Only return unread notifications
-            include_dismissed: Include dismissed notifications
+            trashed_only: When True return only trashed notifications; when False
+                (default) return only active (non-trashed) notifications
             category: Filter by category
             notification_type: Filter by type (info, warning, critical)
             created_after: Only return notifications created after this time
@@ -466,7 +467,9 @@ class NotificationService:
         if unread_only:
             query = query.filter(Notification.is_read == False)
 
-        if not include_dismissed:
+        if trashed_only:
+            query = query.filter(Notification.deleted_at.is_not(None))
+        else:
             query = query.filter(Notification.deleted_at.is_(None))
 
         if category:
@@ -491,7 +494,7 @@ class NotificationService:
         db: Session,
         user_id: int,
         unread_only: bool = False,
-        include_dismissed: bool = False,
+        trashed_only: bool = False,
         category: Optional[str] = None,
         notification_type: Optional[str] = None,
         created_after: Optional[datetime] = None,
@@ -507,7 +510,8 @@ class NotificationService:
             db: Database session
             user_id: User ID
             unread_only: Only count unread notifications
-            include_dismissed: Include dismissed notifications
+            trashed_only: When True count only trashed notifications; when False
+                (default) count only active (non-trashed) notifications
             category: Filter by category
             notification_type: Filter by type (info, warning, critical)
             created_after: Only count notifications created after this time
@@ -533,7 +537,9 @@ class NotificationService:
         if unread_only:
             query = query.filter(Notification.is_read == False)
 
-        if not include_dismissed:
+        if trashed_only:
+            query = query.filter(Notification.deleted_at.is_not(None))
+        else:
             query = query.filter(Notification.deleted_at.is_(None))
 
         if category:

--- a/backend/app/services/notifications/service.py
+++ b/backend/app/services/notifications/service.py
@@ -868,6 +868,7 @@ class NotificationService:
         quiet_hours_start: Optional[time] = None,
         quiet_hours_end: Optional[time] = None,
         min_priority: Optional[int] = None,
+        trash_retention_days: Optional[int] = None,
     ) -> NotificationPreferences:
         """Update or create notification preferences for a user.
 
@@ -881,6 +882,7 @@ class NotificationService:
             quiet_hours_start: Quiet hours start time
             quiet_hours_end: Quiet hours end time
             min_priority: Minimum priority level
+            trash_retention_days: Number of days trashed notifications are kept (1–7)
 
         Returns:
             Updated NotificationPreferences
@@ -905,6 +907,8 @@ class NotificationService:
             prefs.quiet_hours_end = quiet_hours_end
         if min_priority is not None:
             prefs.min_priority = min_priority
+        if trash_retention_days is not None:
+            prefs.trash_retention_days = trash_retention_days
 
         db.commit()
         db.refresh(prefs)

--- a/backend/app/services/notifications/service.py
+++ b/backend/app/services/notifications/service.py
@@ -758,6 +758,27 @@ class NotificationService:
 
         return notification
 
+    def delete_permanently(
+        self,
+        db: Session,
+        notification_id: int,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> bool:
+        """Hard-delete a single notification (any state). Returns True if deleted."""
+        count = (
+            db.query(Notification)
+            .filter(
+                Notification.id == notification_id,
+                self._user_filter(user_id, is_admin),
+            )
+            .delete(synchronize_session=False)
+        )
+        db.commit()
+        if count:
+            logger.debug(f"Hard-deleted notification {notification_id}")
+        return count > 0
+
     def snooze(
         self,
         db: Session,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -317,6 +317,12 @@ def test_user(regular_user: User) -> User:
     return regular_user
 
 
+@pytest.fixture
+def test_admin(admin_user: User) -> User:
+    """Backward-compatible alias used by some tests expecting `test_admin`."""
+    return admin_user
+
+
 # ============================================================================
 # Authentication Helpers
 # ============================================================================

--- a/backend/tests/migrations/test_notification_trash_retention.py
+++ b/backend/tests/migrations/test_notification_trash_retention.py
@@ -2,9 +2,7 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from sqlalchemy import text
 
-from app.core.database import SessionLocal
 from app.models.notification import Notification
 
 

--- a/backend/tests/migrations/test_notification_trash_retention.py
+++ b/backend/tests/migrations/test_notification_trash_retention.py
@@ -1,0 +1,61 @@
+"""Test the notification trash retention migration backfills dismissed rows."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+
+from app.core.database import SessionLocal
+from app.models.notification import Notification
+
+
+def test_existing_notifications_in_inbox_have_deleted_at_null(db_session):
+    """After migration, notifications without deleted_at remain in the inbox."""
+    n = Notification(
+        user_id=None,
+        category="system",
+        notification_type="info",
+        title="Active",
+        message="Still in inbox",
+    )
+    db_session.add(n)
+    db_session.commit()
+    db_session.refresh(n)
+    assert n.deleted_at is None
+
+
+def test_can_write_and_query_deleted_at(db_session):
+    """Migration created the column and index; writes round-trip."""
+    n = Notification(
+        user_id=None,
+        category="system",
+        notification_type="info",
+        title="Trashed",
+        message="In trash",
+        deleted_at=datetime.now(timezone.utc),
+    )
+    db_session.add(n)
+    db_session.commit()
+    db_session.refresh(n)
+    assert n.deleted_at is not None
+
+
+def test_trash_retention_days_defaults_to_7(db_session):
+    """New preferences rows default to 7-day retention."""
+    from app.models.notification import NotificationPreferences
+    prefs = NotificationPreferences(user_id=999999)
+    db_session.add(prefs)
+    db_session.commit()
+    db_session.refresh(prefs)
+    assert prefs.trash_retention_days == 7
+
+
+def test_trash_retention_days_rejects_out_of_range(db_session):
+    """CHECK constraint rejects values outside 1..7."""
+    from app.models.notification import NotificationPreferences
+    from sqlalchemy.exc import IntegrityError
+
+    prefs = NotificationPreferences(user_id=999998, trash_retention_days=0)
+    db_session.add(prefs)
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()

--- a/backend/tests/services/test_notification_service.py
+++ b/backend/tests/services/test_notification_service.py
@@ -570,3 +570,58 @@ class TestTrashSemantics:
         db_session.refresh(n)
         # Second dismiss must not overwrite the original timestamp
         assert n.deleted_at == first
+
+    def test_restore_clears_deleted_at(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="T",
+            message="M",
+        )
+        db_session.add(n)
+        db_session.commit()
+        notification_service.dismiss(db_session, n.id, test_user.id)
+        db_session.refresh(n)
+        assert n.deleted_at is not None
+
+        result = notification_service.restore(db_session, n.id, test_user.id)
+        db_session.refresh(n)
+        assert result is not None
+        assert n.deleted_at is None
+
+    def test_restore_idempotent_on_active(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="T",
+            message="M",
+        )
+        db_session.add(n)
+        db_session.commit()
+
+        result = notification_service.restore(db_session, n.id, test_user.id)
+        assert result is not None
+        assert result.deleted_at is None
+
+    def test_restore_returns_none_for_unknown_id(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        result = notification_service.restore(db_session, 9999999, test_user.id)
+        assert result is None

--- a/backend/tests/services/test_notification_service.py
+++ b/backend/tests/services/test_notification_service.py
@@ -858,3 +858,100 @@ class TestTrashSemantics:
             .all()
         ]
         assert titles == ["fresh_sys"]
+
+    def test_get_user_notifications_inbox_excludes_trashed(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone
+
+        active = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="active",
+            message="m",
+        )
+        trashed = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="trashed",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([active, trashed])
+        db_session.commit()
+
+        results = notification_service.get_user_notifications(
+            db_session, test_user.id
+        )
+        titles = [n.title for n in results]
+        assert "active" in titles
+        assert "trashed" not in titles
+
+    def test_get_user_notifications_trashed_only_returns_trash(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone
+
+        active = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="active",
+            message="m",
+        )
+        trashed = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="trashed",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([active, trashed])
+        db_session.commit()
+
+        results = notification_service.get_user_notifications(
+            db_session, test_user.id, trashed_only=True
+        )
+        titles = [n.title for n in results]
+        assert titles == ["trashed"]
+
+    def test_get_unread_count_ignores_trashed(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone
+
+        unread = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="unread",
+            message="m",
+        )
+        unread_in_trash = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="unread_in_trash",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([unread, unread_in_trash])
+        db_session.commit()
+
+        count = notification_service.get_unread_count(db_session, test_user.id)
+        assert count == 1

--- a/backend/tests/services/test_notification_service.py
+++ b/backend/tests/services/test_notification_service.py
@@ -665,3 +665,77 @@ class TestTrashSemantics:
             db_session, 9999999, test_user.id
         )
         assert deleted is False
+
+    def test_empty_trash_removes_only_trashed_rows(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone
+
+        active = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="active",
+            message="m",
+        )
+        trashed = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="trashed",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([active, trashed])
+        db_session.commit()
+
+        count = notification_service.empty_trash(db_session, test_user.id)
+
+        assert count == 1
+        remaining = db_session.query(Notification).filter(
+            Notification.user_id == test_user.id
+        ).all()
+        assert len(remaining) == 1
+        assert remaining[0].title == "active"
+
+    def test_empty_trash_isolates_users(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+        test_admin,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone
+
+        user_trashed = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="user-trash",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        other_trashed = Notification(
+            user_id=test_admin.id,
+            category="system",
+            notification_type="info",
+            title="admin-trash",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([user_trashed, other_trashed])
+        db_session.commit()
+
+        notification_service.empty_trash(db_session, test_user.id, is_admin=False)
+
+        assert db_session.query(Notification).filter(
+            Notification.user_id == test_user.id
+        ).count() == 0
+        assert db_session.query(Notification).filter(
+            Notification.user_id == test_admin.id
+        ).count() == 1

--- a/backend/tests/services/test_notification_service.py
+++ b/backend/tests/services/test_notification_service.py
@@ -739,3 +739,122 @@ class TestTrashSemantics:
         assert db_session.query(Notification).filter(
             Notification.user_id == test_admin.id
         ).count() == 1
+
+    def test_cleanup_expired_trash_respects_user_retention(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification, NotificationPreferences
+        from datetime import datetime, timezone, timedelta
+
+        # 3-day retention for this user
+        prefs = NotificationPreferences(user_id=test_user.id, trash_retention_days=3)
+        db_session.add(prefs)
+
+        now = datetime.now(timezone.utc)
+        old = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="old",
+            message="m",
+            deleted_at=now - timedelta(days=5),
+        )
+        recent = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="recent",
+            message="m",
+            deleted_at=now - timedelta(days=1),
+        )
+        db_session.add_all([old, recent])
+        db_session.commit()
+
+        count = notification_service.cleanup_expired_trash(db_session)
+
+        assert count == 1
+        titles = [
+            n.title for n in db_session.query(Notification)
+            .filter(Notification.user_id == test_user.id)
+            .all()
+        ]
+        assert titles == ["recent"]
+
+    def test_cleanup_expired_trash_default_when_no_prefs(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone, timedelta
+
+        now = datetime.now(timezone.utc)
+        too_old = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="too_old",
+            message="m",
+            deleted_at=now - timedelta(days=8),
+        )
+        within = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="within",
+            message="m",
+            deleted_at=now - timedelta(days=6),
+        )
+        db_session.add_all([too_old, within])
+        db_session.commit()
+
+        count = notification_service.cleanup_expired_trash(db_session)
+
+        assert count == 1
+        titles = [
+            n.title for n in db_session.query(Notification)
+            .filter(Notification.user_id == test_user.id)
+            .all()
+        ]
+        assert titles == ["within"]
+
+    def test_cleanup_expired_trash_system_notifications_fixed_7d(
+        self,
+        notification_service,
+        db_session,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone, timedelta
+
+        now = datetime.now(timezone.utc)
+        old_system = Notification(
+            user_id=None,
+            category="system",
+            notification_type="info",
+            title="old_sys",
+            message="m",
+            deleted_at=now - timedelta(days=10),
+        )
+        fresh_system = Notification(
+            user_id=None,
+            category="system",
+            notification_type="info",
+            title="fresh_sys",
+            message="m",
+            deleted_at=now - timedelta(days=3),
+        )
+        db_session.add_all([old_system, fresh_system])
+        db_session.commit()
+
+        notification_service.cleanup_expired_trash(db_session)
+
+        titles = [
+            n.title for n in db_session.query(Notification)
+            .filter(Notification.user_id.is_(None))
+            .all()
+        ]
+        assert titles == ["fresh_sys"]

--- a/backend/tests/services/test_notification_service.py
+++ b/backend/tests/services/test_notification_service.py
@@ -60,7 +60,7 @@ class TestNotificationService:
         assert notification.title == "Test Notification"
         assert notification.message == "This is a test message"
         assert notification.is_read is False
-        assert notification.is_dismissed is False
+        assert notification.deleted_at is None
 
     @pytest.mark.asyncio
     async def test_create_notification_with_metadata(
@@ -236,7 +236,7 @@ class TestNotificationService:
         )
 
         assert result is not None
-        assert result.is_dismissed is True
+        assert result.deleted_at is not None
         assert result.is_read is True
 
 
@@ -515,3 +515,58 @@ class TestDeliveryStatusEndpoint:
         from app.core.config import settings
         resp = client.get(f"{settings.api_prefix}/notifications/delivery-status")
         assert resp.status_code in (401, 403)
+
+
+class TestTrashSemantics:
+    """Tests for trash-based dismiss/restore/delete behavior."""
+
+    def test_dismiss_sets_deleted_at(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="T",
+            message="M",
+        )
+        db_session.add(n)
+        db_session.commit()
+        db_session.refresh(n)
+
+        before = n.deleted_at
+        notification_service.dismiss(db_session, n.id, test_user.id)
+        db_session.refresh(n)
+        assert before is None
+        assert n.deleted_at is not None
+        assert n.is_read is True
+
+    def test_dismiss_idempotent_on_already_trashed(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="T",
+            message="M",
+        )
+        db_session.add(n)
+        db_session.commit()
+
+        notification_service.dismiss(db_session, n.id, test_user.id)
+        db_session.refresh(n)
+        first = n.deleted_at
+
+        notification_service.dismiss(db_session, n.id, test_user.id)
+        db_session.refresh(n)
+        # Second dismiss must not overwrite the original timestamp
+        assert n.deleted_at == first

--- a/backend/tests/services/test_notification_service.py
+++ b/backend/tests/services/test_notification_service.py
@@ -625,3 +625,43 @@ class TestTrashSemantics:
     ):
         result = notification_service.restore(db_session, 9999999, test_user.id)
         assert result is None
+
+    def test_delete_permanently_removes_row(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="T",
+            message="M",
+        )
+        db_session.add(n)
+        db_session.commit()
+        notification_id = n.id
+
+        deleted = notification_service.delete_permanently(
+            db_session, notification_id, test_user.id
+        )
+        assert deleted is True
+        assert (
+            db_session.query(Notification)
+            .filter(Notification.id == notification_id)
+            .first()
+            is None
+        )
+
+    def test_delete_permanently_returns_false_for_unknown_id(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        deleted = notification_service.delete_permanently(
+            db_session, 9999999, test_user.id
+        )
+        assert deleted is False

--- a/backend/tests/test_notifications_routes.py
+++ b/backend/tests/test_notifications_routes.py
@@ -33,3 +33,33 @@ class TestTrashRoutes:
         data = resp.json()
         titles = [n["title"] for n in data["notifications"]]
         assert titles == ["trashed"]
+
+    def test_restore_round_trip(
+        self, client, auth_headers, db_session, test_user
+    ):
+        from app.models.notification import Notification
+
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="t",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add(n)
+        db_session.commit()
+
+        resp = client.post(
+            f"/api/notifications/{n.id}/restore", headers=auth_headers
+        )
+        assert resp.status_code == 200
+        assert resp.json()["deleted_at"] is None
+
+    def test_restore_unknown_id_returns_404(
+        self, client, auth_headers
+    ):
+        resp = client.post(
+            "/api/notifications/99999999/restore", headers=auth_headers
+        )
+        assert resp.status_code == 404

--- a/backend/tests/test_notifications_routes.py
+++ b/backend/tests/test_notifications_routes.py
@@ -63,3 +63,62 @@ class TestTrashRoutes:
             "/api/notifications/99999999/restore", headers=auth_headers
         )
         assert resp.status_code == 404
+
+    def test_delete_permanently_removes_row(
+        self, client, auth_headers, db_session, test_user
+    ):
+        from app.models.notification import Notification
+
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="t",
+            message="m",
+        )
+        db_session.add(n)
+        db_session.commit()
+        nid = n.id
+
+        resp = client.delete(
+            f"/api/notifications/{nid}", headers=auth_headers
+        )
+        assert resp.status_code == 204
+        assert (
+            db_session.query(Notification)
+            .filter(Notification.id == nid)
+            .first()
+            is None
+        )
+
+    def test_delete_unknown_id_returns_404(
+        self, client, auth_headers
+    ):
+        resp = client.delete(
+            "/api/notifications/99999999", headers=auth_headers
+        )
+        assert resp.status_code == 404
+
+    def test_empty_trash_returns_count(
+        self, client, auth_headers, db_session, test_user
+    ):
+        from app.models.notification import Notification
+
+        for i in range(3):
+            db_session.add(Notification(
+                user_id=test_user.id,
+                category="system",
+                notification_type="info",
+                title=f"t{i}",
+                message="m",
+                deleted_at=datetime.now(timezone.utc),
+            ))
+        db_session.commit()
+
+        resp = client.delete("/api/notifications/trash", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json() == {"count": 3}
+        assert db_session.query(Notification).filter(
+            Notification.user_id == test_user.id,
+            Notification.deleted_at.is_not(None),
+        ).count() == 0

--- a/backend/tests/test_notifications_routes.py
+++ b/backend/tests/test_notifications_routes.py
@@ -1,0 +1,35 @@
+"""Integration tests for notification routes."""
+from datetime import datetime, timezone
+
+
+class TestTrashRoutes:
+    """Tests for trash-specific route endpoints."""
+
+    def test_get_trash_returns_only_trashed(
+        self, client, auth_headers, db_session, test_user
+    ):
+        from app.models.notification import Notification
+
+        active = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="active",
+            message="m",
+        )
+        trashed = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="trashed",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([active, trashed])
+        db_session.commit()
+
+        resp = client.get("/api/notifications/trash", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        titles = [n["title"] for n in data["notifications"]]
+        assert titles == ["trashed"]

--- a/backend/tests/test_notifications_routes.py
+++ b/backend/tests/test_notifications_routes.py
@@ -122,3 +122,37 @@ class TestTrashRoutes:
             Notification.user_id == test_user.id,
             Notification.deleted_at.is_not(None),
         ).count() == 0
+
+    def test_trash_retention_validation_rejects_out_of_range(
+        self, client, auth_headers
+    ):
+        # 0 → 422
+        resp = client.put(
+            "/api/notifications/preferences",
+            headers=auth_headers,
+            json={"trash_retention_days": 0},
+        )
+        assert resp.status_code == 422
+        # 8 → 422
+        resp = client.put(
+            "/api/notifications/preferences",
+            headers=auth_headers,
+            json={"trash_retention_days": 8},
+        )
+        assert resp.status_code == 422
+
+    def test_trash_retention_persists_via_preferences_endpoint(
+        self, client, auth_headers
+    ):
+        # PUT 3 → 200, then GET returns 3
+        resp = client.put(
+            "/api/notifications/preferences",
+            headers=auth_headers,
+            json={"trash_retention_days": 3},
+        )
+        assert resp.status_code == 200
+        get_resp = client.get(
+            "/api/notifications/preferences", headers=auth_headers
+        )
+        assert get_resp.status_code == 200
+        assert get_resp.json()["trash_retention_days"] == 3

--- a/client/src/__tests__/lib/notificationGrouping.test.ts
+++ b/client/src/__tests__/lib/notificationGrouping.test.ts
@@ -9,7 +9,7 @@ function makeNotification(overrides: Partial<Notification> & { id: number; creat
     title: 'Test',
     message: 'Test message',
     is_read: false,
-    is_dismissed: false,
+    deleted_at: null,
     priority: 0,
     user_id: 1,
     action_url: null,

--- a/client/src/api/notifications.ts
+++ b/client/src/api/notifications.ts
@@ -17,7 +17,7 @@ export interface Notification {
   message: string;
   action_url: string | null;
   is_read: boolean;
-  is_dismissed: boolean;
+  deleted_at: string | null;
   priority: number;
   metadata: Record<string, any> | null;
   time_ago: string | null;
@@ -63,6 +63,7 @@ export interface NotificationPreferences {
   quiet_hours_start: string | null;
   quiet_hours_end: string | null;
   min_priority: number;
+  trash_retention_days: number; // 1-7
   category_preferences: Record<string, CategoryPreference> | null;
 }
 
@@ -73,6 +74,7 @@ export interface NotificationPreferencesUpdate {
   quiet_hours_start?: string | null;
   quiet_hours_end?: string | null;
   min_priority?: number;
+  trash_retention_days?: number;
   category_preferences?: Record<string, CategoryPreference>;
 }
 
@@ -305,3 +307,54 @@ export function getWebSocketUrl(token: string): string {
   const host = window.location.host;
   return `${protocol}//${host}/api/notifications/ws?token=${token}`;
 }
+
+export interface GetTrashNotificationsParams {
+  category?: NotificationCategory;
+  notification_type?: NotificationType;
+  created_after?: string;
+  created_before?: string;
+  page?: number;
+  page_size?: number;
+}
+
+/**
+ * Get paginated list of trashed notifications.
+ */
+export const getTrashNotifications = async (
+  params: GetTrashNotificationsParams = {}
+): Promise<NotificationListResponse> => {
+  const { data } = await apiClient.get<NotificationListResponse>(
+    '/api/notifications/trash',
+    { params }
+  );
+  return data;
+};
+
+/**
+ * Restore a notification from trash.
+ */
+export const restoreNotification = async (
+  id: number
+): Promise<Notification> => {
+  const { data } = await apiClient.post<Notification>(
+    `/api/notifications/${id}/restore`
+  );
+  return data;
+};
+
+/**
+ * Permanently delete a single notification.
+ */
+export const deleteNotificationPermanently = async (id: number): Promise<void> => {
+  await apiClient.delete(`/api/notifications/${id}`);
+};
+
+/**
+ * Empty the current user's trash.
+ */
+export const emptyTrash = async (): Promise<{ count: number }> => {
+  const { data } = await apiClient.delete<{ count: number }>(
+    '/api/notifications/trash'
+  );
+  return data;
+};

--- a/client/src/api/notifications.ts
+++ b/client/src/api/notifications.ts
@@ -94,7 +94,6 @@ export async function getDeliveryStatus(): Promise<DeliveryStatus> {
 export async function getNotifications(
   options: {
     unread_only?: boolean;
-    include_dismissed?: boolean;
     category?: NotificationCategory;
     notification_type?: NotificationType;
     created_after?: string;
@@ -106,7 +105,6 @@ export async function getNotifications(
   const response = await apiClient.get<NotificationListResponse>('/api/notifications', {
     params: {
       unread_only: options.unread_only ?? false,
-      include_dismissed: options.include_dismissed ?? false,
       category: options.category,
       notification_type: options.notification_type,
       created_after: options.created_after,

--- a/client/src/i18n/locales/de/notifications.json
+++ b/client/src/i18n/locales/de/notifications.json
@@ -93,5 +93,12 @@
   },
   "pagination": {
     "pageOf": "Seite {{page}} von {{total}}"
+  },
+  "retention": {
+    "title": "Papierkorb",
+    "label": "Aufbewahrung gelöschter Benachrichtigungen",
+    "days_one": "{{count}} Tag",
+    "days_other": "{{count}} Tage",
+    "hint": "Nach Ablauf werden Einträge automatisch endgültig entfernt."
   }
 }

--- a/client/src/i18n/locales/de/notifications.json
+++ b/client/src/i18n/locales/de/notifications.json
@@ -35,12 +35,20 @@
   },
   "buttons": {
     "save": "Speichern",
-    "back": "Zurück"
+    "back": "Zurück",
+    "markAllRead": "Alle gelesen",
+    "dismissAll": "Alle löschen",
+    "settings": "Einstellungen",
+    "markRead": "Als gelesen markieren",
+    "moveToTrash": "In Papierkorb"
   },
   "toast": {
     "saved": "Einstellungen gespeichert",
     "loadFailed": "Fehler beim Laden der Einstellungen",
-    "saveFailed": "Fehler beim Speichern"
+    "saveFailed": "Fehler beim Speichern",
+    "markedAllRead": "Alle als gelesen markiert",
+    "movedToTrash": "In Papierkorb verschoben",
+    "confirmDismissAll": "{{count}} Benachrichtigungen in Papierkorb verschieben?"
   },
   "noNotifications": "Keine Benachrichtigungen",
   "connected": "Verbunden",
@@ -52,5 +60,38 @@
   "markAllRead": "Alle als gelesen markieren",
   "clearAll": "Alle löschen",
   "clearedAll": "Alle Benachrichtigungen gelöscht",
-  "clearError": "Fehler beim Löschen"
+  "clearError": "Fehler beim Löschen",
+  "tabs": {
+    "inbox": "Posteingang",
+    "trash": "Papierkorb"
+  },
+  "trash": {
+    "empty": "Papierkorb leeren",
+    "emptyConfirm": "Alle {{count}} Einträge endgültig löschen?",
+    "restore": "Wiederherstellen",
+    "deleteForever": "Endgültig löschen",
+    "deleteForeverConfirm": "Diesen Eintrag endgültig löschen?",
+    "banner": "Einträge werden nach {{days}} Tag(en) automatisch endgültig gelöscht.",
+    "restored": "Wiederhergestellt",
+    "deleted": "Endgültig gelöscht",
+    "emptied": "Papierkorb geleert"
+  },
+  "count": {
+    "total": "gesamt",
+    "inTrash": "im Papierkorb",
+    "unread": "ungelesen"
+  },
+  "filters": {
+    "allCategories": "Alle Kategorien",
+    "allTypes": "Alle Typen",
+    "default": "Standard",
+    "unreadOnly": "Nur ungelesen"
+  },
+  "empty": {
+    "inbox": "Keine Benachrichtigungen",
+    "trash": "Papierkorb ist leer"
+  },
+  "pagination": {
+    "pageOf": "Seite {{page}} von {{total}}"
+  }
 }

--- a/client/src/i18n/locales/en/notifications.json
+++ b/client/src/i18n/locales/en/notifications.json
@@ -35,12 +35,20 @@
   },
   "buttons": {
     "save": "Save",
-    "back": "Back"
+    "back": "Back",
+    "markAllRead": "Mark all read",
+    "dismissAll": "Delete all",
+    "settings": "Settings",
+    "markRead": "Mark as read",
+    "moveToTrash": "Move to trash"
   },
   "toast": {
     "saved": "Settings saved",
     "loadFailed": "Failed to load settings",
-    "saveFailed": "Failed to save"
+    "saveFailed": "Failed to save",
+    "markedAllRead": "All marked as read",
+    "movedToTrash": "Moved to trash",
+    "confirmDismissAll": "Move {{count}} notifications to trash?"
   },
   "noNotifications": "No notifications",
   "connected": "Connected",
@@ -52,5 +60,38 @@
   "markAllRead": "Mark all as read",
   "clearAll": "Clear all",
   "clearedAll": "All notifications cleared",
-  "clearError": "Failed to clear notifications"
+  "clearError": "Failed to clear notifications",
+  "tabs": {
+    "inbox": "Inbox",
+    "trash": "Trash"
+  },
+  "trash": {
+    "empty": "Empty trash",
+    "emptyConfirm": "Permanently delete all {{count}} items?",
+    "restore": "Restore",
+    "deleteForever": "Delete forever",
+    "deleteForeverConfirm": "Permanently delete this entry?",
+    "banner": "Entries are automatically deleted after {{days}} day(s).",
+    "restored": "Restored",
+    "deleted": "Permanently deleted",
+    "emptied": "Trash emptied"
+  },
+  "count": {
+    "total": "total",
+    "inTrash": "in trash",
+    "unread": "unread"
+  },
+  "filters": {
+    "allCategories": "All categories",
+    "allTypes": "All types",
+    "default": "Default",
+    "unreadOnly": "Unread only"
+  },
+  "empty": {
+    "inbox": "No notifications",
+    "trash": "Trash is empty"
+  },
+  "pagination": {
+    "pageOf": "Page {{page}} of {{total}}"
+  }
 }

--- a/client/src/i18n/locales/en/notifications.json
+++ b/client/src/i18n/locales/en/notifications.json
@@ -93,5 +93,12 @@
   },
   "pagination": {
     "pageOf": "Page {{page}} of {{total}}"
+  },
+  "retention": {
+    "title": "Trash",
+    "label": "Retention for deleted notifications",
+    "days_one": "{{count}} day",
+    "days_other": "{{count}} days",
+    "hint": "After the retention period entries are automatically removed."
   }
 }

--- a/client/src/pages/NotificationPreferencesPage.tsx
+++ b/client/src/pages/NotificationPreferencesPage.tsx
@@ -67,6 +67,7 @@ export default function NotificationPreferencesPage({ embedded = false }: { embe
   const [quietHoursStart, setQuietHoursStart] = useState('22:00');
   const [quietHoursEnd, setQuietHoursEnd] = useState('07:00');
   const [minPriority, setMinPriority] = useState(0);
+  const [trashRetentionDays, setTrashRetentionDays] = useState<number>(7);
   const [categoryPrefs, setCategoryPrefs] = useState<Record<string, CategoryPreference>>({});
   const [routing, setRouting] = useState<MyNotificationRouting | null>(null);
   const [deliveryStatus, setDeliveryStatus] = useState<DeliveryStatus>({ has_mobile_devices: false, has_desktop_clients: false });
@@ -98,6 +99,7 @@ export default function NotificationPreferencesPage({ embedded = false }: { embe
       setQuietHoursStart(prefs.quiet_hours_start || '22:00');
       setQuietHoursEnd(prefs.quiet_hours_end || '07:00');
       setMinPriority(prefs.min_priority);
+      setTrashRetentionDays(prefs.trash_retention_days ?? 7);
 
       // Migrate old format if needed
       const rawPrefs = prefs.category_preferences || {};
@@ -142,6 +144,7 @@ export default function NotificationPreferencesPage({ embedded = false }: { embe
         quiet_hours_end: quietHoursEnabled ? quietHoursEnd : null,
         min_priority: minPriority,
         category_preferences: categoryPrefs,
+        trash_retention_days: trashRetentionDays,
       });
       toast.success(t('common:toast.saved'));
     } catch {
@@ -315,6 +318,29 @@ export default function NotificationPreferencesPage({ embedded = false }: { embe
             </div>
           </div>
         )}
+      </div>
+
+      {/* Trash Retention */}
+      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+        <div className="mb-3">
+          <h2 className="text-lg font-semibold text-slate-100">{t('retention.title')}</h2>
+          <p className="text-sm text-slate-400">{t('retention.hint')}</p>
+        </div>
+        <label className="block text-sm text-slate-300 mb-2">
+          {t('retention.label')}: <span className="font-medium text-sky-400">{t('retention.days', { count: trashRetentionDays })}</span>
+        </label>
+        <input
+          type="range"
+          min={1}
+          max={7}
+          step={1}
+          value={trashRetentionDays}
+          onChange={(e) => setTrashRetentionDays(Number(e.target.value))}
+          className="w-full max-w-md accent-sky-500"
+        />
+        <div className="flex justify-between text-xs text-slate-500 max-w-md mt-1">
+          <span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span><span>7</span>
+        </div>
       </div>
 
       {/* Category Settings */}

--- a/client/src/pages/NotificationsArchivePage.tsx
+++ b/client/src/pages/NotificationsArchivePage.tsx
@@ -1,16 +1,23 @@
 /**
  * Notifications Archive Page
  *
- * Full paginated list of all notifications with filters.
+ * Full paginated list of notifications with Inbox / Trash tabs and filters.
  */
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import {
-  Bell, CheckCheck, Settings, Filter, ChevronLeft, ChevronRight, Clock, X, Trash2,
+  Bell, CheckCheck, Settings, Filter, ChevronLeft, ChevronRight, Clock,
+  X, Trash2, RotateCcw,
 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import {
   getNotifications,
+  getTrashNotifications,
+  restoreNotification,
+  deleteNotificationPermanently,
+  emptyTrash as apiEmptyTrash,
+  getPreferences,
   snoozeNotification,
   getTypeStyle,
   getCategoryIcon,
@@ -31,72 +38,104 @@ const TYPES: NotificationType[] = ['info', 'warning', 'critical'];
 
 const PAGE_SIZE = 50;
 
+type TabKey = 'inbox' | 'trash';
+
 export default function NotificationsArchivePage() {
+  const { t } = useTranslation(['notifications', 'common']);
   const navigate = useNavigate();
   const {
     markAsRead: ctxMarkAsRead,
     markAllAsRead: ctxMarkAllAsRead,
     dismiss: ctxDismiss,
     dismissAll: ctxDismissAll,
+    refresh: ctxRefresh,
   } = useNotifications();
+
+  const [tab, setTab] = useState<TabKey>('inbox');
   const [data, setData] = useState<NotificationListResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
+  const [retentionDays, setRetentionDays] = useState<number>(7);
 
-  // Filters
   const [categoryFilter, setCategoryFilter] = useState<NotificationCategory | ''>('');
   const [typeFilter, setTypeFilter] = useState<NotificationType | ''>('');
-  const [readFilter, setReadFilter] = useState<'' | 'unread' | 'all'>('');
+  const [readFilter, setReadFilter] = useState<'' | 'unread'>('');
 
-  const fetchNotifications = useCallback(async () => {
+  useEffect(() => {
+    getPreferences()
+      .then((p) => setRetentionDays(p.trash_retention_days ?? 7))
+      .catch(() => setRetentionDays(7));
+  }, []);
+
+  const fetchList = useCallback(async () => {
     setLoading(true);
     try {
-      const result = await getNotifications({
+      const params = {
         page,
         page_size: PAGE_SIZE,
         category: categoryFilter || undefined,
         notification_type: typeFilter || undefined,
-        unread_only: readFilter === 'unread',
-        include_dismissed: readFilter === 'all',
-      });
+      };
+      const result =
+        tab === 'inbox'
+          ? await getNotifications({
+              ...params,
+              unread_only: readFilter === 'unread',
+            })
+          : await getTrashNotifications(params);
       setData(result);
     } catch {
-      toast.error('Fehler beim Laden der Benachrichtigungen');
+      toast.error(t('common:toast.loadFailed'));
     } finally {
       setLoading(false);
     }
-  }, [page, categoryFilter, typeFilter, readFilter]);
+  }, [tab, page, categoryFilter, typeFilter, readFilter, t]);
 
   useEffect(() => {
-    fetchNotifications();
-  }, [fetchNotifications]);
+    fetchList();
+  }, [fetchList]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [tab, categoryFilter, typeFilter, readFilter]);
 
   const handleMarkAllRead = async () => {
     try {
       await ctxMarkAllAsRead();
-      toast.success('Alle als gelesen markiert');
-      // Refetch archive list to reflect server state (pagination, filters)
-      fetchNotifications();
+      toast.success(t('toast.markedAllRead'));
+      fetchList();
     } catch {
-      toast.error('Fehler');
+      toast.error(t('common:toast.error'));
     }
   };
 
-  const handleClearAll = async () => {
+  const handleDismissAll = async () => {
     if (!data || data.total === 0) return;
-    if (!window.confirm(`Alle ${data.total} Benachrichtigungen löschen?`)) return;
+    if (!window.confirm(t('toast.confirmDismissAll', { count: data.total }))) return;
     try {
       await ctxDismissAll();
-      toast.success('Alle Benachrichtigungen gelöscht');
-      fetchNotifications();
+      toast.success(t('toast.movedToTrash'));
+      fetchList();
     } catch {
-      toast.error('Fehler beim Löschen');
+      toast.error(t('common:toast.error'));
+    }
+  };
+
+  const handleEmptyTrash = async () => {
+    if (!data || data.total === 0) return;
+    if (!window.confirm(t('trash.emptyConfirm', { count: data.total }))) return;
+    try {
+      const { count } = await apiEmptyTrash();
+      toast.success(t('trash.emptied'));
+      fetchList();
+      if (count > 0) ctxRefresh();
+    } catch {
+      toast.error(t('common:toast.error'));
     }
   };
 
   const handleMarkRead = async (n: Notification) => {
     if (n.is_read) return;
-    // Optimistic update in local archive state
     setData((prev) => prev && ({
       ...prev,
       notifications: prev.notifications.map((x) =>
@@ -104,13 +143,10 @@ export default function NotificationsArchivePage() {
       ),
       unread_count: Math.max(0, prev.unread_count - 1),
     }));
-    try {
-      await ctxMarkAsRead(n.id);
-    } catch { /* non-critical */ }
+    try { await ctxMarkAsRead(n.id); } catch { /* non-critical */ }
   };
 
   const handleDismiss = async (n: Notification) => {
-    // Optimistic update: remove from local archive list immediately
     setData((prev) => prev && ({
       ...prev,
       notifications: prev.notifications.filter((x) => x.id !== n.id),
@@ -120,8 +156,39 @@ export default function NotificationsArchivePage() {
     try {
       await ctxDismiss(n.id);
     } catch {
-      // Rollback: refetch on failure
-      fetchNotifications();
+      fetchList();
+    }
+  };
+
+  const handleRestore = async (n: Notification) => {
+    setData((prev) => prev && ({
+      ...prev,
+      notifications: prev.notifications.filter((x) => x.id !== n.id),
+      total: prev.total - 1,
+    }));
+    try {
+      await restoreNotification(n.id);
+      toast.success(t('trash.restored'));
+      ctxRefresh();
+    } catch {
+      toast.error(t('common:toast.error'));
+      fetchList();
+    }
+  };
+
+  const handleDeleteForever = async (n: Notification) => {
+    if (!window.confirm(t('trash.deleteForeverConfirm'))) return;
+    setData((prev) => prev && ({
+      ...prev,
+      notifications: prev.notifications.filter((x) => x.id !== n.id),
+      total: prev.total - 1,
+    }));
+    try {
+      await deleteNotificationPermanently(n.id);
+      toast.success(t('trash.deleted'));
+    } catch {
+      toast.error(t('common:toast.error'));
+      fetchList();
     }
   };
 
@@ -129,9 +196,9 @@ export default function NotificationsArchivePage() {
     try {
       await snoozeNotification(n.id, hours);
       toast.success(`${hours}h snoozed`);
-      fetchNotifications();
+      fetchList();
     } catch {
-      toast.error('Snooze fehlgeschlagen');
+      toast.error(t('common:toast.error'));
     }
   };
 
@@ -139,50 +206,87 @@ export default function NotificationsArchivePage() {
 
   return (
     <div className="mx-auto max-w-5xl space-y-6 p-6">
-      {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-slate-100">Benachrichtigungen</h1>
+          <h1 className="text-2xl font-bold text-slate-100">{t('title')}</h1>
           <p className="text-sm text-slate-400">
-            {data ? `${data.total} gesamt, ${data.unread_count} ungelesen` : 'Laden...'}
+            {data
+              ? `${data.total} ${tab === 'inbox' ? t('count.total') : t('count.inTrash')}${tab === 'inbox' ? `, ${data.unread_count} ${t('count.unread')}` : ''}`
+              : t('common:loading')}
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <button
-            onClick={handleMarkAllRead}
-            className="flex items-center gap-1.5 rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 transition hover:border-sky-500/50 hover:text-sky-400"
-          >
-            <CheckCheck className="h-4 w-4" />
-            Alle gelesen
-          </button>
-          <button
-            onClick={handleClearAll}
-            disabled={!data || data.total === 0}
-            className="flex items-center gap-1.5 rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 transition hover:border-rose-500/50 hover:text-rose-400 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-slate-700 disabled:hover:text-slate-300"
-          >
-            <Trash2 className="h-4 w-4" />
-            Alle löschen
-          </button>
+          {tab === 'inbox' && (
+            <>
+              <button
+                onClick={handleMarkAllRead}
+                className="flex items-center gap-1.5 rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 transition hover:border-sky-500/50 hover:text-sky-400"
+              >
+                <CheckCheck className="h-4 w-4" />
+                {t('buttons.markAllRead')}
+              </button>
+              <button
+                onClick={handleDismissAll}
+                disabled={!data || data.total === 0}
+                className="flex items-center gap-1.5 rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 transition hover:border-rose-500/50 hover:text-rose-400 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <Trash2 className="h-4 w-4" />
+                {t('buttons.dismissAll')}
+              </button>
+            </>
+          )}
+          {tab === 'trash' && (
+            <button
+              onClick={handleEmptyTrash}
+              disabled={!data || data.total === 0}
+              className="flex items-center gap-1.5 rounded-lg border border-rose-500/40 px-3 py-2 text-sm text-rose-400 transition hover:border-rose-500 hover:bg-rose-500/10 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Trash2 className="h-4 w-4" />
+              {t('trash.empty')}
+            </button>
+          )}
           <button
             onClick={() => navigate('/settings?tab=notifications')}
             className="flex items-center gap-1.5 rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 transition hover:border-sky-500/50 hover:text-sky-400"
           >
             <Settings className="h-4 w-4" />
-            Einstellungen
+            {t('buttons.settings')}
           </button>
         </div>
       </div>
 
-      {/* Filters */}
+      <div className="flex gap-2 border-b border-slate-800">
+        {(['inbox', 'trash'] as TabKey[]).map((k) => (
+          <button
+            key={k}
+            onClick={() => setTab(k)}
+            className={`relative px-4 py-2 text-sm transition ${
+              tab === k ? 'text-sky-400' : 'text-slate-400 hover:text-slate-200'
+            }`}
+          >
+            {t(`tabs.${k}`)}
+            {tab === k && (
+              <span className="absolute inset-x-2 -bottom-px h-0.5 rounded-full bg-sky-500" />
+            )}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'trash' && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-2 text-xs text-amber-300">
+          {t('trash.banner', { days: retentionDays })}
+        </div>
+      )}
+
       <div className="flex flex-wrap items-center gap-3 rounded-xl border border-slate-800 bg-slate-900/50 p-3">
         <Filter className="h-4 w-4 text-slate-400" />
 
         <select
           value={categoryFilter}
-          onChange={(e) => { setCategoryFilter(e.target.value as NotificationCategory | ''); setPage(1); }}
+          onChange={(e) => setCategoryFilter(e.target.value as NotificationCategory | '')}
           className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-1.5 text-sm text-slate-300"
         >
-          <option value="">Alle Kategorien</option>
+          <option value="">{t('filters.allCategories')}</option>
           {CATEGORIES.map((c) => (
             <option key={c} value={c}>{getCategoryIcon(c)} {getCategoryName(c)}</option>
           ))}
@@ -190,27 +294,27 @@ export default function NotificationsArchivePage() {
 
         <select
           value={typeFilter}
-          onChange={(e) => { setTypeFilter(e.target.value as NotificationType | ''); setPage(1); }}
+          onChange={(e) => setTypeFilter(e.target.value as NotificationType | '')}
           className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-1.5 text-sm text-slate-300"
         >
-          <option value="">Alle Typen</option>
-          {TYPES.map((t) => (
-            <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>
+          <option value="">{t('filters.allTypes')}</option>
+          {TYPES.map((tp) => (
+            <option key={tp} value={tp}>{tp.charAt(0).toUpperCase() + tp.slice(1)}</option>
           ))}
         </select>
 
-        <select
-          value={readFilter}
-          onChange={(e) => { setReadFilter(e.target.value as '' | 'unread' | 'all'); setPage(1); }}
-          className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-1.5 text-sm text-slate-300"
-        >
-          <option value="">Standard</option>
-          <option value="unread">Nur ungelesen</option>
-          <option value="all">Inkl. ausgeblendet</option>
-        </select>
+        {tab === 'inbox' && (
+          <select
+            value={readFilter}
+            onChange={(e) => setReadFilter(e.target.value as '' | 'unread')}
+            className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-1.5 text-sm text-slate-300"
+          >
+            <option value="">{t('filters.default')}</option>
+            <option value="unread">{t('filters.unreadOnly')}</option>
+          </select>
+        )}
       </div>
 
-      {/* Notification List */}
       <div className="space-y-2">
         {loading ? (
           <div className="flex items-center justify-center py-12">
@@ -219,15 +323,18 @@ export default function NotificationsArchivePage() {
         ) : !data || data.notifications.length === 0 ? (
           <div className="py-12 text-center text-slate-400">
             <Bell className="mx-auto mb-3 h-12 w-12 opacity-30" />
-            <p>Keine Benachrichtigungen gefunden</p>
+            <p>{tab === 'inbox' ? t('empty.inbox') : t('empty.trash')}</p>
           </div>
         ) : (
           data.notifications.map((n) => (
             <NotificationRow
               key={n.id}
+              tab={tab}
               notification={n}
               onMarkRead={handleMarkRead}
               onDismiss={handleDismiss}
+              onRestore={handleRestore}
+              onDeleteForever={handleDeleteForever}
               onSnooze={handleSnooze}
               onNavigate={(url) => navigate(url)}
             />
@@ -235,7 +342,6 @@ export default function NotificationsArchivePage() {
         )}
       </div>
 
-      {/* Pagination */}
       {totalPages > 1 && (
         <div className="flex items-center justify-center gap-4">
           <button
@@ -246,7 +352,7 @@ export default function NotificationsArchivePage() {
             <ChevronLeft className="h-4 w-4" />
           </button>
           <span className="text-sm text-slate-400">
-            Seite {page} von {totalPages}
+            {t('pagination.pageOf', { page, total: totalPages })}
           </span>
           <button
             onClick={() => setPage(Math.min(totalPages, page + 1))}
@@ -261,21 +367,27 @@ export default function NotificationsArchivePage() {
   );
 }
 
-/** Individual notification row with actions */
 function NotificationRow({
+  tab,
   notification: n,
   onMarkRead,
   onDismiss,
+  onRestore,
+  onDeleteForever,
   onSnooze,
   onNavigate,
 }: {
+  tab: TabKey;
   notification: Notification;
   onMarkRead: (n: Notification) => void;
   onDismiss: (n: Notification) => void;
+  onRestore: (n: Notification) => void;
+  onDeleteForever: (n: Notification) => void;
   onSnooze: (n: Notification, hours: number) => void;
   onNavigate: (url: string) => void;
 }) {
   const [showSnooze, setShowSnooze] = useState(false);
+  const { t } = useTranslation(['notifications']);
   const typeStyle = getTypeStyle(n.notification_type);
 
   return (
@@ -286,12 +398,10 @@ function NotificationRow({
           : 'border-slate-800/50 bg-slate-900/30'
       }`}
     >
-      {/* Icon */}
       <div className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg border ${typeStyle.bgColor}`}>
         <span className="text-lg">{getCategoryIcon(n.category)}</span>
       </div>
 
-      {/* Content */}
       <div className="min-w-0 flex-1">
         <div className="flex items-start justify-between gap-2">
           <p className={`text-sm font-medium ${!n.is_read ? 'text-slate-100' : 'text-slate-300'}`}>
@@ -314,9 +424,8 @@ function NotificationRow({
         </div>
       </div>
 
-      {/* Actions */}
       <div className="flex flex-shrink-0 items-center gap-1">
-        {n.action_url && (
+        {n.action_url && tab === 'inbox' && (
           <button
             onClick={() => onNavigate(n.action_url!)}
             className="rounded-lg border border-slate-700 px-2.5 py-1 text-xs text-slate-300 transition hover:border-sky-500/50 hover:text-sky-400"
@@ -325,47 +434,69 @@ function NotificationRow({
           </button>
         )}
 
-        {/* Snooze */}
-        <div className="relative">
-          <button
-            onClick={() => setShowSnooze(!showSnooze)}
-            className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-700 hover:text-slate-300"
-            title="Snooze"
-          >
-            <Clock className="h-4 w-4" />
-          </button>
-          {showSnooze && (
-            <div className="absolute right-0 top-8 z-10 rounded-lg border border-slate-700 bg-slate-800 py-1 shadow-xl">
-              {[1, 4, 24].map((h) => (
-                <button
-                  key={h}
-                  onClick={() => { onSnooze(n, h); setShowSnooze(false); }}
-                  className="block w-full px-4 py-1.5 text-left text-xs text-slate-300 transition hover:bg-slate-700"
-                >
-                  {h}h
-                </button>
-              ))}
+        {tab === 'inbox' && (
+          <>
+            <div className="relative">
+              <button
+                onClick={() => setShowSnooze(!showSnooze)}
+                className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-700 hover:text-slate-300"
+                title="Snooze"
+              >
+                <Clock className="h-4 w-4" />
+              </button>
+              {showSnooze && (
+                <div className="absolute right-0 top-8 z-10 rounded-lg border border-slate-700 bg-slate-800 py-1 shadow-xl">
+                  {[1, 4, 24].map((h) => (
+                    <button
+                      key={h}
+                      onClick={() => { onSnooze(n, h); setShowSnooze(false); }}
+                      className="block w-full px-4 py-1.5 text-left text-xs text-slate-300 transition hover:bg-slate-700"
+                    >
+                      {h}h
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
-          )}
-        </div>
 
-        {!n.is_read && (
-          <button
-            onClick={() => onMarkRead(n)}
-            className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-700 hover:text-slate-300"
-            title="Als gelesen markieren"
-          >
-            <CheckCheck className="h-4 w-4" />
-          </button>
+            {!n.is_read && (
+              <button
+                onClick={() => onMarkRead(n)}
+                className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-700 hover:text-slate-300"
+                title={t('buttons.markRead')}
+              >
+                <CheckCheck className="h-4 w-4" />
+              </button>
+            )}
+
+            <button
+              onClick={() => onDismiss(n)}
+              className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-700 hover:text-slate-300"
+              title={t('buttons.moveToTrash')}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </>
         )}
 
-        <button
-          onClick={() => onDismiss(n)}
-          className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-700 hover:text-slate-300"
-          title="Ausblenden"
-        >
-          <X className="h-4 w-4" />
-        </button>
+        {tab === 'trash' && (
+          <>
+            <button
+              onClick={() => onRestore(n)}
+              className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-700 hover:text-sky-400"
+              title={t('trash.restore')}
+            >
+              <RotateCcw className="h-4 w-4" />
+            </button>
+            <button
+              onClick={() => onDeleteForever(n)}
+              className="rounded-lg p-1.5 text-rose-500 transition hover:bg-rose-500/10 hover:text-rose-400"
+              title={t('trash.deleteForever')}
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/docs/superpowers/plans/2026-05-11-notifications-trash-retention.md
+++ b/docs/superpowers/plans/2026-05-11-notifications-trash-retention.md
@@ -1,0 +1,2747 @@
+# Notifications Trash + Retention Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `is_dismissed` (bool) with `deleted_at` (timestamp) to model a real trash with auto-expiry, add per-user retention (1–7 days), and surface a Trash tab with Restore / Permanent-Delete on the notifications page.
+
+**Architecture:** Single source of truth for trash state is `notifications.deleted_at`. A user-configurable `notification_preferences.trash_retention_days` (1–7, default 7) drives an hourly cleanup job that hard-deletes expired rows. System notifications (`user_id IS NULL`) use a fixed 7-day retention. The `_user_filter()` helper already covers admin vs user scoping for system notifications; we reuse it for the new endpoints.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0, Alembic (with `batch_alter_table` for SQLite portability), Pydantic v2, APScheduler. Frontend: React 18, TypeScript, Tailwind CSS, lucide-react, react-hot-toast, i18next, axios via `apiClient`.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-notifications-trash-retention-design.md`
+
+---
+
+## File Map
+
+**Backend — modify:**
+- `backend/app/models/notification.py` — Notification: replace `is_dismissed` with `deleted_at`; NotificationPreferences: add `trash_retention_days`
+- `backend/app/schemas/notification.py` — `NotificationResponse`: drop `is_dismissed`, add `deleted_at`; `NotificationPreferences*`: add `trash_retention_days`
+- `backend/app/services/notifications/service.py` — swap all `is_dismissed` filters to `deleted_at`; rewrite `dismiss`/`dismiss_all`; add `restore`/`delete_permanently`/`empty_trash`/`cleanup_expired_trash`; remove `cleanup_old_notifications`; swap `include_dismissed` parameter for `trashed_only`
+- `backend/app/services/notifications/scheduler.py` — add hourly `notification_trash_cleanup` job; relocate scheduler creation so cleanup runs without Firebase
+- `backend/app/api/routes/notifications.py` — update existing dismiss docstrings; remove `include_dismissed` query param; add 4 new endpoints (GET `/trash`, POST `/{id}/restore`, DELETE `/{id}`, DELETE `/trash`)
+
+**Backend — create:**
+- `backend/alembic/versions/<rev>_notification_trash_retention.py` — schema migration
+- `backend/tests/migrations/test_notification_trash_retention.py` — migration backfill tests
+
+**Backend — modify (tests):**
+- `backend/tests/services/test_notification_service.py` — add trash tests, fix existing dismiss test
+- `backend/tests/test_notifications_routes.py` — add trash route tests (file may need to be created if it doesn't exist; check first)
+
+**Frontend — modify:**
+- `client/src/api/notifications.ts` — type `Notification.is_dismissed` → `deleted_at`; type `NotificationPreferences` add `trash_retention_days`; add `getTrashNotifications`, `restoreNotification`, `deleteNotificationPermanently`, `emptyTrash`
+- `client/src/contexts/NotificationContext.tsx` — context filter (no behavior change beyond field rename); existing `dismiss` semantics now move-to-trash, no code change in context
+- `client/src/pages/NotificationsArchivePage.tsx` — replace `readFilter` with Inbox/Trash tabs; trash tab gets restore + delete-forever row icons and "Papierkorb leeren" button
+- `client/src/pages/NotificationPreferencesPage.tsx` — add retention slider section
+- `client/src/i18n/locales/de/notifications.json` + `client/src/i18n/locales/en/notifications.json` — new keys
+- `client/src/__tests__/lib/notificationGrouping.test.ts` — fixture `is_dismissed: false` → `deleted_at: null`
+
+---
+
+## Task 1: Migration + Model
+
+**Files:**
+- Create: `backend/alembic/versions/<rev>_notification_trash_retention.py`
+- Modify: `backend/app/models/notification.py`
+- Create: `backend/tests/migrations/test_notification_trash_retention.py`
+
+- [ ] **Step 1: Find the current Alembic head**
+
+Run: `cd backend && alembic heads`
+Expected: One revision ID, e.g. `1a2b3c4d5e6f (head)`. Note this — you'll need it as `down_revision`.
+
+- [ ] **Step 2: Create the migration stub**
+
+Run: `cd backend && alembic revision -m "notification trash retention"`
+Expected: A new file `backend/alembic/versions/<auto-id>_notification_trash_retention.py`. Note the path.
+
+- [ ] **Step 3: Replace migration body**
+
+Open the new file. Keep the `revision` and `down_revision` lines exactly as generated. Replace the `upgrade()` and `downgrade()` bodies with:
+
+```python
+"""notification trash retention
+
+Revision ID: <leave the generated id>
+Revises: <leave the generated down_revision>
+Create Date: <leave generated>
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, as used by Alembic.
+# (leave the auto-generated revision/down_revision lines untouched)
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.add_column(
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True)
+        )
+        batch_op.create_index("ix_notifications_deleted_at", ["deleted_at"])
+
+    # Backfill: existing soft-dismissed rows start their retention now.
+    op.execute(
+        "UPDATE notifications SET deleted_at = CURRENT_TIMESTAMP "
+        "WHERE is_dismissed"
+    )
+
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.drop_column("is_dismissed")
+
+    with op.batch_alter_table("notification_preferences") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "trash_retention_days",
+                sa.Integer(),
+                nullable=False,
+                server_default="7",
+            )
+        )
+        batch_op.create_check_constraint(
+            "ck_trash_retention_1_7",
+            "trash_retention_days BETWEEN 1 AND 7",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "is_dismissed",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("0"),
+            )
+        )
+    op.execute(
+        "UPDATE notifications SET is_dismissed = "
+        "(CASE WHEN deleted_at IS NOT NULL THEN 1 ELSE 0 END)"
+    )
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.drop_index("ix_notifications_deleted_at")
+        batch_op.drop_column("deleted_at")
+
+    with op.batch_alter_table("notification_preferences") as batch_op:
+        batch_op.drop_constraint("ck_trash_retention_1_7", type_="check")
+        batch_op.drop_column("trash_retention_days")
+```
+
+- [ ] **Step 4: Apply migration to dev DB**
+
+Run: `cd backend && alembic upgrade head`
+Expected: `INFO  [alembic.runtime.migration] Running upgrade <prev> -> <new>, notification trash retention`. No errors.
+
+- [ ] **Step 5: Update the SQLAlchemy model**
+
+In `backend/app/models/notification.py`:
+
+Replace the `is_dismissed` line (currently line 69):
+
+```python
+    is_dismissed: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+```
+
+with:
+
+```python
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None, index=True
+    )
+```
+
+In the `to_dict` method of `Notification`, replace the `"is_dismissed"` entry (currently line 94) with:
+
+```python
+            "deleted_at": self.deleted_at.isoformat() if self.deleted_at else None,
+```
+
+In the `NotificationPreferences` class, add after `min_priority` (currently line 126):
+
+```python
+    trash_retention_days: Mapped[int] = mapped_column(
+        Integer, default=7, nullable=False
+    )
+```
+
+In the `NotificationPreferences.to_dict` method, add a key before the closing `}` (currently line 145):
+
+```python
+            "trash_retention_days": self.trash_retention_days,
+```
+
+- [ ] **Step 6: Sanity-check model imports**
+
+Run: `cd backend && python -c "from app.models.notification import Notification, NotificationPreferences; print(Notification.__table__.columns.keys()); print(NotificationPreferences.__table__.columns.keys())"`
+Expected: `deleted_at` appears in Notification columns; `trash_retention_days` appears in NotificationPreferences; **`is_dismissed` is NOT in Notification columns**.
+
+- [ ] **Step 7: Write migration backfill test**
+
+Create `backend/tests/migrations/__init__.py` if it doesn't exist (empty file).
+
+Create `backend/tests/migrations/test_notification_trash_retention.py`:
+
+```python
+"""Test the notification trash retention migration backfills dismissed rows."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+
+from app.core.database import SessionLocal
+from app.models.notification import Notification
+
+
+def test_existing_notifications_in_inbox_have_deleted_at_null(db_session):
+    """After migration, notifications without deleted_at remain in the inbox."""
+    n = Notification(
+        user_id=None,
+        category="system",
+        notification_type="info",
+        title="Active",
+        message="Still in inbox",
+    )
+    db_session.add(n)
+    db_session.commit()
+    db_session.refresh(n)
+    assert n.deleted_at is None
+
+
+def test_can_write_and_query_deleted_at(db_session):
+    """Migration created the column and index; writes round-trip."""
+    n = Notification(
+        user_id=None,
+        category="system",
+        notification_type="info",
+        title="Trashed",
+        message="In trash",
+        deleted_at=datetime.now(timezone.utc),
+    )
+    db_session.add(n)
+    db_session.commit()
+    db_session.refresh(n)
+    assert n.deleted_at is not None
+
+
+def test_trash_retention_days_defaults_to_7(db_session):
+    """New preferences rows default to 7-day retention."""
+    from app.models.notification import NotificationPreferences
+    prefs = NotificationPreferences(user_id=999999)
+    db_session.add(prefs)
+    db_session.commit()
+    db_session.refresh(prefs)
+    assert prefs.trash_retention_days == 7
+
+
+def test_trash_retention_days_rejects_out_of_range(db_session):
+    """CHECK constraint rejects values outside 1..7."""
+    from app.models.notification import NotificationPreferences
+    from sqlalchemy.exc import IntegrityError
+
+    prefs = NotificationPreferences(user_id=999998, trash_retention_days=0)
+    db_session.add(prefs)
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+```
+
+- [ ] **Step 8: Run migration tests**
+
+Run: `cd backend && python -m pytest tests/migrations/test_notification_trash_retention.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 9: Smoke-test downgrade then upgrade**
+
+Run:
+```
+cd backend && alembic downgrade -1 && alembic upgrade head
+```
+Expected: Two successful runs, no errors. (This verifies the downgrade path works.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/alembic/versions/*_notification_trash_retention.py backend/app/models/notification.py backend/tests/migrations/
+git commit -m "feat(notifications): migrate is_dismissed → deleted_at with 1-7d retention"
+```
+
+---
+
+## Task 2: Schemas
+
+**Files:**
+- Modify: `backend/app/schemas/notification.py`
+
+- [ ] **Step 1: Update `NotificationResponse`**
+
+In `backend/app/schemas/notification.py`, replace line 63 `is_dismissed: bool = False` with:
+
+```python
+    deleted_at: Optional[datetime] = Field(
+        default=None,
+        description="Timestamp when notification was moved to trash (null = active)"
+    )
+```
+
+In `NotificationResponse.from_db()` (the `return cls(...)` block starting at line 95), replace the line `is_dismissed=notification.is_dismissed,` (line 105) with:
+
+```python
+            deleted_at=notification.deleted_at,
+```
+
+- [ ] **Step 2: Update preferences schemas**
+
+In `NotificationPreferencesBase` (starting line 167), add a new field after `category_preferences` (after line 199):
+
+```python
+    trash_retention_days: int = Field(
+        default=7,
+        ge=1,
+        le=7,
+        description="Days to retain notifications in trash before auto-purge"
+    )
+```
+
+In `NotificationPreferencesUpdate` (starting line 202), add after `category_preferences`:
+
+```python
+    trash_retention_days: Optional[int] = Field(default=None, ge=1, le=7)
+```
+
+In `NotificationPreferencesResponse.from_db()` (the `return cls(...)` block starting at line 225), add after `category_preferences=prefs.category_preferences,`:
+
+```python
+            trash_retention_days=prefs.trash_retention_days,
+```
+
+- [ ] **Step 3: Verify schemas import cleanly**
+
+Run: `cd backend && python -c "from app.schemas.notification import NotificationResponse, NotificationPreferencesResponse, NotificationPreferencesUpdate; print('OK')"`
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/schemas/notification.py
+git commit -m "feat(notifications): expose deleted_at + trash_retention_days in schemas"
+```
+
+---
+
+## Task 3: Service — switch dismiss/internal filters to deleted_at
+
+**Files:**
+- Modify: `backend/app/services/notifications/service.py`
+- Modify: `backend/tests/services/test_notification_service.py`
+
+- [ ] **Step 1: Update existing dismiss test**
+
+In `backend/tests/services/test_notification_service.py`, find `test_dismiss_notification` (around line 216) and replace the final assertion block:
+
+```python
+        result = notification_service.dismiss(
+            db_session, notification.id, test_user.id
+        )
+
+        assert result is not None
+        assert result.is_dismissed is True
+        assert result.is_read is True
+```
+
+with:
+
+```python
+        result = notification_service.dismiss(
+            db_session, notification.id, test_user.id
+        )
+
+        assert result is not None
+        assert result.deleted_at is not None
+        assert result.is_read is True
+```
+
+Also find the assertion `assert notification.is_dismissed is False` (around line 63) and replace with:
+
+```python
+        assert notification.deleted_at is None
+```
+
+- [ ] **Step 2: Add new dismiss test**
+
+Append to `backend/tests/services/test_notification_service.py`:
+
+```python
+class TestTrashSemantics:
+    """Tests for trash-based dismiss/restore/delete behavior."""
+
+    def test_dismiss_sets_deleted_at(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="T",
+            message="M",
+        )
+        db_session.add(n)
+        db_session.commit()
+        db_session.refresh(n)
+
+        before = n.deleted_at
+        notification_service.dismiss(db_session, n.id, test_user.id)
+        db_session.refresh(n)
+        assert before is None
+        assert n.deleted_at is not None
+        assert n.is_read is True
+
+    def test_dismiss_idempotent_on_already_trashed(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="T",
+            message="M",
+        )
+        db_session.add(n)
+        db_session.commit()
+
+        notification_service.dismiss(db_session, n.id, test_user.id)
+        db_session.refresh(n)
+        first = n.deleted_at
+
+        notification_service.dismiss(db_session, n.id, test_user.id)
+        db_session.refresh(n)
+        # Second dismiss must not overwrite the original timestamp
+        assert n.deleted_at == first
+```
+
+- [ ] **Step 3: Run tests — expect failure**
+
+Run: `cd backend && python -m pytest tests/services/test_notification_service.py::TestTrashSemantics -v`
+Expected: FAIL — `dismiss` does not yet set `deleted_at` (still uses `is_dismissed`).
+
+- [ ] **Step 4: Update service filters and `dismiss`/`dismiss_all`**
+
+In `backend/app/services/notifications/service.py`:
+
+Add `func` to the existing SQLAlchemy import (around line 12 — confirm it's already imported via `from sqlalchemy import desc, and_, func, or_`; if not, add `func`).
+
+Find every occurrence of `Notification.is_dismissed == False` and replace with `Notification.deleted_at.is_(None)`. The current locations are lines 470, 537, 578, 617, 747. Use a single replace_all in the file.
+
+Replace the body of `dismiss` (around line 697–727) with:
+
+```python
+    def dismiss(
+        self,
+        db: Session,
+        notification_id: int,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> Optional[Notification]:
+        """Move a notification to trash (idempotent on already-trashed rows)."""
+        notification = db.query(Notification).filter(
+            Notification.id == notification_id,
+            self._user_filter(user_id, is_admin),
+        ).first()
+
+        if notification and notification.deleted_at is None:
+            notification.deleted_at = datetime.now(timezone.utc)
+            notification.is_read = True
+            db.commit()
+            db.refresh(notification)
+            logger.debug(f"Moved notification {notification_id} to trash")
+
+        return notification
+```
+
+Replace the body of `dismiss_all` (around line 729–757) with:
+
+```python
+    def dismiss_all(
+        self,
+        db: Session,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> int:
+        """Move all active notifications for a user to trash."""
+        query = db.query(Notification).filter(
+            self._user_filter(user_id, is_admin),
+            Notification.deleted_at.is_(None),
+        )
+
+        count = query.update({
+            Notification.deleted_at: datetime.now(timezone.utc),
+            Notification.is_read: True,
+        })
+        db.commit()
+
+        logger.info(f"Moved {count} notifications to trash for user {user_id}")
+        return count
+```
+
+- [ ] **Step 5: Run tests — expect pass**
+
+Run: `cd backend && python -m pytest tests/services/test_notification_service.py -v -k "dismiss or Trash"`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/notifications/service.py backend/tests/services/test_notification_service.py
+git commit -m "feat(notifications): dismiss now writes deleted_at timestamp"
+```
+
+---
+
+## Task 4: Service — `restore` method
+
+**Files:**
+- Modify: `backend/app/services/notifications/service.py`
+- Modify: `backend/tests/services/test_notification_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `TestTrashSemantics` class in `backend/tests/services/test_notification_service.py`:
+
+```python
+    def test_restore_clears_deleted_at(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="T",
+            message="M",
+        )
+        db_session.add(n)
+        db_session.commit()
+        notification_service.dismiss(db_session, n.id, test_user.id)
+        db_session.refresh(n)
+        assert n.deleted_at is not None
+
+        result = notification_service.restore(db_session, n.id, test_user.id)
+        db_session.refresh(n)
+        assert result is not None
+        assert n.deleted_at is None
+
+    def test_restore_idempotent_on_active(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="T",
+            message="M",
+        )
+        db_session.add(n)
+        db_session.commit()
+
+        result = notification_service.restore(db_session, n.id, test_user.id)
+        assert result is not None
+        assert result.deleted_at is None
+
+    def test_restore_returns_none_for_unknown_id(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        result = notification_service.restore(db_session, 9999999, test_user.id)
+        assert result is None
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `cd backend && python -m pytest tests/services/test_notification_service.py::TestTrashSemantics -v -k restore`
+Expected: FAIL — `restore` is not defined.
+
+- [ ] **Step 3: Implement `restore`**
+
+In `backend/app/services/notifications/service.py`, add this method immediately after `dismiss_all` (around line 758):
+
+```python
+    def restore(
+        self,
+        db: Session,
+        notification_id: int,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> Optional[Notification]:
+        """Restore a notification from trash (idempotent on already-active rows)."""
+        notification = db.query(Notification).filter(
+            Notification.id == notification_id,
+            self._user_filter(user_id, is_admin),
+        ).first()
+
+        if notification and notification.deleted_at is not None:
+            notification.deleted_at = None
+            db.commit()
+            db.refresh(notification)
+            logger.debug(f"Restored notification {notification_id} from trash")
+
+        return notification
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `cd backend && python -m pytest tests/services/test_notification_service.py::TestTrashSemantics -v -k restore`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/notifications/service.py backend/tests/services/test_notification_service.py
+git commit -m "feat(notifications): add restore() to bring a row back from trash"
+```
+
+---
+
+## Task 5: Service — `delete_permanently`
+
+**Files:**
+- Modify: `backend/app/services/notifications/service.py`
+- Modify: `backend/tests/services/test_notification_service.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `TestTrashSemantics`:
+
+```python
+    def test_delete_permanently_removes_row(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="T",
+            message="M",
+        )
+        db_session.add(n)
+        db_session.commit()
+        notification_id = n.id
+
+        deleted = notification_service.delete_permanently(
+            db_session, notification_id, test_user.id
+        )
+        assert deleted is True
+        assert (
+            db_session.query(Notification)
+            .filter(Notification.id == notification_id)
+            .first()
+            is None
+        )
+
+    def test_delete_permanently_returns_false_for_unknown_id(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        deleted = notification_service.delete_permanently(
+            db_session, 9999999, test_user.id
+        )
+        assert deleted is False
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `cd backend && python -m pytest tests/services/test_notification_service.py::TestTrashSemantics -v -k delete_permanently`
+Expected: FAIL — method not defined.
+
+- [ ] **Step 3: Implement**
+
+In `backend/app/services/notifications/service.py`, add after the `restore` method:
+
+```python
+    def delete_permanently(
+        self,
+        db: Session,
+        notification_id: int,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> bool:
+        """Hard-delete a single notification (any state). Returns True if deleted."""
+        count = (
+            db.query(Notification)
+            .filter(
+                Notification.id == notification_id,
+                self._user_filter(user_id, is_admin),
+            )
+            .delete(synchronize_session=False)
+        )
+        db.commit()
+        if count:
+            logger.debug(f"Hard-deleted notification {notification_id}")
+        return count > 0
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `cd backend && python -m pytest tests/services/test_notification_service.py::TestTrashSemantics -v -k delete_permanently`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/notifications/service.py backend/tests/services/test_notification_service.py
+git commit -m "feat(notifications): add delete_permanently() for hard delete"
+```
+
+---
+
+## Task 6: Service — `empty_trash`
+
+**Files:**
+- Modify: `backend/app/services/notifications/service.py`
+- Modify: `backend/tests/services/test_notification_service.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `TestTrashSemantics`:
+
+```python
+    def test_empty_trash_removes_only_trashed_rows(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone
+
+        active = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="active",
+            message="m",
+        )
+        trashed = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="trashed",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([active, trashed])
+        db_session.commit()
+
+        count = notification_service.empty_trash(db_session, test_user.id)
+
+        assert count == 1
+        remaining = db_session.query(Notification).filter(
+            Notification.user_id == test_user.id
+        ).all()
+        assert len(remaining) == 1
+        assert remaining[0].title == "active"
+
+    def test_empty_trash_isolates_users(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+        test_admin,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone
+
+        user_trashed = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="user-trash",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        other_trashed = Notification(
+            user_id=test_admin.id,
+            category="system",
+            notification_type="info",
+            title="admin-trash",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([user_trashed, other_trashed])
+        db_session.commit()
+
+        notification_service.empty_trash(db_session, test_user.id, is_admin=False)
+
+        # User's trash gone; admin's trash untouched (non-admin scope)
+        assert db_session.query(Notification).filter(
+            Notification.user_id == test_user.id
+        ).count() == 0
+        assert db_session.query(Notification).filter(
+            Notification.user_id == test_admin.id
+        ).count() == 1
+```
+
+Note: this test requires a `test_admin` fixture. If it does not yet exist in `backend/tests/conftest.py` or the same test file, check `conftest.py` for an existing admin fixture (likely `admin_user` or `test_admin`). If missing, add one:
+
+```python
+@pytest.fixture
+def test_admin(db_session):
+    """Create an admin user for tests that need admin scope isolation."""
+    from app.models.user import User
+    user = User(
+        username="admin_for_trash",
+        password_hash="x",
+        role="admin",
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+```
+
+(Adjust password field name if the User model differs — check the existing `test_user` fixture for the pattern.)
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `cd backend && python -m pytest tests/services/test_notification_service.py::TestTrashSemantics -v -k empty_trash`
+Expected: FAIL — `empty_trash` not defined.
+
+- [ ] **Step 3: Implement**
+
+In `backend/app/services/notifications/service.py`, add after `delete_permanently`:
+
+```python
+    def empty_trash(
+        self,
+        db: Session,
+        user_id: int,
+        is_admin: bool = False,
+    ) -> int:
+        """Hard-delete every trashed notification visible to this user."""
+        count = (
+            db.query(Notification)
+            .filter(
+                self._user_filter(user_id, is_admin),
+                Notification.deleted_at.is_not(None),
+            )
+            .delete(synchronize_session=False)
+        )
+        db.commit()
+        logger.info(f"Emptied trash for user {user_id}: {count} rows")
+        return count
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `cd backend && python -m pytest tests/services/test_notification_service.py::TestTrashSemantics -v -k empty_trash`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/notifications/service.py backend/tests/services/test_notification_service.py backend/tests/conftest.py
+git commit -m "feat(notifications): add empty_trash() for bulk hard-delete"
+```
+
+---
+
+## Task 7: Service — `cleanup_expired_trash` (remove `cleanup_old_notifications`)
+
+**Files:**
+- Modify: `backend/app/services/notifications/service.py`
+- Modify: `backend/tests/services/test_notification_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `TestTrashSemantics`:
+
+```python
+    def test_cleanup_expired_trash_respects_user_retention(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification, NotificationPreferences
+        from datetime import datetime, timezone, timedelta
+
+        # 3-day retention for this user
+        prefs = NotificationPreferences(user_id=test_user.id, trash_retention_days=3)
+        db_session.add(prefs)
+
+        now = datetime.now(timezone.utc)
+        old = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="old",
+            message="m",
+            deleted_at=now - timedelta(days=5),
+        )
+        recent = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="recent",
+            message="m",
+            deleted_at=now - timedelta(days=1),
+        )
+        db_session.add_all([old, recent])
+        db_session.commit()
+
+        count = notification_service.cleanup_expired_trash(db_session)
+
+        assert count == 1
+        titles = [
+            n.title for n in db_session.query(Notification)
+            .filter(Notification.user_id == test_user.id)
+            .all()
+        ]
+        assert titles == ["recent"]
+
+    def test_cleanup_expired_trash_default_when_no_prefs(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone, timedelta
+
+        now = datetime.now(timezone.utc)
+        too_old = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="too_old",
+            message="m",
+            deleted_at=now - timedelta(days=8),
+        )
+        within = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="within",
+            message="m",
+            deleted_at=now - timedelta(days=6),
+        )
+        db_session.add_all([too_old, within])
+        db_session.commit()
+
+        count = notification_service.cleanup_expired_trash(db_session)
+
+        assert count == 1
+        titles = [
+            n.title for n in db_session.query(Notification)
+            .filter(Notification.user_id == test_user.id)
+            .all()
+        ]
+        assert titles == ["within"]
+
+    def test_cleanup_expired_trash_system_notifications_fixed_7d(
+        self,
+        notification_service,
+        db_session,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone, timedelta
+
+        now = datetime.now(timezone.utc)
+        old_system = Notification(
+            user_id=None,
+            category="system",
+            notification_type="info",
+            title="old_sys",
+            message="m",
+            deleted_at=now - timedelta(days=10),
+        )
+        fresh_system = Notification(
+            user_id=None,
+            category="system",
+            notification_type="info",
+            title="fresh_sys",
+            message="m",
+            deleted_at=now - timedelta(days=3),
+        )
+        db_session.add_all([old_system, fresh_system])
+        db_session.commit()
+
+        notification_service.cleanup_expired_trash(db_session)
+
+        titles = [
+            n.title for n in db_session.query(Notification)
+            .filter(Notification.user_id.is_(None))
+            .all()
+        ]
+        assert titles == ["fresh_sys"]
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `cd backend && python -m pytest tests/services/test_notification_service.py::TestTrashSemantics -v -k cleanup_expired_trash`
+Expected: FAIL — `cleanup_expired_trash` not defined.
+
+- [ ] **Step 3: Implement and remove old cleanup**
+
+In `backend/app/services/notifications/service.py`, replace the entire `cleanup_old_notifications` method (the `async def cleanup_old_notifications(...)` block, around lines 867–891) with:
+
+```python
+    def cleanup_expired_trash(self, db: Session) -> int:
+        """Hard-delete trashed notifications past their retention.
+
+        Per-user retention comes from NotificationPreferences.trash_retention_days
+        (default 7 if no prefs row). System notifications (user_id IS NULL) use
+        a fixed 7-day retention.
+        """
+        from datetime import timedelta
+
+        now = datetime.now(timezone.utc)
+
+        users_with_trash = (
+            db.query(Notification.user_id)
+            .filter(
+                Notification.deleted_at.is_not(None),
+                Notification.user_id.is_not(None),
+            )
+            .distinct()
+            .all()
+        )
+
+        total = 0
+        for (user_id,) in users_with_trash:
+            prefs = self.get_user_preferences(db, user_id)
+            retention_days = prefs.trash_retention_days if prefs else 7
+            cutoff = now - timedelta(days=retention_days)
+            count = (
+                db.query(Notification)
+                .filter(
+                    Notification.user_id == user_id,
+                    Notification.deleted_at.is_not(None),
+                    Notification.deleted_at < cutoff,
+                )
+                .delete(synchronize_session=False)
+            )
+            total += count
+
+        # System notifications use fixed 7-day retention
+        sys_cutoff = now - timedelta(days=7)
+        total += (
+            db.query(Notification)
+            .filter(
+                Notification.user_id.is_(None),
+                Notification.deleted_at.is_not(None),
+                Notification.deleted_at < sys_cutoff,
+            )
+            .delete(synchronize_session=False)
+        )
+
+        db.commit()
+        if total:
+            logger.info(f"Expired trash cleanup: deleted {total} notifications")
+        return total
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `cd backend && python -m pytest tests/services/test_notification_service.py::TestTrashSemantics -v -k cleanup_expired_trash`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/notifications/service.py backend/tests/services/test_notification_service.py
+git commit -m "feat(notifications): cleanup_expired_trash respects per-user retention"
+```
+
+---
+
+## Task 8: Service — `trashed_only` parameter on list/count
+
+**Files:**
+- Modify: `backend/app/services/notifications/service.py`
+- Modify: `backend/tests/services/test_notification_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `TestTrashSemantics`:
+
+```python
+    def test_get_user_notifications_inbox_excludes_trashed(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone
+
+        active = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="active",
+            message="m",
+        )
+        trashed = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="trashed",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([active, trashed])
+        db_session.commit()
+
+        results = notification_service.get_user_notifications(
+            db_session, test_user.id
+        )
+        titles = [n.title for n in results]
+        assert "active" in titles
+        assert "trashed" not in titles
+
+    def test_get_user_notifications_trashed_only_returns_trash(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone
+
+        active = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="active",
+            message="m",
+        )
+        trashed = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="trashed",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([active, trashed])
+        db_session.commit()
+
+        results = notification_service.get_user_notifications(
+            db_session, test_user.id, trashed_only=True
+        )
+        titles = [n.title for n in results]
+        assert titles == ["trashed"]
+
+    def test_get_unread_count_ignores_trashed(
+        self,
+        notification_service,
+        db_session,
+        test_user,
+    ):
+        from app.models.notification import Notification
+        from datetime import datetime, timezone
+
+        unread = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="unread",
+            message="m",
+        )
+        unread_in_trash = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="unread_in_trash",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([unread, unread_in_trash])
+        db_session.commit()
+
+        count = notification_service.get_unread_count(db_session, test_user.id)
+        assert count == 1
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `cd backend && python -m pytest tests/services/test_notification_service.py::TestTrashSemantics -v -k "inbox or trashed_only or unread_count"`
+Expected: FAIL — `trashed_only` parameter unknown; the trashed row still appears.
+
+- [ ] **Step 3: Refactor `get_user_notifications` and `count_user_notifications`**
+
+In `backend/app/services/notifications/service.py`, change the signature of `get_user_notifications` (around line 423) and `count_user_notifications` (around line 489):
+
+**Replace the parameter** `include_dismissed: bool = False,` (present in both signatures) with:
+
+```python
+        trashed_only: bool = False,
+```
+
+**Replace the filter block** in both methods. Find this in `get_user_notifications` (around line 469):
+
+```python
+        if not include_dismissed:
+            query = query.filter(Notification.is_dismissed == False)
+```
+
+Replace with:
+
+```python
+        if trashed_only:
+            query = query.filter(Notification.deleted_at.is_not(None))
+        else:
+            query = query.filter(Notification.deleted_at.is_(None))
+```
+
+Apply the same replacement in `count_user_notifications` (around line 536):
+
+```python
+        if not include_dismissed:
+            query = query.filter(Notification.is_dismissed == False)
+```
+
+becomes:
+
+```python
+        if trashed_only:
+            query = query.filter(Notification.deleted_at.is_not(None))
+        else:
+            query = query.filter(Notification.deleted_at.is_(None))
+```
+
+Also update the docstrings of both methods: replace any mention of `include_dismissed` with `trashed_only` and re-describe ("If True, return only trashed notifications; otherwise return only active (inbox) notifications").
+
+(At this point the remaining `is_dismissed` filters in `get_unread_count`/`get_unread_counts` should already read `Notification.deleted_at.is_(None)` from Task 3's replace_all.)
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `cd backend && python -m pytest tests/services/test_notification_service.py -v`
+Expected: All tests in this file pass.
+
+- [ ] **Step 5: Run the full service test suite to catch any caller regression**
+
+Run: `cd backend && python -m pytest tests/services/ -v`
+Expected: All previously-passing tests still pass. If something fails citing `include_dismissed`, locate that caller and switch it to `trashed_only`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/notifications/service.py backend/tests/services/test_notification_service.py
+git commit -m "refactor(notifications): swap include_dismissed for trashed_only"
+```
+
+---
+
+## Task 9: Routes — update existing endpoints
+
+**Files:**
+- Modify: `backend/app/api/routes/notifications.py`
+
+- [ ] **Step 1: Update existing `GET /notifications` query parameter**
+
+In `backend/app/api/routes/notifications.py`, find the `get_notifications` handler (around line 35). Replace the `include_dismissed` query parameter (line 38) with nothing — remove that whole `include_dismissed: bool = ...` line.
+
+Also remove its reference inside the two service calls (`include_dismissed=include_dismissed,` — appears in `service.get_user_notifications(...)` and `service.count_user_notifications(...)` around lines 56–83). Just delete those lines; the service defaults to `trashed_only=False`.
+
+- [ ] **Step 2: Update docstrings of dismiss endpoints**
+
+Find `dismiss_all_notifications` (around line 190). Replace its docstring with:
+
+```python
+    """Move all active notifications for the current user to trash.
+
+    Sets deleted_at=NOW() and is_read=True on all active notifications.
+    Items can be restored from the trash view or are auto-purged after the
+    user's configured retention period (default 7 days).
+    """
+```
+
+Find `dismiss_notification` (around line 207). Replace its docstring with:
+
+```python
+    """Move a notification to trash.
+
+    The notification is hidden from inbox views and appears in the trash,
+    where it can be restored or permanently deleted. Auto-purged after the
+    user's configured retention period (default 7 days).
+    """
+```
+
+- [ ] **Step 3: Verify the API still imports cleanly**
+
+Run: `cd backend && python -c "from app.api.routes.notifications import router; print(len(router.routes))"`
+Expected: A positive integer (current number of routes), no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/api/routes/notifications.py
+git commit -m "refactor(notifications): drop include_dismissed param, update dismiss docs"
+```
+
+---
+
+## Task 10: Route — `GET /notifications/trash`
+
+**Files:**
+- Modify: `backend/app/api/routes/notifications.py`
+- Modify (or create): `backend/tests/test_notifications_routes.py`
+
+- [ ] **Step 1: Check whether the route-test file exists**
+
+Run: `cd backend && python -c "import os; print(os.path.exists('tests/test_notifications_routes.py'))"`
+Expected: prints `True` or `False`. If `False`, create the file with the minimal scaffolding in the test step below; if `True`, append to it.
+
+- [ ] **Step 2: Write failing test**
+
+Add (or create the file containing) the following test. If the file already exists, append the class; if creating, prepend the file with imports:
+
+```python
+"""Integration tests for notification routes."""
+from datetime import datetime, timezone
+
+import pytest
+
+
+class TestTrashRoutes:
+    """Tests for trash-specific route endpoints."""
+
+    def test_get_trash_returns_only_trashed(
+        self, client, auth_headers, db_session, test_user
+    ):
+        from app.models.notification import Notification
+
+        active = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="active",
+            message="m",
+        )
+        trashed = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="trashed",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([active, trashed])
+        db_session.commit()
+
+        resp = client.get("/api/notifications/trash", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        titles = [n["title"] for n in data["notifications"]]
+        assert titles == ["trashed"]
+```
+
+If `auth_headers` / `test_user` / `client` fixtures don't exist under those names, check `backend/tests/conftest.py` for the project's conventions (often `client`, `auth_headers`, `test_user` exist). Adjust fixture names to match.
+
+- [ ] **Step 3: Run test — expect failure**
+
+Run: `cd backend && python -m pytest tests/test_notifications_routes.py::TestTrashRoutes::test_get_trash_returns_only_trashed -v`
+Expected: FAIL — 404 Not Found (endpoint doesn't exist).
+
+- [ ] **Step 4: Add the endpoint**
+
+In `backend/app/api/routes/notifications.py`, add this endpoint immediately before the `POST /notifications` create endpoint (around line 357):
+
+```python
+@router.get("/trash", response_model=NotificationListResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def get_trash(
+    request: Request, response: Response,
+    category: Optional[NotificationCategoryEnum] = Query(None),
+    notification_type: Optional[str] = Query(None),
+    created_after: Optional[datetime] = Query(None),
+    created_before: Optional[datetime] = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    current_user: UserPublic = Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+) -> NotificationListResponse:
+    """List trashed notifications for the current user, paginated."""
+    service = get_notification_service()
+    offset = (page - 1) * page_size
+    admin = is_privileged(current_user)
+
+    notifications = service.get_user_notifications(
+        db=db,
+        user_id=current_user.id,
+        trashed_only=True,
+        category=category,
+        notification_type=notification_type,
+        created_after=created_after,
+        created_before=created_before,
+        limit=page_size,
+        offset=offset,
+        is_admin=admin,
+    )
+
+    total = service.count_user_notifications(
+        db=db,
+        user_id=current_user.id,
+        trashed_only=True,
+        category=category,
+        notification_type=notification_type,
+        created_after=created_after,
+        created_before=created_before,
+        is_admin=admin,
+    )
+
+    unread_count = service.get_unread_count(db, current_user.id, is_admin=admin)
+
+    return NotificationListResponse(
+        notifications=[NotificationResponse.from_db(n) for n in notifications],
+        total=total,
+        unread_count=unread_count,
+        page=page,
+        page_size=page_size,
+    )
+```
+
+- [ ] **Step 5: Run test — expect pass**
+
+Run: `cd backend && python -m pytest tests/test_notifications_routes.py::TestTrashRoutes::test_get_trash_returns_only_trashed -v`
+Expected: 1 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/api/routes/notifications.py backend/tests/test_notifications_routes.py
+git commit -m "feat(notifications): add GET /notifications/trash"
+```
+
+---
+
+## Task 11: Route — `POST /notifications/{id}/restore`
+
+**Files:**
+- Modify: `backend/app/api/routes/notifications.py`
+- Modify: `backend/tests/test_notifications_routes.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `TestTrashRoutes`:
+
+```python
+    def test_restore_round_trip(
+        self, client, auth_headers, db_session, test_user
+    ):
+        from app.models.notification import Notification
+
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="t",
+            message="m",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db_session.add(n)
+        db_session.commit()
+
+        resp = client.post(
+            f"/api/notifications/{n.id}/restore", headers=auth_headers
+        )
+        assert resp.status_code == 200
+        assert resp.json()["deleted_at"] is None
+
+    def test_restore_unknown_id_returns_404(
+        self, client, auth_headers
+    ):
+        resp = client.post(
+            "/api/notifications/99999999/restore", headers=auth_headers
+        )
+        assert resp.status_code == 404
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `cd backend && python -m pytest tests/test_notifications_routes.py::TestTrashRoutes -v -k restore`
+Expected: FAIL (404 for the round-trip test because the route doesn't exist).
+
+- [ ] **Step 3: Add the endpoint**
+
+In `backend/app/api/routes/notifications.py`, add directly after the `snooze_notification` endpoint (around line 252):
+
+```python
+@router.post("/{notification_id}/restore", response_model=NotificationResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def restore_notification(
+    request: Request, response: Response,
+    notification_id: int,
+    current_user: UserPublic = Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+) -> NotificationResponse:
+    """Restore a notification from trash."""
+    service = get_notification_service()
+    notification = service.restore(
+        db, notification_id, current_user.id, is_admin=is_privileged(current_user)
+    )
+
+    if not notification:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Notification not found",
+        )
+
+    return NotificationResponse.from_db(notification)
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `cd backend && python -m pytest tests/test_notifications_routes.py::TestTrashRoutes -v -k restore`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes/notifications.py backend/tests/test_notifications_routes.py
+git commit -m "feat(notifications): add POST /{id}/restore endpoint"
+```
+
+---
+
+## Task 12: Route — `DELETE /notifications/{id}`
+
+**Files:**
+- Modify: `backend/app/api/routes/notifications.py`
+- Modify: `backend/tests/test_notifications_routes.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `TestTrashRoutes`:
+
+```python
+    def test_delete_permanently_removes_row(
+        self, client, auth_headers, db_session, test_user
+    ):
+        from app.models.notification import Notification
+
+        n = Notification(
+            user_id=test_user.id,
+            category="system",
+            notification_type="info",
+            title="t",
+            message="m",
+        )
+        db_session.add(n)
+        db_session.commit()
+        nid = n.id
+
+        resp = client.delete(
+            f"/api/notifications/{nid}", headers=auth_headers
+        )
+        assert resp.status_code == 204
+        assert (
+            db_session.query(Notification)
+            .filter(Notification.id == nid)
+            .first()
+            is None
+        )
+
+    def test_delete_unknown_id_returns_404(
+        self, client, auth_headers
+    ):
+        resp = client.delete(
+            "/api/notifications/99999999", headers=auth_headers
+        )
+        assert resp.status_code == 404
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `cd backend && python -m pytest tests/test_notifications_routes.py::TestTrashRoutes -v -k delete_permanently`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the endpoint**
+
+In `backend/app/api/routes/notifications.py`, add after the restore endpoint:
+
+```python
+@router.delete("/{notification_id}", status_code=status.HTTP_204_NO_CONTENT)
+@user_limiter.limit(get_limit("admin_operations"))
+async def delete_notification(
+    request: Request, response: Response,
+    notification_id: int,
+    current_user: UserPublic = Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+) -> Response:
+    """Permanently delete a notification (any state)."""
+    service = get_notification_service()
+    deleted = service.delete_permanently(
+        db, notification_id, current_user.id, is_admin=is_privileged(current_user)
+    )
+
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Notification not found",
+        )
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `cd backend && python -m pytest tests/test_notifications_routes.py::TestTrashRoutes -v -k delete`
+Expected: 2 passed (plus prior tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes/notifications.py backend/tests/test_notifications_routes.py
+git commit -m "feat(notifications): add DELETE /{id} for permanent removal"
+```
+
+---
+
+## Task 13: Route — `DELETE /notifications/trash`
+
+**Files:**
+- Modify: `backend/app/api/routes/notifications.py`
+- Modify: `backend/tests/test_notifications_routes.py`
+
+**Route ordering note:** The DELETE for `/trash` MUST be added BEFORE the DELETE for `/{notification_id}`, otherwise FastAPI matches `"trash"` against the `{notification_id}` path parameter and you get a 422.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `TestTrashRoutes`:
+
+```python
+    def test_empty_trash_returns_count(
+        self, client, auth_headers, db_session, test_user
+    ):
+        from app.models.notification import Notification
+
+        for i in range(3):
+            db_session.add(Notification(
+                user_id=test_user.id,
+                category="system",
+                notification_type="info",
+                title=f"t{i}",
+                message="m",
+                deleted_at=datetime.now(timezone.utc),
+            ))
+        db_session.commit()
+
+        resp = client.delete("/api/notifications/trash", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json() == {"count": 3}
+        assert db_session.query(Notification).filter(
+            Notification.user_id == test_user.id,
+            Notification.deleted_at.is_not(None),
+        ).count() == 0
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+Run: `cd backend && python -m pytest tests/test_notifications_routes.py::TestTrashRoutes::test_empty_trash_returns_count -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the endpoint BEFORE the `DELETE /{notification_id}` endpoint**
+
+In `backend/app/api/routes/notifications.py`, find the `delete_notification` endpoint added in Task 12. Insert this BEFORE it:
+
+```python
+@router.delete("/trash")
+@user_limiter.limit(get_limit("admin_operations"))
+async def empty_trash(
+    request: Request, response: Response,
+    current_user: UserPublic = Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Empty the current user's trash (admins also wipe trashed system notifications)."""
+    service = get_notification_service()
+    count = service.empty_trash(
+        db, current_user.id, is_admin=is_privileged(current_user)
+    )
+    return {"count": count}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `cd backend && python -m pytest tests/test_notifications_routes.py::TestTrashRoutes -v`
+Expected: All trash route tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes/notifications.py backend/tests/test_notifications_routes.py
+git commit -m "feat(notifications): add DELETE /trash to empty current user's trash"
+```
+
+---
+
+## Task 14: Background job — hourly trash cleanup
+
+**Files:**
+- Modify: `backend/app/services/notifications/scheduler.py`
+
+- [ ] **Step 1: Inspect the current scheduler structure**
+
+Open `backend/app/services/notifications/scheduler.py`. Confirm `start_notification_scheduler` (around line 280) currently gates the whole scheduler on `FirebaseService.is_available()` and registers only `device_expiration_check`.
+
+- [ ] **Step 2: Refactor to always-on scheduler, gated device-expiration job**
+
+Replace the entire `start_notification_scheduler` function (lines 280–303 in the current file) with:
+
+```python
+def start_notification_scheduler() -> None:
+    """Start the notification scheduler background job."""
+    global _notification_scheduler
+    if _notification_scheduler is not None:
+        return
+    try:
+        from apscheduler.schedulers.background import BackgroundScheduler
+    except ImportError:
+        logger.warning("APScheduler not installed, notification scheduler disabled")
+        return
+
+    _notification_scheduler = BackgroundScheduler()
+
+    # Always-on: hourly trash cleanup (independent of Firebase)
+    _notification_scheduler.add_job(
+        func=_run_trash_cleanup,
+        trigger="interval",
+        hours=1,
+        id="notification_trash_cleanup",
+        name="Hard-delete expired trashed notifications",
+        replace_existing=True,
+    )
+
+    # Firebase-dependent: device expiration warnings
+    if FirebaseService.is_available():
+        _notification_scheduler.add_job(
+            func=NotificationScheduler.run_periodic_check,
+            trigger="interval",
+            hours=1,
+            id="device_expiration_check",
+            name="Check and send device expiration warnings",
+            replace_existing=True,
+        )
+    else:
+        logger.info("Device expiration check skipped (Firebase not configured)")
+
+    _notification_scheduler.start()
+    logger.info("Notification scheduler started (running every hour)")
+```
+
+- [ ] **Step 3: Add the trash-cleanup helper**
+
+Immediately above `start_notification_scheduler` in the same file, add:
+
+```python
+def _run_trash_cleanup() -> None:
+    """Hourly job: hard-delete notifications past their retention."""
+    db = SessionLocal()
+    try:
+        from app.services.notifications.service import get_notification_service
+        count = get_notification_service().cleanup_expired_trash(db)
+        if count:
+            logger.info("Trash cleanup: deleted %d expired notifications", count)
+    except Exception:
+        logger.exception("Trash cleanup job failed")
+    finally:
+        db.close()
+```
+
+- [ ] **Step 4: Smoke-test import + scheduler startup**
+
+Run: `cd backend && python -c "from app.services.notifications.scheduler import start_notification_scheduler, stop_notification_scheduler; start_notification_scheduler(); stop_notification_scheduler(); print('OK')"`
+Expected: `OK`. No traceback.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/notifications/scheduler.py
+git commit -m "feat(notifications): hourly trash cleanup job (Firebase-independent)"
+```
+
+---
+
+## Task 15: Frontend — API client types and functions
+
+**Files:**
+- Modify: `client/src/api/notifications.ts`
+
+- [ ] **Step 1: Update the `Notification` interface**
+
+In `client/src/api/notifications.ts`, find the `Notification` interface (around line 10) and replace `is_dismissed: boolean;` with:
+
+```ts
+  deleted_at: string | null;
+```
+
+- [ ] **Step 2: Update the `NotificationPreferences` interface**
+
+Find the `NotificationPreferences` type definition (search for `interface NotificationPreferences` in the same file). Add (somewhere near the existing fields like `min_priority`):
+
+```ts
+  trash_retention_days: number; // 1-7
+```
+
+If there's a separate `NotificationPreferencesUpdate` type (for PUT requests), add the same field as `trash_retention_days?: number;`.
+
+- [ ] **Step 3: Add trash API functions**
+
+Append to `client/src/api/notifications.ts` (after the existing `dismissAllNotifications` function):
+
+```ts
+export interface GetTrashNotificationsParams {
+  category?: NotificationCategory;
+  notification_type?: NotificationType;
+  created_after?: string;
+  created_before?: string;
+  page?: number;
+  page_size?: number;
+}
+
+export const getTrashNotifications = async (
+  params: GetTrashNotificationsParams = {}
+): Promise<NotificationListResponse> => {
+  const { data } = await apiClient.get<NotificationListResponse>(
+    "/notifications/trash",
+    { params }
+  );
+  return data;
+};
+
+export const restoreNotification = async (
+  id: number
+): Promise<Notification> => {
+  const { data } = await apiClient.post<Notification>(
+    `/notifications/${id}/restore`
+  );
+  return data;
+};
+
+export const deleteNotificationPermanently = async (id: number): Promise<void> => {
+  await apiClient.delete(`/notifications/${id}`);
+};
+
+export const emptyTrash = async (): Promise<{ count: number }> => {
+  const { data } = await apiClient.delete<{ count: number }>(
+    "/notifications/trash"
+  );
+  return data;
+};
+```
+
+Check the existing `getNotifications` function to verify the actual axios import name (`apiClient`, `api`, or similar) and adjust if needed.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: Errors should be limited to call sites in components that still reference the old `is_dismissed` (we'll fix those in Tasks 16 & 19). The new functions themselves should typecheck.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/api/notifications.ts
+git commit -m "feat(notifications): frontend types + trash API functions"
+```
+
+---
+
+## Task 16: Frontend — Inbox / Trash tabs
+
+**Files:**
+- Modify: `client/src/pages/NotificationsArchivePage.tsx`
+- Modify: `client/src/i18n/locales/de/notifications.json`
+- Modify: `client/src/i18n/locales/en/notifications.json`
+
+- [ ] **Step 1: Add i18n keys**
+
+In `client/src/i18n/locales/de/notifications.json`, add at the top level of the JSON object (mind the trailing comma on the prior field):
+
+```json
+  "tabs": {
+    "inbox": "Posteingang",
+    "trash": "Papierkorb"
+  },
+  "trash": {
+    "empty": "Papierkorb leeren",
+    "emptyConfirm": "Alle {{count}} Einträge endgültig löschen?",
+    "restore": "Wiederherstellen",
+    "deleteForever": "Endgültig löschen",
+    "deleteForeverConfirm": "Diesen Eintrag endgültig löschen?",
+    "banner": "Einträge werden nach {{days}} Tag(en) automatisch endgültig gelöscht.",
+    "restored": "Wiederhergestellt",
+    "deleted": "Endgültig gelöscht",
+    "emptied": "Papierkorb geleert"
+  }
+```
+
+In `client/src/i18n/locales/en/notifications.json`, add the same structure with English values:
+
+```json
+  "tabs": {
+    "inbox": "Inbox",
+    "trash": "Trash"
+  },
+  "trash": {
+    "empty": "Empty trash",
+    "emptyConfirm": "Permanently delete all {{count}} items?",
+    "restore": "Restore",
+    "deleteForever": "Delete forever",
+    "deleteForeverConfirm": "Permanently delete this entry?",
+    "banner": "Entries are automatically deleted after {{days}} day(s).",
+    "restored": "Restored",
+    "deleted": "Permanently deleted",
+    "emptied": "Trash emptied"
+  }
+```
+
+- [ ] **Step 2: Rewrite `NotificationsArchivePage` with tabs**
+
+Replace the entire content of `client/src/pages/NotificationsArchivePage.tsx` with:
+
+```tsx
+/**
+ * Notifications Archive Page
+ *
+ * Full paginated list of notifications with Inbox / Trash tabs and filters.
+ */
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import {
+  Bell, CheckCheck, Settings, Filter, ChevronLeft, ChevronRight, Clock,
+  X, Trash2, RotateCcw,
+} from 'lucide-react';
+import toast from 'react-hot-toast';
+import {
+  getNotifications,
+  getTrashNotifications,
+  restoreNotification,
+  deleteNotificationPermanently,
+  emptyTrash as apiEmptyTrash,
+  getPreferences,
+  snoozeNotification,
+  getTypeStyle,
+  getCategoryIcon,
+  getCategoryName,
+  getActionLabel,
+  type Notification,
+  type NotificationCategory,
+  type NotificationType,
+  type NotificationListResponse,
+} from '../api/notifications';
+import { useNotifications } from '../contexts/NotificationContext';
+
+const CATEGORIES: NotificationCategory[] = [
+  'raid', 'smart', 'backup', 'scheduler', 'system', 'security', 'sync', 'vpn', 'lifecycle',
+];
+
+const TYPES: NotificationType[] = ['info', 'warning', 'critical'];
+
+const PAGE_SIZE = 50;
+
+type TabKey = 'inbox' | 'trash';
+
+export default function NotificationsArchivePage() {
+  const { t } = useTranslation(['notifications', 'common']);
+  const navigate = useNavigate();
+  const {
+    markAsRead: ctxMarkAsRead,
+    markAllAsRead: ctxMarkAllAsRead,
+    dismiss: ctxDismiss,
+    dismissAll: ctxDismissAll,
+    refresh: ctxRefresh,
+  } = useNotifications();
+
+  const [tab, setTab] = useState<TabKey>('inbox');
+  const [data, setData] = useState<NotificationListResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [retentionDays, setRetentionDays] = useState<number>(7);
+
+  // Filters
+  const [categoryFilter, setCategoryFilter] = useState<NotificationCategory | ''>('');
+  const [typeFilter, setTypeFilter] = useState<NotificationType | ''>('');
+  const [readFilter, setReadFilter] = useState<'' | 'unread'>('');
+
+  // Load retention setting once for the trash banner
+  useEffect(() => {
+    getPreferences()
+      .then((p) => setRetentionDays(p.trash_retention_days ?? 7))
+      .catch(() => setRetentionDays(7));
+  }, []);
+
+  const fetchList = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = {
+        page,
+        page_size: PAGE_SIZE,
+        category: categoryFilter || undefined,
+        notification_type: typeFilter || undefined,
+      };
+      const result =
+        tab === 'inbox'
+          ? await getNotifications({
+              ...params,
+              unread_only: readFilter === 'unread',
+            })
+          : await getTrashNotifications(params);
+      setData(result);
+    } catch {
+      toast.error(t('common:toast.loadFailed'));
+    } finally {
+      setLoading(false);
+    }
+  }, [tab, page, categoryFilter, typeFilter, readFilter, t]);
+
+  useEffect(() => {
+    fetchList();
+  }, [fetchList]);
+
+  // Reset to page 1 whenever the tab or any filter changes
+  useEffect(() => {
+    setPage(1);
+  }, [tab, categoryFilter, typeFilter, readFilter]);
+
+  const handleMarkAllRead = async () => {
+    try {
+      await ctxMarkAllAsRead();
+      toast.success(t('toast.markedAllRead'));
+      fetchList();
+    } catch {
+      toast.error(t('common:toast.error'));
+    }
+  };
+
+  const handleDismissAll = async () => {
+    if (!data || data.total === 0) return;
+    if (!window.confirm(t('toast.confirmDismissAll', { count: data.total }))) return;
+    try {
+      await ctxDismissAll();
+      toast.success(t('toast.movedToTrash'));
+      fetchList();
+    } catch {
+      toast.error(t('common:toast.error'));
+    }
+  };
+
+  const handleEmptyTrash = async () => {
+    if (!data || data.total === 0) return;
+    if (!window.confirm(t('trash.emptyConfirm', { count: data.total }))) return;
+    try {
+      const { count } = await apiEmptyTrash();
+      toast.success(t('trash.emptied'));
+      fetchList();
+      // Inbox unread badge is unaffected by trash-empty, but a context refresh is cheap insurance
+      if (count > 0) ctxRefresh();
+    } catch {
+      toast.error(t('common:toast.error'));
+    }
+  };
+
+  const handleMarkRead = async (n: Notification) => {
+    if (n.is_read) return;
+    setData((prev) => prev && ({
+      ...prev,
+      notifications: prev.notifications.map((x) =>
+        x.id === n.id ? { ...x, is_read: true } : x
+      ),
+      unread_count: Math.max(0, prev.unread_count - 1),
+    }));
+    try { await ctxMarkAsRead(n.id); } catch { /* non-critical */ }
+  };
+
+  const handleDismiss = async (n: Notification) => {
+    // Inbox X = move to trash
+    setData((prev) => prev && ({
+      ...prev,
+      notifications: prev.notifications.filter((x) => x.id !== n.id),
+      total: prev.total - 1,
+      unread_count: !n.is_read ? Math.max(0, prev.unread_count - 1) : prev.unread_count,
+    }));
+    try {
+      await ctxDismiss(n.id);
+    } catch {
+      fetchList();
+    }
+  };
+
+  const handleRestore = async (n: Notification) => {
+    setData((prev) => prev && ({
+      ...prev,
+      notifications: prev.notifications.filter((x) => x.id !== n.id),
+      total: prev.total - 1,
+    }));
+    try {
+      await restoreNotification(n.id);
+      toast.success(t('trash.restored'));
+      ctxRefresh();
+    } catch {
+      toast.error(t('common:toast.error'));
+      fetchList();
+    }
+  };
+
+  const handleDeleteForever = async (n: Notification) => {
+    if (!window.confirm(t('trash.deleteForeverConfirm'))) return;
+    setData((prev) => prev && ({
+      ...prev,
+      notifications: prev.notifications.filter((x) => x.id !== n.id),
+      total: prev.total - 1,
+    }));
+    try {
+      await deleteNotificationPermanently(n.id);
+      toast.success(t('trash.deleted'));
+    } catch {
+      toast.error(t('common:toast.error'));
+      fetchList();
+    }
+  };
+
+  const handleSnooze = async (n: Notification, hours: number) => {
+    try {
+      await snoozeNotification(n.id, hours);
+      toast.success(`${hours}h snoozed`);
+      fetchList();
+    } catch {
+      toast.error(t('common:toast.error'));
+    }
+  };
+
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / PAGE_SIZE)) : 1;
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-100">{t('title')}</h1>
+          <p className="text-sm text-slate-400">
+            {data
+              ? `${data.total} ${tab === 'inbox' ? t('count.total') : t('count.inTrash')}${tab === 'inbox' ? `, ${data.unread_count} ${t('count.unread')}` : ''}`
+              : t('common:loading')}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {tab === 'inbox' && (
+            <>
+              <button
+                onClick={handleMarkAllRead}
+                className="flex items-center gap-1.5 rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 transition hover:border-sky-500/50 hover:text-sky-400"
+              >
+                <CheckCheck className="h-4 w-4" />
+                {t('buttons.markAllRead')}
+              </button>
+              <button
+                onClick={handleDismissAll}
+                disabled={!data || data.total === 0}
+                className="flex items-center gap-1.5 rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 transition hover:border-rose-500/50 hover:text-rose-400 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <Trash2 className="h-4 w-4" />
+                {t('buttons.dismissAll')}
+              </button>
+            </>
+          )}
+          {tab === 'trash' && (
+            <button
+              onClick={handleEmptyTrash}
+              disabled={!data || data.total === 0}
+              className="flex items-center gap-1.5 rounded-lg border border-rose-500/40 px-3 py-2 text-sm text-rose-400 transition hover:border-rose-500 hover:bg-rose-500/10 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Trash2 className="h-4 w-4" />
+              {t('trash.empty')}
+            </button>
+          )}
+          <button
+            onClick={() => navigate('/settings?tab=notifications')}
+            className="flex items-center gap-1.5 rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 transition hover:border-sky-500/50 hover:text-sky-400"
+          >
+            <Settings className="h-4 w-4" />
+            {t('buttons.settings')}
+          </button>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-2 border-b border-slate-800">
+        {(['inbox', 'trash'] as TabKey[]).map((k) => (
+          <button
+            key={k}
+            onClick={() => setTab(k)}
+            className={`relative px-4 py-2 text-sm transition ${
+              tab === k
+                ? 'text-sky-400'
+                : 'text-slate-400 hover:text-slate-200'
+            }`}
+          >
+            {t(`tabs.${k}`)}
+            {tab === k && (
+              <span className="absolute inset-x-2 -bottom-px h-0.5 rounded-full bg-sky-500" />
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Trash banner */}
+      {tab === 'trash' && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-2 text-xs text-amber-300">
+          {t('trash.banner', { days: retentionDays })}
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3 rounded-xl border border-slate-800 bg-slate-900/50 p-3">
+        <Filter className="h-4 w-4 text-slate-400" />
+
+        <select
+          value={categoryFilter}
+          onChange={(e) => setCategoryFilter(e.target.value as NotificationCategory | '')}
+          className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-1.5 text-sm text-slate-300"
+        >
+          <option value="">{t('filters.allCategories')}</option>
+          {CATEGORIES.map((c) => (
+            <option key={c} value={c}>{getCategoryIcon(c)} {getCategoryName(c)}</option>
+          ))}
+        </select>
+
+        <select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value as NotificationType | '')}
+          className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-1.5 text-sm text-slate-300"
+        >
+          <option value="">{t('filters.allTypes')}</option>
+          {TYPES.map((tp) => (
+            <option key={tp} value={tp}>{tp.charAt(0).toUpperCase() + tp.slice(1)}</option>
+          ))}
+        </select>
+
+        {tab === 'inbox' && (
+          <select
+            value={readFilter}
+            onChange={(e) => setReadFilter(e.target.value as '' | 'unread')}
+            className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-1.5 text-sm text-slate-300"
+          >
+            <option value="">{t('filters.default')}</option>
+            <option value="unread">{t('filters.unreadOnly')}</option>
+          </select>
+        )}
+      </div>
+
+      {/* List */}
+      <div className="space-y-2">
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-sky-500 border-t-transparent" />
+          </div>
+        ) : !data || data.notifications.length === 0 ? (
+          <div className="py-12 text-center text-slate-400">
+            <Bell className="mx-auto mb-3 h-12 w-12 opacity-30" />
+            <p>{tab === 'inbox' ? t('empty.inbox') : t('empty.trash')}</p>
+          </div>
+        ) : (
+          data.notifications.map((n) => (
+            <NotificationRow
+              key={n.id}
+              tab={tab}
+              notification={n}
+              onMarkRead={handleMarkRead}
+              onDismiss={handleDismiss}
+              onRestore={handleRestore}
+              onDeleteForever={handleDeleteForever}
+              onSnooze={handleSnooze}
+              onNavigate={(url) => navigate(url)}
+            />
+          ))
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-4">
+          <button
+            onClick={() => setPage(Math.max(1, page - 1))}
+            disabled={page <= 1}
+            className="rounded-lg border border-slate-700 p-2 text-slate-400 transition hover:border-sky-500/50 hover:text-sky-400 disabled:opacity-30"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <span className="text-sm text-slate-400">
+            {t('pagination.pageOf', { page, total: totalPages })}
+          </span>
+          <button
+            onClick={() => setPage(Math.min(totalPages, page + 1))}
+            disabled={page >= totalPages}
+            className="rounded-lg border border-slate-700 p-2 text-slate-400 transition hover:border-sky-500/50 hover:text-sky-400 disabled:opacity-30"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Individual notification row with actions */
+function NotificationRow({
+  tab,
+  notification: n,
+  onMarkRead,
+  onDismiss,
+  onRestore,
+  onDeleteForever,
+  onSnooze,
+  onNavigate,
+}: {
+  tab: TabKey;
+  notification: Notification;
+  onMarkRead: (n: Notification) => void;
+  onDismiss: (n: Notification) => void;
+  onRestore: (n: Notification) => void;
+  onDeleteForever: (n: Notification) => void;
+  onSnooze: (n: Notification, hours: number) => void;
+  onNavigate: (url: string) => void;
+}) {
+  const [showSnooze, setShowSnooze] = useState(false);
+  const { t } = useTranslation(['notifications']);
+  const typeStyle = getTypeStyle(n.notification_type);
+
+  return (
+    <div
+      className={`group relative flex items-start gap-4 rounded-xl border px-4 py-3 transition ${
+        !n.is_read
+          ? 'border-slate-700 bg-slate-800/50'
+          : 'border-slate-800/50 bg-slate-900/30'
+      }`}
+    >
+      <div className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg border ${typeStyle.bgColor}`}>
+        <span className="text-lg">{getCategoryIcon(n.category)}</span>
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          <p className={`text-sm font-medium ${!n.is_read ? 'text-slate-100' : 'text-slate-300'}`}>
+            {n.title}
+          </p>
+          <span className="flex-shrink-0 text-xs text-slate-500">{n.time_ago}</span>
+        </div>
+        <p className="mt-0.5 text-xs text-slate-400">{n.message}</p>
+        <div className="mt-1.5 flex items-center gap-2">
+          <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${typeStyle.bgColor} ${typeStyle.color}`}>
+            {n.notification_type}
+          </span>
+          <span className="text-[10px] text-slate-500">{getCategoryName(n.category)}</span>
+          {n.snoozed_until && (
+            <span className="inline-flex items-center gap-1 rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-400">
+              <Clock className="h-3 w-3" />
+              Snoozed bis {new Date(n.snoozed_until).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-shrink-0 items-center gap-1">
+        {n.action_url && tab === 'inbox' && (
+          <button
+            onClick={() => onNavigate(n.action_url!)}
+            className="rounded-lg border border-slate-700 px-2.5 py-1 text-xs text-slate-300 transition hover:border-sky-500/50 hover:text-sky-400"
+          >
+            {getActionLabel(n.category)}
+          </button>
+        )}
+
+        {tab === 'inbox' && (
+          <>
+            <div className="relative">
+              <button
+                onClick={() => setShowSnooze(!showSnooze)}
+                className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-700 hover:text-slate-300"
+                title="Snooze"
+              >
+                <Clock className="h-4 w-4" />
+              </button>
+              {showSnooze && (
+                <div className="absolute right-0 top-8 z-10 rounded-lg border border-slate-700 bg-slate-800 py-1 shadow-xl">
+                  {[1, 4, 24].map((h) => (
+                    <button
+                      key={h}
+                      onClick={() => { onSnooze(n, h); setShowSnooze(false); }}
+                      className="block w-full px-4 py-1.5 text-left text-xs text-slate-300 transition hover:bg-slate-700"
+                    >
+                      {h}h
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {!n.is_read && (
+              <button
+                onClick={() => onMarkRead(n)}
+                className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-700 hover:text-slate-300"
+                title={t('buttons.markRead')}
+              >
+                <CheckCheck className="h-4 w-4" />
+              </button>
+            )}
+
+            <button
+              onClick={() => onDismiss(n)}
+              className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-700 hover:text-slate-300"
+              title={t('buttons.moveToTrash')}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </>
+        )}
+
+        {tab === 'trash' && (
+          <>
+            <button
+              onClick={() => onRestore(n)}
+              className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-700 hover:text-sky-400"
+              title={t('trash.restore')}
+            >
+              <RotateCcw className="h-4 w-4" />
+            </button>
+            <button
+              onClick={() => onDeleteForever(n)}
+              className="rounded-lg p-1.5 text-rose-500 transition hover:bg-rose-500/10 hover:text-rose-400"
+              title={t('trash.deleteForever')}
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Add missing i18n keys this component references**
+
+In `client/src/i18n/locales/de/notifications.json`, ensure these keys exist (add any missing — they are referenced by the new component):
+
+```json
+  "title": "Benachrichtigungen",
+  "count": {
+    "total": "gesamt",
+    "inTrash": "im Papierkorb",
+    "unread": "ungelesen"
+  },
+  "buttons": {
+    "markAllRead": "Alle gelesen",
+    "dismissAll": "Alle löschen",
+    "settings": "Einstellungen",
+    "markRead": "Als gelesen markieren",
+    "moveToTrash": "In Papierkorb"
+  },
+  "filters": {
+    "allCategories": "Alle Kategorien",
+    "allTypes": "Alle Typen",
+    "default": "Standard",
+    "unreadOnly": "Nur ungelesen"
+  },
+  "empty": {
+    "inbox": "Keine Benachrichtigungen",
+    "trash": "Papierkorb ist leer"
+  },
+  "pagination": {
+    "pageOf": "Seite {{page}} von {{total}}"
+  },
+  "toast": {
+    "markedAllRead": "Alle als gelesen markiert",
+    "movedToTrash": "In Papierkorb verschoben",
+    "confirmDismissAll": "{{count}} Benachrichtigungen in Papierkorb verschieben?"
+  }
+```
+
+(Some of these keys may already exist — only add the missing ones. The point is the component now relies on them via `t()`.)
+
+In `client/src/i18n/locales/en/notifications.json`, mirror with English values.
+
+- [ ] **Step 4: Run typecheck and dev server**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: No errors related to this file.
+
+Run dev server (`cd client && npm run dev` in another shell) and visit `/notifications`. Verify:
+- Tabs switch between Inbox and Trash
+- Trash banner displays the correct retention day count
+- X icon in inbox moves a notification to the trash (verify by switching tabs)
+- Restore icon brings it back
+- Delete-forever icon prompts and removes it
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/pages/NotificationsArchivePage.tsx client/src/i18n/locales/de/notifications.json client/src/i18n/locales/en/notifications.json
+git commit -m "feat(notifications): Inbox/Trash tabs with restore + delete-forever"
+```
+
+---
+
+## Task 17: Frontend — Retention slider in preferences
+
+**Files:**
+- Modify: `client/src/pages/NotificationPreferencesPage.tsx`
+- Modify: `client/src/i18n/locales/de/notifications.json`
+- Modify: `client/src/i18n/locales/en/notifications.json`
+
+- [ ] **Step 1: Add i18n keys**
+
+Add to both notifications.json files (DE and EN), at the top level:
+
+```json
+  "retention": {
+    "title": "Papierkorb",
+    "label": "Aufbewahrung gelöschter Benachrichtigungen",
+    "days_one": "{{count}} Tag",
+    "days_other": "{{count}} Tage",
+    "hint": "Nach Ablauf werden Einträge automatisch endgültig entfernt."
+  }
+```
+
+English values:
+
+```json
+  "retention": {
+    "title": "Trash",
+    "label": "Retention for deleted notifications",
+    "days_one": "{{count}} day",
+    "days_other": "{{count}} days",
+    "hint": "After the retention period entries are automatically removed."
+  }
+```
+
+- [ ] **Step 2: Add state and slider section**
+
+In `client/src/pages/NotificationPreferencesPage.tsx`:
+
+After the `const [minPriority, setMinPriority] = useState(0);` line (around line 69), add:
+
+```tsx
+  const [trashRetentionDays, setTrashRetentionDays] = useState<number>(7);
+```
+
+In the `loadPreferences` function, after `setMinPriority(prefs.min_priority);` (around line 100), add:
+
+```tsx
+      setTrashRetentionDays(prefs.trash_retention_days ?? 7);
+```
+
+In `handleSave`, change the `updatePreferences` call (around line 139) to include the new field. Replace:
+
+```tsx
+      await updatePreferences({
+        quiet_hours_enabled: quietHoursEnabled,
+        quiet_hours_start: quietHoursEnabled ? quietHoursStart : null,
+        quiet_hours_end: quietHoursEnabled ? quietHoursEnd : null,
+        min_priority: minPriority,
+        category_preferences: categoryPrefs,
+      });
+```
+
+with:
+
+```tsx
+      await updatePreferences({
+        quiet_hours_enabled: quietHoursEnabled,
+        quiet_hours_start: quietHoursEnabled ? quietHoursStart : null,
+        quiet_hours_end: quietHoursEnabled ? quietHoursEnd : null,
+        min_priority: minPriority,
+        category_preferences: categoryPrefs,
+        trash_retention_days: trashRetentionDays,
+      });
+```
+
+Add the slider section. Place it AFTER the Quiet Hours block (around line 318, after the closing `</div>` of the quiet hours section). Insert this JSX:
+
+```tsx
+      {/* Trash Retention */}
+      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+        <div className="mb-3">
+          <h2 className="text-lg font-semibold text-slate-100">{t('retention.title')}</h2>
+          <p className="text-sm text-slate-400">{t('retention.hint')}</p>
+        </div>
+        <label className="block text-sm text-slate-300 mb-2">
+          {t('retention.label')}: <span className="font-medium text-sky-400">{t('retention.days', { count: trashRetentionDays })}</span>
+        </label>
+        <input
+          type="range"
+          min={1}
+          max={7}
+          step={1}
+          value={trashRetentionDays}
+          onChange={(e) => setTrashRetentionDays(Number(e.target.value))}
+          className="w-full max-w-md accent-sky-500"
+        />
+        <div className="flex justify-between text-xs text-slate-500 max-w-md mt-1">
+          <span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span><span>7</span>
+        </div>
+      </div>
+```
+
+(Note: i18next pluralization picks `days_one` for `count === 1` and `days_other` otherwise — the key `retention.days` resolves correctly.)
+
+- [ ] **Step 3: Typecheck + dev server**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: Clean.
+
+In the dev server, navigate to settings → notifications. Verify:
+- Retention slider renders with the current value (default 7)
+- Moving the slider updates the label
+- Clicking "Save" persists and reloading the page keeps the new value
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/pages/NotificationPreferencesPage.tsx client/src/i18n/locales/de/notifications.json client/src/i18n/locales/en/notifications.json
+git commit -m "feat(notifications): user-configurable trash retention slider (1-7 days)"
+```
+
+---
+
+## Task 18: Frontend — fix `notificationGrouping.test.ts` fixture
+
+**Files:**
+- Modify: `client/src/__tests__/lib/notificationGrouping.test.ts`
+
+- [ ] **Step 1: Update the fixture**
+
+In `client/src/__tests__/lib/notificationGrouping.test.ts`, find line 12 (`is_dismissed: false,`) and replace with:
+
+```ts
+    deleted_at: null,
+```
+
+If there are multiple fixtures in the file with `is_dismissed`, replace all of them in the same manner.
+
+- [ ] **Step 2: Run frontend tests**
+
+Run: `cd client && npm run test`
+Expected: All tests pass. If any other test still references `is_dismissed`, update those too.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/__tests__/lib/notificationGrouping.test.ts
+git commit -m "test(notifications): align grouping fixture with deleted_at field"
+```
+
+---
+
+## Task 19: Full backend + frontend regression run
+
+**Files:** none (sanity gate before smoketest)
+
+- [ ] **Step 1: Run backend test suite**
+
+Run: `cd backend && python -m pytest -v`
+Expected: All previously-passing tests still pass plus the new trash tests added in Tasks 1–13. If anything fails referencing `is_dismissed` or `include_dismissed`, fix the caller in the same style as the service refactor in Task 8.
+
+- [ ] **Step 2: Run frontend typecheck and tests**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: No errors.
+
+Run: `cd client && npm run test`
+Expected: All tests pass.
+
+- [ ] **Step 3: If issues found, fix and re-run**
+
+If any fix is required, commit each fix with a focused message such as `fix(notifications): <what changed>`.
+
+---
+
+## Task 20: Manual E2E smoketest
+
+**Files:** none (manual verification)
+
+- [ ] **Step 1: Start dev server**
+
+Run: `python start_dev.py`
+Expected: Backend on port 3001, frontend on 5173.
+
+- [ ] **Step 2: Click through the user-visible flow**
+
+Log in as admin. Then:
+
+1. Navigate to `/notifications`. Note unread count.
+2. Click the X icon on a notification → the row disappears from inbox.
+3. Switch to the **Papierkorb** tab → confirm the row is here. Verify the banner shows "Einträge werden nach 7 Tag(en) automatisch endgültig gelöscht."
+4. Click **Wiederherstellen** (RotateCcw icon) → row vanishes from trash. Switch back to **Inbox** → row is back.
+5. Click X again, switch to **Papierkorb**, click the red trash icon → confirm → row is gone permanently. Switching back to Inbox does NOT show it.
+6. Click "Alle löschen" on the Inbox → confirm → all rows go to the trash.
+7. In Papierkorb, click "Papierkorb leeren" → confirm → trash is empty.
+8. Navigate to **Settings → Notifications**. Set retention slider to 1 day. Click Save.
+9. Navigate back to `/notifications` → Papierkorb tab → banner now says "1 Tag".
+
+- [ ] **Step 3: Verify the cleanup job (optional, takes patience or DB poke)**
+
+Either wait an hour for the scheduler tick, or in a Python shell:
+
+```python
+from app.core.database import SessionLocal
+from app.models.notification import Notification
+from datetime import datetime, timezone, timedelta
+db = SessionLocal()
+# Mark an existing trashed row as 2 days old
+n = db.query(Notification).filter(Notification.deleted_at.is_not(None)).first()
+n.deleted_at = datetime.now(timezone.utc) - timedelta(days=2)
+db.commit()
+db.close()
+# Trigger cleanup
+from app.services.notifications.service import get_notification_service
+db = SessionLocal()
+print("deleted:", get_notification_service().cleanup_expired_trash(db))
+db.close()
+```
+
+Expected: Prints `deleted: 1` (or more). Refresh the page; the row is gone.
+
+- [ ] **Step 4: Final commit (if any new fixes during smoketest)**
+
+If issues surfaced during smoketest, fix them, run regression again (Task 19), and commit with focused messages.
+
+---
+
+## Self-Review Checklist
+
+After all tasks above complete:
+
+- [ ] All `is_dismissed` references in production code are gone (`PowerShell: Get-ChildItem backend, client -Recurse -Include *.py, *.ts, *.tsx | Select-String 'is_dismissed' -SimpleMatch` should return only the Alembic file `014_add_notification_tables.py` which is historical)
+- [ ] All `include_dismissed` references are gone
+- [ ] `cleanup_old_notifications` is gone
+- [ ] New endpoints are reachable (`curl http://localhost:3001/docs` shows `/trash`, `/{id}/restore`, `/{id} DELETE`, `/trash DELETE`)
+- [ ] Background job is registered (check logs at startup: `Notification scheduler started`)
+- [ ] Frontend dev server: tabs render, slider saves, all actions work

--- a/docs/superpowers/specs/2026-05-11-notifications-trash-retention-design.md
+++ b/docs/superpowers/specs/2026-05-11-notifications-trash-retention-design.md
@@ -1,0 +1,428 @@
+# Notifications Trash + Retention
+
+**Date:** 2026-05-11
+**Status:** Approved
+
+## Problem
+
+The notifications page (`/notifications`) currently exposes two destructive-looking actions ("Alle löschen" header button, X icon per row) that internally call `POST /notifications/dismiss-all` / `POST /notifications/{id}/dismiss`. These set `is_dismissed=TRUE` — a soft-hide. Rows stay in the DB forever, surfaceable via the `include_dismissed=true` filter. There is:
+
+- No real "deleted" state and no recovery UI for accidental dismissals
+- No retention/cleanup — `cleanup_old_notifications(retention_days=90)` exists in the service but is wired to no background job
+- No user-facing way to control how long deleted notifications stick around
+- A UX inconsistency: the button reads "Alle löschen" but the row-icon tooltip reads "Ausblenden"
+
+## Solution
+
+Replace the boolean `is_dismissed` with a `deleted_at: DateTime | None` timestamp that doubles as both the trash-marker and the retention start. Add a per-user retention setting (1–7 days, default 7). Auto-purge expired trash via an hourly background job. Expose a dedicated Trash tab on the existing archive page with Restore / Permanent-Delete actions.
+
+## Requirements
+
+- Dismissing a notification (X icon, "Alle löschen") moves it to the trash, not just hides it
+- The trash is a separate, browsable view with the same filters as the inbox
+- Each user configures retention between 1 and 7 days (default 7); system notifications (`user_id=NULL`) use a fixed 7-day retention
+- Restore returns a notification to the inbox (clears `deleted_at`)
+- Permanent delete is irreversible; "Papierkorb leeren" wipes the current user's trash entirely
+- After retention expires, the background job hard-deletes rows
+- No information about other users' notifications leaks via 403 vs 404 (use 404 uniformly)
+
+## Design
+
+### 1. Schema
+
+#### `notifications` table
+
+| Change | Detail |
+|---|---|
+| Drop column | `is_dismissed BOOLEAN` |
+| Add column | `deleted_at TIMESTAMPTZ NULL` |
+| Add index | `ix_notifications_deleted_at ON (deleted_at)` |
+
+#### `notification_preferences` table
+
+| Change | Detail |
+|---|---|
+| Add column | `trash_retention_days INTEGER NOT NULL DEFAULT 7` |
+| Add check | `CHECK (trash_retention_days BETWEEN 1 AND 7)` |
+
+#### Semantics
+
+- `deleted_at IS NULL` → active (inbox)
+- `deleted_at IS NOT NULL` → in trash, retention starts at `deleted_at`
+- Cleanup deletes rows where `NOW() - deleted_at > retention`
+
+### 2. Migration
+
+Single Alembic revision. Uses `batch_alter_table` so the migration works against both PostgreSQL (prod) and SQLite (dev). `CURRENT_TIMESTAMP` and the truthy-bareword `WHERE is_dismissed` are portable across both engines.
+
+```python
+def upgrade():
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.add_column(
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True)
+        )
+        batch_op.create_index(
+            "ix_notifications_deleted_at", ["deleted_at"]
+        )
+
+    # Backfill: existing soft-dismissed rows start their retention now.
+    op.execute(
+        "UPDATE notifications SET deleted_at = CURRENT_TIMESTAMP "
+        "WHERE is_dismissed"
+    )
+
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.drop_column("is_dismissed")
+
+    with op.batch_alter_table("notification_preferences") as batch_op:
+        batch_op.add_column(
+            sa.Column("trash_retention_days", sa.Integer(),
+                      nullable=False, server_default="7")
+        )
+        batch_op.create_check_constraint(
+            "ck_trash_retention_1_7",
+            "trash_retention_days BETWEEN 1 AND 7"
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.add_column(
+            sa.Column("is_dismissed", sa.Boolean(),
+                      nullable=False, server_default=sa.text("0"))
+        )
+    op.execute(
+        "UPDATE notifications SET is_dismissed = "
+        "(CASE WHEN deleted_at IS NOT NULL THEN 1 ELSE 0 END)"
+    )
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.drop_index("ix_notifications_deleted_at")
+        batch_op.drop_column("deleted_at")
+
+    with op.batch_alter_table("notification_preferences") as batch_op:
+        batch_op.drop_constraint("ck_trash_retention_1_7", type_="check")
+        batch_op.drop_column("trash_retention_days")
+```
+
+Existing dismissed rows get a fresh retention clock starting at migration time. On a production DB with O(thousands) rows the `UPDATE` + `DROP COLUMN` finish in under a second; Postgres performs both atomically inside the migration transaction.
+
+### 3. Backend
+
+#### Model (`backend/app/models/notification.py`)
+
+```python
+class Notification(Base):
+    # ... existing fields except is_dismissed ...
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None, index=True
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            # ... existing fields ...
+            "deleted_at": self.deleted_at.isoformat() if self.deleted_at else None,
+        }
+
+
+class NotificationPreferences(Base):
+    # ... existing fields ...
+    trash_retention_days: Mapped[int] = mapped_column(
+        Integer, default=7, nullable=False
+    )
+```
+
+#### Schemas (`backend/app/schemas/notification.py`)
+
+- `NotificationResponse`: replace `is_dismissed: bool = False` with `deleted_at: Optional[datetime] = None`. `from_db` maps directly.
+- `NotificationPreferencesResponse` + `NotificationPreferencesUpdate`: add `trash_retention_days: int = Field(default=7, ge=1, le=7)`.
+
+#### Service (`backend/app/services/notifications/service.py`)
+
+All existing filters change `Notification.is_dismissed == False` → `Notification.deleted_at.is_(None)`.
+
+Method changes:
+
+| Method | Behavior |
+|---|---|
+| `dismiss(id, user_id, is_admin)` | Sets `deleted_at = func.now()`, `is_read = True`. Idempotent if already trashed (no-op). |
+| `dismiss_all(user_id, is_admin)` | Bulk update over `deleted_at IS NULL`. |
+| `restore(id, user_id, is_admin)` *(new)* | Sets `deleted_at = None`. Idempotent for already-active rows. Returns the notification or `None` if not found. |
+| `delete_permanently(id, user_id, is_admin)` *(new)* | Hard `DELETE` with ownership filter. Returns `True` if a row was deleted, `False` otherwise. |
+| `empty_trash(user_id, is_admin)` *(new)* | `DELETE WHERE deleted_at IS NOT NULL AND <user_filter>`. Returns count. |
+| `cleanup_expired_trash(db)` *(new, replaces `cleanup_old_notifications`)* | Two-step delete: (a) for each user-owned row: `now - deleted_at > prefs.trash_retention_days` (default 7 if no prefs row); (b) for `user_id IS NULL` rows: fixed 7-day cutoff. Returns total deleted count. |
+| `get_user_notifications(...)` | New parameter `trashed_only: bool = False`. Removes `include_dismissed` parameter (callers updated). Inbox: `deleted_at IS NULL`. Trash: `deleted_at IS NOT NULL`. |
+| `count_user_notifications(...)` | Same parameter change as above. |
+| `get_unread_count(s)` | Adds `deleted_at IS NULL` filter (trashed items don't count as unread). |
+
+Delete the unused `cleanup_old_notifications` method — no current caller exists.
+
+Implementation sketch for `cleanup_expired_trash`:
+
+```python
+def cleanup_expired_trash(self, db: Session) -> int:
+    now = datetime.now(timezone.utc)
+
+    # Per-user retention via JOIN with prefs (default 7 if no prefs row)
+    users_with_trash = (
+        db.query(Notification.user_id)
+        .filter(Notification.deleted_at.is_not(None),
+                Notification.user_id.is_not(None))
+        .distinct()
+        .all()
+    )
+
+    total = 0
+    for (user_id,) in users_with_trash:
+        prefs = self.get_user_preferences(db, user_id)
+        retention_days = prefs.trash_retention_days if prefs else 7
+        cutoff = now - timedelta(days=retention_days)
+        count = (
+            db.query(Notification)
+            .filter(Notification.user_id == user_id,
+                    Notification.deleted_at.is_not(None),
+                    Notification.deleted_at < cutoff)
+            .delete(synchronize_session=False)
+        )
+        total += count
+
+    # System notifications (user_id IS NULL): fixed 7-day retention
+    sys_cutoff = now - timedelta(days=7)
+    total += (
+        db.query(Notification)
+        .filter(Notification.user_id.is_(None),
+                Notification.deleted_at.is_not(None),
+                Notification.deleted_at < sys_cutoff)
+        .delete(synchronize_session=False)
+    )
+
+    db.commit()
+    return total
+```
+
+#### Routes (`backend/app/api/routes/notifications.py`)
+
+Existing routes keep their paths but their semantics shift: `POST /{id}/dismiss` and `POST /dismiss-all` now move to trash instead of soft-hiding. Update docstrings.
+
+New endpoints:
+
+| Method | Path | Returns | Description |
+|---|---|---|---|
+| `GET` | `/notifications/trash` | `NotificationListResponse` | Paginated trash, same filter params as inbox (category, type, dates, page) |
+| `POST` | `/notifications/{id}/restore` | `NotificationResponse` | Move back to inbox; 404 if id not found / not owned |
+| `DELETE` | `/notifications/{id}` | `204 No Content` | Hard delete; 404 if not found / not owned |
+| `DELETE` | `/notifications/trash` | `{count: int}` | Empty current user's trash |
+
+All four use `Depends(deps.get_current_user)` and `@user_limiter.limit(get_limit("admin_operations"))` to match existing patterns. Ownership uses the existing `_user_filter(user_id, is_admin)` helper.
+
+After every state change, broadcast a new `unread_count` over WebSocket using the existing manager.
+
+#### Background Job (`backend/app/services/notifications/scheduler.py`)
+
+Move the APScheduler setup so the cleanup job runs even when Firebase is unavailable. Add:
+
+```python
+_scheduler.add_job(
+    func=_run_trash_cleanup,
+    trigger="interval", hours=1,
+    id="notification_trash_cleanup",
+    replace_existing=True,
+)
+
+def _run_trash_cleanup() -> None:
+    db = SessionLocal()
+    try:
+        from app.services.notifications.service import get_notification_service
+        count = get_notification_service().cleanup_expired_trash(db)
+        if count:
+            logger.info("Trash cleanup: deleted %d expired notifications", count)
+    except Exception:
+        logger.exception("Trash cleanup failed")
+    finally:
+        db.close()
+```
+
+The existing `device_expiration_check` job stays where it is (still gated by Firebase availability).
+
+### 4. Frontend
+
+#### API Client (`client/src/api/notifications.ts`)
+
+```ts
+export interface Notification {
+  // ... existing fields except is_dismissed ...
+  deleted_at: string | null;
+}
+
+export interface NotificationPreferences {
+  // ... existing fields ...
+  trash_retention_days: number; // 1-7
+}
+
+export const getTrashNotifications = (params: GetNotificationsParams) =>
+  apiClient.get<NotificationListResponse>("/notifications/trash", { params });
+
+export const restoreNotification = (id: number) =>
+  apiClient.post<Notification>(`/notifications/${id}/restore`);
+
+export const deleteNotificationPermanently = (id: number) =>
+  apiClient.delete<void>(`/notifications/${id}`);
+
+export const emptyTrash = () =>
+  apiClient.delete<{ count: number }>("/notifications/trash");
+```
+
+#### Archive Page (`client/src/pages/NotificationsArchivePage.tsx`)
+
+Replace the existing `readFilter` dropdown ("Standard / Nur ungelesen / Inkl. ausgeblendet") with a tab switcher above the filter bar:
+
+```
+┌── Inbox (8) ──┐ ┌── Papierkorb (3) ──┐
+└───────────────┘ └─────────────────────┘
+```
+
+- Active tab styling matches existing tab patterns (rounded border-bottom emphasis).
+- The category/type filter bar stays and applies to both tabs.
+- Inbox tab:
+  - Header buttons: "Alle gelesen", "Alle löschen", "Einstellungen" (unchanged labels; "Alle löschen" now moves to trash)
+  - Row icons: Snooze, Mark-as-read, X ("In Papierkorb")
+- Trash tab:
+  - Header buttons: "Papierkorb leeren" (rose-500 accent, `window.confirm` first), "Einstellungen"
+  - Banner above the list: `"Einträge werden nach {trash_retention_days} Tag(en) automatisch endgültig gelöscht."`
+  - Row icons: RotateCcw ("Wiederherstellen"), Trash2 in rose ("Endgültig löschen", confirm)
+- Tab counts come from two separate count endpoints / responses (Inbox unread_count + Trash total).
+
+Optimistic updates on Restore / Permanent-Delete mirror the existing dismiss pattern; rollback by refetch on error.
+
+#### Preferences Page (`client/src/pages/NotificationPreferencesPage.tsx`)
+
+Add a new section above the Quiet Hours section:
+
+```
+┌─ Papierkorb ─────────────────────────────────────────┐
+│ Aufbewahrung gelöschter Benachrichtigungen           │
+│ [───●───]  3 Tage                                    │
+│ Nach Ablauf werden Einträge automatisch entfernt.    │
+└──────────────────────────────────────────────────────┘
+```
+
+Slider 1–7 with native HTML `<input type=range>`. Saves via the existing `PUT /notifications/preferences` endpoint (now accepts `trash_retention_days`).
+
+#### Context (`client/src/contexts/NotificationContext.tsx`)
+
+No structural change. The context still tracks active (inbox) notifications. The Trash tab fetches independently and does not feed the context. Optionally expose `restore`, `deletePermanently`, `emptyTrash` from the context so other parts of the UI (e.g., a future bell-dropdown undo toast) can call them — out of scope for this spec but the seam is there.
+
+#### i18n (`client/src/i18n/locales/{de,en}/notifications.json`)
+
+Add keys: `tabs.inbox`, `tabs.trash`, `trash.empty`, `trash.emptyConfirm`, `trash.banner`, `trash.restore`, `trash.deleteForever`, `trash.deleteForeverConfirm`, `preferences.retention.title`, `preferences.retention.label`, `preferences.retention.hint`.
+
+### 5. Edge Cases
+
+| Case | Handling |
+|---|---|
+| `restore(id)` for a row with `deleted_at IS NULL` | 200 OK, idempotent no-op |
+| `restore(id)` / `delete_permanently(id)` for unknown or unowned id | 404 (never 403, to avoid id-enumeration leaks) |
+| User has no `NotificationPreferences` row | Default retention 7 days applied in `cleanup_expired_trash` |
+| System notifications (`user_id=NULL`) | Fixed 7-day retention regardless of admin prefs (admins have independent prefs that would conflict) |
+| Cleanup job error (DB, lock, etc.) | `logger.exception`, swallow; next hourly tick retries |
+| Multiple Uvicorn workers | APScheduler is initialized per worker; the cleanup query is idempotent (one transaction commits; others find nothing to delete) — no `IS_PRIMARY_WORKER` gate needed |
+| Retention < 1 or > 7 in `PUT /preferences` | Pydantic `Field(ge=1, le=7)` → 422 |
+| Existing `is_dismissed=TRUE` rows at migration | Get `deleted_at = NOW()` → visible in trash for 7 more days, then auto-purged |
+| WebSocket clients during dismiss/restore/delete | Existing `unread_count` broadcast covers state changes; no new event type required |
+
+### 6. Tests
+
+#### Service (`backend/tests/services/test_notification_service.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_dismiss_sets_deleted_at` | `dismiss()` populates `deleted_at` with a timestamp ≤ now |
+| `test_dismiss_idempotent_on_already_trashed` | Second `dismiss` does not overwrite original `deleted_at` |
+| `test_restore_clears_deleted_at` | `restore()` sets `deleted_at` back to `None` |
+| `test_restore_idempotent_on_active` | `restore()` on a non-trashed row is a no-op, returns the row |
+| `test_delete_permanently_removes_row` | DB row count drops by 1; subsequent `restore` returns `None` |
+| `test_empty_trash_removes_only_user_rows` | User B's trash is untouched when user A empties theirs |
+| `test_empty_trash_admin_includes_system_notifications` | Admin's empty-trash also hard-deletes `user_id=NULL` trashed rows |
+| `test_cleanup_expired_trash_respects_user_retention` | User with 3-day retention has 4-day-old row deleted; user with 7-day retention does not |
+| `test_cleanup_expired_trash_default_when_no_prefs` | User without `NotificationPreferences` row uses 7-day default |
+| `test_cleanup_expired_trash_system_notifications_fixed_7d` | `user_id=NULL` row older than 7 days is purged regardless of any admin's prefs |
+| `test_get_user_notifications_inbox_excludes_trashed` | Default (`trashed_only=False`) filters out `deleted_at IS NOT NULL` |
+| `test_get_user_notifications_trash_only_returns_trashed` | `trashed_only=True` returns only trashed |
+| `test_get_unread_count_ignores_trashed` | Trashed unread rows do not contribute to count |
+
+#### API (`backend/tests/test_notifications_routes.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_get_trash_paginated` | `GET /notifications/trash?page=1&page_size=10` returns only trashed, paginated |
+| `test_restore_endpoint_round_trip` | After dismiss → restore, GET inbox shows the row again |
+| `test_restore_endpoint_404_for_unknown_id` | 404 returned, not 403, for foreign user's id |
+| `test_delete_permanently_returns_204` | DELETE returns 204 No Content; row gone from DB |
+| `test_empty_trash_returns_count` | Response `{count: N}` matches actual deleted rows |
+| `test_trash_retention_validation` | `PUT /preferences {trash_retention_days: 0}` → 422; `8` → 422; `3` → 200 |
+| `test_trash_retention_persists` | Round-trip: PUT then GET returns same value |
+
+#### Migration (`backend/tests/migrations/test_notification_trash_retention.py`)
+
+Alembic stairway-style test:
+- Seed two rows with `is_dismissed=TRUE` and one with `is_dismissed=FALSE` before upgrade
+- Run `upgrade head` → assert dismissed rows now have `deleted_at IS NOT NULL` and within last 5 seconds; active row has `deleted_at IS NULL`
+- Run `downgrade -1` → assert `is_dismissed` reflects `deleted_at IS NOT NULL`
+
+#### Frontend (`client/src/__tests__/`)
+
+| Test | Verifies |
+|---|---|
+| `NotificationsArchivePage.test.tsx :: switches between Inbox and Trash tabs` | Different list endpoints called, counts displayed |
+| `NotificationsArchivePage.test.tsx :: restore from trash` | Row disappears from trash list optimistically |
+| `NotificationsArchivePage.test.tsx :: empty trash button` | Confirms, then calls `DELETE /notifications/trash`, refetches |
+| `NotificationPreferencesPage.test.tsx :: retention slider saves` | Slider change triggers `PUT /preferences` with new value |
+| `notificationGrouping.test.ts` (existing) | Fixture updated from `is_dismissed: false` to `deleted_at: null` — existing assertions still pass |
+
+#### E2E Smoketest (manual)
+
+1. `python start_dev.py`
+2. Click X on a notification → row vanishes from inbox
+3. Switch to Papierkorb tab → row is there, banner shows 7-day notice
+4. Click "Wiederherstellen" → row returns to inbox
+5. Click X again, switch back to trash, click trash-icon → confirm → row gone
+6. Settings → set retention to 1 day
+7. (For test: manually `UPDATE notifications SET deleted_at = NOW() - INTERVAL '2 days'` on a trashed row)
+8. Wait for next hourly cleanup (or trigger manually) → row physically gone
+
+### 7. Build Order
+
+1. Migration + model + `models/__init__.py` registration
+2. Schema updates (`NotificationResponse`, preferences)
+3. Service: switch existing filters, add new methods, write unit tests first (TDD)
+4. Routes: new endpoints + docstring fixes on existing dismiss routes
+5. Background job hook in `notifications/scheduler.py`
+6. Frontend API client types + functions
+7. `NotificationsArchivePage`: tabs + trash actions
+8. `NotificationPreferencesPage`: retention slider
+9. i18n keys
+10. Smoketest
+
+## Open Questions
+
+None at spec-writing time. The system-notifications retention question raised during design was resolved: fixed 7 days for `user_id IS NULL`, per-user setting for the rest.
+
+## API Compatibility Note
+
+`NotificationResponse.is_dismissed` is removed from the response schema and replaced by `deleted_at`. This is a breaking change for any external consumer (BaluApp Android, BaluDesk) that reads the field. Grep on those repos before release; if either consumer reads `is_dismissed`, ship a coordinated update or keep `is_dismissed` as a computed alias in the schema for one release cycle:
+
+```python
+@computed_field
+@property
+def is_dismissed(self) -> bool:
+    return self.deleted_at is not None
+```
+
+Default plan: clean break, no alias. Reassess only if downstream usage is found.
+
+## Out of Scope
+
+- Per-category retention overrides
+- Bulk restore from trash (only single-row restore via the row icon)
+- Admin-facing global trash management
+- Surfacing the trash on mobile (BaluApp) or desktop sync (BaluDesk) clients — backend changes are universal but client UI is a separate effort
+- Undo-toast pattern after dismiss (the trash itself is the undo affordance)


### PR DESCRIPTION
## Summary

- Replace `Notification.is_dismissed` (bool) with `Notification.deleted_at` (timestamp) — soft-hide becomes a real, browsable trash
- Add `NotificationPreferences.trash_retention_days` (1–7, default 7) — per-user retention, system notifications fixed at 7 days
- New endpoints: `GET /trash`, `POST /{id}/restore`, `DELETE /{id}`, `DELETE /trash`
- Frontend: Inbox/Trash tab switcher on `/notifications`, retention slider in preferences
- Hourly background job hard-deletes expired rows (independent of Firebase)

## Spec & Plan

- Spec: `docs/superpowers/specs/2026-05-11-notifications-trash-retention-design.md`
- Plan: `docs/superpowers/plans/2026-05-11-notifications-trash-retention.md`

## Migration

Existing `is_dismissed=TRUE` rows get `deleted_at = CURRENT_TIMESTAMP` at migration time — they appear in the new Papierkorb tab and auto-purge after the user's configured retention (default 7 days). Migration is `batch_alter_table`-based for SQLite/PostgreSQL portability.

## Test Plan

- [x] Backend: 50 notification-scoped tests pass (`pytest tests/services/test_notification_service.py tests/test_notifications_routes.py tests/migrations/`)
- [x] Backend migration upgrade/downgrade roundtrip clean
- [x] Frontend: 286 vitest tests pass
- [x] Frontend: `tsc --noEmit` clean
- [x] No remaining references to `is_dismissed` / `include_dismissed` / `cleanup_old_notifications` in active code
- [x] Manual smoketest: dismiss → trash → restore → permanent delete → empty trash → retention slider persists

## Deferred / Out of Scope

- WebSocket `unread_count` broadcast on dismiss/restore/delete — kept consistent with existing dismiss endpoint (which doesn't broadcast either). Frontend recovers via re-fetch + WS reconnect. Tracked as future improvement.
- Automated migration backfill stairway-test — manual roundtrip verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)