### PR TITLE
feat(tapo): Admin-triggered energy history import

### DIFF
--- a/backend/app/api/routes/smart_devices.py
+++ b/backend/app/api/routes/smart_devices.py
@@ -23,6 +23,8 @@ from app.plugins.smart_device.schemas import (
     DeviceCommandRequest,
     DeviceCommandResponse,
     DeviceTypeResponse,
+    ImportHistoryRequest,
+    ImportHistoryResponse,
     PowerSummaryResponse,
     SmartDeviceCreate,
     SmartDeviceHistoryResponse,
@@ -492,3 +494,80 @@ def get_device_history(
         period_start=period_start,
         period_end=period_end,
     )
+
+
+# ---------------------------------------------------------------------------
+# POST /smart-devices/{device_id}/import-history — Admin-triggered Tapo backfill
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/{device_id}/import-history",
+    response_model=ImportHistoryResponse,
+    summary="Import historical energy data from a smart-plug device (admin only)",
+)
+@user_limiter.limit(get_limit("smart_device_import_history"))
+async def import_device_history(
+    request: Request,
+    response: Response,
+    device_id: int,
+    payload: ImportHistoryRequest,
+    db: Session = Depends(deps.get_db),
+    current_user: User = Depends(deps.get_current_admin),
+) -> ImportHistoryResponse:
+    """Trigger a manual import of historical energy data from the device.
+
+    Currently supported only for the ``tapo_smart_plug`` plugin. Imported
+    samples are stored alongside live samples with an ``imported_from``
+    marker so retention does not delete them.
+
+    **Admin only.**
+    """
+    manager = get_smart_device_manager()
+    device = manager.get_device(db, device_id)
+    if device is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Smart device {device_id} not found",
+        )
+
+    plugin = manager._plugins.get(device.plugin_name)
+    if plugin is None or not hasattr(plugin, "import_history"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Plugin '{device.plugin_name}' does not support history import",
+        )
+
+    try:
+        result = await plugin.import_history(
+            db=db,
+            device_id=device_id,
+            interval=payload.interval,
+            start=payload.start_date,
+            end=payload.end_date,
+            conflict_strategy=payload.conflict_strategy,
+        )
+    except RuntimeError as exc:
+        logger.warning("History import failed for device %d: %s", device_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+
+    AuditLoggerDB().log_event(
+        event_type="SMART_DEVICE",
+        action="import_history",
+        user=current_user.username,
+        resource=f"device:{device_id}",
+        success=True,
+        details={
+            "device_id": device_id,
+            "interval": payload.interval.value,
+            "start_date": payload.start_date.isoformat(),
+            "end_date": payload.end_date.isoformat(),
+            "conflict_strategy": payload.conflict_strategy.value,
+            "buckets_fetched": result.buckets_fetched,
+            "samples_inserted": result.samples_inserted,
+        },
+    )
+
+    return result

--- a/backend/app/core/rate_limiter.py
+++ b/backend/app/core/rate_limiter.py
@@ -137,6 +137,9 @@ RATE_LIMITS = {
 
     # GPU power management - moderate limits (status, config, demands, history)
     "gpu_power": "60/minute",
+
+    # Smart device admin operations
+    "smart_device_import_history": "5/hour",  # admin-only Tapo backfill
 }
 
 

--- a/backend/app/plugins/installed/tapo_smart_plug/__init__.py
+++ b/backend/app/plugins/installed/tapo_smart_plug/__init__.py
@@ -484,6 +484,92 @@ class TapoSmartPlugPlugin(SmartDevicePlugin):
         )
 
     # ------------------------------------------------------------------
+    # History Import (admin-triggered)
+    # ------------------------------------------------------------------
+
+    # Optional override for tests — set by tests to inject a stub fetcher
+    _fetcher_override: Optional[Any] = None
+
+    async def import_history(
+        self,
+        db: Any,
+        device_id: int,
+        interval: "ImportHistoryInterval",
+        start: "date",
+        end: "date",
+        conflict_strategy: "ImportHistoryConflictStrategy",
+    ) -> "ImportHistoryResponse":
+        """Import historical energy data from a Tapo device into SmartDeviceSample.
+
+        Admin-only. The caller (API route) enforces authorization. This method
+        resolves cached credentials, fetches buckets (real or mock), and writes
+        samples honoring the conflict strategy.
+
+        Args:
+            db: SQLAlchemy session.
+            device_id: Smart device ID.
+            interval: Bucket granularity (hourly/daily/monthly).
+            start: Inclusive start date.
+            end: Inclusive end date.
+            conflict_strategy: How to handle overlap with live samples.
+
+        Returns:
+            ImportHistoryResponse with bucket / sample counts and timing.
+        """
+        from datetime import datetime as _dt, timezone as _tz
+        from app.plugins.smart_device.schemas import ImportHistoryResponse
+        from app.plugins.installed.tapo_smart_plug.import_service import (
+            TapoHistoryImportService,
+        )
+
+        started_at = _dt.now(_tz.utc)
+
+        info = self._ensure_device_info(str(device_id))
+        if info is None:
+            raise RuntimeError(f"No connection info for device {device_id}")
+
+        fetcher = self._fetcher_override or self._build_fetcher()
+        buckets = await fetcher.fetch_buckets(
+            ip=info.ip,
+            email=info.email,
+            password=info.password,
+            start=start,
+            end=end,
+            interval=interval,
+        )
+
+        importer = TapoHistoryImportService()
+        write_result = importer.write_buckets(
+            db=db,
+            device_id=device_id,
+            buckets=buckets,
+            conflict_strategy=conflict_strategy,
+        )
+
+        completed_at = _dt.now(_tz.utc)
+        return ImportHistoryResponse(
+            device_id=device_id,
+            interval=interval,
+            buckets_fetched=len(buckets),
+            samples_inserted=write_result.samples_inserted,
+            samples_skipped_idempotent=write_result.samples_skipped_idempotent,
+            samples_skipped_live=write_result.samples_skipped_live,
+            live_samples_deleted=write_result.live_samples_deleted,
+            started_at=started_at,
+            completed_at=completed_at,
+        )
+
+    def _build_fetcher(self):
+        """Return real or mock history fetcher based on dev_mode."""
+        if self._is_dev_mode():
+            from app.plugins.installed.tapo_smart_plug.history_mock import (
+                TapoHistoryMockFetcher,
+            )
+            return TapoHistoryMockFetcher()
+        from app.plugins.installed.tapo_smart_plug.history import TapoHistoryFetcher
+        return TapoHistoryFetcher()
+
+    # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
 

