### PR TITLE
feat(system-permissions): rename Power→System Permissions + delegatable Desktop toggle

### DIFF
--- a/backend/alembic/versions/73861c57ef63_add_can_toggle_desktop_to_user_power_.py
+++ b/backend/alembic/versions/73861c57ef63_add_can_toggle_desktop_to_user_power_.py
@@ -1,0 +1,30 @@
+"""add can_toggle_desktop to user_power_permissions
+
+Revision ID: 73861c57ef63
+Revises: 88a45a963ed9
+Create Date: 2026-06-04 14:21:28.996955
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '73861c57ef63'
+down_revision: Union[str, Sequence[str], None] = '88a45a963ed9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_power_permissions",
+        sa.Column("can_toggle_desktop", sa.Boolean(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("user_power_permissions") as batch_op:
+        batch_op.drop_column("can_toggle_desktop")

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -379,6 +379,7 @@ require_power_soft_sleep = _make_power_dependency("soft_sleep")
 require_power_wake = _make_power_dependency("wake")
 require_power_suspend = _make_power_dependency("suspend")
 require_power_wol = _make_power_dependency("wol")
+require_power_toggle_desktop = _make_power_dependency("toggle_desktop")
 
 
 async def require_local_or_setup_secret(

--- a/backend/app/api/routes/desktop.py
+++ b/backend/app/api/routes/desktop.py
@@ -42,7 +42,8 @@ async def desktop_disable(
     delegated user with the can_toggle_desktop permission.
     """
     ok, message = await get_desktop_service().disable()
