### PR TITLE
feat(power): add 'enable desktop' quick action to PowerMenu

### DIFF
--- a/client/src/__tests__/components/PowerMenu.test.tsx
+++ b/client/src/__tests__/components/PowerMenu.test.tsx
@@ -19,11 +19,12 @@ vi.mock('../../api/sleep', () => ({
 vi.mock('../../api/desktop', () => ({
   getDesktopStatus: vi.fn(),
   disableDesktop: vi.fn(),
+  enableDesktop: vi.fn(),
 }));
 
 import PowerMenu from '../../components/PowerMenu';
 import { getSleepStatus } from '../../api/sleep';
-import { getDesktopStatus, disableDesktop } from '../../api/desktop';
+import { getDesktopStatus, disableDesktop, enableDesktop } from '../../api/desktop';
 import toast from 'react-hot-toast';
 
 const baseProps = {
@@ -107,6 +108,78 @@ describe('PowerMenu — disable desktop quick action', () => {
     openMenu();
     await act(async () => {});
     expect(screen.queryByText('Disable desktop')).not.toBeInTheDocument();
+    expect(getDesktopStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('PowerMenu — enable desktop quick action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getSleepStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({});
+  });
+
+  it('shows "Enable desktop" when displays are stopped', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'stopped', display_manager: 'sddm', detail: null,
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    expect(await screen.findByText('Enable desktop')).toBeInTheDocument();
+  });
+
+  it('hides "Enable desktop" when displays are running', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'running', display_manager: 'sddm', detail: null,
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    await waitFor(() => {
+      expect(getDesktopStatus).toHaveBeenCalled();
+      expect(screen.queryByText('Enable desktop')).not.toBeInTheDocument();
+    });
+  });
+
+  it('hides "Enable desktop" when the status lookup fails', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('no desktop'));
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    await waitFor(() => {
+      expect(getDesktopStatus).toHaveBeenCalled();
+      expect(screen.queryByText('Enable desktop')).not.toBeInTheDocument();
+    });
+  });
+
+  it('clicking it calls enableDesktop and shows a success toast', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'stopped', display_manager: 'sddm', detail: null,
+    });
+    (enableDesktop as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, message: 'ok' });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    const item = await screen.findByRole('button', { name: /Enable desktop/i });
+    fireEvent.click(item);
+    await waitFor(() => expect(enableDesktop).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+  });
+
+  it('shows an error toast when enableDesktop returns success=false', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'stopped', display_manager: 'sddm', detail: null,
+    });
+    (enableDesktop as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false, message: 'display manager offline',
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByRole('button', { name: /Enable desktop/i }));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('display manager offline'));
+  });
+
+  it('does not show "Enable desktop" for non-admins', async () => {
+    render(<PowerMenu {...baseProps} isAdmin={false} />);
+    openMenu();
+    await act(async () => {});
+    expect(screen.queryByText('Enable desktop')).not.toBeInTheDocument();
     expect(getDesktopStatus).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/PowerMenu.tsx
+++ b/client/src/components/PowerMenu.tsx
@@ -1,9 +1,9 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Power, PowerOff, RotateCcw, LogOut, Moon, Pause, MonitorOff } from 'lucide-react';
+import { Power, PowerOff, RotateCcw, LogOut, Moon, Pause, MonitorOff, Monitor } from 'lucide-react';
 import { ConfirmDialog } from './ui/ConfirmDialog';
 import { getSleepStatus, enterSoftSleep, enterSuspend } from '../api/sleep';
-import { getDesktopStatus, disableDesktop, type DesktopState } from '../api/desktop';
+import { getDesktopStatus, disableDesktop, enableDesktop, type DesktopState } from '../api/desktop';
 import toast from 'react-hot-toast';
 
 interface PowerMenuProps {
@@ -88,6 +88,20 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
       }
     } catch {
       toast.error(t('powerMenu.desktopDisableFailed', 'Failed to disable desktop'));
+    }
+  };
+
+  const handleEnableDesktop = async () => {
+    setIsOpen(false);
+    try {
+      const result = await enableDesktop();
+      if (result.success) {
+        toast.success(t('powerMenu.desktopEnabled', 'Desktop enabled'));
+      } else {
+        toast.error(result.message || t('powerMenu.desktopEnableFailed', 'Failed to enable desktop'));
+      }
+    } catch {
+      toast.error(t('powerMenu.desktopEnableFailed', 'Failed to enable desktop'));
     }
   };
 