--- a/backend/app/plugins/installed/tapo_smart_plug/history.py
+++ b/backend/app/plugins/installed/tapo_smart_plug/history.py
@@ -1,0 +1,195 @@
+"""Real Tapo history fetcher using the mihai-dinculescu ``tapo`` library.
+
+Used only for admin-triggered history import. The live polling path stays on
+plugp100 (``service.py``). Two libraries coexist intentionally — the tapo
+library exposes typed ``get_energy_data`` with hourly/daily/monthly intervals
+that plugp100 v5.x does not surface.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import Awaitable, Callable, List, Optional
+
+from app.plugins.smart_device.schemas import ImportHistoryInterval
+
+logger = logging.getLogger(__name__)
+
+_FETCH_TIMEOUT = 30.0
+_HOURLY_MAX_DAYS = 8  # tapo API constraint
+
+
+@dataclass
+class EnergyBucket:
+    """One time-bucket of energy data from a Tapo device."""
+    bucket_start: datetime          # tz-aware, UTC
+    interval: ImportHistoryInterval
+    energy_kwh: float
+
+
+# Type alias for dependency-injected client factory (eases testing without monkeypatching tapo)
+ClientFactory = Callable[[str, str], object]  # (email, password) -> tapo.ApiClient-like
+
+
+def _default_client_factory(email: str, password: str):
+    """Default factory: real tapo.ApiClient. Imported lazily so tests can run without the lib."""
+    from tapo import ApiClient
+    return ApiClient(email, password)
+
+
+class TapoHistoryFetcher:
+    """Fetch historical energy data from a Tapo P110/P115.
+
+    Splits long ranges into multiple API calls to respect the library's
+    per-call constraints (Hourly <= 8 days, Daily per quarter, Monthly per year).
+    """
+
+    def __init__(self, client_factory: Optional[ClientFactory] = None) -> None:
+        self._client_factory = client_factory or _default_client_factory
+
+    async def fetch_buckets(
+        self,
+        ip: str,
+        email: str,
+        password: str,
+        start: date,
+        end: date,
+        interval: ImportHistoryInterval,
+    ) -> List[EnergyBucket]:
+        """Fetch all buckets for the requested range.
+
+        Args:
+            ip: Device IP address on the local network.
+            email: Tapo cloud account email (used for local key derivation).
+            password: Tapo cloud account password.
+            start: Inclusive start date (UTC).
+            end: Inclusive end date (UTC).
+            interval: Bucket granularity.
+
+        Returns:
+            Flat list of EnergyBucket, sorted by bucket_start ascending.
+            Empty list if no data is available.
+        """
+        if end < start:
+            return []
+
+        client = self._client_factory(email, password)
+        device = await asyncio.wait_for(client.p110(ip), timeout=_FETCH_TIMEOUT)
+
+        if interval == ImportHistoryInterval.HOURLY:
+            return await self._fetch_hourly(device, start, end)
+        elif interval == ImportHistoryInterval.DAILY:
+            return await self._fetch_daily(device, start, end)
+        elif interval == ImportHistoryInterval.MONTHLY:
+            return await self._fetch_monthly(device, start, end)
+        else:
+            raise ValueError(f"Unsupported interval: {interval}")
+
+    # ------------------------------------------------------------------
+    # Per-interval implementations
+    # ------------------------------------------------------------------
+
+    async def _fetch_hourly(self, device, start: date, end: date) -> List[EnergyBucket]:
+        from tapo.requests import EnergyDataInterval
+
+        buckets: List[EnergyBucket] = []
+        chunk_start = start
+        while chunk_start <= end:
+            chunk_end = min(chunk_start + timedelta(days=_HOURLY_MAX_DAYS - 1), end)
+            result = await asyncio.wait_for(
+                device.get_energy_data(EnergyDataInterval.Hourly, chunk_start),
+                timeout=_FETCH_TIMEOUT,
+            )
+            buckets.extend(
+                self._buckets_from_result(result, ImportHistoryInterval.HOURLY, bucket_minutes=60)
+            )
+            chunk_start = chunk_end + timedelta(days=1)
+
+        # Trim trailing buckets past ``end``
+        end_cutoff = datetime.combine(end, datetime.max.time(), tzinfo=timezone.utc)
+        return [b for b in buckets if b.bucket_start <= end_cutoff]
+
+    async def _fetch_daily(self, device, start: date, end: date) -> List[EnergyBucket]:
+        from tapo.requests import EnergyDataInterval
+
+        buckets: List[EnergyBucket] = []
+        # We know start is a quarter start (validated upstream). Advance one quarter at a time.
+        current = start
+        while current <= end:
+            result = await asyncio.wait_for(
+                device.get_energy_data(EnergyDataInterval.Daily, current),
+                timeout=_FETCH_TIMEOUT,
+            )
+            buckets.extend(
+                self._buckets_from_result(result, ImportHistoryInterval.DAILY, bucket_minutes=1440)
+            )
+            # Move to next quarter (add 3 months -- naive but correct because all quarter starts are day=1)
+            month = current.month + 3
+            year = current.year + (month - 1) // 12
+            month = ((month - 1) % 12) + 1
+            current = date(year, month, 1)
+
+        end_cutoff = datetime.combine(end, datetime.max.time(), tzinfo=timezone.utc)
+        return [b for b in buckets if b.bucket_start <= end_cutoff]
+
+    async def _fetch_monthly(self, device, start: date, end: date) -> List[EnergyBucket]:
+        from tapo.requests import EnergyDataInterval
+
+        buckets: List[EnergyBucket] = []
+        current = start  # must be Jan 1
+        while current <= end:
+            result = await asyncio.wait_for(
+                device.get_energy_data(EnergyDataInterval.Monthly, current),
+                timeout=_FETCH_TIMEOUT,
+            )
+            buckets.extend(
+                self._buckets_from_result(result, ImportHistoryInterval.MONTHLY, bucket_minutes=43200)
+            )
+            current = date(current.year + 1, 1, 1)
+
+        end_cutoff = datetime.combine(end, datetime.max.time(), tzinfo=timezone.utc)
+        return [b for b in buckets if b.bucket_start <= end_cutoff]
+
+    # ------------------------------------------------------------------
+    # Result decoding
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _buckets_from_result(result, interval: ImportHistoryInterval, bucket_minutes: int) -> List[EnergyBucket]:
+        """Convert a tapo ``EnergyDataResult`` into EnergyBucket objects.
+
+        The tapo library returns:
+        - ``start_timestamp`` (Unix seconds, UTC) of the first bucket
+        - ``data`` (list[int]) -- energy in Wh per bucket
+        - ``interval`` (minutes per bucket) -- we use the *requested* bucket_minutes
+          because monthly buckets do not have a fixed minute count.
+        """
+        start_ts = getattr(result, "start_timestamp", None)
+        data = getattr(result, "data", None) or []
+        if start_ts is None:
+            return []
+
+        out: List[EnergyBucket] = []
+        for idx, wh in enumerate(data):
+            if interval == ImportHistoryInterval.MONTHLY:
+                # Step forward whole months instead of fixed minutes
+                base = datetime.fromtimestamp(start_ts, tz=timezone.utc).replace(
+                    day=1, hour=0, minute=0, second=0, microsecond=0
+                )
+                month = base.month + idx
+                year = base.year + (month - 1) // 12
+                month = ((month - 1) % 12) + 1
+                bucket_start = base.replace(year=year, month=month)
+            else:
+                bucket_start = datetime.fromtimestamp(
+                    start_ts + idx * bucket_minutes * 60, tz=timezone.utc
+                )
+
+            out.append(EnergyBucket(
+                bucket_start=bucket_start,
+                interval=interval,
+                energy_kwh=round(wh / 1000.0, 4),
+            ))
+        return out

--- a/backend/app/plugins/installed/tapo_smart_plug/history.py
+++ b/backend/app/plugins/installed/tapo_smart_plug/history.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-from typing import Awaitable, Callable, List, Optional
+from typing import Callable, List, Optional
 
 from app.plugins.smart_device.schemas import ImportHistoryInterval
 
@@ -171,17 +171,21 @@ class TapoHistoryFetcher:
         if start_ts is None:
             return []
 
+        # Precompute the month-anchored base for MONTHLY stepping.
+        monthly_base = None
+        if interval == ImportHistoryInterval.MONTHLY:
+            monthly_base = datetime.fromtimestamp(start_ts, tz=timezone.utc).replace(
+                day=1, hour=0, minute=0, second=0, microsecond=0
+            )
+
         out: List[EnergyBucket] = []
         for idx, wh in enumerate(data):
             if interval == ImportHistoryInterval.MONTHLY:
-                # Step forward whole months instead of fixed minutes
-                base = datetime.fromtimestamp(start_ts, tz=timezone.utc).replace(
-                    day=1, hour=0, minute=0, second=0, microsecond=0
-                )
-                month = base.month + idx
-                year = base.year + (month - 1) // 12
+                assert monthly_base is not None  # set above when interval == MONTHLY
+                month = monthly_base.month + idx
+                year = monthly_base.year + (month - 1) // 12
                 month = ((month - 1) % 12) + 1
-                bucket_start = base.replace(year=year, month=month)
+                bucket_start = monthly_base.replace(year=year, month=month)
             else:
                 bucket_start = datetime.fromtimestamp(
                     start_ts + idx * bucket_minutes * 60, tz=timezone.utc

--- a/backend/app/plugins/installed/tapo_smart_plug/history_mock.py
+++ b/backend/app/plugins/installed/tapo_smart_plug/history_mock.py
@@ -1,0 +1,88 @@
+"""Deterministic mock history fetcher for dev mode.
+
+Generates realistic-looking NAS energy buckets without contacting any device.
+"""
+from __future__ import annotations
+
+import random
+from datetime import date, datetime, timedelta, timezone
+from typing import List, Optional
+
+from app.plugins.installed.tapo_smart_plug.history import EnergyBucket
+from app.plugins.smart_device.schemas import ImportHistoryInterval
+
+
+class TapoHistoryMockFetcher:
+    """Mock fetcher with deterministic output for reproducible dev/test runs."""
+
+    def __init__(self, seed: Optional[int] = None) -> None:
+        self._seed = seed
+
+    async def fetch_buckets(
+        self,
+        ip: str,
+        email: str,
+        password: str,
+        start: date,
+        end: date,
+        interval: ImportHistoryInterval,
+    ) -> List[EnergyBucket]:
+        rng = random.Random(self._seed if self._seed is not None else hash((ip, start, end, interval)))
+
+        if interval == ImportHistoryInterval.HOURLY:
+            return self._generate_hourly(rng, start, end)
+        elif interval == ImportHistoryInterval.DAILY:
+            return self._generate_daily(rng, start, end)
+        elif interval == ImportHistoryInterval.MONTHLY:
+            return self._generate_monthly(rng, start, end)
+        return []
+
+    @staticmethod
+    def _generate_hourly(rng: random.Random, start: date, end: date) -> List[EnergyBucket]:
+        out: List[EnergyBucket] = []
+        cur = datetime.combine(start, datetime.min.time(), tzinfo=timezone.utc)
+        end_dt = datetime.combine(end, datetime.max.time(), tzinfo=timezone.utc)
+        while cur <= end_dt:
+            # NAS hourly: 0.05 - 0.20 kWh
+            energy = round(rng.uniform(0.05, 0.20), 4)
+            out.append(EnergyBucket(
+                bucket_start=cur,
+                interval=ImportHistoryInterval.HOURLY,
+                energy_kwh=energy,
+            ))
+            cur += timedelta(hours=1)
+        return out
+
+    @staticmethod
+    def _generate_daily(rng: random.Random, start: date, end: date) -> List[EnergyBucket]:
+        out: List[EnergyBucket] = []
+        cur = start
+        while cur <= end:
+            # NAS daily: 1.5 - 3.5 kWh
+            energy = round(rng.uniform(1.5, 3.5), 3)
+            out.append(EnergyBucket(
+                bucket_start=datetime.combine(cur, datetime.min.time(), tzinfo=timezone.utc),
+                interval=ImportHistoryInterval.DAILY,
+                energy_kwh=energy,
+            ))
+            cur += timedelta(days=1)
+        return out
+
+    @staticmethod
+    def _generate_monthly(rng: random.Random, start: date, end: date) -> List[EnergyBucket]:
+        out: List[EnergyBucket] = []
+        # Iterate month-by-month
+        year, month = start.year, start.month
+        end_year_month = (end.year, end.month)
+        while (year, month) <= end_year_month:
+            energy = round(rng.uniform(50.0, 100.0), 2)
+            out.append(EnergyBucket(
+                bucket_start=datetime(year, month, 1, tzinfo=timezone.utc),
+                interval=ImportHistoryInterval.MONTHLY,
+                energy_kwh=energy,
+            ))
+            month += 1
+            if month > 12:
+                month = 1
+                year += 1
+        return out

--- a/backend/app/plugins/installed/tapo_smart_plug/import_service.py
+++ b/backend/app/plugins/installed/tapo_smart_plug/import_service.py
@@ -1,0 +1,123 @@
+"""History import orchestration: buckets → SmartDeviceSample rows with conflict resolution."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from app.models.smart_device import SmartDeviceSample
+from app.plugins.installed.tapo_smart_plug.history import EnergyBucket
+from app.plugins.smart_device.schemas import (
+    ImportHistoryConflictStrategy,
+    ImportHistoryInterval,
+)
+
+logger = logging.getLogger(__name__)
+
+_POWER_CAPABILITY = "power_monitor"
+_DEFAULT_VOLTAGE = 230.0  # EU; consistent with live polling extraction
+
+
+# Bucket duration in hours used for watts synthesis. Monthly uses an average
+# month length (30.4375 days) — acceptable since aggregation only divides by
+# the actual period_hours observed at query time (see energy.py:215).
+_BUCKET_HOURS = {
+    ImportHistoryInterval.HOURLY: 1.0,
+    ImportHistoryInterval.DAILY: 24.0,
+    ImportHistoryInterval.MONTHLY: 24.0 * 30.4375,
+}
+
+
+@dataclass
+class ImportWriteResult:
+    """Accounting of one import pass."""
+    samples_inserted: int = 0
+    samples_skipped_idempotent: int = 0
+    samples_skipped_live: int = 0
+    live_samples_deleted: int = 0
+
+
+class TapoHistoryImportService:
+    """Convert EnergyBuckets to SmartDeviceSamples and persist them with conflict handling."""
+
+    def write_buckets(
+        self,
+        db: Session,
+        device_id: int,
+        buckets: List[EnergyBucket],
+        conflict_strategy: ImportHistoryConflictStrategy,
+    ) -> ImportWriteResult:
+        result = ImportWriteResult()
+
+        for bucket in buckets:
+            bucket_end = bucket.bucket_start + timedelta(hours=_BUCKET_HOURS[bucket.interval])
+
+            # Idempotency: previously imported bucket with same start ts
+            existing_imported = (
+                db.query(SmartDeviceSample)
+                .filter(
+                    SmartDeviceSample.device_id == device_id,
+                    SmartDeviceSample.capability == _POWER_CAPABILITY,
+                    SmartDeviceSample.timestamp == bucket.bucket_start,
+                    SmartDeviceSample.data_json.contains('"imported_from"'),
+                )
+                .first()
+            )
+            if existing_imported is not None:
+                result.samples_skipped_idempotent += 1
+                continue
+
+            # Overlap with live samples in this bucket's range
+            overlapping = (
+                db.query(SmartDeviceSample)
+                .filter(
+                    SmartDeviceSample.device_id == device_id,
+                    SmartDeviceSample.capability == _POWER_CAPABILITY,
+                    SmartDeviceSample.timestamp >= bucket.bucket_start,
+                    SmartDeviceSample.timestamp < bucket_end,
+                    ~SmartDeviceSample.data_json.contains('"imported_from"'),
+                )
+                .all()
+            )
+
+            if overlapping:
+                if conflict_strategy == ImportHistoryConflictStrategy.LIVE_WINS:
+                    result.samples_skipped_live += 1
+                    continue
+                else:  # IMPORT_WINS
+                    for row in overlapping:
+                        db.delete(row)
+                    result.live_samples_deleted += len(overlapping)
+
+            db.add(self._bucket_to_sample(device_id, bucket))
+            result.samples_inserted += 1
+
+        db.commit()
+        return result
+
+    @staticmethod
+    def _bucket_to_sample(device_id: int, bucket: EnergyBucket) -> SmartDeviceSample:
+        hours = _BUCKET_HOURS[bucket.interval]
+        watts = (bucket.energy_kwh * 1000.0) / hours if hours > 0 else 0.0
+        current_a = watts / _DEFAULT_VOLTAGE if watts > 0 else 0.0
+
+        data = {
+            "watts": round(watts, 2),
+            "voltage": _DEFAULT_VOLTAGE,
+            "current": round(current_a, 4),
+            "energy_today_kwh": None,
+            "is_online": True,
+            "imported_from": "tapo_history",
+            "bucket_interval": bucket.interval.value,
+            "bucket_energy_kwh": bucket.energy_kwh,
+        }
+        return SmartDeviceSample(
+            device_id=device_id,
+            capability=_POWER_CAPABILITY,
+            data_json=json.dumps(data),
+            timestamp=bucket.bucket_start,
+        )

