### PR TITLE
fix(sleep): detect KDE/GNOME via pgrep (session-bus inaccessible to systemd unit)

### DIFF
--- a/backend/app/services/power/os_auto_suspend.py
+++ b/backend/app/services/power/os_auto_suspend.py
@@ -345,8 +345,14 @@ import threading  # noqa: E402
 from time import monotonic  # noqa: E402
 
 _SYSTEMD_DIR = Path("/etc/systemd")
-_DBUS_PROBE_TIMEOUT = 2.0
+_PGREP_TIMEOUT = 2.0
 _DETECT_CACHE_TTL = 30.0
+
+# Process names that indicate an active KDE / GNOME desktop session.
+# Probed via `pgrep -x` because systemd-managed backend services do not
+# inherit DBUS_SESSION_BUS_ADDRESS and cannot reach the session bus.
+_KDE_INDICATOR_PROCS = ("kwin_wayland", "kwin_x11", "plasmashell")
+_GNOME_INDICATOR_PROCS = ("gnome-shell", "gsd-power")
 
 _detect_lock = threading.Lock()
 _detect_cache: tuple[Optional[OsAutoSuspendBackend], float] | None = None
@@ -359,19 +365,28 @@ def _detector_cache_clear() -> None:
         _detect_cache = None
 
 
-def _probe_dbus_service(service: str) -> bool:
-    """True if `service` is reachable on the session bus."""
-    try:
-        proc = subprocess.run(
-            ["qdbus6", service],
-            capture_output=True, text=True,
-            timeout=_DBUS_PROBE_TIMEOUT, check=False,
-        )
-        return proc.returncode == 0
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        return False
-    except OSError:
-        return False
+def _pgrep_any(names: tuple[str, ...]) -> bool:
+    """True if any of the named processes is currently running."""
+    for name in names:
+        try:
+            proc = subprocess.run(
+                ["pgrep", "-x", name],
+                capture_output=True, text=True,
+                timeout=_PGREP_TIMEOUT, check=False,
+            )
+            if proc.returncode == 0:
+                return True
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            continue
+    return False
+
+
+def _kde_session_active() -> bool:
+    return _pgrep_any(_KDE_INDICATOR_PROCS)
+
+
+def _gnome_session_active() -> bool:
+    return _pgrep_any(_GNOME_INDICATOR_PROCS)
 
 
 def detect_active_backend() -> Optional[OsAutoSuspendBackend]:
@@ -386,9 +401,9 @@ def detect_active_backend() -> Optional[OsAutoSuspendBackend]:
                 return backend
 
         backend: Optional[OsAutoSuspendBackend] = None
-        if _probe_dbus_service("org.kde.Solid.PowerManagement"):
+        if _kde_session_active():
             backend = KdeAdapter()
-        elif _probe_dbus_service("org.gnome.SettingsDaemon.Power"):
+        elif _gnome_session_active():
             backend = GnomeAdapter()
         elif _SYSTEMD_DIR.is_dir():
             backend = LogindAdapter()

--- a/backend/tests/services/power/test_os_auto_suspend_detector.py
+++ b/backend/tests/services/power/test_os_auto_suspend_detector.py
@@ -11,23 +11,26 @@ class TestDetector:
         monkeypatch.setattr(sys, "platform", "win32")
         assert oas.detect_active_backend() is None
 
-    def test_prefers_kde_when_dbus_says_yes(self, monkeypatch):
+    def test_prefers_kde_when_kwin_running(self, monkeypatch):
         monkeypatch.setattr(sys, "platform", "linux")
-        monkeypatch.setattr(oas, "_probe_dbus_service", lambda svc: svc == "org.kde.Solid.PowerManagement")
+        monkeypatch.setattr(oas, "_kde_session_active", lambda: True)
+        monkeypatch.setattr(oas, "_gnome_session_active", lambda: False)
         b = oas.detect_active_backend()
         assert b is not None
         assert b.name == "kde"
 
     def test_falls_back_to_gnome(self, monkeypatch):
         monkeypatch.setattr(sys, "platform", "linux")
-        monkeypatch.setattr(oas, "_probe_dbus_service", lambda svc: svc == "org.gnome.SettingsDaemon.Power")
+        monkeypatch.setattr(oas, "_kde_session_active", lambda: False)
+        monkeypatch.setattr(oas, "_gnome_session_active", lambda: True)
         b = oas.detect_active_backend()
         assert b is not None
         assert b.name == "gnome"
 
     def test_falls_back_to_logind_when_no_de(self, monkeypatch, tmp_path):
         monkeypatch.setattr(sys, "platform", "linux")
