### PR TITLE
fix(ui): center ConfirmDialog on viewport (portal to body)

### DIFF
--- a/client/src/__tests__/components/ConfirmDialog.test.tsx
+++ b/client/src/__tests__/components/ConfirmDialog.test.tsx
@@ -17,6 +17,16 @@ describe('ConfirmDialog', () => {
     expect(container.innerHTML).toBe('');
   });
 
+  it('renders through a portal on document.body, not nested in its parent', () => {
+    // The overlay is position:fixed and meant to center on the viewport. If it
+    // stays nested in its parent, an ancestor with backdrop-filter/transform
+    // (e.g. the topbar) becomes the containing block and the dialog drifts to
+    // that ancestor's box ("too high"). Portaling to document.body prevents that.
+    const { container } = render(<ConfirmDialog {...defaultProps} />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.getByText('Are you sure?')).toBeInTheDocument();
+  });
+
   it('renders title, message, and buttons when open=true', () => {
     render(<ConfirmDialog {...defaultProps} />);
 
@@ -60,18 +70,15 @@ describe('ConfirmDialog', () => {
   });
 
   it('renders danger variant with rose styling', () => {
-    const { container } = render(
-      <ConfirmDialog {...defaultProps} variant="danger" />
-    );
-    const card = container.querySelector('.border-rose-500\\/40');
+    // Dialog is portaled to document.body, so query the whole document.
+    render(<ConfirmDialog {...defaultProps} variant="danger" />);
+    const card = document.querySelector('.border-rose-500\\/40');
     expect(card).not.toBeNull();
   });
 
   it('renders warning variant with amber styling', () => {
-    const { container } = render(
-      <ConfirmDialog {...defaultProps} variant="warning" />
-    );
-    const card = container.querySelector('.border-amber-500\\/40');
+    render(<ConfirmDialog {...defaultProps} variant="warning" />);
+    const card = document.querySelector('.border-amber-500\\/40');
     expect(card).not.toBeNull();
   });
 

--- a/client/src/components/ui/ConfirmDialog.tsx
+++ b/client/src/components/ui/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
 
 export interface ConfirmDialogProps {
   open: boolean;
@@ -52,7 +53,11 @@ export function ConfirmDialog({
 
   const styles = variantStyles[variant];
 
-  return (
+  // Render through a portal on document.body. The overlay is position:fixed and
+  // centers on the viewport — but an ancestor with backdrop-filter/transform
+  // (e.g. the topbar with `backdrop-blur`) would otherwise become its containing
+  // block, dragging the centered dialog up into that ancestor's box.
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 backdrop-blur-xl">
       <div className={`card w-full max-w-md ${styles.border} bg-slate-900/80 backdrop-blur-2xl ${styles.shadow}`}>
         <h3 className="text-xl font-semibold text-white">{title}</h3>
@@ -69,6 +74,7 @@ export function ConfirmDialog({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }


### PR DESCRIPTION
## Problem

Die Bestätigungsdialoge der Power-Schnelloptionen (Restart/Shutdown/Sleep/Standby, roter Power-Button in der Topbar) erschienen **zu weit oben** statt mittig im Bildschirm.

## Root Cause

`ConfirmDialog` zentriert sich per `fixed inset-0 … items-center justify-center` — eigentlich relativ zum Viewport. Er wurde aber **inline** gerendert, und sein Aufrufer `PowerMenu` sitzt im `<header>`, der `backdrop-blur-2xl` (= `backdrop-filter`) trägt.

Ein Vorfahr mit `backdrop-filter` / `transform` / `filter` erzeugt einen **Containing Block** für `position: fixed`. Dadurch zentrierte sich der Dialog im ~72px hohen Header statt im ganzen Viewport.

`Modal` (z.B. von `UserMenu` genutzt) hatte das Problem nie, weil es bereits per `createPortal(document.body)` aus dem Header ausbricht.

## Fix

`ConfirmDialog` rendert jetzt ebenfalls per `createPortal(…, document.body)` — dasselbe Muster wie `Modal`. Der Overlay ist damit immer viewport-relativ, unabhängig von Vorfahr-Filtern. Härtet zugleich alle 16+ anderen `ConfirmDialog`-Nutzungen.

## Tests

- Neuer RED→GREEN Test: `ConfirmDialog` rendert per Portal nach `document.body` (nicht im Parent-Subtree)
- 2 Variant-Tests auf dokumentweite Abfrage umgestellt (Inhalt liegt jetzt in `document.body`)
- Volle Client-Suite grün: **385/385** Tests · `tsc` sauber
- Visuell im Dev-Mode bestätigt

🤖 Generated with [Claude Code](https://claude.com/claude-code)