### PR TITLE
fix(tapo): decode entries as EnergyDataIntervalResult objects

### DIFF
--- a/backend/app/plugins/installed/tapo_smart_plug/history.py
+++ b/backend/app/plugins/installed/tapo_smart_plug/history.py
@@ -160,54 +160,40 @@ class TapoHistoryFetcher:
     def _buckets_from_result(result, interval: ImportHistoryInterval, bucket_minutes: int) -> List[EnergyBucket]:
         """Convert a tapo ``EnergyDataResult`` into EnergyBucket objects.
 
-        The mihai-dinculescu/tapo library exposes:
-        - ``start_date_time`` -- datetime of the first bucket (device local time, may be naive)
-        - ``entries`` (list[int]) -- energy in Wh per bucket
-        - ``interval_length`` (minutes per bucket) -- we use the *requested* bucket_minutes
-          because monthly buckets do not have a fixed minute count.
-        - ``local_time`` -- the device's current local datetime when the response was built
+        The mihai-dinculescu/tapo library exposes ``entries`` as a list of
+        ``EnergyDataIntervalResult`` structs, each with its own:
+        - ``start_date_time`` -- datetime (``DateTime<Utc>`` in Rust, tz-aware in Python)
+        - ``energy`` -- int, Wh consumed in that bucket
 
-        Naive datetimes are treated as UTC. This is a deliberate simplification: the
-        Tapo device reports in its own local timezone, but bucket alignment in BaluHost
-        is UTC-anchored. If the device's timezone diverges from UTC, the imported
-        timestamps will be shifted accordingly; admins can re-import after fixing
-        the device timezone if needed.
+        We use the per-entry timestamps directly instead of stepping by
+        ``interval_length`` from the parent ``start_date_time``. This is
+        correct by construction for all three intervals (HOURLY/DAILY/MONTHLY),
+        including the irregular monthly bucket lengths.
+
+        ``bucket_minutes`` is kept for the function signature but is no longer
+        used — the per-entry timestamps make it redundant.
         """
-        start_dt = getattr(result, "start_date_time", None)
         entries = getattr(result, "entries", None) or []
-        if start_dt is None:
-            return []
-
-        # Coerce to tz-aware UTC datetime
-        if isinstance(start_dt, str):
-            try:
-                start_dt = datetime.fromisoformat(start_dt)
-            except ValueError:
-                return []
-        if getattr(start_dt, "tzinfo", None) is None:
-            start_dt = start_dt.replace(tzinfo=timezone.utc)
-
-        # Precompute the month-anchored base for MONTHLY stepping.
-        monthly_base = None
-        if interval == ImportHistoryInterval.MONTHLY:
-            monthly_base = start_dt.replace(
-                day=1, hour=0, minute=0, second=0, microsecond=0
-            )
 
         out: List[EnergyBucket] = []
-        for idx, wh in enumerate(entries):
-            if interval == ImportHistoryInterval.MONTHLY:
-                assert monthly_base is not None  # set above when interval == MONTHLY
-                month = monthly_base.month + idx
-                year = monthly_base.year + (month - 1) // 12
-                month = ((month - 1) % 12) + 1
-                bucket_start = monthly_base.replace(year=year, month=month)
-            else:
-                bucket_start = start_dt + timedelta(minutes=idx * bucket_minutes)
+        for entry in entries:
+            bucket_start = getattr(entry, "start_date_time", None)
+            energy_wh = getattr(entry, "energy", None)
+            if bucket_start is None or energy_wh is None:
+                continue
+
+            # Coerce to tz-aware UTC datetime (defensive — the lib already returns UTC)
+            if isinstance(bucket_start, str):
+                try:
+                    bucket_start = datetime.fromisoformat(bucket_start)
+                except ValueError:
+                    continue
+            if getattr(bucket_start, "tzinfo", None) is None:
+                bucket_start = bucket_start.replace(tzinfo=timezone.utc)
 
             out.append(EnergyBucket(
                 bucket_start=bucket_start,
                 interval=interval,
-                energy_kwh=round(wh / 1000.0, 4),
+                energy_kwh=round(float(energy_wh) / 1000.0, 4),
             ))
         return out

--- a/backend/tests/plugins/tapo_smart_plug/test_history_fetcher.py
+++ b/backend/tests/plugins/tapo_smart_plug/test_history_fetcher.py
@@ -1,7 +1,5 @@
 """Tests for TapoHistoryFetcher — uses a fake tapo client via monkeypatch."""
-from datetime import date, datetime, timezone
-from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
@@ -9,12 +7,34 @@ from app.plugins.installed.tapo_smart_plug.history import TapoHistoryFetcher, En
 from app.plugins.smart_device.schemas import ImportHistoryInterval
 
 
