### PR TITLE
feat: per-unit BaluHost RAM breakdown in System Monitor

### DIFF
--- a/backend/app/api/routes/monitoring.py
+++ b/backend/app/api/routes/monitoring.py
@@ -217,6 +217,7 @@ async def get_memory_current(
         percent=sample.percent,
         available_bytes=sample.available_bytes,
         baluhost_memory_bytes=sample.baluhost_memory_bytes,
+        baluhost_memory_breakdown=sample.baluhost_memory_breakdown,
     )
 
 

--- a/backend/app/schemas/monitoring.py
+++ b/backend/app/schemas/monitoring.py
@@ -106,7 +106,7 @@ class MemorySampleSchema(BaseModel):
     percent: float
     available_bytes: Optional[int] = None
     baluhost_memory_bytes: Optional[int] = None  # Memory used by BaluHost processes
-    baluhost_memory_breakdown: Optional[Dict[str, int]] = None  # Per-unit memory breakdown
+    baluhost_memory_breakdown: Optional[Dict[str, int]] = None  # Per-unit RSS; null for DB-historical rows and on cold start (live-only)
 
     class Config:
         from_attributes = True
@@ -214,7 +214,7 @@ class CurrentMemoryResponse(BaseModel):
     percent: float
     available_bytes: Optional[int] = None
     baluhost_memory_bytes: Optional[int] = None  # Memory used by BaluHost processes
-    baluhost_memory_breakdown: Optional[Dict[str, int]] = None  # Per-unit memory breakdown
+    baluhost_memory_breakdown: Optional[Dict[str, int]] = None  # Per-unit RSS; null for DB-historical rows and on cold start (live-only)
 
 
 class CurrentNetworkResponse(BaseModel):

--- a/backend/app/schemas/monitoring.py
+++ b/backend/app/schemas/monitoring.py
@@ -106,6 +106,7 @@ class MemorySampleSchema(BaseModel):
     percent: float
     available_bytes: Optional[int] = None
     baluhost_memory_bytes: Optional[int] = None  # Memory used by BaluHost processes
+    baluhost_memory_breakdown: Optional[Dict[str, int]] = None  # Per-unit memory breakdown
 
     class Config:
         from_attributes = True
@@ -213,6 +214,7 @@ class CurrentMemoryResponse(BaseModel):
     percent: float
     available_bytes: Optional[int] = None
     baluhost_memory_bytes: Optional[int] = None  # Memory used by BaluHost processes
+    baluhost_memory_breakdown: Optional[Dict[str, int]] = None  # Per-unit memory breakdown
 
 
 class CurrentNetworkResponse(BaseModel):

--- a/backend/app/services/monitoring/memory_collector.py
+++ b/backend/app/services/monitoring/memory_collector.py
@@ -20,34 +20,43 @@ from app.services.monitoring.process_tracker import BALUHOST_PROCESS_PATTERNS
 logger = logging.getLogger(__name__)
 
 
-def get_baluhost_memory_bytes() -> int:
+def get_baluhost_memory_breakdown() -> dict[str, int]:
     """
-    Get total memory used by BaluHost processes.
+    Get RSS memory per BaluHost systemd unit.
 
-    Returns:
-        Total memory in bytes used by all BaluHost processes.
+    Returns a dict keyed by ``process_name`` from ``BALUHOST_PROCESS_PATTERNS``.
+    All defined unit names appear as keys; missing units have value 0 so the
+    UI can distinguish "unit not defined" (key absent) from "unit not running"
+    (key present, value 0).
+
+    Routing is first-match-wins (same order as BALUHOST_PROCESS_PATTERNS) so
+    a process matching multiple patterns is counted under the first.
     """
-    total_memory = 0
+    breakdown: dict[str, int] = {entry["name"]: 0 for entry in BALUHOST_PROCESS_PATTERNS}
 
     try:
         for proc in psutil.process_iter(["pid", "name", "cmdline", "memory_info"]):
             try:
-                proc_info = proc.info
-                name = proc_info.get("name", "").lower()
-                cmdline = " ".join(proc_info.get("cmdline") or []).lower()
+                info = proc.info
+                name = (info.get("name") or "").lower()
+                cmdline = " ".join(info.get("cmdline") or []).lower()
 
-                # Check if any pattern matches
                 for entry in BALUHOST_PROCESS_PATTERNS:
-                    if any(p.lower() in name or p.lower() in cmdline for p in entry["patterns"]):
-                        if proc_info.get("memory_info"):
-                            total_memory += proc_info["memory_info"].rss
-                        break  # Don't count same process twice
+                    if all(p.lower() in name or p.lower() in cmdline for p in entry["patterns"]):
+                        if info.get("memory_info"):
+                            breakdown[entry["name"]] += info["memory_info"].rss
+                        break
             except (psutil.NoSuchProcess, psutil.AccessDenied):
                 continue
     except Exception as e:
-        logger.debug(f"Error getting BaluHost memory: {e}")
+        logger.debug(f"Error getting BaluHost memory breakdown: {e}")
 
-    return total_memory
+    return breakdown
+
+
+def get_baluhost_memory_bytes() -> int:
+    """Backward-compat: total memory across all BaluHost processes."""
+    return sum(get_baluhost_memory_breakdown().values())
 
 
 class MemoryMetricCollector(MetricCollector[MemorySampleSchema]):
@@ -77,11 +86,9 @@ class MemoryMetricCollector(MetricCollector[MemorySampleSchema]):
         try:
             timestamp = datetime.now(timezone.utc)
 
-            # Get memory info
             mem = psutil.virtual_memory()
-
-            # Get BaluHost process memory
-            baluhost_memory = get_baluhost_memory_bytes()
+            breakdown = get_baluhost_memory_breakdown()
+            total_baluhost = sum(breakdown.values())
 
             return MemorySampleSchema(
                 timestamp=timestamp,
@@ -89,7 +96,8 @@ class MemoryMetricCollector(MetricCollector[MemorySampleSchema]):
                 total_bytes=mem.total,
                 percent=round(mem.percent, 2),
                 available_bytes=mem.available,
-                baluhost_memory_bytes=baluhost_memory,
+                baluhost_memory_bytes=total_baluhost,
+                baluhost_memory_breakdown=breakdown,
             )
         except Exception as e:
             logger.error(f"Failed to collect memory sample: {e}")

--- a/backend/app/services/monitoring/memory_collector.py
+++ b/backend/app/services/monitoring/memory_collector.py
@@ -120,6 +120,8 @@ class MemoryMetricCollector(MetricCollector[MemorySampleSchema]):
 
     def db_to_sample(self, db_record: MemorySample) -> MemorySampleSchema:
         """Convert database record to schema."""
