### PR TITLE
fix(deploy): hard-sync git on deploy + rollback to survive dirty tracked files

### DIFF
--- a/deploy/scripts/ci-deploy.sh
+++ b/deploy/scripts/ci-deploy.sh
@@ -190,8 +190,12 @@ rollback() {
     log_info "Rolling back to commit: $PREV_COMMIT"
 
     cd "$INSTALL_DIR"
-    git checkout "$PREV_COMMIT" 2>/dev/null || {
-        log_error "git checkout $PREV_COMMIT failed"
+    # Force-reset rather than `git checkout`: the failed build may have left a
+    # tracked file dirty (same hazard as the forward update, #138), and a plain
+    # checkout would refuse it — exactly when the rollback is needed most.
+    # `--hard` discards those build artifacts; untracked files are left intact.
+    git reset --hard "$PREV_COMMIT" 2>/dev/null || {
+        log_error "git reset --hard $PREV_COMMIT failed"
         deploy_log_write "rollback_failed"
         exit 1
     }
@@ -319,9 +323,16 @@ fi
 log_step "Git Update"
 
 cd "$INSTALL_DIR"
+# Hard-sync to the remote instead of `git pull`. The prod box is a pure deploy
+# target (0 commits ahead of origin/main), so any local change to a tracked file
+# is a build artifact — e.g. client/package-lock.json normalized by `npm ci` —
+# that a plain `git pull` refuses to overwrite, aborting the deploy (#138).
+# `checkout -f` also re-attaches to main from a detached HEAD left by a prior
+# rollback. Untracked files (.env.production, backups/) are NOT touched — no
+# `git clean` is run, so deploy-local state is preserved.
 git fetch --all --prune
-git checkout main
-git pull origin main
+git checkout -f main
+git reset --hard origin/main
 
 NEW_COMMIT=$(git rev-parse HEAD)
 log_info "Updated: $OLD_COMMIT -> $NEW_COMMIT"


### PR DESCRIPTION
Closes #138

## Problem
`deploy/scripts/ci-deploy.sh` updates the prod box with `git pull origin main`. When a build step (`npm ci`) has mutated a **tracked** file (e.g. `client/package-lock.json`), `git pull` aborts with "local changes would be overwritten" and the deploy fails. It recurs reliably whenever the lockfile is re-normalized (observed: Deploy run `26838448995`, PR #135).

The **rollback** path (`rollback()`) had the same latent hazard: `git checkout "$PREV_COMMIT"` would refuse a dirty tracked file — failing exactly when rollback is needed most.

## Fix
Hard-sync to the remote instead of merging:

**Forward update:**
```diff
 git fetch --all --prune
-git checkout main
-git pull origin main
+git checkout -f main
+git reset --hard origin/main
```

**Rollback:**
```diff
-git checkout "$PREV_COMMIT" 2>/dev/null || {
+git reset --hard "$PREV_COMMIT" 2>/dev/null || {
```

`checkout -f main` also re-attaches to `main` from a detached HEAD that an earlier rollback could leave behind.

## Why it's safe
- Prod box is a pure deploy target (`HEAD...origin/main` = 0 ahead) — local tracked-file changes are only regenerable build artifacts.
- `reset --hard` discards **tracked** changes only. **No `git clean`** is run, so untracked files (`.env.production`, `backups/`) are untouched.
- Idempotent: the build step regenerates the artifacts afterward.

## CI/CD security review notes (per .claude/rules/ci-cd-security.md)
- No new shell-injection surface: `$PREV_COMMIT` is an internal deploy-state SHA, `origin/main` is a fixed ref — neither is user-controlled.
- No new `sudo` invocations / sudoers entries.
- Rollback path still works (and is now more robust).
- No runner / trigger / actor-gate / environment changes.

## Test Plan
- [x] `bash -n deploy/scripts/ci-deploy.sh` — syntax valid
- [ ] Next production deploy completes the Git-Update step even with a dirty tracked `package-lock.json` (the original failure condition)
- [ ] Forced-failure rollback drill: simulate a failing health check with a dirty tracked file → `--rollback` resets cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)