### PR TITLE
feat(statusbar): wake pill shows Kernbetriebszeit when Always Awake is off

### DIFF
--- a/backend/app/services/status_bar/collectors.py
+++ b/backend/app/services/status_bar/collectors.py
@@ -161,23 +161,47 @@ def _format_countdown(seconds: float) -> str:
     return f"{m:02d}:{s:02d}"
 
 
+def _format_until(dt) -> Optional[str]:
+    """Format a window-end datetime as 24h HH:MM (server-local). None-safe."""
+    if dt is None:
+        return None
+    try:
+        return dt.strftime("%H:%M")
+    except Exception:  # noqa: BLE001 - value is optional, never block the pill
+        return None
+
+
 @_safe()
 async def collect_always_awake(db: Session, role: str) -> Optional[dict]:
     manager = get_sleep_manager()
     if manager is None:
         return None
     status = manager.get_status()
+
     aa = getattr(status, "always_awake", None)
-    if aa is None or not aa.enabled:
-        return None
-    out = {"kind": "state", "tone": "warning", "label": "Always Awake", "icon": "Coffee"}
-    if aa.until is None:
-        out["value"] = "permanent"
-    else:
-        secs = aa.expires_in_seconds or 0.0
-        out["value"] = _format_countdown(secs)
-        out["extra"] = {"expires_in_seconds": secs}
-    return out
+    if aa is not None and aa.enabled:
+        out = {"kind": "state", "tone": "warning", "label": "Always Awake",
+               "icon": "Coffee", "extra": {"variant": "always_awake"}}
+        if aa.until is None:
+            out["value"] = "permanent"
+        else:
+            secs = aa.expires_in_seconds or 0.0
+            out["value"] = _format_countdown(secs)
+            out["extra"]["expires_in_seconds"] = secs
+        return out
+
+    # Fallback: Kernbetriebszeit window currently active (always-awake overrides it)
+    cu = getattr(status, "core_uptime", None)
+    if cu is not None and getattr(cu, "active", False):
+        out = {"kind": "state", "tone": "success", "label": "Kernbetriebszeit",
+               "icon": "Shield", "extra": {"variant": "core_uptime"}}
+        until = _format_until(getattr(cu, "current_window_ends_at", None))
+        if until:
+            out["value"] = f"bis {until}"
+            out["extra"]["until"] = until
+        return out
+
+    return None
 
 
 # ── vpn ──────────────────────────────────────────────────────────────

--- a/backend/tests/services/test_status_bar_collectors.py
+++ b/backend/tests/services/test_status_bar_collectors.py
@@ -81,6 +81,7 @@ async def test_always_awake_silent_when_disabled():
     from app.services.status_bar import collectors
     fake_status = MagicMock()
     fake_status.always_awake = MagicMock(enabled=False, until=None, expires_in_seconds=None)
+    fake_status.core_uptime = MagicMock(active=False)
     mgr = MagicMock(); mgr.get_status = MagicMock(return_value=fake_status)
     with patch.object(collectors, "get_sleep_manager", return_value=mgr):
         assert await collectors.collect_always_awake(MagicMock(), "admin") is None
@@ -223,3 +224,49 @@ def test_collectors_registry_covers_full_catalog():
     from app.services.status_bar.collectors import COLLECTORS
     from app.services.status_bar.catalog import CATALOG
     assert set(COLLECTORS.keys()) == {p.id for p in CATALOG}
+
+
+@pytest.mark.asyncio
+async def test_always_awake_falls_back_to_core_uptime():
+    from datetime import datetime
+    from app.services.status_bar import collectors
+    fake_status = MagicMock()
+    fake_status.always_awake = MagicMock(enabled=False, until=None, expires_in_seconds=None)
+    fake_status.core_uptime = MagicMock(
+        active=True, current_window_ends_at=datetime(2026, 5, 29, 22, 0))
+    mgr = MagicMock(); mgr.get_status = MagicMock(return_value=fake_status)
+    with patch.object(collectors, "get_sleep_manager", return_value=mgr):
+        result = await collectors.collect_always_awake(MagicMock(), "admin")
+    assert result is not None
+    assert result["icon"] == "Shield"
+    assert result["tone"] == "success"
+    assert result["value"] == "bis 22:00"
+    assert result["extra"]["variant"] == "core_uptime"
+    assert result["extra"]["until"] == "22:00"
+
+
+@pytest.mark.asyncio
+async def test_always_awake_takes_precedence_over_core_uptime():
+    from datetime import datetime
+    from app.services.status_bar import collectors
+    fake_status = MagicMock()
+    fake_status.always_awake = MagicMock(enabled=True, until=None, expires_in_seconds=None)
+    fake_status.core_uptime = MagicMock(
+        active=True, current_window_ends_at=datetime(2026, 5, 29, 22, 0))
+    mgr = MagicMock(); mgr.get_status = MagicMock(return_value=fake_status)
+    with patch.object(collectors, "get_sleep_manager", return_value=mgr):
+        result = await collectors.collect_always_awake(MagicMock(), "admin")
+    assert result["tone"] == "warning"
+    assert result["extra"]["variant"] == "always_awake"
+    assert result["value"] == "permanent"
+
+
+@pytest.mark.asyncio
+async def test_always_awake_and_core_uptime_both_off_silent():
+    from app.services.status_bar import collectors
+    fake_status = MagicMock()
+    fake_status.always_awake = MagicMock(enabled=False, until=None, expires_in_seconds=None)
+    fake_status.core_uptime = MagicMock(active=False)
+    mgr = MagicMock(); mgr.get_status = MagicMock(return_value=fake_status)
+    with patch.object(collectors, "get_sleep_manager", return_value=mgr):
+        assert await collectors.collect_always_awake(MagicMock(), "admin") is None

