### PR TITLE
fix(statusbar): VPN-Pill zeigt verbundene Peers statt roher Client-Anzahl

### DIFF
--- a/backend/app/services/status_bar/collectors.py
+++ b/backend/app/services/status_bar/collectors.py
@@ -205,14 +205,47 @@ async def collect_always_awake(db: Session, role: str) -> Optional[dict]:
 
 
 # ── vpn ──────────────────────────────────────────────────────────────
+# A WireGuard peer counts as "connected" if its last handshake is within this
+# window (WireGuard rekeys roughly every 2 min; ~3 min marks a peer as stale).
+_VPN_HANDSHAKE_TIMEOUT_SECONDS = 180
+
+
+def _vpn_peer_counts(db: Session) -> tuple[int, int]:
+    """Return (connected, active_total) WireGuard peers.
+
+    `connected` = active clients whose last handshake is within
+    `_VPN_HANDSHAKE_TIMEOUT_SECONDS`. `active_total` = clients with is_active=True.
+    Sync helper so tests can patch it without mocking the SQLAlchemy query chain.
+    """
+    from datetime import datetime, timezone, timedelta
+    from app.models.vpn import VPNClient
+
+    clients = db.query(VPNClient).filter(VPNClient.is_active.is_(True)).all()
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=_VPN_HANDSHAKE_TIMEOUT_SECONDS)
+    connected = 0
+    for c in clients:
+        hs = c.last_handshake
+        if hs is None:
+            continue
+        if hs.tzinfo is None:  # naive timestamps are stored as UTC
+            hs = hs.replace(tzinfo=timezone.utc)
+        if hs >= cutoff:
+            connected += 1
+    return connected, len(clients)
+
+
 @_safe()
 async def collect_vpn(db: Session, role: str) -> Optional[dict]:
-    from app.models.vpn import VPNClient
-    count = db.query(VPNClient).count()
-    if count == 0:
-        return None
-    return {"kind": "state", "tone": "success", "label": "VPN",
-            "value": str(count), "icon": "Lock"}
+    connected, active_total = _vpn_peer_counts(db)
+    if active_total == 0:
+        return None  # no VPN clients configured → stay silent
+    return {
+        "kind": "state",
+        "tone": "success" if connected > 0 else "neutral",
+        "label": "VPN",
+        "value": f"{connected} verbunden",
+        "icon": "Lock",
+    }
 
 
 # ── scheduler ────────────────────────────────────────────────────────

--- a/backend/tests/services/test_status_bar_collectors.py
+++ b/backend/tests/services/test_status_bar_collectors.py
@@ -222,6 +222,55 @@ async def test_backup_running_beats_recent_failure():
     assert result["value"] == "läuft"
 
 
+@pytest.mark.asyncio
+async def test_vpn_silent_without_active_clients():
+    from app.services.status_bar import collectors
+    with patch.object(collectors, "_vpn_peer_counts", return_value=(0, 0)):
+        assert await collectors.collect_vpn(MagicMock(), "admin") is None
+
+
+@pytest.mark.asyncio
+async def test_vpn_neutral_when_configured_but_none_connected():
+    from app.services.status_bar import collectors
+    with patch.object(collectors, "_vpn_peer_counts", return_value=(0, 4)):
+        result = await collectors.collect_vpn(MagicMock(), "admin")
+    assert result is not None
+    assert result["tone"] == "neutral"
+    assert result["value"] == "0 verbunden"
+
+
+@pytest.mark.asyncio
+async def test_vpn_success_when_peers_connected():
+    from app.services.status_bar import collectors
+    with patch.object(collectors, "_vpn_peer_counts", return_value=(2, 4)):
+        result = await collectors.collect_vpn(MagicMock(), "admin")
+    assert result["tone"] == "success"
+    assert result["value"] == "2 verbunden"
+    assert result["label"] == "VPN"
+
+
+def test_vpn_peer_counts_only_counts_recent_handshakes():
+    from datetime import datetime, timezone, timedelta
+    from app.services.status_bar import collectors
+
+    def _client(handshake):
+        m = MagicMock()
+        m.last_handshake = handshake
+        return m
+
+    now = datetime.now(timezone.utc)
+    clients = [
+        _client(now - timedelta(seconds=30)),    # connected
+        _client(now - timedelta(minutes=10)),    # stale
+        _client(None),                            # never connected
+    ]
+    fake_db = MagicMock()
+    fake_db.query.return_value.filter.return_value.all.return_value = clients
+    connected, active_total = collectors._vpn_peer_counts(fake_db)
+    assert connected == 1
+    assert active_total == 3
+
+
 def test_collectors_registry_covers_full_catalog():
     from app.services.status_bar.collectors import COLLECTORS
     from app.services.status_bar.catalog import CATALOG


### PR DESCRIPTION
## Problem

Die VPN-Pill in der Topbar-Statusleiste zeigte `VPN 101` — das ist die rohe Gesamtzahl **aller je angelegten** VPN-Clients (`db.query(VPNClient).count()`, inkl. deaktivierter). Unbeschriftet nebeneinander gerendert (`label` + `value`) wirkt das irreführend (sieht aus wie ein Port oder Fehlercode) und sagt nichts über den tatsächlichen VPN-Status aus.

## Fix

`collect_vpn` zeigt jetzt **aktuell verbundene WireGuard-Peers** — analog zur Pi-hole-Pill, die echten Live-Status zeigt:

- **kein** aktiver Client konfiguriert → Pill ausgeblendet (wie bisher bei 0)
- konfiguriert, niemand verbunden → neutral/grau: `VPN 0 verbunden`
- ≥1 verbunden → success/grün: z. B. `VPN 2 verbunden`

„Verbunden" = aktiver Client (`is_active=True`) mit letztem Handshake innerhalb von 3 Min (WireGuard rekeyt ~alle 2 Min; ~3 Min markiert einen Peer als stale).

Die Zähl-Logik liegt im testbaren Sync-Helper `_vpn_peer_counts(db)` (Pattern wie `_active_executions` / `_running_backup`).

## Tests

Vier neue Tests in `test_status_bar_collectors.py` (silent / neutral / success / Handshake-Fenster). Gesamte Datei: **26 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)