### PR TITLE
fix(monitoring): hide Frontend (dev) in prod, overlay RAM breakdown

### DIFF
--- a/backend/app/services/monitoring/memory_collector.py
+++ b/backend/app/services/monitoring/memory_collector.py
@@ -15,7 +15,7 @@ import psutil
 from app.models.monitoring import MemorySample
 from app.schemas.monitoring import MemorySampleSchema
 from app.services.monitoring.base import MetricCollector
-from app.services.monitoring.process_tracker import BALUHOST_PROCESS_PATTERNS
+from app.services.monitoring.process_tracker import get_baluhost_process_patterns
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,8 @@ def get_baluhost_memory_breakdown() -> dict[str, int]:
     Routing is first-match-wins (same order as BALUHOST_PROCESS_PATTERNS) so
     a process matching multiple patterns is counted under the first.
     """
-    breakdown: dict[str, int] = {entry["name"]: 0 for entry in BALUHOST_PROCESS_PATTERNS}
+    patterns = get_baluhost_process_patterns()
+    breakdown: dict[str, int] = {entry["name"]: 0 for entry in patterns}
 
     try:
         for proc in psutil.process_iter(["pid", "name", "cmdline", "memory_info"]):
@@ -41,7 +42,7 @@ def get_baluhost_memory_breakdown() -> dict[str, int]:
                 name = (info.get("name") or "").lower()
                 cmdline = " ".join(info.get("cmdline") or []).lower()
 
-                for entry in BALUHOST_PROCESS_PATTERNS:
+                for entry in patterns:
                     if all(p.lower() in name or p.lower() in cmdline for p in entry["patterns"]):
                         if info.get("memory_info"):
                             breakdown[entry["name"]] += info["memory_info"].rss

--- a/backend/app/services/monitoring/process_tracker.py
+++ b/backend/app/services/monitoring/process_tracker.py
@@ -38,6 +38,22 @@ BALUHOST_PROCESS_PATTERNS = [
 ]
 
 
+def get_baluhost_process_patterns() -> List[Dict]:
+    """Return the process patterns that are meaningful for the current run mode.
+
+    The ``baluhost-frontend-dev`` unit only exists while the Vite dev server is
+    running (started by ``start_dev.py``). In production the frontend is a
+    static build served by nginx — there is no BaluHost frontend process — so
+    the fragile ``vite`` substring match is dropped to avoid mislabelling an
+    unrelated process as "Frontend (dev)".
+    """
+    from app.core.config import settings
+
+    if getattr(settings, "is_dev_mode", False):
+        return BALUHOST_PROCESS_PATTERNS
+    return [p for p in BALUHOST_PROCESS_PATTERNS if p["name"] != "baluhost-frontend-dev"]
+
+
 class ProcessTracker:
     """
     Tracks BaluHost-related processes.
@@ -72,6 +88,7 @@ class ProcessTracker:
         samples: List[ProcessSampleSchema] = []
         timestamp = datetime.now(timezone.utc)
         seen_names: set[str] = set()
+        active_patterns = get_baluhost_process_patterns()
 
         try:
             for proc in psutil.process_iter(
@@ -83,7 +100,7 @@ class ProcessTracker:
                     cmdline = " ".join(info.get("cmdline") or []).lower()
 
                     matched_name: Optional[str] = None
-                    for entry in BALUHOST_PROCESS_PATTERNS:
+                    for entry in active_patterns:
                         patterns = entry["patterns"]
                         if all(p.lower() in name or p.lower() in cmdline for p in patterns):
                             matched_name = entry["name"]

--- a/backend/tests/monitoring/test_process_tracker.py
+++ b/backend/tests/monitoring/test_process_tracker.py
@@ -8,6 +8,7 @@ from app.services.monitoring import process_tracker
 from app.services.monitoring.process_tracker import (
     BALUHOST_PROCESS_PATTERNS,
     ProcessTracker,
+    get_baluhost_process_patterns,
 )
 
 
@@ -70,6 +71,28 @@ def test_find_processes_single_pattern_still_matches():
         matched = tracker._find_processes(["scheduler_worker.py"])
     pids = [m["pid"] for m in matched]
     assert pids == [201]
+
+
+def test_frontend_dev_pattern_dropped_in_prod_mode(monkeypatch):
+    """In production there is no BaluHost frontend process (static build served
+    by nginx), so the fragile ``vite`` match must not surface as 'Frontend (dev)'."""
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "is_dev_mode", False, raising=False)
+    names = {entry["name"] for entry in get_baluhost_process_patterns()}
+    assert "baluhost-frontend-dev" not in names
+    # The real units are still tracked.
+    assert "baluhost-backend" in names
+    assert "baluhost-scheduler" in names
+
+
+def test_frontend_dev_pattern_present_in_dev_mode(monkeypatch):
+    """The Vite dev server is a real process under start_dev.py, so dev keeps it."""
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "is_dev_mode", True, raising=False)
+    names = {entry["name"] for entry in get_baluhost_process_patterns()}
+    assert "baluhost-frontend-dev" in names
 
 
 def test_collect_samples_routes_backend_local_to_its_own_bucket():

