### PR TITLE
feat(power): show active preset + dynamic governor in power status pill

### DIFF
--- a/backend/app/services/status_bar/collectors.py
+++ b/backend/app/services/status_bar/collectors.py
@@ -32,6 +32,14 @@ async def collect_power(db: Session, role: str) -> Optional[dict]:
     from app.services.power.manager import get_power_manager
     status = await get_power_manager().get_power_status()
 
+    # Dynamic mode: the kernel governor controls the CPU directly — the demand
+    # profile and preset are frozen and no longer reflect what's running, so we
+    # surface the mode + governor instead of a stale "preset · level".
+    if getattr(status, "dynamic_mode_enabled", False):
+        gov = getattr(getattr(status, "dynamic_mode_config", None), "governor", None)
+        label = f"Dynamisch · {gov}" if gov else "Dynamisch"
+        return {"kind": "state", "tone": "info", "label": label, "icon": "Zap"}
+
     profile = getattr(status, "current_profile", None)
     if not profile:
         return None

--- a/backend/app/services/status_bar/collectors.py
+++ b/backend/app/services/status_bar/collectors.py
@@ -31,18 +31,18 @@ def _safe(default=None):
 async def collect_power(db: Session, role: str) -> Optional[dict]:
     from app.services.power.manager import get_power_manager
     status = await get_power_manager().get_power_status()
-    # PowerStatusResponse exposes the active profile as `current_profile`
-    # (a PowerProfile enum). Keep defensive fallbacks for older shapes.
-    profile = (
-        getattr(status, "current_profile", None)
-        or getattr(status, "active_profile", None)
-        or getattr(status, "profile", None)
-    )
+
+    profile = getattr(status, "current_profile", None)
     if not profile:
         return None
-    # PowerProfile is a str-enum; its `.value` (e.g. "idle") is the display text.
-    raw = getattr(profile, "value", profile)
-    label = str(raw).replace("_", " ").title()
+    # PowerProfile is a str-enum; its `.value` (e.g. "surge") is the level text.
+    level = str(getattr(profile, "value", profile)).replace("_", " ").title()
+
+    # Active preset (e.g. "Balanced"/"Performance") maps each level to MHz —
+    # it's what actually configures the CPU, so show it as the prominent part.
+    preset = getattr(status, "active_preset", None)
+    preset_name = getattr(preset, "name", None) if preset else None
+    label = f"{preset_name} · {level}" if preset_name else level
     return {"kind": "state", "tone": "info", "label": label, "icon": "Zap"}
 
 

--- a/backend/tests/services/test_status_bar_collectors.py
+++ b/backend/tests/services/test_status_bar_collectors.py
@@ -413,12 +413,7 @@ async def test_power_pill_no_preset_fallback():
 @pytest.mark.asyncio
 async def test_power_pill_silent_without_profile():
     from app.services.status_bar import collectors
-    status = MagicMock(
-        dynamic_mode_enabled=False,
-        current_profile=None,
-        active_profile=None,
-        profile=None,
-    )
+    status = MagicMock(dynamic_mode_enabled=False, current_profile=None)
     mgr = MagicMock()
     mgr.get_power_status = AsyncMock(return_value=status)
     with patch("app.services.power.manager.get_power_manager", return_value=mgr):

--- a/backend/tests/services/test_status_bar_collectors.py
+++ b/backend/tests/services/test_status_bar_collectors.py
@@ -418,3 +418,33 @@ async def test_power_pill_silent_without_profile():
     mgr.get_power_status = AsyncMock(return_value=status)
     with patch("app.services.power.manager.get_power_manager", return_value=mgr):
         assert await collectors.collect_power(MagicMock(), "admin") is None
+
+
+@pytest.mark.asyncio
+async def test_power_pill_dynamic_mode_with_governor():
+    from app.services.status_bar import collectors
+    status = MagicMock(
+        dynamic_mode_enabled=True,
+        dynamic_mode_config=MagicMock(governor="schedutil"),
+    )
+    mgr = MagicMock()
+    mgr.get_power_status = AsyncMock(return_value=status)
+    with patch("app.services.power.manager.get_power_manager", return_value=mgr):
+        result = await collectors.collect_power(MagicMock(), "admin")
+    assert result["label"] == "Dynamisch · schedutil"
+    assert result["tone"] == "info"
+    assert result["icon"] == "Zap"
+
+
+@pytest.mark.asyncio
+async def test_power_pill_dynamic_mode_no_config():
+    from app.services.status_bar import collectors
+    status = MagicMock(
+        dynamic_mode_enabled=True,
+        dynamic_mode_config=None,
+    )
+    mgr = MagicMock()
+    mgr.get_power_status = AsyncMock(return_value=status)
+    with patch("app.services.power.manager.get_power_manager", return_value=mgr):
+        result = await collectors.collect_power(MagicMock(), "admin")
+    assert result["label"] == "Dynamisch"

