### PR TITLE
docs: reposition BaluHost as a self-hosted home server platform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Grep/Glob nur als Fallback verwenden, wenn vectordb-search keine passenden Ergeb
 
 ## Project Overview
 
-BaluHost is a full-stack NAS management platform with multiple components:
+BaluHost is a full-stack self-hosted home server platform (NAS at its core) with multiple components:
 - **Backend**: Python FastAPI (primary), located in `backend/`
 - **Frontend**: React + TypeScript + Vite (Web UI), located in `client/`
 - **TUI**: Terminal UI (Textual), located in `backend/baluhost_tui/`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # BaluHost
 
-**Self-Hosted NAS Management Platform**
+**Self-Hosted Home Server Platform**
 
 [![Version](https://img.shields.io/github/v/release/Xveyn/BaluHost?color=blue&label=version)](https://github.com/Xveyn/BaluHost/releases/latest)
 [![Python](https://img.shields.io/badge/python-3.11+-3776AB.svg)](https://www.python.org/downloads/)
@@ -11,7 +11,7 @@
 [![React](https://img.shields.io/badge/React-18+-61dafb.svg)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-purple.svg)](LICENSE)
 
-A full-stack web interface for managing your Network Attached Storage — file management, RAID monitoring, system telemetry, power control, VPN, and more.
+Manage your home server end to end — file & RAID storage at the core, plus system & power monitoring, VPN and networking, and a plugin marketplace to extend it — all from one web UI, with production-grade deployment built in.
 
 [Features](#features) · [Quick Start](#quick-start) · [Architecture](#architecture) · [Documentation](#documentation)
 
@@ -19,9 +19,21 @@ A full-stack web interface for managing your Network Attached Storage — file m
 
 ---
 
-## Production Status
+## Reference System
 
-Deployed since January 25, 2026 on Debian 13 (Ryzen 5 5600GT, 16GB RAM).
+BaluHost is developed and tested against a single reference configuration — the maintainer's production box, in service since January 25, 2026:
+
+| Spec | Detail |
+|------|--------|
+| **OS** | Debian 13 |
+| **Kernel** | `6.12.74+deb13+1-amd64` (x86_64) |
+| **CPU** | AMD Ryzen 5 5600GT |
+| **Memory** | 16 GB RAM |
+| **GPU** | AMD Radeon RX 7900 XT (20 GB VRAM) |
+
+The same machine doubles as a KDE Plasma desktop and — thanks to the Radeon GPU — an optional Linux gaming rig / "Steam Machine" (Proton). That gaming use case is not part of this repository; it simply shares the reference hardware.
+
+### Production Stack
 
 | Component | Status | Details |
 |-----------|--------|---------|
@@ -84,9 +96,16 @@ Deployed since January 25, 2026 on Debian 13 (Ryzen 5 5600GT, 16GB RAM).
 - Service health monitoring
 - Secure read-only database inspection (sensitive fields redacted)
 - Cloud import (rclone integration)
-- Plugin system
 - Self-hosted update mechanism
 - System benchmarking
+
+### Plugins & Extensibility
+- Plugin marketplace — browse, install, update & remove plugins from a UI tab
+- Plugins distributed from a separate Git repo, installed in one click
+- Isolated per-plugin Python dependencies (no pollution of the core environment)
+- Frontend SDK (`window.BaluHost`) for plugin dashboard panels & UI bundles
+- Inter-plugin event bus and lifecycle hooks
+- SmartDevice framework for hardware-device plugins (e.g. Tapo smart plugs)
 
 ### Multi-Platform
 - **BaluHost** — Web UI (this repo)
@@ -230,7 +249,7 @@ All routes prefixed with `/api`:
 | **Admin** | `/admin-db/*`, `/admin/*` | Database inspection, services |
 | **Logging** | `/logging/audit`, `/logging/disk-io` | Audit trail |
 | **Pi-hole** | `/pihole/*` | DNS management |
-| **Plugins** | `/plugins/*` | Plugin system |
+| **Plugins** | `/plugins/*`, `/plugins/marketplace/*` | Plugin runtime & marketplace |
 
 ---
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,6 +1,6 @@
 # BaluHost Frontend
 
-Modern React TypeScript frontend for BaluHost NAS Management Platform.
+Modern React TypeScript frontend for the BaluHost home server platform.
 
 ## 🚀 Technology Stack
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 ## 📐 System Overview
 
-BaluHost is a modern, full-stack NAS management application designed for self-hosted file storage and system monitoring. The architecture follows a clear separation of concerns with a React frontend, FastAPI backend, and simulated/real hardware integration.
+BaluHost is a modern, full-stack self-hosted home server platform, built around a NAS core (file storage, RAID) and extended with system monitoring, power & hardware control, networking, and a plugin marketplace. The architecture follows a clear separation of concerns with a React frontend, FastAPI backend, and simulated/real hardware integration.
 
 ```
 ┌───────────────────────────────────────────────────────────┐


### PR DESCRIPTION
## Summary

Repositions BaluHost in the user-facing docs from a **NAS management platform** to a **self-hosted home server platform** — NAS stays the core, but the wording now reflects how far the project has grown beyond storage (plugin marketplace, deployment infrastructure, power/networking, multi-platform clients).

## Changes

- **README.md**
  - Headline → `Self-Hosted Home Server Platform`; new tagline (NAS *at its core*, plus marketplace/monitoring/VPN/deploy)
  - `Production Status` → **`Reference System`**: dedicated hardware table (OS Debian 13, kernel `6.12.74+deb13+1-amd64`, Ryzen 5 5600GT, 16 GB RAM, Radeon RX 7900 XT 20 GB) framed as the config the project is developed/tested against, plus a note on the optional KDE desktop / Steam Machine (Proton) secondary use — explicitly *not* part of this repo
  - Existing prod stack table kept as `Production Stack` (STATS markers preserved for the auto-update script)
  - New **`Plugins & Extensibility`** feature section (marketplace, external plugin repo, isolated per-plugin deps, frontend SDK, event bus, SmartDevice framework) — replaces the single `Plugin system` bullet
  - API table: Plugins row now includes `/plugins/marketplace/*`
- **CLAUDE.md**, **docs/ARCHITECTURE.md**, **client/README.md** — same reframe (NAS as the core, not the whole product)

Code identifiers (`NAS_MODE`, `NAS_STORAGE_PATH`) and historical plan/spec docs were intentionally left untouched.

> Note: the GitHub repo description & topics were already updated out-of-band to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)