### PR TITLE
fix(deploy): install + sync hardware sudoers (#131)

### DIFF
--- a/deploy/install/modules/10-systemd-services.sh
+++ b/deploy/install/modules/10-systemd-services.sh
@@ -91,6 +91,29 @@ else
     log_warn "Deploy sudoers template not found: $DEPLOY_SUDOERS_TEMPLATE (skipping)"
 fi
 
+# --- Install hardware sudoers rule ---
+log_step "Hardware Sudoers"
+
+HARDWARE_SUDOERS_TEMPLATE="$TEMPLATE_DIR/baluhost-hardware-sudoers"
+HARDWARE_SUDOERS_OUTPUT="/etc/sudoers.d/baluhost-hardware"
+
+if [[ -f "$HARDWARE_SUDOERS_TEMPLATE" ]]; then
+    process_template "$HARDWARE_SUDOERS_TEMPLATE" "$HARDWARE_SUDOERS_OUTPUT" \
+        "BALUHOST_USER=$BALUHOST_USER"
+    chmod 440 "$HARDWARE_SUDOERS_OUTPUT"
+    log_info "Installed hardware sudoers rule: $HARDWARE_SUDOERS_OUTPUT"
+
+    if visudo -cf "$HARDWARE_SUDOERS_OUTPUT" &>/dev/null; then
+        log_info "Hardware sudoers syntax OK."
+    else
+        log_error "Hardware sudoers syntax check failed! Removing $HARDWARE_SUDOERS_OUTPUT"
+        rm -f "$HARDWARE_SUDOERS_OUTPUT"
+        exit 1
+    fi
+else
+    log_warn "Hardware sudoers template not found: $HARDWARE_SUDOERS_TEMPLATE (skipping)"
+fi
+
 # --- Install polkit rule for core-uptime sleep inhibitor ---
 log_step "Polkit Rule (Core Uptime Inhibitor)"
 

--- a/deploy/install/templates/baluhost-deploy-sudoers
+++ b/deploy/install/templates/baluhost-deploy-sudoers
@@ -15,3 +15,5 @@
 # script as root — only this specific, version-controlled file.
 @@BALUHOST_USER@@ ALL=(root) NOPASSWD: /bin/bash /opt/baluhost/deploy/scripts/install-amd-gpu-permissions.sh
 @@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/bash /opt/baluhost/deploy/scripts/install-amd-gpu-permissions.sh
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /bin/bash /opt/baluhost/deploy/scripts/install-hardware-sudoers.sh
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/bash /opt/baluhost/deploy/scripts/install-hardware-sudoers.sh

--- a/deploy/install/templates/baluhost-hardware-sudoers
+++ b/deploy/install/templates/baluhost-hardware-sudoers
@@ -1,7 +1,12 @@
 # BaluHost Hardware - sudoers rules
 # Allows the baluhost backend to manage RAID arrays, disk health,
 # fan control (PWM), CPU frequency, and power management.
-# Installed by module 10 (systemd-services).
+#
+# Fresh install: rendered by module 10 (10-systemd-services.sh).
+# Existing box:  changes to this template reach prod ONLY via a
+#   SYNC_PERMISSIONS=1 deploy (ci-deploy.sh section 4b) or by running
+#   deploy/scripts/install-hardware-sudoers.sh manually. A routine deploy
+#   does NOT re-render it.
 
 # RAID management (mdadm)
 @@BALUHOST_USER@@ ALL=(root) NOPASSWD: /sbin/mdadm

--- a/deploy/scripts/ci-deploy.sh
+++ b/deploy/scripts/ci-deploy.sh
@@ -367,6 +367,25 @@ if [[ "${SYNC_PERMISSIONS:-0}" == "1" || "${SYNC_PERMISSIONS,,}" == "true" ]]; t
         log_warn "AMD GPU permission script not found at $AMD_GPU_SCRIPT (skipping)."
     fi
 
+    # Hardware sudoers: RAID/SMART/fan/CPU-freq/suspend/rtcwake/ethtool grants.
+    # The installer renders @@BALUHOST_USER@@ from the running service user and
+    # validates with visudo before replacing the live file. This is the path by
+    # which baluhost-hardware-sudoers template changes reach an installed box.
+    # Invoked with no env vars (like the AMD-GPU script): the deploy sudoers rule
+    # whitelists this exact `bash <abs-path>` invocation, and the script's
+    # internal TEMPLATE default (/opt/baluhost/...) matches the prod INSTALL_DIR.
+    HARDWARE_SUDOERS_SCRIPT="$INSTALL_DIR/deploy/scripts/install-hardware-sudoers.sh"
+    if [[ -f "$HARDWARE_SUDOERS_SCRIPT" ]]; then
+        log_info "Re-applying hardware sudoers..."
+        if sudo bash "$HARDWARE_SUDOERS_SCRIPT"; then
+            log_info "Hardware sudoers sync OK."
+        else
+            log_warn "Hardware sudoers sync failed (non-fatal — deploy continues)."
+        fi
+    else
+        log_warn "Hardware sudoers script not found at $HARDWARE_SUDOERS_SCRIPT (skipping)."
+    fi
+
     # Future permission scripts go here following the same pattern:
     # if [[ -f "$INSTALL_DIR/deploy/scripts/install-<thing>-permissions.sh" ]]; then ...
 else

--- a/deploy/scripts/install-hardware-sudoers.sh
+++ b/deploy/scripts/install-hardware-sudoers.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Re-install (or update) the baluhost-hardware sudoers file on an existing host.
+#
+# Why: the hardware sudoers template (RAID/mdadm, SMART, fan + CPU-freq sysfs,
+# dmidecode, suspend, rtcwake, ethtool) is rendered once at install time, but
+# ci-deploy.sh does NOT re-run installer modules on a routine deploy. Template
+# fixes therefore never reach an already-installed box — e.g. the
+# `systemctl can-suspend` + `ethtool` capability-probe rules (added 2026-05-04)
+# left the Sleep page's Suspend/WoL badges greyed out on prod even though both
+# features worked. Operators run this script — or a SYNC_PERMISSIONS=1 deploy,
+# which calls it — to push template changes onto /etc/sudoers.d/baluhost-hardware.
+#
+# Safe by construction:
+#   - renders @@BALUHOST_USER@@ from the actual service user,
+#   - validates with `visudo -cf` BEFORE replacing the live file,
+#   - keeps a timestamped backup of the previous live file,
+#   - installs -m 0440 -o root -g root.
+#
+# Run as root.
+
+set -euo pipefail
+
+TEMPLATE="${TEMPLATE:-/opt/baluhost/deploy/install/templates/baluhost-hardware-sudoers}"
+TARGET="/etc/sudoers.d/baluhost-hardware"
+SERVICE="${SERVICE:-baluhost-backend.service}"
+
+if [[ "$EUID" -ne 0 ]]; then
+    echo "ERROR: must run as root (use sudo)." >&2
+    exit 1
+fi
+
+if [[ ! -f "$TEMPLATE" ]]; then
+    echo "ERROR: template not found: $TEMPLATE" >&2
+    echo "Did you 'git pull' /opt/baluhost first?" >&2
+    exit 1
+fi
+
+# Derive the service user from baluhost-backend.service 'User=' so the sudoers
+# rules are granted to whoever actually runs the backend — not a hardcoded name.
+# Order: explicit BALUHOST_USER override > systemd 'User=' > error out.
+SERVICE_USER="$(systemctl show -p User --value "$SERVICE" 2>/dev/null || true)"
+BALUHOST_USER="${BALUHOST_USER:-${SERVICE_USER:-}}"
+if [[ -z "$BALUHOST_USER" ]]; then
+    echo "ERROR: could not determine the service user from '$SERVICE' (User=)" >&2
+    echo "       and BALUHOST_USER is unset. Set BALUHOST_USER explicitly." >&2
+    exit 1
+fi
+echo "  ..  rendering hardware sudoers for user: $BALUHOST_USER"
+
+# Substitute @@BALUHOST_USER@@ placeholder into a temp file.
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+sed "s|@@BALUHOST_USER@@|$BALUHOST_USER|g" "$TEMPLATE" >"$TMP"
+
+# Validate BEFORE touching the live file — never leave an invalid sudoers file.
+if ! visudo -cf "$TMP" >/dev/null 2>&1; then
+    echo "ERROR: generated sudoers file fails visudo syntax check; live file untouched." >&2
+    visudo -cf "$TMP" || true
+    exit 1
+fi
+
+# Timestamped backup of the existing live file (if any), so a bad change can be
+# rolled back by hand.
+if [[ -f "$TARGET" ]]; then
+    BACKUP="${TARGET}.bak.$(date +%Y%m%d%H%M%S)"
+    cp -p "$TARGET" "$BACKUP"
+    echo "  OK  backed up existing file to: $BACKUP"
+fi
+
+install -m 0440 -o root -g root "$TMP" "$TARGET"
+echo "  OK  installed: $TARGET"
+visudo -cf "$TARGET" >/dev/null && echo "  OK  visudo syntax check passed"


### PR DESCRIPTION
Closes #131.

## Problem

`/etc/sudoers.d/baluhost-hardware` was **never installed or refreshed by any automated path**:

- Module 10 (`10-systemd-services.sh`) only installed the **update** and **deploy** sudoers — never `baluhost-hardware`, despite the template claiming "Installed by module 10".
- `ci-deploy.sh` section 4b (the `SYNC_PERMISSIONS=1` path) only re-applied the **AMD-GPU** permission script.

Consequence: template fixes never reached prod. The `systemctl can-suspend` + `ethtool` capability probes added in `ed10a193` (2026-05-04) left the Sleep page → *System Capabilities* showing **Suspend** and **WoL** greyed out even though both features work (detection probes use sudo; the live file stayed at its March version).

## Fix

1. **`deploy/scripts/install-hardware-sudoers.sh`** — idempotent installer mirroring `install-deploy-sudoers.sh`:
   - derives the service user from `baluhost-backend.service` `User=` (not hardcoded; `BALUHOST_USER` override still honoured),
   - renders `@@BALUHOST_USER@@` to a temp file,
   - `visudo -cf` validates **before** replacing the live file,
   - timestamped backup of the previous file,
   - `install -m 0440 -o root -g root`.
2. **Wired into `ci-deploy.sh` section 4b** next to the AMD-GPU script (no env vars — same invocation pattern; relies on the script's `TEMPLATE` default which matches the prod `INSTALL_DIR`).
3. **Module 10** now installs hardware sudoers too (fresh installs).
4. **`baluhost-deploy-sudoers`** whitelists the new script (both `/bin/bash` and `/usr/bin/bash` absolute-path pins).
5. **Template header** corrected — no longer claims module 10 installs it; documents the `SYNC_PERMISSIONS=1` requirement.

## Acceptance criteria

- [x] Editing the template + a `SYNC_PERMISSIONS=1` deploy updates `/etc/sudoers.d/baluhost-hardware`.
- [x] Installer validates with `visudo -cf` and never leaves an invalid live file.
- [x] Service user derived from `baluhost-backend.service` `User=`.
- [ ] Sleep → System Capabilities shows Suspend + WoL after sync — **prod runtime check** (cannot verify on Windows dev; template already carries the can-suspend + ethtool rules).

## Bootstrapping note (operator action on existing prod)

The new whitelist line in `baluhost-deploy-sudoers` itself only reaches an already-installed box via module 10 or `install-deploy-sudoers.sh`. So on the current prod box: run `sudo BALUHOST_USER=<svc-user> install-deploy-sudoers.sh` **once** after pulling, then `SYNC_PERMISSIONS=1` deploys can re-sync hardware sudoers. Same limitation that applies to any deploy-sudoers change.

## Not included (blocked)

Issue point 4 also asked for a reviewer-checklist note in `.claude/rules/ci-cd-security.md`. That edit was blocked by the harness self-modification guard. Suggested wording is in the PR thread / can be added by the maintainer. CODEOWNERS already covers `/deploy/` so the new script is owner-flagged.

## Testing

Bash-only change (no Python touched). Verified: `bash -n` on all three modified/added scripts, and template renders cleanly (no leftover `@@` placeholders) for both hardware and deploy sudoers. `visudo`/`systemctl` paths exercise on the Linux prod host only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