--- a/backend/tests/services/test_status_bar_collectors.py
+++ b/backend/tests/services/test_status_bar_collectors.py
@@ -448,3 +448,5 @@ async def test_power_pill_dynamic_mode_no_config():
     with patch("app.services.power.manager.get_power_manager", return_value=mgr):
         result = await collectors.collect_power(MagicMock(), "admin")
     assert result["label"] == "Dynamisch"
+    assert result["tone"] == "info"
+    assert result["icon"] == "Zap"

--- a/backend/tests/services/test_status_bar_collectors.py
+++ b/backend/tests/services/test_status_bar_collectors.py
@@ -371,3 +371,55 @@ async def test_collect_desktop_swallows_error():
 def test_desktop_registered_in_collectors():
     from app.services.status_bar.collectors import COLLECTORS
     assert "desktop" in COLLECTORS
+
+
+# ── power ────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_power_pill_preset_and_level():
+    from app.services.status_bar import collectors
+    preset = MagicMock()
+    preset.name = "Balanced"
+    status = MagicMock(
+        dynamic_mode_enabled=False,
+        current_profile=MagicMock(value="surge"),
+        active_preset=preset,
+    )
+    mgr = MagicMock()
+    mgr.get_power_status = AsyncMock(return_value=status)
+    with patch("app.services.power.manager.get_power_manager", return_value=mgr):
+        result = await collectors.collect_power(MagicMock(), "admin")
+    assert result["label"] == "Balanced · Surge"
+    assert result["tone"] == "info"
+    assert result["icon"] == "Zap"
+    assert "value" not in result
+
+
+@pytest.mark.asyncio
+async def test_power_pill_no_preset_fallback():
+    from app.services.status_bar import collectors
+    status = MagicMock(
+        dynamic_mode_enabled=False,
+        current_profile=MagicMock(value="surge"),
+        active_preset=None,
+    )
+    mgr = MagicMock()
+    mgr.get_power_status = AsyncMock(return_value=status)
+    with patch("app.services.power.manager.get_power_manager", return_value=mgr):
+        result = await collectors.collect_power(MagicMock(), "admin")
+    assert result["label"] == "Surge"
+    assert "value" not in result
+
+
+@pytest.mark.asyncio
+async def test_power_pill_silent_without_profile():
+    from app.services.status_bar import collectors
+    status = MagicMock(
+        dynamic_mode_enabled=False,
+        current_profile=None,
+        active_profile=None,
+        profile=None,
+    )
+    mgr = MagicMock()
+    mgr.get_power_status = AsyncMock(return_value=status)
+    with patch("app.services.power.manager.get_power_manager", return_value=mgr):
+        assert await collectors.collect_power(MagicMock(), "admin") is None