--- a/backend/tests/services/test_status_bar_collectors.py
+++ b/backend/tests/services/test_status_bar_collectors.py
@@ -92,6 +92,7 @@ async def test_always_awake_permanent_has_permanent_value():
     from app.services.status_bar import collectors
     fake_status = MagicMock()
     fake_status.always_awake = MagicMock(enabled=True, until=None, expires_in_seconds=None)
+    fake_status.core_uptime = MagicMock(active=False)
     mgr = MagicMock(); mgr.get_status = MagicMock(return_value=fake_status)
     with patch.object(collectors, "get_sleep_manager", return_value=mgr):
         result = await collectors.collect_always_awake(MagicMock(), "admin")
@@ -104,6 +105,7 @@ async def test_always_awake_with_expiry_exposes_seconds():
     from app.services.status_bar import collectors
     fake_status = MagicMock()
     fake_status.always_awake = MagicMock(enabled=True, until="2026-05-28T12:00:00Z", expires_in_seconds=3600.0)
+    fake_status.core_uptime = MagicMock(active=False)
     mgr = MagicMock(); mgr.get_status = MagicMock(return_value=fake_status)
     with patch.object(collectors, "get_sleep_manager", return_value=mgr):
         result = await collectors.collect_always_awake(MagicMock(), "admin")

