### PR TITLE
fix(deps): bump axios to ^1.16.0 (4 Dependabot advisories)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "baluhost-client",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baluhost-client",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "axios": "^1.15.2",
+        "axios": "^1.16.0",
         "i18next": "^25.8.0",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.554.0",
@@ -2908,6 +2908,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3083,13 +3095,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -4752,6 +4765,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/i18next": {

--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "axios": "^1.15.2",
+    "axios": "^1.16.0",
     "i18next": "^25.8.0",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.554.0",


### PR DESCRIPTION
@
Behebt die 4 offenen Dependabot-Alerts auf `axios` (Client war auf der verwundbaren `1.15.2` gepinnt).

## Behobene Advisories

| # | Severity | Advisory |
|---|----------|----------|
| 39 | **high** | GHSA-35jp-ww65-95wh — Full MitM via Prototype Pollution in `config.proxy` |
| 38 | **high** | GHSA-pjwm-pj3p-43mv — `NO_PROXY`-Bypass via IPv4-mapped IPv6 (Follow-up zu CVE-2025-62718) |
| 37 | medium | GHSA-898c-q2cr-xwhg — DoS & Header Injection via Prototype Pollution in den merge-Funktionen |
| 36 | low | GHSA-654m-c8p4-x5fp — Proxy-Authorization Header Injection (trifft exakt `1.15.2`) |

## Änderungen

- `client/package.json`: `axios ^1.15.2` → `^1.16.0`
- `client/package-lock.json`: löst auf `axios 1.16.1` auf; axios 1.16 zieht zusätzlich `https-proxy-agent`/`agent-base` als transitive Deps. Nebenbei wird die Lockfile-`version` von `1.32.0` auf `1.33.0` korrigiert (bestehender Drift).

## Verifikation

- `npm run build` ✓
- `npm run test` → 52 Test-Dateien, 366 Tests ✓

## Nicht enthalten

- Der paramiko-Alert (#35, low, SHA-1) hat noch keinen Patch (`first_patched_version` = null) und bleibt offen.
- Zwei transitive Dev-Dep-Audit-Meldungen (`brace-expansion`, `yaml`) sind nicht Teil der Dependabot-Alerts und außerhalb des Scopes dieses Bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@