### PR TITLE
fix(power): resolve multiple alembic heads (prod deploy migration failure)

### DIFF
--- a/backend/alembic/versions/a3ef59de2014_add_power_authority_config.py
+++ b/backend/alembic/versions/a3ef59de2014_add_power_authority_config.py
@@ -1,7 +1,7 @@
 """add power_authority_config table
 
 Revision ID: a3ef59de2014
-Revises: 37ae61688702
+Revises: b48340a96a5a
 Create Date: 2026-05-30 12:00:00.000000
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = 'a3ef59de2014'
-down_revision: Union[str, Sequence[str], None] = '37ae61688702'
+down_revision: Union[str, Sequence[str], None] = 'b48340a96a5a'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Problem

The production deploy for PR #123 failed at the **Database Migration** step:

```
ERROR [alembic.util.messaging] Multiple head revisions are present for given argument 'head'
FAILED: Multiple head revisions are present ...
[ERROR] Alembic migration failed!
```

The deploy auto-rolled-back cleanly — **production is unaffected** (DB still at `b48340a96a5a`, git reverted to `fc97d45a`).

## Root cause

The two power migrations from #123 were chained onto `37ae61688702` (an *ancestor*), not the real head. They were created against a stale dev-DB alembic head. Meanwhile `main`'s status-bar feature added `b48340a96a5a` from that same parent `37ae61688702`. Result: two alembic heads (`9c4dcf5d487b` and `b48340a96a5a`), which makes `alembic upgrade head` ambiguous and fail.

## Fix

Re-point `a3ef59de2014` (`add power_authority_config`) `down_revision` from `37ae61688702` → `b48340a96a5a`. The chain is now linear:

```
… → 37ae61688702 → b48340a96a5a (status bar) → a3ef59de2014 (power_authority_config) → 9c4dcf5d487b (power_boost_rules, single head)
```

Verified locally: `alembic heads` now reports exactly one head (`9c4dcf5d487b`). The migrations' `upgrade()` SQL is unchanged — only the parent pointer. Nothing was applied on the failed run, so prod is at `b48340a96a5a` and this chains cleanly on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)