### PR TITLE
feat(power): quick 'disable desktop' action in the PowerMenu

### DIFF
--- a/client/src/__tests__/components/PowerMenu.test.tsx
+++ b/client/src/__tests__/components/PowerMenu.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+// Deterministic translations: return the inline default (2nd arg), else the key.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, def?: string) => def ?? _key }),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../api/sleep', () => ({
+  getSleepStatus: vi.fn(),
+  enterSoftSleep: vi.fn(),
+  enterSuspend: vi.fn(),
+}));
+
+vi.mock('../../api/desktop', () => ({
+  getDesktopStatus: vi.fn(),
+  disableDesktop: vi.fn(),
+}));
+
+import PowerMenu from '../../components/PowerMenu';
+import { getSleepStatus } from '../../api/sleep';
+import { getDesktopStatus, disableDesktop } from '../../api/desktop';
+import toast from 'react-hot-toast';
+
+const baseProps = {
+  isAdmin: true,
+  onShutdown: vi.fn().mockResolvedValue(undefined),
+  onRestart: vi.fn().mockResolvedValue(undefined),
+  onLogout: vi.fn(),
+};
+
+function openMenu() {
+  fireEvent.click(screen.getByTitle('Power'));
+}
+
+describe('PowerMenu — disable desktop quick action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getSleepStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({});
+  });
+
+  it('shows "Disable desktop" when displays are running', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'running', display_manager: 'sddm', detail: null,
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    expect(await screen.findByText('Disable desktop')).toBeInTheDocument();
+  });
+
+  it('hides "Disable desktop" when displays are stopped', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'stopped', display_manager: 'sddm', detail: null,
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    await waitFor(() => expect(getDesktopStatus).toHaveBeenCalled());
+    await act(async () => {});
+    expect(screen.queryByText('Disable desktop')).not.toBeInTheDocument();
+  });
+
+  it('hides "Disable desktop" when the status lookup fails', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('no desktop'));
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    await waitFor(() => expect(getDesktopStatus).toHaveBeenCalled());
+    await act(async () => {});
+    expect(screen.queryByText('Disable desktop')).not.toBeInTheDocument();
+  });
+
+  it('clicking it calls disableDesktop and shows a success toast', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'running', display_manager: 'sddm', detail: null,
+    });
+    (disableDesktop as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, message: 'ok' });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    const item = await screen.findByText('Disable desktop');
+    fireEvent.click(item);
+    await waitFor(() => expect(disableDesktop).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+  });
+
+  it('does not show "Disable desktop" for non-admins', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'running', display_manager: 'sddm', detail: null,
+    });
+    render(<PowerMenu {...baseProps} isAdmin={false} />);
+    openMenu();
+    await act(async () => {});
+    expect(screen.queryByText('Disable desktop')).not.toBeInTheDocument();
+    expect(getDesktopStatus).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/components/PowerMenu.test.tsx
+++ b/client/src/__tests__/components/PowerMenu.test.tsx
@@ -58,18 +58,20 @@ describe('PowerMenu — disable desktop quick action', () => {
     });
     render(<PowerMenu {...baseProps} />);
     openMenu();
