### PR TITLE
fix(sleep): query logind CanSuspend via D-Bus, not phantom `systemctl can-suspend`

### DIFF
--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -1305,17 +1305,27 @@ class SleepManagerService:
 
         can_suspend = systemctl
         if not settings.is_dev_mode:
-            # The service user has no active logind session, so polkit returns
-            # "challenge" without sudo even though `sudo systemctl suspend`
-            # itself is allowed via NOPASSWD. Run the check via sudo too so the
-            # capability badge reflects reality.
+            # Query logind's CanSuspend over D-Bus. NOTE: `systemctl can-suspend`
+            # is NOT a valid verb (systemd has no such command) — we must ask
+            # logind directly. The service user has no active login session, so
+            # polkit returns "challenge" rather than "yes"; but "challenge" still
+            # means the system *supports* suspend (it only needs authorization,
+            # which we have via `sudo systemctl suspend` NOPASSWD). Treat both
+            # "yes" and "challenge" as capable; "no"/"na" mean not capable.
             try:
                 import subprocess
                 result = subprocess.run(
-                    ["sudo", "systemctl", "can-suspend"],
+                    [
+                        "busctl", "call", "org.freedesktop.login1",
+                        "/org/freedesktop/login1",
+                        "org.freedesktop.login1.Manager", "CanSuspend",
+                    ],
                     capture_output=True, text=True, timeout=5,
                 )
-                can_suspend = result.returncode == 0 and "yes" in result.stdout.lower()
+                out = result.stdout.lower()
+                can_suspend = result.returncode == 0 and (
+                    '"yes"' in out or '"challenge"' in out
+                )
             except Exception:
                 can_suspend = False
 


### PR DESCRIPTION
## Problem

The prod Sleep page → *System Capabilities* showed **Suspend** greyed out even though `sudo systemctl suspend` works. Root cause: `get_capabilities()` in `backend/app/services/power/sleep.py` probed `sudo systemctl can-suspend` — but **`systemctl` has no `can-suspend` verb** (systemd 257 returns `Unknown command verb 'can-suspend'`, rc=1). So `can_suspend` was always `False` in prod, independent of sudoers.

This is the *second* bug behind the greyed-out badges; the first (deploy drift of `baluhost-hardware` sudoers, which fixed the **WoL** badge via `ethtool`) was addressed in #132. The `systemctl can-suspend` sudoers rule #132 deployed is for a non-existent command and is now dead.

## Fix

Query logind's `CanSuspend` over D-Bus (`busctl`) instead — no sudo needed:

```python
busctl call org.freedesktop.login1 /org/freedesktop/login1 \
  org.freedesktop.login1.Manager CanSuspend
```

Treat both `"yes"` and `"challenge"` as capable. The no-session service user (`sven`) gets `"challenge"`, which still means the system *supports* suspend — only polkit auth is required, which we already have via the `sudo systemctl suspend` NOPASSWD rule. `"no"`/`"na"` → not capable.

## Verification

Hot-patched + verified live on prod (Debian 13, systemd 257) before this PR:

- `busctl … CanSuspend` → `s "challenge"` (rc=0) → new logic yields `can_suspend=True`.
- Backend restarted clean (`systemctl is-active` → active).
- WoL probe (`sudo ethtool enp12s0`) → `Wake-on: g` (already green after #132).

## Follow-up (not in this PR)

- Drop the dead `/usr/bin/systemctl can-suspend` line from `deploy/install/templates/baluhost-hardware-sudoers` (harmless meanwhile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)