### PR TITLE
chore(ci): bump actions/* off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Assert runner identity (defense-in-depth tripwire)
         run: |
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/deploy-pi.yml
+++ b/.github/workflows/deploy-pi.yml
@@ -12,9 +12,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -57,7 +57,7 @@ jobs:
       # monotonic per version, independent of any workflow run_number.
       - name: Checkout repo for tagging
         if: success()
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.run == 'mock'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -48,7 +48,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     environment: live-e2e
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Verify RUN_LIVE_E2E secret is enabled
         run: |
@@ -58,12 +58,12 @@ jobs:
           fi
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/raid-mdadm-selfhosted.yml
+++ b/.github/workflows/raid-mdadm-selfhosted.yml
@@ -7,9 +7,9 @@ jobs:
   raid-mdadm-selfhosted:
     runs-on: [self-hosted, linux, mdadm]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install backend (dev extras)

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.DEPLOY_PAT }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -14,10 +14,10 @@ jobs:
     permissions:
       contents: write  # required for tag-triggered release uploads
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload artifacts (push to main)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: baluhost-companion-dev
           path: |


### PR DESCRIPTION
## Was

Hebt alle offiziellen `actions/*` von der **deprecated Node-20-Runtime** auf die kleinste Major-Version, die auf **Node 24** läuft. Grund ist die GitHub-Actions-Annotation:

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

## Änderungen

| Action | von | nach | Node-24 ab |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | v5 (einzige Option) |
| `actions/setup-node` | v4 | **v5** | v5 (`using: node24` bestätigt) |
| `actions/setup-python` | v4 / v5 | **v6** | v6 (v5 = Node 20) |
| `actions/upload-artifact` | v4 | **v6** | v6 (v7 hätte ESM/`archive`-Breaking-Changes) |

Betroffene Workflows: `ci-check`, `create-release`, `deploy-pi`, `deploy-production`, `playwright-e2e`, `raid-mdadm-selfhosted`, `release-stable`, `tauri-build`.

Dritt-Anbieter-Actions (`peaceiris/actions-gh-pages`, `dtolnay/rust-toolchain`, `Swatinem/rust-cache`, `softprops/action-gh-release`) bewusst **unangetastet** — nicht Teil dieser Deprecation, eigene Runtimes.

## Kompatibilität geprüft

- **Runner-Mindestversion:** node24-Actions verlangen Runner-Agent ≥ v2.327.1. `BaluNode` & `BaluNode-ci-sandbox` laufen auf **v2.334.0** ✓, `ubuntu-latest` ohnehin ✓.
- **checkout@v5** verlagert persistierte Credentials nach `$RUNNER_TEMP` (statt git-config): `deploy-production` nutzt `persist-credentials: false` + inline-PAT → unberührt; `release-stable` nutzt das Standard-`token`-Pattern → funktioniert in v5.
- **upload-artifact v4→v6:** gleiche API (`name`/`path`/`retention-days`); der Breaking-Change war v3→v4 (immutable artifacts), darüber sind wir bereits.
- **`node-version: '20'`** in setup-node bleibt — das ist die Build-Toolchain, nicht die Action-Runtime.

## CI/CD-Security (`.claude/rules/ci-cd-security.md`)

Reine Versions-Bumps: **kein** Runner-/Trigger-/Actor-Gate-/Environment-/PAT-Scope-Change. Reviewer-Checklist unberührt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