+class _FakeIntervalEntry:
+    """Stub mimicking tapo's EnergyDataIntervalResult (one bucket)."""
+    def __init__(self, start_dt: datetime, energy_wh: int):
+        self.start_date_time = start_dt
+        self.energy = energy_wh
+
+
 class _FakeEnergyDataResult:
     """Stub mimicking tapo's EnergyDataResult (mihai-dinculescu library)."""
-    def __init__(self, start_dt: datetime, interval_minutes: int, entries: list[int]):
+    def __init__(self, start_dt: datetime, interval_minutes: int, entries: list[_FakeIntervalEntry]):
         self.start_date_time = start_dt
         self.interval_length = interval_minutes
         self.entries = entries
+
+
+def _hourly_entries(start_dt: datetime, values_wh: list[int]) -> list[_FakeIntervalEntry]:
+    return [_FakeIntervalEntry(start_dt + timedelta(hours=i), wh) for i, wh in enumerate(values_wh)]
+
+
+def _monthly_entries(start_year: int, values_wh: list[int]) -> list[_FakeIntervalEntry]:
+    out = []
+    for i, wh in enumerate(values_wh):
+        month = (i % 12) + 1
+        year = start_year + (i // 12)
+        out.append(_FakeIntervalEntry(
+            datetime(year, month, 1, tzinfo=timezone.utc), wh,
+        ))
+    return out
 
 
 class _FakeTapoP110:
@@ -45,7 +65,10 @@ async def test_fetch_hourly_single_chunk():
         _FakeEnergyDataResult(
             start_dt=datetime(2026, 4, 1, tzinfo=timezone.utc),
             interval_minutes=60,
-            entries=[10, 20, 30] + [0] * 21,  # 3 buckets, rest zero
+            entries=_hourly_entries(
+                datetime(2026, 4, 1, tzinfo=timezone.utc),
+                [10, 20, 30] + [0] * 21,
+            ),
         )
     ])
     fake_client = _FakeApiClient(fake_device)
@@ -79,6 +102,7 @@ async def test_fetch_hourly_chunks_above_8_days():
             interval_minutes=60, entries=[],
         ),
     ])
+    # Note: entries is empty here on purpose; the test only counts the API calls.
     fake_client = _FakeApiClient(fake_device)
     fetcher = TapoHistoryFetcher(client_factory=lambda email, pw: fake_client)
 
@@ -98,7 +122,10 @@ async def test_fetch_monthly_single_year():
         _FakeEnergyDataResult(
             start_dt=datetime(2026, 1, 1, tzinfo=timezone.utc),
             interval_minutes=43200,  # 30 days in minutes -- tapo's monthly convention
-            entries=[100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210],
+            entries=_monthly_entries(
+                2026,
+                [100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210],
+            ),
         )
     ])
     fake_client = _FakeApiClient(fake_device)


### PR DESCRIPTION
## Summary

Follow-up hotfix to #88. Production now responds **500** instead of returning 0 buckets, because `EnergyDataResult.entries` is `list[EnergyDataIntervalResult]` (a struct), not `list[int]`. Doing `wh / 1000.0` on the struct raises `TypeError` which is not caught in the route handler, so it surfaces as a generic FastAPI 500 with a 21-byte body.

## Real library shape (confirmed via dir() on the installed wheel)

```rust
pub struct EnergyDataResult {
    pub local_time: NaiveDateTime,
    pub start_date_time: DateTime<Utc>,
    pub entries: Vec<EnergyDataIntervalResult>,  // <- struct, not int
    pub interval_length: u64,
}

pub struct EnergyDataIntervalResult {
    pub start_date_time: DateTime<Utc>,
    pub energy: u64,  // Wh
}
```

Each entry already carries its correct UTC-aligned bucket start, so the previous \"step from start_date_time by interval_length * idx\" math is dead code — even better, it removes the only place where monthly bucket length (irregular!) had to be approximated.

## Changes

- `backend/app/plugins/installed/tapo_smart_plug/history.py` — `_buckets_from_result` now reads per-entry `start_date_time` and `energy`; UTC fallback retained as defensive code; the `bucket_minutes` parameter is kept for signature stability but is no longer used internally
- `backend/tests/plugins/tapo_smart_plug/test_history_fetcher.py` — fake `_FakeIntervalEntry` introduced; `_hourly_entries` and `_monthly_entries` helpers build realistic structs; the three existing tests pass against the new shape

## Test plan

- [x] `pytest tests/plugins/tapo_smart_plug/test_history_fetcher.py` — 3/3 pass
- [ ] **Live retest on prod**: import 1 day hourly, expect HTTP 200 with `buckets_fetched: 24` and 24 inserted `SmartDeviceSample` rows aligned to whole UTC hours

## Defensive backstop (not in this PR)

The route handler currently only catches `RuntimeError`. Any other exception (like the `TypeError` here) escapes to FastAPI's default handler and becomes a generic 500. Worth a separate small PR to broaden the catch to `Exception` and return a structured error message — happy to do that as a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)