-    get_audit_logger_db().log_event(
+    audit_logger = get_audit_logger_db()
+    audit_logger.log_event(
         event_type="POWER",
         action="desktop_disable",
         user=current_user.username,
@@ -50,6 +51,16 @@ async def desktop_disable(
         success=ok,
         details={"message": message},
     )
+    if current_user.role != "admin":
+        # Mirror the sleep routes: record that a delegated (non-admin) user
+        # invoked a privileged power action, for the security-audit trail.
+        audit_logger.log_security_event(
+            action="delegated_power_action",
+            user=current_user.username,
+            resource="toggle_desktop",
+            details={"action": "desktop_disable"},
+            success=True,
+        )
     return {"success": ok, "message": message}
 
 
@@ -65,7 +76,8 @@ async def desktop_enable(
     Admin or a delegated user with the can_toggle_desktop permission.
     """
     ok, message = await get_desktop_service().enable()
-    get_audit_logger_db().log_event(
+    audit_logger = get_audit_logger_db()
+    audit_logger.log_event(
         event_type="POWER",
         action="desktop_enable",
         user=current_user.username,
@@ -73,4 +85,14 @@ async def desktop_enable(
         success=ok,
         details={"message": message},
     )
+    if current_user.role != "admin":
+        # Mirror the sleep routes: record that a delegated (non-admin) user
+        # invoked a privileged power action, for the security-audit trail.
+        audit_logger.log_security_event(
+            action="delegated_power_action",
+            user=current_user.username,
+            resource="toggle_desktop",
+            details={"action": "desktop_enable"},
+            success=True,
+        )
     return {"success": ok, "message": message}

--- a/backend/app/api/routes/desktop.py
+++ b/backend/app/api/routes/desktop.py
@@ -38,7 +38,8 @@ async def desktop_disable(
     """Turn the desktop displays off (DPMS) so the GPU can drop to idle.
 
     Keeps the KWin session running; stopping sddm would instead light all
-    outputs via the framebuffer console and pin the dGPU at ~78W. Admin only.
+    outputs via the framebuffer console and pin the dGPU at ~78W. Admin or a
+    delegated user with the can_toggle_desktop permission.
     """
     ok, message = await get_desktop_service().disable()
     get_audit_logger_db().log_event(
@@ -59,7 +60,10 @@ async def desktop_enable(
     response: Response,
     current_user=Depends(require_power_toggle_desktop),
 ) -> dict:
-    """Turn the desktop displays back on (DPMS). Admin only."""
+    """Turn the desktop displays back on (DPMS).
+
+    Admin or a delegated user with the can_toggle_desktop permission.
+    """
     ok, message = await get_desktop_service().enable()
     get_audit_logger_db().log_event(
         event_type="POWER",

--- a/backend/app/api/routes/desktop.py
+++ b/backend/app/api/routes/desktop.py
@@ -6,7 +6,7 @@ import logging
 
 from fastapi import APIRouter, Depends, Request, Response
 
-from app.api.deps import get_current_user, get_current_admin
+from app.api.deps import get_current_user, require_power_toggle_desktop
 from app.core.rate_limiter import user_limiter, get_limit
 from app.schemas.desktop import DesktopStatus
 from app.services.power.desktop import get_desktop_service
@@ -33,7 +33,7 @@ async def desktop_status(
 async def desktop_disable(
     request: Request,
     response: Response,
-    current_user=Depends(get_current_admin),
+    current_user=Depends(require_power_toggle_desktop),
 ) -> dict:
     """Turn the desktop displays off (DPMS) so the GPU can drop to idle.
 
@@ -57,7 +57,7 @@ async def desktop_disable(
 async def desktop_enable(
     request: Request,
     response: Response,
-    current_user=Depends(get_current_admin),
+    current_user=Depends(require_power_toggle_desktop),
 ) -> dict:
     """Turn the desktop displays back on (DPMS). Admin only."""
     ok, message = await get_desktop_service().enable()

--- a/backend/app/api/routes/sleep.py
+++ b/backend/app/api/routes/sleep.py
@@ -325,6 +325,7 @@ async def get_my_power_permissions(
     if current_user.role == "admin":
         return MyPowerPermissionsResponse(
             can_soft_sleep=True, can_wake=True, can_suspend=True, can_wol=True,
+            can_toggle_desktop=True,
         )
     from app.services.power_permissions import get_permissions
     perms = get_permissions(db, current_user.id)
@@ -333,6 +334,7 @@ async def get_my_power_permissions(
         can_wake=perms.can_wake,
         can_suspend=perms.can_suspend,
         can_wol=perms.can_wol,
+        can_toggle_desktop=perms.can_toggle_desktop,
     )
 
 

--- a/backend/app/models/CLAUDE.md
+++ b/backend/app/models/CLAUDE.md
@@ -18,7 +18,7 @@ SQLAlchemy 2.0 ORM models. All models inherit from `Base` (declarative base in `
 
 **Monitoring & Metrics**: `monitoring.py` (CpuSample, MemorySample, NetworkSample, DiskIoSample, ProcessSample, MonitoringConfig), `service_heartbeat.py`
 
-**Power & Hardware**: `power.py` (profiles, demands, auto-scaling), `power_preset.py`, `fans.py` (config, samples, schedules, curve profiles), `sleep.py`, `smart_device.py`, `power_permissions.py`
+**Power & Hardware**: `power.py` (profiles, demands, auto-scaling), `power_preset.py`, `fans.py` (config, samples, schedules, curve profiles), `sleep.py`, `smart_device.py`, `power_permissions.py` (UI name: "System Permissions / Systemberechtigungen"; table/columns keep the `power_permissions` name)
 
 **Networking**: `vpn.py` (VPNConfig, VPNClient), `vpn_profile.py`, `mobile.py`, `server_profile.py`, `fritzbox.py`, `webdav_state.py`
 

--- a/backend/app/models/power_permissions.py
+++ b/backend/app/models/power_permissions.py
@@ -24,6 +24,7 @@ class UserPowerPermission(Base):
     can_wake: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
     can_suspend: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
     can_wol: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+    can_toggle_desktop: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
 
     granted_by: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True

--- a/backend/app/schemas/CLAUDE.md
+++ b/backend/app/schemas/CLAUDE.md
@@ -24,7 +24,7 @@ Pydantic v2 models for API request/response validation. One file per feature dom
 
 **Power** (`power.py`): `PowerProfile` enum (IDLE/LOW/MEDIUM/SURGE), `ServicePowerProperty`, profile configs
 
-**Power Permissions** (`power_permissions.py`): `UserPowerPermissionsResponse`, `UserPowerPermissionsUpdate`, `MyPowerPermissionsResponse` — per-user power action delegation
+**Power Permissions** (`power_permissions.py`): `UserPowerPermissionsResponse`, `UserPowerPermissionsUpdate`, `MyPowerPermissionsResponse` — per-user power action delegation (incl. `can_toggle_desktop`). UI name: "System Permissions / Systemberechtigungen"; backend stays `power_permissions`.
 
 ## Adding a Schema
 

--- a/backend/app/schemas/power_permissions.py
+++ b/backend/app/schemas/power_permissions.py
@@ -14,6 +14,7 @@ class UserPowerPermissionsResponse(BaseModel):
     can_wake: bool = False
     can_suspend: bool = False
     can_wol: bool = False
+    can_toggle_desktop: bool = False
     granted_by: Optional[int] = None
     granted_by_username: Optional[str] = None
     granted_at: Optional[datetime] = None
@@ -28,6 +29,7 @@ class UserPowerPermissionsUpdate(BaseModel):
     can_wake: Optional[bool] = Field(default=None, description="Allow waking from soft sleep")
     can_suspend: Optional[bool] = Field(default=None, description="Allow system suspend")
     can_wol: Optional[bool] = Field(default=None, description="Allow sending Wake-on-LAN")
+    can_toggle_desktop: Optional[bool] = Field(default=None, description="Allow toggling the desktop (DPMS on/off)")
 
 
 class MyPowerPermissionsResponse(BaseModel):
@@ -37,3 +39,4 @@ class MyPowerPermissionsResponse(BaseModel):
     can_wake: bool = False
     can_suspend: bool = False
     can_wol: bool = False
+    can_toggle_desktop: bool = False

--- a/backend/app/services/CLAUDE.md
+++ b/backend/app/services/CLAUDE.md
@@ -24,7 +24,7 @@ Business logic layer. Routes delegate to services — services contain the actua
 | `totp_service.py` | TOTP 2FA setup, verification, backup codes |
 | `token_service.py` | Refresh token management, rotation |
 | `plugin_service.py` | Plugin install/uninstall/toggle operations |
-| `power_permissions.py` | Per-user power action permissions (get, update, check) |
+| `power_permissions.py` | Per-user power action permissions (get, update, check), incl. `can_toggle_desktop`. UI name: "System Permissions / Systemberechtigungen"; backend identifiers stay `power_permissions` (deliberate — no rename/migration). |
 | `samba_service.py` | Samba/SMB share management |
 | `webdav_service.py` | WebDAV server lifecycle control |
 | `rate_limit_config.py` | DB-backed rate limit configuration |

--- a/backend/app/services/power_permissions.py
+++ b/backend/app/services/power_permissions.py
@@ -19,6 +19,7 @@ _ACTION_FIELD_MAP = {
     "wake": "can_wake",
     "suspend": "can_suspend",
     "wol": "can_wol",
+    "toggle_desktop": "can_toggle_desktop",
 }
 
 
@@ -44,6 +45,7 @@ def get_permissions(db: Session, user_id: int) -> UserPowerPermissionsResponse:
         can_wake=perm.can_wake,
         can_suspend=perm.can_suspend,
         can_wol=perm.can_wol,
+        can_toggle_desktop=perm.can_toggle_desktop,
         granted_by=perm.granted_by,
         granted_by_username=granted_by_username,
         granted_at=perm.granted_at,
@@ -114,6 +116,7 @@ def update_permissions(
         "can_wake": perm.can_wake,
         "can_suspend": perm.can_suspend,
         "can_wol": perm.can_wol,
+        "can_toggle_desktop": perm.can_toggle_desktop,
     }
 
     # Track which fields were explicitly set so implications can be applied
@@ -142,6 +145,8 @@ def update_permissions(
         perm.can_wol = update.can_wol
         if not update.can_wol:
             explicit_false.add("can_wol")
+    if update.can_toggle_desktop is not None:
+        perm.can_toggle_desktop = update.can_toggle_desktop
 
     # Apply implication rules
     perm.can_soft_sleep, perm.can_wake, perm.can_suspend, perm.can_wol = (
@@ -162,6 +167,7 @@ def update_permissions(
         "can_wake": perm.can_wake,
         "can_suspend": perm.can_suspend,
         "can_wol": perm.can_wol,
+        "can_toggle_desktop": perm.can_toggle_desktop,
     }
 
     # Audit log

--- a/backend/app/services/power_permissions.py
+++ b/backend/app/services/power_permissions.py
@@ -193,7 +193,7 @@ def check_permission(db: Session, user_id: int, action: str) -> bool:
     Args:
         db: Database session
         user_id: User ID to check
-        action: One of 'soft_sleep', 'wake', 'suspend', 'wol'
+        action: One of 'soft_sleep', 'wake', 'suspend', 'wol', 'toggle_desktop'
 
     Returns:
         True if the user has the permission, False otherwise.

--- a/backend/tests/api/test_power_permissions_routes.py
+++ b/backend/tests/api/test_power_permissions_routes.py
@@ -202,6 +202,12 @@ class TestDelegatedDesktopAccess:
         )
         assert resp.status_code == 200
         assert resp.json()["success"] is True
+        # Reset so later tests asserting can_toggle_desktop == False aren't polluted.
+        client.put(
+            f"/api/users/{regular_user.id}/power-permissions",
+            json={"can_toggle_desktop": False},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
 
     def test_admin_still_works(self, client: TestClient, admin_token: str):
         resp = client.post(

--- a/backend/tests/api/test_power_permissions_routes.py
+++ b/backend/tests/api/test_power_permissions_routes.py
@@ -151,6 +151,13 @@ class TestToggleDesktopPermission:
         assert data["can_wake"] is False
         assert data["can_suspend"] is False
         assert data["can_wol"] is False
+        # Reset the shared regular_user row so this grant doesn't leak into
+        # order-independent runs of test_default_is_false.
+        client.put(
+            f"/api/users/{regular_user.id}/power-permissions",
+            json={"can_toggle_desktop": False},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
 
     def test_my_permissions_includes_toggle_desktop(self, client: TestClient, user_token: str):
         resp = client.get(

--- a/backend/tests/api/test_power_permissions_routes.py
+++ b/backend/tests/api/test_power_permissions_routes.py
@@ -125,3 +125,37 @@ class TestDelegatedSleepAccess:
             headers={"Authorization": f"Bearer {admin_token}"},
         )
         assert resp.status_code != 403  # 503 expected (service not running), not 403
+
+
+class TestToggleDesktopPermission:
+    def test_default_is_false(self, client: TestClient, admin_token: str, regular_user: User):
+        resp = client.get(
+            f"/api/users/{regular_user.id}/power-permissions",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["can_toggle_desktop"] is False
+
+    def test_grant_does_not_imply_other_permissions(
+        self, client: TestClient, admin_token: str, regular_user: User,
+    ):
+        resp = client.put(
+            f"/api/users/{regular_user.id}/power-permissions",
+            json={"can_toggle_desktop": True},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["can_toggle_desktop"] is True
+        assert data["can_soft_sleep"] is False
+        assert data["can_wake"] is False
+        assert data["can_suspend"] is False
+        assert data["can_wol"] is False
+
+    def test_my_permissions_includes_toggle_desktop(self, client: TestClient, user_token: str):
+        resp = client.get(
+            "/api/system/sleep/my-permissions",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["can_toggle_desktop"] is False

--- a/backend/tests/api/test_power_permissions_routes.py
+++ b/backend/tests/api/test_power_permissions_routes.py
@@ -166,3 +166,46 @@ class TestToggleDesktopPermission:
         )
         assert resp.status_code == 200
         assert resp.json()["can_toggle_desktop"] is False
+
+
+class TestDelegatedDesktopAccess:
+    @pytest.fixture(autouse=True)
+    def _dev_desktop(self):
+        # Force the in-memory dev backend so the endpoint result is
+        # deterministic and cross-platform (no kscreen-doctor / os.getuid()).
+        import app.services.power.desktop as desktop_mod
+        from app.services.power.desktop import DesktopService
+        from app.services.power.desktop_backend import DevDesktopBackend
+        prev = desktop_mod._service
+        desktop_mod._service = DesktopService(backend=DevDesktopBackend())
+        yield
+        desktop_mod._service = prev
+
+    def test_user_without_permission_gets_403(self, client: TestClient, user_token: str):
+        resp = client.post(
+            "/api/system/sleep/desktop/disable",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert resp.status_code == 403
+
+    def test_user_with_permission_can_access(
+        self, client: TestClient, admin_token: str, user_token: str, regular_user: User,
+    ):
+        client.put(
+            f"/api/users/{regular_user.id}/power-permissions",
+            json={"can_toggle_desktop": True},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        resp = client.post(
+            "/api/system/sleep/desktop/disable",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+    def test_admin_still_works(self, client: TestClient, admin_token: str):
+        resp = client.post(
+            "/api/system/sleep/desktop/enable",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code == 200

--- a/backend/tests/test_desktop_routes.py
+++ b/backend/tests/test_desktop_routes.py
@@ -14,7 +14,6 @@ def client():
         username = "admin"
         role = "admin"
     app.dependency_overrides[deps.get_current_user] = lambda: _User()
-    app.dependency_overrides[deps.get_current_admin] = lambda: _User()
     import app.services.power.desktop as desktop_mod
     desktop_mod._service = DesktopService(backend=DevDesktopBackend())
     with TestClient(app) as c:

--- a/client/src/api/powerPermissions.ts
+++ b/client/src/api/powerPermissions.ts
@@ -10,6 +10,7 @@ export interface UserPowerPermissions {
   can_wake: boolean;
   can_suspend: boolean;
   can_wol: boolean;
+  can_toggle_desktop: boolean;
   granted_by: number | null;
   granted_by_username: string | null;
   granted_at: string | null;
@@ -20,6 +21,7 @@ export interface UserPowerPermissionsUpdate {
   can_wake?: boolean;
   can_suspend?: boolean;
   can_wol?: boolean;
+  can_toggle_desktop?: boolean;
 }
 
 export interface MyPowerPermissions {
@@ -27,6 +29,7 @@ export interface MyPowerPermissions {
   can_wake: boolean;
   can_suspend: boolean;
   can_wol: boolean;
+  can_toggle_desktop: boolean;
 }
 
 /**

--- a/client/src/components/user-management/PowerPermissionsSection.tsx
+++ b/client/src/components/user-management/PowerPermissionsSection.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { Moon, Sun, Power, Wifi, Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Moon, Sun, Power, Wifi, MonitorOff, Loader2 } from 'lucide-react';
 import {
   getUserPowerPermissions,
   updateUserPowerPermissions,
@@ -16,45 +17,31 @@ interface PowerPermissionsSectionProps {
 
 interface PermissionToggle {
   key: keyof UserPowerPermissionsUpdate;
-  label: string;
-  description: string;
   icon: React.ReactNode;
   impliedBy?: keyof UserPowerPermissionsUpdate;
   implies?: keyof UserPowerPermissionsUpdate;
 }
 
+// Maps an API field name to its i18n item key under
+// admin:users.systemPermissions.items.*
+const FIELD_TO_I18N: Record<string, string> = {
+  can_soft_sleep: 'softSleep',
+  can_wake: 'wake',
+  can_suspend: 'suspend',
+  can_wol: 'wol',
+  can_toggle_desktop: 'toggleDesktop',
+};
+
 const PERMISSION_TOGGLES: PermissionToggle[] = [
-  {
-    key: 'can_soft_sleep',
-    label: 'Soft Sleep',
-    description: 'Server in Soft Sleep versetzen',
-    icon: <Moon className="h-4 w-4" />,
-    implies: 'can_wake',
-  },
-  {
-    key: 'can_wake',
-    label: 'Wake',
-    description: 'Server aus Soft Sleep aufwecken',
-    icon: <Sun className="h-4 w-4" />,
-    impliedBy: 'can_soft_sleep',
-  },
-  {
-    key: 'can_suspend',
-    label: 'Suspend',
-    description: 'System Suspend (S3 Sleep)',
-    icon: <Power className="h-4 w-4" />,
-    implies: 'can_wol',
-  },
-  {
-    key: 'can_wol',
-    label: 'Wake-on-LAN',
-    description: 'WoL Magic Packet senden',
-    icon: <Wifi className="h-4 w-4" />,
-    impliedBy: 'can_suspend',
-  },
+  { key: 'can_soft_sleep', icon: <Moon className="h-4 w-4" />, implies: 'can_wake' },
+  { key: 'can_wake', icon: <Sun className="h-4 w-4" />, impliedBy: 'can_soft_sleep' },
+  { key: 'can_suspend', icon: <Power className="h-4 w-4" />, implies: 'can_wol' },
+  { key: 'can_wol', icon: <Wifi className="h-4 w-4" />, impliedBy: 'can_suspend' },
+  { key: 'can_toggle_desktop', icon: <MonitorOff className="h-4 w-4" /> },
 ];
 
 export function PowerPermissionsSection({ userId, userRole }: PowerPermissionsSectionProps) {
+  const { t } = useTranslation('admin');
   const [permissions, setPermissions] = useState<UserPowerPermissions | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -74,7 +61,7 @@ export function PowerPermissionsSection({ userId, userRole }: PowerPermissionsSe
     return (
       <div className="flex items-center gap-2 py-3 text-sm text-slate-400">
         <Loader2 className="h-4 w-4 animate-spin" />
-        Lade Power Permissions...
+        {t('users.systemPermissions.loading')}
       </div>
     );
   }
@@ -85,9 +72,9 @@ export function PowerPermissionsSection({ userId, userRole }: PowerPermissionsSe
       const update: UserPowerPermissionsUpdate = { [key]: newValue };
       const result = await updateUserPowerPermissions(userId, update);
       setPermissions(result);
-      toast.success('Power Permissions aktualisiert');
+      toast.success(t('users.systemPermissions.saved'));
     } catch (error) {
-      handleApiError(error, 'Fehler beim Speichern');
+      handleApiError(error, t('users.systemPermissions.saveError'));
     } finally {
       setSaving(false);
     }
@@ -100,23 +87,30 @@ export function PowerPermissionsSection({ userId, userRole }: PowerPermissionsSe
 
   return (
     <div className="border-t border-slate-800 pt-3 mt-3">
-      <h3 className="text-sm font-medium text-slate-300 mb-1">Power Permissions</h3>
+      <h3 className="text-sm font-medium text-slate-300 mb-1">
+        {t('users.systemPermissions.title')}
+      </h3>
       <p className="text-xs text-slate-500 mb-3">
-        Erlaubt diesem User, Power-Aktionen ueber die Mobile App auszufuehren.
+        {t('users.systemPermissions.description')}
       </p>
 
       <div className="space-y-2">
         {PERMISSION_TOGGLES.map((toggle) => {
           const value = permissions?.[toggle.key] ?? false;
           const implied = isImplied(toggle);
+          const i18nKey = FIELD_TO_I18N[toggle.key];
 
           return (
             <div key={toggle.key} className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2 min-w-0">
                 <span className="text-slate-400">{toggle.icon}</span>
                 <div>
-                  <span className="text-sm text-slate-200">{toggle.label}</span>
-                  <span className="text-xs text-slate-500 ml-2">{toggle.description}</span>
+                  <span className="text-sm text-slate-200">
+                    {t(`users.systemPermissions.items.${i18nKey}.label`)}
+                  </span>
+                  <span className="text-xs text-slate-500 ml-2">
+                    {t(`users.systemPermissions.items.${i18nKey}.desc`)}
+                  </span>
                 </div>
               </div>
               <button
@@ -125,7 +119,13 @@ export function PowerPermissionsSection({ userId, userRole }: PowerPermissionsSe
                 aria-checked={value}
                 disabled={saving || implied}
                 onClick={() => handleToggle(toggle.key, !value)}
-                title={implied ? `Impliziert durch ${toggle.impliedBy === 'can_soft_sleep' ? 'Soft Sleep' : 'Suspend'}` : undefined}
+                title={
+                  implied && toggle.impliedBy
+                    ? t('users.systemPermissions.impliedBy', {
+                        name: t(`users.systemPermissions.items.${FIELD_TO_I18N[toggle.impliedBy]}.label`),
+                      })
+                    : undefined
+                }
                 className={`relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors
                   ${value ? 'bg-sky-500' : 'bg-slate-700'}
                   ${implied ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'}
@@ -145,8 +145,12 @@ export function PowerPermissionsSection({ userId, userRole }: PowerPermissionsSe
 
       {permissions?.granted_by_username && (
         <p className="text-xs text-slate-500 mt-2">
-          Zuletzt geaendert von {permissions.granted_by_username}
-          {permissions.granted_at && ` am ${new Date(permissions.granted_at).toLocaleDateString('de-DE')}`}
+          {t('users.systemPermissions.lastChangedBy', {
+            name: permissions.granted_by_username,
+            date: permissions.granted_at
+              ? new Date(permissions.granted_at).toLocaleDateString()
+              : '',
+          })}
         </p>
       )}
     </div>

--- a/client/src/components/user-management/PowerPermissionsSection.tsx
+++ b/client/src/components/user-management/PowerPermissionsSection.tsx
@@ -24,7 +24,7 @@ interface PermissionToggle {
 
 // Maps an API field name to its i18n item key under
 // admin:users.systemPermissions.items.*
-const FIELD_TO_I18N: Record<string, string> = {
+const FIELD_TO_I18N: Record<keyof UserPowerPermissionsUpdate, string> = {
   can_soft_sleep: 'softSleep',
   can_wake: 'wake',
   can_suspend: 'suspend',
@@ -41,7 +41,7 @@ const PERMISSION_TOGGLES: PermissionToggle[] = [
 ];
 
 export function PowerPermissionsSection({ userId, userRole }: PowerPermissionsSectionProps) {
-  const { t } = useTranslation('admin');
+  const { t, i18n } = useTranslation('admin');
   const [permissions, setPermissions] = useState<UserPowerPermissions | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -148,7 +148,7 @@ export function PowerPermissionsSection({ userId, userRole }: PowerPermissionsSe
           {t('users.systemPermissions.lastChangedBy', {
             name: permissions.granted_by_username,
             date: permissions.granted_at
-              ? new Date(permissions.granted_at).toLocaleDateString()
+              ? new Date(permissions.granted_at).toLocaleDateString(i18n.language)
               : '',
           })}
         </p>

--- a/client/src/i18n/locales/de/admin.json
+++ b/client/src/i18n/locales/de/admin.json
@@ -76,6 +76,22 @@
       "toggleFailed": "Benutzerstatus konnte nicht geändert werden",
       "bulkDeleteFailed": "Benutzer konnten nicht gelöscht werden",
       "invalidEmail": "Bitte eine gültige E-Mail-Adresse eingeben"
+    },
+    "systemPermissions": {
+      "title": "Systemberechtigungen",
+      "description": "Erlaubt diesem User, System-Aktionen über die Mobile App auszuführen.",
+      "loading": "Systemberechtigungen werden geladen…",
+      "saved": "Systemberechtigungen aktualisiert",
+      "saveError": "Fehler beim Speichern",
+      "lastChangedBy": "Zuletzt geändert von {{name}} am {{date}}",
+      "impliedBy": "Impliziert durch {{name}}",
+      "items": {
+        "softSleep": { "label": "Soft Sleep", "desc": "Server in Soft Sleep versetzen" },
+        "wake": { "label": "Wake", "desc": "Server aus Soft Sleep aufwecken" },
+        "suspend": { "label": "Suspend", "desc": "System Suspend (S3 Sleep)" },
+        "wol": { "label": "Wake-on-LAN", "desc": "WoL Magic Packet senden" },
+        "toggleDesktop": { "label": "Desktop", "desc": "Desktop aktivieren/deaktivieren (spart GPU-Strom)" }
+      }
     }
   },
   "system": {

--- a/client/src/i18n/locales/en/admin.json
+++ b/client/src/i18n/locales/en/admin.json
@@ -76,6 +76,22 @@
       "toggleFailed": "Failed to toggle user status",
       "bulkDeleteFailed": "Failed to delete users",
       "invalidEmail": "Please enter a valid email address"
+    },
+    "systemPermissions": {
+      "title": "System Permissions",
+      "description": "Allows this user to perform system actions via the mobile app.",
+      "loading": "Loading system permissions…",
+      "saved": "System permissions updated",
+      "saveError": "Failed to save",
+      "lastChangedBy": "Last changed by {{name}} on {{date}}",
+      "impliedBy": "Implied by {{name}}",
+      "items": {
+        "softSleep": { "label": "Soft Sleep", "desc": "Put the server into soft sleep" },
+        "wake": { "label": "Wake", "desc": "Wake the server from soft sleep" },
+        "suspend": { "label": "Suspend", "desc": "System suspend (S3 sleep)" },
+        "wol": { "label": "Wake-on-LAN", "desc": "Send a WoL magic packet" },
+        "toggleDesktop": { "label": "Desktop", "desc": "Enable/disable the desktop (saves GPU power)" }
+      }
     }
   },
   "system": {

--- a/docs/superpowers/plans/2026-06-04-system-permissions-desktop-toggle.md
+++ b/docs/superpowers/plans/2026-06-04-system-permissions-desktop-toggle.md
@@ -1,0 +1,716 @@
+# System Permissions: Rename + Desktop-Toggle Permission — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the user-facing "Power Permissions" feature to "System Permissions / Systemberechtigungen", internationalize its UI, and add a new grantable `can_toggle_desktop` permission that delegates the KDE desktop enable/disable endpoints to non-admins (parallel to the existing sleep/suspend/WoL delegation).
+
+**Architecture:** Extend the existing `user_power_permissions` table/service/schemas with one independent boolean column (no implication logic). Broaden the desktop `enable`/`disable` endpoints from admin-only to `admin OR can_toggle_desktop` via the existing `_make_power_dependency` factory. Backend identifiers stay `power_permissions` (UI-only rename); CLAUDE.md notes record the mapping. Frontend: internationalize `PowerPermissionsSection.tsx` and add the 5th toggle.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0, Alembic, Pydantic v2, pytest — React 18 + TypeScript + i18next + Tailwind.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-system-permissions-desktop-toggle-design.md`
+
+**Coordination note (parallel work):** A parallel worktree (`feat/monitoring-retention-ui`) edits the same two i18n files (`en/admin.json`, `de/admin.json`) but in disjoint key regions (`database.tabs.retention`, `databaseStats.metrics.{uptime,gpu}`, top-level `retentionSettings`) — this plan only adds `users.systemPermissions`, so a 3-way merge is clean. That feature adds **no Alembic migration**, so this plan's migration off head `88a45a963ed9` is the only new one — no multi-head risk. If that changes, re-point this migration's `down_revision` onto whatever lands first.
+
+---
+
+## Task 1: Model column + Alembic migration
+
+**Files:**
+- Modify: `backend/app/models/power_permissions.py`
+- Create: `backend/alembic/versions/<generated>_add_can_toggle_desktop.py`
+
+- [ ] **Step 1: Add the column to the model**
+
+In `backend/app/models/power_permissions.py`, after the `can_wol` column (line 26), add:
+```python
+    can_toggle_desktop: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+```
+
+- [ ] **Step 2: Confirm the current Alembic head**
+
+Run (from `backend/`): `python -m alembic heads`
+Expected: `88a45a963ed9 (head)` — a single head. If it shows more than one head, STOP and reconcile before continuing (multi-head will break prod deploy).
+
+- [ ] **Step 3: Generate an empty migration chained onto that head**
+
+Run (from `backend/`): `python -m alembic revision -m "add can_toggle_desktop to user_power_permissions"`
+Expected: a new file `backend/alembic/versions/<revid>_add_can_toggle_desktop_to_user_power_permissions.py` whose `down_revision = "88a45a963ed9"` was filled in automatically. (Plain `revision`, NOT `--autogenerate` — we hand-write the ops to avoid picking up unrelated dev-DB drift.)
+
+- [ ] **Step 4: Fill in upgrade/downgrade**
+
+In the generated migration, set the `upgrade()` and `downgrade()` bodies to:
+```python
+def upgrade() -> None:
+    op.add_column(
+        "user_power_permissions",
+        sa.Column("can_toggle_desktop", sa.Boolean(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("user_power_permissions") as batch_op:
+        batch_op.drop_column("can_toggle_desktop")
+```
+Leave the auto-generated `revision`, `down_revision`, and the `import sqlalchemy as sa` / `from alembic import op` header as generated. (`server_default="0"` matches the sibling columns and is a valid boolean default on both SQLite and PostgreSQL; `batch_alter_table` on downgrade keeps the drop portable to SQLite.)
+
+- [ ] **Step 5: Apply the migration to the dev DB**
+
+Run (from `backend/`): `python -m alembic upgrade head`
+Expected: completes without error; `python -m alembic heads` again shows the new single head.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/models/power_permissions.py backend/alembic/versions/*_add_can_toggle_desktop*.py
+git commit -m "feat(system-permissions): add can_toggle_desktop column + migration"
+```
+
+---
+
+## Task 2: Schemas
+
+**Files:**
+- Modify: `backend/app/schemas/power_permissions.py`
+
+- [ ] **Step 1: Add the field to all three schemas**
+
+In `backend/app/schemas/power_permissions.py`:
+
+In `UserPowerPermissionsResponse`, after `can_wol: bool = False` (line 16):
+```python
+    can_toggle_desktop: bool = False
+```
+
+In `UserPowerPermissionsUpdate`, after the `can_wol` field (line 30):
+```python
+    can_toggle_desktop: Optional[bool] = Field(default=None, description="Allow toggling the desktop (DPMS on/off)")
+```
+
+In `MyPowerPermissionsResponse`, after `can_wol: bool = False` (line 39):
+```python
+    can_toggle_desktop: bool = False
+```
+
+- [ ] **Step 2: Sanity-check the module imports**
+
+Run (from `backend/`): `python -c "import app.schemas.power_permissions as m; print(m.UserPowerPermissionsUpdate.model_fields.keys())"`
+Expected: the printed keys include `can_toggle_desktop`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/schemas/power_permissions.py
+git commit -m "feat(system-permissions): add can_toggle_desktop to permission schemas"
+```
+
+---
+
+## Task 3: Service layer (get/update + audit, no implication)
+
+**Files:**
+- Modify: `backend/app/services/power_permissions.py`
+- Test: `backend/tests/api/test_power_permissions_routes.py`
+
+- [ ] **Step 1: Write the failing tests (GET/PUT round-trip + no implication)**
+
+Append to `backend/tests/api/test_power_permissions_routes.py`:
+```python
+class TestToggleDesktopPermission:
+    def test_default_is_false(self, client: TestClient, admin_token: str, regular_user: User):
+        resp = client.get(
+            f"/api/users/{regular_user.id}/power-permissions",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["can_toggle_desktop"] is False
+
+    def test_grant_does_not_imply_other_permissions(
+        self, client: TestClient, admin_token: str, regular_user: User,
+    ):
+        resp = client.put(
+            f"/api/users/{regular_user.id}/power-permissions",
+            json={"can_toggle_desktop": True},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["can_toggle_desktop"] is True
+        # independent permission — must NOT pull in any sleep permission
+        assert data["can_soft_sleep"] is False
+        assert data["can_wake"] is False
+        assert data["can_suspend"] is False
+        assert data["can_wol"] is False
+
+    def test_my_permissions_includes_toggle_desktop(self, client: TestClient, user_token: str):
+        resp = client.get(
+            "/api/system/sleep/my-permissions",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["can_toggle_desktop"] is False
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (from `backend/`): `python -m pytest tests/api/test_power_permissions_routes.py::TestToggleDesktopPermission -v`
+Expected: FAIL — `can_toggle_desktop` missing from responses (KeyError / assertion error). The `my_permissions` one already passes via the schema default but the GET/PUT ones fail until the service writes the field.
+
+- [ ] **Step 3: Update `_ACTION_FIELD_MAP`**
+
+In `backend/app/services/power_permissions.py`, in `_ACTION_FIELD_MAP` (lines 17-22), add:
+```python
+    "toggle_desktop": "can_toggle_desktop",
+```
+
+- [ ] **Step 4: Include the field in `get_permissions`**
+
+In `get_permissions`, in the returned `UserPowerPermissionsResponse(...)` (lines 41-50), after `can_wol=perm.can_wol,` add:
+```python
+        can_toggle_desktop=perm.can_toggle_desktop,
+```
+
+- [ ] **Step 5: Handle the field in `update_permissions` (explicit set + audit)**
+
+In `update_permissions`:
+
+In `old_values` (lines 112-117), add:
+```python
+        "can_toggle_desktop": perm.can_toggle_desktop,
+```
+
+In the explicit-updates block, after the `can_wol` handling (lines 141-144), add:
+```python
+    if update.can_toggle_desktop is not None:
+        perm.can_toggle_desktop = update.can_toggle_desktop
+```
+(No `explicit_true`/`explicit_false` tracking — `can_toggle_desktop` is independent of the sleep/suspend implication chains, so it must NOT be passed to `_apply_implications`.)
+
+In `new_values` (lines 160-165), add:
+```python
+        "can_toggle_desktop": perm.can_toggle_desktop,
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run (from `backend/`): `python -m pytest tests/api/test_power_permissions_routes.py -v`
+Expected: PASS — the whole file (existing tests + `TestToggleDesktopPermission`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/power_permissions.py backend/tests/api/test_power_permissions_routes.py
+git commit -m "feat(system-permissions): persist can_toggle_desktop in service + audit"
+```
+
+---
+
+## Task 4: Backend wiring — deps dependency, my-permissions, desktop gating
+
+**Files:**
+- Modify: `backend/app/api/deps.py`
+- Modify: `backend/app/api/routes/sleep.py`
+- Modify: `backend/app/api/routes/desktop.py`
+- Test: `backend/tests/api/test_power_permissions_routes.py`
+
+- [ ] **Step 1: Write the failing delegated-desktop tests**
+
+Append to `backend/tests/api/test_power_permissions_routes.py`:
+```python
+class TestDelegatedDesktopAccess:
+    @pytest.fixture(autouse=True)
+    def _dev_desktop(self):
+        # Force the in-memory dev backend so the endpoint result is
+        # deterministic and cross-platform (no kscreen-doctor / os.getuid()).
+        import app.services.power.desktop as desktop_mod
+        from app.services.power.desktop import DesktopService
+        from app.services.power.desktop_backend import DevDesktopBackend
+        prev = desktop_mod._service
+        desktop_mod._service = DesktopService(backend=DevDesktopBackend())
+        yield
+        desktop_mod._service = prev
+
+    def test_user_without_permission_gets_403(self, client: TestClient, user_token: str):
+        resp = client.post(
+            "/api/system/sleep/desktop/disable",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert resp.status_code == 403
+
+    def test_user_with_permission_can_access(
+        self, client: TestClient, admin_token: str, user_token: str, regular_user: User,
+    ):
+        client.put(
+            f"/api/users/{regular_user.id}/power-permissions",
+            json={"can_toggle_desktop": True},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        resp = client.post(
+            "/api/system/sleep/desktop/disable",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+    def test_admin_still_works(self, client: TestClient, admin_token: str):
+        resp = client.post(
+            "/api/system/sleep/desktop/enable",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code == 200
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (from `backend/`): `python -m pytest tests/api/test_power_permissions_routes.py::TestDelegatedDesktopAccess -v`
+Expected: FAIL — `test_user_without_permission_gets_403` currently gets 200/4xx-other because the endpoint is admin-only via `get_current_admin` (a non-admin gets 403 from `get_current_admin` actually — verify) and the granted-user test gets 403 because the permission isn't wired. The key failing assertion is `test_user_with_permission_can_access` (403 instead of 200). Proceed regardless; Step 6 turns the class green.
+
+- [ ] **Step 3: Add the desktop permission dependency in `deps.py`**
+
+In `backend/app/api/deps.py`, immediately after `require_power_wol = _make_power_dependency("wol")`, add:
+```python
+require_power_toggle_desktop = _make_power_dependency("toggle_desktop")
+```
+
+- [ ] **Step 4: Include `can_toggle_desktop` in `/my-permissions`**
+
+In `backend/app/api/routes/sleep.py`, in `get_my_power_permissions`:
+
+In the admin branch (the `MyPowerPermissionsResponse(can_soft_sleep=True, ...)`), add `can_toggle_desktop=True,`:
+```python
+        return MyPowerPermissionsResponse(
+            can_soft_sleep=True, can_wake=True, can_suspend=True, can_wol=True,
+            can_toggle_desktop=True,
+        )
+```
+
+In the non-admin return, add `can_toggle_desktop=perms.can_toggle_desktop,`:
+```python
+    return MyPowerPermissionsResponse(
+        can_soft_sleep=perms.can_soft_sleep,
+        can_wake=perms.can_wake,
+        can_suspend=perms.can_suspend,
+        can_wol=perms.can_wol,
+        can_toggle_desktop=perms.can_toggle_desktop,
+    )
+```
+
+- [ ] **Step 5: Gate the desktop enable/disable endpoints**
+
+In `backend/app/api/routes/desktop.py`:
+
+Change the deps import line:
+```python
+# from:
+from app.api.deps import get_current_user, get_current_admin
+# to:
+from app.api.deps import get_current_user, require_power_toggle_desktop
+```
+
+In `desktop_disable` and `desktop_enable`, change the auth dependency:
+```python
+# from:
+    current_user=Depends(get_current_admin),
+# to:
+    current_user=Depends(require_power_toggle_desktop),
+```
+Leave `desktop_status` on `Depends(get_current_user)`. Rate-limiting and audit logging stay unchanged. (The audit `log_event` already records `current_user.username`, so a delegated user's desktop action is attributed correctly.)
+
+- [ ] **Step 6: Run the new tests to verify they pass**
+
+Run (from `backend/`): `python -m pytest tests/api/test_power_permissions_routes.py::TestDelegatedDesktopAccess -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Run the desktop route tests to confirm no regression**
+
+Run (from `backend/`): `python -m pytest tests/test_desktop_routes.py -v`
+Expected: PASS (3 tests). These override `get_current_user` to an admin `_User`, so `require_power_toggle_desktop` short-circuits on `role == "admin"` without touching the DB — unchanged behaviour.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/app/api/deps.py backend/app/api/routes/sleep.py backend/app/api/routes/desktop.py backend/tests/api/test_power_permissions_routes.py
+git commit -m "feat(system-permissions): delegate desktop enable/disable via can_toggle_desktop"
+```
+
+---
+
+## Task 5: Frontend API client types
+
+**Files:**
+- Modify: `client/src/api/powerPermissions.ts`
+
+- [ ] **Step 1: Add `can_toggle_desktop` to the three interfaces**
+
+In `client/src/api/powerPermissions.ts`:
+
+In `UserPowerPermissions`, after `can_wol: boolean;` (line 12):
+```ts
+  can_toggle_desktop: boolean;
+```
+
+In `UserPowerPermissionsUpdate`, after `can_wol?: boolean;` (line 22):
+```ts
+  can_toggle_desktop?: boolean;
+```
+
+In `MyPowerPermissions`, after `can_wol: boolean;` (line 29):
+```ts
+  can_toggle_desktop: boolean;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add client/src/api/powerPermissions.ts
+git commit -m "feat(system-permissions): add can_toggle_desktop to frontend API types"
+```
+
+---
+
+## Task 6: i18n locale strings (en + de)
+
+**Files:**
+- Modify: `client/src/i18n/locales/en/admin.json`
+- Modify: `client/src/i18n/locales/de/admin.json`
+
+- [ ] **Step 1: Add the `systemPermissions` block to EN**
+
+In `client/src/i18n/locales/en/admin.json`, inside the top-level `"users"` object (as a sibling of the existing `users.*` keys such as `fields`, `roles`, `buttons`, `placeholders`), add the following key. Ensure valid JSON — add a comma after the preceding sibling, and no trailing comma if this becomes the last key in `users`:
+```json
+    "systemPermissions": {
+      "title": "System Permissions",
+      "description": "Allows this user to perform system actions via the mobile app.",
+      "loading": "Loading system permissions…",
+      "saved": "System permissions updated",
+      "saveError": "Failed to save",
+      "lastChangedBy": "Last changed by {{name}} on {{date}}",
+      "impliedBy": "Implied by {{name}}",
+      "items": {
+        "softSleep": { "label": "Soft Sleep", "desc": "Put the server into soft sleep" },
+        "wake": { "label": "Wake", "desc": "Wake the server from soft sleep" },
+        "suspend": { "label": "Suspend", "desc": "System suspend (S3 sleep)" },
+        "wol": { "label": "Wake-on-LAN", "desc": "Send a WoL magic packet" },
+        "toggleDesktop": { "label": "Desktop", "desc": "Enable/disable the desktop (saves GPU power)" }
+      }
+    }
+```
+
+- [ ] **Step 2: Add the `systemPermissions` block to DE**
+
+In `client/src/i18n/locales/de/admin.json`, inside the top-level `"users"` object (same placement rules as Step 1), add:
+```json
+    "systemPermissions": {
+      "title": "Systemberechtigungen",
+      "description": "Erlaubt diesem User, System-Aktionen über die Mobile App auszuführen.",
+      "loading": "Systemberechtigungen werden geladen…",
+      "saved": "Systemberechtigungen aktualisiert",
+      "saveError": "Fehler beim Speichern",
+      "lastChangedBy": "Zuletzt geändert von {{name}} am {{date}}",
+      "impliedBy": "Impliziert durch {{name}}",
+      "items": {
+        "softSleep": { "label": "Soft Sleep", "desc": "Server in Soft Sleep versetzen" },
+        "wake": { "label": "Wake", "desc": "Server aus Soft Sleep aufwecken" },
+        "suspend": { "label": "Suspend", "desc": "System Suspend (S3 Sleep)" },
+        "wol": { "label": "Wake-on-LAN", "desc": "WoL Magic Packet senden" },
+        "toggleDesktop": { "label": "Desktop", "desc": "Desktop aktivieren/deaktivieren (spart GPU-Strom)" }
+      }
+    }
+```
+
+- [ ] **Step 3: Validate both JSON files parse**
+
+Run (from `client/`):
+```bash
+node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/en/admin.json','utf8')); JSON.parse(require('fs').readFileSync('src/i18n/locales/de/admin.json','utf8')); console.log('JSON OK')"
+```
+Expected: `JSON OK` (no trailing-comma / syntax error).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/i18n/locales/en/admin.json client/src/i18n/locales/de/admin.json
+git commit -m "feat(system-permissions): i18n strings for System Permissions (en+de)"
+```
+
+---
+
+## Task 7: Frontend component — internationalize + add Desktop toggle
+
+**Files:**
+- Modify: `client/src/components/user-management/PowerPermissionsSection.tsx`
+
+- [ ] **Step 1: Replace the component with the i18n + 5-toggle version**
+
+Replace the entire contents of `client/src/components/user-management/PowerPermissionsSection.tsx` with:
+```tsx
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Moon, Sun, Power, Wifi, MonitorOff, Loader2 } from 'lucide-react';
+import {
+  getUserPowerPermissions,
+  updateUserPowerPermissions,
+  type UserPowerPermissions,
+  type UserPowerPermissionsUpdate,
+} from '../../api/powerPermissions';
+import { handleApiError } from '../../lib/errorHandling';
+import toast from 'react-hot-toast';
+
+interface PowerPermissionsSectionProps {
+  userId: number;
+  userRole: string;
+}
+
+interface PermissionToggle {
+  key: keyof UserPowerPermissionsUpdate;
+  icon: React.ReactNode;
+  impliedBy?: keyof UserPowerPermissionsUpdate;
+  implies?: keyof UserPowerPermissionsUpdate;
+}
+
+// Maps an API field name to its i18n item key under
+// admin:users.systemPermissions.items.*
+const FIELD_TO_I18N: Record<string, string> = {
+  can_soft_sleep: 'softSleep',
+  can_wake: 'wake',
+  can_suspend: 'suspend',
+  can_wol: 'wol',
+  can_toggle_desktop: 'toggleDesktop',
+};
+
+const PERMISSION_TOGGLES: PermissionToggle[] = [
+  { key: 'can_soft_sleep', icon: <Moon className="h-4 w-4" />, implies: 'can_wake' },
+  { key: 'can_wake', icon: <Sun className="h-4 w-4" />, impliedBy: 'can_soft_sleep' },
+  { key: 'can_suspend', icon: <Power className="h-4 w-4" />, implies: 'can_wol' },
+  { key: 'can_wol', icon: <Wifi className="h-4 w-4" />, impliedBy: 'can_suspend' },
+  { key: 'can_toggle_desktop', icon: <MonitorOff className="h-4 w-4" /> },
+];
+
+export function PowerPermissionsSection({ userId, userRole }: PowerPermissionsSectionProps) {
+  const { t } = useTranslation('admin');
+  const [permissions, setPermissions] = useState<UserPowerPermissions | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (userRole === 'admin') return;
+    setLoading(true);
+    getUserPowerPermissions(userId)
+      .then(setPermissions)
+      .catch(() => setPermissions(null))
+      .finally(() => setLoading(false));
+  }, [userId, userRole]);
+
+  if (userRole === 'admin') return null;
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 py-3 text-sm text-slate-400">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        {t('users.systemPermissions.loading')}
+      </div>
+    );
+  }
+
+  const handleToggle = async (key: keyof UserPowerPermissionsUpdate, newValue: boolean) => {
+    setSaving(true);
+    try {
+      const update: UserPowerPermissionsUpdate = { [key]: newValue };
+      const result = await updateUserPowerPermissions(userId, update);
+      setPermissions(result);
+      toast.success(t('users.systemPermissions.saved'));
+    } catch (error) {
+      handleApiError(error, t('users.systemPermissions.saveError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const isImplied = (toggle: PermissionToggle): boolean => {
+    if (!toggle.impliedBy || !permissions) return false;
+    return permissions[toggle.impliedBy] === true;
+  };
+
+  return (
+    <div className="border-t border-slate-800 pt-3 mt-3">
+      <h3 className="text-sm font-medium text-slate-300 mb-1">
+        {t('users.systemPermissions.title')}
+      </h3>
+      <p className="text-xs text-slate-500 mb-3">
+        {t('users.systemPermissions.description')}
+      </p>
+
+      <div className="space-y-2">
+        {PERMISSION_TOGGLES.map((toggle) => {
+          const value = permissions?.[toggle.key] ?? false;
+          const implied = isImplied(toggle);
+          const i18nKey = FIELD_TO_I18N[toggle.key];
+
+          return (
+            <div key={toggle.key} className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-slate-400">{toggle.icon}</span>
+                <div>
+                  <span className="text-sm text-slate-200">
+                    {t(`users.systemPermissions.items.${i18nKey}.label`)}
+                  </span>
+                  <span className="text-xs text-slate-500 ml-2">
+                    {t(`users.systemPermissions.items.${i18nKey}.desc`)}
+                  </span>
+                </div>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={value}
+                disabled={saving || implied}
+                onClick={() => handleToggle(toggle.key, !value)}
+                title={
+                  implied && toggle.impliedBy
+                    ? t('users.systemPermissions.impliedBy', {
+                        name: t(`users.systemPermissions.items.${FIELD_TO_I18N[toggle.impliedBy]}.label`),
+                      })
+                    : undefined
+                }
+                className={`relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors
+                  ${value ? 'bg-sky-500' : 'bg-slate-700'}
+                  ${implied ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'}
+                  ${saving ? 'opacity-50' : ''}
+                `}
+              >
+                <span
+                  className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform
+                    ${value ? 'translate-x-4' : 'translate-x-0.5'}
+                  `}
+                />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {permissions?.granted_by_username && (
+        <p className="text-xs text-slate-500 mt-2">
+          {t('users.systemPermissions.lastChangedBy', {
+            name: permissions.granted_by_username,
+            date: permissions.granted_at
+              ? new Date(permissions.granted_at).toLocaleDateString()
+              : '',
+          })}
+        </p>
+      )}
+    </div>
+  );
+}
+```
+(The component keeps its filename and export name `PowerPermissionsSection` — `UserFormModal.tsx` imports it unchanged. Only the user-visible strings change, plus the new 5th toggle.)
+
+- [ ] **Step 2: Type-check / build the frontend**
+
+Run (from `client/`): `npm run build`
+Expected: build succeeds, no TypeScript errors. (A missing `can_toggle_desktop` on the API types from Task 5, or a missing `MonitorOff` import, would surface here.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/components/user-management/PowerPermissionsSection.tsx
+git commit -m "feat(system-permissions): i18n + Desktop toggle in permissions section"
+```
+
+---
+
+## Task 8: CLAUDE.md notes (name mapping)
+
+**Files:**
+- Modify: `backend/app/services/CLAUDE.md`
+- Modify: `backend/app/schemas/CLAUDE.md`
+- Modify: `backend/app/models/CLAUDE.md`
+
+- [ ] **Step 1: services/CLAUDE.md**
+
+In `backend/app/services/CLAUDE.md`, replace the line:
+```
+| `power_permissions.py` | Per-user power action permissions (get, update, check) |
+```
+with:
+```
+| `power_permissions.py` | Per-user power action permissions (get, update, check), incl. `can_toggle_desktop`. UI name: "System Permissions / Systemberechtigungen"; backend identifiers stay `power_permissions` (deliberate — no rename/migration). |
+```
+
+- [ ] **Step 2: schemas/CLAUDE.md**
+
+In `backend/app/schemas/CLAUDE.md`, replace the line:
+```
+**Power Permissions** (`power_permissions.py`): `UserPowerPermissionsResponse`, `UserPowerPermissionsUpdate`, `MyPowerPermissionsResponse` — per-user power action delegation
+```
+with:
+```
+**Power Permissions** (`power_permissions.py`): `UserPowerPermissionsResponse`, `UserPowerPermissionsUpdate`, `MyPowerPermissionsResponse` — per-user power action delegation (incl. `can_toggle_desktop`). UI name: "System Permissions / Systemberechtigungen"; backend stays `power_permissions`.
+```
+
+- [ ] **Step 3: models/CLAUDE.md**
+
+In `backend/app/models/CLAUDE.md`, in the **Power & Hardware** line, replace the trailing fragment:
+```
+`sleep.py`, `smart_device.py`, `power_permissions.py`
+```
+with:
+```
+`sleep.py`, `smart_device.py`, `power_permissions.py` (UI name: "System Permissions / Systemberechtigungen"; table/columns keep the `power_permissions` name)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/services/CLAUDE.md backend/app/schemas/CLAUDE.md backend/app/models/CLAUDE.md
+git commit -m "docs(system-permissions): note UI rename vs kept backend identifiers"
+```
+
+---
+
+## Task 9: Full verification
+
+**Files:** none changed.
+
+- [ ] **Step 1: Backend — run the touched suites**
+
+Run (from `backend/`):
+```bash
+python -m pytest tests/api/test_power_permissions_routes.py tests/test_desktop_routes.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Backend — regression sweep of related areas**
+
+Run (from `backend/`):
+```bash
+python -m pytest tests/api tests/test_desktop_routes.py tests/test_desktop_service.py tests/test_desktop_backend.py -q
+```
+Expected: no new failures. (Per repo memory, two auth/permission delete tests can flake only in the full Windows run; if you see exactly those, re-run them standalone to confirm they pass in isolation. Anything else is a real regression.)
+
+- [ ] **Step 3: Frontend — production build**
+
+Run (from `client/`): `npm run build`
+Expected: build succeeds, no TypeScript errors.
+
+- [ ] **Step 4: Manual smoke (dev)**
+
+Run `python start_dev.py`. As admin, open User Management → edit a **non-admin** user. Confirm:
+- The section heading reads **"System Permissions"** (EN) / **"Systemberechtigungen"** (DE, depending on UI language).
+- Five toggles are shown: Soft Sleep, Wake, Suspend, Wake-on-LAN, **Desktop**.
+- Toggling **Desktop** shows the success toast and persists across reopening the modal.
+- (Optional) `GET /api/system/sleep/my-permissions` (as that user) returns `can_toggle_desktop: true`.
+
+- [ ] **Step 5: Update the vectordb index**
+
+Run the `mcp__vectordb-search__index_update` tool with `projectPath: D:/Programme (x86)/Baluhost` so the new/changed symbols are searchable.
+
+---
+
+## Self-Review notes (already reconciled)
+
+- **Spec coverage:** rename (Tasks 6–8), `can_toggle_desktop` column/schema/service (Tasks 1–3), my-permissions + endpoint gating (Task 4), API client + component + i18n (Tasks 5–7), CLAUDE.md notes (Task 8), tests + verification (Tasks 3/4/9). All spec sections map to a task.
+- **Type consistency:** `can_toggle_desktop` (snake_case) is the single field name across model, schemas, service `_ACTION_FIELD_MAP` value, sleep response, API client, and component `FIELD_TO_I18N`. The permission *action* string is `toggle_desktop` (used by `_make_power_dependency("toggle_desktop")` and the `_ACTION_FIELD_MAP` key). i18n item key is `toggleDesktop`.
+- **No implication:** `can_toggle_desktop` is deliberately excluded from `_apply_implications` and has no `implies`/`impliedBy` in `PERMISSION_TOGGLES`.
+```
+

--- a/docs/superpowers/specs/2026-06-04-system-permissions-desktop-toggle-design.md
+++ b/docs/superpowers/specs/2026-06-04-system-permissions-desktop-toggle-design.md
@@ -1,0 +1,236 @@
+# System Permissions: Rename + Desktop-Toggle Permission — Design
+
+**Date:** 2026-06-04
+**Status:** Approved
+**Author:** Sven (Xveyn) + Claude
+
+## Problem
+
+Admins grant per-user "Power Permissions" in the User-Management edit modal
+(`PowerPermissionsSection`) — four delegated power actions (Soft Sleep, Wake,
+Suspend, Wake-on-LAN) that non-admin users may invoke from client apps (Mobile,
+later BaluDesk). Two gaps:
+
+1. **Naming.** The concept now covers more than power actions. The user-facing
+   name should be **"System Permissions / Systemberechtigungen"**.
+2. **Missing capability.** The KDE desktop toggle (DPMS displays on/off, a recent
+   feature) is **admin-only**. There is no way to delegate it to a non-admin the
+   way sleep/suspend/WoL already are.
+
+Additionally, the existing `PowerPermissionsSection` is **hardcoded German with no
+i18n** — it must be internationalized as part of the rename.
+
+## What already exists (reused)
+
+- **Table** `user_power_permissions` — bools `can_soft_sleep`, `can_wake`,
+  `can_suspend`, `can_wol` + `granted_by`/`granted_at`/`updated_at`
+  (`backend/app/models/power_permissions.py`).
+- **Service** `services/power_permissions.py` — `get_permissions`,
+  `update_permissions` (implication logic + `power_permission_changed` audit
+  event), `check_permission(db, user_id, action)` driven by `_ACTION_FIELD_MAP`.
+- **Schemas** `schemas/power_permissions.py` — `UserPowerPermissionsResponse`,
+  `UserPowerPermissionsUpdate`, `MyPowerPermissionsResponse`.
+- **Admin endpoints** `GET/PUT /api/users/{user_id}/power-permissions`
+  (`get_current_admin`).
+- **Self endpoint** `GET /api/system/sleep/my-permissions` (`get_current_user`),
+  consumed by the Mobile app to decide which buttons to show.
+- **Sleep delegation dependencies** in `deps.py` — `_make_power_dependency(action)`
+  factory + `require_power_soft_sleep` / `_wake` / `_suspend` / `_wol`. Each calls
+  `check_permission(db, user.id, action)`; admins pass unconditionally; failures
+  are audit-logged and return 403.
+- **Desktop feature** `routes/desktop.py` + `services/power/desktop*.py`:
+  `GET /api/system/sleep/desktop/status` (`get_current_user`),
+  `POST .../enable` and `POST .../disable` (**`get_current_admin`**, rate-limited,
+  audit-logged `POWER`/`desktop_enable|disable`). `disable` = `kscreen-doctor
+  --dpms off` (displays off so the dGPU deep-idles); `enable` = displays on. Dev
+  backend toggles in-memory.
+- **Frontend** `PowerPermissionsSection.tsx` rendered in `UserFormModal`
+  (namespace `admin`, keys `users.*`). API client `api/powerPermissions.ts`.
+
+## Decisions (locked)
+
+1. **Rename scope: UI + i18n only.** Backend identifiers (`user_power_permissions`
+   table, `/power-permissions` API path, `power_permissions.py` files, schema/class
+   names) stay unchanged — no migration risk, no breaking change for Mobile/BaluDesk.
+   Add a clarifying note in the relevant backend CLAUDE.md files recording that the
+   user-facing name is "System Permissions" while backend identifiers stay
+   `power_permissions`.
+2. **Desktop permission: a single `can_toggle_desktop`** covering enable AND
+   disable. Desktop on/off is symmetric — no separate "wake" counterpart like
+   sleep — so one column / one switch. **No implication logic.**
+3. **Backend gating: yes.** The desktop `enable`/`disable` endpoints switch from
+   admin-only to **admin OR `can_toggle_desktop`**, consistent with the existing
+   sleep delegation model. A granted non-admin can then toggle the desktop from the
+   Mobile app.
+
+## Architecture
+
+### Backend
+
+**1. Model** (`backend/app/models/power_permissions.py`)
+Add column, mirroring the existing bool columns:
+```python
+can_toggle_desktop: Mapped[bool] = mapped_column(
+    Boolean, nullable=False, default=False, server_default="0"
+)
+```
+
+**2. Alembic migration**
+Add `can_toggle_desktop` to `user_power_permissions` (`server_default="0"`,
+not null). **Chain `down_revision` onto the real `alembic heads`** (run
+`alembic heads` first — do NOT assume the stale dev-DB head; multi-head chains
+broke a prior prod deploy). `upgrade` = `op.add_column(...)`; `downgrade` =
+`op.drop_column(...)`.
+
+**3. Schemas** (`backend/app/schemas/power_permissions.py`)
+- `UserPowerPermissionsResponse`: `can_toggle_desktop: bool = False`
+- `UserPowerPermissionsUpdate`: `can_toggle_desktop: Optional[bool] = Field(default=None, description="Allow toggling the desktop (DPMS on/off)")`
+- `MyPowerPermissionsResponse`: `can_toggle_desktop: bool = False`
+
+**4. Service** (`backend/app/services/power_permissions.py`)
+- `_ACTION_FIELD_MAP`: add `"toggle_desktop": "can_toggle_desktop"`.
+- `get_permissions`: include `can_toggle_desktop` in the returned response.
+- `update_permissions`: apply explicit `update.can_toggle_desktop` when not None;
+  include the field in the `old_values`/`new_values` audit dicts. **No implication**
+  — it is independent of the sleep/suspend chains (the existing `_apply_implications`
+  is untouched).
+
+**5. Sleep route** (`backend/app/api/routes/sleep.py` → `get_my_power_permissions`)
+Include `can_toggle_desktop` in `MyPowerPermissionsResponse`: `True` for admins,
+else from `get_permissions(...)`.
+
+**6. Desktop delegation dependency** (`backend/app/api/deps.py`)
+Add next to the existing power dependencies:
+```python
+require_power_toggle_desktop = _make_power_dependency("toggle_desktop")
+```
+(If `_make_power_dependency`/the `require_power_*` names differ from the design's
+assumption, match whatever is actually in `deps.py` — verify at implementation.)
+
+**7. Desktop route** (`backend/app/api/routes/desktop.py`)
+`desktop_enable` and `desktop_disable`: change
+`current_user = Depends(get_current_admin)` →
+`current_user = Depends(require_power_toggle_desktop)`. `desktop_status` stays
+`get_current_user`. Rate-limiting + audit logging unchanged. Update the imports.
+
+### Frontend
+
+**8. API client** (`client/src/api/powerPermissions.ts`)
+Add `can_toggle_desktop: boolean` to `UserPowerPermissions` and `MyPowerPermissions`;
+`can_toggle_desktop?: boolean` to `UserPowerPermissionsUpdate`.
+
+**9. Component** (`client/src/components/user-management/PowerPermissionsSection.tsx`)
+- **Keep the filename** (preserves git history, stays backend-aligned; invisible
+  to users).
+- Internationalize fully via `useTranslation('admin')` — replace every hardcoded
+  German string with `t('users.systemPermissions.*')`.
+- Heading → System Permissions (i18n). Description → i18n.
+- Restructure `PERMISSION_TOGGLES` so each entry carries a stable `i18nKey`
+  (`softSleep`, `wake`, `suspend`, `wol`, `toggleDesktop`) used to look up
+  `items.<i18nKey>.label` / `.desc`; keep `key` (the API field), `icon`,
+  `impliedBy`/`implies`.
+- Add the 5th toggle: `key: 'can_toggle_desktop'`, `i18nKey: 'toggleDesktop'`,
+  `icon: <MonitorOff className="h-4 w-4" />` (matches the PowerMenu desktop-disable
+  action), no `implies`/`impliedBy`.
+- Loading text, success toast, error toast, and the "last changed by" line all use
+  i18n (with `{{name}}`/`{{date}}` interpolation). The `impliedBy` tooltip uses
+  `t('users.systemPermissions.impliedBy', { name })`.
+
+**10. i18n** (`client/src/i18n/locales/en/admin.json` + `de/admin.json`)
+Merge a `systemPermissions` block under the existing `users` object (do not
+overwrite the files):
+```jsonc
+"systemPermissions": {
+  "title": "System Permissions",                  // DE: "Systemberechtigungen"
+  "description": "Allows this user to perform system actions via the mobile app.",
+  // DE: "Erlaubt diesem User, System-Aktionen über die Mobile App auszuführen."
+  "loading": "Loading system permissions…",        // DE: "Systemberechtigungen werden geladen…"
+  "saved": "System permissions updated",           // DE: "Systemberechtigungen aktualisiert"
+  "saveError": "Failed to save",                   // DE: "Fehler beim Speichern"
+  "lastChangedBy": "Last changed by {{name}} on {{date}}",
+  // DE: "Zuletzt geändert von {{name}} am {{date}}"
+  "impliedBy": "Implied by {{name}}",              // DE: "Impliziert durch {{name}}"
+  "items": {
+    "softSleep":     { "label": "Soft Sleep",   "desc": "Put the server into soft sleep" },
+    "wake":          { "label": "Wake",         "desc": "Wake the server from soft sleep" },
+    "suspend":       { "label": "Suspend",      "desc": "System suspend (S3 sleep)" },
+    "wol":           { "label": "Wake-on-LAN",  "desc": "Send a WoL magic packet" },
+    "toggleDesktop": { "label": "Desktop",      "desc": "Enable/disable the desktop (saves GPU power)" }
+  }
+}
+```
+(German descriptions mirror the current hardcoded strings: "Server in Soft Sleep
+versetzen", "Server aus Soft Sleep aufwecken", "System Suspend (S3 Sleep)", "WoL
+Magic Packet senden", "Desktop aktivieren/deaktivieren (spart GPU-Strom)".)
+The `impliedBy` tooltip replaces the current inline German ternary; pass the
+implied-prerequisite's translated label as `name`.
+
+### Docs
+
+**11. CLAUDE.md note** in `backend/app/services/CLAUDE.md`,
+`backend/app/schemas/CLAUDE.md`, `backend/app/models/CLAUDE.md`: on the
+`power_permissions` line, append a short parenthetical — user-facing name is
+"System Permissions / Systemberechtigungen"; backend identifiers remain
+`power_permissions` (deliberate, no rename/migration).
+
+## Data flow
+
+```
+Admin opens user edit modal
+  → PowerPermissionsSection GET /api/users/{id}/power-permissions  (5 bools)
+  → admin toggles "Desktop"
+  → PUT /api/users/{id}/power-permissions { can_toggle_desktop: true }
+      → service writes column, audit "power_permission_changed" (old/new incl. new field)
+
+Granted non-admin (Mobile app)
+  → GET /api/system/sleep/my-permissions  → { …, can_toggle_desktop: true }
+  → POST /api/system/sleep/desktop/disable
+      → require_power_toggle_desktop: admin? no → check_permission("toggle_desktop") → allowed
+      → kscreen-doctor --dpms off, audit "desktop_disable"
+Ungranted non-admin → 403 (audit authorization_failure)
+Admin → unchanged (always allowed)
+```
+
+## Error handling
+
+- Missing permission → 403 with audit `authorization_failure` (existing
+  `_make_power_dependency` behaviour; no change).
+- Permission PUT failures surface via `handleApiError` → toast (existing).
+- Migration is additive with a server default → safe on existing rows (all default
+  to `false`/denied).
+
+## Testing
+
+- **Backend**
+  - Extend power-permissions route/service tests: GET/PUT round-trip including
+    `can_toggle_desktop`; `my-permissions` includes the field (admin → True,
+    granted user → True, ungranted → False); audit old/new include the field.
+  - Update `tests/test_desktop_routes.py`: with the new dependency, a granted
+    non-admin gets non-403 on enable/disable, an ungranted non-admin gets 403, an
+    admin still succeeds. (Mirror the override pattern already used there.)
+  - `python -m pytest` for the touched files, then a broader run for regressions.
+- **Frontend**
+  - `npm run build` (type-check) — there is no unit harness for this component.
+  - Manual dev smoke: open a non-admin user in the edit modal → "System
+    Permissions" heading, 5 toggles incl. "Desktop"; toggle persists.
+
+## Security review
+
+- Desktop `enable`/`disable` remain authenticated, rate-limited, and audit-logged;
+  the only change is broadening the gate to `admin OR can_toggle_desktop` — a
+  deliberate delegation matching the sleep model. Default-deny preserved (no row /
+  unset = denied).
+- ORM-only; migration adds a column (no raw SQL). New column is a boolean
+  permission flag — not sensitive, no `REDACT_PATTERN` impact.
+- No new secrets, no subprocess/path surface.
+
+## Out of scope
+
+- Renaming backend table/columns/API/files (explicitly deferred — UI rename only).
+- Splitting desktop into separate enable/disable permissions.
+- Mobile app UI changes (the app already reads `my-permissions`; surfacing the new
+  field is a Mobile-repo task).
+- Adding the desktop toggle to the web PowerMenu for delegated users (web stays
+  admin-driven for power; the PowerMenu quick-action is a separate feature).
+```
+


### PR DESCRIPTION
@
## Summary

Renames the user-facing **Power Permissions** feature to **System Permissions / Systemberechtigungen** (UI + i18n only — backend identifiers stay `power_permissions`, no table/API rename, no migration churn) and adds one new grantable permission **`can_toggle_desktop`** that delegates the KDE desktop enable/disable endpoints to non-admins, parallel to the existing sleep/suspend/WoL delegation.

### Backend
- New independent boolean column `can_toggle_desktop` on `user_power_permissions` (migration `73861c57ef63`, chained on head `88a45a963ed9`; additive, `server_default="0"`, portable downgrade). **No implication logic** — granting it does not pull in/out any sleep permission.
- Added to the 3 schemas, the service (`get`/`update`/audit + `_ACTION_FIELD_MAP`), and `GET /system/sleep/my-permissions`.
- `POST /system/sleep/desktop/{enable,disable}` move from admin-only → **admin OR `can_toggle_desktop`** via `require_power_toggle_desktop`. `…/status` stays any-authenticated. Default-deny preserved (no row = denied). Non-admin invocations emit a `delegated_power_action` SECURITY audit event, matching the sleep routes.

### Frontend
- `PowerPermissionsSection` fully internationalized (was hardcoded German), heading renamed to System Permissions, plus a 5th **Desktop** toggle (`MonitorOff`). EN/DE strings under `users.systemPermissions`.

### Docs
- CLAUDE.md notes (`models`/`schemas`/`services`) record the UI-rename-only decision.

Built feature-first via spec → plan → per-layer subagent implementation with spec + code-quality review at each step; final whole-branch review = ready to merge.

## Test Plan
- [x] `tests/api/test_power_permissions_routes.py` + `tests/test_desktop_routes.py` — 18 passed (incl. default-false, no-implication, my-permissions field, delegated desktop access: ungranted→403 / granted→200 / admin→200)
- [x] `npm run build` (client) — type-check clean
- [ ] Manual smoke: admin → User Management → edit a non-admin → "System Permissions" heading + 5 toggles incl. Desktop; toggle persists; `my-permissions` shows `can_toggle_desktop`
- Note: 3 pre-existing `test_desktop_backend.py::test_linux_status_*` failures on Windows (`os.getuid()`) are unrelated — that file is untouched here and passes on the Linux CI runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@