@@ -177,6 +191,21 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
                       <div>
                         <p className="text-sm font-medium text-slate-100">{t('powerMenu.desktopDisable', 'Disable desktop')}</p>
                         <p className="text-xs text-slate-400">{t('powerMenu.desktopDisableDesc', 'Turn off displays (saves GPU power)')}</p>
+                      </div>
+                    </button>
+                  )}
+
+                  {desktopState === 'stopped' && (
+                    <button
+                      onClick={handleEnableDesktop}
+                      className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-emerald-500/10"
+                    >
+                      <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-emerald-500/30 bg-emerald-500/10">
+                        <Monitor className="h-4 w-4 text-emerald-400" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium text-slate-100">{t('powerMenu.desktopEnable', 'Enable desktop')}</p>
+                        <p className="text-xs text-slate-400">{t('powerMenu.desktopEnableDesc', 'Turn displays back on')}</p>
                       </div>
                     </button>
                   )}

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -257,7 +257,11 @@
     "desktopDisable": "Desktop deaktivieren",
     "desktopDisableDesc": "Bildschirme ausschalten (GPU spart Strom)",
     "desktopDisabled": "Desktop deaktiviert",
-    "desktopDisableFailed": "Desktop konnte nicht deaktiviert werden"
+    "desktopDisableFailed": "Desktop konnte nicht deaktiviert werden",
+    "desktopEnable": "Desktop aktivieren",
+    "desktopEnableDesc": "Bildschirme wieder einschalten",
+    "desktopEnabled": "Desktop aktiviert",
+    "desktopEnableFailed": "Desktop konnte nicht aktiviert werden"
   },
   "adminOnly": "Nur für Admins",
   "local_only_action_hint": "Nur über die BaluHost-Companion-App am Server selbst möglich.",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -257,7 +257,11 @@
     "desktopDisable": "Disable desktop",
     "desktopDisableDesc": "Turn off displays (saves GPU power)",
     "desktopDisabled": "Desktop disabled",
-    "desktopDisableFailed": "Failed to disable desktop"
+    "desktopDisableFailed": "Failed to disable desktop",
+    "desktopEnable": "Enable desktop",
+    "desktopEnableDesc": "Turn displays back on",
+    "desktopEnabled": "Desktop enabled",
+    "desktopEnableFailed": "Failed to enable desktop"
   },
   "adminOnly": "Admin only",
   "local_only_action_hint": "Only available via the BaluHost Companion app running on the server itself.",


### PR DESCRIPTION
## Was

Spiegelt die kürzlich gebaute **Disable desktop**-Aktion im PowerMenu mit einer **Enable desktop**-Aktion.

- Zeigt einen "Enable desktop"-Eintrag (grün, `Monitor`-Icon), wenn der Display-Manager **gestoppt** ist (`desktopState === 'stopped'`) — symmetrisch zu "Disable desktop", das bei `running` erscheint.
- Ruft den bereits existierenden Endpoint `POST /api/system/sleep/desktop/enable` über `enableDesktop()` auf.
- Bestätigungs-Toast bei Erfolg, Fehler-Toast bei `success=false` oder Exception.

## Warum

Backend (`/desktop/enable`) und Client-API (`enableDesktop()`) existierten bereits — es fehlte nur der UI-Einstieg, um den Desktop nach dem Deaktivieren wieder einzuschalten, ohne über die Sleep-Seite zu gehen.

## i18n

Neue Keys unter `powerMenu.*` (DE + EN): `desktopEnable`, `desktopEnableDesc`, `desktopEnabled`, `desktopEnableFailed`.

## Tests

- 6 neue Vitest-Fälle (zeigt/versteckt je nach State, Admin-Gate, Erfolgs-/Fehler-Toast) analog zur Disable-Suite.
- `npx vitest run PowerMenu.test.tsx` → **12/12 grün**.
- `npx tsc --noEmit` → sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)