### PR TITLE
fix(deploy): use @@BALUHOST_USER@@ token in power sudoers template

### DIFF
--- a/deploy/install/templates/sudoers-baluhost-power
+++ b/deploy/install/templates/sudoers-baluhost-power
@@ -2,10 +2,10 @@
 # via the locked-down helper script. Scoped to one binary; args wildcard
 # allowed but the helper validates strictly.
 #
-# Installed by deploy/install/modules/13-power-helpers.sh; uses %BALUHOST_USER%
-# template variable replaced by process_template().
+# Installed by deploy/install/modules/13-power-helpers.sh; the service-user
+# placeholder is substituted by process_template() (see lib/common.sh).
 
-%BALUHOST_USER% ALL=(root) NOPASSWD: /usr/local/lib/baluhost/baluhost-write-logind-idle *
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/local/lib/baluhost/baluhost-write-logind-idle *
 
 # BaluHost CPU power authority: stop/mask power-profiles-daemon so BaluHost is
 # the sole CPU frequency authority (and restore it when authority is disabled).
@@ -13,15 +13,15 @@
 # wildcards, no ALL. See backend/app/services/power/ppd_authority.py and
 # .claude/rules/ci-cd-security.md. Adjust the systemctl path if it differs from
 # /usr/bin/systemctl on the target distro.
-%BALUHOST_USER% ALL=(root) NOPASSWD: /usr/bin/systemctl stop power-profiles-daemon
-%BALUHOST_USER% ALL=(root) NOPASSWD: /usr/bin/systemctl start power-profiles-daemon
-%BALUHOST_USER% ALL=(root) NOPASSWD: /usr/bin/systemctl mask power-profiles-daemon
-%BALUHOST_USER% ALL=(root) NOPASSWD: /usr/bin/systemctl unmask power-profiles-daemon
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/systemctl stop power-profiles-daemon
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/systemctl start power-profiles-daemon
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/systemctl mask power-profiles-daemon
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/systemctl unmask power-profiles-daemon
 
 # BaluHost: allow the service user to start/stop the KDE display manager
 # (sddm) at runtime, so the desktop can be toggled off to let the dGPU drop
 # to idle (display_count == 0) and back on. Scoped to the single sddm.service
 # unit with explicit verbs — no wildcards, no general service control.
-%BALUHOST_USER% ALL=(root) NOPASSWD: /usr/bin/systemctl start sddm.service
-%BALUHOST_USER% ALL=(root) NOPASSWD: /usr/bin/systemctl stop sddm.service
-%BALUHOST_USER% ALL=(root) NOPASSWD: /usr/bin/systemctl restart sddm.service
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/systemctl start sddm.service
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/systemctl stop sddm.service
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/systemctl restart sddm.service


### PR DESCRIPTION
## Fix: power sudoers template uses the wrong substitution token

`process_template()` in `deploy/install/lib/common.sh` substitutes **`@@KEY@@`** tokens:

```sh
content="${content//@@${key}@@/$val}"
```

But `deploy/install/templates/sudoers-baluhost-power` used **`%BALUHOST_USER%`** since its initial commit (`915295f5`). Consequently `13-power-helpers.sh` rendered the template **without** substituting the user, leaving the literal `%BALUHOST_USER%` in the output — which fails `visudo -cf`, so the module aborts (`rm -f` + `exit 1`) and never installs the file.

Every other sudoers template (e.g. `baluhost-wireguard-sudoers`) correctly uses `@@BALUHOST_USER@@`.

### Change
- Replace all `%BALUHOST_USER%` → `@@BALUHOST_USER@@` (8 rule lines).
- Reword the header comment so it no longer embeds the literal placeholder.

### Verification
Rendered via the real `process_template` and validated:
```
process_template … BALUHOST_USER=sven  →  no leftover tokens  →  visudo -cf … "Analyse OK"
```

### Note
On the prod box the live `/etc/sudoers.d/baluhost-power` was just installed by manually rendering this template (replacing the placeholder by hand) as part of the PR #122 desktop-toggle rollout. This fix makes the installer module itself correct, so future installs/re-runs work without the manual workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