--- a/backend/app/plugins/installed/tapo_smart_plug/import_service.py
+++ b/backend/app/plugins/installed/tapo_smart_plug/import_service.py
@@ -57,6 +57,7 @@ class TapoHistoryImportService:
             bucket_end = bucket.bucket_start + timedelta(hours=_BUCKET_HOURS[bucket.interval])
 
             # Idempotency: previously imported bucket with same start ts
+            # Safe: live power_monitor data_json is machine-generated and never contains this key.
             existing_imported = (
                 db.query(SmartDeviceSample)
                 .filter(
@@ -72,6 +73,7 @@ class TapoHistoryImportService:
                 continue
 
             # Overlap with live samples in this bucket's range
+            # Safe: live power_monitor data_json is machine-generated and never contains this key.
             overlapping = (
                 db.query(SmartDeviceSample)
                 .filter(
@@ -88,10 +90,12 @@ class TapoHistoryImportService:
                 if conflict_strategy == ImportHistoryConflictStrategy.LIVE_WINS:
                     result.samples_skipped_live += 1
                     continue
-                else:  # IMPORT_WINS
-                    for row in overlapping:
-                        db.delete(row)
-                    result.live_samples_deleted += len(overlapping)
+                # IMPORT_WINS — bulk delete the overlapping live rows
+                overlap_ids = [row.id for row in overlapping]
+                db.query(SmartDeviceSample).filter(
+                    SmartDeviceSample.id.in_(overlap_ids)
+                ).delete(synchronize_session=False)
+                result.live_samples_deleted += len(overlap_ids)
 
             db.add(self._bucket_to_sample(device_id, bucket))
             result.samples_inserted += 1
@@ -106,9 +110,9 @@ class TapoHistoryImportService:
         current_a = watts / _DEFAULT_VOLTAGE if watts > 0 else 0.0
 
         data = {
-            "watts": round(watts, 2),
+            "watts": round(watts, 1),
             "voltage": _DEFAULT_VOLTAGE,
-            "current": round(current_a, 4),
+            "current": round(current_a, 3),
             "energy_today_kwh": None,
             "is_online": True,
             "imported_from": "tapo_history",

--- a/backend/app/plugins/smart_device/schemas.py
+++ b/backend/app/plugins/smart_device/schemas.py
@@ -1,10 +1,11 @@
 """Pydantic schemas for the Smart Device plugin API."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 # ---------------------------------------------------------------------------
@@ -127,3 +128,71 @@ class SmartDeviceHistoryResponse(BaseModel):
     samples: List[Dict[str, Any]]
     period_start: datetime
     period_end: datetime
+
+
+# ---------------------------------------------------------------------------
+# History Import (Task 3 — Tapo energy backfill)
+# ---------------------------------------------------------------------------
+
+
+class ImportHistoryInterval(str, Enum):
+    """Bucket granularity for history import."""
+
+    HOURLY = "hourly"
+    DAILY = "daily"
+    MONTHLY = "monthly"
+
+
+class ImportHistoryConflictStrategy(str, Enum):
+    """How to resolve overlap between imported buckets and existing live samples."""
+
+    LIVE_WINS = "live_wins"      # Skip imported bucket if any live sample exists in its time range.
+    IMPORT_WINS = "import_wins"  # Delete live samples in the bucket's range, then write import.
+
+
+class ImportHistoryRequest(BaseModel):
+    """Admin-triggered request to import historical energy data from the device."""
+
+    interval: ImportHistoryInterval
+    start_date: date
+    end_date: date
+    conflict_strategy: ImportHistoryConflictStrategy
+
+    @field_validator("end_date")
+    @classmethod
+    def _end_after_start(cls, v: date, info) -> date:
+        start = info.data.get("start_date")
+        if start is not None and v < start:
+            raise ValueError("end_date must be >= start_date")
+        return v
+
+    @model_validator(mode="after")
+    def _check_interval_constraints(self) -> "ImportHistoryRequest":
+        if self.interval == ImportHistoryInterval.DAILY:
+            # Tapo requires start_date == first day of a quarter (Jan/Apr/Jul/Oct, day=1)
+            if self.start_date.day != 1 or self.start_date.month not in (1, 4, 7, 10):
+                raise ValueError(
+                    "Daily interval requires start_date to be the first day of a quarter "
+                    "(Jan 1, Apr 1, Jul 1, or Oct 1)"
+                )
+        elif self.interval == ImportHistoryInterval.MONTHLY:
+            # Tapo requires start_date == Jan 1 of some year
+            if self.start_date.day != 1 or self.start_date.month != 1:
+                raise ValueError(
+                    "Monthly interval requires start_date to be January 1 of some year"
+                )
+        return self
+
+
+class ImportHistoryResponse(BaseModel):
+    """Result of a history import operation."""
+
+    device_id: int
+    interval: ImportHistoryInterval
+    buckets_fetched: int                  # how many buckets the device returned
+    samples_inserted: int                 # how many SmartDeviceSamples were created
+    samples_skipped_idempotent: int       # already imported (Task 2B)
+    samples_skipped_live: int             # blocked by LIVE_WINS strategy
+    live_samples_deleted: int             # cleared by IMPORT_WINS strategy
+    started_at: datetime
+    completed_at: datetime

--- a/backend/app/services/power/energy.py
+++ b/backend/app/services/power/energy.py
@@ -308,6 +308,10 @@ def cleanup_old_samples(db: Session, days_to_keep: int = 30) -> int:
     """
     Delete power monitor samples older than specified days.
 
+    Samples flagged with ``imported_from`` in ``data_json`` are preserved
+    regardless of age — they represent manually imported history that
+    cannot be re-fetched easily.
+
     Args:
         db: Database session
         days_to_keep: Number of days to retain
@@ -317,14 +321,17 @@ def cleanup_old_samples(db: Session, days_to_keep: int = 30) -> int:
     """
     cutoff_date = datetime.now(timezone.utc) - timedelta(days=days_to_keep)
 
+    # PostgreSQL and SQLite both support JSON-text LIKE on the data_json column.
+    # We exclude rows that contain ``"imported_from"`` anywhere in their JSON.
     deleted = db.query(SmartDeviceSample).filter(
         SmartDeviceSample.capability == _POWER_CAPABILITY,
         SmartDeviceSample.timestamp < cutoff_date,
-    ).delete()
+        ~SmartDeviceSample.data_json.contains('"imported_from"'),
+    ).delete(synchronize_session=False)
 
     db.commit()
 
-    logger.info(f"Cleaned up {deleted} power monitor samples older than {days_to_keep} days")
+    logger.info(f"Cleaned up {deleted} power monitor samples older than {days_to_keep} days (imported rows preserved)")
     return deleted
 
 

--- a/backend/tests/api/test_smart_devices_import_history.py
+++ b/backend/tests/api/test_smart_devices_import_history.py
@@ -1,0 +1,108 @@
+"""Integration tests for POST /api/smart-devices/{id}/import-history."""
+from unittest.mock import patch
+
+import pytest
+
+from app.models.smart_device import SmartDevice
+
+
+@pytest.fixture
+def tapo_device(db_session):
+    d = SmartDevice(
+        name="Test Tapo",
+        plugin_name="tapo_smart_plug",
+        device_type_id="tapo_p110",
+        address="192.168.1.50",
+        capabilities=["switch", "power_monitor"],
+        is_active=True,
+        is_online=True,
+        created_by_user_id=1,
+    )
+    db_session.add(d)
+    db_session.commit()
+    db_session.refresh(d)
+    return d
+
+
+def test_import_history_requires_admin(client, user_headers, tapo_device):
+    """Non-admin users get 403."""
+    resp = client.post(
+        f"/api/smart-devices/{tapo_device.id}/import-history",
+        json={
+            "interval": "hourly",
+            "start_date": "2026-04-01",
+            "end_date": "2026-04-01",
+            "conflict_strategy": "live_wins",
+        },
+        headers=user_headers,
+    )
+    assert resp.status_code == 403
+
+
+def test_import_history_404_for_unknown_device(client, admin_headers):
+    resp = client.post(
+        "/api/smart-devices/99999/import-history",
+        json={
+            "interval": "hourly",
+            "start_date": "2026-04-01",
+            "end_date": "2026-04-01",
+            "conflict_strategy": "live_wins",
+        },
+        headers=admin_headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_import_history_validation_error(client, admin_headers, tapo_device):
+    """Daily interval with non-quarter start should be rejected by schema."""
+    resp = client.post(
+        f"/api/smart-devices/{tapo_device.id}/import-history",
+        json={
+            "interval": "daily",
+            "start_date": "2026-04-15",  # not a quarter start
+            "end_date": "2026-06-30",
+            "conflict_strategy": "live_wins",
+        },
+        headers=admin_headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_import_history_success(client, admin_headers, tapo_device, db_session):
+    """End-to-end import via API (uses dev mock fetcher because _is_dev_mode is patched True)."""
+    from app.plugins.installed.tapo_smart_plug import TapoSmartPlugPlugin
+    from app.plugins.smart_device.manager import get_smart_device_manager
+
+    # Register the plugin so the route can look it up via manager._plugins
+    plugin_instance = TapoSmartPlugPlugin()
+    manager = get_smart_device_manager()
+    manager.register_plugin(plugin_instance)
+
+    _fake_info = type("Info", (), {"ip": "192.168.1.50", "email": "x@x.com", "password": "secret"})()
+
+    with patch.object(
+        plugin_instance,
+        "_ensure_device_info",
+        return_value=_fake_info,
+    ), patch.object(
+        plugin_instance,
+        "_is_dev_mode",
+        return_value=True,
+    ):
+        resp = client.post(
+            f"/api/smart-devices/{tapo_device.id}/import-history",
+            json={
+                "interval": "hourly",
+                "start_date": "2026-04-01",
+                "end_date": "2026-04-01",
+                "conflict_strategy": "live_wins",
+            },
+            headers=admin_headers,
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["device_id"] == tapo_device.id
+    assert body["interval"] == "hourly"
+    assert body["buckets_fetched"] == 24  # mock generates 24 hourly buckets
+    assert body["samples_inserted"] == 24

--- a/backend/tests/plugins/tapo_smart_plug/test_history_fetcher.py
+++ b/backend/tests/plugins/tapo_smart_plug/test_history_fetcher.py
@@ -38,8 +38,9 @@ class _FakeApiClient:
 
 @pytest.mark.asyncio
 async def test_fetch_hourly_single_chunk():
-    """Hourly fetch for <= 8 days fits in one API call. Result: bucket per non-zero Wh entry."""
-    # 24 hours of data for 2026-04-01, in Wh (some zero entries are dropped per documented behavior)
+    """Hourly fetch for <= 8 days fits in one API call. All 24 buckets are returned, including zero-Wh entries."""
+    # 24 hours of data for 2026-04-01, in Wh — zero entries are NOT filtered here
+    # (any filtering is deferred to the import_service layer)
     fake_device = _FakeTapoP110([
         _FakeEnergyDataResult(
             start_ts=int(datetime(2026, 4, 1, tzinfo=timezone.utc).timestamp()),

--- a/backend/tests/plugins/tapo_smart_plug/test_history_fetcher.py
+++ b/backend/tests/plugins/tapo_smart_plug/test_history_fetcher.py
@@ -1,0 +1,115 @@
+"""Tests for TapoHistoryFetcher — uses a fake tapo client via monkeypatch."""
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.plugins.installed.tapo_smart_plug.history import TapoHistoryFetcher, EnergyBucket
+from app.plugins.smart_device.schemas import ImportHistoryInterval
+
+
+class _FakeEnergyDataResult:
+    """Stub mimicking tapo's EnergyDataResult.data attribute (list of Wh values per bucket)."""
+    def __init__(self, start_ts: int, interval_minutes: int, data: list[int]):
+        self.start_timestamp = start_ts
+        self.interval = interval_minutes
+        self.data = data
+
+
+class _FakeTapoP110:
+    """Fake P110 device. The test seeds it with canned responses per interval."""
+    def __init__(self, responses_by_call):
+        self._responses = list(responses_by_call)
+        self.calls = []
+
+    async def get_energy_data(self, interval, start_date):
+        self.calls.append((interval, start_date))
+        return self._responses.pop(0)
+
+
+class _FakeApiClient:
+    def __init__(self, device):
+        self._device = device
+
+    async def p110(self, ip):
+        return self._device
+
+
+@pytest.mark.asyncio
+async def test_fetch_hourly_single_chunk():
+    """Hourly fetch for <= 8 days fits in one API call. Result: bucket per non-zero Wh entry."""
+    # 24 hours of data for 2026-04-01, in Wh (some zero entries are dropped per documented behavior)
+    fake_device = _FakeTapoP110([
+        _FakeEnergyDataResult(
+            start_ts=int(datetime(2026, 4, 1, tzinfo=timezone.utc).timestamp()),
+            interval_minutes=60,
+            data=[10, 20, 30] + [0] * 21,  # 3 buckets, rest zero
+        )
+    ])
+    fake_client = _FakeApiClient(fake_device)
+
+    fetcher = TapoHistoryFetcher(client_factory=lambda email, pw: fake_client)
+    buckets = await fetcher.fetch_buckets(
+        ip="192.168.1.10",
+        email="x@y", password="pw",
+        start=date(2026, 4, 1),
+        end=date(2026, 4, 1),
+        interval=ImportHistoryInterval.HOURLY,
+    )
+
+    assert len(buckets) == 24  # all 24 buckets, even zero entries (drop later if needed)
+    assert buckets[0].bucket_start == datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc)
+    assert buckets[0].energy_kwh == pytest.approx(0.010)
+    assert buckets[0].interval == ImportHistoryInterval.HOURLY
+
+
+@pytest.mark.asyncio
+async def test_fetch_hourly_chunks_above_8_days():
+    """A 16-day hourly range must be split into 2 API calls."""
+    # Two empty chunks just to count the calls
+    fake_device = _FakeTapoP110([
+        _FakeEnergyDataResult(
+            start_ts=int(datetime(2026, 4, 1, tzinfo=timezone.utc).timestamp()),
+            interval_minutes=60, data=[],
+        ),
+        _FakeEnergyDataResult(
+            start_ts=int(datetime(2026, 4, 9, tzinfo=timezone.utc).timestamp()),
+            interval_minutes=60, data=[],
+        ),
+    ])
+    fake_client = _FakeApiClient(fake_device)
+    fetcher = TapoHistoryFetcher(client_factory=lambda email, pw: fake_client)
+
+    await fetcher.fetch_buckets(
+        ip="192.168.1.10", email="x@y", password="pw",
+        start=date(2026, 4, 1), end=date(2026, 4, 16),
+        interval=ImportHistoryInterval.HOURLY,
+    )
+
+    assert len(fake_device.calls) == 2  # split into two 8-day chunks
+
+
+@pytest.mark.asyncio
+async def test_fetch_monthly_single_year():
+    """Monthly fetch starting Jan 1: 12 buckets, one per month."""
+    fake_device = _FakeTapoP110([
+        _FakeEnergyDataResult(
+            start_ts=int(datetime(2026, 1, 1, tzinfo=timezone.utc).timestamp()),
+            interval_minutes=43200,  # 30 days in minutes -- tapo's monthly convention
+            data=[100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210],
+        )
+    ])
+    fake_client = _FakeApiClient(fake_device)
+    fetcher = TapoHistoryFetcher(client_factory=lambda email, pw: fake_client)
+
+    buckets = await fetcher.fetch_buckets(
+        ip="192.168.1.10", email="x@y", password="pw",
+        start=date(2026, 1, 1), end=date(2026, 12, 31),
+        interval=ImportHistoryInterval.MONTHLY,
+    )
+
+    assert len(buckets) == 12
+    assert buckets[0].bucket_start.month == 1
+    assert buckets[11].bucket_start.month == 12
+    assert buckets[0].energy_kwh == pytest.approx(0.100)

--- a/backend/tests/plugins/tapo_smart_plug/test_history_mock.py
+++ b/backend/tests/plugins/tapo_smart_plug/test_history_mock.py
@@ -1,0 +1,36 @@
+from datetime import date, timezone
+
+import pytest
+
+from app.plugins.installed.tapo_smart_plug.history_mock import TapoHistoryMockFetcher
+from app.plugins.smart_device.schemas import ImportHistoryInterval
+
+
+@pytest.mark.asyncio
+async def test_mock_hourly_returns_24_buckets_per_day():
+    fetcher = TapoHistoryMockFetcher(seed=42)
+    buckets = await fetcher.fetch_buckets(
+        ip="x", email="x", password="x",
+        start=date(2026, 4, 1), end=date(2026, 4, 1),
+        interval=ImportHistoryInterval.HOURLY,
+    )
+    assert len(buckets) == 24
+    # First bucket starts at 00:00 UTC
+    assert buckets[0].bucket_start.hour == 0
+    assert buckets[0].bucket_start.tzinfo is not None
+    # All values are reasonable for a NAS (0 - 0.3 kWh/h)
+    for b in buckets:
+        assert 0.0 <= b.energy_kwh <= 0.3
+
+
+@pytest.mark.asyncio
+async def test_mock_monthly_returns_12_buckets_for_full_year():
+    fetcher = TapoHistoryMockFetcher(seed=42)
+    buckets = await fetcher.fetch_buckets(
+        ip="x", email="x", password="x",
+        start=date(2026, 1, 1), end=date(2026, 12, 31),
+        interval=ImportHistoryInterval.MONTHLY,
+    )
+    assert len(buckets) == 12
+    assert buckets[0].bucket_start.month == 1
+    assert buckets[11].bucket_start.month == 12

--- a/backend/tests/plugins/tapo_smart_plug/test_import_service.py
+++ b/backend/tests/plugins/tapo_smart_plug/test_import_service.py
@@ -1,0 +1,149 @@
+"""Tests for TapoHistoryImportService — DB-touching, uses db_session fixture."""
+import json
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
+from app.models.smart_device import SmartDevice, SmartDeviceSample
+from app.plugins.installed.tapo_smart_plug.history import EnergyBucket
+from app.plugins.installed.tapo_smart_plug.import_service import TapoHistoryImportService
+from app.plugins.smart_device.schemas import (
+    ImportHistoryConflictStrategy,
+    ImportHistoryInterval,
+)
+
+
+@pytest.fixture
+def device_row(db_session):
+    """A SmartDevice row to attach samples to. Re-uses existing helper fixtures if available."""
+    d = SmartDevice(
+        name="Test Tapo",
+        plugin_name="tapo_smart_plug",
+        device_type_id="tapo_p110",
+        address="192.168.1.50",
+        capabilities=["switch", "power_monitor"],
+        is_active=True,
+        is_online=True,
+        created_by_user_id=1,
+    )
+    db_session.add(d)
+    db_session.commit()
+    db_session.refresh(d)
+    return d
+
+
+@pytest.fixture
+def hourly_buckets():
+    """Three consecutive hourly buckets starting at 2026-04-01 10:00 UTC."""
+    base = datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc)
+    return [
+        EnergyBucket(base + timedelta(hours=i), ImportHistoryInterval.HOURLY, 0.1 * (i + 1))
+        for i in range(3)
+    ]
+
+
+def test_buckets_to_samples_marks_imported(db_session, device_row, hourly_buckets):
+    svc = TapoHistoryImportService()
+    result = svc.write_buckets(
+        db_session, device_row.id, hourly_buckets,
+        conflict_strategy=ImportHistoryConflictStrategy.LIVE_WINS,
+    )
+    assert result.samples_inserted == 3
+
+    rows = db_session.query(SmartDeviceSample).filter(
+        SmartDeviceSample.device_id == device_row.id,
+    ).order_by(SmartDeviceSample.timestamp).all()
+    assert len(rows) == 3
+
+    first_data = json.loads(rows[0].data_json)
+    assert first_data["imported_from"] == "tapo_history"
+    assert first_data["bucket_interval"] == "hourly"
+    assert first_data["is_online"] is True
+    # 0.1 kWh / 1 hour = 100 W
+    assert first_data["watts"] == pytest.approx(100.0)
+
+
+def test_idempotent_skip(db_session, device_row, hourly_buckets):
+    """Second import of the same buckets must skip them (2B: per-timestamp check)."""
+    svc = TapoHistoryImportService()
+    svc.write_buckets(db_session, device_row.id, hourly_buckets,
+                      conflict_strategy=ImportHistoryConflictStrategy.LIVE_WINS)
+
+    # Second pass
+    result = svc.write_buckets(db_session, device_row.id, hourly_buckets,
+                               conflict_strategy=ImportHistoryConflictStrategy.LIVE_WINS)
+    assert result.samples_inserted == 0
+    assert result.samples_skipped_idempotent == 3
+
+    rows = db_session.query(SmartDeviceSample).filter(
+        SmartDeviceSample.device_id == device_row.id,
+    ).all()
+    assert len(rows) == 3  # not duplicated
+
+
+def test_live_wins_skips_overlap(db_session, device_row, hourly_buckets):
+    """If a live (non-imported) sample exists in a bucket's range, the bucket is skipped."""
+    # Seed a live sample at 2026-04-01 10:30 — inside the first bucket's hour
+    live = SmartDeviceSample(
+        device_id=device_row.id,
+        capability="power_monitor",
+        data_json=json.dumps({"watts": 80.0, "is_online": True}),
+        timestamp=datetime(2026, 4, 1, 10, 30, tzinfo=timezone.utc),
+    )
+    db_session.add(live)
+    db_session.commit()
+
+    svc = TapoHistoryImportService()
+    result = svc.write_buckets(
+        db_session, device_row.id, hourly_buckets,
+        conflict_strategy=ImportHistoryConflictStrategy.LIVE_WINS,
+    )
+    assert result.samples_inserted == 2          # bucket 2 and 3
+    assert result.samples_skipped_live == 1      # bucket 1 blocked by live sample
+    assert result.live_samples_deleted == 0
+
+
+def test_import_wins_deletes_overlapping_live(db_session, device_row, hourly_buckets):
+    """IMPORT_WINS removes live samples whose timestamp falls inside an imported bucket."""
+    live = SmartDeviceSample(
+        device_id=device_row.id,
+        capability="power_monitor",
+        data_json=json.dumps({"watts": 80.0, "is_online": True}),
+        timestamp=datetime(2026, 4, 1, 10, 30, tzinfo=timezone.utc),
+    )
+    db_session.add(live)
+    db_session.commit()
+
+    svc = TapoHistoryImportService()
+    result = svc.write_buckets(
+        db_session, device_row.id, hourly_buckets,
+        conflict_strategy=ImportHistoryConflictStrategy.IMPORT_WINS,
+    )
+    assert result.samples_inserted == 3
+    assert result.live_samples_deleted == 1
+
+    rows = db_session.query(SmartDeviceSample).filter(
+        SmartDeviceSample.device_id == device_row.id,
+    ).all()
+    # 3 imported, 0 live left
+    assert len(rows) == 3
+    for r in rows:
+        assert json.loads(r.data_json).get("imported_from") == "tapo_history"
+
+
+def test_synthesized_watts_for_daily(db_session, device_row):
+    """1.2 kWh over a 24h daily bucket → 50 W."""
+    bucket = EnergyBucket(
+        bucket_start=datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc),
+        interval=ImportHistoryInterval.DAILY,
+        energy_kwh=1.2,
+    )
+    svc = TapoHistoryImportService()
+    svc.write_buckets(db_session, device_row.id, [bucket],
+                      conflict_strategy=ImportHistoryConflictStrategy.LIVE_WINS)
+
+    row = db_session.query(SmartDeviceSample).filter(
+        SmartDeviceSample.device_id == device_row.id,
+    ).one()
+    data = json.loads(row.data_json)
+    assert data["watts"] == pytest.approx(50.0)

--- a/backend/tests/plugins/tapo_smart_plug/test_plugin_import_history.py
+++ b/backend/tests/plugins/tapo_smart_plug/test_plugin_import_history.py
@@ -1,0 +1,78 @@
+"""Tests for TapoSmartPlugPlugin.import_history() — top-level plugin entry point."""
+from datetime import date, datetime, timezone
+
+import pytest
+
+from app.models.smart_device import SmartDevice, SmartDeviceSample
+from app.plugins.installed.tapo_smart_plug import TapoSmartPlugPlugin
+from app.plugins.installed.tapo_smart_plug.history import EnergyBucket
+from app.plugins.smart_device.schemas import (
+    ImportHistoryConflictStrategy,
+    ImportHistoryInterval,
+)
+
+
+class _StubFetcher:
+    """Returns pre-canned buckets regardless of arguments."""
+    def __init__(self, buckets):
+        self._buckets = buckets
+        self.last_call = None
+
+    async def fetch_buckets(self, ip, email, password, start, end, interval):
+        self.last_call = {"ip": ip, "email": email, "interval": interval}
+        return list(self._buckets)
+
+
+@pytest.fixture
+def device_row(db_session):
+    d = SmartDevice(
+        name="Test Tapo",
+        plugin_name="tapo_smart_plug",
+        device_type_id="tapo_p110",
+        address="192.168.1.50",
+        capabilities=["switch", "power_monitor"],
+        is_active=True,
+        is_online=True,
+        created_by_user_id=1,
+    )
+    db_session.add(d)
+    db_session.commit()
+    db_session.refresh(d)
+    return d
+
+
+@pytest.mark.asyncio
+async def test_import_history_writes_samples(db_session, device_row, monkeypatch):
+    plugin = TapoSmartPlugPlugin()
+
+    stub = _StubFetcher([
+        EnergyBucket(datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc),
+                     ImportHistoryInterval.HOURLY, 0.1),
+        EnergyBucket(datetime(2026, 4, 1, 1, 0, tzinfo=timezone.utc),
+                     ImportHistoryInterval.HOURLY, 0.15),
+    ])
+
+    # Inject the fetcher and cached device info
+    plugin._fetcher_override = stub
+    plugin._device_info[str(device_row.id)] = type("Info", (), {
+        "ip": "192.168.1.50", "email": "test@example.com", "password": "pw",
+    })()
+
+    response = await plugin.import_history(
+        db=db_session,
+        device_id=device_row.id,
+        interval=ImportHistoryInterval.HOURLY,
+        start=date(2026, 4, 1),
+        end=date(2026, 4, 1),
+        conflict_strategy=ImportHistoryConflictStrategy.LIVE_WINS,
+    )
+
+    assert response.buckets_fetched == 2
+    assert response.samples_inserted == 2
+    assert response.interval == ImportHistoryInterval.HOURLY
+    assert stub.last_call["ip"] == "192.168.1.50"
+
+    rows = db_session.query(SmartDeviceSample).filter(
+        SmartDeviceSample.device_id == device_row.id,
+    ).count()
+    assert rows == 2

--- a/backend/tests/plugins/test_smart_device_schemas.py
+++ b/backend/tests/plugins/test_smart_device_schemas.py
@@ -1,0 +1,63 @@
+"""Tests for SmartDevice Pydantic schemas — focusing on history import."""
+from datetime import datetime, timezone
+import pytest
+from pydantic import ValidationError
+
+from app.plugins.smart_device.schemas import (
+    ImportHistoryRequest,
+    ImportHistoryInterval,
+    ImportHistoryConflictStrategy,
+)
+
+
+class TestImportHistoryRequest:
+    def test_valid_hourly_request(self):
+        req = ImportHistoryRequest(
+            interval=ImportHistoryInterval.HOURLY,
+            start_date="2026-04-01",
+            end_date="2026-04-08",
+            conflict_strategy=ImportHistoryConflictStrategy.LIVE_WINS,
+        )
+        assert req.interval == ImportHistoryInterval.HOURLY
+        assert req.start_date.year == 2026
+
+    def test_daily_requires_quarter_start(self):
+        # April 1 is a quarter start — should pass
+        ImportHistoryRequest(
+            interval=ImportHistoryInterval.DAILY,
+            start_date="2026-04-01",
+            end_date="2026-06-30",
+            conflict_strategy=ImportHistoryConflictStrategy.LIVE_WINS,
+        )
+        # April 15 is NOT a quarter start — must fail
+        with pytest.raises(ValidationError):
+            ImportHistoryRequest(
+                interval=ImportHistoryInterval.DAILY,
+                start_date="2026-04-15",
+                end_date="2026-06-30",
+                conflict_strategy=ImportHistoryConflictStrategy.LIVE_WINS,
+            )
+
+    def test_monthly_requires_year_start(self):
+        ImportHistoryRequest(
+            interval=ImportHistoryInterval.MONTHLY,
+            start_date="2026-01-01",
+            end_date="2026-12-31",
+            conflict_strategy=ImportHistoryConflictStrategy.LIVE_WINS,
+        )
+        with pytest.raises(ValidationError):
+            ImportHistoryRequest(
+                interval=ImportHistoryInterval.MONTHLY,
+                start_date="2026-03-01",
+                end_date="2026-12-31",
+                conflict_strategy=ImportHistoryConflictStrategy.LIVE_WINS,
+            )
+
+    def test_end_before_start_rejected(self):
+        with pytest.raises(ValidationError):
+            ImportHistoryRequest(
+                interval=ImportHistoryInterval.HOURLY,
+                start_date="2026-04-10",
+                end_date="2026-04-01",
+                conflict_strategy=ImportHistoryConflictStrategy.LIVE_WINS,
+            )

--- a/backend/tests/services/test_energy_service.py
+++ b/backend/tests/services/test_energy_service.py
@@ -248,6 +248,45 @@ class TestCleanup:
         deleted = cleanup_old_samples(db_session, days_to_keep=30)
         assert deleted == 0
 
+    def test_cleanup_preserves_imported_samples(self, db_session, smart_device):
+        """Imported samples (imported_from set) must never be deleted by retention."""
+        now = datetime.now(timezone.utc)
+
+        # Old live sample (60 days) — should be deleted
+        live_old = json.dumps({"watts": 50.0, "is_online": True})
+        db_session.add(SmartDeviceSample(
+            device_id=smart_device.id,
+            capability="power_monitor",
+            data_json=live_old,
+            timestamp=now - timedelta(days=60),
+        ))
+
+        # Old imported sample (60 days) — must SURVIVE cleanup
+        imported_old = json.dumps({
+            "watts": 18.0,
+            "is_online": True,
+            "imported_from": "tapo_history",
+            "bucket_interval": "hourly",
+        })
+        db_session.add(SmartDeviceSample(
+            device_id=smart_device.id,
+            capability="power_monitor",
+            data_json=imported_old,
+            timestamp=now - timedelta(days=60),
+        ))
+
+        db_session.commit()
+
+        deleted = cleanup_old_samples(db_session, days_to_keep=30)
+        assert deleted == 1
+
+        remaining = db_session.query(SmartDeviceSample).filter(
+            SmartDeviceSample.capability == "power_monitor"
+        ).all()
+        assert len(remaining) == 1
+        data = json.loads(remaining[0].data_json)
+        assert data.get("imported_from") == "tapo_history"
+
 
 # ============================================================================
 # Cumulative Energy Data

--- a/client/src/api/smart-devices.ts
+++ b/client/src/api/smart-devices.ts
@@ -113,3 +113,42 @@ export const smartDevicesApi = {
       params: { capability, hours },
     }),
 };
