### PR TITLE
fix(tauri): drop strict CSP that blocked initialization_script

### DIFF
--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -12,7 +12,7 @@
   "app": {
     "windows": [],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' http://127.0.0.1:*; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self'"
+      "csp": null
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

The Companion app's webview never received `window.__BALU_API_BASE__`, so the React bundle's axios instance fell back to `baseURL=""`, sent API calls to `tauri://localhost/api/...`, and showed the "Backend nicht erreichbar" state — even though the UDS-backed `baluhost-backend-local.service` is up and reachable.

## Root cause

The previous CSP in `client/src-tauri/tauri.conf.json` set `script-src 'self'` without `'unsafe-inline'`. WebKitGTK silently drops the `webkit_user_content_manager` script that Tauri 2 uses to honor `WebviewWindowBuilder::initialization_script` when the document CSP is that strict (known `wry` interaction with WebKitGTK 4.1). Result: `init_script` runs through Rust fine, but the script never executes in the webview document context, leaving `window.__BALU_API_BASE__` undefined.

## Evidence collected locally (BaluHost prod, branch `main` @ 6e5828b9)

| Check | Result |
|---|---|
| `curl --unix-socket /run/baluhost/local.sock http://localhost/api/health` | `200 OK` |
| Direct `curl http://127.0.0.1:<tauri-proxy-port>/api/health` while app running | `200 OK` (so the Rust TCP→UDS proxy is fine) |
| TCP connections from `WebKitNetworkProcess` to the proxy port over 4s | **0** |
| Backend journal during app lifetime | no HTTP requests, only background tasks |
| Frontend bundle reads `window.__BALU_API_BASE__` | yes (confirmed in `index-O5YE4nzu.js`) |
| Init-script embedded in binary | yes (visible in `strings`) |

The proxy works, the backend works, the frontend is wired correctly — only the bridge variable is missing in the webview. CSP is the only mechanism that can silently swallow an injected user-script while letting the bundle scripts load.

## Fix

Setting `"csp": null`. Acceptable here because:

- The webview loads **only embedded assets** from the bundle's custom protocol — no third-party origins
- Backend access is gated by the UDS socket (per-user filesystem permission), not by web CSP
- The previous CSP was strict enough to be self-defeating but didn't actually constrain any real attack surface specific to this app

## Test plan

- [ ] `tauri-build.yml` builds `.deb` for the Companion
- [ ] Install the new `.deb` on BaluHost: `sudo dpkg -i baluhost-companion_*.deb`
- [ ] Launch `baluhost-companion`, confirm login screen reaches backend (no "Backend nicht erreichbar")
- [ ] Spot-check: `ss -tnp | grep <proxy-port>` shows active connections from WebKitNetworkProcess while the app runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)