### PR TITLE
fix(update): derive service user/group from install dir owner

### DIFF
--- a/deploy/install/lib/config.sh
+++ b/deploy/install/lib/config.sh
@@ -8,8 +8,15 @@ BALUHOST_CONFIG="${BALUHOST_CONFIG:-/etc/baluhost/install.conf}"
 # ─── Default Values ──────────────────────────────────────────────────
 
 : "${INSTALL_DIR:=/opt/baluhost}"
-: "${BALUHOST_USER:=baluhost}"
-: "${BALUHOST_GROUP:=baluhost}"
+# Derive the service user/group from the install directory owner when not
+# explicitly set (env or install.conf). Without this, a host installed under a
+# different account (e.g. "sven") falls back to a non-existent "baluhost" user,
+# and every in-app update fails at the first `sudo -u "$BALUHOST_USER" ...`.
+_balu_dir_owner="$(stat -c '%U' "$INSTALL_DIR" 2>/dev/null || true)"
+_balu_dir_group="$(stat -c '%G' "$INSTALL_DIR" 2>/dev/null || true)"
+: "${BALUHOST_USER:=${_balu_dir_owner:-baluhost}}"
+: "${BALUHOST_GROUP:=${_balu_dir_group:-baluhost}}"
+unset _balu_dir_owner _balu_dir_group
 : "${FRONTEND_STATIC_DIR:=/var/www/baluhost}"
 : "${POSTGRES_DB:=baluhost}"
 : "${POSTGRES_USER:=baluhost}"


### PR DESCRIPTION
## Problem
The in-app updater never completes on installs where the service user is not literally `baluhost`. It reaches ~10 % then fails; rollback fails too. Symptom: download starts, then nothing in the frontend.

## Root cause (confirmed on prod)
`deploy/update/run-update.sh` runs each step as `sudo -u "$BALUHOST_USER" …` (e.g. `run-update.sh:178`). `BALUHOST_USER` comes from `load_config` (`deploy/install/lib/config.sh`), which reads `/etc/baluhost/install.conf`; when that file is **absent** it defaults to `baluhost`. The prod host runs as **`sven`** (systemd `User=sven`, `/opt/baluhost` owned by `sven:sven`) and `/etc/baluhost/install.conf` was never written → `BALUHOST_USER=baluhost`, a non-existent user:

```
sudo: unknown user baluhost
[ERROR] Update failed at line 178 (exit code 1)
[ERROR] Rollback also failed!
```
`/var/lib/baluhost/update-status/10.json`: `status=failed, progress_percent=10, current_step="Update failed at line 178 (exit code 1)"`.

## Fix
Derive `BALUHOST_USER`/`BALUHOST_GROUP` from the owner of `INSTALL_DIR` when not set explicitly (env or `install.conf`). Explicit values still win; missing `INSTALL_DIR` still falls back to `baluhost`.

## Verification
```
bash -n config.sh                         -> OK
no override (INSTALL_DIR=/opt/baluhost)    -> USER=sven GROUP=sven  (was baluhost)
BALUHOST_USER=foo env override            -> USER=foo
install.conf BALUHOST_USER=cfguser        -> USER=cfguser
INSTALL_DIR=/nonexistent                  -> USER=baluhost (fallback)
```

## Notes
- Immediate operational alternative (no deploy): create `/etc/baluhost/install.conf` with `BALUHOST_USER=sven`/`BALUHOST_GROUP=sven`.
- Touches CODEOWNERS-protected `deploy/`.
- Separate follow-ups: dev-channel update checks the retired `origin/development`; `parse_version` ranks a pre-release as newer than its final stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)