### PR TITLE
ci: parallelize backend tests with pytest-xdist (~3x speedup)

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -26,7 +26,9 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Run tests
-        run: python -m pytest -q --timeout=120
+        # -n auto: parallelize across all available cores via pytest-xdist
+        # --no-cov: coverage disabled in CI for speed; run locally if needed
+        run: python -m pytest -q --timeout=120 -n auto --no-cov
         env:
           NAS_MODE: dev
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -57,7 +57,8 @@ dev = [
   "qrcode>=7.0.0",
   "apscheduler>=3.10.0,<4.0.0",
   "pytest-timeout>=2.2.0,<3.0.0",
-  "pytest-cov>=7.0.0,<8.0.0"
+  "pytest-cov>=7.0.0,<8.0.0",
+  "pytest-xdist>=3.6.0,<4.0.0"
 ]
 
 scheduler = [

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,11 +25,36 @@ os.environ.setdefault("NAS_QUOTA_BYTES", str(10 * 1024 * 1024 * 1024))
 # Prevent the application startup lifecycle from performing full DB init/seed during tests
 # Tests create an in-memory DB and manage schema; skip app-level init to avoid touching production DB.
 os.environ.setdefault("SKIP_APP_INIT", "1")
-# Ensure tests write storage into a temporary directory (avoids protected program folders)
-_tmp_storage = tempfile.mkdtemp(prefix="baluhost_test_storage_")
-os.environ.setdefault("NAS_STORAGE_PATH", _tmp_storage)
-os.environ.setdefault("NAS_TEMP_PATH", tempfile.mkdtemp(prefix="baluhost_test_tmp_"))
-os.environ.setdefault("NAS_BACKUP_PATH", tempfile.mkdtemp(prefix="baluhost_test_backups_"))
+# Per-worker isolation for storage directories and the SQLite DB. xdist
+# workers inherit env vars from the controller, so plain `setdefault` would
+# keep all workers pointing at the controller's path and they'd race on the
+# same `<temp>/baluhost.db`. We key on PYTEST_XDIST_WORKER (set inside
+# workers, "main" otherwise) and force-override env in xdist workers so each
+# worker gets its own tempdirs and DB file. Sequential runs keep the
+# `setdefault` semantics so a user-supplied DATABASE_URL or NAS_STORAGE_PATH
+# still wins.
+_xdist_worker_id = os.environ.get("PYTEST_XDIST_WORKER", "main")
+_force_isolation = _xdist_worker_id != "main"
+
+
+def _setenv(key: str, value: str) -> None:
+    if _force_isolation or key not in os.environ:
+        os.environ[key] = value
+
+
+_tmp_storage = tempfile.mkdtemp(prefix=f"baluhost_test_storage_{_xdist_worker_id}_")
+_setenv("NAS_STORAGE_PATH", _tmp_storage)
+_setenv("NAS_TEMP_PATH", tempfile.mkdtemp(prefix=f"baluhost_test_tmp_{_xdist_worker_id}_"))
+_setenv("NAS_BACKUP_PATH", tempfile.mkdtemp(prefix=f"baluhost_test_backups_{_xdist_worker_id}_"))
+# Override DATABASE_URL so tests that import `app.core.database.engine`
+# directly (power command queue, GPU manager) get a worker-isolated SQLite
+# file instead of the default `<temp>/baluhost.db` derived from
+# `nas_storage_path.parent`. Place the DB in its OWN tempdir (not under
+# NAS_STORAGE_PATH) so `scripts.debug.reset_dev_storage` — used by some
+# tests to wipe storage between runs — doesn't try to unlink the file
+# while SQLAlchemy holds it open (Windows: PermissionError).
+_tmp_db_dir = tempfile.mkdtemp(prefix=f"baluhost_test_db_{_xdist_worker_id}_")
+_setenv("DATABASE_URL", f"sqlite:///{_tmp_db_dir}/baluhost.db")
 # By default disable strict rate limits during tests to avoid flakiness.
 # Individual tests that need to assert rate-limit behavior should opt-in
 # by setting `ENABLE_RATE_LIMITS_IN_TESTS=1` in their own fixture or runtime.
@@ -92,11 +117,19 @@ except ImportError:
 
 from app.main import app
 from app.core.config import settings
-from app.core.database import get_db
+from app.core.database import get_db, engine as _global_engine
 from app.models.base import Base
 from app.models.user import User
 from app.models.file_metadata import FileMetadata
 from app.schemas.user import UserCreate
+
+# Create all tables on the per-worker global SQLite engine. Tests that import
+# `app.core.database.engine` directly (power command queue, GPU manager) and
+# bypass the function-scoped `db_session` fixture rely on the schema being
+# present. In sequential local runs this happened by accident because the
+# shared `<temp>/baluhost.db` accumulated tables across runs. With xdist each
+# worker gets a fresh DB and we must create the schema explicitly.
+Base.metadata.create_all(bind=_global_engine)
 from app.services import users as user_service
 from app.models.vpn import VPNClient
 from app.services.vpn import VPNService


### PR DESCRIPTION
## Summary
- Adds `pytest-xdist` and runs backend tests with `-n auto` in CI, dropping the suite from ~7:25 to ~2:20 on a 12-core machine.
- Disables coverage in CI (`--no-cov`); coverage is still configured in `addopts` for local runs.
- Fixes two pre-existing test-isolation bugs that surfaced under xdist:
  1. `os.environ.setdefault` in conftest was no-op'd in xdist worker subprocesses (env inherited from controller), so all workers shared the same `<temp>/baluhost.db` and raced. Now keyed on `PYTEST_XDIST_WORKER` and force-overridden in workers.
  2. The global engine's per-worker DB had no schema; sequential local runs got away with this because the shared DB accumulated tables across sessions. Now `Base.metadata.create_all(engine)` runs in conftest after env is set.
- Moves the per-worker DB into its own tempdir so `scripts.debug.reset_dev_storage` doesn't unlink it while SQLAlchemy holds it open (Windows `PermissionError`).

## Test plan
- [x] Local sequential baseline: ~7:25 with 3 xdist-specific failures
- [x] Local parallel with fixes: 2769 passed, 22 skipped, 0 failures in 2:20
- [x] Verified the 3 originally-failing tests (`test_power_command_queue.py` and `test_manager_multi_worker.py`) now pass under both isolated and full-suite xdist runs
- [ ] First CI run on this PR — confirm Ubuntu/Linux behaves the same as local Windows; ubuntu-latest has 4 cores so expect ~4x not 12x speedup
- [ ] Watch for flaky-test reports in the next few merges; some tests may have isolation issues that only surface under specific worker counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)