### PR TITLE
fix(tapo): use correct EnergyDataResult attribute names

### DIFF
--- a/backend/app/plugins/installed/tapo_smart_plug/history.py
+++ b/backend/app/plugins/installed/tapo_smart_plug/history.py
@@ -160,26 +160,42 @@ class TapoHistoryFetcher:
     def _buckets_from_result(result, interval: ImportHistoryInterval, bucket_minutes: int) -> List[EnergyBucket]:
         """Convert a tapo ``EnergyDataResult`` into EnergyBucket objects.
 
-        The tapo library returns:
-        - ``start_timestamp`` (Unix seconds, UTC) of the first bucket
-        - ``data`` (list[int]) -- energy in Wh per bucket
-        - ``interval`` (minutes per bucket) -- we use the *requested* bucket_minutes
+        The mihai-dinculescu/tapo library exposes:
+        - ``start_date_time`` -- datetime of the first bucket (device local time, may be naive)
+        - ``entries`` (list[int]) -- energy in Wh per bucket
+        - ``interval_length`` (minutes per bucket) -- we use the *requested* bucket_minutes
           because monthly buckets do not have a fixed minute count.
+        - ``local_time`` -- the device's current local datetime when the response was built
+
+        Naive datetimes are treated as UTC. This is a deliberate simplification: the
+        Tapo device reports in its own local timezone, but bucket alignment in BaluHost
+        is UTC-anchored. If the device's timezone diverges from UTC, the imported
+        timestamps will be shifted accordingly; admins can re-import after fixing
+        the device timezone if needed.
         """
-        start_ts = getattr(result, "start_timestamp", None)
-        data = getattr(result, "data", None) or []
-        if start_ts is None:
+        start_dt = getattr(result, "start_date_time", None)
+        entries = getattr(result, "entries", None) or []
+        if start_dt is None:
             return []
+
+        # Coerce to tz-aware UTC datetime
+        if isinstance(start_dt, str):
+            try:
+                start_dt = datetime.fromisoformat(start_dt)
+            except ValueError:
+                return []
+        if getattr(start_dt, "tzinfo", None) is None:
+            start_dt = start_dt.replace(tzinfo=timezone.utc)
 
         # Precompute the month-anchored base for MONTHLY stepping.
         monthly_base = None
         if interval == ImportHistoryInterval.MONTHLY:
