### PR TITLE
feat(deploy): build & install Tauri Companion on BaluNode (opt-in)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,6 +10,11 @@ on:
         type: boolean
         required: false
         default: false
+      install_companion:
+        description: "Build the Tauri Companion app from source on BaluNode and install it system-wide (.deb). Leave off for routine deploys."
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: production-deploy
@@ -35,7 +40,10 @@ jobs:
       && github.actor == 'Xveyn'
     runs-on: [self-hosted, prod]
     environment: production
-    timeout-minutes: 15
+    # 30 (not 15): an opt-in companion build does a cold Rust compile the first
+    # time, which can take several minutes on top of the normal deploy. Routine
+    # deploys finish well under this regardless.
+    timeout-minutes: 30
 
     steps:
       - name: Run deploy script
@@ -44,6 +52,7 @@ jobs:
           DEPLOY_ACTOR: ${{ github.actor }}
           # Push-triggered deploys default to off; workflow_dispatch can opt-in.
           SYNC_PERMISSIONS: ${{ inputs.sync_permissions == true && '1' || '0' }}
+          INSTALL_COMPANION: ${{ inputs.install_companion == true && '1' || '0' }}
         run: |
           export GITHUB_ACTOR="$DEPLOY_ACTOR"
           /opt/baluhost/deploy/scripts/ci-deploy.sh

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ Thumbs.db
 # Claude Code local settings (user-specific permissions)
 .claude/settings.local.json
 
+# Claude Code isolated worktrees (embedded git repos, never committed)
+.claude/worktrees/
+
 # Testing
 coverage/
 htmlcov/

--- a/deploy/install/templates/baluhost-deploy-sudoers
+++ b/deploy/install/templates/baluhost-deploy-sudoers
@@ -17,3 +17,12 @@
 @@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/bash /opt/baluhost/deploy/scripts/install-amd-gpu-permissions.sh
 @@BALUHOST_USER@@ ALL=(root) NOPASSWD: /bin/bash /opt/baluhost/deploy/scripts/install-hardware-sudoers.sh
 @@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/bash /opt/baluhost/deploy/scripts/install-hardware-sudoers.sh
+
+# Companion (Tauri) install — only invoked when INSTALL_COMPANION=1 in
+# ci-deploy.sh; off by default. The script installs ONLY the .deb staged by
+# the deploy at the fixed path /opt/baluhost/.companion/baluhost-companion.deb.
+# dpkg/apt are deliberately NOT whitelisted directly — pinning this exact,
+# version-controlled script means the deploy user cannot install arbitrary
+# packages, only this one.
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /bin/bash /opt/baluhost/deploy/scripts/install-companion.sh
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/bash /opt/baluhost/deploy/scripts/install-companion.sh

--- a/deploy/scripts/ci-deploy.sh
+++ b/deploy/scripts/ci-deploy.sh
@@ -35,6 +35,15 @@ BACKUP_RETENTION=10
 # Database handling is unaffected — alembic still runs, no schema reset.
 SYNC_PERMISSIONS="${SYNC_PERMISSIONS:-0}"
 
