### PR TITLE
fix(tauri): route bare fetch + URL builders through buildApiUrl

### DIFF
--- a/client/src/api/backup.ts
+++ b/client/src/api/backup.ts
@@ -2,7 +2,7 @@
  * API client for backup functionality
  */
 
-import { apiClient, memoizedApiRequest } from '../lib/api';
+import { apiClient, memoizedApiRequest, buildApiUrl } from '../lib/api';
 
 export interface Backup {
   id: number;
@@ -103,9 +103,8 @@ export async function restoreBackup(request: RestoreBackupRequest): Promise<Rest
  * Download backup file
  */
 export function getBackupDownloadUrl(backupId: number): string {
-  const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000';
   const token = localStorage.getItem('token');
-  return `${baseUrl}/api/backups/${backupId}/download?token=${token}`;
+  return `${buildApiUrl(`/api/backups/${backupId}/download`)}?token=${token}`;
 }
 
 /**

--- a/client/src/components/MockDiskWizard.tsx
+++ b/client/src/components/MockDiskWizard.tsx
@@ -1,6 +1,7 @@
 import { type FormEvent, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
+import { buildApiUrl } from '../lib/api';
 
 interface MockDiskWizardProps {
   onClose: () => void;
@@ -26,7 +27,7 @@ export default function MockDiskWizard({ onClose, onSuccess }: MockDiskWizardPro
 
     try {
       // Dev-Mode API Call (to be implemented in backend)
-      const response = await fetch('/api/system/raid/dev/add-mock-disk', {
+      const response = await fetch(buildApiUrl('/api/system/raid/dev/add-mock-disk'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/client/src/components/scheduler/MaintenancePanel.tsx
+++ b/client/src/components/scheduler/MaintenancePanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { buildApiUrl } from '../../lib/api';
 import { getRaidStatus } from '../../api/raid';
 import { fetchSmartStatus, getSmartMode, toggleSmartMode, runSmartTest } from '../../api/smart';
 import type { RaidStatusResponse, RaidArray, RaidDevice } from '../../api/raid';
@@ -119,7 +120,7 @@ export function MaintenancePanel({ addToast, schedulers, onRunNow }: Maintenance
 
   // Dev-mode detection
   const { data: modeData } = useAsyncData<{ dev_mode: boolean }>(
-    () => fetch('/api/system/mode').then(r => r.json()),
+    () => fetch(buildApiUrl('/api/system/mode')).then(r => r.json()),
   );
   const isDevMode = modeData?.dev_mode === true;
 

--- a/client/src/lib/localApi.ts
+++ b/client/src/lib/localApi.ts
@@ -7,11 +7,17 @@
  */
 
 import { getToken, storeToken, clearToken } from './secureStore';
+import { buildApiUrl } from './api';
 
-// In production: use same origin (via Nginx proxy)
-// In development: use localhost:3001
+// In Tauri Companion: window.__BALU_API_BASE__ points at the local HTTP-to-UDS
+// proxy injected by the Rust shell. In dev: hit the backend directly. In a
+// regular web build: same origin (Vite/nginx proxies relative /api).
 const isDevelopment = import.meta.env.DEV;
-const LOCAL_API_BASE = isDevelopment ? 'http://127.0.0.1:8000' : '';
+const tauriApiBase =
+  typeof window !== 'undefined' && window.__BALU_API_BASE__
+    ? window.__BALU_API_BASE__
+    : undefined;
+const LOCAL_API_BASE = tauriApiBase ?? (isDevelopment ? 'http://127.0.0.1:8000' : '');
 const API_PREFIX = '/api';
 
 export interface LocalApiConfig {
@@ -279,7 +285,7 @@ export class LocalApi {
       // Fallback for dev setup where backend runs on same origin (uvicorn on :8000)
       // or when the local HTTP proxy is not available. Attempt a same-origin call.
       try {
-        const res = await fetch(`${API_PREFIX}/system/shutdown`, {
+        const res = await fetch(buildApiUrl(`${API_PREFIX}/system/shutdown`), {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -311,7 +317,7 @@ export class LocalApi {
       return await this.request('/system/restart', { method: 'POST' });
     } catch (err) {
       try {
-        const res = await fetch(`${API_PREFIX}/system/restart`, {
+        const res = await fetch(buildApiUrl(`${API_PREFIX}/system/restart`), {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/client/src/lib/pluginLoader.ts
+++ b/client/src/lib/pluginLoader.ts
@@ -2,6 +2,7 @@
  * Plugin Loader for dynamically loading plugin UI bundles
  */
 import React from 'react';
+import { buildApiUrl } from './api';
 
 // Cache for loaded plugin modules
 const moduleCache = new Map<string, Record<string, unknown>>();
@@ -33,7 +34,7 @@ export async function loadPluginBundle(
     try {
       // Add cache-buster to force fresh load
       const cacheBuster = `?v=${Date.now()}`;
-      const bundleUrl = `/api/plugins/${pluginName}/ui/${bundlePath}${cacheBuster}`;
+      const bundleUrl = `${buildApiUrl(`/api/plugins/${pluginName}/ui/${bundlePath}`)}${cacheBuster}`;
 
       // Dynamically import the bundle
       // Using dynamic import with webpackIgnore to prevent bundler interference

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { Eye, EyeOff } from 'lucide-react';
 import type { User } from '../types/auth';
 import logoMark from '../assets/baluhost-logo.png';
 import { localApi } from '../lib/localApi';
+import { buildApiUrl } from '../lib/api';
 import { useVersion } from '../contexts/VersionContext';
 import { DeveloperBadge } from '../components/ui/DeveloperBadge';
 import { useAuth } from '../contexts/AuthContext';
@@ -41,7 +42,7 @@ export default function Login() {
 
   // Check if running in dev mode (for showing default credentials)
   useEffect(() => {
-    fetch('/api/system/mode')
+    fetch(buildApiUrl('/api/system/mode'))
       .then(res => res.json())
       .then(data => {
         if (data.dev_mode === true && data.dev_credentials) {
@@ -93,7 +94,7 @@ export default function Login() {
       }
 
       // Strategy 2: Fall back to regular fetch (via proxy or IPC)
-      const response = await fetch('/api/auth/login', {
+      const response = await fetch(buildApiUrl('/api/auth/login'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -148,7 +149,7 @@ export default function Login() {
     setLoading(true);
 
     try {
-      const response = await fetch('/api/auth/verify-2fa', {
+      const response = await fetch(buildApiUrl('/api/auth/verify-2fa'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ pending_token: pendingToken, code: totpCode }),


### PR DESCRIPTION
## Summary

Multiple frontend call sites still constructed API URLs without going through `buildApiUrl()` / `apiClient`. In a regular web build that's fine — Vite/nginx route relative `/api/...` to the backend. In the Tauri Companion the webview is loaded from `tauri://localhost`, so relative or hostname-less URLs resolve against the **custom protocol** instead of the local TCP→UDS proxy. Symptoms observed live: login produced `Server error: 200` because the custom protocol returned the embedded index.html (HTML, content-type `text/html`, status 200), and the UI mode indicator flipped to "Fallback".

## Why `Server error: 200`

`Login.tsx`'s Strategy 2 reads `response.headers.get('content-type')`; if it's not JSON it throws `new Error(\`Server error: \${response.status}\`)`. With the custom protocol returning HTML, status is 200 but content-type is `text/html`, hence the misleading "200" in the error.

## Why "Fallback" mode shows up

`localApi.isAvailable()` issues `fetch('/api/health')` against the same custom protocol, which (because of the SPA fallback to index.html) returned `200 OK`. That falsely flipped `localBackendAvailable=true`, so Strategy 1 (`localApi.login()`) was tried first, failed on JSON parsing, and the catch block set `connectionMode='fallback'`.

## Fixes

| File | Change |
|---|---|
| `client/src/pages/Login.tsx` | `fetch('/api/system/mode')`, `/api/auth/login`, `/api/auth/verify-2fa` → `fetch(buildApiUrl(...))` |
| `client/src/components/MockDiskWizard.tsx` | `/api/system/raid/dev/add-mock-disk` → `buildApiUrl(...)` |
| `client/src/components/scheduler/MaintenancePanel.tsx` | `/api/system/mode` → `buildApiUrl(...)` |
| `client/src/lib/localApi.ts` | `LOCAL_API_BASE` reads `window.__BALU_API_BASE__` first; fallback shutdown/restart use `buildApiUrl` |
| `client/src/lib/pluginLoader.ts` | dynamic `import()` of plugin bundles uses `buildApiUrl` |
| `client/src/api/backup.ts` | `getBackupDownloadUrl` uses `buildApiUrl` instead of hardcoded `http://localhost:8000` |

Web build behavior is unchanged everywhere (`buildApiUrl` returns the path untouched when no base URL is configured).

Out-of-scope (separate work needed — the local proxy doesn't yet upgrade WebSocket): live notifications WS in `hooks/useNotificationSocket.ts`, `pages/SmartDevicesPage.tsx`, `components/dashboard/PluginDashboardPanel.tsx`, and the log-stream EventSource in `components/monitoring/BackendLogsTab.tsx`.

## Test plan

- [ ] `tauri-build.yml` rebuilds `.deb`
- [ ] Install on BaluHost: `sudo dpkg -i baluhost-companion_*.deb`
- [ ] Launch `baluhost-companion`, log in — should reach Dashboard without "Server error: 200" or "Fallback mode"
- [ ] Spot-check via the socat-bridge that `/api/auth/login` POST arrives with `Origin: http://localhost`, returns 200/401 (not 200 with HTML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)