+
+// --- History Import (admin-only Tapo backfill) ---
+
+export type ImportHistoryInterval = 'hourly' | 'daily' | 'monthly';
+export type ImportHistoryConflictStrategy = 'live_wins' | 'import_wins';
+
+export interface ImportHistoryRequest {
+  interval: ImportHistoryInterval;
+  start_date: string; // ISO date 'YYYY-MM-DD'
+  end_date: string;
+  conflict_strategy: ImportHistoryConflictStrategy;
+}
+
+export interface ImportHistoryResponse {
+  device_id: number;
+  interval: ImportHistoryInterval;
+  buckets_fetched: number;
+  samples_inserted: number;
+  samples_skipped_idempotent: number;
+  samples_skipped_live: number;
+  live_samples_deleted: number;
+  started_at: string;
+  completed_at: string;
+}
+
+/**
+ * Trigger a historical energy import on a smart-plug device. Admin-only.
+ * The backend rate-limits this to 5/hour.
+ */
+export async function importDeviceHistory(
+  deviceId: number,
+  body: ImportHistoryRequest,
+): Promise<ImportHistoryResponse> {
+  const res = await apiClient.post<ImportHistoryResponse>(
+    `/api/smart-devices/${deviceId}/import-history`,
+    body,
+  );
+  return res.data;
+}