-            monthly_base = datetime.fromtimestamp(start_ts, tz=timezone.utc).replace(
+            monthly_base = start_dt.replace(
                 day=1, hour=0, minute=0, second=0, microsecond=0
             )
 
         out: List[EnergyBucket] = []
-        for idx, wh in enumerate(data):
+        for idx, wh in enumerate(entries):
             if interval == ImportHistoryInterval.MONTHLY:
                 assert monthly_base is not None  # set above when interval == MONTHLY
                 month = monthly_base.month + idx
@@ -187,9 +203,7 @@ class TapoHistoryFetcher:
                 month = ((month - 1) % 12) + 1
                 bucket_start = monthly_base.replace(year=year, month=month)
             else:
-                bucket_start = datetime.fromtimestamp(
-                    start_ts + idx * bucket_minutes * 60, tz=timezone.utc
-                )
+                bucket_start = start_dt + timedelta(minutes=idx * bucket_minutes)
 
             out.append(EnergyBucket(
                 bucket_start=bucket_start,

--- a/backend/tests/plugins/tapo_smart_plug/test_history_fetcher.py
+++ b/backend/tests/plugins/tapo_smart_plug/test_history_fetcher.py
@@ -10,11 +10,11 @@ from app.plugins.smart_device.schemas import ImportHistoryInterval
 
 
 class _FakeEnergyDataResult:
-    """Stub mimicking tapo's EnergyDataResult.data attribute (list of Wh values per bucket)."""
-    def __init__(self, start_ts: int, interval_minutes: int, data: list[int]):
-        self.start_timestamp = start_ts
-        self.interval = interval_minutes
-        self.data = data
+    """Stub mimicking tapo's EnergyDataResult (mihai-dinculescu library)."""
+    def __init__(self, start_dt: datetime, interval_minutes: int, entries: list[int]):
+        self.start_date_time = start_dt
+        self.interval_length = interval_minutes
+        self.entries = entries
 
 
 class _FakeTapoP110:
@@ -43,9 +43,9 @@ async def test_fetch_hourly_single_chunk():
     # (any filtering is deferred to the import_service layer)
     fake_device = _FakeTapoP110([
         _FakeEnergyDataResult(
-            start_ts=int(datetime(2026, 4, 1, tzinfo=timezone.utc).timestamp()),
+            start_dt=datetime(2026, 4, 1, tzinfo=timezone.utc),
             interval_minutes=60,
-            data=[10, 20, 30] + [0] * 21,  # 3 buckets, rest zero
+            entries=[10, 20, 30] + [0] * 21,  # 3 buckets, rest zero
         )
     ])
     fake_client = _FakeApiClient(fake_device)
@@ -71,12 +71,12 @@ async def test_fetch_hourly_chunks_above_8_days():
     # Two empty chunks just to count the calls
     fake_device = _FakeTapoP110([
         _FakeEnergyDataResult(
-            start_ts=int(datetime(2026, 4, 1, tzinfo=timezone.utc).timestamp()),
-            interval_minutes=60, data=[],
+            start_dt=datetime(2026, 4, 1, tzinfo=timezone.utc),
+            interval_minutes=60, entries=[],
         ),
         _FakeEnergyDataResult(
-            start_ts=int(datetime(2026, 4, 9, tzinfo=timezone.utc).timestamp()),
-            interval_minutes=60, data=[],
+            start_dt=datetime(2026, 4, 9, tzinfo=timezone.utc),
+            interval_minutes=60, entries=[],
         ),
     ])
     fake_client = _FakeApiClient(fake_device)
@@ -96,9 +96,9 @@ async def test_fetch_monthly_single_year():
     """Monthly fetch starting Jan 1: 12 buckets, one per month."""
     fake_device = _FakeTapoP110([
         _FakeEnergyDataResult(
-            start_ts=int(datetime(2026, 1, 1, tzinfo=timezone.utc).timestamp()),
+            start_dt=datetime(2026, 1, 1, tzinfo=timezone.utc),
             interval_minutes=43200,  # 30 days in minutes -- tapo's monthly convention
-            data=[100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210],
+            entries=[100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210],
         )
     ])
     fake_client = _FakeApiClient(fake_device)


### PR DESCRIPTION
## Summary

Hotfix for PR #87: the history import returned 0 buckets on production because `_buckets_from_result` was reading attribute names from the `tapo` library that don't exist.

The mihai-dinculescu `tapo` library exposes:

| BaluHost was reading | Actual attribute | Type |
|---|---|---|
| `start_timestamp` | `start_date_time` | datetime (device-local) |
| `data` | `entries` | list[int] Wh |
| `interval` | `interval_length` | int minutes |

Both `getattr` calls silently fell back to defaults (None / []) → empty bucket list → response `buckets_fetched: 0`. No exception, no log noise.

## Changes

- `backend/app/plugins/installed/tapo_smart_plug/history.py` — read the correct attributes, treat naive datetimes as UTC, step buckets via `timedelta` from `start_dt` instead of Unix-epoch math
- `backend/tests/plugins/tapo_smart_plug/test_history_fetcher.py` — fake stub now exposes the same attribute names so the test would have caught this if it had run against real lib types

## Caveat (not fixed here)

The library returns naive datetimes in the **device's local timezone**, not UTC. This fix treats them as UTC. If the plug's timezone differs from UTC, imported bucket timestamps will be shifted by that offset (no data loss — just a horizontal shift in charts). Worth a follow-up to read the device timezone and offset accordingly. Sag Bescheid wenn das stört.

## Test plan

- [x] `test_fetch_hourly_single_chunk`, `test_fetch_hourly_chunks_above_8_days`, `test_fetch_monthly_single_year` — pass against the updated fake
- [ ] **Live test against real P110**: import 1 day hourly, verify `buckets_fetched: 24` and timestamps land on `:00`

🤖 Generated with [Claude Code](https://claude.com/claude-code)