### PR TITLE
fix(updates): pre-release builds no longer shown as "Stable"

### DIFF
--- a/client/src/__tests__/components/updates/UpdateOverviewTab.test.tsx
+++ b/client/src/__tests__/components/updates/UpdateOverviewTab.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import UpdateOverviewTab from '../../../components/updates/UpdateOverviewTab';
+import type { UpdateCheckResponse, VersionInfo } from '../../../api/updates';
+
+// i18n is not initialized in component tests; the component receives `t` as a
+// prop, so we pass a mock that echoes the key back.
+const t = (key: string) => key;
+
+function version(overrides: Partial<VersionInfo>): VersionInfo {
+  return {
+    version: '1.33.1',
+    commit: 'ab14257deadbeef',
+    commit_short: 'ab14257',
+    tag: 'v1.33.1',
+    date: null,
+    is_dev_build: false,
+    is_prerelease: false,
+    ...overrides,
+  };
+}
+
+function checkResult(current: VersionInfo): UpdateCheckResponse {
+  return {
+    update_available: false,
+    current_version: current,
+    latest_version: null,
+    changelog: [],
+    channel: 'stable',
+    last_checked: null,
+    blockers: [],
+    can_update: false,
+    dev_version_available: false,
+    dev_version: null,
+    dev_commits_ahead: null,
+    dev_commits: [],
+  };
+}
+
+function renderTab(current: VersionInfo) {
+  return render(
+    <UpdateOverviewTab
+      t={t}
+      checkResult={checkResult(current)}
+      currentUpdate={null}
+      releaseNotes={null}
+      updateLoading={false}
+      rollbackLoading={false}
+      cancelLoading={false}
+      devUpdateLoading={false}
+      showUpdateConfirm={false}
+      showDevUpdateConfirm={false}
+      onSetShowUpdateConfirm={vi.fn()}
+      onSetShowDevUpdateConfirm={vi.fn()}
+      onSetShowRollbackConfirm={vi.fn()}
+      onStartUpdate={vi.fn()}
+      onStartDevUpdate={vi.fn()}
+      onCancel={vi.fn()}
+    />,
+  );
+}
+
+describe('UpdateOverviewTab — stability indicator', () => {
+  it('does NOT label a pre-release build as Stable', () => {
+    renderTab(version({ version: '1.33.1-pre.2', tag: 'v1.33.1-pre.2', is_prerelease: true }));
+    // The amber Pre-Release badge next to the version must still be present.
+    expect(screen.getByText('preRelease.badge')).toBeInTheDocument();
+    // The contradictory "Stable" indicator must be gone.
+    expect(screen.queryByText('version.stable')).not.toBeInTheDocument();
+    expect(screen.queryByText('Stable')).not.toBeInTheDocument();
+  });
+
+  it('labels a genuine stable release via the i18n key (not a hardcoded string)', () => {
+    renderTab(version({ is_prerelease: false, is_dev_build: false }));
+    expect(screen.getByText('version.stable')).toBeInTheDocument();
+    expect(screen.queryByText('preRelease.badge')).not.toBeInTheDocument();
+  });
+
+  it('labels a dev build as Dev Build', () => {
+    renderTab(version({ is_dev_build: true, tag: null }));
+    expect(screen.getByText('version.devBuild')).toBeInTheDocument();
+    expect(screen.queryByText('version.stable')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/updates/UpdateOverviewTab.tsx
+++ b/client/src/components/updates/UpdateOverviewTab.tsx
@@ -125,15 +125,19 @@ export default function UpdateOverviewTab({
                   </span>
                 )}
               </div>
-              <div className="flex items-center gap-2 text-sm">
-                {checkResult.current_version.is_dev_build ? (
+              {checkResult.current_version.is_dev_build ? (
+                <div className="flex items-center gap-2 text-sm">
                   <span className="px-2 py-0.5 bg-amber-500/20 text-amber-400 rounded text-xs font-medium">
                     {t('version.devBuild')}
                   </span>
-                ) : (
-                  <span className="text-emerald-400">Stable</span>
-                )}
-              </div>
+                </div>
+              ) : !checkResult.current_version.is_prerelease ? (
+                /* Pre-releases are already flagged by the amber badge next to the
+                   version; only genuine stable builds get the "Stable" indicator. */
+                <div className="flex items-center gap-2 text-sm">
+                  <span className="text-emerald-400">{t('version.stable')}</span>
+                </div>
+              ) : null}
             </div>
           )}
         </div>

--- a/client/src/i18n/locales/de/updates.json
+++ b/client/src/i18n/locales/de/updates.json
@@ -32,6 +32,7 @@
     "devVersionAvailable": "Dev-Version verfügbar",
     "devCommitsAhead": "{{count}} Commit(s) voraus",
     "devBuild": "Dev Build",
+    "stable": "Stabil",
     "devUpToDate": "Dev-Branch ist aktuell",
     "devWarning": "Development-Versionen können instabil sein. Vor dem Update wird ein Backup erstellt."
   },

--- a/client/src/i18n/locales/en/updates.json
+++ b/client/src/i18n/locales/en/updates.json
@@ -32,6 +32,7 @@
     "devVersionAvailable": "Dev version available",
     "devCommitsAhead": "{{count}} commit(s) ahead",
     "devBuild": "Dev Build",
+    "stable": "Stable",
     "devUpToDate": "Dev branch is up to date",
     "devWarning": "Development versions may be unstable. A backup will be created before updating."
   },


### PR DESCRIPTION
## Problem

Auf der **System Updates**-Seite zeigte ein Pre-Release (z.B. `v1.33.1-pre.2`) gleichzeitig das amber **Pre-Release**-Badge **und** ein grünes **Stable** darunter — ein Widerspruch.

## Root Cause

Der Stabilitäts-Indikator in `UpdateOverviewTab.tsx` war binär:

```tsx
is_dev_build ? "Dev Build" : "Stable"
```

`is_prerelease` wurde komplett ignoriert. Ein Pre-Release (`is_dev_build=false`, `is_prerelease=true`) fiel in den `else`-Zweig → „Stable". Das Backend (`prod_backend.py`) liefert `is_prerelease` korrekt aus dem Tag-Suffix; der Fehler war rein im Frontend.

| Zustand | is_dev_build | is_prerelease | vorher | nachher |
|---|---|---|---|---|
| Dev-Build | true | false | Dev Build | Dev Build |
| Stable | false | false | Stable | Stable |
| **Pre-Release** | false | true | **Stable** ❌ | *(keine Zeile)* ✅ |

## Fix

- Dreiwertige Logik: **Dev Build** → **Pre-Release** (keine eigene Zeile, das Badge neben der Version sagt es bereits) → **Stable**.
- Das hartkodierte `"Stable"` wird i18n'd über den neuen Key `updates.version.stable` (de: „Stabil", en: „Stable"). Vorher zeigte das deutsche UI englisches „Stable".

## Tests

Neuer Test `UpdateOverviewTab.test.tsx` deckt alle drei Stabilitäts-Zustände ab.

- `npx vitest run` → 53 Dateien, 369 Tests ✓
- `npx tsc --noEmit` ✓
- `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