+# Build the Tauri Companion app from source on this host and install it
+# system-wide (.deb). Off by default so a routine deploy never pays the Rust
+# compile cost. Enable via:
+#   - GitHub: workflow_dispatch input "install_companion" = true
+#   - Manual: INSTALL_COMPANION=1 ./ci-deploy.sh
+# Runs only after a successful deploy + health check, and is fully non-fatal:
+# a companion build/install failure never rolls back a healthy backend deploy.
+INSTALL_COMPANION="${INSTALL_COMPANION:-0}"
+
 # Load .env.production into environment (needed by Alembic/Pydantic)
 load_env_production() {
     local env_file="$INSTALL_DIR/.env.production"
@@ -170,6 +179,58 @@ restart_services() {
     log_info "Reloading nginx..."
     sudo systemctl reload nginx
     log_info "All services restarted."
+}
+
+# ─── Companion (Tauri) Build + Install ────────────────────────────────
+#
+# Opt-in (INSTALL_COMPANION=1). Builds the BaluHost Companion desktop app from
+# source on this host — Rust must be installed — and installs the resulting
+# .deb system-wide. Build runs as the unprivileged deploy user; only the final
+# dpkg/apt install needs root, and that goes through the pinned-path sudoers
+# entry for install-companion.sh. Every failure path is non-fatal: the backend
+# deploy has already succeeded and must not be rolled back by a companion issue.
+build_install_companion() {
+    log_step "BaluHost Companion (Tauri) Build + Install"
+
+    local client_dir="$INSTALL_DIR/client"
+    local deb_glob="$INSTALL_DIR/client/src-tauri/target/release/bundle/deb/*.deb"
+    local stage_dir="$INSTALL_DIR/.companion"
+    local staged_deb="$stage_dir/baluhost-companion.deb"
+
+    if ! command -v cargo >/dev/null 2>&1; then
+        log_warn "Rust/cargo not found on this host — cannot build companion. Skipping."
+        log_warn "Install Rust (see docs) then re-run with INSTALL_COMPANION=1."
+        return 0
+    fi
+
+    # node_modules are already populated by the Frontend Build step (npm ci),
+    # so the tauri CLI from devDependencies is available without a second install.
+    cd "$client_dir"
+    log_info "Building companion .deb from source (cold builds take several minutes)..."
+    if ! VITE_TAURI=1 npm run tauri:build -- --bundles deb; then
+        log_warn "Companion build failed — backend deploy is unaffected. Skipping install."
+        return 0
+    fi
+
+    # Stage the freshly built .deb at a FIXED path. The installer's sudoers
+    # entry pins this exact, non-user-controlled path, so the version-stamped
+    # build filename never reaches a sudo command line.
+    mkdir -p "$stage_dir"
+    local built
+    # shellcheck disable=SC2086
+    built=$(ls -t $deb_glob 2>/dev/null | head -1 || true)
+    if [[ -z "$built" ]]; then
+        log_warn "Build reported success but no .deb was found at $deb_glob — skipping install."
+        return 0
+    fi
+    cp -f "$built" "$staged_deb"
+    log_info "Staged: $(basename "$built") -> $staged_deb"
+
+    if sudo bash "$INSTALL_DIR/deploy/scripts/install-companion.sh"; then
+        log_info "Companion installed/updated system-wide."
+    else
+        log_warn "Companion install failed (non-fatal — deploy stays green)."
+    fi
 }
 
 # ─── Rollback ─────────────────────────────────────────────────────────
@@ -451,6 +512,14 @@ if health_check; then
     log_info "DB: $OLD_DB_REV -> $NEW_DB_REV"
     log_info "Duration: ${DURATION}s"
     log_info "Backup: $BACKUP_FILE"
+
+    # Opt-in companion build+install runs last, after the deploy is already
+    # marked successful, so it can never trigger a rollback of a healthy box.
+    if [[ "${INSTALL_COMPANION:-0}" == "1" || "${INSTALL_COMPANION,,}" == "true" ]]; then
+        build_install_companion
+    else
+        log_info "Companion build skipped (set INSTALL_COMPANION=1 to enable)."
+    fi
 else
     log_error "Health check failed after deploy!"
     rollback

--- a/deploy/scripts/install-companion.sh
+++ b/deploy/scripts/install-companion.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Install (or update) the BaluHost Companion desktop app system-wide from the
+# .deb that ci-deploy.sh built and staged at a fixed path.
+#
+# Why a dedicated root script (and not `sudo dpkg` directly in ci-deploy.sh):
+# the deploy user has NOPASSWD sudo for exactly this pinned-path invocation
+# (see deploy/install/templates/baluhost-deploy-sudoers). dpkg/apt are NOT
+# whitelisted directly, so the deploy user cannot install arbitrary packages —
+# only this version-controlled script, which installs only the staged .deb at a
+# fixed, non-user-controlled path. Same isolation pattern as
+# install-amd-gpu-permissions.sh / install-hardware-sudoers.sh.
+#
+# Run as root.
+
+set -euo pipefail
+
+INSTALL_DIR="${INSTALL_DIR:-/opt/baluhost}"
+# Fixed staging path written by ci-deploy.sh's build_install_companion().
+# Pinning it here is what lets the sudoers entry pin a single, exact command.
+DEB_PATH="$INSTALL_DIR/.companion/baluhost-companion.deb"
+
+if [[ "$EUID" -ne 0 ]]; then
+    echo "ERROR: must run as root (use sudo)." >&2
+    exit 1
+fi
+
+if [[ ! -f "$DEB_PATH" ]]; then
+    echo "ERROR: staged companion package not found: $DEB_PATH" >&2
+    echo "       ci-deploy.sh stages it after a successful Tauri build." >&2
+    exit 1
+fi
+
+echo "  ..  installing $DEB_PATH"
+
+# apt resolves runtime dependencies; a bare `dpkg -i` can leave them unmet.
+# --reinstall forces a re-install when the version is unchanged (the common
+# case for a routine re-deploy of the same companion version).
+export DEBIAN_FRONTEND=noninteractive
+if apt-get install -y --reinstall "$DEB_PATH"; then
+    echo "  OK  BaluHost Companion installed via apt"
+else
+    echo "  WARN apt install failed — falling back to dpkg + apt -f install" >&2
+    dpkg -i "$DEB_PATH" || true
+    apt-get -f install -y
+    echo "  OK  BaluHost Companion installed via dpkg fallback"
+fi
+
+echo "  OK  BaluHost Companion is installed/updated system-wide"


### PR DESCRIPTION
@
## Was & Warum

Der Prod-Deploy hat die **BaluHost Companion** Desktop-App nie auf dem Host installiert. Dieser PR ergänzt einen **Opt-in-Schritt** im Deploy (`INSTALL_COMPANION` / Workflow-Input `install_companion`, analog zu `SYNC_PERMISSIONS`): die `.deb` wird aus Source auf BaluNode gebaut (Rust ist dort installiert) und systemweit installiert.

## Änderungen

- **`deploy-production.yml`** — neuer `workflow_dispatch`-Input `install_companion` → `INSTALL_COMPANION` env; Timeout 15→30 min (kalter Rust-Build).
- **`ci-deploy.sh`** — `build_install_companion()` baut als unprivilegierter Deploy-User, stagt die `.deb` auf festen Pfad, installiert via pinned-path Root-Script. Läuft **erst nach erfolgreichem Health-Check** und ist **komplett non-fatal** — ein Companion-Fehler rollt einen gesunden Deploy nie zurück.
- **`install-companion.sh`** — Root-Installer, fixer `.deb`-Pfad, `apt --reinstall` mit `dpkg` + `apt -f` Fallback.
- **`baluhost-deploy-sudoers`** — pinned-path NOPASSWD-Zeilen für den Installer. `dpkg`/`apt` sind **nicht** direkt freigegeben.

## Trust-Modell (ci-cd-security.md)

Unverändert: kein neuer Runner, kein neuer Trigger. Läuft im bereits self-hosted + actor-gated + `production`-environment-gated Deploy-Job, gleiches Trust-Level wie das vorhandene `npm ci` / `pip install`. `tauri-build.yml` bleibt auf `ubuntu-latest` (Layer 2 intakt). sudoers-Regel auf ein einziges versionskontrolliertes Script mit exaktem Pfad gepinnt — kein `ALL`, kein Glob.

Enthält außerdem einen kleinen Chore-Commit: `.claude/worktrees/` in `.gitignore`.

## Einmal-Setup auf BaluNode (nach Merge)

```bash
# Tauri-Build-Deps
sudo apt-get update && sudo apt-get install -y \
  libwebkit2gtk-4.1-dev build-essential curl wget file \
  libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
# neue sudoers-Regel aktivieren
cd /opt/baluhost && git pull
sudo BALUHOST_USER=sven bash /opt/baluhost/deploy/scripts/install-deploy-sudoers.sh
```

Auslösen danach: `gh workflow run deploy-production.yml -f install_companion=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@