-    await waitFor(() => expect(getDesktopStatus).toHaveBeenCalled());
-    await act(async () => {});
-    expect(screen.queryByText('Disable desktop')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(getDesktopStatus).toHaveBeenCalled();
+      expect(screen.queryByText('Disable desktop')).not.toBeInTheDocument();
+    });
   });
 
   it('hides "Disable desktop" when the status lookup fails', async () => {
     (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('no desktop'));
     render(<PowerMenu {...baseProps} />);
     openMenu();
-    await waitFor(() => expect(getDesktopStatus).toHaveBeenCalled());
-    await act(async () => {});
-    expect(screen.queryByText('Disable desktop')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(getDesktopStatus).toHaveBeenCalled();
+      expect(screen.queryByText('Disable desktop')).not.toBeInTheDocument();
+    });
   });
 
   it('clicking it calls disableDesktop and shows a success toast', async () => {
@@ -79,16 +81,28 @@ describe('PowerMenu — disable desktop quick action', () => {
     (disableDesktop as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, message: 'ok' });
     render(<PowerMenu {...baseProps} />);
     openMenu();
-    const item = await screen.findByText('Disable desktop');
+    const item = await screen.findByRole('button', { name: /Disable desktop/i });
     fireEvent.click(item);
     await waitFor(() => expect(disableDesktop).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(toast.success).toHaveBeenCalled());
   });
 
-  it('does not show "Disable desktop" for non-admins', async () => {
+  it('shows an error toast when disableDesktop returns success=false', async () => {
     (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       state: 'running', display_manager: 'sddm', detail: null,
     });
+    (disableDesktop as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false, message: 'DPMS unavailable',
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByRole('button', { name: /Disable desktop/i }));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('DPMS unavailable'));
+  });
+
+  it('does not show "Disable desktop" for non-admins', async () => {
+    // No getDesktopStatus mock needed: the effect is gated on isAdmin,
+    // so a non-admin never triggers the lookup.
     render(<PowerMenu {...baseProps} isAdmin={false} />);
     openMenu();
     await act(async () => {});

--- a/client/src/components/PowerMenu.tsx
+++ b/client/src/components/PowerMenu.tsx
@@ -21,7 +21,9 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
   const [desktopState, setDesktopState] = useState<DesktopState | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Check sleep + desktop availability when dropdown opens
+  // Check sleep + desktop availability when dropdown opens. Both states are
+  // intentionally kept from the previous open and re-fetched on every open, so
+  // there is no flash of a missing item during the re-fetch.
   useEffect(() => {
     if (isOpen && isAdmin) {
       getSleepStatus()

--- a/client/src/components/PowerMenu.tsx
+++ b/client/src/components/PowerMenu.tsx
@@ -1,8 +1,9 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Power, PowerOff, RotateCcw, LogOut, Moon, Pause } from 'lucide-react';
+import { Power, PowerOff, RotateCcw, LogOut, Moon, Pause, MonitorOff } from 'lucide-react';
 import { ConfirmDialog } from './ui/ConfirmDialog';
 import { getSleepStatus, enterSoftSleep, enterSuspend } from '../api/sleep';
+import { getDesktopStatus, disableDesktop, type DesktopState } from '../api/desktop';
 import toast from 'react-hot-toast';
 
 interface PowerMenuProps {
@@ -17,14 +18,18 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
   const [isOpen, setIsOpen] = useState(false);
   const [confirmAction, setConfirmAction] = useState<'shutdown' | 'restart' | 'sleep' | 'suspend' | null>(null);
   const [sleepAvailable, setSleepAvailable] = useState(false);
+  const [desktopState, setDesktopState] = useState<DesktopState | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Check sleep availability when dropdown opens
+  // Check sleep + desktop availability when dropdown opens
   useEffect(() => {
     if (isOpen && isAdmin) {
       getSleepStatus()
         .then(() => setSleepAvailable(true))
         .catch(() => setSleepAvailable(false));
+      getDesktopStatus()
+        .then((s) => setDesktopState(s.state))
+        .catch(() => setDesktopState(null));
     }
   }, [isOpen, isAdmin]);
 
@@ -67,6 +72,20 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
       } catch {
         toast.error(t('powerMenu.suspendFailed', 'Failed to suspend system'));
       }
+    }
+  };
+
+  const handleDisableDesktop = async () => {
+    setIsOpen(false);
+    try {
+      const result = await disableDesktop();
+      if (result.success) {
+        toast.success(t('powerMenu.desktopDisabled', 'Desktop disabled'));
+      } else {
+        toast.error(result.message || t('powerMenu.desktopDisableFailed', 'Failed to disable desktop'));
+      }
+    } catch {
+      toast.error(t('powerMenu.desktopDisableFailed', 'Failed to disable desktop'));
     }
   };
 
@@ -143,6 +162,21 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
                         </div>
                       </button>
                     </>
+                  )}
+
+                  {desktopState === 'running' && (
+                    <button
+                      onClick={handleDisableDesktop}
+                      className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-cyan-500/10"
+                    >
+                      <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-cyan-500/30 bg-cyan-500/10">
+                        <MonitorOff className="h-4 w-4 text-cyan-400" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium text-slate-100">{t('powerMenu.desktopDisable', 'Disable desktop')}</p>
+                        <p className="text-xs text-slate-400">{t('powerMenu.desktopDisableDesc', 'Turn off displays (saves GPU power)')}</p>
+                      </div>
+                    </button>
                   )}
                 </div>
 

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -253,7 +253,11 @@
     "suspendDesc": "System in Standby versetzen",
     "suspendConfirm": "System in Standby versetzen? Der Server ist nicht erreichbar, bis er aufgeweckt wird.",
     "suspendActivated": "System wird in Standby versetzt",
-    "suspendFailed": "Standby konnte nicht aktiviert werden"
+    "suspendFailed": "Standby konnte nicht aktiviert werden",
+    "desktopDisable": "Desktop deaktivieren",
+    "desktopDisableDesc": "Bildschirme ausschalten (GPU spart Strom)",
+    "desktopDisabled": "Desktop deaktiviert",
+    "desktopDisableFailed": "Desktop konnte nicht deaktiviert werden"
   },
   "adminOnly": "Nur für Admins",
   "local_only_action_hint": "Nur über die BaluHost-Companion-App am Server selbst möglich.",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -253,7 +253,11 @@
     "suspendDesc": "Suspend system",
     "suspendConfirm": "Suspend the system? The server will be unreachable until woken up.",
     "suspendActivated": "System suspended",
