### PR TITLE
fix(power): idempotent PPD acquire (500 on re-activate while cap already at 400)

### DIFF
--- a/backend/app/api/routes/power.py
+++ b/backend/app/api/routes/power.py
@@ -505,6 +505,23 @@ async def switch_power_backend(
     )
 
 
+def _authority_status_payload() -> AuthorityStatusResponse:
+    """Build the authority status response. Plain helper so both the GET and PUT
+    endpoints can reuse it without one route function calling another decorated
+    (rate-limited) route function directly."""
+    cfg = config_store.load_authority_config()
+    ppd = ppd_authority.status()
+    mgr = get_power_manager()
+    return AuthorityStatusResponse(
+        external_authority_enabled=cfg["external_authority_enabled"],
+        boost_rules_enabled=cfg["boost_rules_enabled"],
+        ppd_active=ppd["ppd_active"],
+        ppd_masked=ppd["ppd_masked"],
+        cap_unenforceable=getattr(mgr, "_cap_unenforceable", False),
+        last_drift=getattr(mgr, "_last_drift", None),
+    )
+
+
 @router.get("/authority", response_model=AuthorityStatusResponse)
 @user_limiter.limit(get_limit("admin_operations"))
 async def get_authority_status(
@@ -518,17 +535,7 @@ async def get_authority_status(
     Returns whether BaluHost has exclusive CPU authority, whether boost
     rules are active, and the current state of power-profiles-daemon.
     """
-    cfg = config_store.load_authority_config()
-    ppd = ppd_authority.status()
-    mgr = get_power_manager()
-    return AuthorityStatusResponse(
-        external_authority_enabled=cfg["external_authority_enabled"],
-        boost_rules_enabled=cfg["boost_rules_enabled"],
-        ppd_active=ppd["ppd_active"],
-        ppd_masked=ppd["ppd_masked"],
-        cap_unenforceable=getattr(mgr, "_cap_unenforceable", False),
-        last_drift=getattr(mgr, "_last_drift", None),
-    )
+    return _authority_status_payload()
 
 
 @router.put("/authority", response_model=AuthorityStatusResponse)
@@ -582,7 +589,7 @@ async def update_authority(
         },
         success=True,
     )
-    return await get_authority_status(request, response, user)
+    return _authority_status_payload()
 
 
 @router.get("/boost-rules", response_model=BoostRulesResponse)

--- a/backend/app/services/power/ppd_authority.py
+++ b/backend/app/services/power/ppd_authority.py
@@ -31,23 +31,36 @@ def _systemctl_state(verb: str) -> bool:
 
 
 async def acquire() -> bool:
-    """Stop and mask power-profiles-daemon, recording its previous state."""
+    """Stop and mask power-profiles-daemon so BaluHost is the sole CPU authority.
+
+    Idempotent: success is judged by the END STATE (is the unit masked?), not by
+    each command's return code. ``systemctl stop`` on an already-masked unit
+    exits non-zero ("Unit is masked"), so checking per-command rc made a second
+    activation fail spuriously. Returns True iff PPD is masked afterwards.
+    """
     def _do() -> bool:
-        prev_active = _systemctl_state("is-active")
-        prev_enabled = _systemctl_state("is-enabled")
-        config_store.save_authority_config({"ppd_prev_active": prev_active, "ppd_prev_enabled": prev_enabled})
-        ok = True
+        # Only record the prior state the FIRST time (before we change anything).
+        # On a re-acquire the unit is already masked — don't clobber the real
+        # pre-feature state with the masked one.
+        if not _is_masked():
+            config_store.save_authority_config({
+                "ppd_prev_active": _systemctl_state("is-active"),
+                "ppd_prev_enabled": _systemctl_state("is-enabled"),
+            })
         for verb in ("stop", "mask"):
             res = _run(["sudo", "-n", "systemctl", verb, UNIT])
             if res.returncode != 0:
-                ok = False
+                # Non-fatal: stop on a masked/inactive unit is expected to be non-zero.
                 logger.warning(
-                    "PPD %s failed (rc=%s): %s",
+                    "PPD %s returned rc=%s: %s",
                     verb,
                     res.returncode,
                     (res.stderr or b"").decode(errors="ignore").strip(),
                 )
-        return ok
+        masked = _is_masked()
+        if not masked:
+            logger.error("PPD did not end up masked after acquire (sudoers missing?)")
+        return masked
     return await asyncio.get_running_loop().run_in_executor(None, _do)
 
 

--- a/backend/tests/api/test_power_authority_routes.py
+++ b/backend/tests/api/test_power_authority_routes.py
@@ -16,6 +16,33 @@ def test_get_authority_status_ok(client, admin_headers):
     assert "ppd_active" in body
 
 
+def test_enable_authority_success_returns_200(client, admin_headers, monkeypatch):
+    """The success path (acquire OK) must return 200 with the new status, not 500.
+
+    Regression: update_authority used to `return await get_authority_status(...)`,
+    calling a rate-limited route function directly. Now it uses a plain helper.
+    """
+    from app.services.power import config_store
+
+    config_store.save_authority_config({"external_authority_enabled": False})
+
+    async def fake_acquire():
+        return True
+
+    monkeypatch.setattr("app.services.power.ppd_authority.acquire", fake_acquire)
+    monkeypatch.setattr("app.services.power.ppd_authority.status",
+                        lambda: {"ppd_active": False, "ppd_masked": True})
+
+    r = client.put("/api/power/authority", json={"external_authority_enabled": True}, headers=admin_headers)
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["external_authority_enabled"] is True
+    assert body["ppd_masked"] is True
+
+    config_store.save_authority_config({"external_authority_enabled": False})
+
+
 def test_enable_authority_fails_when_acquire_fails(client, admin_headers, monkeypatch):
     """If PPD can't be stood down, the flag must NOT be persisted (no split authority)."""
     from app.services.power import config_store

--- a/backend/tests/services/test_ppd_authority.py
+++ b/backend/tests/services/test_ppd_authority.py
@@ -34,3 +34,26 @@ async def test_release_unmasks_ppd(monkeypatch):
                         lambda args, **kw: calls.append(args) or type("R", (), {"returncode": 0, "stdout": b""})())
     await ppd_authority.release()
     assert ["sudo", "-n", "systemctl", "unmask", "power-profiles-daemon"] in calls
+
+
+@pytest.mark.asyncio
+async def test_acquire_is_idempotent_when_already_masked(monkeypatch):
+    """Re-acquiring must succeed even though `stop` on a masked unit exits non-zero.
+
+    Regression: per-command rc check made the second activation return False → 500.
+    Success is now judged by the end state (unit masked).
+    """
+    def fake_run(args, **kwargs):
+        rc = 0
+        stderr = b""
+        # `systemctl stop` on an already-masked unit fails like the real systemd
+        if args[:4] == ["sudo", "-n", "systemctl", "stop"]:
+            rc, stderr = 1, b"Unit power-profiles-daemon.service is masked."
+        stdout = b"masked\n" if args[:2] == ["systemctl", "is-enabled"] else b""
+        return type("R", (), {"returncode": rc, "stdout": stdout, "stderr": stderr})()
+
+    monkeypatch.setattr(ppd_authority.subprocess, "run", fake_run)
+
+    result = await ppd_authority.acquire()
+
+    assert result is True  # masked end state → success despite stop rc=1


### PR DESCRIPTION
## Symptom (prod)

After the sudoers rule was provisioned, enabling CPU authority **masks power-profiles-daemon and the CPU drops to 400 MHz** — but the API still returns **500**, and `external_authority_enabled` never gets persisted (so the enforcement loop / boost watcher don't actually start).

## Root cause

`ppd_authority.acquire()` ran `systemctl stop` then `systemctl mask` and judged success by **each command's return code**. `systemctl stop` on an **already-masked** unit exits non-zero (`Unit … is masked`). So:

- 1st activation: stop(active)=0, mask=0 → masked. (Could already 500 on the response-build path — see below.)
- Every **subsequent** activation: stop(masked)=**non-zero** → `acquire()` returns False → endpoint raises 500. The cap looks "on" only because PPD is masked; BaluHost's own enforcement is not actually active (flag never saved).

A second, latent issue: `update_authority` ended with `return await get_authority_status(request, response, user)` — calling a rate-limited route function directly (an untested success path).

## Fix

1. **Idempotent acquire** — success is judged by the **end state** (`is the unit masked?`), tolerating the expected non-zero rc when stop/mask hit an already-stood-down unit. Prior PPD state is recorded only on the first acquire (not clobbered on re-acquire). A genuinely failed mask (e.g. sudoers missing) still returns False → the helpful 500 with the sudoers hint.
2. **Plain status helper** — `update_authority` and `get_authority_status` both build the response via a new undecorated `_authority_status_payload()`; no route function calls another decorated route directly.

## Tests
- `test_acquire_is_idempotent_when_already_masked` — stop rc=1 + masked end state → acquire True.
- `test_enable_authority_success_returns_200` — the previously-untested PUT success path now asserted (200 + `external_authority_enabled=true`).
- Existing PPD/authority tests still green (14 passed locally).

## After deploy
Toggle authority once more: it will now return 200, persist `external_authority_enabled=true`, and the 2 s enforcement loop + game-session watcher actually start (cap held + boost-on-game).

🤖 Generated with [Claude Code](https://claude.com/claude-code)