### PR TITLE
fix(ci): pre-release tag derives from last stable + patch bump

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -70,9 +70,24 @@ jobs:
         env:
           DEPLOY_PAT: ${{ secrets.DEPLOY_PAT }}
         run: |
-          VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' backend/pyproject.toml || true)
+          # Derive the prerelease base from the last STABLE tag + a patch bump so
+          # the prerelease always sorts ABOVE the latest stable. pyproject.toml
+          # holds the last RELEASED version (release-stable.yml does not advance it
+          # afterwards), so reading it directly produced v<released>-pre.N tags that
+          # sort BELOW the stable of the same number (semver: 1.33.0-pre.1 < 1.33.0).
+          # Bumping the patch is safe regardless of the eventual stable bump type:
+          # v1.33.1-pre.N stays below both v1.33.1 and v1.34.0, and above v1.33.0.
+          LAST_STABLE=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -Ev -- '-(pre|rc|alpha|beta|unstable)' | sort -V | tail -1)
+          if [ -n "$LAST_STABLE" ]; then
+            BASE=${LAST_STABLE#v}
+            IFS=. read -r MAJ MIN PAT <<< "$BASE"
+            VERSION="${MAJ}.${MIN}.$((PAT + 1))"
+          else
+            # No stable release yet -- fall back to the pyproject version.
+            VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' backend/pyproject.toml || true)
+          fi
           if [ -z "$VERSION" ]; then
-            echo "Could not read version from pyproject.toml -- skipping pre-release tag"
+            echo "Could not determine prerelease base version -- skipping pre-release tag"
             exit 0
           fi
           LATEST=$(git tag -l "v${VERSION}-pre.*" | sed -E 's/.*-pre\.//' | sort -n | tail -1)


### PR DESCRIPTION
## Problem

Pre-releases stopped working correctly after the `development` branch was retired (2026-05-06) and everything moved to direct-to-main + deploy.

`deploy-production.yml`'s auto-tag step read the pre-release base **straight from `backend/pyproject.toml`**, which `release-stable.yml` leaves at the *last released* version. So after cutting `v1.33.0` stable, every merge produced `v1.33.0-pre.N` — and in semver `1.33.0-pre.1` sorts **below** `1.33.0`, so the new pre-releases ranked under the already-shipped stable and never appeared as newer.

`gh release list` showed the symptom:

```
v1.33.0-pre.2   Pre-release   2026-05-29   ← newest by date
v1.33.0-pre.1   Pre-release   2026-05-29
v1.33.0         Latest        2026-05-28   ← still "Latest" (higher semver)
```

This worked under the old flow because pre-releases of `vX` accumulated *before* `vX` was released. Direct-to-main broke that ordering since nothing advances the version past the last release.

## Fix

Derive the pre-release base from the **last stable tag + a patch bump** (reusing the exact tag filter `release-stable.yml` already uses), with a `pyproject.toml` fallback when no stable tag exists yet:

- `v1.33.0` stable → next pre-release `v1.33.1-pre.1`

A patch bump is safe regardless of the eventual stable bump type: `v1.33.1-pre.N` stays **above** `v1.33.0` and **below** any eventual `v1.33.1` / `v1.34.0` stable. No label logic involved — pre-releases remain label-free.

Validated locally against the repo's real tags: last stable `v1.33.0` → `v1.33.1-pre.1`.

## Not included
The two orphaned `v1.33.0-pre.1` / `v1.33.0-pre.2` releases remain published below the stable; cleaning those up (deleting the releases + tags) is a separate manual decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
