### PR TITLE
fix(tauri): skip WS/SSE in Companion to prevent crash after login

### DIFF
--- a/client/src/components/dashboard/PluginDashboardPanel.tsx
+++ b/client/src/components/dashboard/PluginDashboardPanel.tsx
@@ -64,12 +64,38 @@ export const PluginDashboardPanel: React.FC = () => {
   // WebSocket subscription for live updates
   useEffect(() => {
     if (!token) return;
+    // Tauri Companion: the Rust HTTP→UDS proxy can't relay WebSocket
+    // upgrades yet, and `window.location.host` resolves to `tauri.localhost`
+    // which produces a malformed WS URL that crashes the constructor.
+    // Fall through to REST polling (started below) instead.
+    if (typeof window !== 'undefined' && window.__BALU_API_BASE__) {
+      pollRef.current = setInterval(fetchPanel, REST_POLL_INTERVAL);
+      return () => {
+        if (pollRef.current) {
+          clearInterval(pollRef.current);
+          pollRef.current = null;
+        }
+      };
+    }
 
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const host = window.location.host;
     const wsUrl = `${protocol}//${host}${buildApiUrl('/api/notifications/ws')}?token=${token}`;
 
-    const ws = new WebSocket(wsUrl);
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(wsUrl);
+    } catch {
+      // Constructor can throw (malformed URL, insecure context). Degrade
+      // to REST polling instead of bubbling to the ErrorBoundary.
+      pollRef.current = setInterval(fetchPanel, REST_POLL_INTERVAL);
+      return () => {
+        if (pollRef.current) {
+          clearInterval(pollRef.current);
+          pollRef.current = null;
+        }
+      };
+    }
     wsRef.current = ws;
 
     ws.onmessage = (event) => {

--- a/client/src/components/monitoring/BackendLogsTab.tsx
+++ b/client/src/components/monitoring/BackendLogsTab.tsx
@@ -53,9 +53,20 @@ export function BackendLogsTab() {
   const connectSSE = useCallback(() => {
     const token = localStorage.getItem('token');
     if (!token) return;
+    // Tauri Companion: SSE not proxied yet; skip to avoid constructor throw.
+    if (typeof window !== 'undefined' && window.__BALU_API_BASE__) {
+      setConnected(false);
+      return;
+    }
 
     const url = backendLogsApi.getStreamUrl(token);
-    const es = new EventSource(url);
+    let es: EventSource;
+    try {
+      es = new EventSource(url);
+    } catch {
+      setConnected(false);
+      return;
+    }
     eventSourceRef.current = es;
 
     es.addEventListener('log', (e) => {

--- a/client/src/pages/SmartDevicesPage.tsx
+++ b/client/src/pages/SmartDevicesPage.tsx
@@ -62,6 +62,8 @@ export default function SmartDevicesPage() {
 
   useEffect(() => {
     if (!token) return;
+    // Tauri Companion: WS not proxied yet; skip to avoid constructor throw.
+    if (typeof window !== 'undefined' && window.__BALU_API_BASE__) return;
 
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const host = window.location.host;
@@ -69,7 +71,12 @@ export default function SmartDevicesPage() {
     // smart_device_update messages on the same channel.
     const wsUrl = `${protocol}//${host}${buildApiUrl('/api/notifications/ws')}?token=${token}`;
 
-    const ws = new WebSocket(wsUrl);
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(wsUrl);
+    } catch {
+      return;
+    }
     wsRef.current = ws;
 
     ws.onmessage = (event) => {


### PR DESCRIPTION
## Summary

- **Bug**: After login, the Tauri Companion crashes on Dashboard mount with `Something went wrong: This operation is not secure` (rendered by the global ErrorBoundary).
- **Cause**: Three components build realtime URLs from \`window.location.protocol\` + \`window.location.host\`, which in the Companion webview resolves to \`tauri://localhost\`. The resulting URL (e.g. \`ws://tauri.localhost/http://127.0.0.1:<port>/api/...\`) is malformed and makes \`new WebSocket(...)\` / \`new EventSource(...)\` throw synchronously inside a \`useEffect\`. \`PluginDashboardPanel\` runs on the Dashboard, so the throw bubbles to the ErrorBoundary right after login.
- **Fix**: Detect the Companion shell via \`window.__BALU_API_BASE__\` and skip live setup there. The Rust HTTP→UDS proxy in \`client/src-tauri/src/proxy.rs\` doesn't yet handle the WebSocket Upgrade handshake (out-of-scope follow-up flagged in #105), so any attempt would fail anyway. Also wrap the remaining \`new WebSocket()\` / \`new EventSource()\` calls in try/catch so a future malformed URL can never escape to the ErrorBoundary.

## Affected files

- \`client/src/components/dashboard/PluginDashboardPanel.tsx\` — falls back to existing 10s REST polling under Tauri (initial state still loads, just no live deltas).
- \`client/src/pages/SmartDevicesPage.tsx\` — keeps initial REST fetch; loses smart-device live state under Tauri until WS proxying lands.
- \`client/src/components/monitoring/BackendLogsTab.tsx\` — keeps initial 500-entry history; loses live log stream under Tauri until SSE proxying lands.

## Web behavior

Unchanged. \`__BALU_API_BASE__\` is undefined outside the Companion.

## Note on process

This was patched directly on the production server to unblock login (Companion app crashing with no remote alternative). PR exists for the git history + future builds via CI.

## Test plan

- [x] Tauri rebuild locally on BaluNode (cargo + libwebkit2gtk-4.1-dev etc.), \`.deb\` installed via \`sudo dpkg -i\`, login completed end-to-end, Dashboard renders without ErrorBoundary
- [ ] CI \`Tauri Build\` workflow succeeds for this branch
- [ ] Regular web build (non-Tauri) still receives WS notifications + SSE logs (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)