### PR TITLE
fix(monitoring): lift BaluHost breakdown overlay above RAM chart

### DIFF
--- a/client/src/components/system-monitor/MemoryTab.tsx
+++ b/client/src/components/system-monitor/MemoryTab.tsx
@@ -99,8 +99,15 @@ export function MemoryTab({ timeRange }: { timeRange: TimeRange }) {
         {/* BaluHost breakdown card. overflow-visible (overrides .card) + relative
             let the expanded breakdown render as an overlay anchored below the
             card, so toggling it open never changes the height of the sibling
-            stat cards in the same grid row. */}
-        <div className="card relative overflow-visible border-slate-800/60 bg-slate-900/55 p-3 sm:p-4 flex flex-col">
+            stat cards in the same grid row. While open, z-30 lifts the card's
+            whole stacking context above the chart card below (the .card
+            backdrop-blur creates a stacking context, so the overlay's own
+            z-index can't escape it otherwise). */}
+        <div
+          className={`card relative overflow-visible border-slate-800/60 bg-slate-900/55 p-3 sm:p-4 flex flex-col ${
+            breakdownOpen ? 'z-30' : ''
+          }`}
+        >
           <button
             type="button"
             onClick={() => setBreakdownOpen((v) => !v)}


### PR DESCRIPTION
## Was

Follow-up zu #117. Der z-index-Fix kam zu spät — #117 war schon auto-gemerged, als ich ihn gepusht habe. Dieser PR holt ihn nach.

## Problem

Das ausgeklappte BaluHost-Breakdown-Overlay lag **hinter** dem RAM-History-Chart. Ursache: die `.card`-Klasse nutzt `backdrop-blur-xl`, und `backdrop-filter` erzeugt einen eigenen Stacking Context — dadurch war das `z-20` des Overlay-Panels innerhalb der BaluHost-Karte eingesperrt und konnte den im DOM später folgenden Chart-Card nicht überlagern.

## Fix

`z-30` auf die ganze BaluHost-Karte, solange ausgeklappt. Hebt deren kompletten Stacking Context über den Chart; das Overlay erscheint korrekt darüber. Eingeklappt kein z-index (kein Nebeneffekt auf andere Karten).

## Geänderte Dateien
- `client/src/components/system-monitor/MemoryTab.tsx`

## Tests
- `npx tsc --noEmit` (client) → 0 Fehler

⚠️ Visueller Smoketest im Prod-UI (Panel deckend über dem Chart) steht nach Deploy aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