+        # baluhost_memory_breakdown is live-only (no DB column); defaults to None.
+        # Frontend consumers must handle null for history endpoints.
         return MemorySampleSchema(
             timestamp=db_record.timestamp,
             used_bytes=db_record.used_bytes,

--- a/backend/app/services/monitoring/process_tracker.py
+++ b/backend/app/services/monitoring/process_tracker.py
@@ -1,8 +1,9 @@
 """
 Process tracker for BaluHost-related processes.
 
-Tracks backend (uvicorn), frontend (node), and other BaluHost processes
-for historical analysis and crash detection.
+Tracks the BaluHost systemd units (backend, backend-local, scheduler, webdav,
+monitoring) plus optional dev/operator processes (TUI, frontend-dev) for
+historical analysis and crash detection.
 """
 
 from __future__ import annotations
@@ -132,7 +133,9 @@ class ProcessTracker:
         Find processes matching the given patterns.
 
         Args:
-            patterns: List of substrings to match in process name or cmdline
+            patterns: List of substrings — ALL must appear in process name or
+                combined cmdline (all-of semantics; supports multi-token patterns
+                like ["uvicorn app.main", "--fd 3"] to disambiguate units).
 
         Returns:
             List of process info dicts

--- a/backend/app/services/monitoring/process_tracker.py
+++ b/backend/app/services/monitoring/process_tracker.py
@@ -21,11 +21,19 @@ from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
-# Process patterns to track
+# Process patterns to track.
+#
+# Order matters: more-specific patterns first so first-match-wins routes
+# baluhost-backend-local before baluhost-backend (both match "uvicorn app.main").
+# `_find_processes` uses all-of matching — every token must appear in name or cmdline.
 BALUHOST_PROCESS_PATTERNS = [
-    {"name": "baluhost-backend", "patterns": ["uvicorn", "app.main"]},
-    {"name": "baluhost-frontend", "patterns": ["node", "vite"]},
-    {"name": "baluhost-tui", "patterns": ["baluhost-tui", "baluhost_tui"]},
+    {"name": "baluhost-backend-local",  "patterns": ["uvicorn app.main", "--fd 3"]},
+    {"name": "baluhost-backend",        "patterns": ["uvicorn app.main"]},
+    {"name": "baluhost-scheduler",      "patterns": ["scheduler_worker.py"]},
+    {"name": "baluhost-webdav",         "patterns": ["webdav_worker.py"]},
+    {"name": "baluhost-monitoring",     "patterns": ["monitoring_worker.py"]},
+    {"name": "baluhost-tui",            "patterns": ["baluhost_tui"]},
+    {"name": "baluhost-frontend-dev",   "patterns": ["vite"]},
 ]
 
 
@@ -138,8 +146,8 @@ class ProcessTracker:
                     name = proc_info.get("name", "").lower()
                     cmdline = " ".join(proc_info.get("cmdline") or []).lower()
 
-                    # Check if any pattern matches
-                    if any(p.lower() in name or p.lower() in cmdline for p in patterns):
+                    # All patterns must match (in name or cmdline)
+                    if all(p.lower() in name or p.lower() in cmdline for p in patterns):
                         memory_mb = 0.0
                         if proc_info.get("memory_info"):
                             memory_mb = proc_info["memory_info"].rss / (1024 * 1024)

--- a/backend/app/services/monitoring/process_tracker.py
+++ b/backend/app/services/monitoring/process_tracker.py
@@ -154,6 +154,10 @@ class ProcessTracker:
 
         Returns:
             List of process info dicts
+
+        Note:
+            This is a standalone utility; `collect_samples` no longer calls it.
+            For tracked, crash-detecting sampling use `collect_samples` instead.
         """
         matching = []
 

--- a/backend/app/services/monitoring/process_tracker.py
+++ b/backend/app/services/monitoring/process_tracker.py
@@ -65,66 +65,81 @@ class ProcessTracker:
         """
         Collect samples for all BaluHost processes.
 
-        Returns:
-            List of process samples
+        Iterates processes once and classifies each PID under the first pattern
+        whose tokens all match. This prevents double-counting when a process
+        matches multiple patterns (e.g. backend-local also matches backend).
         """
-        samples = []
+        samples: List[ProcessSampleSchema] = []
         timestamp = datetime.now(timezone.utc)
+        seen_names: set[str] = set()
 
-        for process_def in BALUHOST_PROCESS_PATTERNS:
-            process_name = process_def["name"]
-            patterns = process_def["patterns"]
+        try:
+            for proc in psutil.process_iter(
+                ["pid", "name", "cmdline", "cpu_percent", "memory_info", "status"]
+            ):
+                try:
+                    info = proc.info
+                    name = (info.get("name") or "").lower()
+                    cmdline = " ".join(info.get("cmdline") or []).lower()
 
-            # Find matching processes
-            matching_procs = self._find_processes(patterns)
+                    matched_name: Optional[str] = None
+                    for entry in BALUHOST_PROCESS_PATTERNS:
+                        patterns = entry["patterns"]
+                        if all(p.lower() in name or p.lower() in cmdline for p in patterns):
+                            matched_name = entry["name"]
+                            break
 
-            if matching_procs:
-                for proc_info in matching_procs:
+                    if matched_name is None:
+                        continue
+
+                    memory_mb = 0.0
+                    if info.get("memory_info"):
+                        memory_mb = info["memory_info"].rss / (1024 * 1024)
+
                     sample = ProcessSampleSchema(
                         timestamp=timestamp,
-                        process_name=process_name,
-                        pid=proc_info["pid"],
-                        cpu_percent=round(proc_info["cpu_percent"], 2),
-                        memory_mb=round(proc_info["memory_mb"], 2),
-                        status=proc_info["status"],
+                        process_name=matched_name,
+                        pid=info["pid"],
+                        cpu_percent=round(info.get("cpu_percent", 0.0) or 0.0, 2),
+                        memory_mb=round(memory_mb, 2),
+                        status=info.get("status", "unknown"),
                         is_alive=True,
                     )
                     samples.append(sample)
+                    seen_names.add(matched_name)
 
-                    # Store in buffer
                     with self._lock:
-                        if process_name not in self._process_buffers:
-                            self._process_buffers[process_name] = []
-                        self._process_buffers[process_name].append(sample)
-                        if len(self._process_buffers[process_name]) > self.buffer_size:
-                            self._process_buffers[process_name].pop(0)
+                        self._process_buffers.setdefault(matched_name, []).append(sample)
+                        if len(self._process_buffers[matched_name]) > self.buffer_size:
+                            self._process_buffers[matched_name].pop(0)
+                        self._known_pids[matched_name] = info["pid"]
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    continue
+        except Exception as e:
+            logger.error(f"Error iterating processes: {e}")
 
-                        # Track PID for crash detection
-                        self._known_pids[process_name] = proc_info["pid"]
-            else:
-                # Process not found - check if it crashed
-                with self._lock:
-                    if process_name in self._known_pids:
-                        # Was running before, now gone = crash or stop
-                        sample = ProcessSampleSchema(
-                            timestamp=timestamp,
-                            process_name=process_name,
-                            pid=self._known_pids[process_name],
-                            cpu_percent=0.0,
-                            memory_mb=0.0,
-                            status="stopped",
-                            is_alive=False,
-                        )
-                        samples.append(sample)
-
-                        if process_name not in self._process_buffers:
-                            self._process_buffers[process_name] = []
-                        self._process_buffers[process_name].append(sample)
-                        if len(self._process_buffers[process_name]) > self.buffer_size:
-                            self._process_buffers[process_name].pop(0)
-
-                        logger.warning(f"Process '{process_name}' (PID {self._known_pids[process_name]}) stopped or crashed")
-                        del self._known_pids[process_name]
+        # Emit synthetic "stopped" samples for previously seen names that are now gone
+        with self._lock:
+            gone = set(self._known_pids.keys()) - seen_names
+            for matched_name in gone:
+                last_pid = self._known_pids[matched_name]
+                sample = ProcessSampleSchema(
+                    timestamp=timestamp,
+                    process_name=matched_name,
+                    pid=last_pid,
+                    cpu_percent=0.0,
+                    memory_mb=0.0,
+                    status="stopped",
+                    is_alive=False,
+                )
+                samples.append(sample)
+                self._process_buffers.setdefault(matched_name, []).append(sample)
+                if len(self._process_buffers[matched_name]) > self.buffer_size:
+                    self._process_buffers[matched_name].pop(0)
+                logger.warning(
+                    f"Process '{matched_name}' (PID {last_pid}) stopped or crashed"
+                )
+                del self._known_pids[matched_name]
 
         return samples
 

--- a/backend/tests/api/test_monitoring_routes.py
+++ b/backend/tests/api/test_monitoring_routes.py
@@ -103,6 +103,27 @@ class TestMemoryEndpoints:
         assert "samples" in data
         assert "sample_count" in data
 
+    def test_memory_current_includes_breakdown_field(self, client: TestClient, user_headers: dict):
+        """Memory current response carries baluhost_memory_breakdown (may be null on cold start)."""
+        response = client.get("/api/monitoring/memory/current", headers=user_headers)
+        assert response.status_code in [200, 503]
+        if response.status_code == 200:
+            data = response.json()
+            assert "baluhost_memory_breakdown" in data
+            # Either None (no sample yet on this worker) or a dict
+            breakdown = data["baluhost_memory_breakdown"]
+            assert breakdown is None or isinstance(breakdown, dict)
+            if isinstance(breakdown, dict):
+                # All defined units should be keys
+                for name in [
+                    "baluhost-backend",
+                    "baluhost-backend-local",
+                    "baluhost-scheduler",
+                    "baluhost-webdav",
+                    "baluhost-monitoring",
+                ]:
+                    assert name in breakdown
+
 
 class TestNetworkEndpoints:
     """Tests for Network monitoring endpoints."""

--- a/backend/tests/monitoring/test_memory_collector.py
+++ b/backend/tests/monitoring/test_memory_collector.py
@@ -1,0 +1,75 @@
+"""Tests for memory_collector breakdown logic."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.monitoring import memory_collector
+from app.services.monitoring.memory_collector import (
+    MemoryMetricCollector,
+    get_baluhost_memory_breakdown,
+)
+from app.services.monitoring.process_tracker import BALUHOST_PROCESS_PATTERNS
+
+
+def _fake_proc(pid: int, cmdline_str: str, rss_bytes: int):
+    proc = MagicMock()
+    proc.info = {
+        "pid": pid,
+        "name": "python",
+        "cmdline": cmdline_str.split(),
+        "memory_info": MagicMock(rss=rss_bytes),
+    }
+    return proc
+
+
+def test_breakdown_contains_all_defined_units():
+    """All names from BALUHOST_PROCESS_PATTERNS appear as keys (zero-filled)."""
+    with patch.object(memory_collector.psutil, "process_iter", return_value=[]):
+        result = get_baluhost_memory_breakdown()
+    for entry in BALUHOST_PROCESS_PATTERNS:
+        assert entry["name"] in result
+        assert result[entry["name"]] == 0
+
+
+def test_breakdown_routes_processes_to_their_unit():
+    """Each matched process contributes RSS to its unit bucket."""
+    procs = [
+        _fake_proc(401, "python -m uvicorn app.main --port 8000", rss_bytes=200_000_000),
+        _fake_proc(402, "python -m uvicorn app.main --port 8000", rss_bytes=150_000_000),  # worker 2
+        _fake_proc(403, "python -m uvicorn app.main --fd 3 --workers 2", rss_bytes=100_000_000),
+        _fake_proc(404, "python scripts/scheduler_worker.py", rss_bytes=50_000_000),
+        _fake_proc(405, "python scripts/webdav_worker.py", rss_bytes=40_000_000),
+        _fake_proc(406, "python scripts/monitoring_worker.py", rss_bytes=30_000_000),
+    ]
+    with patch.object(memory_collector.psutil, "process_iter", return_value=procs):
+        result = get_baluhost_memory_breakdown()
+
+    assert result["baluhost-backend"] == 350_000_000
+    assert result["baluhost-backend-local"] == 100_000_000
+    assert result["baluhost-scheduler"] == 50_000_000
+    assert result["baluhost-webdav"] == 40_000_000
+    assert result["baluhost-monitoring"] == 30_000_000
+
+
+def test_collect_sample_populates_breakdown_and_total():
+    """MemoryMetricCollector.collect_sample fills both breakdown and total."""
+    procs = [
+        _fake_proc(501, "python -m uvicorn app.main --port 8000", rss_bytes=200_000_000),
+        _fake_proc(502, "python scripts/scheduler_worker.py", rss_bytes=50_000_000),
+    ]
+    fake_vmem = MagicMock(
+        total=16 * 1024**3,
+        available=8 * 1024**3,
+        percent=50.0,
+    )
+    with patch.object(memory_collector.psutil, "process_iter", return_value=procs), \
+         patch.object(memory_collector.psutil, "virtual_memory", return_value=fake_vmem):
+        collector = MemoryMetricCollector()
+        sample = collector.collect_sample()
+
+    assert sample is not None
+    assert sample.baluhost_memory_bytes == 250_000_000  # total backward-compat
+    assert sample.baluhost_memory_breakdown is not None
+    assert sample.baluhost_memory_breakdown["baluhost-backend"] == 200_000_000
+    assert sample.baluhost_memory_breakdown["baluhost-scheduler"] == 50_000_000

--- a/backend/tests/monitoring/test_memory_collector.py
+++ b/backend/tests/monitoring/test_memory_collector.py
@@ -13,6 +13,7 @@ from app.services.monitoring.process_tracker import BALUHOST_PROCESS_PATTERNS
 
 
 def _fake_proc(pid: int, cmdline_str: str, rss_bytes: int):
+    """Build a MagicMock matching the .info dict shape requested by get_baluhost_memory_breakdown (pid/name/cmdline/memory_info)."""
     proc = MagicMock()
     proc.info = {
         "pid": pid,

--- a/backend/tests/monitoring/test_orchestrator.py
+++ b/backend/tests/monitoring/test_orchestrator.py
@@ -258,3 +258,25 @@ class TestConstants:
     def test_default_persist_interval(self):
         """Test default persist interval value."""
         assert DEFAULT_PERSIST_INTERVAL == 12  # Every minute at 5s
+
+
+def test_memory_sample_model_dump_includes_breakdown():
+    """SHM serialization (model_dump) must include the new breakdown field."""
+    from datetime import datetime, timezone
+    from app.schemas.monitoring import MemorySampleSchema
+
+    sample = MemorySampleSchema(
+        timestamp=datetime.now(timezone.utc),
+        used_bytes=8_000_000_000,
+        total_bytes=16_000_000_000,
+        percent=50.0,
+        available_bytes=8_000_000_000,
+        baluhost_memory_bytes=300_000_000,
+        baluhost_memory_breakdown={
+            "baluhost-backend": 200_000_000,
+            "baluhost-scheduler": 100_000_000,
+        },
+    )
+    dumped = sample.model_dump(mode="json")
+    assert "baluhost_memory_breakdown" in dumped
+    assert dumped["baluhost_memory_breakdown"]["baluhost-backend"] == 200_000_000

--- a/backend/tests/monitoring/test_process_tracker.py
+++ b/backend/tests/monitoring/test_process_tracker.py
@@ -70,3 +70,22 @@ def test_find_processes_single_pattern_still_matches():
         matched = tracker._find_processes(["scheduler_worker.py"])
     pids = [m["pid"] for m in matched]
     assert pids == [201]
+
+
+def test_collect_samples_routes_backend_local_to_its_own_bucket():
+    """A uvicorn process with --fd 3 is sampled as baluhost-backend-local, NOT baluhost-backend."""
+    tracker = ProcessTracker()
+    procs = [
+        # Backend (HTTP): uvicorn app.main without --fd
+        _fake_proc(301, "python", "python -m uvicorn app.main --port 8000", rss_bytes=200 * 1024 * 1024),
+        # Backend (Local): uvicorn app.main with --fd 3
+        _fake_proc(302, "python", "python -m uvicorn app.main --fd 3 --workers 2", rss_bytes=100 * 1024 * 1024),
+    ]
+    with patch.object(process_tracker.psutil, "process_iter", return_value=procs):
+        samples = tracker.collect_samples()
+
+    by_pid = {s.pid: s for s in samples}
+    assert by_pid[301].process_name == "baluhost-backend"
+    assert by_pid[302].process_name == "baluhost-backend-local"
+    # The same PID is NOT duplicated under two names
+    assert sum(1 for s in samples if s.pid == 302) == 1

--- a/backend/tests/monitoring/test_process_tracker.py
+++ b/backend/tests/monitoring/test_process_tracker.py
@@ -26,7 +26,10 @@ def _fake_proc(pid: int, name: str, cmdline_str: str, rss_bytes: int = 1024 * 10
 
 
 def test_patterns_include_all_five_systemd_units():
-    """All five prod systemd units have a process_name entry."""
+    """All five production systemd units are present in BALUHOST_PROCESS_PATTERNS.
+
+    (TUI and frontend-dev are optional/dev-only and not asserted here.)
+    """
     names = {entry["name"] for entry in BALUHOST_PROCESS_PATTERNS}
     assert "baluhost-backend" in names
     assert "baluhost-backend-local" in names
@@ -45,7 +48,7 @@ def test_find_processes_requires_all_patterns_to_match():
     """Multi-token pattern: all tokens must be in cmdline."""
     tracker = ProcessTracker()
     procs = [
-        # Has only first token → should NOT match a two-token pattern
+        # Has "uvicorn app.main" but not "--fd 3" → should NOT match a two-token pattern
         _fake_proc(101, "python", "python -m uvicorn app.main --port 8000"),
         # Has both tokens → should match
         _fake_proc(102, "python", "python -m uvicorn app.main --fd 3 --workers 2"),

--- a/backend/tests/monitoring/test_process_tracker.py
+++ b/backend/tests/monitoring/test_process_tracker.py
@@ -1,0 +1,69 @@
+"""Tests for ProcessTracker pattern matching and BALUHOST_PROCESS_PATTERNS."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.monitoring import process_tracker
+from app.services.monitoring.process_tracker import (
+    BALUHOST_PROCESS_PATTERNS,
+    ProcessTracker,
+)
+
+
+def _fake_proc(pid: int, name: str, cmdline_str: str, rss_bytes: int = 1024 * 1024):
+    """Build a MagicMock that behaves like a psutil.Process .info dict source."""
+    proc = MagicMock()
+    proc.info = {
+        "pid": pid,
+        "name": name,
+        "cmdline": cmdline_str.split(),
+        "cpu_percent": 0.0,
+        "memory_info": MagicMock(rss=rss_bytes),
+        "status": "running",
+    }
+    return proc
+
+
+def test_patterns_include_all_five_systemd_units():
+    """All five prod systemd units have a process_name entry."""
+    names = {entry["name"] for entry in BALUHOST_PROCESS_PATTERNS}
+    assert "baluhost-backend" in names
+    assert "baluhost-backend-local" in names
+    assert "baluhost-scheduler" in names
+    assert "baluhost-webdav" in names
+    assert "baluhost-monitoring" in names
+
+
+def test_patterns_order_puts_backend_local_before_backend():
+    """First-match-wins requires backend-local to precede backend in the list."""
+    order = [entry["name"] for entry in BALUHOST_PROCESS_PATTERNS]
+    assert order.index("baluhost-backend-local") < order.index("baluhost-backend")
+
+
+def test_find_processes_requires_all_patterns_to_match():
+    """Multi-token pattern: all tokens must be in cmdline."""
+    tracker = ProcessTracker()
+    procs = [
+        # Has only first token → should NOT match a two-token pattern
+        _fake_proc(101, "python", "python -m uvicorn app.main --port 8000"),
+        # Has both tokens → should match
+        _fake_proc(102, "python", "python -m uvicorn app.main --fd 3 --workers 2"),
+    ]
+    with patch.object(process_tracker.psutil, "process_iter", return_value=procs):
+        matched = tracker._find_processes(["uvicorn app.main", "--fd 3"])
+    pids = [m["pid"] for m in matched]
+    assert pids == [102]
+
+
+def test_find_processes_single_pattern_still_matches():
+    """Single-token pattern behaves like before (no regression)."""
+    tracker = ProcessTracker()
+    procs = [
+        _fake_proc(201, "python", "python scripts/scheduler_worker.py"),
+        _fake_proc(202, "python", "python scripts/webdav_worker.py"),
+    ]
+    with patch.object(process_tracker.psutil, "process_iter", return_value=procs):
+        matched = tracker._find_processes(["scheduler_worker.py"])
+    pids = [m["pid"] for m in matched]
+    assert pids == [201]

--- a/client/src/api/monitoring.ts
+++ b/client/src/api/monitoring.ts
@@ -134,6 +134,7 @@ export interface CurrentMemoryResponse {
   percent: number;
   available_bytes?: number;
   baluhost_memory_bytes?: number;  // Memory used by BaluHost processes
+  baluhost_memory_breakdown?: Record<string, number>;  // RSS bytes per systemd unit; null for DB-historical rows and on cold start (live-only)
 }
 
 export type InterfaceType = 'wifi' | 'ethernet' | 'unknown';

--- a/client/src/api/monitoring.ts
+++ b/client/src/api/monitoring.ts
@@ -63,7 +63,8 @@ export interface MemorySample {
   total_bytes: number;
   percent: number;
   available_bytes?: number;
-  baluhost_memory_bytes?: number;  // Memory used by BaluHost processes
+  baluhost_memory_bytes?: number;  // Total memory used by BaluHost processes
+  baluhost_memory_breakdown?: Record<string, number>;  // RSS bytes per systemd unit; null for DB-historical rows and on cold start (live-only)
 }
 
 export interface NetworkSample {

--- a/client/src/components/system-monitor/MemoryTab.tsx
+++ b/client/src/components/system-monitor/MemoryTab.tsx
@@ -1,8 +1,9 @@
 /**
- * MemoryTab -- RAM monitoring tab with usage chart.
+ * MemoryTab -- RAM monitoring tab with usage chart and BaluHost per-unit breakdown.
  */
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { MetricChart } from '../monitoring';
 import type { TimeRange } from '../../api/monitoring';
@@ -10,17 +11,38 @@ import { useMemoryMonitoring } from '../../hooks/useMonitoring';
 import { formatBytes, formatNumber } from '../../lib/formatters';
 import { StatCard } from '../ui/StatCard';
 
+// Display order of units in the breakdown (matches BALUHOST_PROCESS_PATTERNS in backend).
+const UNIT_DISPLAY_ORDER = [
+  'baluhost-backend',
+  'baluhost-backend-local',
+  'baluhost-scheduler',
+  'baluhost-webdav',
+  'baluhost-monitoring',
+  'baluhost-tui',
+  'baluhost-frontend-dev',
+] as const;
+
+// i18n key per unit (under `system:monitor.units.*`).
+const UNIT_LABEL_KEY: Record<string, string> = {
+  'baluhost-backend':       'monitor.units.backend',
+  'baluhost-backend-local': 'monitor.units.backendLocal',
+  'baluhost-scheduler':     'monitor.units.scheduler',
+  'baluhost-webdav':        'monitor.units.webdav',
+  'baluhost-monitoring':    'monitor.units.monitoring',
+  'baluhost-tui':           'monitor.units.tui',
+  'baluhost-frontend-dev':  'monitor.units.frontendDev',
+};
+
 export function MemoryTab({ timeRange }: { timeRange: TimeRange }) {
   const { t } = useTranslation(['system', 'common']);
   const { current, history, loading, error } = useMemoryMonitoring({ historyDuration: timeRange });
+  const [breakdownOpen, setBreakdownOpen] = useState(false);
 
-  // Calculate total RAM in GB for chart domain
   const totalGb = current ? current.total_bytes / (1024 * 1024 * 1024) : 16;
 
-  // Filter out samples with invalid data and convert to GB
   const chartData = useMemo(() => {
     return history
-      .filter((s) => s.used_bytes > 0 && s.total_bytes > 0) // Only valid samples
+      .filter((s) => s.used_bytes > 0 && s.total_bytes > 0)
       .map((s) => ({
         time: s.timestamp,
         usedGb: s.used_bytes / (1024 * 1024 * 1024),
@@ -32,13 +54,21 @@ export function MemoryTab({ timeRange }: { timeRange: TimeRange }) {
 
   const hasBaluhostData = chartData.some((d) => d.baluhostGb !== null);
 
+  // Visible units = units with > 0 bytes, in canonical order.
+  const visibleUnits = useMemo(() => {
+    const breakdown = current?.baluhost_memory_breakdown;
+    if (!breakdown) return [];
+    return UNIT_DISPLAY_ORDER
+      .filter((name) => (breakdown[name] ?? 0) > 0)
+      .map((name) => ({ name, bytes: breakdown[name] }));
+  }, [current]);
+
   if (error) {
     return <div className="text-red-400 text-center py-8">{error}</div>;
   }
 
   return (
     <div className="space-y-4 sm:space-y-6 min-w-0">
-      {/* Current Stats */}
       <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-3 sm:gap-5 lg:grid-cols-5">
         <StatCard
           label={t('monitor.used')}
@@ -65,15 +95,46 @@ export function MemoryTab({ timeRange }: { timeRange: TimeRange }) {
           color="orange"
           icon={<span className="text-orange-400 text-base sm:text-xl">%</span>}
         />
-        <StatCard
-          label="BaluHost"
-          value={current?.baluhost_memory_bytes ? formatBytes(current.baluhost_memory_bytes) : '-'}
-          color="cyan"
-          icon={<span className="text-cyan-400 text-base sm:text-xl">🏠</span>}
-        />
+
+        {/* BaluHost breakdown card */}
+        <div className="card border-slate-800/60 bg-slate-900/55 p-3 sm:p-4 flex flex-col">
+          <button
+            type="button"
+            onClick={() => setBreakdownOpen((v) => !v)}
+            className="flex items-center justify-between gap-2 text-left"
+            aria-expanded={breakdownOpen}
+          >
+            <span className="flex items-center gap-2 text-xs sm:text-sm text-slate-400">
+              <span className="text-cyan-400 text-base sm:text-xl">🏠</span>
+              BaluHost
+            </span>
+            {visibleUnits.length > 0 && (
+              breakdownOpen
+                ? <ChevronDown className="h-4 w-4 text-slate-500" />
+                : <ChevronRight className="h-4 w-4 text-slate-500" />
+            )}
+          </button>
+          <div className="mt-1 text-xl sm:text-2xl font-semibold text-white tabular-nums">
+            {current?.baluhost_memory_bytes ? formatBytes(current.baluhost_memory_bytes) : '-'}
+          </div>
+
+          {breakdownOpen && visibleUnits.length > 0 && (
+            <ul className="mt-3 space-y-1 text-xs sm:text-sm">
+              {visibleUnits.map((unit) => (
+                <li key={unit.name} className="flex justify-between gap-2">
+                  <span className="text-slate-400 truncate">
+                    {t(UNIT_LABEL_KEY[unit.name] ?? unit.name)}
+                  </span>
+                  <span className="text-slate-200 tabular-nums shrink-0">
+                    {formatBytes(unit.bytes)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
 
-      {/* Chart - Absolute values in GB */}
       <div className="card border-slate-800/60 bg-slate-900/55 p-4 sm:p-6">
         <h3 className="mb-3 sm:mb-4 text-base sm:text-lg font-semibold text-white">{t('monitor.ramHistory')}</h3>
         <MetricChart

--- a/client/src/i18n/locales/de/system.json
+++ b/client/src/i18n/locales/de/system.json
@@ -190,6 +190,15 @@
       "avgPower": "Durchschn. Leistung",
       "maxPower": "Max. Leistung",
       "minPower": "Min. Leistung"
+    },
+    "units": {
+      "backend": "Backend (HTTP)",
+      "backendLocal": "Backend (Lokal)",
+      "scheduler": "Scheduler",
+      "webdav": "WebDAV",
+      "monitoring": "Monitoring",
+      "tui": "TUI",
+      "frontendDev": "Frontend (Dev)"
     }
   },
   "logging": {

--- a/client/src/i18n/locales/en/system.json
+++ b/client/src/i18n/locales/en/system.json
@@ -195,6 +195,15 @@
       "avgPower": "Avg. Power",
       "maxPower": "Max. Power",
       "minPower": "Min. Power"
+    },
+    "units": {
+      "backend": "Backend (HTTP)",
+      "backendLocal": "Backend (Local)",
+      "scheduler": "Scheduler",
+      "webdav": "WebDAV",
+      "monitoring": "Monitoring",
+      "tui": "TUI",
+      "frontendDev": "Frontend (dev)"
     }
   },
   "logging": {

--- a/docs/superpowers/plans/2026-05-27-baluhost-ram-per-unit-breakdown.md
+++ b/docs/superpowers/plans/2026-05-27-baluhost-ram-per-unit-breakdown.md
@@ -1,0 +1,1125 @@
+# BaluHost RAM Per-Unit Breakdown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix BaluHost RAM tracking so the System Monitor counts all five systemd units (backend, backend-local, scheduler, webdav, monitoring) and breaks the total down per-unit in the UI.
+
+**Architecture:** cmdline-pattern matching extended to all systemd `ExecStart` strings, first-match-wins to keep backend-local separate from backend. `MemorySampleSchema` gains `baluhost_memory_breakdown: dict[str, int]` (live-only, no DB migration — per-unit history already lives in `process_samples`). The `MemoryTab` StatCard becomes a small breakdown panel.
+
+**Tech Stack:** Python 3.11+, FastAPI, Pydantic v2, psutil, SQLAlchemy 2.0, React 18, TypeScript, Tailwind, i18next.
+
+**Spec:** [`docs/superpowers/specs/2026-05-27-baluhost-ram-per-unit-breakdown-design.md`](../specs/2026-05-27-baluhost-ram-per-unit-breakdown-design.md)
+
+---
+
+## Pre-flight
+
+- [ ] **Step 1: Verify base branch**
+
+Spec is committed on `fix/tauri-icon-rgba`. Move work to a clean feature branch off `main`.
+
+Run from repo root:
+```powershell
+git fetch origin
+git checkout -b feat/memory-per-unit-breakdown origin/main
+git cherry-pick fix/tauri-icon-rgba -- docs/superpowers/specs/2026-05-27-baluhost-ram-per-unit-breakdown-design.md
+```
+
+Expected: a new branch with the spec file present and clean tree otherwise.
+
+- [ ] **Step 2: Confirm test infrastructure**
+
+Run:
+```powershell
+cd backend
+python -m pytest tests/monitoring/test_collectors.py -q --collect-only
+```
+
+Expected: tests are collected without import errors. If `tests/monitoring/test_process_tracker.py` does not exist, that's fine — Task 1 creates it.
+
+---
+
+## Task 1: Add new BaluHost process patterns + all-of matching
+
+**Files:**
+- Modify: `backend/app/services/monitoring/process_tracker.py:25-29` (the `BALUHOST_PROCESS_PATTERNS` list)
+- Modify: `backend/app/services/monitoring/process_tracker.py:122-158` (`_find_processes` matching)
+- Create: `backend/tests/monitoring/test_process_tracker.py`
+
+The current matching uses `any(p in cmdline ...)`. We need `all(...)` so a multi-token pattern like `["uvicorn app.main", "--fd 3"]` requires both tokens. The semantic for single-element patterns is unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/monitoring/test_process_tracker.py`:
+
+```python
+"""Tests for ProcessTracker pattern matching and BALUHOST_PROCESS_PATTERNS."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.monitoring import process_tracker
+from app.services.monitoring.process_tracker import (
+    BALUHOST_PROCESS_PATTERNS,
+    ProcessTracker,
+)
+
+
+def _fake_proc(pid: int, name: str, cmdline_str: str, rss_bytes: int = 1024 * 1024):
+    """Build a MagicMock that behaves like a psutil.Process .info dict source."""
+    proc = MagicMock()
+    proc.info = {
+        "pid": pid,
+        "name": name,
+        "cmdline": cmdline_str.split(),
+        "cpu_percent": 0.0,
+        "memory_info": MagicMock(rss=rss_bytes),
+        "status": "running",
+    }
+    return proc
+
+
+def test_patterns_include_all_five_systemd_units():
+    """All five prod systemd units have a process_name entry."""
+    names = {entry["name"] for entry in BALUHOST_PROCESS_PATTERNS}
+    assert "baluhost-backend" in names
+    assert "baluhost-backend-local" in names
+    assert "baluhost-scheduler" in names
+    assert "baluhost-webdav" in names
+    assert "baluhost-monitoring" in names
+
+
+def test_patterns_order_puts_backend_local_before_backend():
+    """First-match-wins requires backend-local to precede backend in the list."""
+    order = [entry["name"] for entry in BALUHOST_PROCESS_PATTERNS]
+    assert order.index("baluhost-backend-local") < order.index("baluhost-backend")
+
+
+def test_find_processes_requires_all_patterns_to_match():
+    """Multi-token pattern: all tokens must be in cmdline."""
+    tracker = ProcessTracker()
+    procs = [
+        # Has only first token → should NOT match a two-token pattern
+        _fake_proc(101, "python", "python -m uvicorn app.main --port 8000"),
+        # Has both tokens → should match
+        _fake_proc(102, "python", "python -m uvicorn app.main --fd 3 --workers 2"),
+    ]
+    with patch.object(process_tracker.psutil, "process_iter", return_value=procs):
+        matched = tracker._find_processes(["uvicorn app.main", "--fd 3"])
+    pids = [m["pid"] for m in matched]
+    assert pids == [102]
+
+
+def test_find_processes_single_pattern_still_matches():
+    """Single-token pattern behaves like before (no regression)."""
+    tracker = ProcessTracker()
+    procs = [
+        _fake_proc(201, "python", "python scripts/scheduler_worker.py"),
+        _fake_proc(202, "python", "python scripts/webdav_worker.py"),
+    ]
+    with patch.object(process_tracker.psutil, "process_iter", return_value=procs):
+        matched = tracker._find_processes(["scheduler_worker.py"])
+    pids = [m["pid"] for m in matched]
+    assert pids == [201]
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+```powershell
+cd backend
+python -m pytest tests/monitoring/test_process_tracker.py -v
+```
+
+Expected: `test_patterns_include_all_five_systemd_units` FAILS (scheduler/webdav/monitoring/backend-local keys missing). `test_find_processes_requires_all_patterns_to_match` FAILS (current code uses `any(...)`).
+
+- [ ] **Step 3: Update `BALUHOST_PROCESS_PATTERNS`**
+
+In `backend/app/services/monitoring/process_tracker.py`, replace lines 25-29 with:
+
+```python
+# Process patterns to track.
+#
+# Order matters: more-specific patterns first so first-match-wins routes
+# baluhost-backend-local before baluhost-backend (both match "uvicorn app.main").
+# `_find_processes` uses all-of matching — every token must appear in name or cmdline.
+BALUHOST_PROCESS_PATTERNS = [
+    {"name": "baluhost-backend-local",  "patterns": ["uvicorn app.main", "--fd 3"]},
+    {"name": "baluhost-backend",        "patterns": ["uvicorn app.main"]},
+    {"name": "baluhost-scheduler",      "patterns": ["scheduler_worker.py"]},
+    {"name": "baluhost-webdav",         "patterns": ["webdav_worker.py"]},
+    {"name": "baluhost-monitoring",     "patterns": ["monitoring_worker.py"]},
+    {"name": "baluhost-tui",            "patterns": ["baluhost_tui"]},
+    {"name": "baluhost-frontend-dev",   "patterns": ["vite"]},
+]
+```
+
+- [ ] **Step 4: Switch `_find_processes` matching to all-of**
+
+In `backend/app/services/monitoring/process_tracker.py`, in `_find_processes` (around line 142), replace:
+
+```python
+                    # Check if any pattern matches
+                    if any(p.lower() in name or p.lower() in cmdline for p in patterns):
+```
+
+With:
+
+```python
+                    # All patterns must match (in name or cmdline)
+                    if all(p.lower() in name or p.lower() in cmdline for p in patterns):
+```
+
+- [ ] **Step 5: Run tests and verify they pass**
+
+Run:
+```powershell
+cd backend
+python -m pytest tests/monitoring/test_process_tracker.py -v
+```
+
+Expected: all four tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add backend/app/services/monitoring/process_tracker.py backend/tests/monitoring/test_process_tracker.py
+git commit -m "feat(monitoring): expand BaluHost process patterns to all systemd units"
+```
+
+---
+
+## Task 2: First-match-wins routing in `collect_samples`
+
+**Files:**
+- Modify: `backend/app/services/monitoring/process_tracker.py:55-120` (`collect_samples`)
+- Modify: `backend/tests/monitoring/test_process_tracker.py` (extend)
+
+A backend-local uvicorn process matches both `baluhost-backend-local` and `baluhost-backend` token sets. With the current per-pattern loop it would be sampled under both names. We need first-match-wins per PID.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/monitoring/test_process_tracker.py`:
+
+```python
+def test_collect_samples_routes_backend_local_to_its_own_bucket():
+    """A uvicorn process with --fd 3 is sampled as baluhost-backend-local, NOT baluhost-backend."""
+    tracker = ProcessTracker()
+    procs = [
+        # Backend (HTTP): uvicorn app.main without --fd
+        _fake_proc(301, "python", "python -m uvicorn app.main --port 8000", rss_bytes=200 * 1024 * 1024),
+        # Backend (Local): uvicorn app.main with --fd 3
+        _fake_proc(302, "python", "python -m uvicorn app.main --fd 3 --workers 2", rss_bytes=100 * 1024 * 1024),
+    ]
+    with patch.object(process_tracker.psutil, "process_iter", return_value=procs):
+        samples = tracker.collect_samples()
+
+    by_pid = {s.pid: s for s in samples}
+    assert by_pid[301].process_name == "baluhost-backend"
+    assert by_pid[302].process_name == "baluhost-backend-local"
+    # The same PID is NOT duplicated under two names
+    assert sum(1 for s in samples if s.pid == 302) == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```powershell
+cd backend
+python -m pytest tests/monitoring/test_process_tracker.py::test_collect_samples_routes_backend_local_to_its_own_bucket -v
+```
+
+Expected: FAIL. PID 302 appears under both names because `collect_samples` iterates patterns and `_find_processes` matches independently.
+
+- [ ] **Step 3: Refactor `collect_samples` to iterate processes once, classify by first-matching pattern**
+
+In `backend/app/services/monitoring/process_tracker.py`, replace the body of `collect_samples` (lines 55-120) with:
+
+```python
+    def collect_samples(self) -> List[ProcessSampleSchema]:
+        """
+        Collect samples for all BaluHost processes.
+
+        Iterates processes once and classifies each PID under the first pattern
+        whose tokens all match. This prevents double-counting when a process
+        matches multiple patterns (e.g. backend-local also matches backend).
+        """
+        samples: List[ProcessSampleSchema] = []
+        timestamp = datetime.now(timezone.utc)
+        seen_names: set[str] = set()
+
+        try:
+            for proc in psutil.process_iter(
+                ["pid", "name", "cmdline", "cpu_percent", "memory_info", "status"]
+            ):
+                try:
+                    info = proc.info
+                    name = (info.get("name") or "").lower()
+                    cmdline = " ".join(info.get("cmdline") or []).lower()
+
+                    matched_name: Optional[str] = None
+                    for entry in BALUHOST_PROCESS_PATTERNS:
+                        patterns = entry["patterns"]
+                        if all(p.lower() in name or p.lower() in cmdline for p in patterns):
+                            matched_name = entry["name"]
+                            break
+
+                    if matched_name is None:
+                        continue
+
+                    memory_mb = 0.0
+                    if info.get("memory_info"):
+                        memory_mb = info["memory_info"].rss / (1024 * 1024)
+
+                    sample = ProcessSampleSchema(
+                        timestamp=timestamp,
+                        process_name=matched_name,
+                        pid=info["pid"],
+                        cpu_percent=round(info.get("cpu_percent", 0.0) or 0.0, 2),
+                        memory_mb=round(memory_mb, 2),
+                        status=info.get("status", "unknown"),
+                        is_alive=True,
+                    )
+                    samples.append(sample)
+                    seen_names.add(matched_name)
+
+                    with self._lock:
+                        self._process_buffers.setdefault(matched_name, []).append(sample)
+                        if len(self._process_buffers[matched_name]) > self.buffer_size:
+                            self._process_buffers[matched_name].pop(0)
+                        self._known_pids[matched_name] = info["pid"]
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    continue
+        except Exception as e:
+            logger.error(f"Error iterating processes: {e}")
+
+        # Emit synthetic "stopped" samples for previously seen names that are now gone
+        with self._lock:
+            gone = set(self._known_pids.keys()) - seen_names
+            for matched_name in gone:
+                last_pid = self._known_pids[matched_name]
+                sample = ProcessSampleSchema(
+                    timestamp=timestamp,
+                    process_name=matched_name,
+                    pid=last_pid,
+                    cpu_percent=0.0,
+                    memory_mb=0.0,
+                    status="stopped",
+                    is_alive=False,
+                )
+                samples.append(sample)
+                self._process_buffers.setdefault(matched_name, []).append(sample)
+                if len(self._process_buffers[matched_name]) > self.buffer_size:
+                    self._process_buffers[matched_name].pop(0)
+                logger.warning(
+                    f"Process '{matched_name}' (PID {last_pid}) stopped or crashed"
+                )
+                del self._known_pids[matched_name]
+
+        return samples
+```
+
+Also add to the imports at the top of the file (if not already present):
+
+```python
+from typing import Dict, List, Optional, Set, Type
+```
+
+(`Optional` may already be imported — keep one declaration.)
+
+- [ ] **Step 4: Run all process tracker tests**
+
+Run:
+```powershell
+cd backend
+python -m pytest tests/monitoring/test_process_tracker.py -v
+```
+
+Expected: all five tests PASS.
+
+- [ ] **Step 5: Run the broader monitoring suite for regressions**
+
+Run:
+```powershell
+cd backend
+python -m pytest tests/monitoring/ -v
+```
+
+Expected: no new failures.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add backend/app/services/monitoring/process_tracker.py backend/tests/monitoring/test_process_tracker.py
+git commit -m "feat(monitoring): first-match-wins routing in process_tracker.collect_samples"
+```
+
+---
+
+## Task 3: `get_baluhost_memory_breakdown` (replace flat total)
+
+**Files:**
+- Modify: `backend/app/services/monitoring/memory_collector.py:23-50` (replace `get_baluhost_memory_bytes`)
+- Modify: `backend/app/services/monitoring/memory_collector.py:75-96` (`collect_sample`)
+- Modify: `backend/tests/monitoring/test_collectors.py` (extend) OR create `backend/tests/monitoring/test_memory_collector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/monitoring/test_memory_collector.py`:
+
+```python
+"""Tests for memory_collector breakdown logic."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.monitoring import memory_collector
+from app.services.monitoring.memory_collector import (
+    MemoryMetricCollector,
+    get_baluhost_memory_breakdown,
+)
+from app.services.monitoring.process_tracker import BALUHOST_PROCESS_PATTERNS
+
+
+def _fake_proc(pid: int, cmdline_str: str, rss_bytes: int):
+    proc = MagicMock()
+    proc.info = {
+        "pid": pid,
+        "name": "python",
+        "cmdline": cmdline_str.split(),
+        "memory_info": MagicMock(rss=rss_bytes),
+    }
+    return proc
+
+
+def test_breakdown_contains_all_defined_units():
+    """All names from BALUHOST_PROCESS_PATTERNS appear as keys (zero-filled)."""
+    with patch.object(memory_collector.psutil, "process_iter", return_value=[]):
+        result = get_baluhost_memory_breakdown()
+    for entry in BALUHOST_PROCESS_PATTERNS:
+        assert entry["name"] in result
+        assert result[entry["name"]] == 0
+
+
+def test_breakdown_routes_processes_to_their_unit():
+    """Each matched process contributes RSS to its unit bucket."""
+    procs = [
+        _fake_proc(401, "python -m uvicorn app.main --port 8000", rss_bytes=200_000_000),
+        _fake_proc(402, "python -m uvicorn app.main --port 8000", rss_bytes=150_000_000),  # worker 2
+        _fake_proc(403, "python -m uvicorn app.main --fd 3 --workers 2", rss_bytes=100_000_000),
+        _fake_proc(404, "python scripts/scheduler_worker.py", rss_bytes=50_000_000),
+        _fake_proc(405, "python scripts/webdav_worker.py", rss_bytes=40_000_000),
+        _fake_proc(406, "python scripts/monitoring_worker.py", rss_bytes=30_000_000),
+    ]
+    with patch.object(memory_collector.psutil, "process_iter", return_value=procs):
+        result = get_baluhost_memory_breakdown()
+
+    assert result["baluhost-backend"] == 350_000_000
+    assert result["baluhost-backend-local"] == 100_000_000
+    assert result["baluhost-scheduler"] == 50_000_000
+    assert result["baluhost-webdav"] == 40_000_000
+    assert result["baluhost-monitoring"] == 30_000_000
+
+
+def test_collect_sample_populates_breakdown_and_total():
+    """MemoryMetricCollector.collect_sample fills both breakdown and total."""
+    procs = [
+        _fake_proc(501, "python -m uvicorn app.main --port 8000", rss_bytes=200_000_000),
+        _fake_proc(502, "python scripts/scheduler_worker.py", rss_bytes=50_000_000),
+    ]
+    fake_vmem = MagicMock(
+        total=16 * 1024**3,
+        available=8 * 1024**3,
+        percent=50.0,
+    )
+    with patch.object(memory_collector.psutil, "process_iter", return_value=procs), \
+         patch.object(memory_collector.psutil, "virtual_memory", return_value=fake_vmem):
+        collector = MemoryMetricCollector()
+        sample = collector.collect_sample()
+
+    assert sample is not None
+    assert sample.baluhost_memory_bytes == 250_000_000  # total backward-compat
+    assert sample.baluhost_memory_breakdown is not None
+    assert sample.baluhost_memory_breakdown["baluhost-backend"] == 200_000_000
+    assert sample.baluhost_memory_breakdown["baluhost-scheduler"] == 50_000_000
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+```powershell
+cd backend
+python -m pytest tests/monitoring/test_memory_collector.py -v
+```
+
+Expected: ImportError or AttributeError — `get_baluhost_memory_breakdown` and `baluhost_memory_breakdown` don't exist yet.
+
+- [ ] **Step 3: Replace `get_baluhost_memory_bytes` with `get_baluhost_memory_breakdown`**
+
+In `backend/app/services/monitoring/memory_collector.py`, replace lines 23-50 with:
+
+```python
+def get_baluhost_memory_breakdown() -> dict[str, int]:
+    """
+    Get RSS memory per BaluHost systemd unit.
+
+    Returns a dict keyed by ``process_name`` from ``BALUHOST_PROCESS_PATTERNS``.
+    All defined unit names appear as keys; missing units have value 0 so the
+    UI can distinguish "unit not defined" (key absent) from "unit not running"
+    (key present, value 0).
+
+    Routing is first-match-wins (same order as BALUHOST_PROCESS_PATTERNS) so
+    a process matching multiple patterns is counted under the first.
+    """
+    breakdown: dict[str, int] = {entry["name"]: 0 for entry in BALUHOST_PROCESS_PATTERNS}
+
+    try:
+        for proc in psutil.process_iter(["pid", "name", "cmdline", "memory_info"]):
+            try:
+                info = proc.info
+                name = (info.get("name") or "").lower()
+                cmdline = " ".join(info.get("cmdline") or []).lower()
+
+                for entry in BALUHOST_PROCESS_PATTERNS:
+                    if all(p.lower() in name or p.lower() in cmdline for p in entry["patterns"]):
+                        if info.get("memory_info"):
+                            breakdown[entry["name"]] += info["memory_info"].rss
+                        break
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+    except Exception as e:
+        logger.debug(f"Error getting BaluHost memory breakdown: {e}")
+
+    return breakdown
+
+
+def get_baluhost_memory_bytes() -> int:
+    """Backward-compat: total memory across all BaluHost processes."""
+    return sum(get_baluhost_memory_breakdown().values())
+```
+
+- [ ] **Step 4: Update `collect_sample` to emit both fields**
+
+In `backend/app/services/monitoring/memory_collector.py`, replace the `collect_sample` body (lines 75-96) with:
+
+```python
+    def collect_sample(self) -> Optional[MemorySampleSchema]:
+        """Collect memory metrics sample."""
+        try:
+            timestamp = datetime.now(timezone.utc)
+
+            mem = psutil.virtual_memory()
+            breakdown = get_baluhost_memory_breakdown()
+            total_baluhost = sum(breakdown.values())
+
+            return MemorySampleSchema(
+                timestamp=timestamp,
+                used_bytes=mem.total - mem.available,
+                total_bytes=mem.total,
+                percent=round(mem.percent, 2),
+                available_bytes=mem.available,
+                baluhost_memory_bytes=total_baluhost,
+                baluhost_memory_breakdown=breakdown,
+            )
+        except Exception as e:
+            logger.error(f"Failed to collect memory sample: {e}")
+            return None
+```
+
+- [ ] **Step 5: Run the tests — they will still fail until Task 4 lands**
+
+Run:
+```powershell
+cd backend
+python -m pytest tests/monitoring/test_memory_collector.py::test_breakdown_contains_all_defined_units tests/monitoring/test_memory_collector.py::test_breakdown_routes_processes_to_their_unit -v
+```
+
+Expected: these two PASS. `test_collect_sample_populates_breakdown_and_total` still FAILS because `MemorySampleSchema` doesn't have the field yet (Task 4 adds it). Continue.
+
+- [ ] **Step 6: Commit (intermediate — schema still missing)**
+
+```powershell
+git add backend/app/services/monitoring/memory_collector.py backend/tests/monitoring/test_memory_collector.py
+git commit -m "feat(monitoring): get_baluhost_memory_breakdown() per-unit RSS map"
+```
+
+---
+
+## Task 4: Extend `MemorySampleSchema` + API response
+
+**Files:**
+- Modify: `backend/app/schemas/monitoring.py` (`MemorySampleSchema`, `CurrentMemoryResponse`)
+- Modify: `backend/app/api/routes/monitoring.py:198-220` (`get_memory_current` response constructor)
+
+- [ ] **Step 1: Find the schemas**
+
+The schemas live in `backend/app/schemas/monitoring.py`. Locate `class MemorySampleSchema` and `class CurrentMemoryResponse`.
+
+- [ ] **Step 2: Add the new field to both schemas**
+
+In `backend/app/schemas/monitoring.py`, in `MemorySampleSchema`, add after `available_bytes`:
+
+```python
+    baluhost_memory_bytes: int = 0
+    baluhost_memory_breakdown: Optional[Dict[str, int]] = None
+```
+
+(If `baluhost_memory_bytes` is already present, just add `baluhost_memory_breakdown`.)
+
+In `CurrentMemoryResponse`, add the matching field — if the response mirrors `MemorySampleSchema` field-for-field, add `baluhost_memory_breakdown: Optional[Dict[str, int]] = None` there too.
+
+Check that `Dict` and `Optional` are imported at the top of the file:
+```python
+from typing import Dict, List, Optional
+```
+
+- [ ] **Step 3: Update the route handler**
+
+In `backend/app/api/routes/monitoring.py`, in `get_memory_current` (around line 198-220), update the response construction:
+
+```python
+    return CurrentMemoryResponse(
+        timestamp=sample.timestamp,
+        used_bytes=sample.used_bytes,
+        total_bytes=sample.total_bytes,
+        percent=sample.percent,
+        available_bytes=sample.available_bytes,
+        baluhost_memory_bytes=sample.baluhost_memory_bytes,
+        baluhost_memory_breakdown=sample.baluhost_memory_breakdown,
+    )
+```
+
+- [ ] **Step 4: Run the Task-3 test that was still failing**
+
+Run:
+```powershell
+cd backend
+python -m pytest tests/monitoring/test_memory_collector.py -v
+```
+
+Expected: all three tests PASS.
+
+- [ ] **Step 5: Add an integration test for the route**
+
+Append to `backend/tests/api/test_monitoring_routes.py` (inside the class that already has `test_memory_current_returns_data_or_503`):
+
+```python
+    def test_memory_current_includes_breakdown_field(self, client: TestClient, user_headers: dict):
+        """Memory current response carries baluhost_memory_breakdown (may be null on cold start)."""
+        response = client.get("/api/monitoring/memory/current", headers=user_headers)
+        assert response.status_code in [200, 503]
+        if response.status_code == 200:
+            data = response.json()
+            assert "baluhost_memory_breakdown" in data
+            # Either None (no sample yet on this worker) or a dict
+            breakdown = data["baluhost_memory_breakdown"]
+            assert breakdown is None or isinstance(breakdown, dict)
+            if isinstance(breakdown, dict):
+                # All defined units should be keys
+                for name in [
+                    "baluhost-backend",
+                    "baluhost-backend-local",
+                    "baluhost-scheduler",
+                    "baluhost-webdav",
+                    "baluhost-monitoring",
+                ]:
+                    assert name in breakdown
+```
+
+- [ ] **Step 6: Run the integration test**
+
+Run:
+```powershell
+cd backend
+python -m pytest tests/api/test_monitoring_routes.py::TestMemoryEndpoints::test_memory_current_includes_breakdown_field -v
+```
+
+(Adjust class name if the test class is named differently — find it with `python -m pytest tests/api/test_monitoring_routes.py --collect-only`.)
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the broader monitoring test suite**
+
+Run:
+```powershell
+cd backend
+python -m pytest tests/monitoring/ tests/api/test_monitoring_routes.py -v
+```
+
+Expected: no regressions.
+
+- [ ] **Step 8: Commit**
+
+```powershell
+git add backend/app/schemas/monitoring.py backend/app/api/routes/monitoring.py backend/tests/api/test_monitoring_routes.py
+git commit -m "feat(api): expose baluhost_memory_breakdown in /monitoring/memory/current"
+```
+
+---
+
+## Task 5: Verify SHM payload carries the new field
+
+**Files:**
+- Read only: `backend/app/services/monitoring/worker_service.py` (no edits expected)
+- Modify: `backend/tests/monitoring/test_orchestrator.py` (new test)
+
+`worker_service._write_orchestrator_data_snapshot` serializes the memory sample via `model_dump(mode="json")`, so the new field flows through automatically. This task adds a regression test to lock that behavior in.
+
+- [ ] **Step 1: Confirm by reading**
+
+Run:
+```powershell
+type "backend\app\services\monitoring\worker_service.py" | findstr /n "memory_current"
+```
+
+Verify line that does `mem_cur.model_dump(mode="json")` — that's what carries `baluhost_memory_breakdown` through SHM.
+
+- [ ] **Step 2: Add a regression test**
+
+Append to `backend/tests/monitoring/test_orchestrator.py`:
+
+```python
+def test_memory_sample_model_dump_includes_breakdown():
+    """SHM serialization (model_dump) must include the new breakdown field."""
+    from datetime import datetime, timezone
+    from app.schemas.monitoring import MemorySampleSchema
+
+    sample = MemorySampleSchema(
+        timestamp=datetime.now(timezone.utc),
+        used_bytes=8_000_000_000,
+        total_bytes=16_000_000_000,
+        percent=50.0,
+        available_bytes=8_000_000_000,
+        baluhost_memory_bytes=300_000_000,
+        baluhost_memory_breakdown={
+            "baluhost-backend": 200_000_000,
+            "baluhost-scheduler": 100_000_000,
+        },
+    )
+    dumped = sample.model_dump(mode="json")
+    assert "baluhost_memory_breakdown" in dumped
+    assert dumped["baluhost_memory_breakdown"]["baluhost-backend"] == 200_000_000
+```
+
+- [ ] **Step 3: Run it**
+
+Run:
+```powershell
+cd backend
+python -m pytest tests/monitoring/test_orchestrator.py::test_memory_sample_model_dump_includes_breakdown -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add backend/tests/monitoring/test_orchestrator.py
+git commit -m "test(monitoring): SHM payload regression test for memory breakdown"
+```
+
+---
+
+## Task 6: Frontend — extend `MemorySample` type
+
+**Files:**
+- Modify: `client/src/api/monitoring.ts:60-67`
+
+- [ ] **Step 1: Add the field**
+
+In `client/src/api/monitoring.ts`, replace the `MemorySample` interface (lines 60-67):
+
+```ts
+export interface MemorySample {
+  timestamp: string;
+  used_bytes: number;
+  total_bytes: number;
+  percent: number;
+  available_bytes?: number;
+  baluhost_memory_bytes?: number;  // Total memory used by BaluHost processes
+  baluhost_memory_breakdown?: Record<string, number>;  // RSS bytes per systemd unit
+}
+```
+
+- [ ] **Step 2: Run the frontend type check**
+
+Run:
+```powershell
+cd client
+npx tsc --noEmit
+```
+
+Expected: no new errors. If there are pre-existing errors unrelated to this change, ignore.
+
+- [ ] **Step 3: Commit**
+
+```powershell
+git add client/src/api/monitoring.ts
+git commit -m "feat(client): MemorySample.baluhost_memory_breakdown type"
+```
+
+---
+
+## Task 7: Frontend — BaluHost breakdown card in MemoryTab
+
+**Files:**
+- Modify: `client/src/components/system-monitor/MemoryTab.tsx`
+
+Replace the single "BaluHost" `StatCard` with a panel that lists per-unit RSS underneath the total. Layout: takes the same 5th-card slot in the grid; on `width < sm` it is collapsible.
+
+- [ ] **Step 1: Write the new component logic**
+
+Replace the entire content of `client/src/components/system-monitor/MemoryTab.tsx` with:
+
+```tsx
+/**
+ * MemoryTab -- RAM monitoring tab with usage chart and BaluHost per-unit breakdown.
+ */
+
+import { useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { MetricChart } from '../monitoring';
+import type { TimeRange } from '../../api/monitoring';
+import { useMemoryMonitoring } from '../../hooks/useMonitoring';
+import { formatBytes, formatNumber } from '../../lib/formatters';
+import { StatCard } from '../ui/StatCard';
+
+// Display order of units in the breakdown (matches BALUHOST_PROCESS_PATTERNS in backend).
+const UNIT_DISPLAY_ORDER = [
+  'baluhost-backend',
+  'baluhost-backend-local',
+  'baluhost-scheduler',
+  'baluhost-webdav',
+  'baluhost-monitoring',
+  'baluhost-tui',
+  'baluhost-frontend-dev',
+] as const;
+
+// i18n key per unit (under `system:monitor.units.*`).
+const UNIT_LABEL_KEY: Record<string, string> = {
+  'baluhost-backend':       'monitor.units.backend',
+  'baluhost-backend-local': 'monitor.units.backendLocal',
+  'baluhost-scheduler':     'monitor.units.scheduler',
+  'baluhost-webdav':        'monitor.units.webdav',
+  'baluhost-monitoring':    'monitor.units.monitoring',
+  'baluhost-tui':           'monitor.units.tui',
+  'baluhost-frontend-dev':  'monitor.units.frontendDev',
+};
+
+export function MemoryTab({ timeRange }: { timeRange: TimeRange }) {
+  const { t } = useTranslation(['system', 'common']);
+  const { current, history, loading, error } = useMemoryMonitoring({ historyDuration: timeRange });
+  const [breakdownOpen, setBreakdownOpen] = useState(false);
+
+  const totalGb = current ? current.total_bytes / (1024 * 1024 * 1024) : 16;
+
+  const chartData = useMemo(() => {
+    return history
+      .filter((s) => s.used_bytes > 0 && s.total_bytes > 0)
+      .map((s) => ({
+        time: s.timestamp,
+        usedGb: s.used_bytes / (1024 * 1024 * 1024),
+        baluhostGb: s.baluhost_memory_bytes && s.baluhost_memory_bytes > 0
+          ? s.baluhost_memory_bytes / (1024 * 1024 * 1024)
+          : null,
+      }));
+  }, [history]);
+
+  const hasBaluhostData = chartData.some((d) => d.baluhostGb !== null);
+
+  // Visible units = units with > 0 bytes, in canonical order.
+  const visibleUnits = useMemo(() => {
+    const breakdown = current?.baluhost_memory_breakdown;
+    if (!breakdown) return [];
+    return UNIT_DISPLAY_ORDER
+      .filter((name) => (breakdown[name] ?? 0) > 0)
+      .map((name) => ({ name, bytes: breakdown[name] }));
+  }, [current]);
+
+  if (error) {
+    return <div className="text-red-400 text-center py-8">{error}</div>;
+  }
+
+  return (
+    <div className="space-y-4 sm:space-y-6 min-w-0">
+      <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-3 sm:gap-5 lg:grid-cols-5">
+        <StatCard
+          label={t('monitor.used')}
+          value={current ? formatBytes(current.used_bytes) : '-'}
+          color="purple"
+          icon={<span className="text-purple-400 text-base sm:text-xl">📊</span>}
+        />
+        <StatCard
+          label={t('monitor.total')}
+          value={current ? formatBytes(current.total_bytes) : '-'}
+          color="blue"
+          icon={<span className="text-blue-400 text-base sm:text-xl">Σ</span>}
+        />
+        <StatCard
+          label={t('monitor.available')}
+          value={current?.available_bytes ? formatBytes(current.available_bytes) : '-'}
+          color="green"
+          icon={<span className="text-green-400 text-base sm:text-xl">✓</span>}
+        />
+        <StatCard
+          label={t('monitor.utilization')}
+          value={current?.percent != null ? formatNumber(current.percent, 1) : '0'}
+          unit="%"
+          color="orange"
+          icon={<span className="text-orange-400 text-base sm:text-xl">%</span>}
+        />
+
+        {/* BaluHost breakdown card */}
+        <div className="card border-slate-800/60 bg-slate-900/55 p-3 sm:p-4 flex flex-col">
+          <button
+            type="button"
+            onClick={() => setBreakdownOpen((v) => !v)}
+            className="flex items-center justify-between gap-2 text-left"
+            aria-expanded={breakdownOpen}
+          >
+            <span className="flex items-center gap-2 text-xs sm:text-sm text-slate-400">
+              <span className="text-cyan-400 text-base sm:text-xl">🏠</span>
+              BaluHost
+            </span>
+            {visibleUnits.length > 0 && (
+              breakdownOpen
+                ? <ChevronDown className="h-4 w-4 text-slate-500" />
+                : <ChevronRight className="h-4 w-4 text-slate-500" />
+            )}
+          </button>
+          <div className="mt-1 text-xl sm:text-2xl font-semibold text-white tabular-nums">
+            {current?.baluhost_memory_bytes ? formatBytes(current.baluhost_memory_bytes) : '-'}
+          </div>
+
+          {breakdownOpen && visibleUnits.length > 0 && (
+            <ul className="mt-3 space-y-1 text-xs sm:text-sm">
+              {visibleUnits.map((unit) => (
+                <li key={unit.name} className="flex justify-between gap-2">
+                  <span className="text-slate-400 truncate">
+                    {t(UNIT_LABEL_KEY[unit.name] ?? unit.name)}
+                  </span>
+                  <span className="text-slate-200 tabular-nums shrink-0">
+                    {formatBytes(unit.bytes)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      <div className="card border-slate-800/60 bg-slate-900/55 p-4 sm:p-6">
+        <h3 className="mb-3 sm:mb-4 text-base sm:text-lg font-semibold text-white">{t('monitor.ramHistory')}</h3>
+        <MetricChart
+          data={chartData}
+          lines={[
+            { dataKey: 'usedGb', name: t('monitor.usedGb'), color: '#a855f7' },
+            ...(hasBaluhostData
+              ? [{ dataKey: 'baluhostGb', name: t('monitor.baluhostGb'), color: '#06b6d4' }]
+              : []),
+          ]}
+          yAxisLabel="GB"
+          yAxisDomain={[0, Math.ceil(totalGb)]}
+          height={300}
+          loading={loading}
+          showArea
+          timeRange={timeRange}
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run:
+```powershell
+cd client
+npx tsc --noEmit
+```
+
+Expected: no new errors (translation keys added in Task 8 — TS doesn't validate i18next keys).
+
+- [ ] **Step 3: Build check**
+
+Run:
+```powershell
+cd client
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add client/src/components/system-monitor/MemoryTab.tsx
+git commit -m "feat(ui): per-unit BaluHost memory breakdown in MemoryTab"
+```
+
+---
+
+## Task 8: i18n keys (en + de)
+
+**Files:**
+- Modify: `client/src/i18n/locales/en/system.json`
+- Modify: `client/src/i18n/locales/de/system.json`
+
+- [ ] **Step 1: Locate the `monitor` group in both files**
+
+Both files have a top-level `monitor` object. Add a new `units` sub-group.
+
+- [ ] **Step 2: Add English keys**
+
+In `client/src/i18n/locales/en/system.json`, inside the `monitor` object, add:
+
+```json
+    "units": {
+      "backend": "Backend (HTTP)",
+      "backendLocal": "Backend (Local)",
+      "scheduler": "Scheduler",
+      "webdav": "WebDAV",
+      "monitoring": "Monitoring",
+      "tui": "TUI",
+      "frontendDev": "Frontend (dev)"
+    }
+```
+
+(Place inside the `monitor: { ... }` block, before its closing brace. Add a trailing comma to the previous key inside `monitor` if needed.)
+
+- [ ] **Step 3: Add German keys**
+
+In `client/src/i18n/locales/de/system.json`, inside the `monitor` object, add:
+
+```json
+    "units": {
+      "backend": "Backend (HTTP)",
+      "backendLocal": "Backend (Lokal)",
+      "scheduler": "Scheduler",
+      "webdav": "WebDAV",
+      "monitoring": "Monitoring",
+      "tui": "TUI",
+      "frontendDev": "Frontend (Dev)"
+    }
+```
+
+- [ ] **Step 4: Validate JSON syntax**
+
+Run:
+```powershell
+cd client
+node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/en/system.json'))"
+node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/de/system.json'))"
+```
+
+Expected: no output (both parse successfully).
+
+- [ ] **Step 5: Build to verify**
+
+Run:
+```powershell
+cd client
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add client/src/i18n/locales/en/system.json client/src/i18n/locales/de/system.json
+git commit -m "feat(i18n): BaluHost memory unit labels (en/de)"
+```
+
+---
+
+## Task 9: Final verification
+
+- [ ] **Step 1: Full backend test suite (monitoring + api)**
+
+Run:
+```powershell
+cd backend
+python -m pytest tests/monitoring/ tests/api/test_monitoring_routes.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Quick smoke against dev server**
+
+Start dev:
+```powershell
+python start_dev.py
+```
+
+In a separate terminal, log in and hit:
+```powershell
+curl -s http://localhost:3001/api/monitoring/memory/current -H "Authorization: Bearer <dev-token>" | python -m json.tool
+```
+
+Expected response contains a `baluhost_memory_breakdown` object with at least `baluhost-backend` non-zero (Uvicorn dev worker). Other units will likely be zero in dev unless `start_dev.py` runs them.
+
+- [ ] **Step 3: Manual UI check**
+
+Open `http://localhost:5173/system-monitor` → Memory tab. Verify:
+- 5th card shows "BaluHost" with total + expandable arrow
+- Expanding lists at least `Backend (HTTP)` with a non-zero value
+- Chart still shows used + BaluHost lines
+
+- [ ] **Step 4: Update vectordb index**
+
+Use the MCP tool:
+```
+mcp__vectordb-search__index_update with projectPath D:/Programme (x86)/Baluhost
+```
+
+- [ ] **Step 5: Final commit (if any cleanup) and push**
+
+Confirm clean tree:
+```powershell
+git status
+```
+
+If clean, push:
+```powershell
+git push -u origin feat/memory-per-unit-breakdown
+```
+
+- [ ] **Step 6: Open PR**
+
+```powershell
+gh pr create --title "feat: per-unit BaluHost RAM breakdown in System Monitor" --body "$(cat <<'EOF'
+## Summary
+
+- Fix RAM tracking so all five BaluHost systemd units are counted (scheduler / webdav / monitoring were silently missing)
+- Separate `baluhost-backend-local` from `baluhost-backend` via first-match-wins on `--fd 3`
+- Expose `baluhost_memory_breakdown` per unit in `/api/monitoring/memory/current`
+- System Monitor → Memory tab: BaluHost card is now expandable, showing RSS per unit
+
+## Test plan
+
+- [ ] `python -m pytest backend/tests/monitoring/ backend/tests/api/test_monitoring_routes.py`
+- [ ] Manual: open Memory tab, expand BaluHost card, see per-unit values
+- [ ] Deploy to BaluNode, curl `/api/monitoring/memory/current` and confirm all five units have non-zero RSS
+
+Spec: docs/superpowers/specs/2026-05-27-baluhost-ram-per-unit-breakdown-design.md
+Plan: docs/superpowers/plans/2026-05-27-baluhost-ram-per-unit-breakdown.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Checklist (already applied)
+
+- Spec coverage: every section of the spec maps to a task (patterns → T1, first-match-wins → T2, breakdown helper → T3, schema/route → T4, SHM regression → T5, frontend type → T6, UI → T7, i18n → T8, verification → T9). ✓
+- No placeholders. ✓
+- Type consistency: `baluhost_memory_breakdown` named identically across Python/TS, schema, route, SHM, UI consumer. ✓
+- File paths and line ranges match what was read in spec preparation. ✓
+- Out-of-scope items from spec (per-worker drill-down, cgroup detection, DB persistence of breakdown) are not introduced in any task. ✓

--- a/docs/superpowers/specs/2026-05-27-baluhost-ram-per-unit-breakdown-design.md
+++ b/docs/superpowers/specs/2026-05-27-baluhost-ram-per-unit-breakdown-design.md
@@ -1,0 +1,281 @@
+# BaluHost RAM Anzeige: Aufschlüsselung pro systemd-Unit
+
+**Datum:** 2026-05-27
+**Status:** Spec — pending implementation plan
+**Branch:** *(neu)* `feat/memory-per-unit-breakdown`
+
+## Problem
+
+Der System Monitor zeigt einen einzelnen RAM-Wert für "BaluHost" (`MemoryTab.tsx:68-73`). Hinter dem Wert steht `get_baluhost_memory_bytes()` (`backend/app/services/monitoring/memory_collector.py:23`), das `psutil.process_iter` durchläuft und RSS aller Prozesse summiert, deren Name oder cmdline einem der Patterns in `BALUHOST_PROCESS_PATTERNS` entspricht (`backend/app/services/monitoring/process_tracker.py:25`):
+
+```python
+BALUHOST_PROCESS_PATTERNS = [
+    {"name": "baluhost-backend",  "patterns": ["uvicorn", "app.main"]},
+    {"name": "baluhost-frontend", "patterns": ["node", "vite"]},
+    {"name": "baluhost-tui",      "patterns": ["baluhost-tui", "baluhost_tui"]},
+]
+```
+
+In Production läuft BaluHost als **fünf separate systemd-Units**:
+
+| Unit | ExecStart | Aktuell erfasst? |
+|---|---|---|
+| `baluhost-backend.service` | `uvicorn app.main:app --workers 4` (1 Master + 4 Worker) | ✓ via `"uvicorn"` |
+| `baluhost-backend-local.service` | `uvicorn app.main:app --fd 3 --workers 2` (1 Master + 2 Worker, Unix-Socket) | ✓ via `"uvicorn"`, aber **als Backend-Topf**, nicht separat |
+| `baluhost-scheduler.service` | `python scripts/scheduler_worker.py` | ✗ kein Pattern matcht |
+| `baluhost-webdav.service` | `python scripts/webdav_worker.py` | ✗ kein Pattern matcht |
+| `baluhost-monitoring.service` | `python scripts/monitoring_worker.py` | ✗ kein Pattern matcht |
+
+Daraus folgen drei konkrete Defekte:
+
+1. **3 von 5 Units fehlen in der Gesamtsumme** — Scheduler, WebDAV und Monitoring-Worker tauchen im "BaluHost"-Wert gar nicht auf.
+2. **Pattern `"node"` ist Substring-fragil** — In Production läuft kein Vite/Node; auf Dev-Boxen kann `"node"` an beliebige unrelated Node-Prozesse anschlagen.
+3. **Keine Aufschlüsselung** — `MemorySampleSchema` hat nur ein Feld `baluhost_memory_bytes: int`. Die UI hat keine Möglichkeit, "wo geht das RAM eigentlich hin" zu beantworten.
+
+## Goal
+
+Die "BaluHost"-RAM-Anzeige zeigt:
+- Eine korrekte **Gesamtsumme** über alle BaluHost-Prozesse (inklusive Scheduler/WebDAV/Monitoring).
+- Eine **Aufschlüsselung pro systemd-Unit**:
+  - `baluhost-backend` — aggregiert über Master + 4 Worker
+  - `baluhost-backend-local` — eigene Zeile (separat von `baluhost-backend`)
+  - `baluhost-scheduler`
+  - `baluhost-webdav`
+  - `baluhost-monitoring`
+  - `baluhost-tui` (nur wenn präsent)
+  - `baluhost-frontend-dev` (nur Dev-Modus)
+
+## Non-Goals
+
+- **Per-Worker-Drill-down** (welcher der 4 Uvicorn-Worker wie viel) — vertagt. `process_samples` speichert pro PID, der Daten-Pfad ist da; nur UI fehlt.
+- **cgroup-basierte Erkennung** (Hybrid-Ansatz aus dem Brainstorm) — vertagt. cmdline-Patterns reichen, solange Units immer per systemd oder `start_dev.py`/`start_prod.py` gestartet werden.
+- **Postgres-/Nginx-/Redis-RAM** — sind keine BaluHost-Prozesse; gehört in eine eigene "Stack View" wenn überhaupt.
+- **Migration auf JSON-Spalte in `memory_samples`** — Historie pro Unit lebt schon in `process_samples` (existierende Tabelle); keine zusätzliche Migration nötig.
+
+## Approach
+
+**Ansatz A** aus dem Brainstorm: cmdline-Patterns präzisieren und erweitern. Begründung:
+- Cross-platform (Windows-Dev läuft auch ohne systemd).
+- Minimal-invasiv: die `ProcessTracker`-Pipeline existiert, schreibt schon pro `process_name` in `process_samples`.
+- Die ExecStart-Strings sind eindeutig genug (`scheduler_worker.py`, `webdav_worker.py`, `monitoring_worker.py`, `uvicorn app.main`), dass Substring-Matching robust ist.
+- cgroup-Hybrid kann später nachgezogen werden ohne API-Bruch.
+
+### Unterscheidung `baluhost-backend` vs. `baluhost-backend-local`
+
+Beide laufen mit `uvicorn app.main:app`. Unterscheidungsmerkmal in cmdline:
+- **Backend (HTTP)**: `--host 0.0.0.0 --port 8000 --workers 4`
+- **Backend-Local (Unix-Socket)**: `--fd 3 --workers 2` und Env `BALUHOST_CHANNEL=local`
+
+Patterns müssen also Backend-Local **zuerst** matchen (z. B. via `"--fd 3"`), damit nicht beides in den `baluhost-backend`-Topf fällt.
+
+## Components
+
+### Backend
+
+#### `process_tracker.py` — Pattern-Definition
+
+`BALUHOST_PROCESS_PATTERNS` wird zu einer geordneten Liste, in der spezifischere Einträge zuerst stehen. Erste Übereinstimmung gewinnt — Prozesse werden nicht doppelt gezählt.
+
+```python
+BALUHOST_PROCESS_PATTERNS = [
+    # Order matters: more-specific patterns first.
+    {"name": "baluhost-backend-local",  "patterns": ["uvicorn app.main", "--fd 3"]},       # both must match
+    {"name": "baluhost-backend",        "patterns": ["uvicorn app.main"]},                 # remaining uvicorn procs
+    {"name": "baluhost-scheduler",      "patterns": ["scheduler_worker.py"]},
+    {"name": "baluhost-webdav",         "patterns": ["webdav_worker.py"]},
+    {"name": "baluhost-monitoring",     "patterns": ["monitoring_worker.py"]},
+    {"name": "baluhost-tui",            "patterns": ["baluhost_tui"]},
+    {"name": "baluhost-frontend-dev",   "patterns": ["vite"]},                              # dev only; "node" alone removed
+]
+```
+
+**Match-Semantik-Änderung**: Bisher war `patterns` ein "any-of" (jeder Substring-Treffer reicht). Für `baluhost-backend-local` brauchen wir **all-of**, damit `--fd 3` zusätzlich zu `uvicorn app.main` matchen muss. Anpassung in `_find_processes()` und `get_baluhost_memory_bytes()`:
+
+```python
+def _matches(cmdline: str, name: str, patterns: list[str]) -> bool:
+    return all(p.lower() in name or p.lower() in cmdline for p in patterns)
+```
+
+(Bisher `any(...)`. Alle bestehenden Patterns sind ein-elementige Listen, also Verhalten identisch — bis auf Backend-Local.)
+
+**First-match-wins**: In der Sammel-Schleife durch `BALUHOST_PROCESS_PATTERNS` wird ein PID, der für `baluhost-backend-local` gematcht hat, beim `baluhost-backend`-Pattern übersprungen. Implementierung: pro PID nach erstem Match `break`, dann zur nächsten PID — also Match-Schleife pro Prozess, nicht pro Pattern.
+
+#### `memory_collector.py` — Aufschlüsselung
+
+`get_baluhost_memory_bytes()` wird zu `get_baluhost_memory_breakdown() -> dict[str, int]`:
+
+```python
+def get_baluhost_memory_breakdown() -> dict[str, int]:
+    """RSS bytes pro process_name. Keys aus BALUHOST_PROCESS_PATTERNS."""
+    breakdown: dict[str, int] = {entry["name"]: 0 for entry in BALUHOST_PROCESS_PATTERNS}
+    for proc in psutil.process_iter(["pid", "name", "cmdline", "memory_info"]):
+        # match in first-wins order, accumulate RSS in breakdown[name]
+        ...
+    return breakdown
+```
+
+`MemoryMetricCollector.collect_sample()` ruft das auf und schreibt:
+- `baluhost_memory_breakdown` (neues Feld) — komplette Aufschlüsselung
+- `baluhost_memory_bytes` (bestehend) — `sum(breakdown.values())` für Backward-Compat
+
+Units mit `0` Bytes (Prozess nicht gefunden) bleiben im Dict mit Wert `0`. Das ist absichtlich: der Konsument sieht den Unterschied zwischen "Unit nicht definiert" (Key fehlt) und "Unit läuft gerade nicht" (Key da, Wert 0).
+
+#### `schemas/monitoring.py` — Schema-Erweiterung
+
+```python
+class MemorySampleSchema(BaseModel):
+    timestamp: datetime
+    used_bytes: int
+    total_bytes: int
+    percent: float
+    available_bytes: int
+    baluhost_memory_bytes: int  # Gesamtsumme (Backward-Compat)
+    baluhost_memory_breakdown: Optional[Dict[str, int]] = None  # NEU
+```
+
+`Optional`, weil ältere DB-Rows das Feld nicht haben (s. nächster Punkt).
+
+#### Persistenz
+
+Zwei Optionen:
+
+| Option | Beschreibung | Empfehlung |
+|---|---|---|
+| **Live-only** | Breakdown nur im API-Response (`/api/monitoring/memory/current`), nicht in `memory_samples` persistiert | ✓ |
+| **In DB-Spalte (JSON)** | Neue Spalte `memory_samples.baluhost_breakdown JSONB` + Alembic-Migration | ✗ |
+
+**Empfehlung: Live-only.** Die Historie pro Unit lebt bereits in `process_samples` (über `ProcessTracker`), das ist die natürliche Quelle für Zeitreihen. Doppeltes Schreiben wäre Redundanz. `MemorySample.baluhost_memory_bytes` (Gesamtsumme) bleibt persistent — das ist die Series, die auf der Memory-Chart als zweite Linie liegt.
+
+#### API-Route — Process-History
+
+Das Frontend braucht eine Endpoint, um pro Unit eine RAM-History zu plotten. Existiert vermutlich schon (`orchestrator.get_process_history()` ist da). Wenn nicht direkt unter `/api/monitoring/processes`, dann hinzufügen:
+
+```
+GET /api/monitoring/processes/history?process_name=baluhost-backend&minutes=10
+→ List[ProcessSampleSchema]
+```
+
+Mit DB-Fallback (siehe `ProcessTracker.get_history_db()`).
+
+**Zu prüfen während der Implementation**: ob die Route schon existiert. Falls ja, nur konsumieren; falls nein, hinzufügen.
+
+### Frontend
+
+#### `api/monitoring.ts` — Type-Erweiterung
+
+```ts
+export interface MemorySample {
+  timestamp: string;
+  used_bytes: number;
+  total_bytes: number;
+  percent: number;
+  available_bytes: number;
+  baluhost_memory_bytes: number;
+  baluhost_memory_breakdown?: Record<string, number>;  // NEU
+}
+```
+
+#### `MemoryTab.tsx` — UI-Änderungen
+
+Aktuell (`MemoryTab.tsx:42-74`): fünf StatCards (Used, Total, Available, Utilization, BaluHost). Die "BaluHost"-StatCard wird ersetzt durch eine **kompaktere Komponente** mit Drill-down:
+
+```
+┌─────────────────────────────────┐
+│ 🏠 BaluHost            842 MB   │
+├─────────────────────────────────┤
+│  Backend (HTTP)         612 MB  │   ← aggregiert: Master + 4 Worker
+│  Backend (Local)        180 MB  │   ← Unix-Socket Channel
+│  Scheduler               24 MB  │
+│  WebDAV                  18 MB  │
+│  Monitoring               8 MB  │
+└─────────────────────────────────┘
+```
+
+Layout-Entscheidung: die Aufschlüsselung ersetzt nicht die "Total"/"Used"-StatCards, sondern nimmt deren Slot (5. Karte). Bei `width < sm` klappbar (default zu) damit das Grid auf Mobile nicht überquillt.
+
+**Translation-Keys** (`client/src/i18n/locales/{en,de}/system.json`):
+- `monitor.baluhostBreakdown` — Header "BaluHost Breakdown"
+- `monitor.units.backend` — "Backend (HTTP)"
+- `monitor.units.backend-local` — "Backend (Local)"
+- `monitor.units.scheduler`, `.webdav`, `.monitoring`, `.tui`, `.frontend-dev`
+
+Mapping `process_name → translation-key` zentral in einer Konstante:
+```ts
+const UNIT_LABELS: Record<string, string> = {
+  "baluhost-backend":       "monitor.units.backend",
+  "baluhost-backend-local": "monitor.units.backend-local",
+  "baluhost-scheduler":     "monitor.units.scheduler",
+  // ...
+};
+```
+
+#### Chart-Erweiterung — vertagt im Rahmen dieser Spec
+
+Das Chart in `MemoryTab.tsx:77-94` bleibt vorerst zweispurig (System Used + BaluHost Total). Per-Unit-Stacked-Area wäre ein eigenes Feature mit Historien-Pull aus `process_samples` — dafür braucht es die Process-History-Route + neue Hook + Chart-Anpassung. Falls die Route schon existiert, kann das in einer **Stretch-Task** mitgehen; sonst separates Folge-Ticket.
+
+## Data Flow
+
+```
+psutil.process_iter()
+  └─→ ProcessTracker.collect_samples()      ← pro PID + process_name (DB-persistent in process_samples)
+  └─→ get_baluhost_memory_breakdown()       ← {unit_name: total_rss_bytes}
+                                            ↓
+                          MemorySampleSchema.baluhost_memory_breakdown
+                                            ↓
+                          GET /api/monitoring/memory/current
+                                            ↓
+                                  MemoryTab.tsx → Breakdown-Card
+```
+
+## Error Handling
+
+- `psutil.NoSuchProcess` / `psutil.AccessDenied` während Iteration: skip, bestehende Logik (`memory_collector.py:45`) bleibt.
+- Wenn alle Patterns 0 Bytes ergeben (z. B. Tests, frisch gebooteter Container): Breakdown-Dict mit allen Keys auf 0, Total = 0. UI zeigt dann "—" oder Nullzeile.
+- DB-Row ohne `baluhost_memory_breakdown` (historisch persistierte Samples gibt's nicht — Live-only — also nur möglich, falls jemand zwischenzeitlich Persistierung nachzieht): Feld ist `Optional`, Frontend zeigt nur Gesamtsumme.
+
+## Testing
+
+### Unit Tests
+- `tests/services/monitoring/test_process_tracker.py`:
+  - Pattern `baluhost-backend-local` matcht nur cmdline mit *beiden* `uvicorn app.main` und `--fd 3`.
+  - First-match-wins: ein Mock-Prozess mit cmdline `uvicorn app.main --fd 3` landet in `baluhost-backend-local`, **nicht** in `baluhost-backend`.
+  - Mock-Prozess mit `scheduler_worker.py` landet in `baluhost-scheduler`.
+- `tests/services/monitoring/test_memory_collector.py`:
+  - `get_baluhost_memory_breakdown()` liefert ein Dict mit allen `BALUHOST_PROCESS_PATTERNS`-Keys.
+  - Gesamtsumme = sum(breakdown.values()).
+  - Backward-Compat: `MemorySampleSchema.baluhost_memory_bytes` weiterhin gefüllt.
+
+### Integration Test
+- `tests/api/test_monitoring.py`:
+  - `GET /api/monitoring/memory/current` enthält `baluhost_memory_breakdown` mit erwarteten Keys.
+
+### Manual / Production Smoke
+Nach Deploy auf BaluNode:
+```bash
+curl -s -H "Authorization: Bearer <token>" http://localhost/api/monitoring/memory/current | jq '.baluhost_memory_breakdown'
+# Erwartet: alle 5 prod-Units mit nicht-null RSS
+```
+
+## Files to Modify
+
+### Backend
+- `backend/app/services/monitoring/process_tracker.py` — `BALUHOST_PROCESS_PATTERNS` erweitern, `_find_processes()` auf `all(...)` umstellen, first-match-wins in `collect_samples()`
+- `backend/app/services/monitoring/memory_collector.py` — `get_baluhost_memory_bytes()` → `get_baluhost_memory_breakdown()`, Sample befüllen
+- `backend/app/schemas/monitoring.py` — `MemorySampleSchema.baluhost_memory_breakdown` hinzufügen
+- `backend/tests/services/monitoring/test_process_tracker.py` — neue/erweiterte Tests
+- `backend/tests/services/monitoring/test_memory_collector.py` — neue/erweiterte Tests
+
+### Frontend
+- `client/src/api/monitoring.ts` — `MemorySample.baluhost_memory_breakdown` Type
+- `client/src/components/system-monitor/MemoryTab.tsx` — Breakdown-Card statt einfacher StatCard
+- `client/src/i18n/locales/en/system.json` — neue Keys
+- `client/src/i18n/locales/de/system.json` — neue Keys
+
+### Optional (sofern Route nicht schon existiert)
+- `backend/app/api/routes/monitoring.py` — `/processes/history?process_name=...` Endpoint hinzufügen
+
+## Open Verifications Before Implementation
+
+- [ ] Existiert `/api/monitoring/processes/history` schon? (für späteren Per-Unit-Chart)
+- [ ] Wo wird `MemoryMetricCollector` instanziiert (lifespan? monitoring worker?) — sicherstellen, dass `BALUHOST_PROCESS_PATTERNS`-Erweiterung dort durchschlägt
+- [ ] In welchem Worker läuft die Memory-Collection? Wenn nur Monitoring-Worker, sieht der seinen eigenen `monitoring_worker.py` korrekt

--- a/docs/superpowers/specs/2026-05-27-topbar-statusbar-design.md
+++ b/docs/superpowers/specs/2026-05-27-topbar-statusbar-design.md
@@ -1,0 +1,476 @@
+# Topbar Status Strip — Design (Refresh)
+
+**Date:** 2026-05-27
+**Status:** Approved
+**Author:** Sven (Xveyn) + Claude
+**Supersedes:** `docs/superpowers/specs/2026-05-10-topbar-statusbar-design.md` (commit `fc4663ad`, branch `feat/sleep-os-settings-and-custom-datetime`). That earlier spec was approved but its implementation plan was never written; the catalog has since gained three new pills.
+
+## Problem
+
+The BaluHost topbar has empty horizontal space between the mobile-header block and the right-side controls (NotificationCenter, UserMenu, PowerMenu). Status information that admins and users currently need to dig into individual pages for — power profile, Pi-hole on/off, active uploads, RAID health, sleep schedule, VPN clients, **Always-Awake overrides, running scheduler jobs, backup state** — has no at-a-glance surface.
+
+## Solution
+
+A read-only status strip in the topbar that shows admin-configurable pills. Each pill is a click-through link to its detail page. Admin can pick which pills appear, choose per-pill visibility ("Admin only" or "All Users"), and reorder them via drag-and-drop. The strip is hidden on mobile and in Pi-mode. Configuration lives under **System Control → System → Status Bar**.
+
+## Requirements
+
+- Admin enables/disables each pill from a fixed catalog (**11 pills initially**)
+- Admin chooses visibility per pill: **Admin only** or **All Users**
+- Pills with sensitive data (RAID, Sleep, VPN, Temp, Always Awake, Scheduler, Backup) are `visibility_locked=True` — visibility cannot be set to "All Users" via UI or API
+- Admin reorders pills via drag-and-drop; order is global (same for everyone)
+- A separate setting controls whether the existing bottom-right `UploadProgressBar` is shown (independent from the Uploads pill in the topbar)
+- The strip is read-only — no mutations from the header, only navigation
+- The strip is hidden on viewports `< lg` (1024px) and in Pi-mode (`__DEVICE_MODE__ === 'pi'`)
+- Pills marked `silent_when_ok` are omitted from the response payload when there is nothing to report (RAID OK, Temp normal, no active uploads, Always-Awake off, no running jobs, no backup activity within 24h of a successful run, etc.) — they cost no pixels in the idle state
+- Status payload polled every 10 seconds; pause polling when tab is hidden
+- The Always-Awake pill renders a per-second client-side countdown derived from `expires_in_seconds` between polls; on every poll the server value re-anchors (drift > 5s wins)
+- All pill data flows through one aggregator endpoint, filtered server-side by user role
+- WCAG: status conveyed via icon + text + tone (never color alone); focus-visible ring on every pill; tooltip dismissable per WCAG 1.4.13
+
+## Architecture
+
+### Data flow
+
+```
+Admin                                   Any logged-in user
+ │                                       │
+ │  PUT /api/system/statusbar/config     │  GET /api/system/statusbar/state
+ │  (enable, visibility, order, upload   │  (returns pill payload filtered
+ │   bar toggle)                          │   by role; polled every 10s)
+ │                                       │
+ ▼                                       ▼
+status_bar_pill_config (DB)          status_bar service
+status_bar_settings    (DB)               │ collect_all_states()
+                                          │   ↳ existing services
+                                          │     (power, pihole, uploads,
+                                          │      sync, raid, sleep, vpn,
+                                          │      temp, always_awake,
+                                          │      scheduler, backup)
+                                          ▼
+                                       <TopbarStatusStrip /> in Layout.tsx
+```
+
+### Persistence
+
+Two new tables (additive migration, safe for live PostgreSQL 17.7):
+
+```python
+# backend/app/models/status_bar.py
+class StatusBarPillConfig(Base):
+    __tablename__ = "status_bar_pill_config"
+    id          = Column(Integer, primary_key=True)
+    pill_id     = Column(String(32), unique=True, nullable=False)
+    enabled     = Column(Boolean, nullable=False, default=False)
+    visibility  = Column(String(8), nullable=False, default="admin")  # "admin" | "all"
+    sort_order  = Column(Integer, nullable=False, default=0)
+    updated_at  = Column(DateTime(timezone=True), server_onupdate=func.now())
+
+class StatusBarSettings(Base):
+    __tablename__ = "status_bar_settings"
+    id                  = Column(Integer, primary_key=True, default=1)  # singleton
+    show_bottom_upload  = Column(Boolean, nullable=False, default=True)
+```
+
+The service layer ensures both tables are populated with sensible defaults on first read — fresh DB or new pills introduced in a future version are auto-inserted as `enabled=False`.
+
+### Pill Catalog
+
+Hardcoded registry in `backend/app/services/status_bar/catalog.py`. Mirrored frontend renderer-map in `client/src/components/topbar/pillRenderers.tsx`.
+
+| `pill_id` | Name | Default visibility | `visibility_locked` | `silent_when_ok` | Click-through |
+|---|---|---|---|---|---|
+| `power`         | Power Profile        | admin | false    | false | `/admin/system-control?tab=energy` |
+| `pihole`        | Pi-hole DNS          | admin | false    | false | `/pihole` |
+| `uploads`       | Uploads / Downloads  | all   | false    | true  | `/files` |
+| `sync`          | Sync                 | all   | false    | true  | `/devices` |
+| `raid`          | RAID Health          | admin | **true** | true  | `/admin/system-control?tab=raid` |
+| `sleep`         | Sleep Mode           | admin | **true** | true  | `/admin/system-control?tab=sleep` |
+| `vpn`           | VPN Clients          | admin | **true** | false | `/admin/system-control?tab=vpn` |
+| `temp`          | Temperature / Fans   | admin | **true** | true  | `/admin/system-control?tab=fan` |
+| `always_awake`  | Always Awake         | admin | **true** | true  | `/admin/system-control?tab=sleep` |
+| `scheduler`     | Scheduler            | admin | **true** | true  | `/admin/schedulers` |
+| `backup`        | Backup               | admin | **true** | true  | `/admin/system-control?tab=backup` |
+
+Free-to-expose-to-all (admin can choose): `power`, `pihole`, `uploads`, `sync`. Locked admin-only: `raid`, `sleep`, `vpn`, `temp`, `always_awake`, `scheduler`, `backup`.
+
+`PillDefinition` shape:
+
+```python
+@dataclass
+class PillDefinition:
+    id: str
+    name_key: str
+    default_visibility: str            # "admin" | "all"
+    visibility_locked: bool
+    silent_when_ok: bool
+    href: str
+    collector: Callable[[Session, str], dict | None]
+```
+
+Each `collector` is a thin wrapper (5–20 LOC) around an existing service:
+
+- `collect_power` → `power_manager.get_status()`
+- `collect_pihole` → `pihole_backend.get_status()`
+- `collect_uploads` → `upload_progress_manager.get_summary()`
+- `collect_sync` → `sync_scheduler.get_active_summary()`
+- `collect_raid` → `raid_backend.list_arrays()` filtered to `degraded/resync/failed`
+- `collect_sleep` → `sleep_manager.get_schedule_summary()`
+- `collect_vpn` → `vpn_service.get_active_peers_count()`
+- `collect_temp` → `fan_control.get_status()` filtered to threshold-exceeded
+- `collect_always_awake` → `sleep_manager.get_status().always_awake` (active only)
+- `collect_scheduler` → count of `SchedulerExecution.status IN (RUNNING, REQUESTED)` plus up to 3 job-display names
+- `collect_backup` → backup activity (see Backup-Pill semantics below)
+
+A collector returns `None` for `silent_when_ok` pills with no signal, or wraps in try/except to return `None` on backend failure (no 5xx leaks into the strip).
+
+#### Always-Awake-Pill semantics
+
+- Returns `None` when `always_awake.enabled == False`.
+- Returns a payload otherwise with:
+  - `tone = "warning"` (auto-sleep is actively blocked)
+  - `value = "permanent"` when `until is None`
+  - `value = formatted countdown` when `until` is set (e.g. `"03:42"` for MM:SS, `"02:15:00"` for HH:MM:SS when >1h)
+  - `extra = {"expires_in_seconds": float}` so the frontend can run a per-second client countdown between polls
+- The pill **coexists** with the `sleep` pill — `sleep` shows the schedule status (e.g. "Sleep at 23:00"); `always_awake` shows the active override. When both are active simultaneously, the admin sees at a glance that the override is blocking the scheduled sleep.
+
+#### Scheduler-Pill semantics
+
+- Returns `None` when no execution is in `RUNNING` or `REQUESTED`.
+- Returns `tone="info"`, `value="3"` (active count), `extra={"jobs": ["Backup", "Health Check", "..."]}` with up to 3 most-recently-started display names.
+- The frontend renders the count as the pill value and the job names as a native `title` tooltip.
+
+#### Backup-Pill semantics
+
+Three states:
+
+| Condition | Output |
+|---|---|
+| Any backup in `running` or `requested` state | `tone="info"`, `value="47%"` (progress) or `value="läuft"` if no progress available |
+| Most recent finished backup is `status="failed"` **and** finished < 24h ago | `tone="danger"`, `value="fehlgeschlagen"` |
+| Most recent backup older than 24h ago, or finished status is `completed` | `None` (silent) |
+
+The 24h window prevents a failure from haunting the topbar indefinitely; if it really matters, the admin will see it on the Backup page. After 24h the failure age is too old to be actionable from a status pill.
+
+## API
+
+New router `backend/app/api/routes/status_bar.py`, mounted at `/api/system/statusbar`:
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| `GET`  | `/api/system/statusbar/config` | admin | Full catalog + current persisted config + `show_bottom_upload` |
+| `PUT`  | `/api/system/statusbar/config` | admin | Bulk update (per-pill `enabled`/`visibility`/`sort_order` + `show_bottom_upload`) |
+| `GET`  | `/api/system/statusbar/state`  | any-auth | Aggregated pill payload, filtered by user role |
+
+All endpoints rate-limited via `@limiter.limit(get_limit(...))`. Use the existing `admin_operations` key for the admin write endpoints; for the high-frequency `GET /state` (every 10s per logged-in user), introduce a new rate-limit key `status_polling` in `backend/app/core/rate_limiter.py` with a generous default (e.g. 30/minute) so it doesn't trip on legitimate use. Pydantic schemas in `backend/app/schemas/status_bar.py`:
+
+```python
+PILL_IDS = Literal[
+    "power","pihole","uploads","sync","raid","sleep","vpn","temp",
+    "always_awake","scheduler","backup",
+]
+
+class PillConfigItem(BaseModel):
+    pill_id: PILL_IDS
+    enabled: bool
+    visibility: Literal["admin", "all"]
+    sort_order: int
+
+class StatusBarConfigUpdate(BaseModel):
+    pills: list[PillConfigItem]
+    show_bottom_upload: bool
+
+class PillState(BaseModel):
+    id: PILL_IDS
+    kind: Literal["state", "activity", "alert"]
+    tone: Literal["success", "info", "warning", "danger", "neutral"]
+    label: str
+    value: str | None = None
+    icon: str | None = None
+    href: str
+    extra: dict | None = None    # e.g. {"expires_in_seconds": 3742.5} for always_awake
+
+class StatusBarStateResponse(BaseModel):
+    pills: list[PillState]
+    show_bottom_upload: bool
+```
+
+Server-side validation rejects PUT with `visibility="all"` for any `visibility_locked=True` pill → 400 Bad Request.
+
+> **Schema note:** the `PILL_IDS` Literal is hardcoded to the current 11-pill catalog. When a future pill is added, both the Python `CATALOG` list and the Pydantic `Literal` need updating — the schema validator should fail loudly if these drift apart, and the catalog has a unit test (`test_pill_id_literal_matches_catalog`) that asserts equality.
+
+### Audit logging
+
+Every successful PUT writes one audit event `status_bar.config_changed` with the user_id and a JSON diff (added/removed pills, visibility changes, reordering, upload-bar toggle).
+
+## Frontend
+
+### Component tree
+
+```
+client/src/components/topbar/
+├── TopbarStatusStrip.tsx          — container, ≥ lg only, fetches state, maps to renderers
+├── pillRenderers.tsx              — { pill_id → React component }
+├── pills/
+│   ├── PowerPill.tsx · PiholePill.tsx · UploadsPill.tsx · SyncPill.tsx
+│   ├── RaidPill.tsx · SleepPill.tsx · VpnPill.tsx · TempPill.tsx
+│   └── AlwaysAwakePill.tsx · SchedulerPill.tsx · BackupPill.tsx
+└── useStatusBarState.ts            — polling hook, 10s interval, pause-when-hidden
+
+client/src/components/ui/Pill.tsx    — generic primitive (tone, icon, label, value, href)
+
+client/src/components/status-bar-config/
+├── StatusBarConfigTab.tsx          — admin config UI (System Control tab)
+├── PillRow.tsx                     — single row: drag-handle + label + visibility-select + enabled-toggle
+└── usePillConfig.ts                — admin write/read hook
+```
+
+`AlwaysAwakePill.tsx` includes a `useCountdown(expiresInSeconds)` hook that decrements once per second. When a new poll arrives with a fresh `expires_in_seconds`, the countdown re-anchors to the server value; if the local countdown has drifted >5s from the server value, the server value wins immediately (defensive against tab-throttling).
+
+### Layout integration
+
+`Layout.tsx:517` currently has `<div className="hidden lg:block flex-1" />` as a desktop-only spacer. That becomes:
+
+```tsx
+<div className="hidden lg:flex flex-1 items-center justify-center px-6">
+  {!isPi && <TopbarStatusStrip />}
+</div>
+```
+
+Mobile header is unchanged.
+
+### `<Pill>` primitive
+
+Generic, theme-aware. Tone → tailwind classes via a small lookup. A11y: rendered as `<Link>`, `aria-label` derived from `label`+`value`, `title` attribute for native browser tooltip on desktop, focus-visible ring inherited from project's existing button styles.
+
+```tsx
+type PillTone = 'success' | 'info' | 'warning' | 'danger' | 'neutral';
+type PillProps = {
+  tone: PillTone;
+  icon?: React.ReactNode;
+  label: string;
+  value?: string;
+  href: string;
+  ariaLabel?: string;
+};
+```
+
+Tone classes (matching existing glass-accent slate theme):
+- `success` → `border-emerald-500/40 bg-emerald-500/10 text-emerald-300`
+- `info`    → `border-sky-500/40 bg-sky-500/10 text-sky-300`
+- `warning` → `border-amber-500/40 bg-amber-500/10 text-amber-300`
+- `danger`  → `border-rose-500/40 bg-rose-500/10 text-rose-300`
+- `neutral` → `border-slate-700 bg-slate-800/60 text-slate-300`
+
+### `useStatusBarState` hook
+
+Uses TanStack Query (already a project dependency) which natively supports `refetchIntervalInBackground: false` via the Page Visibility API:
+
+```ts
+useStatusBarState({
+  refetchInterval: 10_000,
+  refetchIntervalInBackground: false,   // pauses when document.hidden === true
+  staleTime: 8_000,                      // tolerate brief network hiccups
+})
+```
+
+On 3 consecutive failures → return last-known state with a stale flag; if no last-known state → return empty pill list.
+
+### Config UI (System Control tab)
+
+New tab registered in `client/src/pages/SystemControlPage.tsx` under category `system`:
+
+```tsx
+{ id: 'statusbar', labelKey: 'systemControl.tabs.statusBar', icon: <LayoutPanelTop className="h-5 w-5" /> }
+```
+
+Layout (11 rows, scrollable if needed):
+
+```
+[Header: "Topbar Status Strip" + helper text]
+
+[Card: Pills — drag to reorder]
+  ┌─────────────────────────────────────────────────────────────────┐
+  │ ≡  ⚡ Power Profile                [▼ Admin only]   [●——] active │
+  │ ≡  🛡  Pi-hole DNS                 [▼ All Users]    [●——] active │
+  │ ≡  ↑   Uploads/Downloads           [▼ All Users]    [——●] off    │
+  │ ≡  ⟳   Sync                        [▼ All Users]    [——●] off    │
+  │ ≡  ⚠   RAID Health                 [🔒 Admin only]  [●——] active │
+  │ ≡  🌙  Sleep Mode                  [🔒 Admin only]  [——●] off    │
+  │ ≡  🔐  VPN Clients                 [🔒 Admin only]  [——●] off    │
+  │ ≡  🌡  Temperature                 [🔒 Admin only]  [——●] off    │
+  │ ≡  ⏰  Always Awake                [🔒 Admin only]  [●——] active │
+  │ ≡  ⚙   Scheduler                   [🔒 Admin only]  [——●] off    │
+  │ ≡  💾  Backup                      [🔒 Admin only]  [——●] off    │
+  └─────────────────────────────────────────────────────────────────┘
+
+[Card: Bottom Upload Bar]
+  ┌────────────────────────────────────────────────┐
+  │ Show bottom upload bar          [●——] on        │
+  │ Independent from the Uploads pill in the topbar │
+  └────────────────────────────────────────────────┘
+
+[Card: Live Preview]
+  ┌────────────────────────────────────────────────────────┐
+  │ [⚡ Performance] [🛡 Pi-hole · 23%] [⏰ Always Awake 03:42] │
+  └────────────────────────────────────────────────────────┘
+
+[Footer: Save / Reset to defaults]
+```
+
+Drag-and-drop via `@dnd-kit/sortable` with `verticalListSortingStrategy`. The visibility-select is a small dropdown; for `visibility_locked=true` pills it renders as a read-only badge with a lock icon.
+
+`<TopbarStatusStrip>` accepts an optional `previewState?: StatusBarStateResponse` prop. When provided, it renders the supplied state and skips polling — the Config tab's Live Preview uses this to render the unsaved config exactly as the real strip would render it server-side, with no API roundtrip.
+
+### i18n
+
+New namespace `statusBar` with keys `tabTitle`, `description`, `pills.<id>.name` (11 entries), `visibility.{admin,all,locked}`, `uploadBar.{title,desc}`, `preview.{title,empty}`. Plus `systemControl.tabs.statusBar` in `common.json`. DE + EN.
+
+## Edge Cases
+
+| Case | Handling |
+|---|---|
+| No pill enabled | Container renders empty, no visual artifact |
+| `/state` returns 5xx | Hook holds last-known state; after 3 failures, clear pills + console warning. No toast. |
+| Pi-hole backend unreachable | Collector returns `None` → pill missing from payload, no error in UI |
+| User role changes mid-session (promote/demote) | Next poll returns role-correct payload; pills update transparently |
+| Pi-mode (`__DEVICE_MODE__=pi`) | `<TopbarStatusStrip>` not rendered, tree-shaken from build |
+| Setup wizard active | `Layout.tsx` not rendered, no conflict |
+| Visibility changed from "all" to "admin" while user views | Next poll filters pill out, it disappears |
+| Catalog pill missing in DB (fresh install or new pill in update) | Service inserts it with `enabled=False, visibility=default_visibility, sort_order=999` |
+| Migration re-run | `CREATE TABLE IF NOT EXISTS` + `INSERT ... ON CONFLICT DO NOTHING` — idempotent |
+| Pill collector raises | Wrapped in try/except, returns `None`, pill silently absent |
+| New pill introduced in future version | Appears in admin config tab disabled by default — no auto-enable |
+| PUT with `visibility="all"` for locked pill | 400 Bad Request from server-side validator |
+| Config changed by another admin in second tab | Frontend re-fetches on focus; latest wins (last-write-wins is acceptable here) |
+| `always_awake` expires between polls | Client countdown hits 00:00, pill remains until next poll returns `None`; visually OK (≤10s lag) |
+| Always-Awake `until` race (server clears just after a poll) | Next poll returns `None`, pill disappears |
+| Scheduler executes >50 jobs concurrently | Pill shows count, `extra.jobs` capped at 3 most-recently-started entries (consistent with collector ordering) |
+| Backup just transitioned `running` → `failed` between polls | Next poll within 10s flips pill from info to danger |
+| Backup `running` and previous failure within 24h | `running` state wins (in-progress is more actionable) |
+
+## Security
+
+- `PUT /api/system/statusbar/config` → `Depends(get_current_admin)`, rate-limited
+- `GET /api/system/statusbar/state` → `Depends(get_current_user)` (any auth), server filters by role
+- `visibility_locked` enforced server-side, not just UI — prevents privilege escalation via crafted PUT
+- Audit-log entry on every config change (who, what, when, diff)
+- No sensitive data in `/state` payload — no IPs, no file paths, no disk serials, no usernames; only display-ready strings
+- Pi-hole pill exposed to non-admins shows only on/off + global block percent — no per-client query data
+- VPN, RAID, Sleep, Temp, Always-Awake, Scheduler, Backup pills are `visibility_locked` — non-admins never see this data, even if a future bug allows toggling visibility
+- Scheduler pill's `extra.jobs` contains user-facing display names only, not internal job IDs or parameter dumps
+
+## Tests
+
+### Backend (`backend/tests/test_status_bar.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_default_config_returns_full_catalog` | Fresh DB → GET returns all 11 catalog pills with defaults |
+| `test_admin_can_enable_pill` | PUT with `enabled=True` → subsequent GET shows pill enabled |
+| `test_visibility_locked_rejects_all` | PUT `pill_id=raid, visibility=all` → 400 |
+| `test_state_endpoint_filters_admin_pills_for_user` | Non-admin user → enabled admin-only pill not in payload |
+| `test_state_endpoint_includes_all_pill_for_user` | Non-admin → pill with `visibility=all` is in payload |
+| `test_silent_when_ok_pill_omitted_when_no_signal` | RAID all OK → no RAID pill in payload |
+| `test_silent_when_ok_pill_present_when_problem` | RAID degraded → RAID pill with `tone=warning` in payload |
+| `test_collector_failure_returns_none_not_500` | Pi-hole backend raises → pill missing, endpoint returns 200 |
+| `test_sort_order_respected_in_state_payload` | Pills in payload are sorted by `sort_order` |
+| `test_show_bottom_upload_setting_in_state` | `show_bottom_upload` is in `/state` response |
+| `test_audit_log_on_config_change` | PUT creates audit-log entry with user_id and diff |
+| `test_user_endpoint_rejects_anonymous` | GET `/state` without JWT → 401 |
+| `test_admin_endpoint_rejects_user` | PUT `/config` as non-admin → 403 |
+| `test_new_catalog_pill_auto_inserted_on_read` | Catalog has 12th pill → service inserts row, GET returns 12 pills |
+| `test_pill_id_literal_matches_catalog` | `PILL_IDS` Literal values exactly match `CATALOG` ids — drift detection |
+| `test_always_awake_pill_active_with_countdown` | `always_awake.enabled=True, until=now+1h` → pill with `extra.expires_in_seconds ≈ 3600` |
+| `test_always_awake_pill_active_permanent` | `enabled=True, until=None` → pill with `value="permanent"`, no `expires_in_seconds` |
+| `test_always_awake_pill_silent_when_disabled` | `enabled=False` → no pill in payload |
+| `test_scheduler_pill_shows_active_count` | 2 RUNNING + 1 REQUESTED → pill with `value="3"`, `extra.jobs` list ≤3 entries |
+| `test_scheduler_pill_silent_when_no_jobs` | No active executions → no pill |
+| `test_scheduler_pill_caps_jobs_at_three` | 5 RUNNING → `extra.jobs` has exactly 3 entries (newest-started first) |
+| `test_backup_pill_in_progress` | One backup `status=running` → pill with `tone=info`, `value=progress%` or `"läuft"` |
+| `test_backup_pill_failed_within_24h` | Last backup `status=failed, finished 2h ago` → pill with `tone=danger` |
+| `test_backup_pill_silent_when_failed_older_than_24h` | Last backup `status=failed, finished 25h ago` → no pill |
+| `test_backup_pill_silent_when_last_completed` | Last backup `status=completed` → no pill |
+| `test_backup_pill_running_beats_failed` | One `running` + one recent `failed` → pill shows `running`, not `failed` |
+
+### Frontend (`client/src/components/topbar/__tests__/`, `status-bar-config/__tests__/`)
+
+| Test | Verifies |
+|---|---|
+| `TopbarStatusStrip renders nothing when no pills` | Empty payload → no children |
+| `TopbarStatusStrip renders pills in order` | Payload with 3 pills → 3 anchors in correct order |
+| `TopbarStatusStrip is hidden on mobile` | Test viewport `< lg` → strip not in DOM |
+| `TopbarStatusStrip is hidden in Pi mode` | `__DEVICE_MODE__=pi` → strip not rendered |
+| `Pill renders correct tone classes` | Snapshot per tone |
+| `Pill click navigates to href` | userEvent.click → `useNavigate` invoked with href |
+| `AlwaysAwakePill counts down per second` | Render with `expires_in_seconds=120`, fake-timer +5s → value "01:55" |
+| `AlwaysAwakePill re-anchors on new poll` | Drift >5s between local countdown and incoming poll → server value applied |
+| `AlwaysAwakePill renders 'permanent' when no expiry` | `expires_in_seconds=null` → static "permanent" label |
+| `SchedulerPill renders count and tooltip` | Payload with 3 jobs → value="3", `title` contains all 3 names |
+| `BackupPill in-progress tone` | `tone=info, value="47%"` → info classes applied |
+| `BackupPill failed tone` | `tone=danger, value="fehlgeschlagen"` → danger classes applied |
+| `StatusBarConfigTab disables visibility-select for locked pills` | Locked pill → select is `aria-disabled` |
+| `StatusBarConfigTab updates sort_order on drag` | dnd-kit fireEvent → API call with new order |
+| `StatusBarConfigTab live preview reflects unsaved changes` | Toggle changes preview without save |
+| `StatusBarConfigTab save then reload preserves order` | Save → reload → order unchanged |
+
+### Manual smoketest (post-deploy)
+
+1. Login as admin, open System Control → System → Status Bar
+2. Enable Power, Pi-hole, Uploads, Always Awake, Scheduler, Backup with mixed visibilities
+3. Drag-reorder, save → verify topbar reflects order
+4. Toggle bottom-upload off → verify `<UploadProgressBar>` disappears
+5. Trigger an upload → verify Uploads pill appears with progress
+6. Login as non-admin user (second browser) → verify only "All Users" pills visible (Always-Awake/Scheduler/Backup NOT visible)
+7. Simulate RAID degraded (dev backend) → verify RAID pill appears with warning tone
+8. Toggle Always Awake on with 5-minute preset → verify pill appears with live countdown
+9. Trigger a manual scheduler run → verify Scheduler pill appears with count=1, name in tooltip
+10. Simulate backup failure (dev backend) → verify Backup pill appears with danger tone; advance time >24h → pill disappears
+11. Promote user to admin via DB → on next poll, admin-only pills appear
+12. Open in Pi-mode build → strip not shown
+13. Resize to mobile → strip not shown
+
+## Build Order
+
+1. **Backend foundation** — Migration, models, catalog (11 entries) with stub collectors
+2. **Backend collectors** — One commit per real collector (11 commits, of which 3 are new vs. 2026-05-10)
+3. **Backend API + service** — Routes, schemas, service layer, tests
+4. **Frontend foundation** — `<Pill>` primitive, `useStatusBarState()`, `<TopbarStatusStrip>` with mock data
+5. **Frontend pill renderers** — 11 small components (3 new: `AlwaysAwakePill`, `SchedulerPill`, `BackupPill`)
+6. **Frontend countdown hook** — `useCountdown` for Always-Awake re-anchoring
+7. **Layout integration** — replace empty spacer in `Layout.tsx`
+8. **Config tab (MVP)** — Up/Down buttons for reorder
+9. **dnd-kit reorder** — drag-and-drop replacement for buttons
+10. **Live Preview** — preview card in config tab
+11. **i18n** — DE+EN strings (11 pill names)
+12. **Audit logging** — hook in `update_config`
+13. **Frontend tests** — parallel to implementation
+14. **Smoketest** — full manual run-through
+
+Estimated: ~14–18 hours focused work (3–4h more than the 2026-05-10 spec, due to 3 extra pills + countdown hook), splittable into ~5–6 PRs (backend / frontend strip / countdown+new pills / config tab / dnd reorder / polish).
+
+## Out of Scope
+
+- Plugin-defined pills (catalog is hardcoded; later extension if a plugin needs it)
+- WebSocket push (10s polling sufficient; Always-Awake countdown handled client-side between polls)
+- Per-user pill customization (admin decides globally)
+- Mobile mini-bar (mobile keeps current header unchanged)
+- Popovers / quick-actions in pills (read-only click-through only)
+- Custom tooltip widget (browser-native `title` is enough)
+- Updates-available pill, Live-Power-W pill, Free-Storage pill, Services-Health pill — discussed and explicitly deferred (2026-05-27 brainstorming session)
+- Acked-failure persistence for backup pill — 24h time-window deemed sufficient
+
+## References
+
+- `client/src/components/Layout.tsx` — host file for `<TopbarStatusStrip>` integration (replaces line 517 spacer)
+- `client/src/pages/SystemControlPage.tsx` — receives new `statusbar` tab under `system` category
+- `client/src/App.tsx:233` — confirms Backup route `/admin/system-control?tab=backup`
+- `client/src/components/UploadProgressBar.tsx` — gated by new `show_bottom_upload` setting
+- `backend/app/services/upload_progress.py` — already exposes `get_summary()` for collector
+- `backend/app/services/power/manager.py` — `get_status()` for power collector
+- `backend/app/services/power/sleep.py` — `get_status().always_awake` for always-awake collector (incl. `expires_in_seconds`)
+- `backend/app/services/scheduler/service.py` — `SchedulerExecution` table query for scheduler collector
+- `backend/app/services/backup/service.py` — backup state query for backup collector
+- `docs/superpowers/specs/2026-05-07-always-awake-design.md` — Always-Awake feature this pill reflects
+- `docs/superpowers/specs/2026-05-10-topbar-statusbar-design.md` — superseded base spec
+- `.claude/rules/security-agent.md` — auth dependencies, audit-logging patterns


### PR DESCRIPTION
## Summary

- Fix RAM tracking so all five BaluHost systemd units are counted (scheduler / webdav / monitoring were silently missing)
- Separate `baluhost-backend-local` from `baluhost-backend` via first-match-wins on `--fd 3`
- Expose `baluhost_memory_breakdown` per unit in `/api/monitoring/memory/current`
- System Monitor → Memory tab: BaluHost card is now expandable, showing RSS per unit

## Test plan

- [ ] `cd backend && python -m pytest tests/monitoring/ tests/api/test_monitoring_routes.py`
- [ ] `cd client && npm run build`
- [ ] Manual: open Memory tab, expand BaluHost card, see per-unit values
- [ ] Deploy to BaluNode, curl `/api/monitoring/memory/current` and confirm all five production units have non-zero RSS

Spec: docs/superpowers/specs/2026-05-27-baluhost-ram-per-unit-breakdown-design.md
Plan: docs/superpowers/plans/2026-05-27-baluhost-ram-per-unit-breakdown.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)