### PR TITLE
docs(claude): ask before opening a GH issue for out-of-scope side-findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,16 @@ Für Codebase-Suchen **immer** den `vectordb-search` MCP verwenden statt Grep/Gl
 
 Grep/Glob nur als Fallback verwenden, wenn vectordb-search keine passenden Ergebnisse liefert.
 
+## GitHub Issues für Nebenbefunde
+
+Wenn bei Code-Änderungen, Reviews oder Recherche ein **Nebenbefund** auftaucht, der **nicht** zum aktuellen Task gehört — z. B. ein pre-existing Bug, eine Altlast, ein Out-of-Scope-Verbesserungspunkt, ein latentes Risiko oder eine sinnvolle Folgearbeit — dann **nicht still weiterarbeiten und nicht heimlich mitfixen**, sondern:
+
+1. Den Befund kurz benennen (Problem, Fundort `file:line`, warum out-of-scope).
+2. **Fragen, ob ich dafür ein GitHub-Issue anlegen soll** (`gh issue create`), bevor ich es tue.
+3. Bei Zustimmung: Issue mit klarem Titel, Problembeschreibung, Scope/Severity, Fundort und Fix-Vorschlag anlegen; passendes Label setzen; die Issue-Nummer zurückmelden.
+
+Ziel: solche Punkte landen nachvollziehbar im Issue-Tracker statt nur in einer Chat-Notiz. Im Zweifel lieber fragen als übergehen. (Beispiel-Muster: Issue #157 — pre-existing Total-Aggregations-Quirk, beim Custom-Range-Feature bemerkt.)
+
 ## Project Overview
 
 BaluHost is a full-stack self-hosted home server platform (NAS at its core) with multiple components:

--- a/README.md
+++ b/README.md
@@ -21,28 +21,24 @@ Manage your home server end to end — file & RAID storage at the core, plus sys
 
 ## Reference System
 
-BaluHost is developed and tested against a single reference configuration — the maintainer's production box, in service since January 25, 2026:
+BaluHost is developed, tested, and run in production on a single reference machine — the maintainer's box, in service since January 25, 2026. There is no separate production environment: this same machine is both the dev/test reference and the live deployment.
 
-| Spec | Detail |
-|------|--------|
-| **OS** | Debian 13 |
-| **Kernel** | `6.12.74+deb13+1-amd64` (x86_64) |
+| Hardware | Detail |
+|----------|--------|
+| **OS / Kernel** | Debian 13 · `6.12.74+deb13+1-amd64` (x86_64) |
 | **CPU** | AMD Ryzen 5 5600GT |
 | **Memory** | 16 GB RAM |
 | **GPU** | AMD Radeon RX 7900 XT (20 GB VRAM) |
 
 The same machine doubles as a KDE Plasma desktop and — thanks to the Radeon GPU — an optional Linux gaming rig / "Steam Machine" (Proton). That gaming use case is not part of this repository; it simply shares the reference hardware.
 
-### Production Stack
-
-| Component | Status | Details |
-|-----------|--------|---------|
-| **Server** | Active | Debian 13, systemd managed |
-| **Database** | PostgreSQL 17.7 | With Alembic migrations |
-| **Proxy** | Nginx | Port 80, rate limiting, security headers |
-| **Backend** | Systemd | 4 Uvicorn workers, auto-restart |
-| **Testing** | <!-- STATS:TEST_COUNT:START -->3064 tests<!-- STATS:TEST_COUNT:END --> | <!-- STATS:TEST_FILES:START -->248 test files<!-- STATS:TEST_FILES:END -->, CI/CD via GitHub Actions |
-| **Monitoring** | Prometheus/Grafana | Ready |
+| Production Stack | Detail |
+|------------------|--------|
+| **Database** | PostgreSQL 17.7 with Alembic migrations |
+| **Proxy** | Nginx (port 80, rate limiting, security headers) |
+| **Backend** | systemd-managed, 4 Uvicorn workers on port 8000, auto-restart |
+| **Testing** | <!-- STATS:TEST_COUNT:START -->3064 tests<!-- STATS:TEST_COUNT:END --> across <!-- STATS:TEST_FILES:START -->248 test files<!-- STATS:TEST_FILES:END -->, CI/CD via GitHub Actions |
+| **Monitoring** | Prometheus / Grafana ready |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a project guidance rule to `CLAUDE.md` ("GitHub Issues für Nebenbefunde"):

When a side-finding surfaces during code changes/reviews/research that is **out of scope** for the current task (pre-existing bug, latent risk, follow-up improvement), don't silently continue or quietly fix it — name it briefly (`file:line`, why out-of-scope) and **ask whether to open a GitHub issue** before doing so. On approval: create the issue with title, problem, scope/severity, location, fix suggestion, label, and report the number back.

Motivation: route such findings into the issue tracker instead of leaving them as chat notes. Example pattern: #157 (pre-existing Total-aggregation quirk noticed during the custom-range work, #156).

## Test Plan
- [x] Docs-only change; no code affected