-    "suspendFailed": "Failed to suspend system"
+    "suspendFailed": "Failed to suspend system",
+    "desktopDisable": "Disable desktop",
+    "desktopDisableDesc": "Turn off displays (saves GPU power)",
+    "desktopDisabled": "Desktop disabled",
+    "desktopDisableFailed": "Failed to disable desktop"
   },
   "adminOnly": "Admin only",
   "local_only_action_hint": "Only available via the BaluHost Companion app running on the server itself.",

--- a/docs/superpowers/plans/2026-06-02-powermenu-desktop-disable.md
+++ b/docs/superpowers/plans/2026-06-02-powermenu-desktop-disable.md
@@ -1,0 +1,339 @@
+# PowerMenu „Desktop deaktivieren" — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eine Ein-Weg-Schnellaktion „Desktop deaktivieren" im PowerMenu (Power-Button oben rechts), die nur erscheint, wenn die KDE-Bildschirme laufen, und per Klick sofort `disableDesktop()` (DPMS-Screen-Off) auslöst.
+
+**Architecture:** Reine Frontend-Änderung an einer Komponente (`client/src/components/PowerMenu.tsx`) plus i18n-Keys. Status wird beim Öffnen des Menüs über das bestehende `getDesktopStatus()` geladen; der Punkt rendert conditional auf `state === 'running'`. Kein Backend-/API-Client-/Schema-Change — `getDesktopStatus`/`disableDesktop` existieren bereits in `client/src/api/desktop.ts`.
+
+**Tech Stack:** React + TypeScript, Tailwind, react-i18next, react-hot-toast, lucide-react; Vitest + @testing-library/react.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-powermenu-desktop-disable-design.md`
+
+---
+
+## Prerequisites
+
+This worktree has no `node_modules`. Before running any `npm` command (vitest/build) once:
+
+```bash
+cd client && npm install
+```
+
+(May take a few minutes. Required for Task 1 Step 2 onward and Task 3.)
+
+## File Structure
+
+| Datei | Verantwortung | Aktion |
+|---|---|---|
+| `client/src/components/PowerMenu.tsx` | PowerMenu-Dropdown — neue Aktion + Status-Laden + Handler | Modify |
+| `client/src/i18n/locales/en/common.json` | EN-Strings (`powerMenu.*`) | Modify |
+| `client/src/i18n/locales/de/common.json` | DE-Strings (`powerMenu.*`) | Modify |
+| `client/src/__tests__/components/PowerMenu.test.tsx` | Vitest-Test der neuen Aktion | Create |
+
+Reference — the current `PowerMenu.tsx` relevant regions (origin/main):
+- Imports (line 3): `import { Power, PowerOff, RotateCcw, LogOut, Moon, Pause } from 'lucide-react';`
+- Sleep API import (line 5): `import { getSleepStatus, enterSoftSleep, enterSuspend } from '../api/sleep';`
+- State (line 19): `const [sleepAvailable, setSleepAvailable] = useState(false);`
+- Availability `useEffect` (lines 23-29): calls `getSleepStatus()` on open.
+- The Standby button closes at line 144; the `{sleepAvailable && (…)}` block closes at line 146; the wrapping `<div className="p-1.5">` closes at line 147.
+
+---
+
+## Task 1: PowerMenu component + Vitest test
+
+Add the quick action (imports, status state, fetch, handler, conditional menu item) to `PowerMenu.tsx`, test-first.
+
+**Files:**
+- Create: `client/src/__tests__/components/PowerMenu.test.tsx`
+- Modify: `client/src/components/PowerMenu.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/components/PowerMenu.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+// Deterministic translations: return the inline default (2nd arg), else the key.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, def?: string) => def ?? _key }),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../api/sleep', () => ({
+  getSleepStatus: vi.fn(),
+  enterSoftSleep: vi.fn(),
+  enterSuspend: vi.fn(),
+}));
+
+vi.mock('../../api/desktop', () => ({
+  getDesktopStatus: vi.fn(),
+  disableDesktop: vi.fn(),
+}));
+
+import PowerMenu from '../../components/PowerMenu';
+import { getSleepStatus } from '../../api/sleep';
+import { getDesktopStatus, disableDesktop } from '../../api/desktop';
+import toast from 'react-hot-toast';
+
+const baseProps = {
+  isAdmin: true,
+  onShutdown: vi.fn().mockResolvedValue(undefined),
+  onRestart: vi.fn().mockResolvedValue(undefined),
+  onLogout: vi.fn(),
+};
+
+function openMenu() {
+  fireEvent.click(screen.getByTitle('Power'));
+}
+
+describe('PowerMenu — disable desktop quick action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getSleepStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({});
+  });
+
+  it('shows "Disable desktop" when displays are running', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'running', display_manager: 'sddm', detail: null,
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    expect(await screen.findByText('Disable desktop')).toBeInTheDocument();
+  });
+
+  it('hides "Disable desktop" when displays are stopped', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'stopped', display_manager: 'sddm', detail: null,
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    await waitFor(() => expect(getDesktopStatus).toHaveBeenCalled());
+    await act(async () => {});
+    expect(screen.queryByText('Disable desktop')).not.toBeInTheDocument();
+  });
+
+  it('hides "Disable desktop" when the status lookup fails', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('no desktop'));
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    await waitFor(() => expect(getDesktopStatus).toHaveBeenCalled());
+    await act(async () => {});
+    expect(screen.queryByText('Disable desktop')).not.toBeInTheDocument();
+  });
+
+  it('clicking it calls disableDesktop and shows a success toast', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'running', display_manager: 'sddm', detail: null,
+    });
+    (disableDesktop as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, message: 'ok' });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    const item = await screen.findByText('Disable desktop');
+    fireEvent.click(item);
+    await waitFor(() => expect(disableDesktop).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+  });
+
+  it('does not show "Disable desktop" for non-admins', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'running', display_manager: 'sddm', detail: null,
+    });
+    render(<PowerMenu {...baseProps} isAdmin={false} />);
+    openMenu();
+    await act(async () => {});
+    expect(screen.queryByText('Disable desktop')).not.toBeInTheDocument();
+    expect(getDesktopStatus).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — expect FAIL**
+
+Run: `cd client && npm test -- PowerMenu`
+Expected: FAIL — the "Disable desktop" item does not exist yet (`findByText` times out; `disableDesktop` never called).
+
+- [ ] **Step 3: Add imports**
+
+In `client/src/components/PowerMenu.tsx`, change the lucide import (line 3) to include `MonitorOff`:
+
+```tsx
+import { Power, PowerOff, RotateCcw, LogOut, Moon, Pause, MonitorOff } from 'lucide-react';
+```
+
+Directly after the sleep API import (line 5), add the desktop API import:
+
+```tsx
+import { getDesktopStatus, disableDesktop, type DesktopState } from '../api/desktop';
+```
+
+- [ ] **Step 4: Add status state**
+
+Immediately after the `sleepAvailable` state (line 19), add:
+
+```tsx
+  const [desktopState, setDesktopState] = useState<DesktopState | null>(null);
+```
+
+- [ ] **Step 5: Fetch desktop status when the menu opens**
+
+Replace the availability `useEffect` (lines 23-29) with:
+
+```tsx
+  // Check sleep + desktop availability when dropdown opens
+  useEffect(() => {
+    if (isOpen && isAdmin) {
+      getSleepStatus()
+        .then(() => setSleepAvailable(true))
+        .catch(() => setSleepAvailable(false));
+      getDesktopStatus()
+        .then((s) => setDesktopState(s.state))
+        .catch(() => setDesktopState(null));
+    }
+  }, [isOpen, isAdmin]);
+```
+
+- [ ] **Step 6: Add the click handler**
+
+Immediately after the `handleConfirm` function (after its closing `};`, around line 71), add:
+
+```tsx
+  const handleDisableDesktop = async () => {
+    setIsOpen(false);
+    try {
+      const result = await disableDesktop();
+      if (result.success) {
+        toast.success(t('powerMenu.desktopDisabled', 'Desktop disabled'));
+      } else {
+        toast.error(result.message || t('powerMenu.desktopDisableFailed', 'Failed to disable desktop'));
+      }
+    } catch {
+      toast.error(t('powerMenu.desktopDisableFailed', 'Failed to disable desktop'));
+    }
+  };
+```
+
+- [ ] **Step 7: Add the menu item**
+
+In `PowerMenu.tsx`, insert the new button between the close of the `{sleepAvailable && (…)}` block (`)}` on line 146) and the close of the `<div className="p-1.5">` (`</div>` on line 147) — i.e. as the last child of that admin-actions `<div>`:
+
+```tsx
+                  {desktopState === 'running' && (
+                    <button
+                      onClick={handleDisableDesktop}
+                      className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-cyan-500/10"
+                    >
+                      <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-cyan-500/30 bg-cyan-500/10">
+                        <MonitorOff className="h-4 w-4 text-cyan-400" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium text-slate-100">{t('powerMenu.desktopDisable', 'Disable desktop')}</p>
+                        <p className="text-xs text-slate-400">{t('powerMenu.desktopDisableDesc', 'Turn off displays (saves GPU power)')}</p>
+                      </div>
+                    </button>
+                  )}
+```
+
+- [ ] **Step 8: Run the test — expect PASS**
+
+Run: `cd client && npm test -- PowerMenu`
+Expected: all 5 tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add client/src/components/PowerMenu.tsx client/src/__tests__/components/PowerMenu.test.tsx
+git commit -m "feat(power): add 'disable desktop' quick action to PowerMenu"
+```
+
+---
+
+## Task 2: i18n strings (DE + EN)
+
+Add the four `powerMenu.*` keys so production shows localized text (the component already falls back to inline English defaults).
+
+**Files:**
+- Modify: `client/src/i18n/locales/en/common.json`
+- Modify: `client/src/i18n/locales/de/common.json`
+
+- [ ] **Step 1: English keys**
+
+In `client/src/i18n/locales/en/common.json`, in the `powerMenu` object, replace the line:
+
+```json
+    "suspendFailed": "Failed to suspend system"
+```
+
+with:
+
+```json
+    "suspendFailed": "Failed to suspend system",
+    "desktopDisable": "Disable desktop",
+    "desktopDisableDesc": "Turn off displays (saves GPU power)",
+    "desktopDisabled": "Desktop disabled",
+    "desktopDisableFailed": "Failed to disable desktop"
+```
+
+- [ ] **Step 2: German keys**
+
+In `client/src/i18n/locales/de/common.json`, in the `powerMenu` object, replace the line:
+
+```json
+    "suspendFailed": "Standby konnte nicht aktiviert werden"
+```
+
+with:
+
+```json
+    "suspendFailed": "Standby konnte nicht aktiviert werden",
+    "desktopDisable": "Desktop deaktivieren",
+    "desktopDisableDesc": "Bildschirme ausschalten (GPU spart Strom)",
+    "desktopDisabled": "Desktop deaktiviert",
+    "desktopDisableFailed": "Desktop konnte nicht deaktiviert werden"
+```
+
+- [ ] **Step 3: Validate both JSON files parse**
+
+Run: `cd client && node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/en/common.json','utf8')); JSON.parse(require('fs').readFileSync('src/i18n/locales/de/common.json','utf8')); console.log('JSON OK')"`
+Expected: `JSON OK` (no trailing-comma / syntax error).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/i18n/locales/en/common.json client/src/i18n/locales/de/common.json
+git commit -m "feat(power): i18n strings for PowerMenu disable-desktop action (de+en)"
+```
+
+---
+
+## Task 3: Verification
+
+**Files:** none changed.
+
+- [ ] **Step 1: Type-check + full PowerMenu test**
+
+Run: `cd client && npx tsc --noEmit && npm test -- PowerMenu`
+Expected: tsc passes (no type errors); 5 PowerMenu tests PASS.
+
+- [ ] **Step 2: Production build**
+
+Run: `cd client && npm run build`
+Expected: build succeeds, no unresolved-import / missing-icon warnings for `MonitorOff`.
+
+- [ ] **Step 3: Manual smoke (optional, on the KDE box / dev)**
+
+In dev (`python start_dev.py`, dev backend reports `state='running'`): open the PowerMenu (top-right power button) as admin → a cyan **„Desktop deaktivieren"** item appears below **Standby**. Click → toast „Desktop deaktiviert", menu closes. (Dev backend just flips in-memory state; reopen → item gone since state is now `stopped`.)
+
+---
+
+## Out of Scope (per spec)
+
+- Toggle / re-enable in the PowerMenu (stays on the Sleep page)
+- Confirmation dialog (action is reversible → immediate)
+- Backend `available` flag / panel gating fix
+- Mobile / Pi rendering

--- a/docs/superpowers/specs/2026-06-02-powermenu-desktop-disable-design.md
+++ b/docs/superpowers/specs/2026-06-02-powermenu-desktop-disable-design.md
@@ -1,0 +1,181 @@
+# PowerMenu: Schnell-Option „Desktop deaktivieren" — Design
+
+**Date:** 2026-06-02
+**Status:** Approved
+**Author:** Sven (Xveyn) + Claude
+
+## Problem
+
+Das KDE-Desktop-Deaktivieren (Bildschirme via DPMS ausschalten, damit die dGPU
+deep-idlen kann) ist heute nur über **System Control → Sleep → Desktop (KDE)**
+(`DesktopTogglePanel`) erreichbar. Für den häufigen „mach den Bildschirm aus"-Griff
+fehlt eine Schnell-Option im global sichtbaren PowerMenu (Power-Button oben rechts).
+
+## Was bereits existiert (wiederverwendet)
+
+- **Backend:** `POST /api/system/sleep/desktop/disable` → `kscreen-doctor --dpms off`
+  (`LinuxDesktopBackend.disable`). Schaltet nur die Display-Ausgänge aus; KWin/sddm-Session
+  läuft weiter, dGPU fällt von ~78W auf ~18W. **Reversibel & ungefährlich.**
+- **Status:** `GET /api/system/sleep/desktop/status` → `DesktopStatus { state, display_manager, detail }`,
+  `state ∈ {running, stopped, unknown}`. `running` = mind. 1 aktives DRM-Display.
+- **API-Client:** `client/src/api/desktop.ts` — `getDesktopStatus()`, `disableDesktop()`, `enableDesktop()`.
+- **PowerMenu:** `client/src/components/PowerMenu.tsx` — Admin-Aktionen (Restart/Shutdown/Sleep/Standby)
+  + Logout. Sleep/Standby erscheinen nur wenn `getSleepStatus()` beim Öffnen erfolgreich ist
+  (`sleepAvailable`-Muster). Bestätigungspflichtige Aktionen laufen über `confirmAction`-State +
+  `ConfirmDialog`; Logout schließt sofort ohne Dialog.
+
+> Hinweis: Der Kommentar in `api/desktop.ts` („stoppt den Display-Manager / Session neu starten")
+> ist **veraltet**. Maßgeblich sind `DesktopTogglePanel`-Doku und `desktop_backend.py`:
+> es ist ein DPMS-Screen-Off, kein Service-Stop.
+
+## Lösung
+
+Eine **Ein-Weg-Schnellaktion** „Desktop deaktivieren" im PowerMenu-Admin-Block, die nur erscheint,
+wenn die Bildschirme gerade laufen (`state === 'running'`). Klick → sofort `disableDesktop()`
+(kein Bestätigungsdialog) + Toast. Re-Aktivieren bleibt der Sleep-Seite vorbehalten.
+
+### Warum Ein-Weg + nur bei `running`
+
+Headless-Server melden `state === 'stopped'` (0 Displays), nicht `unknown` — eine reine
+Sichtbarkeitslogik über „nicht unknown" würde den Punkt fälschlich auf Servern ohne Desktop zeigen.
+`state === 'running'` ist das eindeutige Signal „es gibt aktive Bildschirme, die man ausschalten kann".
+Das vermeidet Menü-Clutter ohne Backend-Änderung und deckt den Wunsch („schnell deaktivieren") exakt ab.
+
+## Architektur
+
+**Einzige geänderte Komponente:** `client/src/components/PowerMenu.tsx`. Kein Backend-, Schema-,
+Migrations- oder API-Client-Change.
+
+### Zustand & Laden
+
+Neuer State `const [desktopState, setDesktopState] = useState<DesktopState | null>(null);`.
+
+Im bestehenden `useEffect` (`isOpen && isAdmin`) zusätzlich:
+
+```tsx
+getDesktopStatus()
+  .then((s) => setDesktopState(s.state))
+  .catch(() => setDesktopState(null));
+```
+
+(parallel zum vorhandenen `getSleepStatus()`-Aufruf; unabhängig von `sleepAvailable`).
+
+### Menüpunkt
+
+Im Admin-Block, **nach** dem Standby-Button und **vor** dem `border-t`-Divider, nur gerendert wenn
+`desktopState === 'running'`:
+
+```tsx
+{desktopState === 'running' && (
+  <button
+    onClick={handleDisableDesktop}
+    className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-cyan-500/10"
+  >
+    <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-cyan-500/30 bg-cyan-500/10">
+      <MonitorOff className="h-4 w-4 text-cyan-400" />
+    </div>
+    <div>
+      <p className="text-sm font-medium text-slate-100">
+        {t('powerMenu.desktopDisable', 'Disable desktop')}
+      </p>
+      <p className="text-xs text-slate-400">
+        {t('powerMenu.desktopDisableDesc', 'Turn off displays (saves GPU power)')}
+      </p>
+    </div>
+  </button>
+)}
+```
+
+`MonitorOff` wird aus `lucide-react` importiert (zur bestehenden Icon-Import-Zeile hinzufügen).
+
+### Klick-Handler (sofort, kein Dialog)
+
+```tsx
+const handleDisableDesktop = async () => {
+  setIsOpen(false);
+  try {
+    const result = await disableDesktop();
+    if (result.success) {
+      toast.success(t('powerMenu.desktopDisabled', 'Desktop disabled'));
+    } else {
+      toast.error(result.message || t('powerMenu.desktopDisableFailed', 'Failed to disable desktop'));
+    }
+  } catch {
+    toast.error(t('powerMenu.desktopDisableFailed', 'Failed to disable desktop'));
+  }
+};
+```
+
+Das Menü schließt sofort (wie Logout) → kein Doppelklick-Schutz nötig. `disableDesktop` wird
+aus `../api/desktop` importiert.
+
+### i18n
+
+Neue Keys im `common`-Namespace unter `powerMenu` (DE + EN), Inline-Defaults wie bei den
+bestehenden `powerMenu`-Strings:
+
+| Key | DE | EN |
+|---|---|---|
+| `powerMenu.desktopDisable` | „Desktop deaktivieren" | „Disable desktop" |
+| `powerMenu.desktopDisableDesc` | „Bildschirme ausschalten (GPU spart Strom)" | „Turn off displays (saves GPU power)" |
+| `powerMenu.desktopDisabled` | „Desktop deaktiviert" | „Desktop disabled" |
+| `powerMenu.desktopDisableFailed` | „Desktop konnte nicht deaktiviert werden" | „Failed to disable desktop" |
+
+## Edge Cases
+
+| Fall | Verhalten |
+|---|---|
+| `getDesktopStatus()` schlägt fehl | `desktopState = null` → Punkt ausgeblendet |
+| `state === 'stopped'` (inkl. headless) | Punkt ausgeblendet |
+| `state === 'unknown'` | Punkt ausgeblendet |
+| `disableDesktop()` schlägt fehl | Fehler-Toast; Menü ist bereits geschlossen |
+| Nutzer ist kein Admin | Gesamter Admin-Block (inkl. Punkt) nicht gerendert |
+| Status zwischen Öffnen und Klick veraltet (Displays inzwischen aus) | `disableDesktop()` ist idempotent (`--dpms off` erneut) → Erfolg/harmlos |
+
+## Security
+
+Keine neue Datenexposition oder neue Endpunkte. Der Punkt liegt im `isAdmin`-Block; die
+Backend-Endpunkte unter `/api/system/sleep/desktop/*` haben ihre bestehende Admin-Absicherung.
+Keine sensiblen Daten im Status (`state`, `display_manager`, `detail`).
+
+## Tests
+
+`client/src/__tests__/components/PowerMenu.test.tsx` (neu — PowerMenu hat bisher keinen Test).
+Mocks: `../../api/desktop` (`getDesktopStatus`, `disableDesktop`), `../../api/sleep` (`getSleepStatus`),
+`react-hot-toast`.
+
+| Test | Verifiziert |
+|---|---|
+| `zeigt Desktop-Deaktivieren wenn running` | `isAdmin`, `getDesktopStatus`→`{state:'running'}`, Menü offen → Button „Disable desktop" sichtbar |
+| `verbirgt Desktop-Deaktivieren wenn stopped` | `getDesktopStatus`→`{state:'stopped'}` → Button nicht im DOM |
+| `verbirgt Desktop-Deaktivieren bei Status-Fehler` | `getDesktopStatus` rejected → Button nicht im DOM |
+| `Klick ruft disableDesktop + Erfolg-Toast` | Klick auf den Button → `disableDesktop` aufgerufen, `toast.success` |
+| `verbirgt Punkt für Nicht-Admin` | `isAdmin={false}` → Button nicht sichtbar (Admin-Block nicht gerendert) |
+
+Hinweis: `getSleepStatus` in den Tests mit `mockResolvedValue` stubben, damit das `sleepAvailable`-`useEffect`
+nicht stört; der Desktop-Punkt ist unabhängig davon.
+
+## Build Order
+
+1. `MonitorOff`-Import + `disableDesktop`/`getDesktopStatus`-Import + `DesktopState`-Typ in `PowerMenu.tsx`
+2. `desktopState`-State + Status-Fetch im bestehenden `useEffect`
+3. `handleDisableDesktop`-Handler
+4. Menüpunkt (conditional auf `desktopState === 'running'`)
+5. i18n-Keys (DE + EN `common.json`)
+6. Vitest-Test
+7. `cd client && npm run build` + `npm test -- PowerMenu` grün
+
+## Out of Scope
+
+- Umschalter/Re-Aktivieren im PowerMenu (bleibt auf der Sleep-Seite)
+- Bestätigungsdialog (Aktion ist reversibel/ungefährlich → sofort)
+- Backend-`available`-Flag / Panel-Gating-Korrektur (separat, falls je gewünscht)
+- Mobile/Pi-Darstellung (PowerMenu unverändert)
+
+## References
+
+- `client/src/components/PowerMenu.tsx` — zu ändernde Komponente
+- `client/src/api/desktop.ts` — `getDesktopStatus()`, `disableDesktop()` (bestehend)
+- `client/src/components/power/DesktopTogglePanel.tsx` — bestehende Voll-UI (Sleep-Seite)
+- `backend/app/services/power/desktop_backend.py` — `--dpms off`-Semantik (maßgeblich)
+- `docs/superpowers/plans/2026-05-30-desktop-toggle.md` — Ursprungs-Feature


### PR DESCRIPTION
## Summary
- Adds a one-way **„Desktop deaktivieren"** quick action to the PowerMenu dropdown (top-right power button), reusing the existing desktop-toggle feature from System Control → Sleep.
- The item appears **only for admins and only when the KDE displays are running** (`getDesktopStatus().state === 'running'`); on click it calls `disableDesktop()` (DPMS screen-off, dGPU can deep-idle) **immediately with a toast — no confirm dialog**, since the action is reversible. Re-enabling stays on the Sleep page.
- Headless servers report `stopped` → the item never shows, so no menu clutter.
- Frontend-only: `PowerMenu.tsx` + DE/EN i18n keys. No backend/API-client change (`getDesktopStatus`/`disableDesktop` already exist).

Spec: `docs/superpowers/specs/2026-06-02-powermenu-desktop-disable-design.md`
Plan: `docs/superpowers/plans/2026-06-02-powermenu-desktop-disable.md`

## Test Plan
- [x] `npm test -- PowerMenu` — 6/6 (running shows; stopped/error/non-admin hide; click → disableDesktop + success toast; success=false → error toast)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [ ] Manual (KDE box): open PowerMenu as admin → cyan „Desktop deaktivieren" under Standby → click → displays off, toast; reopen → item gone (state now stopped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)