--- a/client/src/components/system-monitor/MemoryTab.tsx
+++ b/client/src/components/system-monitor/MemoryTab.tsx
@@ -96,8 +96,11 @@ export function MemoryTab({ timeRange }: { timeRange: TimeRange }) {
           icon={<span className="text-orange-400 text-base sm:text-xl">%</span>}
         />
 
-        {/* BaluHost breakdown card */}
-        <div className="card border-slate-800/60 bg-slate-900/55 p-3 sm:p-4 flex flex-col">
+        {/* BaluHost breakdown card. overflow-visible (overrides .card) + relative
+            let the expanded breakdown render as an overlay anchored below the
+            card, so toggling it open never changes the height of the sibling
+            stat cards in the same grid row. */}
+        <div className="card relative overflow-visible border-slate-800/60 bg-slate-900/55 p-3 sm:p-4 flex flex-col">
           <button
             type="button"
             onClick={() => setBreakdownOpen((v) => !v)}
@@ -119,7 +122,7 @@ export function MemoryTab({ timeRange }: { timeRange: TimeRange }) {
           </div>
 
           {breakdownOpen && visibleUnits.length > 0 && (
-            <ul className="mt-3 space-y-1 text-xs sm:text-sm">
+            <ul className="absolute left-0 right-0 top-full z-20 mt-2 space-y-1 rounded-2xl border border-slate-700/70 bg-slate-900/95 p-3 text-xs shadow-[0_20px_60px_rgba(2,6,23,0.65)] backdrop-blur-xl sm:text-sm">
               {visibleUnits.map((unit) => (
                 <li key={unit.name} className="flex justify-between gap-2">
                   <span className="text-slate-400 truncate">


### PR DESCRIPTION
## Was

Zwei kleine Fixes im System Monitor → Memory → BaluHost-RAM-Aufschlüsselung.

### 1. "Frontend (dev)" in Production
In Prod ist das Frontend ein statischer nginx-Build — es gibt **keinen** BaluHost-Frontend-Prozess. Die Zeile "Frontend (dev)" entstand durch das fragile Substring-Pattern `vite`, das einen fremden Prozess auf der Prod-Box als BaluHost-Frontend einsortierte.

Fix: Neue `get_baluhost_process_patterns()` blendet `baluhost-frontend-dev` außerhalb des Dev-Modus aus. Genutzt von `process_tracker.collect_samples()` und `memory_collector.get_baluhost_memory_breakdown()`. Im Dev-Modus (Vite-Dev-Server ist ein echter Prozess) bleibt alles unverändert.

### 2. Ausklappen änderte die Höhe aller Karten
Die Aufschlüsselung lag im Flow eines `align-items: stretch`-Grids → beim Ausklappen wuchs die ganze Reihe. Jetzt rendert die Liste als absolutes Overlay (`overflow-visible` + `top-full z-20`) unter der BaluHost-Karte: Geschwister-StatCards behalten ihre Höhe, das Panel überdeckt den Chart darunter.

## Geänderte Dateien
- `backend/app/services/monitoring/process_tracker.py` — `get_baluhost_process_patterns()` Helper, dev-mode-Gating
- `backend/app/services/monitoring/memory_collector.py` — nutzt den Helper im Breakdown
- `backend/tests/monitoring/test_process_tracker.py` — 2 Regressionstests (prod/dev)
- `client/src/components/system-monitor/MemoryTab.tsx` — Overlay-Panel

## Tests
- `pytest tests/monitoring/test_process_tracker.py tests/monitoring/test_memory_collector.py` → 10 passed
- `pytest tests/monitoring/ tests/api/test_monitoring_routes.py` → grün
- `npx tsc --noEmit` (client) → 0 Fehler

⚠️ Manueller Smoketest im Prod-UI (Karte aus-/einklappen, "Frontend (dev)" verschwunden) steht nach Deploy noch aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
