### PR TITLE
fix(sleep): always-awake holds logind inhibitor like core-uptime

### DIFF
--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -320,6 +320,35 @@ class SleepManagerService:
             logger.warning("Failed to load core uptime windows: %s", e)
             return False, []
 
+    def _reconcile_sleep_inhibitor(self, config, in_core: bool) -> None:
+        """Converge the logind block-sleep inhibitor to the desired state.
+
+        The inhibitor is held while EITHER an active core-uptime window OR an
+        active Always-Awake override is in effect. Both conditions block
+        third-party suspend (logind idle, desktop daemons, manual systemctl
+        suspend) at the logind layer. Releasing/acquiring is idempotent.
+
+        Args:
+            config: SleepConfig row (or None — treated as nothing active).
+            in_core: Whether we are currently inside a core-uptime window.
+                     Caller passes the already-computed value to avoid
+                     re-querying the DB on every tick.
+        """
+        core_active = bool(in_core)
+        aa_active = self._is_always_awake(config)
+        should_hold = core_active or aa_active
+
+        if should_hold and not self._core_uptime_inhibitor.is_held():
+            if core_active and aa_active:
+                reason = "core_uptime_and_always_awake_active"
+            elif aa_active:
+                reason = "always_awake_active"
+            else:
+                reason = "core_uptime_active"
+            self._core_uptime_inhibitor.acquire(reason)
+        elif not should_hold and self._core_uptime_inhibitor.is_held():
+            self._core_uptime_inhibitor.release()
+
     def _next_core_start_for_guard(self) -> Optional[datetime]:
         """Provider used by CoreUptimeRtcGuard. Returns None on any failure
         so the guard cleanly skips arming the RTC."""

--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -543,13 +543,10 @@ class SleepManagerService:
                     await self.exit_soft_sleep("core_uptime_started")
 
                 # Logind inhibitor management — converged to the desired state
-                # every tick so a crashed inhibitor subprocess gets re-acquired
-                # and a master-toggle-off promptly releases.
-                should_hold = master and in_core
-                if should_hold and not self._core_uptime_inhibitor.is_held():
-                    self._core_uptime_inhibitor.acquire("core_uptime_active")
-                elif not should_hold and self._core_uptime_inhibitor.is_held():
-                    self._core_uptime_inhibitor.release()
+                # every tick so a crashed inhibitor subprocess gets re-acquired,
+                # a master-toggle-off promptly releases, and Always-Awake also
+                # blocks third-party suspends.
+                self._reconcile_sleep_inhibitor(config, in_core=in_core)
 
                 # Track edge state regardless. When master is off we force False so
                 # that re-enabling the toggle while inside an active window registers

--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -666,10 +666,21 @@ class SleepManagerService:
         4. Spin down data disks
         5. Log state change
         """
-        # Clear always-awake override if set: manual sleep ends the override
+        # Clear always-awake override if set: manual sleep ends the override.
+        # Then reconcile the inhibitor synchronously so a manual sleep is not
+        # blocked by our own logind lock during the gap before the next loop tick.
         config_check = self._load_config()
         if config_check and self._is_always_awake(config_check):
             self._clear_always_awake("always_awake_cleared_by_sleep")
+            config_check = self._load_config()
+            try:
+                master, windows = self._load_core_uptime()
+                in_core = False
+                if master:
+                    in_core, _ = core_uptime_helpers.is_in_core_uptime(datetime.now(), windows)
+                self._reconcile_sleep_inhibitor(config_check, in_core=in_core)
+            except Exception as exc:
+                logger.warning("Post-clear inhibitor reconcile failed (soft sleep): %s", exc)
 
         if self._current_state != SleepState.AWAKE:
             logger.warning("Cannot enter soft sleep from state %s", self._current_state)
@@ -941,10 +952,21 @@ class SleepManagerService:
         If awake, enters soft sleep first.
         Then suspends the system.
         """
-        # Clear always-awake override if set: manual suspend ends the override
+        # Clear always-awake override if set: manual suspend ends the override.
+        # Then reconcile the inhibitor synchronously so a manual suspend reaches
+        # the backend before the next loop tick (logind would otherwise refuse).
         config_check = self._load_config()
         if config_check and self._is_always_awake(config_check):
             self._clear_always_awake("always_awake_cleared_by_sleep")
