### PR TITLE
fix(ci): pre-release tag push 403 (persist-credentials)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          # Do not persist GITHUB_TOKEN as http.extraheader — it would override
+          # the inline DEPLOY_PAT URL on push and 403 as github-actions[bot].
+          persist-credentials: false
 
       - name: Auto-tag pre-release
         if: success()


### PR DESCRIPTION
## Problem

PR #108's Deploy Production succeeded at the deploy step but **failed at the new "Auto-tag pre-release" step**:

```
remote: Permission to Xveyn/BaluHost.git denied to github-actions[bot].
... 403 ... exit code 128
```

Production deployed fine — only the tag was not created.

## Root cause

`actions/checkout@v4` persists `GITHUB_TOKEN` as `http.extraheader` in git config by default. That header overrode the inline `x-access-token:${DEPLOY_PAT}` URL on `git push`, so the push authenticated as `github-actions[bot]` (read-only) → 403.

## Fix

Add `persist-credentials: false` to the tagging checkout. The fetch still authenticates transiently; nothing is written to git config; the push then uses the DEPLOY_PAT URL — which also keeps `create-release.yml` firing (PAT, not GITHUB_TOKEN).

## Test plan

- [ ] Merge manually → Deploy Production runs
- [ ] Approve `production` gate; deploy succeeds
- [ ] "Auto-tag pre-release" step pushes `v1.32.0-pre.330` (no 403)
- [ ] `create-release.yml` creates the GitHub pre-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)