### PR TITLE
fix(tauri): rewrite Origin so backend CORS accepts proxy calls

### DIFF
--- a/client/src-tauri/src/proxy.rs
+++ b/client/src-tauri/src/proxy.rs
@@ -67,6 +67,18 @@ async fn forward(
     let target_uri: hyper::Uri = UnixUri::new(&uds_path, &path_and_query).into();
 
     let (parts, body) = req.into_parts();
+
+    // The webview runs at tauri://localhost, which is not in the backend's
+    // CORS whitelist. Override Origin to http://localhost (whitelisted) for
+    // the upstream call so the backend's CORSMiddleware accepts the request
+    // (especially preflight OPTIONS), then echo the original Origin back in
+    // the response's Access-Control-Allow-Origin so the webview's CORS check
+    // sees a matching value.
+    let original_origin = parts
+        .headers
+        .get(hyper::header::ORIGIN)
+        .cloned();
+
     let body_bytes = match body.collect().await {
         Ok(c) => c.to_bytes(),
         Err(_) => Bytes::new(),
@@ -76,8 +88,15 @@ async fn forward(
         .method(parts.method)
         .uri(target_uri);
     for (k, v) in parts.headers.iter() {
+        if k == hyper::header::ORIGIN {
+            continue;
+        }
         new_req_builder = new_req_builder.header(k, v);
     }
+    new_req_builder = new_req_builder.header(
+        hyper::header::ORIGIN,
+        hyper::header::HeaderValue::from_static("http://localhost"),
+    );
     let new_req = match new_req_builder.body(Full::new(body_bytes)) {
         Ok(r) => r,
         Err(_) => {
@@ -100,7 +119,18 @@ async fn forward(
                 body.collect().await.map(|c| c.to_bytes()).unwrap_or_default();
             let mut out = Response::builder().status(parts.status);
             for (k, v) in parts.headers.iter() {
+                // Drop the upstream Allow-Origin so we can echo the webview's
+                // real Origin (the backend saw our spoofed http://localhost).
+                if k == hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN {
+                    continue;
+                }
                 out = out.header(k, v);
+            }
+            if let Some(origin) = original_origin {
+                out = out.header(
+                    hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN,
+                    origin,
+                );
             }
             Ok(out.body(Full::new(bytes)).unwrap())
         }


### PR DESCRIPTION
## Summary

After #103 fixed the double-`/api/` path, the Companion app still rendered the \"Backend nicht erreichbar\" state. Live socat capture of the UDS traffic revealed: the webview now sends `GET /api/health` correctly, the backend answers `200 OK`, but the response is **missing `Access-Control-Allow-Origin`**.

The webview's Origin is `tauri://localhost` (the Tauri custom protocol), which is not in `CORS_ORIGINS`. FastAPI's CORSMiddleware therefore drops the Allow-Origin header. WebKit then treats the response as a CORS violation, hides the body from JS, and axios resolves to a network error.

Adding `tauri://localhost` to the production CORS whitelist would work but couples backend config to the local-only Companion app. Cleaner to handle it entirely inside the local proxy that already bridges TCP ↔ UDS.

## Change (`client/src-tauri/src/proxy.rs`)

1. **Request:** before forwarding, swap `Origin: tauri://localhost` for `Origin: http://localhost` (already whitelisted in prod). The backend processes preflight + actual request normally.
2. **Response:** drop the backend's `Access-Control-Allow-Origin: http://localhost` and replace it with `Access-Control-Allow-Origin: <original webview origin>`. WebKit's CORS check now sees an exact-match origin and lets JS read the body.

This also fixes preflight OPTIONS for non-simple requests (any POST with `Authorization`), which would otherwise fail with `400` from the middleware short-circuit.

## Test plan

- [ ] `tauri-build.yml` rebuilds `.deb`
- [ ] Install on BaluHost: `sudo dpkg -i baluhost-companion_*.deb`
- [ ] Verify via socat bridge: requests reach backend with `Origin: http://localhost`, responses leave proxy with `Access-Control-Allow-Origin: tauri://localhost`
- [ ] In-app: login screen reachable, login succeeds, no \"Backend nicht erreichbar\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)