### PR TITLE
fix(2fa): readable contrast for secret + backup codes in setup modal

### DIFF
--- a/client/src/components/quickSettings/TwoFactorSetupFlow.tsx
+++ b/client/src/components/quickSettings/TwoFactorSetupFlow.tsx
@@ -120,7 +120,7 @@ export function TwoFactorSetupFlow({
           {backupCodes.map((code) => (
             <div
               key={code}
-              className="px-3 py-2 rounded-lg bg-slate-800/60 border border-slate-700/40 font-mono text-sm text-center"
+              className="px-3 py-2 rounded-lg bg-slate-800/60 border border-slate-700/40 font-mono text-sm text-slate-200 text-center"
             >
               {code}
             </div>
@@ -170,7 +170,7 @@ export function TwoFactorSetupFlow({
         <label className="block text-xs font-medium text-slate-400 mb-1">
           {t('security.manualEntry')}
         </label>
-        <div className="px-3 py-2 rounded-lg bg-slate-800/60 border border-slate-700/40 font-mono text-sm break-all select-all">
+        <div className="px-3 py-2 rounded-lg bg-slate-800/60 border border-slate-700/40 font-mono text-sm text-slate-200 break-all select-all">
           {setupData.secret}
         </div>
       </div>


### PR DESCRIPTION
## Problem
In the **Set up Two-Factor Authentication** modal (user menu → 2FA), the **Manual entry key** (the TOTP secret) and the **backup-code** cells were nearly illegible — dark text on the dark `bg-slate-800/60` field.

## Cause
`ui/Modal.tsx` sets no base text color, and the two value cells in `TwoFactorSetupFlow.tsx` had **no explicit `text-*` color** — so they inherited a near-dark default. (Sibling explanatory text uses `text-slate-300`, which is why only these two cells looked broken.)

## Fix
Add `text-slate-200` to both cells, matching the modal's other text contrast:
- Manual-entry secret value (verify step)
- Backup-code cells (backup-codes step)

This also improves the inline 2FA setup on the Settings page, since `TwoFactorCard` renders the same `TwoFactorSetupFlow`.

The `000000` placeholder in the verification-code input is the app-wide `.input` style (`placeholder-slate-500`) and is intentionally left unchanged to avoid altering every input across the app.

## Test Plan
- [ ] User menu → 2FA → "Set up": the Manual entry key secret is clearly legible
- [ ] Complete verification → backup codes are clearly legible
- [ ] Settings → Security → Enable 2FA: same flow, same legibility

> Verification note: class-only change adding the already-used `text-slate-200` utility (no TS/import/structural change). No local `npm run build` was run — the worktree has no `node_modules` — but the edit carries no build risk; visual confirmation pending on the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)