### PR TITLE
fix: chunked_upload event-loop teardown + Tauri icon RGBA

### DIFF
--- a/backend/tests/files/test_chunked_upload.py
+++ b/backend/tests/files/test_chunked_upload.py
@@ -26,8 +26,15 @@ def manager():
     """Create a fresh ChunkedUploadManager for each test."""
     mgr = ChunkedUploadManager()
     yield mgr
-    # Clean up any temp files
-    asyncio.get_event_loop().run_until_complete(mgr.shutdown())
+    # Clean up any temp files. asyncio.get_event_loop() raises in Py 3.11+
+    # when no loop is current in the main thread (which happens when a prior
+    # test on the same xdist worker closed its loop), so explicitly create a
+    # fresh one for the shutdown coroutine.
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(mgr.shutdown())
+    finally:
+        loop.close()
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Two post-merge fixups for #99 (Tauri Companion + local-channel gate):

### 1. `chunked_upload` fixture teardown — `RuntimeError: no current event loop`

`tests/files/test_chunked_upload.py:30` uses the deprecated `asyncio.get_event_loop()` pattern which raises on Python 3.11+ when no loop is set on the main thread. Latent bug — pytest-xdist used to schedule it on a worker with an active loop, but #99's 80+ new tests shifted xdist's distribution and now place a loop-closing test before it on gw3. All 19 tests in the file errored in CI.

Fix: explicit `asyncio.new_event_loop()` / `loop.close()` pair so the fixture is self-contained.

### 2. Tauri icon — `is not RGBA`

`tauri::generate_context!()` macro panics during the Tauri build:
```
proc macro panicked
help: message: icon /home/runner/work/BaluHost/BaluHost/client/src-tauri/icons/icon.png is not RGBA
```

Task 23 generated the placeholder via `Image.new('RGB', ...)` (3-channel). Tauri 2 requires RGBA.

Fix: regenerated as `Image.new('RGBA', (1024,1024), (40,80,180,255))`.

## Test plan

- [x] `cd backend && python -m pytest tests/files/test_chunked_upload.py -v` → **19 passed** locally
- [x] `python -c "from PIL import Image; print(Image.open('client/src-tauri/icons/icon.png').mode)"` → `RGBA`
- [ ] CI `backend-tests` no longer reports 19 errors
- [ ] CI `Tauri Build` produces .deb + AppImage successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)