### PR TITLE
fix(tauri): drop /api from injected base URL; restore CSP

### DIFF
--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -25,8 +25,11 @@ pub fn run() {
         .block_on(async { proxy::start(uds_path).await })
         .expect("proxy startup failed");
 
+    // No `/api` suffix: the React client already prefixes paths with `/api`
+    // (see api.ts), so the base URL must be the proxy origin only, otherwise
+    // axios produces `/api/api/...` and the backend returns 404.
     let init_script = format!(
-        "window.__BALU_API_BASE__ = 'http://127.0.0.1:{}/api';",
+        "window.__BALU_API_BASE__ = 'http://127.0.0.1:{}';",
         proxy_port,
     );
 

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -12,7 +12,7 @@
   "app": {
     "windows": [],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; connect-src 'self' http://127.0.0.1:*; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self'"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

The real cause of \"Backend nicht erreichbar\" in the Companion app: the injected `window.__BALU_API_BASE__` ends in `/api`, but the React client paths *also* start with `/api`. axios concatenates the two and produces `GET /api/api/health`, which FastAPI returns as `404 Not Found`.

This PR also reverts the CSP change from #102. That change was based on a wrong hypothesis (CSP blocking `initialization_script`) born from a misleading `ss -tn` filter that only showed `ESTABLISHED` connections and hid the very-short-lived TIME-WAIT entries. The init script was running correctly from the start; only the URL was wrong.

## Evidence (captured live on BaluHost)

I intercepted the Companion → UDS traffic with `socat` between a logging UNIX socket and `/run/baluhost/local.sock`. Every single request from the running app looked like:

```
GET /api/api/health HTTP/1.1
origin: tauri://localhost
user-agent: Mozilla/5.0 (...) AppleWebKit/605.1.15 ... Safari/605.1.15
...
HTTP/1.1 404 Not Found
{\"detail\":\"Not Found\"}
```

…repeating every ~2 s (the React health-poll), all 404. Direct `curl http://127.0.0.1:<proxy>/api/health` from the host: 200 OK. So proxy + UDS + backend are fine, only the in-app concat is broken.

The CSP revert is verified to leave behavior unchanged: both pre- and post-CSP-fix binaries make the same ~2 conn/4 s pattern to the proxy.

## Change

- `client/src-tauri/src/lib.rs`: init script now sets the base URL to the proxy origin only (`http://127.0.0.1:<port>`), with a comment explaining the trap.
- `client/src-tauri/tauri.conf.json`: CSP restored to the pre-#102 value.

## Test plan

- [ ] `tauri-build.yml` rebuilds `.deb`/AppImage
- [ ] Install new `.deb` on BaluHost; launch `baluhost-companion`
- [ ] Verify with the logging-socat bridge: requests now appear as `GET /api/...` (single `/api`)
- [ ] Verify in-app: login screen reaches backend, login succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)