--- a/client/src/__tests__/components/status-bar-config/pillName.i18n.test.ts
+++ b/client/src/__tests__/components/status-bar-config/pillName.i18n.test.ts
@@ -16,7 +16,7 @@ describe('statusBar pill name i18n resolution', () => {
   it('resolves the ns-relative key to the real English translation', () => {
     // This is the form the component must pass after stripping the backend "statusBar." prefix.
     expect(i18n.t('pills.power.name', { ns: 'statusBar' })).toBe('Power Profile');
-    expect(i18n.t('pills.alwaysAwake.name', { ns: 'statusBar' })).toBe('Always Awake');
+    expect(i18n.t('pills.alwaysAwake.name', { ns: 'statusBar' })).toBe('Always Awake / Core Hours');
   });
 
   it('does NOT resolve the raw backend key (regression guard for the namespace bug)', () => {

--- a/client/src/__tests__/components/topbar/AlwaysAwakePill.test.tsx
+++ b/client/src/__tests__/components/topbar/AlwaysAwakePill.test.tsx
@@ -17,15 +17,28 @@ function renderPill(pill: PillState) {
 }
 
 describe('AlwaysAwakePill', () => {
-  it('renders permanent label when no expiry', () => {
-    renderPill(base(null, 'permanent'));
-    expect(screen.getByText('permanent')).toBeInTheDocument();
+  // i18n is not initialized in component tests, so t() returns the raw key.
+  it('renders the permanent label key when no expiry', () => {
+    renderPill(base({ variant: 'always_awake' }, 'permanent'));
+    expect(screen.getByText('pills.alwaysAwake.live')).toBeInTheDocument();
+    expect(screen.getByText('pills.alwaysAwake.permanent')).toBeInTheDocument();
   });
 
   it('counts down from extra.expires_in_seconds', () => {
-    renderPill(base({ expires_in_seconds: 120 }, '02:00'));
+    renderPill(base({ variant: 'always_awake', expires_in_seconds: 120 }, '02:00'));
     expect(screen.getByText('02:00')).toBeInTheDocument();
     act(() => { vi.advanceTimersByTime(5000); });
     expect(screen.getByText('01:55')).toBeInTheDocument();
+  });
+
+  it('renders the core-uptime variant with the Kernbetriebszeit label + until value', () => {
+    const pill: PillState = {
+      id: 'always_awake', kind: 'state', tone: 'success', label: 'Kernbetriebszeit',
+      value: 'bis 22:00', href: '/admin/system-control?tab=sleep', icon: 'Shield',
+      extra: { variant: 'core_uptime', until: '22:00' },
+    };
+    renderPill(pill);
+    expect(screen.getByText('pills.alwaysAwake.coreUptimeLive')).toBeInTheDocument();
+    expect(screen.getByText('pills.alwaysAwake.coreUptimeUntil')).toBeInTheDocument();
   });
 });

--- a/client/src/__tests__/components/topbar/pillRenderers.test.tsx
+++ b/client/src/__tests__/components/topbar/pillRenderers.test.tsx
@@ -18,7 +18,10 @@ describe('PillRenderer', () => {
 
   it('routes always_awake to the countdown pill', () => {
     renderPill({ id: 'always_awake', kind: 'state', tone: 'warning', label: 'Always Awake',
-                 value: '02:00', href: '/x', icon: 'Coffee', extra: { expires_in_seconds: 120 } });
-    expect(screen.getByText('Always Awake')).toBeInTheDocument();
+                 value: '02:00', href: '/x', icon: 'Coffee',
+                 extra: { variant: 'always_awake', expires_in_seconds: 120 } });
+    // i18n is not initialized in component tests, so t() returns the raw key.
+    expect(screen.getByText('pills.alwaysAwake.live')).toBeInTheDocument();
+    expect(screen.getByText('02:00')).toBeInTheDocument();
   });
 });

--- a/client/src/components/topbar/pills/AlwaysAwakePill.tsx
+++ b/client/src/components/topbar/pills/AlwaysAwakePill.tsx
@@ -1,22 +1,35 @@
 import { createElement } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Pill } from '../../ui/Pill';
 import { useCountdown } from '../../../hooks/useCountdown';
 import { resolveIcon } from '../iconMap';
 import type { PillState } from '../../../api/statusBar';
 
 export function AlwaysAwakePill({ pill, flat }: { pill: PillState; flat?: boolean }) {
+  const { t } = useTranslation('statusBar');
+  const variant = pill.extra?.variant;
   const expires = typeof pill.extra?.expires_in_seconds === 'number'
     ? (pill.extra!.expires_in_seconds as number)
     : null;
   const countdown = useCountdown(expires);
-  const value = countdown ?? pill.value ?? undefined;
+
+  let label: string;
+  let value: string | undefined;
+  if (variant === 'core_uptime') {
+    label = t('pills.alwaysAwake.coreUptimeLive');
+    const until = typeof pill.extra?.until === 'string' ? (pill.extra!.until as string) : undefined;
+    value = until ? t('pills.alwaysAwake.coreUptimeUntil', { time: until }) : undefined;
+  } else {
+    label = t('pills.alwaysAwake.live');
+    value = countdown ?? (expires === null ? t('pills.alwaysAwake.permanent') : pill.value ?? undefined);
+  }
 
   const iconComp = resolveIcon(pill.icon);
   const icon = iconComp ? createElement(iconComp, { className: 'h-3.5 w-3.5' }) : undefined;
   return (
     <Pill
       tone={pill.tone}
-      label={pill.label}
+      label={label}
       value={value}
       href={pill.href}
       icon={icon}

--- a/client/src/i18n/locales/de/statusBar.json
+++ b/client/src/i18n/locales/de/statusBar.json
@@ -10,7 +10,13 @@
     "sleep": { "name": "Sleep-Modus" },
     "vpn": { "name": "VPN-Clients" },
     "temp": { "name": "Temperatur / Lüfter" },
-    "alwaysAwake": { "name": "Immer wach" },
+    "alwaysAwake": {
+      "name": "Immer wach / Kernbetriebszeit",
+      "live": "Immer wach",
+      "permanent": "Dauerhaft",
+      "coreUptimeLive": "Kernbetriebszeit",
+      "coreUptimeUntil": "bis {{time}}"
+    },
     "scheduler": { "name": "Scheduler" },
     "backup": { "name": "Backup" }
   },

--- a/client/src/i18n/locales/en/statusBar.json
+++ b/client/src/i18n/locales/en/statusBar.json
@@ -10,7 +10,13 @@
     "sleep": { "name": "Sleep Mode" },
     "vpn": { "name": "VPN Clients" },
     "temp": { "name": "Temperature / Fans" },
-    "alwaysAwake": { "name": "Always Awake" },
+    "alwaysAwake": {
+      "name": "Always Awake / Core Hours",
+      "live": "Always Awake",
+      "permanent": "Permanent",
+      "coreUptimeLive": "Core Hours",
+      "coreUptimeUntil": "until {{time}}"
+    },
     "scheduler": { "name": "Scheduler" },
     "backup": { "name": "Backup" }
   },

--- a/docs/superpowers/plans/2026-05-29-statusbar-wake-pill.md
+++ b/docs/superpowers/plans/2026-05-29-statusbar-wake-pill.md
@@ -1,0 +1,318 @@
+# Status-Strip Wake Pill (Always Awake + Kernbetriebszeit) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the topbar `always_awake` status pill fall back to showing the active Kernbetriebszeit (core-uptime) window when the manual Always-Awake override is off, with proper DE/EN translations.
+
+**Architecture:** One backend collector (`collect_always_awake`) gains a priority fallback — Always Awake first (unchanged), else the currently-active core-uptime window, else silent. Both states already come from a single `sleep_manager.get_status()` call. The dedicated `AlwaysAwakePill` renderer becomes i18n-driven and branches on an `extra.variant` discriminator the backend now emits.
+
+**Tech Stack:** Python / FastAPI / pytest (backend); React + TypeScript / react-i18next (frontend).
+
+**Spec:** `docs/superpowers/specs/2026-05-29-statusbar-wake-pill-design.md`
+
+**Working dir:** All paths are relative to the worktree root `D:/Programme (x86)/Baluhost/.claude/worktrees/topbar-statusbar`. Backend `pytest` runs from the `backend/` subfolder.
+
+---
+
+### Task 1: Backend collector fallback to Kernbetriebszeit (TDD)
+
+**Files:**
+- Modify: `backend/app/services/status_bar/collectors.py` (`collect_always_awake`, new `_format_until`)
+- Test: `backend/tests/services/test_status_bar_collectors.py`
+
+- [ ] **Step 1: Fix the existing silent-when-disabled test**
+
+In `backend/tests/services/test_status_bar_collectors.py`, the test `test_always_awake_silent_when_disabled` builds a bare `MagicMock()` status; after the change `status.core_uptime.active` would be a truthy auto-mock and the collector would no longer return `None`. Pin it false. Replace the test body with:
+
+```python
+@pytest.mark.asyncio
+async def test_always_awake_silent_when_disabled():
+    from app.services.status_bar import collectors
+    fake_status = MagicMock()
+    fake_status.always_awake = MagicMock(enabled=False, until=None, expires_in_seconds=None)
+    fake_status.core_uptime = MagicMock(active=False)
+    mgr = MagicMock(); mgr.get_status = MagicMock(return_value=fake_status)
+    with patch.object(collectors, "get_sleep_manager", return_value=mgr):
+        assert await collectors.collect_always_awake(MagicMock(), "admin") is None
+```
+
+- [ ] **Step 2: Add the three new failing tests**
+
+Append to `backend/tests/services/test_status_bar_collectors.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_always_awake_falls_back_to_core_uptime():
+    from datetime import datetime
+    from app.services.status_bar import collectors
+    fake_status = MagicMock()
+    fake_status.always_awake = MagicMock(enabled=False, until=None, expires_in_seconds=None)
+    fake_status.core_uptime = MagicMock(
+        active=True, current_window_ends_at=datetime(2026, 5, 29, 22, 0))
+    mgr = MagicMock(); mgr.get_status = MagicMock(return_value=fake_status)
+    with patch.object(collectors, "get_sleep_manager", return_value=mgr):
+        result = await collectors.collect_always_awake(MagicMock(), "admin")
+    assert result is not None
+    assert result["icon"] == "Shield"
+    assert result["tone"] == "success"
+    assert result["value"] == "bis 22:00"
+    assert result["extra"]["variant"] == "core_uptime"
+    assert result["extra"]["until"] == "22:00"
+
+
+@pytest.mark.asyncio
+async def test_always_awake_takes_precedence_over_core_uptime():
+    from datetime import datetime
+    from app.services.status_bar import collectors
+    fake_status = MagicMock()
+    fake_status.always_awake = MagicMock(enabled=True, until=None, expires_in_seconds=None)
+    fake_status.core_uptime = MagicMock(
+        active=True, current_window_ends_at=datetime(2026, 5, 29, 22, 0))
+    mgr = MagicMock(); mgr.get_status = MagicMock(return_value=fake_status)
+    with patch.object(collectors, "get_sleep_manager", return_value=mgr):
+        result = await collectors.collect_always_awake(MagicMock(), "admin")
+    assert result["tone"] == "warning"
+    assert result["extra"]["variant"] == "always_awake"
+    assert result["value"] == "permanent"
+
+
+@pytest.mark.asyncio
+async def test_always_awake_and_core_uptime_both_off_silent():
+    from app.services.status_bar import collectors
+    fake_status = MagicMock()
+    fake_status.always_awake = MagicMock(enabled=False, until=None, expires_in_seconds=None)
+    fake_status.core_uptime = MagicMock(active=False)
+    mgr = MagicMock(); mgr.get_status = MagicMock(return_value=fake_status)
+    with patch.object(collectors, "get_sleep_manager", return_value=mgr):
+        assert await collectors.collect_always_awake(MagicMock(), "admin") is None
+```
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/services/test_status_bar_collectors.py -v -k "always_awake"`
+Expected: `test_always_awake_falls_back_to_core_uptime` FAILS (collector returns `None`, has no Shield branch); precedence/both-off tests may already pass. `test_always_awake_permanent_has_permanent_value` and `test_always_awake_with_expiry_exposes_seconds` still PASS.
+
+- [ ] **Step 4: Implement the fallback in the collector**
+
+In `backend/app/services/status_bar/collectors.py`, add `_format_until` next to `_format_countdown` (above `collect_always_awake`):
+
+```python
+def _format_until(dt) -> Optional[str]:
+    """Format a window-end datetime as 24h HH:MM (server-local). None-safe."""
+    if dt is None:
+        return None
+    try:
+        return dt.strftime("%H:%M")
+    except Exception:  # noqa: BLE001 - value is optional, never block the pill
+        return None
+```
+
+Then replace the body of `collect_always_awake` with:
+
+```python
+@_safe()
+async def collect_always_awake(db: Session, role: str) -> Optional[dict]:
+    manager = get_sleep_manager()
+    if manager is None:
+        return None
+    status = manager.get_status()
+
+    aa = getattr(status, "always_awake", None)
+    if aa is not None and aa.enabled:
+        out = {"kind": "state", "tone": "warning", "label": "Always Awake",
+               "icon": "Coffee", "extra": {"variant": "always_awake"}}
+        if aa.until is None:
+            out["value"] = "permanent"
+        else:
+            secs = aa.expires_in_seconds or 0.0
+            out["value"] = _format_countdown(secs)
+            out["extra"]["expires_in_seconds"] = secs
+        return out
+
+    # Fallback: Kernbetriebszeit window currently active (always-awake overrides it)
+    cu = getattr(status, "core_uptime", None)
+    if cu is not None and getattr(cu, "active", False):
+        out = {"kind": "state", "tone": "success", "label": "Kernbetriebszeit",
+               "icon": "Shield", "extra": {"variant": "core_uptime"}}
+        until = _format_until(getattr(cu, "current_window_ends_at", None))
+        if until:
+            out["value"] = f"bis {until}"
+            out["extra"]["until"] = until
+        return out
+
+    return None
+```
+
+- [ ] **Step 5: Run the full collector test file to verify all pass**
+
+Run: `cd backend && python -m pytest tests/services/test_status_bar_collectors.py -v`
+Expected: PASS (all, including the unchanged scheduler/backup/pihole/raid/sync tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/status_bar/collectors.py backend/tests/services/test_status_bar_collectors.py
+git commit -m "feat(statusbar): always-awake pill falls back to active Kernbetriebszeit"
+```
+
+---
+
+### Task 2: i18n keys for both pill variants (DE + EN)
+
+**Files:**
+- Modify: `client/src/i18n/locales/de/statusBar.json`
+- Modify: `client/src/i18n/locales/en/statusBar.json`
+
+- [ ] **Step 1: Update the German keys**
+
+In `client/src/i18n/locales/de/statusBar.json`, replace the `alwaysAwake` entry inside `pills` (currently `"alwaysAwake": { "name": "Immer wach" }`) with:
+
+```json
+    "alwaysAwake": {
+      "name": "Immer wach / Kernbetriebszeit",
+      "live": "Immer wach",
+      "permanent": "Dauerhaft",
+      "coreUptimeLive": "Kernbetriebszeit",
+      "coreUptimeUntil": "bis {{time}}"
+    },
+```
+
+- [ ] **Step 2: Update the English keys**
+
+In `client/src/i18n/locales/en/statusBar.json`, replace the corresponding `alwaysAwake` entry inside `pills` with:
+
+```json
+    "alwaysAwake": {
+      "name": "Always Awake / Core Hours",
+      "live": "Always Awake",
+      "permanent": "Permanent",
+      "coreUptimeLive": "Core Hours",
+      "coreUptimeUntil": "until {{time}}"
+    },
+```
+
+- [ ] **Step 3: Validate both JSON files parse**
+
+Run: `cd client && node -e "require('./src/i18n/locales/de/statusBar.json'); require('./src/i18n/locales/en/statusBar.json'); console.log('ok')"`
+Expected: prints `ok` (no JSON syntax error).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/i18n/locales/de/statusBar.json client/src/i18n/locales/en/statusBar.json
+git commit -m "i18n(statusbar): wake-pill keys for always-awake + core-hours (de/en)"
+```
+
+---
+
+### Task 3: i18n-driven AlwaysAwakePill renderer
+
+**Files:**
+- Modify: `client/src/components/topbar/pills/AlwaysAwakePill.tsx`
+
+- [ ] **Step 1: Replace the component with the variant-aware, i18n version**
+
+Replace the entire contents of `client/src/components/topbar/pills/AlwaysAwakePill.tsx` with:
+
+```tsx
+import { createElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Pill } from '../../ui/Pill';
+import { useCountdown } from '../../../hooks/useCountdown';
+import { resolveIcon } from '../iconMap';
+import type { PillState } from '../../../api/statusBar';
+
+export function AlwaysAwakePill({ pill, flat }: { pill: PillState; flat?: boolean }) {
+  const { t } = useTranslation('statusBar');
+  const variant = pill.extra?.variant;
+  const expires = typeof pill.extra?.expires_in_seconds === 'number'
+    ? (pill.extra!.expires_in_seconds as number)
+    : null;
+  const countdown = useCountdown(expires);
+
+  let label: string;
+  let value: string | undefined;
+  if (variant === 'core_uptime') {
+    label = t('pills.alwaysAwake.coreUptimeLive');
+    const until = typeof pill.extra?.until === 'string' ? (pill.extra!.until as string) : undefined;
+    value = until ? t('pills.alwaysAwake.coreUptimeUntil', { time: until }) : undefined;
+  } else {
+    label = t('pills.alwaysAwake.live');
+    value = countdown ?? (expires === null ? t('pills.alwaysAwake.permanent') : pill.value ?? undefined);
+  }
+
+  const iconComp = resolveIcon(pill.icon);
+  const icon = iconComp ? createElement(iconComp, { className: 'h-3.5 w-3.5' }) : undefined;
+  return (
+    <Pill
+      tone={pill.tone}
+      label={label}
+      value={value}
+      href={pill.href}
+      icon={icon}
+      flat={flat}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: Type-check the frontend**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: no errors referencing `AlwaysAwakePill.tsx`.
+
+- [ ] **Step 3: Build the frontend to confirm no compile regressions**
+
+Run: `cd client && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/components/topbar/pills/AlwaysAwakePill.tsx
+git commit -m "feat(statusbar): i18n-driven wake pill (always-awake + core-hours variants)"
+```
+
+---
+
+### Task 4: End-to-end verification (dev mode)
+
+**Files:** none (manual run-through)
+
+- [ ] **Step 1: Run the backend status-bar test suites once more**
+
+Run: `cd backend && python -m pytest tests/services/test_status_bar_collectors.py tests/services/test_status_bar_service.py tests/api/test_status_bar_routes.py -v`
+Expected: all PASS.
+
+- [ ] **Step 2: Start dev mode**
+
+Run (from worktree root): `python start_dev.py`
+Log in as `admin` / `DevMode2024`. Open **System Control → System → Status Bar**, enable the **Immer wach / Kernbetriebszeit** pill (admin-only, locked), save.
+
+- [ ] **Step 3: Verify the Always-Awake branch (unchanged)**
+
+In **System Control → Hardware → Sleep**, turn **Immer wach** on with a 1h preset. Within ~10s the topbar pill shows ☕ **Immer wach** with a live countdown. Switch UI language to English → label reads **Always Awake**; permanent mode → value **Permanent**.
+
+- [ ] **Step 4: Verify the Kernbetriebszeit fallback**
+
+Turn **Immer wach** off. In the **Kernbetriebszeit** panel, add a window covering the current time (e.g. `00:00 → 23:59`, all weekdays) and enable the master toggle. Within ~10s the topbar pill shows 🛡 **Kernbetriebszeit · bis 23:59** (DE) / **Core Hours · until 23:59** (EN), tone green.
+
+- [ ] **Step 5: Verify precedence and silence**
+
+Turn **Immer wach** back on while the window is still active → pill flips to ☕ Always Awake (override wins). Turn both off → pill disappears from the strip.
+
+- [ ] **Step 6: Final commit (only if any verification fix was needed)**
+
+```bash
+git add -A
+git commit -m "test(statusbar): verify wake-pill core-uptime fallback in dev mode"
+```
+
+---
+
+## Notes for the implementer
+
+- The `_safe()` decorator wrapping `collect_always_awake` guarantees the collector never raises — do not add try/except inside the body beyond what the spec shows.
+- `extra.variant` is the single source of truth the frontend branches on; keep it in sync if the backend payload changes.
+- Time is rendered as 24h `HH:MM` server-side (matching the existing `sleep` pill); only the `bis`/`until` prefix is translated client-side.
+- Frontend unit tests are placeholders in this repo (per convention) — coverage for this change is the backend collector tests plus the manual dev-mode run-through.

--- a/docs/superpowers/specs/2026-05-29-statusbar-wake-pill-design.md
+++ b/docs/superpowers/specs/2026-05-29-statusbar-wake-pill-design.md
@@ -1,0 +1,194 @@
+# Status-Strip "Wach-Grund" Pill — Always Awake + Kernbetriebszeit-Fallback
+
+**Date:** 2026-05-29
+**Status:** Approved (brainstorming complete)
+**Author:** Sven (Xveyn) + Claude
+**Context branch:** `worktree-topbar-statusbar` (PR #110), builds on `docs/superpowers/specs/2026-05-27-topbar-statusbar-design.md`
+
+## Problem
+
+The topbar status strip has an `always_awake` pill that appears only while the manual
+**Always Awake** override is active, and is silent otherwise. The recurring
+**Kernbetriebszeit** (core-uptime) feature *also* keeps the NAS awake by suppressing
+auto-sleep, but it has no presence in the strip at all. In the sleep logic, Always
+Awake already takes precedence over Kernbetriebszeit (`_idle_detection_loop` /
+`_schedule_check_loop` check always-awake first). The pill should mirror that
+override relationship instead of going dark whenever the manual override is off but a
+core-uptime window is keeping the system awake.
+
+## Solution
+
+Repurpose the existing `always_awake` pill into a single **"why the system stays
+awake"** indicator with a priority fallback. Same pill id, same catalog slot, same
+visibility lock — no new catalog entry, no schema, no migration.
+
+Both states are already available from the **one call** the collector makes:
+`sleep_manager.get_status()` returns both `.always_awake` and `.core_uptime`
+(`active`, `current_window_label`, `current_window_ends_at`). `Shield` is already in
+the frontend `iconMap.ts`. So this is a focused change to one collector + the one
+dedicated pill renderer + i18n + tests.
+
+## Behavior
+
+Priority order inside `collect_always_awake`:
+
+| # | Condition | Pill output |
+|---|---|---|
+| 1 | `always_awake.enabled` | **unchanged**: icon `Coffee`, tone `warning`, value = live countdown (`03:42`) or `permanent`; `extra.expires_in_seconds` when timed |
+| 2 | else `core_uptime.active` | **new**: icon `Shield`, tone `success`, label `Kernbetriebszeit`, value `bis HH:MM` (from `current_window_ends_at`, server-local 24h); no countdown |
+| 3 | else | `None` (silent — same as today) |
+
+Always Awake wins; Kernbetriebszeit shows only when a window is *currently* active;
+nothing shows when neither blocks auto-sleep. No "next window" preview (deliberate —
+keeps the strip quiet).
+
+## i18n (explicit requirement)
+
+The live-strip label is today a hardcoded backend string. To respect translations,
+the **frontend** `AlwaysAwakePill` renders its label/value via
+`useTranslation('statusBar')` for **both** variants. The backend passes a `variant`
+discriminator and the raw `HH:MM` so the frontend can localize the `bis`/`until`
+prefix; the backend `label`/`value` remain valid fallbacks.
+
+New keys in `client/src/i18n/locales/{de,en}/statusBar.json` under `pills.alwaysAwake`:
+
+| Key | DE | EN |
+|---|---|---|
+| `name` (rename) | `Immer wach / Kernbetriebszeit` | `Always Awake / Core Hours` |
+| `live` | `Immer wach` | `Always Awake` |
+| `permanent` | `Dauerhaft` | `Permanent` |
+| `coreUptimeLive` | `Kernbetriebszeit` | `Core Hours` |
+| `coreUptimeUntil` | `bis {{time}}` | `until {{time}}` |
+
+`name` is the config-tab label (now reflects the dual purpose); the others drive the
+live strip. Time stays 24h `HH:MM` (consistent with the existing Sleep pill, which
+also renders a raw `HH:MM`).
+
+## Backend — `backend/app/services/status_bar/collectors.py`
+
+`collect_always_awake` gains the fallback branch and a `variant` marker in `extra`:
+
+```python
+def _format_until(dt) -> Optional[str]:
+    if dt is None:
+        return None
+    try:
+        return dt.strftime("%H:%M")
+    except Exception:  # noqa: BLE001 - value is optional, never block the pill
+        return None
+
+
+@_safe()
+async def collect_always_awake(db: Session, role: str) -> Optional[dict]:
+    manager = get_sleep_manager()
+    if manager is None:
+        return None
+    status = manager.get_status()
+
+    aa = getattr(status, "always_awake", None)
+    if aa is not None and aa.enabled:
+        out = {"kind": "state", "tone": "warning", "label": "Always Awake",
+               "icon": "Coffee", "extra": {"variant": "always_awake"}}
+        if aa.until is None:
+            out["value"] = "permanent"
+        else:
+            secs = aa.expires_in_seconds or 0.0
+            out["value"] = _format_countdown(secs)
+            out["extra"]["expires_in_seconds"] = secs
+        return out
+
+    # Fallback: Kernbetriebszeit window currently active (always-awake overrides it)
+    cu = getattr(status, "core_uptime", None)
+    if cu is not None and getattr(cu, "active", False):
+        out = {"kind": "state", "tone": "success", "label": "Kernbetriebszeit",
+               "icon": "Shield", "extra": {"variant": "core_uptime"}}
+        until = _format_until(getattr(cu, "current_window_ends_at", None))
+        if until:
+            out["value"] = f"bis {until}"
+            out["extra"]["until"] = until
+        return out
+
+    return None
+```
+
+The `_safe()` decorator already guarantees the collector never raises. `extra.variant`
+is additive — existing always-awake consumers (countdown via `expires_in_seconds`)
+are unaffected.
+
+## Frontend — `client/src/components/topbar/pills/AlwaysAwakePill.tsx`
+
+i18n-driven, branches on `extra.variant`:
+
+```tsx
+import { createElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Pill } from '../../ui/Pill';
+import { useCountdown } from '../../../hooks/useCountdown';
+import { resolveIcon } from '../iconMap';
+import type { PillState } from '../../../api/statusBar';
+
+export function AlwaysAwakePill({ pill, flat }: { pill: PillState; flat?: boolean }) {
+  const { t } = useTranslation('statusBar');
+  const variant = pill.extra?.variant;
+  const expires = typeof pill.extra?.expires_in_seconds === 'number'
+    ? (pill.extra!.expires_in_seconds as number)
+    : null;
+  const countdown = useCountdown(expires);
+
+  let label: string;
+  let value: string | undefined;
+  if (variant === 'core_uptime') {
+    label = t('pills.alwaysAwake.coreUptimeLive');
+    const until = typeof pill.extra?.until === 'string' ? (pill.extra!.until as string) : undefined;
+    value = until ? t('pills.alwaysAwake.coreUptimeUntil', { time: until }) : undefined;
+  } else {
+    label = t('pills.alwaysAwake.live');
+    value = countdown ?? (expires === null ? t('pills.alwaysAwake.permanent') : pill.value ?? undefined);
+  }
+
+  const iconComp = resolveIcon(pill.icon);
+  const icon = iconComp ? createElement(iconComp, { className: 'h-3.5 w-3.5' }) : undefined;
+  return (
+    <Pill tone={pill.tone} label={label} value={value} href={pill.href} icon={icon} flat={flat} />
+  );
+}
+```
+
+No change to `PillRenderer` (already routes `always_awake` here), `iconMap`
+(`Shield` present), `Pill`, `useCountdown`, or `api/statusBar.ts`
+(`extra: Record<string, unknown>` already permits `variant`/`until`).
+
+## Tests — `backend/tests/services/test_status_bar_collectors.py`
+
+- **Fix** `test_always_awake_silent_when_disabled`: the bare `MagicMock` status makes
+  `core_uptime.active` truthy, so the test must set
+  `fake_status.core_uptime = MagicMock(active=False)` to keep asserting `None`.
+- **Add** `test_always_awake_falls_back_to_core_uptime`: `always_awake.enabled=False`,
+  `core_uptime.active=True`, `current_window_ends_at=<dt 22:00>` → result has
+  `icon="Shield"`, `tone="success"`, `value="bis 22:00"`, `extra.variant="core_uptime"`.
+- **Add** `test_always_awake_takes_precedence_over_core_uptime`: both active → result is
+  the always-awake payload (`tone="warning"`, `extra.variant="always_awake"`).
+- **Add** `test_always_awake_and_core_uptime_both_off_silent`: both off → `None`.
+
+`test_always_awake_permanent_has_permanent_value` and
+`test_always_awake_with_expiry_exposes_seconds` keep passing (always-awake branch
+returns before the core-uptime check; assertions check keys that still exist).
+
+Frontend tests are placeholders per repo convention — none added.
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| `current_window_ends_at` is `None` while `active=True` | `value` omitted; pill shows label only (`Kernbetriebszeit`) |
+| `core_uptime` attr missing on status (older shape) | `getattr(..., None)` → silent |
+| Always-awake expires between polls while a core window is active | next poll falls through to the core-uptime branch; pill flips Coffee→Shield (≤10s lag) |
+| Collector raises | `_safe()` returns `None`; pill silently absent |
+| Window-ends datetime is tz-aware | `strftime("%H:%M")` works regardless of tzinfo |
+
+## Out of scope
+
+- No new pill / catalog entry / schema / migration / API change.
+- No "next window" upcoming-state preview.
+- No client-side locale time formatting (24h `HH:MM` kept, matching the Sleep pill).
+- No changes to the `sleep` pill (still shows the schedule sleep time).


### PR DESCRIPTION
@
## Was

Das `always_awake`-Status-Pill in der Topbar wird zu einem kombinierten „Wach-Grund"-Indikator:

- **Always Awake aktiv** → wie bisher: ☕ *Immer wach* mit Live-Countdown bzw. *Dauerhaft*.
- **Sonst, Kernbetriebszeit-Fenster gerade aktiv** → 🛡 *Kernbetriebszeit · bis HH:MM* (grün).
- **Sonst** → still (kein Pill).

Spiegelt die echte Sleep-Logik wider, in der Always Awake die Kernbetriebszeit überschreibt. Beide Zustände kommen aus demselben `sleep_manager.get_status()`-Call — keine neue Pill, kein Schema, keine Migration.

## i18n

Das Pill rendert Label/Wert jetzt über `useTranslation(statusBar)` (DE/EN), Backend liefert einen `extra.variant`-Diskriminator + rohe `HH:MM`, damit das `bis`/`until`-Präfix übersetzt wird. Config-Tab-Name → „Immer wach / Kernbetriebszeit" / „Always Awake / Core Hours".

## Änderungen

- `backend/app/services/status_bar/collectors.py` — Fallback-Branch + `_format_until`
- `client/src/components/topbar/pills/AlwaysAwakePill.tsx` — variant-basiertes, i18n-getriebenes Rendering
- `client/src/i18n/locales/{de,en}/statusBar.json` — neue Keys
- `backend/tests/services/test_status_bar_collectors.py` — 3 neue Tests + Härtung
- Spec + Plan unter `docs/superpowers/`

## Tests

- `test_status_bar_collectors.py`: 22 passed (inkl. Fallback / Precedence / both-off)
- Status-Bar-Suites gesamt (collectors + service + routes): 46 passed
- Frontend `tsc --noEmit` clean, `npm run build` erfolgreich

## Offen

- Manueller Dev-Mode-Smoketest (visuelles Umschalten des Pills) noch ausstehend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@