+            config_check = self._load_config()
+            try:
+                master, windows = self._load_core_uptime()
+                in_core_after = False
+                if master:
+                    in_core_after, _ = core_uptime_helpers.is_in_core_uptime(datetime.now(), windows)
+                self._reconcile_sleep_inhibitor(config_check, in_core=in_core_after)
+            except Exception as exc:
+                logger.warning("Post-clear inhibitor reconcile failed (true suspend): %s", exc)
 
         prev_state = self._current_state
 

--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -196,18 +196,20 @@ class SleepManagerService:
             # Start schedule check loop
             self._schedule_task = asyncio.create_task(self._schedule_check_loop())
 
-            # If service starts INSIDE a core-uptime window, immediately acquire
-            # the logind inhibitor — the schedule loop only fires in 60s and an
-            # idle desktop daemon could suspend us before the first tick.
+            # If service starts INSIDE a core-uptime window OR with Always-Awake
+            # active, immediately reconcile the logind inhibitor — the schedule
+            # loop only fires in 60s and an idle desktop daemon could suspend us
+            # before the first tick.
             try:
                 master, windows = self._load_core_uptime()
+                in_core = False
                 if master:
                     in_core, _ = core_uptime_helpers.is_in_core_uptime(datetime.now(), windows)
-                    if in_core:
-                        self._core_uptime_inhibitor.acquire("startup_in_core_uptime")
-                        self._was_in_core_uptime = True
+                self._reconcile_sleep_inhibitor(config, in_core=in_core)
+                if master and in_core:
+                    self._was_in_core_uptime = True
             except Exception as exc:
-                logger.warning("Initial core-uptime inhibitor check failed: %s", exc)
+                logger.warning("Initial sleep inhibitor reconcile failed: %s", exc)
 
         logger.info("Sleep manager started (monitoring=%s, auto_idle=%s, schedule=%s)",
                      monitoring,

--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -149,9 +149,11 @@ class SleepManagerService:
         self._error_count: int = 0
         self._last_error: Optional[str] = None
         self._last_error_at: Optional[datetime] = None
-        # Logind block-sleep inhibitor — held while inside an active core-uptime
-        # window so third-party suspend (mate-screensaver, gnome-power-manager,
-        # logind idle, manual `systemctl suspend`) is refused by logind.
+        # Logind block-sleep inhibitor — held while EITHER an active core-uptime
+        # window OR an Always-Awake override is in effect. Both reasons block
+        # third-party suspend (mate-screensaver, gnome-power-manager, logind
+        # idle, manual `systemctl suspend`) at the logind layer. Reconciled
+        # every schedule-loop tick by `_reconcile_sleep_inhibitor`.
         self._core_uptime_inhibitor = CoreUptimeInhibitor()
         self._baluhost_suspend_in_progress: bool = False
         self._core_uptime_rtc_guard = CoreUptimeRtcGuard(

--- a/backend/tests/services/test_sleep_always_awake.py
+++ b/backend/tests/services/test_sleep_always_awake.py
@@ -529,3 +529,42 @@ async def test_start_acquires_inhibitor_when_always_awake_active():
         await svc.start(monitoring=True)
 
     fake_inhibitor.acquire.assert_called_once_with("always_awake_active")
+
+
+@pytest.mark.asyncio
+async def test_enter_true_suspend_releases_inhibitor_before_backend_call():
+    """Manual suspend while Always-Awake is on must release the inhibitor BEFORE backend.suspend_system runs,
+    so logind doesn't refuse the suspend."""
+    svc = _build_service()
+    cfg = _config(always_awake_enabled=True, always_awake_until=None)
+
+    # Track call order: inhibitor release vs backend suspend
+    call_order: list[str] = []
+
+    fake_inhibitor = MagicMock()
+    fake_inhibitor.is_held.return_value = True
+    fake_inhibitor.release.side_effect = lambda: call_order.append("release")
+    svc._core_uptime_inhibitor = fake_inhibitor
+
+    async def fake_suspend(*a, **k):
+        call_order.append("suspend")
+        return True
+
+    svc._current_state = SleepState.SOFT_SLEEP
+
+    # _is_always_awake: first call (outer guard) → True so the if-block runs and
+    # _clear_always_awake is called; second call (inside _reconcile_sleep_inhibitor
+    # after the clear) → False so reconcile decides to release the inhibitor.
+    aa_responses = iter([True, False])
+
+    with patch.object(svc, "_load_config", return_value=cfg), \
+         patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
+         patch.object(svc, "_clear_always_awake", new=MagicMock()), \
+         patch.object(svc, "_log_state_change", new=MagicMock()), \
+         patch.object(svc, "_is_always_awake", side_effect=lambda _cfg: next(aa_responses)), \
+         patch.object(svc._backend, "suspend_system", new=AsyncMock(side_effect=fake_suspend)):
+        await svc.enter_true_suspend("test", SleepTrigger.MANUAL)
+
+    assert call_order == ["release", "suspend"], (
+        f"Expected release before suspend, got {call_order}"
+    )

--- a/backend/tests/services/test_sleep_always_awake.py
+++ b/backend/tests/services/test_sleep_always_awake.py
@@ -478,3 +478,35 @@ def test_reconcile_inhibitor_reason_when_both_active():
     svc._reconcile_sleep_inhibitor(cfg, in_core=True)
 
     fake_inhibitor.acquire.assert_called_once_with("core_uptime_and_always_awake_active")
+
+
+@pytest.mark.asyncio
+async def test_schedule_loop_calls_reconcile_inhibitor_each_tick():
+    """Every schedule-loop tick must call _reconcile_sleep_inhibitor with the current (config, in_core)."""
+    svc = _build_service()
+    cfg = _config(always_awake_enabled=True, always_awake_until=None)
+
+    reconcile_calls = []
+
+    def fake_reconcile(c, in_core):
+        reconcile_calls.append((c, in_core))
+
+    svc._reconcile_sleep_inhibitor = fake_reconcile
+    svc._is_running = True
+    svc._current_state = SleepState.AWAKE
+
+    call_count = [0]
+
+    async def fake_sleep(*_a, **_k):
+        call_count[0] += 1
+        if call_count[0] >= 2:
+            svc._is_running = False
+
+    with patch.object(svc, "_load_config", return_value=cfg), \
+         patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
+         patch("app.services.power.sleep.asyncio.sleep", side_effect=fake_sleep):
+        await svc._schedule_check_loop()
+
+    assert len(reconcile_calls) == 1
+    assert reconcile_calls[0][0] is cfg
+    assert reconcile_calls[0][1] is False

--- a/backend/tests/services/test_sleep_always_awake.py
+++ b/backend/tests/services/test_sleep_always_awake.py
@@ -417,3 +417,18 @@ def test_update_config_disabling_normalizes_until():
 
     assert fake_row.always_awake_enabled is False
     assert fake_row.always_awake_until is None
+
+
+def test_reconcile_inhibitor_acquires_for_always_awake_only():
+    """When only Always-Awake is active (no core uptime), the sleep inhibitor must be acquired."""
+    svc = _build_service()
+    cfg = _config(always_awake_enabled=True, always_awake_until=None)
+
+    fake_inhibitor = MagicMock()
+    fake_inhibitor.is_held.return_value = False
+    svc._core_uptime_inhibitor = fake_inhibitor
+
+    svc._reconcile_sleep_inhibitor(cfg, in_core=False)
+
+    fake_inhibitor.acquire.assert_called_once_with("always_awake_active")
+    fake_inhibitor.release.assert_not_called()

--- a/backend/tests/services/test_sleep_always_awake.py
+++ b/backend/tests/services/test_sleep_always_awake.py
@@ -510,3 +510,22 @@ async def test_schedule_loop_calls_reconcile_inhibitor_each_tick():
     assert len(reconcile_calls) == 1
     assert reconcile_calls[0][0] is cfg
     assert reconcile_calls[0][1] is False
+
+
+@pytest.mark.asyncio
+async def test_start_acquires_inhibitor_when_always_awake_active():
+    """If the service starts while Always-Awake is on, the inhibitor must be acquired at startup."""
+    svc = _build_service()
+    cfg = _config(always_awake_enabled=True, always_awake_until=None)
+
+    fake_inhibitor = MagicMock()
+    fake_inhibitor.is_held.return_value = False
+    svc._core_uptime_inhibitor = fake_inhibitor
+
+    with patch.object(svc, "_load_config", return_value=cfg), \
+         patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
+         patch.object(svc._core_uptime_rtc_guard, "start", new=AsyncMock()), \
+         patch("app.services.power.sleep.asyncio.create_task", side_effect=lambda coro: coro.close() or None):
+        await svc.start(monitoring=True)
+
+    fake_inhibitor.acquire.assert_called_once_with("always_awake_active")

--- a/backend/tests/services/test_sleep_always_awake.py
+++ b/backend/tests/services/test_sleep_always_awake.py
@@ -432,3 +432,49 @@ def test_reconcile_inhibitor_acquires_for_always_awake_only():
 
     fake_inhibitor.acquire.assert_called_once_with("always_awake_active")
     fake_inhibitor.release.assert_not_called()
+
+
+def test_reconcile_inhibitor_releases_when_nothing_active():
+    """When neither core-uptime nor always-awake is active, an held inhibitor must be released."""
+    svc = _build_service()
+    cfg = _config(always_awake_enabled=False, always_awake_until=None)
+
+    fake_inhibitor = MagicMock()
+    fake_inhibitor.is_held.return_value = True
+    svc._core_uptime_inhibitor = fake_inhibitor
+
+    svc._reconcile_sleep_inhibitor(cfg, in_core=False)
+
+    fake_inhibitor.release.assert_called_once_with()
+    fake_inhibitor.acquire.assert_not_called()
+
+
+def test_reconcile_inhibitor_keeps_held_when_one_of_two_remains_active():
+    """Releasing only one of (core_uptime, always_awake) while the other stays active must NOT release."""
+    svc = _build_service()
+    cfg = _config(always_awake_enabled=True, always_awake_until=None)
+
+    fake_inhibitor = MagicMock()
+    fake_inhibitor.is_held.return_value = True
+    svc._core_uptime_inhibitor = fake_inhibitor
+
+    # core uptime has ended (in_core=False) but always-awake is still on
+    svc._reconcile_sleep_inhibitor(cfg, in_core=False)
+
+    fake_inhibitor.release.assert_not_called()
+    # already held; reconcile should not re-acquire either
+    fake_inhibitor.acquire.assert_not_called()
+
+
+def test_reconcile_inhibitor_reason_when_both_active():
+    """If both core-uptime and always-awake are active, the acquire reason must reflect both."""
+    svc = _build_service()
+    cfg = _config(always_awake_enabled=True, always_awake_until=None, core_uptime_enabled=True)
+
+    fake_inhibitor = MagicMock()
+    fake_inhibitor.is_held.return_value = False
+    svc._core_uptime_inhibitor = fake_inhibitor
+
+    svc._reconcile_sleep_inhibitor(cfg, in_core=True)
+
+    fake_inhibitor.acquire.assert_called_once_with("core_uptime_and_always_awake_active")


### PR DESCRIPTION
## Summary
- Always-Awake currently only suppresses BaluHost's internal auto-sleep paths (`_idle_detection_loop`, `_schedule_check_loop`, `_escalation_monitor`). External suspend triggers — logind idle, desktop session daemons (mate-screensaver, gnome-power-manager, KDE), manual `systemctl suspend` outside BaluHost — went through unimpeded. That is why the user observes Always-Awake "being ignored" in practice while Kernbetriebszeit (which holds a `systemd-inhibit --mode=block --what=sleep` lock) works in production.
- This PR makes Always-Awake reuse the same `CoreUptimeInhibitor` mechanism via a new `_reconcile_sleep_inhibitor(config, in_core)` helper. The inhibitor is held whenever **either** condition is active and released only when **both** are off. Manual sleep/suspend paths now reconcile the inhibitor synchronously after `_clear_always_awake` so they are not blocked by our own lock.

## Files touched
- `backend/app/services/power/sleep.py` — new helper, wired into `start()`, `_schedule_check_loop`, `enter_soft_sleep`, `enter_true_suspend`; docstring update on the `_core_uptime_inhibitor` field.
- `backend/tests/services/test_sleep_always_awake.py` — added 7 tests covering acquire/release/dual-active/startup/manual-suspend-ordering.

## Plan
`docs/superpowers/plans/2026-05-14-always-awake-logind-inhibitor.md`

## Test plan
- [x] `pytest tests/services/test_sleep_always_awake.py tests/services/test_sleep_core_uptime_integration.py` — 51 green locally
- [x] Focused sleep + power suite (`tests/services/test_sleep_*.py`, `tests/api/test_sleep_*.py`, `tests/test_sleep_schemas.py`, `tests/services/power/`) — 165 passed in 25s locally
- [ ] CI: full backend pytest run
- [ ] Production verification (post-merge): with Always-Awake on, leave the box idle past its logind `IdleAction=suspend` timeout; system should stay awake. `journalctl -u systemd-logind` should show inhibitor refusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)