### PR TITLE
fix(power): serve dynamic-mode capabilities to follower workers (fix intermittent 400)

### DIFF
--- a/backend/app/api/routes/power.py
+++ b/backend/app/api/routes/power.py
@@ -397,7 +397,12 @@ async def update_dynamic_mode(
 
     # Apply partial updates
     if body.governor is not None:
-        if body.governor not in current.available_governors:
+        # Only pre-validate when this worker actually knows the available
+        # governors. A follower with a cold/stale SHM snapshot reports an empty
+        # list; in that case defer to the primary worker, which validates the
+        # governor against real hardware. (Without this, ~3/4 of switch requests
+        # under multi-worker deployments would 400 on a valid governor.)
+        if current.available_governors and body.governor not in current.available_governors:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Governor '{body.governor}' not available. Available: {', '.join(current.available_governors)}"

--- a/backend/app/services/power/manager.py
+++ b/backend/app/services/power/manager.py
@@ -239,14 +239,33 @@ class PowerManagerService:
         return True, None
 
     async def get_dynamic_mode_config(self) -> DynamicModeConfigResponse:
-        """Get dynamic mode configuration and system capabilities."""
+        """Get dynamic mode configuration and system capabilities.
+
+        Capabilities (available governors + system frequency range) live on the
+        backend, which only the primary worker owns. Followers have no backend,
+        so they read the primary's SHM snapshot instead. Without this, a follower
+        reports ``available_governors=[]``, which leaves the UI governor list
+        empty and makes the PUT governor validation 400 on most requests under
+        multi-worker deployments.
+        """
         config = self._dynamic_mode_config or load_dynamic_mode_config() or DynamicModeConfig()  # type: ignore[call-arg]
 
-        available_governors = []
+        available_governors: List[str] = []
         sys_min, sys_max = 400, 4600
         if self._backend:
             available_governors = await self._backend.get_available_governors()
             sys_min, sys_max = await self._backend.get_system_freq_range()
+        else:
+            # Follower worker: source capabilities from the primary's snapshot.
+            shm_status = None
+            try:
+                shm_status = shm.read_shm("power_status.json", max_age_seconds=15.0)
+            except Exception:
+                shm_status = None
+            if shm_status:
+                available_governors = shm_status.get("available_governors") or []
+                sys_min = shm_status.get("system_min_freq_mhz") or sys_min
+                sys_max = shm_status.get("system_max_freq_mhz") or sys_max
 
         return DynamicModeConfigResponse(
             config=config,
@@ -495,7 +514,7 @@ class PowerManagerService:
 
                 await self._check_expired_demands()
                 await self._check_auto_scaling()
-                self._write_status_shm()
+                await self._write_status_shm()
             except Exception as e:
                 logger.error(f"Error in power monitor loop: {e}")
 
@@ -508,10 +527,14 @@ class PowerManagerService:
         except Exception as exc:
             logger.debug(f"Demand cache refresh failed: {exc}")
 
-    def _write_status_shm(self) -> None:
+    async def _write_status_shm(self) -> None:
         """
         Write a snapshot of live status to shared memory so secondary workers
-        can answer ``GET /api/power/status`` without holding their own state.
+        can answer ``GET /api/power/status`` and ``GET /api/power/dynamic-mode``
+        without holding their own backend.
+
+        Followers have no backend, so the hardware capabilities (available
+        governors + system frequency range) must be published here for them.
         """
         try:
             backend_kind = (
@@ -530,6 +553,12 @@ class PowerManagerService:
                     "errors": perm_info.get("errors", []),
                     "has_write_access": self._backend.has_write_permission(),
                 }
+            available_governors: List[str] = []
+            sys_min: Optional[int] = None
+            sys_max: Optional[int] = None
+            if self._backend is not None:
+                available_governors = await self._backend.get_available_governors()
+                sys_min, sys_max = await self._backend.get_system_freq_range()
             shm.write_shm(
                 "power_status.json",
                 {
@@ -537,6 +566,9 @@ class PowerManagerService:
                     "backend_kind": backend_kind,
                     "linux_backend_available": LinuxCpuPowerBackend._is_available_static(),
                     "permission_status": permission_status,
+                    "available_governors": available_governors,
+                    "system_min_freq_mhz": sys_min,
+                    "system_max_freq_mhz": sys_max,
                 },
             )
         except Exception as exc:

--- a/backend/tests/api/test_power_routes.py
+++ b/backend/tests/api/test_power_routes.py
@@ -252,3 +252,79 @@ class TestSwitchBackend:
         data = response.json()
         assert data["success"] is True
         assert "new_backend" in data
+
+
+class TestUpdateDynamicMode:
+    """Tests for PUT /api/power/dynamic-mode."""
+
+    def test_unknown_capabilities_does_not_false_400(
+        self, client: TestClient, admin_headers: dict, monkeypatch
+    ):
+        """A worker that can't enumerate governors must not pre-reject the body.
+
+        Regression (multi-worker): a follower with a cold/stale SHM snapshot
+        returns ``available_governors=[]``. The route used to raise 400
+        ("Governor not available") for any governor in that state, which under
+        4 Uvicorn workers caused intermittent 400s on ~3/4 of switch requests.
+        When the governor list is empty the route must defer to the primary
+        (the hardware authority) instead of guessing.
+        """
+        from unittest.mock import AsyncMock
+        import app.api.routes.power as power_routes
+        from app.schemas.power import DynamicModeConfig, DynamicModeConfigResponse
+
+        empty_caps = DynamicModeConfigResponse(
+            config=DynamicModeConfig(),
+            available_governors=[],  # capabilities unknown on this worker
+            system_min_freq_mhz=400,
+            system_max_freq_mhz=4600,
+        )
+
+        manager = AsyncMock()
+        manager.get_dynamic_mode_config = AsyncMock(return_value=empty_caps)
+        manager.enable_dynamic_mode = AsyncMock(return_value=(True, None))
+        manager.disable_dynamic_mode = AsyncMock(return_value=(True, None))
+        monkeypatch.setattr(power_routes, "get_power_manager", lambda: manager)
+
+        response = client.put(
+            "/api/power/dynamic-mode",
+            json={
+                "enabled": True,
+                "governor": "schedutil",
+                "min_freq_mhz": 400,
+                "max_freq_mhz": 4600,
+            },
+            headers=admin_headers,
+        )
+
+        assert response.status_code != 400
+        manager.enable_dynamic_mode.assert_awaited()
+
+    def test_known_capabilities_still_rejects_bad_governor(
+        self, client: TestClient, admin_headers: dict, monkeypatch
+    ):
+        """When the worker DOES know the governors, an unknown one still 400s."""
+        from unittest.mock import AsyncMock
+        import app.api.routes.power as power_routes
+        from app.schemas.power import DynamicModeConfig, DynamicModeConfigResponse
+
+        caps = DynamicModeConfigResponse(
+            config=DynamicModeConfig(),
+            available_governors=["powersave", "performance", "schedutil"],
+            system_min_freq_mhz=400,
+            system_max_freq_mhz=4600,
+        )
+
+        manager = AsyncMock()
+        manager.get_dynamic_mode_config = AsyncMock(return_value=caps)
+        manager.enable_dynamic_mode = AsyncMock(return_value=(True, None))
+        monkeypatch.setattr(power_routes, "get_power_manager", lambda: manager)
+
+        response = client.put(
+            "/api/power/dynamic-mode",
+            json={"enabled": True, "governor": "bogus-governor"},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 400
+        manager.enable_dynamic_mode.assert_not_awaited()

--- a/backend/tests/services/test_power_manager.py
+++ b/backend/tests/services/test_power_manager.py
@@ -602,6 +602,58 @@ class TestPowerManagerServiceStatus:
         assert "surge" in payload_json
 
     @pytest.mark.asyncio
+    async def test_follower_dynamic_mode_config_reads_capabilities_from_shm(self):
+        """A follower (no backend) must source governors + freq range from SHM.
+
+        Regression (multi-worker): with 4 Uvicorn workers only the primary owns
+        a backend; followers have ``self._backend is None``. GET/PUT
+        /dynamic-mode landing on a follower returned ``available_governors=[]``,
+        which left the UI governor list empty and made the PUT governor
+        validation raise 400 (``governor not in []``).
+        """
+        from app.services.monitoring import shm
+
+        follower = PowerManagerService()
+        follower._is_running = True
+        follower._primary = False
+        follower._backend = None  # follower owns no hardware backend
+        follower._dynamic_mode_config = None
+
+        shm.write_shm(
+            "power_status.json",
+            {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "backend_kind": "linux",
+                "available_governors": ["powersave", "performance", "schedutil"],
+                "system_min_freq_mhz": 400,
+                "system_max_freq_mhz": 4600,
+            },
+        )
+
+        resp = await follower.get_dynamic_mode_config()
+
+        assert resp.available_governors == ["powersave", "performance", "schedutil"]
+        assert resp.system_min_freq_mhz == 400
+        assert resp.system_max_freq_mhz == 4600
+
+    @pytest.mark.asyncio
+    async def test_primary_writes_capabilities_into_shm(self, service):
+        """The primary's status SHM snapshot must carry governors + freq range
+        so followers can answer GET /dynamic-mode and validate PUT bodies."""
+        from app.services.monitoring import shm
+
+        service._primary = True
+        await service._write_status_shm()
+
+        snapshot = shm.read_shm("power_status.json", max_age_seconds=30.0)
+        assert snapshot is not None
+        # Dev backend governors
+        assert "powersave" in snapshot["available_governors"]
+        assert "performance" in snapshot["available_governors"]
+        assert snapshot["system_min_freq_mhz"] is not None
+        assert snapshot["system_max_freq_mhz"] is not None
+
+    @pytest.mark.asyncio
     async def test_active_demands_are_db_backed(self, service):
         """register_demand should write to power_demands; get_active_demands reads from it."""
         await service.register_demand(


### PR DESCRIPTION
## Problem

Switching **Energy → Dynamic Mode** intermittently returned **400** in production, and the *Governor* field rendered empty.

## Root cause — multi-worker state

Prod runs **4 Uvicorn workers**, but only the **primary** `PowerManagerService` worker owns a CPU backend; followers have `self._backend = None` (`manager.py` `start()`).

- `get_dynamic_mode_config()` read `available_governors` straight from `self._backend` → `[]` on followers.
- The frontend always sends `governor` on save/toggle (`DynamicModeSection.tsx`), and the route rejected it: `body.governor not in [] → 400 "Governor not available"`.
- Round-robin meant ~3/4 of requests hit a follower → "often" a 400. The empty UI list had the same cause (GET hit a follower). Never reproduced in dev (single worker = primary).

## Fix

1. **Primary publishes capabilities to SHM** — `_write_status_shm` (now `async`) writes `available_governors` + `system_min/max_freq_mhz` into `power_status.json`, mirroring the existing follower read-path used by `get_power_status`.
2. **Followers read from SHM** — `get_dynamic_mode_config()` sources capabilities from the SHM snapshot when it has no backend. Fixes both the empty UI and the PUT validation.
3. **Defense-in-depth in the route** — the governor is only pre-validated when the capability list is non-empty; otherwise the route defers to the primary (the hardware authority). Closes the cold/stale-SHM window right after a deploy.

No frontend change required.

## Tests

- `test_power_manager.py`: follower reads governors/freq-range from SHM; primary writes capabilities into SHM.
- `test_power_routes.py`: no false 400 when capabilities are unknown (empty list); a genuinely unknown governor still 400s when capabilities are known.

**Verification:** full power suite green — `test_power_manager` + `test_power_routes` (66 passed), plus enforcement / command_queue / authority / presets / permissions (55 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)