--- a/client/src/components/smart-devices/SmartDeviceCard.tsx
+++ b/client/src/components/smart-devices/SmartDeviceCard.tsx
@@ -5,7 +5,8 @@
  */
 
 import { useState } from 'react';
-import { AlertTriangle, Trash2, WifiOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, History, Trash2, WifiOff } from 'lucide-react';
 import type { SmartDevice, CommandResponse } from '../../api/smart-devices';
 import { smartDevicesApi } from '../../api/smart-devices';
 import {
@@ -15,6 +16,7 @@ import {
   DimmerControl,
   ColorControl,
 } from './CapabilityControls';
+import { TapoHistoryImportModal } from './TapoHistoryImportModal';
 import toast from 'react-hot-toast';
 
 interface SmartDeviceCardProps {
@@ -42,6 +44,8 @@ export function SmartDeviceCard({
   onStateChange,
 }: SmartDeviceCardProps) {
   const [cmdLoading, setCmdLoading] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const { t } = useTranslation('devices');
 
   const sendCommand = async (
     capability: string,
@@ -185,13 +189,24 @@ export function SmartDeviceCard({
 
         {/* Admin actions */}
         {isAdmin && (
-          <button
-            onClick={() => onDelete(device.id)}
-            className="flex-shrink-0 rounded-lg border border-rose-500/20 bg-rose-500/5 p-1.5 text-rose-400 hover:border-rose-500/40 hover:bg-rose-500/10 transition touch-manipulation active:scale-95"
-            title="Delete device"
-          >
-            <Trash2 className="h-4 w-4" />
-          </button>
+          <div className="flex items-center gap-1.5 flex-shrink-0">
+            {device.plugin_name === 'tapo_smart_plug' && (
+              <button
+                onClick={() => setHistoryOpen(true)}
+                className="rounded-lg border border-sky-500/20 bg-sky-500/5 p-1.5 text-sky-400 hover:border-sky-500/40 hover:bg-sky-500/10 transition touch-manipulation active:scale-95"
+                title={t('historyImport.title')}
+              >
+                <History className="h-4 w-4" />
+              </button>
+            )}
+            <button
+              onClick={() => onDelete(device.id)}
+              className="rounded-lg border border-rose-500/20 bg-rose-500/5 p-1.5 text-rose-400 hover:border-rose-500/40 hover:bg-rose-500/10 transition touch-manipulation active:scale-95"
+              title="Delete device"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          </div>
         )}
       </div>
 
@@ -231,6 +246,15 @@ export function SmartDeviceCard({
           </span>
         )}
       </div>
+
+      {/* History Import modal (Tapo only) */}
+      {device.plugin_name === 'tapo_smart_plug' && (
+        <TapoHistoryImportModal
+          deviceId={device.id}
+          isOpen={historyOpen}
+          onClose={() => setHistoryOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/components/smart-devices/TapoHistoryImportModal.tsx
+++ b/client/src/components/smart-devices/TapoHistoryImportModal.tsx
@@ -1,0 +1,181 @@
+/**
+ * Modal for admin-triggered historical energy data import from Tapo plugs.
+ * Calls POST /api/smart-devices/{id}/import-history.
+ */
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+import { Select } from '../ui/Select';
+import {
+  importDeviceHistory,
+  type ImportHistoryConflictStrategy,
+  type ImportHistoryInterval,
+  type ImportHistoryResponse,
+} from '../../api/smart-devices';
+
+interface TapoHistoryImportModalProps {
+  deviceId: number;
+  isOpen: boolean;
+  onClose: () => void;
+  onCompleted?: (result: ImportHistoryResponse) => void;
+}
+
+export function TapoHistoryImportModal({
+  deviceId,
+  isOpen,
+  onClose,
+  onCompleted,
+}: TapoHistoryImportModalProps) {
+  const { t } = useTranslation('devices');
+
+  const [interval, setInterval] = useState<ImportHistoryInterval>('hourly');
+  const [startDate, setStartDate] = useState<string>('');
+  const [endDate, setEndDate] = useState<string>('');
+  const [conflict, setConflict] = useState<ImportHistoryConflictStrategy>('live_wins');
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<ImportHistoryResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setInterval('hourly');
+    setStartDate('');
+    setEndDate('');
+    setConflict('live_wins');
+    setRunning(false);
+    setResult(null);
+    setError(null);
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    setError(null);
+    setResult(null);
+    setRunning(true);
+    try {
+      const res = await importDeviceHistory(deviceId, {
+        interval,
+        start_date: startDate,
+        end_date: endDate,
+        conflict_strategy: conflict,
+      });
+      setResult(res);
+      onCompleted?.(res);
+      toast.success(
+        t('historyImport.resultSummary', {
+          inserted: res.samples_inserted,
+          skippedIdempotent: res.samples_skipped_idempotent,
+          skippedLive: res.samples_skipped_live,
+          deletedLive: res.live_samples_deleted,
+        }),
+      );
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setError(message);
+      toast.error(t('historyImport.errorTitle'));
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const intervalOptions = [
+    { value: 'hourly', label: t('historyImport.intervalHourly') },
+    { value: 'daily', label: t('historyImport.intervalDaily') },
+    { value: 'monthly', label: t('historyImport.intervalMonthly') },
+  ];
+
+  const conflictOptions = [
+    { value: 'live_wins', label: t('historyImport.conflictLiveWins') },
+    { value: 'import_wins', label: t('historyImport.conflictImportWins') },
+  ];
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title={t('historyImport.title')}>
+      <div className="space-y-4">
+        <p className="text-sm text-slate-300">{t('historyImport.description')}</p>
+
+        <div className="space-y-1">
+          <label className="block text-sm font-medium text-slate-200">
+            {t('historyImport.intervalLabel')}
+          </label>
+          <Select
+            value={interval}
+            options={intervalOptions}
+            onChange={(e) => setInterval(e.target.value as ImportHistoryInterval)}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1">
+            <label className="block text-sm font-medium text-slate-200">
+              {t('historyImport.startLabel')}
+            </label>
+            <Input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="block text-sm font-medium text-slate-200">
+              {t('historyImport.endLabel')}
+            </label>
+            <Input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <label className="block text-sm font-medium text-slate-200">
+            {t('historyImport.conflictLabel')}
+          </label>
+          <Select
+            value={conflict}
+            options={conflictOptions}
+            onChange={(e) => setConflict(e.target.value as ImportHistoryConflictStrategy)}
+          />
+        </div>
+
+        {error && (
+          <div className="rounded-md border border-red-500/50 bg-red-500/10 p-2 text-sm text-red-400">
+            {error}
+          </div>
+        )}
+
+        {result && (
+          <div className="rounded-md border border-emerald-500/50 bg-emerald-500/10 p-2 text-sm text-emerald-300">
+            {t('historyImport.resultSummary', {
+              inserted: result.samples_inserted,
+              skippedIdempotent: result.samples_skipped_idempotent,
+              skippedLive: result.samples_skipped_live,
+              deletedLive: result.live_samples_deleted,
+            })}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="ghost" onClick={handleClose} disabled={running}>
+            {t('historyImport.cancel')}
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={running || !startDate || !endDate}
+          >
+            {running ? t('historyImport.running') : t('historyImport.submit')}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/client/src/i18n/locales/de/devices.json
+++ b/client/src/i18n/locales/de/devices.json
@@ -174,5 +174,23 @@
     "pairButton": "Desktop koppeln"
   },
   "loading": "Geräte werden geladen...",
-  "error": "Fehler"
+  "error": "Fehler",
+  "historyImport": {
+    "title": "Energieverlauf importieren",
+    "description": "Holt gespeicherte Verbrauchsdaten direkt aus der Tapo-Steckdose. Sinnvoll einmalig nach dem Einrichten, damit du nicht weiter auf die Tapo App angewiesen bist.",
+    "intervalLabel": "Granularität",
+    "intervalHourly": "Stündlich (max. 8 Tage pro Anfrage)",
+    "intervalDaily": "Täglich (Start muss Quartalsanfang sein: 1. Jan / 1. Apr / 1. Jul / 1. Okt)",
+    "intervalMonthly": "Monatlich (Start muss 1. Januar sein)",
+    "startLabel": "Startdatum",
+    "endLabel": "Enddatum",
+    "conflictLabel": "Bei Überschneidung mit Live-Daten",
+    "conflictLiveWins": "Live-Daten behalten (überlappende Buckets überspringen)",
+    "conflictImportWins": "Mit Import überschreiben (Live-Samples im Bereich löschen)",
+    "submit": "Importieren",
+    "cancel": "Abbrechen",
+    "running": "Importiere…",
+    "errorTitle": "Import fehlgeschlagen",
+    "resultSummary": "{{inserted}} Samples geschrieben. {{skippedIdempotent}} bereits importiert, {{skippedLive}} wegen Live-Daten übersprungen, {{deletedLive}} Live-Samples gelöscht."
+  }
 }

--- a/client/src/i18n/locales/en/devices.json
+++ b/client/src/i18n/locales/en/devices.json
@@ -174,5 +174,23 @@
     "pairButton": "Pair Desktop"
   },
   "loading": "Loading devices...",
-  "error": "Error"
+  "error": "Error",
+  "historyImport": {
+    "title": "Import historical energy data",
+    "description": "Manually pull stored energy data from the Tapo device. Useful once after pairing so you don't depend on the Tapo app for older readings.",
+    "intervalLabel": "Granularity",
+    "intervalHourly": "Hourly (max 8 days back per request)",
+    "intervalDaily": "Daily (start must be a quarter start: Jan 1 / Apr 1 / Jul 1 / Oct 1)",
+    "intervalMonthly": "Monthly (start must be January 1)",
+    "startLabel": "Start date",
+    "endLabel": "End date",
+    "conflictLabel": "If existing live data overlaps",
+    "conflictLiveWins": "Keep live data (skip overlapping buckets)",
+    "conflictImportWins": "Overwrite with imported data (delete live samples in range)",
+    "submit": "Import",
+    "cancel": "Cancel",
+    "running": "Importing…",
+    "errorTitle": "Import failed",
+    "resultSummary": "{{inserted}} samples inserted. {{skippedIdempotent}} already imported, {{skippedLive}} skipped due to live data, {{deletedLive}} live samples deleted."
+  }
 }


### PR DESCRIPTION
## Summary

Admin-only manual import of historical energy data from TP-Link Tapo P110/P115 smart plugs into BaluHost's existing power-monitor sample timeline. Closes the gap so users see continuous energy charts without needing the Tapo app for older readings.

- New `tapo` library (mihai-dinculescu) alongside the existing `plugp100` poller — two libs by design: live polling stays on plugp100, history fetch uses tapo because plugp100 v5 doesn't expose `get_energy_data` typed
- Imported buckets stored as standard `SmartDeviceSample` rows with `imported_from="tapo_history"` marker; existing aggregation in `services/power/energy.py` Just Works
- Synthesized watts from `bucket_kWh × 1000 / bucket_hours`; per-bucket idempotency; admin-chosen conflict strategy (live_wins / import_wins) for overlap with live samples
- `cleanup_old_samples` now preserves imported rows so the retention sweep never erases a manual backfill
- New `POST /api/smart-devices/{id}/import-history`, admin-only, rate-limited 5/hour, audit-logged
- Frontend: \`TapoHistoryImportModal\` (DE/EN i18n in \`devices\` namespace) wired to a History icon button in \`SmartDeviceCard\` for admins on Tapo devices

## Architecture

```
SmartDeviceCard (admin button)
        |
        v
TapoHistoryImportModal -> importDeviceHistory()
        |
        v
POST /api/smart-devices/{id}/import-history (admin, rate-limited)
        |
        v
TapoSmartPlugPlugin.import_history()
        |
        +-- TapoHistoryFetcher (prod) or TapoHistoryMockFetcher (dev)
        |        |
        |        v
        |   tapo.ApiClient -> get_energy_data(Hourly|Daily|Monthly)
        |        |
        |        v
        |   List[EnergyBucket]
        |
        +-- TapoHistoryImportService.write_buckets()
                 |
                 v
            SmartDeviceSample rows with imported_from marker
```

## Test plan

- [x] Backend pytest (\`backend/tests/\`) green: ~1500 tests, exit 0
- [x] New unit/integration tests cover all five conflict-disposition paths (idempotent skip, LIVE_WINS skip, IMPORT_WINS delete+write, fresh insert, synthesized watts)
- [x] Schema validators reject non-quarter daily starts and non-Jan-1 monthly starts (422)
- [x] API requires admin (403 for user, 404 for unknown device, 200 success path via dev mock fetcher)
- [x] \`cleanup_old_samples\` preserves rows with \`imported_from\` set
- [x] Frontend \`tsc --noEmit\` clean
- [x] Frontend \`npm run build\` succeeds
- [x] **Manual browser smoke test**: open Smart Devices page as admin, click new History icon on a Tapo device, run an import for 2026-04-01 hourly, verify success summary + DB rows (reviewer)
- [ ] **Hardware dry-run** (optional, prod mode): if a real Tapo P110 is reachable, repeat the manual test against real history rather than dev mock

## Heads-up for reviewer

A stray commit \`3e014a44\` exists on the \`feat/pihole-ui-consistency\` branch in the main repo (a subagent committed there by mistake before being cherry-picked into this worktree as \`e010b682\`). That commit needs to be rebased/reverted out of \`feat/pihole-ui-consistency\` before its own PR lands, or the tapo dependency will be added twice across two PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)