### PR TITLE
fix(2fa): readable contrast for 'Verification Code' label in setup modal

### DIFF
--- a/client/src/components/quickSettings/TwoFactorSetupFlow.tsx
+++ b/client/src/components/quickSettings/TwoFactorSetupFlow.tsx
@@ -179,7 +179,7 @@ export function TwoFactorSetupFlow({
 
       <form onSubmit={handleVerify} className="space-y-3">
         <div>
-          <label className="block text-sm font-medium mb-1">
+          <label className="block text-sm font-medium text-slate-300 mb-1">
             {t('security.verificationCode')}
           </label>
           <input


### PR DESCRIPTION
## Summary
Follow-up to #141. The **"Verification Code"** label above the input in the 2FA setup modal had no text color (`block text-sm font-medium mb-1`) and inherited near-black inside the `Modal` (which sets no base text color) → unreadable on the dark background.

Same root cause as the secret/backup-code cells fixed in #141 — this one label was missed (its sibling "Manual entry key" label already had `text-slate-400`, so the gap wasn't obvious).

## Fix
Add `text-slate-300` to the label. One line. Also benefits the inline 2FA setup on the Settings page (same `TwoFactorSetupFlow` component).

## Test Plan
- [ ] User menu → 2FA → "Set up": the "Verification Code" label is clearly readable
- [ ] Settings → Security → Enable 2FA: same

> Verification note: class-only change adding the already-used `text-slate-200`-family utility `text-slate-300` (no TS/import/structural change). No local `npm run build` (this worktree has no `node_modules`); visual confirmation pending on the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)