-        monkeypatch.setattr(oas, "_probe_dbus_service", lambda svc: False)
+        monkeypatch.setattr(oas, "_kde_session_active", lambda: False)
+        monkeypatch.setattr(oas, "_gnome_session_active", lambda: False)
         etc_systemd = tmp_path / "systemd"
         etc_systemd.mkdir()
         monkeypatch.setattr(oas, "_SYSTEMD_DIR", etc_systemd)
@@ -37,11 +40,12 @@ class TestDetector:
 
     def test_returns_none_when_nothing_detected(self, monkeypatch, tmp_path):
         monkeypatch.setattr(sys, "platform", "linux")
-        monkeypatch.setattr(oas, "_probe_dbus_service", lambda svc: False)
+        monkeypatch.setattr(oas, "_kde_session_active", lambda: False)
+        monkeypatch.setattr(oas, "_gnome_session_active", lambda: False)
         monkeypatch.setattr(oas, "_SYSTEMD_DIR", tmp_path / "nope")
         assert oas.detect_active_backend() is None
 
-    def test_dbus_timeout_treated_as_unavailable(self, monkeypatch):
+    def test_pgrep_timeout_treated_as_unavailable(self, monkeypatch):
         import subprocess as sp
         monkeypatch.setattr(sys, "platform", "linux")
         def fake_run(args, **kwargs):
@@ -50,13 +54,20 @@ class TestDetector:
         # Should not raise; should return None or fall through to logind
         oas.detect_active_backend()  # just no exception
 
+    def test_pgrep_missing_treated_as_unavailable(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        def fake_run(args, **kwargs):
+            raise FileNotFoundError("pgrep not installed")
+        monkeypatch.setattr(oas.subprocess, "run", fake_run)
+        oas.detect_active_backend()  # no exception; returns None or logind fallback
+
     def test_cache_within_ttl(self, monkeypatch):
         monkeypatch.setattr(sys, "platform", "linux")
         calls = {"n": 0}
-        def probe(svc):
+        def probe():
             calls["n"] += 1
-            return svc == "org.kde.Solid.PowerManagement"
-        monkeypatch.setattr(oas, "_probe_dbus_service", probe)
+            return True
+        monkeypatch.setattr(oas, "_kde_session_active", probe)
         oas.detect_active_backend()
         oas.detect_active_backend()
         oas.detect_active_backend()


### PR DESCRIPTION
## Summary

Detector in `os_auto_suspend.py` used `qdbus6 <service>` to probe the session bus for KDE/GNOME. `baluhost-backend.service` runs as `user` UID 1000 but as a system-managed systemd unit, so `DBUS_SESSION_BUS_ADDRESS` is not in its env and `qdbus6` cannot reach the session bus. On prod (Debian 13 + KDE Plasma 6), this made the detector fall through to the logind fallback even though KDE PowerDevil was the actual idle-suspend driver.

## Fix

Replace the D-Bus probe with `pgrep -x <name>` against the characteristic processes:

- **KDE:** `kwin_wayland`, `kwin_x11`, `plasmashell`
- **GNOME:** `gnome-shell`, `gsd-power`

`pgrep` reads `/proc` directly, so no session bus is required. The detection cache (30s) is unchanged.

## What's unaffected

- **KDE read/write path** — uses direct file IO on `~/.config/powerdevilrc`, no DBus needed
- **logind read/write path** — already uses the sudo helper, not DBus
- **GNOME read/write path** — still uses `gsettings`, which itself depends on session bus / dconf-service. If a GNOME deployment ever surfaces, that's a follow-up — out of scope here

## Verified on prod (PR #93 deploy)

```bash
$ pgrep -ax kwin_wayland
2468 /usr/bin/kwin_wayland --wayland-fd 7 ...
$ pgrep -ax plasmashell
2994 /usr/bin/plasmashell --no-respawn
```

Before fix: `curl /api/system/sleep/os-auto-suspend` returned `source: "logind"`.
After fix: should return `source: "kde"` with `backend_label: "KDE PowerDevil"`.

## Test plan

- [x] 52 backend tests in `tests/services/power/test_os_auto_suspend_*.py` + inspector extension all green locally
- [ ] CI `backend-tests`
- [ ] Manual prod smoke after merge:
  ```bash
  curl -s -H "Authorization: Bearer $TOKEN" \
    http://localhost:8000/api/system/sleep/os-auto-suspend | jq
  # expect: source="kde", backend_label="KDE PowerDevil"
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)