--- a/docs/superpowers/plans/2026-06-02-power-pill-preset.md
+++ b/docs/superpowers/plans/2026-06-02-power-pill-preset.md
@@ -1,0 +1,279 @@
+# Power-Pille: Profil/Preset anzeigen — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Die Topbar-Power-Pille zeigt statt nur der Intensitätsstufe (idle/low/medium/surge) das, was die CPU tatsächlich steuert: das aktive Preset + die Stufe, bzw. im Dynamic Mode den Kernel-Governor.
+
+**Architecture:** Reine Backend-Änderung an genau einem Collector (`collect_power` in `backend/app/services/status_bar/collectors.py`). Drei Zustände: (1) Dynamic Mode → `Dynamisch · <governor>`; (2) Profil-Modus + aktives Preset → `<Preset> · <Stufe>`; (3) Profil-Modus ohne Preset → `<Stufe>` (heutiges Verhalten). Die generische `<Pill>`-Komponente rendert `label` bereits — kein Frontend-Code.
+
+**Tech Stack:** Python 3, pytest, `unittest.mock` (`AsyncMock`/`MagicMock`/`patch`). FastAPI-Service-Layer.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-power-pill-profile-design.md`
+
+---
+
+## File Structure
+
+| Datei | Verantwortung | Aktion |
+|---|---|---|
+| `backend/app/services/status_bar/collectors.py` | `collect_power` — mappt `get_power_status()` auf einen Pill-State-Dict | Modify (nur die `collect_power`-Funktion, Zeilen 30-46) |
+| `backend/tests/services/test_status_bar_collectors.py` | Unit-Tests der Collectoren | Modify (5 neue Tests anhängen) |
+
+Keine neuen Dateien. Kein Frontend-, Schema-, Migrations- oder i18n-Key-Change.
+
+**Wichtige Mock-Hinweise (gelten für alle Tests unten):**
+- `collect_power` importiert `get_power_manager` **lokal** aus `app.services.power.manager` → dort patchen: `patch("app.services.power.manager.get_power_manager", return_value=mgr)`.
+- `get_power_status` ist `async` → `mgr.get_power_status = AsyncMock(return_value=status)`.
+- Preset-Name **nicht** via `MagicMock(name="Balanced")` setzen (`name` ist ein reserviertes MagicMock-Kwarg, das den Mock benennt statt das Attribut). Stattdessen: `preset = MagicMock(); preset.name = "Balanced"`.
+- `MagicMock()` liefert für nicht gesetzte Attribute neue Mock-Objekte (truthy). Felder, die `None`/`False` sein müssen (`current_profile`, `active_preset`, `dynamic_mode_enabled`), **explizit** im Konstruktor setzen.
+
+`AsyncMock`, `MagicMock`, `patch` sind in der Testdatei bereits importiert (`from unittest.mock import AsyncMock, MagicMock, patch`).
+
+---
+
+## Task 1: Profil-Modus — Preset + Stufe (und Fallback)
+
+Stellt `collect_power` von „nur Stufe" auf „Preset · Stufe" um, mit Fallback auf reine Stufe, wenn kein Preset aktiv ist. Der Dynamic-Mode-Sonderfall kommt in Task 2.
+
+**Files:**
+- Modify: `backend/app/services/status_bar/collectors.py:30-46`
+- Test: `backend/tests/services/test_status_bar_collectors.py` (anhängen)
+
+- [ ] **Step 1: Failing tests anhängen**
+
+Ans Ende von `backend/tests/services/test_status_bar_collectors.py` anfügen:
+
+```python
+# ── power ────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_power_pill_preset_and_level():
+    from app.services.status_bar import collectors
+    preset = MagicMock()
+    preset.name = "Balanced"
+    status = MagicMock(
+        dynamic_mode_enabled=False,
+        current_profile=MagicMock(value="surge"),
+        active_preset=preset,
+    )
+    mgr = MagicMock()
+    mgr.get_power_status = AsyncMock(return_value=status)
+    with patch("app.services.power.manager.get_power_manager", return_value=mgr):
+        result = await collectors.collect_power(MagicMock(), "admin")
+    assert result["label"] == "Balanced · Surge"
+    assert result["tone"] == "info"
+    assert result["icon"] == "Zap"
+    assert "value" not in result
+
+
+@pytest.mark.asyncio
+async def test_power_pill_no_preset_fallback():
+    from app.services.status_bar import collectors
+    status = MagicMock(
+        dynamic_mode_enabled=False,
+        current_profile=MagicMock(value="surge"),
+        active_preset=None,
+    )
+    mgr = MagicMock()
+    mgr.get_power_status = AsyncMock(return_value=status)
+    with patch("app.services.power.manager.get_power_manager", return_value=mgr):
+        result = await collectors.collect_power(MagicMock(), "admin")
+    assert result["label"] == "Surge"
+    assert "value" not in result
+
+
+@pytest.mark.asyncio
+async def test_power_pill_silent_without_profile():
+    from app.services.status_bar import collectors
+    status = MagicMock(
+        dynamic_mode_enabled=False,
+        current_profile=None,
+        active_profile=None,
+        profile=None,
+    )
+    mgr = MagicMock()
+    mgr.get_power_status = AsyncMock(return_value=status)
+    with patch("app.services.power.manager.get_power_manager", return_value=mgr):
+        assert await collectors.collect_power(MagicMock(), "admin") is None
+```
+
+- [ ] **Step 2: Tests laufen lassen — erwarte FAIL**
+
+Run: `cd backend && python -m pytest tests/services/test_status_bar_collectors.py -k power -v --no-cov`
+Expected: `test_power_pill_preset_and_level` schlägt fehl (heutiger Code zeigt `label == "Surge"`, kein Preset). Die anderen beiden können je nach Altverhalten passen — entscheidend ist der rote `preset_and_level`-Test.
+
+- [ ] **Step 3: `collect_power` umsetzen**
+
+In `backend/app/services/status_bar/collectors.py` die bestehende `collect_power`-Funktion (Zeilen 30-46) **vollständig** ersetzen durch:
+
+```python
+# ── power ────────────────────────────────────────────────────────────
+@_safe()
+async def collect_power(db: Session, role: str) -> Optional[dict]:
+    from app.services.power.manager import get_power_manager
+    status = await get_power_manager().get_power_status()
+
+    profile = getattr(status, "current_profile", None)
+    if not profile:
+        return None
+    # PowerProfile is a str-enum; its `.value` (e.g. "surge") is the level text.
+    level = str(getattr(profile, "value", profile)).replace("_", " ").title()
+
+    # Active preset (e.g. "Balanced"/"Performance") maps each level to MHz —
+    # it's what actually configures the CPU, so show it as the prominent part.
+    preset = getattr(status, "active_preset", None)
+    preset_name = getattr(preset, "name", None) if preset else None
+    label = f"{preset_name} · {level}" if preset_name else level
+    return {"kind": "state", "tone": "info", "label": label, "icon": "Zap"}
+```
+
+- [ ] **Step 4: Tests laufen lassen — erwarte PASS**
+
+Run: `cd backend && python -m pytest tests/services/test_status_bar_collectors.py -k power -v --no-cov`
+Expected: `test_power_pill_preset_and_level`, `test_power_pill_no_preset_fallback`, `test_power_pill_silent_without_profile` PASS. (`test_power_pill_dynamic_*` existieren noch nicht.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/status_bar/collectors.py backend/tests/services/test_status_bar_collectors.py
+git commit -m "feat(power): show active preset + level in power status pill"
+```
+
+---
+
+## Task 2: Dynamic-Mode-Sonderfall — Modus + Governor
+
+Wenn Dynamic Mode aktiv ist, regelt der Kernel-Governor direkt; Preset/Stufe sind eingefroren und irreführend. Die Pille zeigt dann `Dynamisch · <governor>`.
+
+**Files:**
+- Modify: `backend/app/services/status_bar/collectors.py` (`collect_power`, Dynamic-Branch ergänzen)
+- Test: `backend/tests/services/test_status_bar_collectors.py` (anhängen)
+
+- [ ] **Step 1: Failing tests anhängen**
+
+Ans Ende von `backend/tests/services/test_status_bar_collectors.py` anfügen:
+
+```python
+@pytest.mark.asyncio
+async def test_power_pill_dynamic_mode_with_governor():
+    from app.services.status_bar import collectors
+    status = MagicMock(
+        dynamic_mode_enabled=True,
+        dynamic_mode_config=MagicMock(governor="schedutil"),
+    )
+    mgr = MagicMock()
+    mgr.get_power_status = AsyncMock(return_value=status)
+    with patch("app.services.power.manager.get_power_manager", return_value=mgr):
+        result = await collectors.collect_power(MagicMock(), "admin")
+    assert result["label"] == "Dynamisch · schedutil"
+    assert result["tone"] == "info"
+    assert result["icon"] == "Zap"
+
+
+@pytest.mark.asyncio
+async def test_power_pill_dynamic_mode_no_config():
+    from app.services.status_bar import collectors
+    status = MagicMock(
+        dynamic_mode_enabled=True,
+        dynamic_mode_config=None,
+    )
+    mgr = MagicMock()
+    mgr.get_power_status = AsyncMock(return_value=status)
+    with patch("app.services.power.manager.get_power_manager", return_value=mgr):
+        result = await collectors.collect_power(MagicMock(), "admin")
+    assert result["label"] == "Dynamisch"
+```
+
+- [ ] **Step 2: Tests laufen lassen — erwarte FAIL**
+
+Run: `cd backend && python -m pytest tests/services/test_status_bar_collectors.py -k "dynamic_mode" -v --no-cov`
+Expected: Beide FAIL — der aktuelle Code ignoriert `dynamic_mode_enabled` und bildet `label` aus dem (gemockten) `current_profile`/`active_preset`, statt `"Dynamisch · schedutil"`/`"Dynamisch"`.
+
+- [ ] **Step 3: Dynamic-Branch ergänzen**
+
+In `backend/app/services/status_bar/collectors.py`, in `collect_power`, **direkt nach** der Zeile `status = await get_power_manager().get_power_status()` und **vor** `profile = getattr(...)` einfügen:
+
+```python
+    # Dynamic mode: the kernel governor controls the CPU directly — the demand
+    # profile and preset are frozen and no longer reflect what's running, so we
+    # surface the mode + governor instead of a stale "preset · level".
+    if getattr(status, "dynamic_mode_enabled", False):
+        gov = getattr(getattr(status, "dynamic_mode_config", None), "governor", None)
+        label = f"Dynamisch · {gov}" if gov else "Dynamisch"
+        return {"kind": "state", "tone": "info", "label": label, "icon": "Zap"}
+```
+
+Die Funktion lautet danach vollständig:
+
+```python
+# ── power ────────────────────────────────────────────────────────────
+@_safe()
+async def collect_power(db: Session, role: str) -> Optional[dict]:
+    from app.services.power.manager import get_power_manager
+    status = await get_power_manager().get_power_status()
+
+    # Dynamic mode: the kernel governor controls the CPU directly — the demand
+    # profile and preset are frozen and no longer reflect what's running, so we
+    # surface the mode + governor instead of a stale "preset · level".
+    if getattr(status, "dynamic_mode_enabled", False):
+        gov = getattr(getattr(status, "dynamic_mode_config", None), "governor", None)
+        label = f"Dynamisch · {gov}" if gov else "Dynamisch"
+        return {"kind": "state", "tone": "info", "label": label, "icon": "Zap"}
+
+    profile = getattr(status, "current_profile", None)
+    if not profile:
+        return None
+    # PowerProfile is a str-enum; its `.value` (e.g. "surge") is the level text.
+    level = str(getattr(profile, "value", profile)).replace("_", " ").title()
+
+    # Active preset (e.g. "Balanced"/"Performance") maps each level to MHz —
+    # it's what actually configures the CPU, so show it as the prominent part.
+    preset = getattr(status, "active_preset", None)
+    preset_name = getattr(preset, "name", None) if preset else None
+    label = f"{preset_name} · {level}" if preset_name else level
+    return {"kind": "state", "tone": "info", "label": label, "icon": "Zap"}
+```
+
+- [ ] **Step 4: Tests laufen lassen — erwarte PASS**
+
+Run: `cd backend && python -m pytest tests/services/test_status_bar_collectors.py -k power -v --no-cov`
+Expected: Alle 5 Power-Tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/status_bar/collectors.py backend/tests/services/test_status_bar_collectors.py
+git commit -m "feat(power): show dynamic-mode governor in power status pill"
+```
+
+---
+
+## Task 3: Regression-Verifikation
+
+Sicherstellen, dass die gesamte Status-Bar-Test-Suite (Collectoren + Service + Routes) weiterhin grün ist.
+
+**Files:** keine Änderung.
+
+- [ ] **Step 1: Volle Status-Bar-Suite**
+
+Run: `cd backend && python -m pytest tests/services/test_status_bar_collectors.py tests/services/test_status_bar_service.py tests/api/test_status_bar_routes.py -q --no-cov`
+Expected: Alle Tests PASS (vorher 31 in collectors; jetzt 36 dort + Service/Routes unverändert grün).
+
+- [ ] **Step 2: Falls rot — Service-/Routes-Erwartungen prüfen**
+
+`test_status_bar_service.py` aggregiert Collectoren. Sollte ein dortiger Test eine konkrete Power-Pill-`label` erwartet haben (z.B. `"Surge"`), die jetzt `"Balanced · Surge"` lautet, den Test an das neue Verhalten anpassen (nicht das Feature). Andernfalls keine Aktion.
+
+---
+
+## Manual Smoketest (nach Deploy)
+
+1. Als Admin einloggen, Power-Pille in der Topbar aktiviert (`System Control → System → Status Bar`).
+2. Energy-Tab öffnen, ein anderes Preset aktivieren → Pille zeigt innerhalb von ~10s `<NeuerPreset> · <Stufe>`.
+3. Dynamic Mode einschalten → Pille wechselt zu `Dynamisch · <governor>` (z.B. `Dynamisch · schedutil`).
+4. Dynamic Mode ausschalten → Pille zeigt wieder `<Preset> · <Stufe>`.
+
+## Out of Scope (laut Spec)
+
+- Lokalisierung der Stufen-Namen (bleiben englisch title-case)
+- Dedizierter Frontend-`PowerPill.tsx`-Renderer
+- MHz/Live-Frequenz in der Pille
+- Tooltip mit Preset-Details (browser-natives `title` aus `label` genügt)

--- a/docs/superpowers/specs/2026-06-02-power-pill-profile-design.md
+++ b/docs/superpowers/specs/2026-06-02-power-pill-profile-design.md
@@ -1,0 +1,179 @@
+# Power-Pille: Profil/Preset anzeigen — Design
+
+**Date:** 2026-06-02
+**Status:** Approved
+**Author:** Sven (Xveyn) + Claude
+**Context:** Erweiterung der Topbar-Statusleiste (`docs/superpowers/specs/2026-05-27-topbar-statusbar-design.md`)
+
+## Problem
+
+Die Power-Pille in der Topbar-Statusleiste zeigt aktuell nur die **Stufe** (idle/low/medium/surge),
+die der PowerManager je nach Last/Demand wählt — vom Nutzer als „Intensität" wahrgenommen.
+Das **benannte Preset** (z.B. „Balanced", „Performance" oder ein eigenes), das die CPU-Steuerung
+tatsächlich konfiguriert, wird nicht angezeigt.
+
+Heutiges Verhalten (`backend/app/services/status_bar/collectors.py:30-46`):
+
+```python
+@_safe()
+async def collect_power(db, role):
+    status = await get_power_manager().get_power_status()
+    profile = (getattr(status, "current_profile", None) or ...)
+    if not profile:
+        return None
+    raw = getattr(profile, "value", profile)
+    label = str(raw).replace("_", " ").title()
+    return {"kind": "state", "tone": "info", "label": label, "icon": "Zap"}
+```
+
+→ Pille zeigt nur z.B. `⚡ Surge`.
+
+## Leitprinzip
+
+**Die Pille zeigt das, was in der Praxis die CPU-Frequenz bestimmt.**
+
+Dynamic Mode und Presets schließen sich faktisch aus:
+
+- **Profil-/Preset-Modus** (Normalfall): Auto-Scaling wählt eine Stufe; das **aktive Preset**
+  mappt jede Stufe auf konkrete MHz-Werte. → Preset bestimmt die Steuerung.
+- **Dynamic Mode** (`manager.py:549-551`: `if self._dynamic_mode_enabled: return`):
+  Die Stufen-Auswahl ist eingefroren; der **Kernel-Governor** (z.B. `schedutil`/`ondemand`/`powersave`)
+  regelt die Frequenz direkt innerhalb der Dynamic-Min/Max-Grenzen. Das Preset wird **nicht**
+  angewendet; `current_profile`/`active_preset` bleiben stale. → Governor bestimmt die Steuerung.
+
+`get_power_status()` (`manager.py:1074-1173`) liefert alle nötigen Felder:
+`dynamic_mode_enabled: bool`, `dynamic_mode_config.governor`, `current_profile: PowerProfile`,
+`active_preset: Optional[PowerPresetSummary]` (mit `.name`).
+
+## Lösung
+
+Drei Pille-Zustände, abgeleitet aus dem Leitprinzip:
+
+| Situation | Steuert tatsächlich | Pille (`label`) |
+|---|---|---|
+| Dynamic Mode aktiv | Kernel-Governor | `Dynamisch · schedutil` |
+| Profil-Modus + aktives Preset | Preset (Stufe → MHz) | `Balanced · Surge` |
+| Profil-Modus, kein Preset | Default-Mapping der Stufe | `Surge` |
+
+Darstellung: alles im `label` mit `·`-Trenner, kein `value`-Feld. Icon bleibt `Zap`, Tone bleibt `info`.
+
+## Architektur
+
+**Einziger geänderter Code:** `collect_power` in `backend/app/services/status_bar/collectors.py`.
+Reine Backend-Änderung — die generische `Pill`-Komponente (`client/src/components/ui/Pill.tsx`)
+und der `PillRenderer` (`client/src/components/topbar/pillRenderers.tsx`) bleiben unverändert,
+da sie `label` bereits rendern.
+
+```python
+@_safe()
+async def collect_power(db, role):
+    status = await get_power_manager().get_power_status()
+
+    # Dynamic Mode: Kernel-Governor regelt direkt — Preset/Stufe sind eingefroren
+    # und spiegeln nicht die Realität, daher Modus + Governor zeigen.
+    if getattr(status, "dynamic_mode_enabled", False):
+        gov = getattr(getattr(status, "dynamic_mode_config", None), "governor", None)
+        label = f"Dynamisch · {gov}" if gov else "Dynamisch"
+        return {"kind": "state", "tone": "info", "label": label, "icon": "Zap"}
+
+    profile = getattr(status, "current_profile", None)
+    if not profile:
+        return None
+    level = str(getattr(profile, "value", profile)).replace("_", " ").title()  # "Surge"
+
+    preset = getattr(status, "active_preset", None)
+    preset_name = getattr(preset, "name", None) if preset else None
+    label = f"{preset_name} · {level}" if preset_name else level
+    return {"kind": "state", "tone": "info", "label": label, "icon": "Zap"}
+```
+
+Der `@_safe()`-Dekorator bleibt: jeder Fehler im Collector → `None` (Pille verschwindet, kein 5xx).
+
+## i18n
+
+Die Stufe wird wie bisher roh englisch title-case dargestellt (`Surge`/`Idle`/...), unverändert
+zum heutigen Verhalten. Das deutsche Literal `"Dynamisch"` ist konsistent mit anderen Collectorn
+in derselben Datei (`"läuft"`, `"fehlgeschlagen"`, `"verbunden"`). Der Governor-Name (`schedutil`)
+ist ein technischer Bezeichner und bleibt unverändert. Keine neuen i18n-Keys nötig.
+
+## Edge Cases
+
+| Fall | Verhalten |
+|---|---|
+| `dynamic_mode_enabled=True`, aber `dynamic_mode_config=None` | `label = "Dynamisch"` (ohne Governor) |
+| `active_preset=None` (kein Preset aktiv) | Fallback: nur Stufe, z.B. `Surge` (heutiges Verhalten) |
+| `current_profile=None` (kein Status) | `None` → Pille verschwindet (wie heute) |
+| Langer eigener Preset-Name | Pille wird breiter; Topbar hat Platz (akzeptiert) |
+| `get_power_status()` wirft | `@_safe()` fängt ab → `None`, kein 5xx |
+| Follower-Worker (nicht primary) | `get_power_status()` hydratisiert aus SHM/DB — gleiche Felder verfügbar |
+
+## Security
+
+Keine neue Datenexposition: `active_preset.name`, `current_profile` und Governor-Name sind keine
+sensiblen Daten (kein Pfad, keine Seriennummer, kein Geheimnis). Die `power`-Pille ist im Katalog
+nicht `visibility_locked` und darf laut bestehendem Design für „All Users" freigeschaltet werden —
+der Preset-Name ändert daran nichts. Auth/Rate-Limiting des `/state`-Endpoints bleiben unberührt.
+
+## Tests
+
+Ergänzung in `backend/tests/services/test_status_bar_collectors.py` (bestehende Collector-Test-Datei;
+es existiert noch **kein** `collect_power`-Test). Es gibt keinen Power-Eintrag dort, der angepasst werden müsste.
+
+| Test | Verifiziert |
+|---|---|
+| `test_power_pill_preset_and_level` | `active_preset.name="Balanced"`, `current_profile.value="surge"`, dynamic aus → `label == "Balanced · Surge"`, kein `value` |
+| `test_power_pill_no_preset_fallback` | `active_preset=None`, `current_profile.value="surge"`, dynamic aus → `label == "Surge"` |
+| `test_power_pill_dynamic_mode_with_governor` | `dynamic_mode_enabled=True`, `dynamic_mode_config.governor="schedutil"` → `label == "Dynamisch · schedutil"` |
+| `test_power_pill_dynamic_mode_no_config` | `dynamic_mode_enabled=True`, `dynamic_mode_config=None` → `label == "Dynamisch"` |
+| `test_power_pill_silent_without_profile` | `current_profile=None`, dynamic aus → `None` (Pille verschwindet) |
+
+**Mock-Strategie** (analog zu den bestehenden Tests in der Datei, `unittest.mock` + `AsyncMock`):
+`collect_power` importiert `get_power_manager` lokal aus `app.services.power.manager`, daher dort patchen.
+`get_power_status` ist `async` → `AsyncMock`. Beispielmuster:
+
+```python
+@pytest.mark.asyncio
+async def test_power_pill_preset_and_level():
+    from app.services.status_bar import collectors
+    preset = MagicMock()
+    preset.name = "Balanced"            # WICHTIG: nicht MagicMock(name="Balanced") —
+                                        # `name` ist ein reserviertes MagicMock-Kwarg!
+    status = MagicMock(
+        dynamic_mode_enabled=False,
+        current_profile=MagicMock(value="surge"),
+        active_preset=preset,
+    )
+    mgr = MagicMock(); mgr.get_power_status = AsyncMock(return_value=status)
+    with patch("app.services.power.manager.get_power_manager", return_value=mgr):
+        result = await collectors.collect_power(MagicMock(), "admin")
+    assert result["label"] == "Balanced · Surge"
+    assert "value" not in result
+```
+
+Für den Fallback-Test `current_profile=MagicMock(value="surge")`, `active_preset=None`.
+Für `silent_without_profile` muss `current_profile=None` **und** `active_profile`/`profile` fehlen
+(im MagicMock explizit auf `None` setzen, da `getattr` sonst neue Mock-Attribute liefert):
+`status = MagicMock(dynamic_mode_enabled=False, current_profile=None, active_profile=None, profile=None)`.
+
+## Out of Scope
+
+- Lokalisierung der Stufen-Namen (idle/low/medium/surge) — bleibt wie heute englisch
+- Dedizierter Frontend-`PowerPill.tsx`-Renderer (nicht nötig, generische Pille genügt)
+- Anzeige der Live-Frequenz/MHz in der Pille (eigener Click-Through zum Energy-Tab genügt)
+- Tooltip mit Preset-Details (browser-natives `title` aus `label` reicht)
+
+## Build Order
+
+1. `collect_power` in `collectors.py` auf Drei-Zustands-Logik umstellen
+2. 5 Tests in `backend/tests/services/test_status_bar_collectors.py` ergänzen
+3. `cd backend && python -m pytest tests/services/test_status_bar_collectors.py -v` — grün
+4. Manueller Smoketest: Energy-Tab Preset wechseln → Pille zeigt neuen Namen; Dynamic Mode an/aus → Pille wechselt zu `Dynamisch · <governor>` und zurück
+
+## References
+
+- `backend/app/services/status_bar/collectors.py:30-46` — zu ändernder Collector
+- `backend/app/services/power/manager.py:1074-1173` — `get_power_status()`, befüllt `active_preset` + Dynamic-Felder
+- `backend/app/services/power/manager.py:549-551` — Dynamic Mode deaktiviert Auto-Scaling (Beleg für „schließt sich aus")
+- `backend/app/schemas/power.py:111-130` — `PowerStatusResponse` (Felder), `PowerPresetSummary`
+- `client/src/components/ui/Pill.tsx` — generische Pille (`label`/`value`-Rendering, unverändert)
+- `docs/superpowers/specs/2026-05-27-topbar-statusbar-design.md` — Basis-Design der Statusleiste


### PR DESCRIPTION
## Summary
- Die Topbar-Power-Pille zeigt jetzt, was die CPU **tatsächlich** steuert, statt nur die Intensitätsstufe:
  - **Dynamic Mode aktiv** → `Dynamisch · <governor>` (z.B. `Dynamisch · schedutil`)
  - **Profil-Modus + aktives Preset** → `<Preset> · <Stufe>` (z.B. `Balanced · Surge`)
  - **Profil-Modus, kein Preset** → `<Stufe>` (bisheriges Verhalten als Fallback)
- Reine Backend-Änderung an `collect_power` (`backend/app/services/status_bar/collectors.py`); die generische `<Pill>` rendert das `label` bereits, kein Frontend-Change.
- Begründung Dynamic-Mode-Sonderfall: bei aktivem Dynamic Mode regelt der Kernel-Governor direkt, die Demand-Stufe/das Preset sind eingefroren und wären irreführend.

Spec: `docs/superpowers/specs/2026-06-02-power-pill-profile-design.md`
Plan: `docs/superpowers/plans/2026-06-02-power-pill-preset.md`

## Test Plan
- [x] `pytest tests/services/test_status_bar_collectors.py` — 36 grün (5 neue Power-Tests: dynamic+governor, dynamic+no-config, preset+level, no-preset-fallback, no-profile-silent)
- [x] `pytest tests/services/test_status_bar_collectors.py tests/services/test_status_bar_service.py tests/api/test_status_bar_routes.py` — 75 grün, keine Regression
- [ ] Manuell: Energy-Tab Preset wechseln → Pille zeigt neuen Namen; Dynamic Mode an/aus → Pille wechselt zu `Dynamisch · <governor>` und zurück

🤖 Generated with [Claude Code](https://claude.com/claude-code)