### PR TITLE
fix(energy): import-aware, gap-capped consumption integration (over-reported by ~76%)

### DIFF
--- a/backend/app/services/power/energy.py
+++ b/backend/app/services/power/energy.py
@@ -218,7 +218,9 @@ def get_period_stats(
     if not samples:
         return None
 
-    # Parse all samples (keep timestamps for integration)
+    # Parse all samples (keep timestamps for integration). We can't reuse
+    # _load_parsed_online_sorted here because stats also need the OFFLINE
+    # samples for uptime_percentage / downtime_minutes.
     parsed = []
     for s in samples:
         p = _parse_power_from_sample(s.data_json)

--- a/backend/app/services/power/energy.py
+++ b/backend/app/services/power/energy.py
@@ -125,7 +125,10 @@ def _interval_energy_wh(prev: Dict, cur: Dict) -> float:
     ``bucket_energy_kwh``).
 
     - Imported buckets contribute their own measured ``bucket_energy_kwh``
-      (no integration, independent of the gap to ``prev``).
+      (no integration, independent of the gap to ``prev``). A malformed import
+      lacking ``bucket_energy_kwh`` falls through to the live path below and,
+      at hourly+ spacing, is gap-zeroed — a deliberate conservative under-count
+      (never invents energy).
     - Live samples are trapezoid-integrated only when the gap to ``prev`` is
       within ``GAP_THRESHOLD_MINUTES``; larger gaps are treated as downtime
       (0 Wh — the poller was down / device asleep, drawing ~0).

--- a/backend/app/services/power/energy.py
+++ b/backend/app/services/power/energy.py
@@ -120,13 +120,17 @@ def _parse_power_from_sample(data_json: str) -> Optional[Dict]:
 def _interval_energy_wh(prev: Dict, cur: Dict) -> float:
     """Energy in Wh attributed to the interval ending at ``cur``.
 
+    ``prev`` and ``cur`` are parsed sample dicts (from ``_parse_power_from_sample``,
+    so they always carry ``timestamp``, ``watts``, ``imported`` and
+    ``bucket_energy_kwh``).
+
     - Imported buckets contribute their own measured ``bucket_energy_kwh``
       (no integration, independent of the gap to ``prev``).
     - Live samples are trapezoid-integrated only when the gap to ``prev`` is
       within ``GAP_THRESHOLD_MINUTES``; larger gaps are treated as downtime
       (0 Wh — the poller was down / device asleep, drawing ~0).
     """
-    if cur.get("imported") and cur.get("bucket_energy_kwh") is not None:
+    if cur["imported"] and cur["bucket_energy_kwh"] is not None:
         return cur["bucket_energy_kwh"] * 1000.0
     gap_h = (cur["timestamp"] - prev["timestamp"]).total_seconds() / 3600.0
     if gap_h * 60.0 > GAP_THRESHOLD_MINUTES:
@@ -436,6 +440,7 @@ def _device_cumulative_series(parsed: List[Dict]) -> tuple[List[Dict], float]:
 
     Returns (points, total_wh); points are
     {"timestamp": datetime, "cumulative_kwh": float, "instant_watts": float}.
+    Energy is accumulated internally in Wh and converted to kWh per point.
     """
     points: List[Dict] = []
     cumulative_wh = 0.0
@@ -451,7 +456,7 @@ def _device_cumulative_series(parsed: List[Dict]) -> tuple[List[Dict], float]:
 
 
 def _downsample(data_points: List[Dict], max_points: int = 200) -> List[Dict]:
-    """Evenly thin a list of chart points down to at most max_points."""
+    """Evenly thin a list of chart points to ~max_points (first and last kept)."""
     if len(data_points) <= max_points:
         return data_points
     step = len(data_points) // max_points

--- a/backend/app/services/power/energy.py
+++ b/backend/app/services/power/energy.py
@@ -567,20 +567,19 @@ def get_cumulative_energy_total(
     start: Optional[datetime] = None,
     end: Optional[datetime] = None,
 ) -> Dict:
-    """
-    Aggregate cumulative energy across all active power-monitoring devices.
+    """Aggregate cumulative energy across all active power-monitoring devices.
 
-    Args:
-        db: Database session
-        period: 'today', 'week', or 'month'
-        cost_per_kwh: Cost per kWh for cost calculation
-        start: Optional explicit window start (keyword-only); overrides period
-        end: Optional explicit window end (keyword-only); overrides period
-
-    Returns:
-        Dict with aggregated totals and data_points array
+    Builds each device's full-resolution cumulative curve (import-aware,
+    gap-capped) and sums them via carry-forward over the merged timeline, so
+    the Total equals the exact sum of per-device totals.
     """
-    # Fetch all active devices, filter for power_monitor capability in Python
+    now = datetime.now(timezone.utc)
+    if start is not None and end is not None:
+        start_time, end_time, period_label = start, end, "custom"
+    else:
+        start_time, end_time = _resolve_period_range(period, now)
+        period_label = period
+
     all_devices = db.query(SmartDevice).filter(
         SmartDevice.is_active == True,  # noqa: E712
     ).all()
@@ -589,67 +588,64 @@ def get_cumulative_energy_total(
         if isinstance(d.capabilities, list) and _POWER_CAPABILITY in d.capabilities
     ]
 
-    period_label = "custom" if (start is not None and end is not None) else period
+    def _result(total_kwh: float, data_points: List[Dict]) -> Dict:
+        return {
+            "device_id": 0,
+            "device_name": "Total",
+            "period": period_label,
+            "cost_per_kwh": cost_per_kwh,
+            "currency": "EUR",
+            "total_kwh": round(total_kwh, 4),
+            "total_cost": round(total_kwh * cost_per_kwh, 2),
+            "data_points": data_points,
+        }
 
-    empty_result = {
-        "device_id": 0,
-        "device_name": "Total",
-        "period": period_label,
-        "cost_per_kwh": cost_per_kwh,
-        "currency": "EUR",
-        "total_kwh": 0.0,
-        "total_cost": 0.0,
-        "data_points": [],
-    }
+    # Per-device full-resolution series
+    device_series: List[List[Dict]] = []
+    for d in power_devices:
+        parsed = _load_parsed_online_sorted(db, d.id, start_time, end_time)
+        series, _ = _device_cumulative_series(parsed)
+        if series:
+            device_series.append(series)
 
-    if not power_devices:
-        return empty_result
+    if not device_series:
+        if start is not None and end is not None:
+            return _result(0.0, [
+                {"timestamp": start_time.isoformat(), "cumulative_kwh": 0.0,
+                 "cumulative_cost": 0.0, "instant_watts": 0.0},
+                {"timestamp": end_time.isoformat(), "cumulative_kwh": 0.0,
+                 "cumulative_cost": 0.0, "instant_watts": 0.0},
+            ])
+        return _result(0.0, [])
 
-    # Collect instant_watts per timestamp from all devices
-    watts_by_ts: Dict[str, float] = {}
-    for device in power_devices:
-        device_data = get_cumulative_energy_data(
-            db, device.id, period, cost_per_kwh, start=start, end=end,
+    # Carry-forward sum across devices over the merged timeline
+    threshold = timedelta(minutes=GAP_THRESHOLD_MINUTES)
+    all_ts = sorted({p["timestamp"] for s in device_series for p in s})
+    n = len(device_series)
+    idx = [0] * n
+    last_cum = [0.0] * n
+    last_w = [0.0] * n
+    last_w_ts: List[Optional[datetime]] = [None] * n
+
+    data_points: List[Dict] = []
+    for ts in all_ts:
+        for k, s in enumerate(device_series):
+            while idx[k] < len(s) and s[idx[k]]["timestamp"] <= ts:
+                last_cum[k] = s[idx[k]]["cumulative_kwh"]
+                last_w[k] = s[idx[k]]["instant_watts"]
+                last_w_ts[k] = s[idx[k]]["timestamp"]
+                idx[k] += 1
+        combined_cum = sum(last_cum)
+        combined_w = sum(
+            last_w[k] if (last_w_ts[k] is not None and ts - last_w_ts[k] <= threshold) else 0.0
+            for k in range(n)
         )
-        if device_data is None:
-            continue
-        for point in device_data.get("data_points", []):
-            ts = point["timestamp"]
-            watts_by_ts[ts] = watts_by_ts.get(ts, 0.0) + point["instant_watts"]
-
-    if not watts_by_ts:
-        return empty_result
-
-    # Re-compute cumulative via trapezoidal integration on summed watts
-    sorted_ts = sorted(watts_by_ts.keys())
-    data_points = []
-    cumulative_wh = 0.0
-
-    for i, ts in enumerate(sorted_ts):
-        if i > 0:
-            prev_ts = sorted_ts[i - 1]
-            t0 = datetime.fromisoformat(prev_ts)
-            t1 = datetime.fromisoformat(ts)
-            hours = (t1 - t0).total_seconds() / 3600
-            avg_watts = (watts_by_ts[prev_ts] + watts_by_ts[ts]) / 2
-            cumulative_wh += avg_watts * hours
-
-        cumulative_kwh = cumulative_wh / 1000
         data_points.append({
-            "timestamp": ts,
-            "cumulative_kwh": round(cumulative_kwh, 4),
-            "cumulative_cost": round(cumulative_kwh * cost_per_kwh, 4),
-            "instant_watts": round(watts_by_ts[ts], 1),
+            "timestamp": ts.isoformat(),
+            "cumulative_kwh": round(combined_cum, 4),
+            "cumulative_cost": round(combined_cum * cost_per_kwh, 4),
+            "instant_watts": round(combined_w, 1),
         })
 
-    total_kwh = cumulative_wh / 1000
-    return {
-        "device_id": 0,
-        "device_name": "Total",
-        "period": period_label,
-        "cost_per_kwh": cost_per_kwh,
-        "currency": "EUR",
-        "total_kwh": round(total_kwh, 3),
-        "total_cost": round(total_kwh * cost_per_kwh, 2),
-        "data_points": data_points,
-    }
+    total_kwh = sum(last_cum)  # final cumulative == sum of device totals
+    return _result(total_kwh, _downsample(data_points))

--- a/backend/app/services/power/energy.py
+++ b/backend/app/services/power/energy.py
@@ -24,6 +24,11 @@ logger = logging.getLogger(__name__)
 # The capability name used by power-monitoring plugins
 _POWER_CAPABILITY = "power_monitor"
 
+# A live-sample gap longer than this is treated as downtime: the trapezoidal
+# integration does NOT bridge it (the poller was down / device asleep, ~0 draw).
+# Imported buckets carry their own energy and are exempt from this cap.
+GAP_THRESHOLD_MINUTES = 15
+
 
 class EnergyPeriod:
     """Energy consumption statistics for a time period."""
@@ -99,13 +104,34 @@ def _parse_power_from_sample(data_json: str) -> Optional[Dict]:
 
     is_online = data.get("is_online", True)
 
+    bucket_energy_kwh = data.get("bucket_energy_kwh")
+
     return {
         "watts": float(watts),
         "voltage": float(voltage) if voltage is not None else None,
         "current": current_a,
         "energy_today": energy_today_kwh,
         "is_online": bool(is_online),
+        "imported": bool(data.get("imported_from")),
+        "bucket_energy_kwh": float(bucket_energy_kwh) if bucket_energy_kwh is not None else None,
     }
+
+
+def _interval_energy_wh(prev: Dict, cur: Dict) -> float:
+    """Energy in Wh attributed to the interval ending at ``cur``.
+
+    - Imported buckets contribute their own measured ``bucket_energy_kwh``
+      (no integration, independent of the gap to ``prev``).
+    - Live samples are trapezoid-integrated only when the gap to ``prev`` is
+      within ``GAP_THRESHOLD_MINUTES``; larger gaps are treated as downtime
+      (0 Wh — the poller was down / device asleep, drawing ~0).
+    """
+    if cur.get("imported") and cur.get("bucket_energy_kwh") is not None:
+        return cur["bucket_energy_kwh"] * 1000.0
+    gap_h = (cur["timestamp"] - prev["timestamp"]).total_seconds() / 3600.0
+    if gap_h * 60.0 > GAP_THRESHOLD_MINUTES:
+        return 0.0
+    return (prev["watts"] + cur["watts"]) / 2.0 * gap_h
 
 
 def save_power_sample(

--- a/backend/app/services/power/energy.py
+++ b/backend/app/services/power/energy.py
@@ -213,17 +213,17 @@ def get_period_stats(
             SmartDeviceSample.timestamp >= start_time,
             SmartDeviceSample.timestamp <= end_time,
         )
-    ).all()
+    ).order_by(SmartDeviceSample.timestamp).all()
 
     if not samples:
         return None
 
-    # Parse all samples
+    # Parse all samples (keep timestamps for integration)
     parsed = []
     for s in samples:
         p = _parse_power_from_sample(s.data_json)
         if p is not None:
-            parsed.append(p)
+            parsed.append({"timestamp": s.timestamp, **p})
 
     if not parsed:
         return None
@@ -241,8 +241,8 @@ def get_period_stats(
         min_watts = 0.0
         max_watts = 0.0
 
-    period_hours = (end_time - start_time).total_seconds() / 3600
-    total_energy_kwh = (avg_watts / 1000) * period_hours if online_samples else 0.0
+    _, total_wh = _device_cumulative_series(online_samples)
+    total_energy_kwh = total_wh / 1000.0
 
     uptime_percentage = (len(online_samples) / samples_count * 100) if samples_count > 0 else 0.0
 

--- a/backend/app/services/power/energy.py
+++ b/backend/app/services/power/energy.py
@@ -412,6 +412,56 @@ def _resolve_period_range(period: str, now: datetime) -> tuple[datetime, datetim
     return start, now
 
 
+def _load_parsed_online_sorted(db: Session, device_id: int,
+                               start_time: datetime, end_time: datetime) -> List[Dict]:
+    """Query power samples in [start, end], parse, keep online, sorted by time."""
+    samples = db.query(SmartDeviceSample).filter(
+        and_(
+            SmartDeviceSample.device_id == device_id,
+            SmartDeviceSample.capability == _POWER_CAPABILITY,
+            SmartDeviceSample.timestamp >= start_time,
+            SmartDeviceSample.timestamp <= end_time,
+        )
+    ).order_by(SmartDeviceSample.timestamp).all()
+    parsed: List[Dict] = []
+    for s in samples:
+        p = _parse_power_from_sample(s.data_json)
+        if p is not None and p["is_online"]:
+            parsed.append({"timestamp": s.timestamp, **p})
+    return parsed
+
+
+def _device_cumulative_series(parsed: List[Dict]) -> tuple[List[Dict], float]:
+    """Full-resolution cumulative series from online, time-sorted samples.
+
+    Returns (points, total_wh); points are
+    {"timestamp": datetime, "cumulative_kwh": float, "instant_watts": float}.
+    """
+    points: List[Dict] = []
+    cumulative_wh = 0.0
+    for i, s in enumerate(parsed):
+        if i > 0:
+            cumulative_wh += _interval_energy_wh(parsed[i - 1], s)
+        points.append({
+            "timestamp": s["timestamp"],
+            "cumulative_kwh": cumulative_wh / 1000.0,
+            "instant_watts": s["watts"],
+        })
+    return points, cumulative_wh
+
+
+def _downsample(data_points: List[Dict], max_points: int = 200) -> List[Dict]:
+    """Evenly thin a list of chart points down to at most max_points."""
+    if len(data_points) <= max_points:
+        return data_points
+    step = len(data_points) // max_points
+    out = [data_points[0]]
+    for i in range(step, len(data_points) - 1, step):
+        out.append(data_points[i])
+    out.append(data_points[-1])
+    return out
+
+
 def get_cumulative_energy_data(
     db: Session,
     device_id: int,
@@ -447,21 +497,7 @@ def get_cumulative_energy_data(
         start_time, end_time = _resolve_period_range(period, now)
         period_label = period
 
-    samples = db.query(SmartDeviceSample).filter(
-        and_(
-            SmartDeviceSample.device_id == device_id,
-            SmartDeviceSample.capability == _POWER_CAPABILITY,
-            SmartDeviceSample.timestamp >= start_time,
-            SmartDeviceSample.timestamp <= end_time,
-        )
-    ).order_by(SmartDeviceSample.timestamp).all()
-
-    # Parse and filter online samples
-    parsed_samples = []
-    for s in samples:
-        p = _parse_power_from_sample(s.data_json)
-        if p is not None and p["is_online"]:
-            parsed_samples.append({"timestamp": s.timestamp, **p})
+    parsed_samples = _load_parsed_online_sorted(db, device_id, start_time, end_time)
 
     if not parsed_samples:
         if start is not None and end is not None:
@@ -492,40 +528,20 @@ def get_cumulative_energy_data(
             "data_points": []
         }
 
-    # Calculate cumulative energy using trapezoidal integration
-    data_points = []
-    cumulative_wh = 0.0
+    series, total_wh = _device_cumulative_series(parsed_samples)
+    data_points = [
+        {
+            "timestamp": p["timestamp"].isoformat(),
+            "cumulative_kwh": round(p["cumulative_kwh"], 4),
+            "cumulative_cost": round(p["cumulative_kwh"] * cost_per_kwh, 4),
+            "instant_watts": round(p["instant_watts"], 1),
+        }
+        for p in series
+    ]
+    data_points = _downsample(data_points)
 
-    for i, sample in enumerate(parsed_samples):
-        if i > 0:
-            prev = parsed_samples[i - 1]
-            time_diff_hours = (sample["timestamp"] - prev["timestamp"]).total_seconds() / 3600
-            avg_power = (prev["watts"] + sample["watts"]) / 2
-            cumulative_wh += avg_power * time_diff_hours
-
-        cumulative_kwh = cumulative_wh / 1000
-        cumulative_cost = cumulative_kwh * cost_per_kwh
-
-        data_points.append({
-            "timestamp": sample["timestamp"].isoformat(),
-            "cumulative_kwh": round(cumulative_kwh, 4),
-            "cumulative_cost": round(cumulative_cost, 4),
-            "instant_watts": round(sample["watts"], 1)
-        })
-
-    # Downsample if too many points
-    max_points = 200
-    if len(data_points) > max_points:
-        step = len(data_points) // max_points
-        downsampled = [data_points[0]]
-        for i in range(step, len(data_points) - 1, step):
-            downsampled.append(data_points[i])
-        downsampled.append(data_points[-1])
-        data_points = downsampled
-
-    total_kwh = cumulative_wh / 1000
+    total_kwh = total_wh / 1000.0
     total_cost = total_kwh * cost_per_kwh
-
     return {
         "device_id": device_id,
         "device_name": device.name,
@@ -534,7 +550,7 @@ def get_cumulative_energy_data(
         "currency": "EUR",
         "total_kwh": round(total_kwh, 4),
         "total_cost": round(total_cost, 2),
-        "data_points": data_points
+        "data_points": data_points,
     }
 
 

--- a/backend/tests/services/test_energy_service.py
+++ b/backend/tests/services/test_energy_service.py
@@ -410,3 +410,27 @@ class TestTotalEqualsSumOfDevices:
                                             start=now - timedelta(hours=2), end=now)
         assert total["period"] == "custom"
         assert total["total_kwh"] == pytest.approx(a["total_kwh"] + b["total_kwh"], abs=1e-6)
+
+
+class TestPeriodStatsEnergyMatchesIntegration:
+    def test_period_total_does_not_bridge_gaps(self, db_session, smart_device):
+        now = datetime.now(timezone.utc)
+        _add_sample(db_session, smart_device.id, now - timedelta(hours=2), 100.0)
+        _add_sample(db_session, smart_device.id, now, 100.0)
+        db_session.commit()
+        stats = get_period_stats(db_session, smart_device.id,
+                                 now - timedelta(hours=3), now)
+        assert stats is not None
+        assert stats.total_energy_kwh == pytest.approx(0.0, abs=1e-6)
+
+    def test_period_total_matches_cumulative(self, db_session, smart_device):
+        now = datetime.now(timezone.utc)
+        for i in range(7):
+            _add_sample(db_session, smart_device.id,
+                        now - timedelta(minutes=60 - i * 10), 90.0)
+        db_session.commit()
+        stats = get_period_stats(db_session, smart_device.id,
+                                 now - timedelta(hours=2), now)
+        cum = get_cumulative_energy_data(db_session, smart_device.id, "today", 0.40,
+                                         start=now - timedelta(hours=2), end=now)
+        assert stats.total_energy_kwh == pytest.approx(cum["total_kwh"], abs=1e-6)

--- a/backend/tests/services/test_energy_service.py
+++ b/backend/tests/services/test_energy_service.py
@@ -383,3 +383,30 @@ class TestCumulativeTotalCustomRange:
         assert result["total_kwh"] == 0.0
         assert len(result["data_points"]) == 2
         assert result["data_points"][0]["timestamp"] == start.isoformat()
+
+
+class TestTotalEqualsSumOfDevices:
+    def test_total_equals_sum_of_device_totals(self, db_session):
+        now = datetime.now(timezone.utc)
+        dev_a = SmartDevice(name="A", plugin_name="tapo_smart_plug",
+                            device_type_id="tapo_p110", address="10.0.0.1",
+                            capabilities=["power_monitor"], is_active=True,
+                            is_online=True, created_by_user_id=1)
+        dev_b = SmartDevice(name="B", plugin_name="tapo_smart_plug",
+                            device_type_id="tapo_p110", address="10.0.0.2",
+                            capabilities=["power_monitor"], is_active=True,
+                            is_online=True, created_by_user_id=1)
+        db_session.add_all([dev_a, dev_b]); db_session.commit()
+        for i in range(7):
+            _add_sample(db_session, dev_a.id, now - timedelta(minutes=60 - i * 10), 100.0)
+            _add_sample(db_session, dev_b.id, now - timedelta(minutes=55 - i * 10), 50.0)
+        db_session.commit()
+
+        a = get_cumulative_energy_data(db_session, dev_a.id, "today", 0.40,
+                                       start=now - timedelta(hours=2), end=now)
+        b = get_cumulative_energy_data(db_session, dev_b.id, "today", 0.40,
+                                       start=now - timedelta(hours=2), end=now)
+        total = get_cumulative_energy_total(db_session, "today", 0.40,
+                                            start=now - timedelta(hours=2), end=now)
+        assert total["period"] == "custom"
+        assert total["total_kwh"] == pytest.approx(a["total_kwh"] + b["total_kwh"], abs=1e-6)

--- a/backend/tests/services/test_energy_service.py
+++ b/backend/tests/services/test_energy_service.py
@@ -65,6 +65,48 @@ class TestIntervalEnergyPrimitive:
         assert _interval_energy_wh(prev, cur) == 0.0
 
 
+def _add_sample(db, device_id, ts, watts=None, *, imported=False, bucket_kwh=None, online=True):
+    if imported:
+        data = {"watts": watts if watts is not None else 0.0, "is_online": online,
+                "imported_from": "tapo_history", "bucket_interval": "hourly",
+                "bucket_energy_kwh": bucket_kwh}
+    else:
+        data = {"current_power": watts if watts is not None else 0.0, "is_online": online}
+    db.add(SmartDeviceSample(device_id=device_id, capability="power_monitor",
+                             data_json=json.dumps(data), timestamp=ts))
+
+
+class TestCumulativeGapAndImport:
+    def test_long_gap_is_not_bridged(self, db_session, smart_device):
+        now = datetime.now(timezone.utc)
+        _add_sample(db_session, smart_device.id, now - timedelta(hours=2), 100.0)
+        _add_sample(db_session, smart_device.id, now, 100.0)
+        db_session.commit()
+        res = get_cumulative_energy_data(db_session, smart_device.id, "today", 0.40,
+                                         start=now - timedelta(hours=3), end=now)
+        assert res["total_kwh"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_short_gap_is_integrated(self, db_session, smart_device):
+        now = datetime.now(timezone.utc)
+        _add_sample(db_session, smart_device.id, now - timedelta(minutes=10), 120.0)
+        _add_sample(db_session, smart_device.id, now, 120.0)
+        db_session.commit()
+        res = get_cumulative_energy_data(db_session, smart_device.id, "today", 0.40,
+                                         start=now - timedelta(hours=1), end=now)
+        assert res["total_kwh"] == pytest.approx(120.0 * (10 / 60) / 1000, abs=1e-6)
+
+    def test_imported_bucket_counts_own_energy(self, db_session, smart_device):
+        now = datetime.now(timezone.utc)
+        _add_sample(db_session, smart_device.id, now - timedelta(hours=2),
+                    imported=True, bucket_kwh=0.1)
+        _add_sample(db_session, smart_device.id, now - timedelta(hours=1),
+                    imported=True, bucket_kwh=0.1)
+        db_session.commit()
+        res = get_cumulative_energy_data(db_session, smart_device.id, "today", 0.40,
+                                         start=now - timedelta(hours=3), end=now)
+        assert res["total_kwh"] == pytest.approx(0.1, abs=1e-6)
+
+
 @pytest.fixture
 def smart_device(db_session) -> SmartDevice:
     """Create a mock SmartDevice for testing."""

--- a/backend/tests/services/test_energy_service.py
+++ b/backend/tests/services/test_energy_service.py
@@ -23,7 +23,46 @@ from app.services.power.energy import (
     get_cumulative_energy_data,
     get_cumulative_energy_total,
     get_hourly_samples,
+    _parse_power_from_sample,
+    _interval_energy_wh,
+    GAP_THRESHOLD_MINUTES,
 )
+
+
+class TestIntervalEnergyPrimitive:
+    def test_parse_exposes_import_fields(self):
+        live = _parse_power_from_sample(json.dumps({"current_power": 50.0, "is_online": True}))
+        assert live["imported"] is False
+        assert live["bucket_energy_kwh"] is None
+
+        imp = _parse_power_from_sample(json.dumps({
+            "watts": 100.0, "is_online": True,
+            "imported_from": "tapo_history", "bucket_energy_kwh": 0.1,
+        }))
+        assert imp["imported"] is True
+        assert imp["bucket_energy_kwh"] == 0.1
+
+    def test_imported_bucket_uses_own_energy(self):
+        t0 = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        prev = {"timestamp": t0, "watts": 0.0, "imported": False, "bucket_energy_kwh": None}
+        cur = {"timestamp": t0 + timedelta(days=5), "watts": 100.0,
+               "imported": True, "bucket_energy_kwh": 0.1}
+        assert _interval_energy_wh(prev, cur) == pytest.approx(100.0)
+
+    def test_live_within_cap_is_integrated(self):
+        t0 = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        prev = {"timestamp": t0, "watts": 100.0, "imported": False, "bucket_energy_kwh": None}
+        cur = {"timestamp": t0 + timedelta(minutes=10), "watts": 100.0,
+               "imported": False, "bucket_energy_kwh": None}
+        assert _interval_energy_wh(prev, cur) == pytest.approx(100.0 * (10 / 60))
+
+    def test_live_gap_beyond_cap_is_zero(self):
+        t0 = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        prev = {"timestamp": t0, "watts": 200.0, "imported": False, "bucket_energy_kwh": None}
+        cur = {"timestamp": t0 + timedelta(hours=2), "watts": 200.0,
+               "imported": False, "bucket_energy_kwh": None}
+        assert GAP_THRESHOLD_MINUTES == 15
+        assert _interval_energy_wh(prev, cur) == 0.0
 
 
 @pytest.fixture

--- a/docs/superpowers/plans/2026-06-05-energy-consumption-gap-integration.md
+++ b/docs/superpowers/plans/2026-06-05-energy-consumption-gap-integration.md
@@ -1,0 +1,613 @@
+# Energy Consumption — Import-Aware, Gap-Capped Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the over-reported energy consumption by integrating power samples import-aware and gap-capped, and computing the Total as the sum of per-device curves (not a timestamp merge).
+
+**Architecture:** All work is in one service file. A small per-interval energy primitive (`_interval_energy_wh`) plus two helpers (`_load_parsed_online_sorted`, `_device_cumulative_series`) become the single source of truth; `get_cumulative_energy_data`, `get_cumulative_energy_total`, and `get_period_stats` all route through them. Everything is computed on-read, so the fix retroactively corrects all displayed numbers with no migration.
+
+**Tech Stack:** Python, SQLAlchemy, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-energy-consumption-gap-integration-design.md`
+**Issue:** #159 (closes #157)
+
+---
+
+## File Structure
+
+- Modify: `backend/app/services/power/energy.py` — constant, parse extension, the integration primitive + helpers, and rewire the three public functions.
+- Test (extend): `backend/tests/services/test_energy_service.py`
+
+No new files; the change is cohesive and belongs in the existing energy service.
+
+---
+
+## Task 1: Primitives — constant, parse fields, `_interval_energy_wh`
+
+**Files:**
+- Modify: `backend/app/services/power/energy.py` (constant near line 25; `_parse_power_from_sample` return dict ~line 102; new helper after it)
+- Test: `backend/tests/services/test_energy_service.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `backend/tests/services/test_energy_service.py`. Note: `json`, `pytest`, and `datetime, timedelta, timezone` are already imported at the top of this file, as are `SmartDevice`, `SmartDeviceSample`, `get_period_stats`, and `get_cumulative_energy_data`. Add ONLY the new imports below to the top-of-file import block (do not duplicate existing ones):
+
+```python
+from app.services.power.energy import _parse_power_from_sample, _interval_energy_wh, GAP_THRESHOLD_MINUTES
+```
+
+Then add this test class:
+
+```python
+class TestIntervalEnergyPrimitive:
+    def test_parse_exposes_import_fields(self):
+        live = _parse_power_from_sample(json.dumps({"current_power": 50.0, "is_online": True}))
+        assert live["imported"] is False
+        assert live["bucket_energy_kwh"] is None
+
+        imp = _parse_power_from_sample(json.dumps({
+            "watts": 100.0, "is_online": True,
+            "imported_from": "tapo_history", "bucket_energy_kwh": 0.1,
+        }))
+        assert imp["imported"] is True
+        assert imp["bucket_energy_kwh"] == 0.1
+
+    def test_imported_bucket_uses_own_energy(self):
+        t0 = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        prev = {"timestamp": t0, "watts": 0.0, "imported": False, "bucket_energy_kwh": None}
+        cur = {"timestamp": t0 + timedelta(days=5), "watts": 100.0,
+               "imported": True, "bucket_energy_kwh": 0.1}
+        # 0.1 kWh regardless of the (huge) gap to prev
+        assert _interval_energy_wh(prev, cur) == pytest.approx(100.0)
+
+    def test_live_within_cap_is_integrated(self):
+        t0 = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        prev = {"timestamp": t0, "watts": 100.0, "imported": False, "bucket_energy_kwh": None}
+        cur = {"timestamp": t0 + timedelta(minutes=10), "watts": 100.0,
+               "imported": False, "bucket_energy_kwh": None}
+        # 100 W over 10 min = 16.667 Wh
+        assert _interval_energy_wh(prev, cur) == pytest.approx(100.0 * (10 / 60))
+
+    def test_live_gap_beyond_cap_is_zero(self):
+        t0 = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        prev = {"timestamp": t0, "watts": 200.0, "imported": False, "bucket_energy_kwh": None}
+        cur = {"timestamp": t0 + timedelta(hours=2), "watts": 200.0,
+               "imported": False, "bucket_energy_kwh": None}
+        assert GAP_THRESHOLD_MINUTES == 15
+        assert _interval_energy_wh(prev, cur) == 0.0  # downtime, not bridged
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/services/test_energy_service.py::TestIntervalEnergyPrimitive -v --no-cov`
+Expected: FAIL — `cannot import name '_interval_energy_wh'` / `GAP_THRESHOLD_MINUTES`.
+
+- [ ] **Step 3: Add the constant**
+
+In `backend/app/services/power/energy.py`, just below `_POWER_CAPABILITY = "power_monitor"`:
+
+```python
+# A live-sample gap longer than this is treated as downtime: the trapezoidal
+# integration does NOT bridge it (the poller was down / device asleep, ~0 draw).
+# Imported buckets carry their own energy and are exempt from this cap.
+GAP_THRESHOLD_MINUTES = 15
+```
+
+- [ ] **Step 4: Extend `_parse_power_from_sample`**
+
+In the returned dict of `_parse_power_from_sample` (currently ends with `"is_online": bool(is_online),`), add two fields:
+
+```python
+    bucket_energy_kwh = data.get("bucket_energy_kwh")
+
+    return {
+        "watts": float(watts),
+        "voltage": float(voltage) if voltage is not None else None,
+        "current": current_a,
+        "energy_today": energy_today_kwh,
+        "is_online": bool(is_online),
+        "imported": bool(data.get("imported_from")),
+        "bucket_energy_kwh": float(bucket_energy_kwh) if bucket_energy_kwh is not None else None,
+    }
+```
+
+- [ ] **Step 5: Add the `_interval_energy_wh` primitive**
+
+Add after `_parse_power_from_sample`:
+
+```python
+def _interval_energy_wh(prev: Dict, cur: Dict) -> float:
+    """Energy in Wh attributed to the interval ending at ``cur``.
+
+    - Imported buckets contribute their own measured ``bucket_energy_kwh``
+      (no integration, independent of the gap to ``prev``).
+    - Live samples are trapezoid-integrated only when the gap to ``prev`` is
+      within ``GAP_THRESHOLD_MINUTES``; larger gaps are treated as downtime
+      (0 Wh — the poller was down / device asleep, drawing ~0).
+    """
+    if cur.get("imported") and cur.get("bucket_energy_kwh") is not None:
+        return cur["bucket_energy_kwh"] * 1000.0
+    gap_h = (cur["timestamp"] - prev["timestamp"]).total_seconds() / 3600.0
+    if gap_h * 60.0 > GAP_THRESHOLD_MINUTES:
+        return 0.0
+    return (prev["watts"] + cur["watts"]) / 2.0 * gap_h
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/test_energy_service.py::TestIntervalEnergyPrimitive -v --no-cov`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/power/energy.py backend/tests/services/test_energy_service.py
+git commit -m "feat(energy): import-aware, gap-capped interval energy primitive"
+```
+
+---
+
+## Task 2: Per-device helpers + rewire `get_cumulative_energy_data`
+
+**Files:**
+- Modify: `backend/app/services/power/energy.py` (`get_cumulative_energy_data` ~lines 389-507; add three helpers before it)
+- Test: `backend/tests/services/test_energy_service.py`
+
+- [ ] **Step 1: Write the failing reproduction tests**
+
+Add to `backend/tests/services/test_energy_service.py` (no new imports needed — `SmartDeviceSample` and `get_cumulative_energy_data` are already imported at the top). This `_add_sample` module-level helper is reused by Tasks 3 and 4, so define it once here:
+
+```python
+def _add_sample(db, device_id, ts, watts=None, *, imported=False, bucket_kwh=None, online=True):
+    if imported:
+        data = {"watts": watts if watts is not None else 0.0, "is_online": online,
+                "imported_from": "tapo_history", "bucket_interval": "hourly",
+                "bucket_energy_kwh": bucket_kwh}
+    else:
+        data = {"current_power": watts if watts is not None else 0.0, "is_online": online}
+    db.add(SmartDeviceSample(device_id=device_id, capability="power_monitor",
+                             data_json=json.dumps(data), timestamp=ts))
+
+
+class TestCumulativeGapAndImport:
+    def test_long_gap_is_not_bridged(self, db_session, smart_device):
+        now = datetime.now(timezone.utc)
+        # Two live samples 2h apart at 100W; the gap must contribute 0.
+        _add_sample(db_session, smart_device.id, now - timedelta(hours=2), 100.0)
+        _add_sample(db_session, smart_device.id, now, 100.0)
+        db_session.commit()
+        res = get_cumulative_energy_data(db_session, smart_device.id, "today", 0.40,
+                                         start=now - timedelta(hours=3), end=now)
+        assert res["total_kwh"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_short_gap_is_integrated(self, db_session, smart_device):
+        now = datetime.now(timezone.utc)
+        _add_sample(db_session, smart_device.id, now - timedelta(minutes=10), 120.0)
+        _add_sample(db_session, smart_device.id, now, 120.0)
+        db_session.commit()
+        res = get_cumulative_energy_data(db_session, smart_device.id, "today", 0.40,
+                                         start=now - timedelta(hours=1), end=now)
+        # 120 W over 10 min = 0.02 kWh
+        assert res["total_kwh"] == pytest.approx(120.0 * (10 / 60) / 1000, abs=1e-6)
+
+    def test_imported_bucket_counts_own_energy(self, db_session, smart_device):
+        now = datetime.now(timezone.utc)
+        # Two hourly imported buckets (0.1 kWh each); 60-min spacing must NOT be
+        # treated as a gap — each counts its own energy → 0.1 kWh total
+        # (first sample contributes nothing; the second bucket adds 0.1).
+        _add_sample(db_session, smart_device.id, now - timedelta(hours=2),
+                    imported=True, bucket_kwh=0.1)
+        _add_sample(db_session, smart_device.id, now - timedelta(hours=1),
+                    imported=True, bucket_kwh=0.1)
+        db_session.commit()
+        res = get_cumulative_energy_data(db_session, smart_device.id, "today", 0.40,
+                                         start=now - timedelta(hours=3), end=now)
+        assert res["total_kwh"] == pytest.approx(0.1, abs=1e-6)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/services/test_energy_service.py::TestCumulativeGapAndImport -v --no-cov`
+Expected: FAIL — `test_long_gap_is_not_bridged` returns ~0.2 (old bridging), `test_imported_bucket_counts_own_energy` returns the trapezoid of avg watts (~0.1 by luck or different), i.e. assertions don't hold under the current integration.
+
+- [ ] **Step 3: Add the three helpers**
+
+In `backend/app/services/power/energy.py`, add just above `get_cumulative_energy_data`:
+
+```python
+def _load_parsed_online_sorted(db: Session, device_id: int,
+                               start_time: datetime, end_time: datetime) -> List[Dict]:
+    """Query power samples in [start, end], parse, keep online, sorted by time."""
+    samples = db.query(SmartDeviceSample).filter(
+        and_(
+            SmartDeviceSample.device_id == device_id,
+            SmartDeviceSample.capability == _POWER_CAPABILITY,
+            SmartDeviceSample.timestamp >= start_time,
+            SmartDeviceSample.timestamp <= end_time,
+        )
+    ).order_by(SmartDeviceSample.timestamp).all()
+    parsed: List[Dict] = []
+    for s in samples:
+        p = _parse_power_from_sample(s.data_json)
+        if p is not None and p["is_online"]:
+            parsed.append({"timestamp": s.timestamp, **p})
+    return parsed
+
+
+def _device_cumulative_series(parsed: List[Dict]) -> tuple[List[Dict], float]:
+    """Full-resolution cumulative series from online, time-sorted samples.
+
+    Returns (points, total_wh); points are
+    {"timestamp": datetime, "cumulative_kwh": float, "instant_watts": float}.
+    """
+    points: List[Dict] = []
+    cumulative_wh = 0.0
+    for i, s in enumerate(parsed):
+        if i > 0:
+            cumulative_wh += _interval_energy_wh(parsed[i - 1], s)
+        points.append({
+            "timestamp": s["timestamp"],
+            "cumulative_kwh": cumulative_wh / 1000.0,
+            "instant_watts": s["watts"],
+        })
+    return points, cumulative_wh
+
+
+def _downsample(data_points: List[Dict], max_points: int = 200) -> List[Dict]:
+    """Evenly thin a list of chart points down to at most max_points."""
+    if len(data_points) <= max_points:
+        return data_points
+    step = len(data_points) // max_points
+    out = [data_points[0]]
+    for i in range(step, len(data_points) - 1, step):
+        out.append(data_points[i])
+    out.append(data_points[-1])
+    return out
+```
+
+- [ ] **Step 4: Rewire `get_cumulative_energy_data` to use the helpers**
+
+In `get_cumulative_energy_data`, replace the inline query+parse block (the `samples = db.query(...)` through the `parsed_samples` build) with a single call:
+
+```python
+    parsed_samples = _load_parsed_online_sorted(db, device_id, start_time, end_time)
+```
+
+Keep the existing `if not parsed_samples:` empty-handling block unchanged. Then replace the integration loop + downsample + final return (everything from `# Calculate cumulative energy using trapezoidal integration` onward) with:
+
+```python
+    series, total_wh = _device_cumulative_series(parsed_samples)
+    data_points = [
+        {
+            "timestamp": p["timestamp"].isoformat(),
+            "cumulative_kwh": round(p["cumulative_kwh"], 4),
+            "cumulative_cost": round(p["cumulative_kwh"] * cost_per_kwh, 4),
+            "instant_watts": round(p["instant_watts"], 1),
+        }
+        for p in series
+    ]
+    data_points = _downsample(data_points)
+
+    total_kwh = total_wh / 1000.0
+    total_cost = total_kwh * cost_per_kwh
+    return {
+        "device_id": device_id,
+        "device_name": device.name,
+        "period": period_label,
+        "cost_per_kwh": cost_per_kwh,
+        "currency": "EUR",
+        "total_kwh": round(total_kwh, 4),
+        "total_cost": round(total_cost, 2),
+        "data_points": data_points,
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/test_energy_service.py::TestCumulativeGapAndImport tests/services/test_energy_service.py::TestCumulativeCustomRange -v --no-cov`
+Expected: PASS (new reproduction tests + the pre-existing custom-range tests still hold — the empty-window path is unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/power/energy.py backend/tests/services/test_energy_service.py
+git commit -m "fix(energy): gap-capped import-aware integration in get_cumulative_energy_data"
+```
+
+---
+
+## Task 3: Rewrite `get_cumulative_energy_total` (sum of per-device curves)
+
+**Files:**
+- Modify: `backend/app/services/power/energy.py` (`get_cumulative_energy_total`, the whole function body)
+- Test: `backend/tests/services/test_energy_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `backend/tests/services/test_energy_service.py`. `SmartDevice` is already imported at the top; add only the new function import. The `_add_sample` helper from Task 2 is reused here.
+
+```python
+from app.services.power.energy import get_cumulative_energy_total
+```
+
+```python
+class TestTotalEqualsSumOfDevices:
+    def test_total_equals_sum_of_device_totals(self, db_session):
+        now = datetime.now(timezone.utc)
+        # Two devices with OFFSET live timestamps (never share a timestamp),
+        # both 10-min spacing (within cap) at constant power.
+        dev_a = SmartDevice(name="A", plugin_name="tapo_smart_plug",
+                            device_type_id="tapo_p110", address="10.0.0.1",
+                            capabilities=["power_monitor"], is_active=True,
+                            is_online=True, created_by_user_id=1)
+        dev_b = SmartDevice(name="B", plugin_name="tapo_smart_plug",
+                            device_type_id="tapo_p110", address="10.0.0.2",
+                            capabilities=["power_monitor"], is_active=True,
+                            is_online=True, created_by_user_id=1)
+        db_session.add_all([dev_a, dev_b]); db_session.commit()
+        for i in range(7):
+            _add_sample(db_session, dev_a.id, now - timedelta(minutes=60 - i * 10), 100.0)
+            _add_sample(db_session, dev_b.id, now - timedelta(minutes=55 - i * 10), 50.0)
+        db_session.commit()
+
+        a = get_cumulative_energy_data(db_session, dev_a.id, "today", 0.40,
+                                       start=now - timedelta(hours=2), end=now)
+        b = get_cumulative_energy_data(db_session, dev_b.id, "today", 0.40,
+                                       start=now - timedelta(hours=2), end=now)
+        total = get_cumulative_energy_total(db_session, "today", 0.40,
+                                            start=now - timedelta(hours=2), end=now)
+        assert total["period"] == "custom"
+        # Exact: Total == sum of per-device totals (no timestamp-merge averaging)
+        assert total["total_kwh"] == pytest.approx(a["total_kwh"] + b["total_kwh"], abs=1e-6)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/services/test_energy_service.py::TestTotalEqualsSumOfDevices -v --no-cov`
+Expected: FAIL — current merge averages interleaved points, so `total_kwh` < `a+b`.
+
+- [ ] **Step 3: Rewrite `get_cumulative_energy_total`**
+
+Replace the entire `get_cumulative_energy_total` function body with:
+
+```python
+def get_cumulative_energy_total(
+    db: Session,
+    period: str,
+    cost_per_kwh: float,
+    *,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+) -> Dict:
+    """Aggregate cumulative energy across all active power-monitoring devices.
+
+    Builds each device's full-resolution cumulative curve (import-aware,
+    gap-capped) and sums them via carry-forward over the merged timeline, so
+    the Total equals the exact sum of per-device totals.
+    """
+    now = datetime.now(timezone.utc)
+    if start is not None and end is not None:
+        start_time, end_time, period_label = start, end, "custom"
+    else:
+        start_time, end_time = _resolve_period_range(period, now)
+        period_label = period
+
+    all_devices = db.query(SmartDevice).filter(
+        SmartDevice.is_active == True,  # noqa: E712
+    ).all()
+    power_devices = [
+        d for d in all_devices
+        if isinstance(d.capabilities, list) and _POWER_CAPABILITY in d.capabilities
+    ]
+
+    def _result(total_kwh: float, data_points: List[Dict]) -> Dict:
+        return {
+            "device_id": 0,
+            "device_name": "Total",
+            "period": period_label,
+            "cost_per_kwh": cost_per_kwh,
+            "currency": "EUR",
+            "total_kwh": round(total_kwh, 3),
+            "total_cost": round(total_kwh * cost_per_kwh, 2),
+            "data_points": data_points,
+        }
+
+    # Per-device full-resolution series
+    device_series: List[List[Dict]] = []
+    for d in power_devices:
+        parsed = _load_parsed_online_sorted(db, d.id, start_time, end_time)
+        series, _ = _device_cumulative_series(parsed)
+        if series:
+            device_series.append(series)
+
+    if not device_series:
+        if start is not None and end is not None:
+            return _result(0.0, [
+                {"timestamp": start_time.isoformat(), "cumulative_kwh": 0.0,
+                 "cumulative_cost": 0.0, "instant_watts": 0.0},
+                {"timestamp": end_time.isoformat(), "cumulative_kwh": 0.0,
+                 "cumulative_cost": 0.0, "instant_watts": 0.0},
+            ])
+        return _result(0.0, [])
+
+    # Carry-forward sum across devices over the merged timeline
+    threshold = timedelta(minutes=GAP_THRESHOLD_MINUTES)
+    all_ts = sorted({p["timestamp"] for s in device_series for p in s})
+    n = len(device_series)
+    idx = [0] * n
+    last_cum = [0.0] * n
+    last_w = [0.0] * n
+    last_w_ts: List[Optional[datetime]] = [None] * n
+
+    data_points: List[Dict] = []
+    for ts in all_ts:
+        for k, s in enumerate(device_series):
+            while idx[k] < len(s) and s[idx[k]]["timestamp"] <= ts:
+                last_cum[k] = s[idx[k]]["cumulative_kwh"]
+                last_w[k] = s[idx[k]]["instant_watts"]
+                last_w_ts[k] = s[idx[k]]["timestamp"]
+                idx[k] += 1
+        combined_cum = sum(last_cum)
+        combined_w = sum(
+            last_w[k] if (last_w_ts[k] is not None and ts - last_w_ts[k] <= threshold) else 0.0
+            for k in range(n)
+        )
+        data_points.append({
+            "timestamp": ts.isoformat(),
+            "cumulative_kwh": round(combined_cum, 4),
+            "cumulative_cost": round(combined_cum * cost_per_kwh, 4),
+            "instant_watts": round(combined_w, 1),
+        })
+
+    total_kwh = sum(last_cum)  # final cumulative == sum of device totals
+    return _result(total_kwh, _downsample(data_points))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/test_energy_service.py::TestTotalEqualsSumOfDevices tests/services/test_energy_service.py::TestCumulativeTotalCustomRange -v --no-cov`
+Expected: PASS (new test + the pre-existing total custom-range tests still hold — empty-window returns 2 boundary points).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/power/energy.py backend/tests/services/test_energy_service.py
+git commit -m "fix(energy): Total = carry-forward sum of per-device curves (closes #157)"
+```
+
+---
+
+## Task 4: `get_period_stats` energy via the same integration
+
+**Files:**
+- Modify: `backend/app/services/power/energy.py` (`get_period_stats` lines ~157-234)
+- Test: `backend/tests/services/test_energy_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `backend/tests/services/test_energy_service.py` (no new imports — `get_period_stats` is already imported at the top; `_add_sample` from Task 2 is reused).
+
+```python
+class TestPeriodStatsEnergyMatchesIntegration:
+    def test_period_total_does_not_bridge_gaps(self, db_session, smart_device):
+        now = datetime.now(timezone.utc)
+        # Two live samples 2h apart at 100W within a 3h window:
+        # old avg*hours would report ~0.3 kWh; integration with gap-cap = 0.
+        _add_sample(db_session, smart_device.id, now - timedelta(hours=2), 100.0)
+        _add_sample(db_session, smart_device.id, now, 100.0)
+        db_session.commit()
+        stats = get_period_stats(db_session, smart_device.id,
+                                 now - timedelta(hours=3), now)
+        assert stats is not None
+        assert stats.total_energy_kwh == pytest.approx(0.0, abs=1e-6)
+
+    def test_period_total_matches_cumulative(self, db_session, smart_device):
+        now = datetime.now(timezone.utc)
+        for i in range(7):
+            _add_sample(db_session, smart_device.id,
+                        now - timedelta(minutes=60 - i * 10), 90.0)
+        db_session.commit()
+        stats = get_period_stats(db_session, smart_device.id,
+                                 now - timedelta(hours=2), now)
+        cum = get_cumulative_energy_data(db_session, smart_device.id, "today", 0.40,
+                                         start=now - timedelta(hours=2), end=now)
+        assert stats.total_energy_kwh == pytest.approx(cum["total_kwh"], abs=1e-6)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/services/test_energy_service.py::TestPeriodStatsEnergyMatchesIntegration -v --no-cov`
+Expected: FAIL — current `total_energy_kwh = avg_watts * period_hours` bridges the gap (≈0.3) and won't match the cumulative.
+
+- [ ] **Step 3: Rewire `get_period_stats` energy**
+
+Two edits in `get_period_stats`:
+
+(a) Add ordering + keep timestamps on the parsed samples. Change the query `.all()` to ordered, and the parse loop to attach timestamps:
+
+```python
+    samples = db.query(SmartDeviceSample).filter(
+        and_(
+            SmartDeviceSample.device_id == device_id,
+            SmartDeviceSample.capability == _POWER_CAPABILITY,
+            SmartDeviceSample.timestamp >= start_time,
+            SmartDeviceSample.timestamp <= end_time,
+        )
+    ).order_by(SmartDeviceSample.timestamp).all()
+
+    if not samples:
+        return None
+
+    # Parse all samples (keep timestamps for integration)
+    parsed = []
+    for s in samples:
+        p = _parse_power_from_sample(s.data_json)
+        if p is not None:
+            parsed.append({"timestamp": s.timestamp, **p})
+
+    if not parsed:
+        return None
+
+    samples_count = len(parsed)
+    online_samples = [p for p in parsed if p["is_online"]]
+    offline_samples = [p for p in parsed if not p["is_online"]]
+```
+
+(b) Replace the energy computation:
+
+```python
+    period_hours = (end_time - start_time).total_seconds() / 3600  # kept for reference/uptime
+
+    _, total_wh = _device_cumulative_series(online_samples)
+    total_energy_kwh = total_wh / 1000.0
+```
+
+(The `avg/min/max_watts`, `uptime_percentage`, and `downtime_minutes` lines stay as they are — they already operate on `online_samples` / `offline_samples` / `samples_count`. `period_hours` may now be unused by the energy calc; if a linter flags it as unused, delete that line.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/test_energy_service.py::TestPeriodStatsEnergyMatchesIntegration -v --no-cov`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/power/energy.py backend/tests/services/test_energy_service.py
+git commit -m "fix(energy): period-stats energy uses gap-capped integration (matches chart)"
+```
+
+---
+
+## Task 5: Full-suite verification
+
+**Files:**
+- Test: `backend/tests/services/test_energy_service.py` (and any other energy tests)
+
+- [ ] **Step 1: Run the whole energy test file**
+
+Run: `cd backend && python -m pytest tests/services/test_energy_service.py -v --no-cov`
+Expected: PASS. The pre-existing `sample_data` fixture uses 5-minute spacing (all gaps ≤ 15 min, all live, no imports), so the new live integration matches the old trapezoidal result and those tests are unaffected. The only changed behavior is for gaps > 15 min, imported buckets, the Total aggregation, and `get_period_stats.total_energy_kwh`.
+
+- [ ] **Step 2: If any legacy assertion fails, reconcile it**
+
+For any failing pre-existing test, read the assertion. If it asserted a value produced by the old bridging/avg×hours/merge math, recompute the expected value by hand from the fixture data using the new rules (imported→own energy; live gap >15 min→0; else trapezoid; Total=sum of devices) and update the literal. Do **not** weaken an assertion to make it pass; correct the expected number.
+
+- [ ] **Step 3: Run the route-level energy tests too**
+
+Run: `cd backend && python -m pytest tests/services/test_energy_service.py tests/api/test_energy_routes.py -q --no-cov`
+Expected: PASS (route tests exercise empty-window behavior, which is unchanged).
+
+- [ ] **Step 4: Commit (only if Step 2 changed anything)**
+
+```bash
+git add backend/tests/services/test_energy_service.py
+git commit -m "test(energy): reconcile legacy expectations with gap-capped integration"
+```
+
+---
+
+## Notes / Validation
+
+- Expected production result after the fix (range 2026-01-01 … now): Total ≈ **38.4 kWh** (was 67.7); BaluNode ≈ **24.3** (was 62.5); Sven PC ≈ **14.1** (was 29.8).
+- No migration: all numbers are computed on-read, so the correction applies retroactively to every range and view.
+- Instant-mode chart cosmetics across a >15-min gap (a line drawn over the gap) are out of scope — the cumulative/energy is correct; synthetic 0-watt boundary points for the instant curve are a possible follow-up.

--- a/docs/superpowers/plans/2026-06-05-energy-consumption-gap-integration.md
+++ b/docs/superpowers/plans/2026-06-05-energy-consumption-gap-integration.md
@@ -407,7 +407,7 @@ def get_cumulative_energy_total(
             "period": period_label,
             "cost_per_kwh": cost_per_kwh,
             "currency": "EUR",
-            "total_kwh": round(total_kwh, 3),
+            "total_kwh": round(total_kwh, 4),  # 4dp to match get_cumulative_energy_data
             "total_cost": round(total_kwh * cost_per_kwh, 2),
             "data_points": data_points,
         }

--- a/docs/superpowers/specs/2026-06-05-energy-consumption-gap-integration-design.md
+++ b/docs/superpowers/specs/2026-06-05-energy-consumption-gap-integration-design.md
@@ -1,0 +1,122 @@
+# Energy Consumption — Import-Aware, Gap-Capped Integration
+
+**Date:** 2026-06-05
+**Status:** Draft
+**Branch:** `fix/energy-consumption-gap-integration`
+**Issue:** #159 (supersedes/closes #157)
+
+## Problem
+
+The energy calculation in `backend/app/services/power/energy.py` **over-reports consumption**, badly over long ranges. Confirmed against real production data (BaluNode, range 2026-01-01 … 2026-06-05): the UI Total shows **67.7 kWh**, the true value is **~38.4 kWh** (over-reported ~76%). Two compounding bugs:
+
+### Bug 1 — Trapezoidal integration bridges downtime gaps (dominant)
+
+`get_cumulative_energy_data` integrates instantaneous-power samples trapezoidally with **no cap on the inter-sample gap**. When the poller is down (the BaluNode server itself asleep/off), there are no samples; the integration assumes power flowed at the boundary average across the *entire* gap → invents energy.
+
+| Device | bridged (app) | gap-capped | phantom | gap-hours | max gap |
+|---|---|---|---|---|---|
+| BaluNode | 62.5 kWh | 24.3 | **+38.2** | 3467 h | 169 h |
+| Sven PC | 29.8 kWh | 14.1 | **+15.8** | 3466 h | 97 h |
+
+Both devices share one poller (on BaluNode), so gap-hours are nearly identical → the gaps are **server downtime**. **Validation:** the Tapo history-import buckets for those periods carry only ~0.43 / ~0.27 kWh (~1 W avg) — the plug's own measurement confirms the device drew ≈0 while down. The bridged energy is genuinely phantom.
+
+### Bug 2 — Total aggregates by exact-timestamp merge (#157)
+
+`get_cumulative_energy_total` sums `instant_watts` keyed by exact ISO timestamp. Independently-sampled devices almost never share a timestamp, so in the overlap period the code **averages instead of sums** → Total under-counts by ~half the overlap energy.
+
+The two bugs partially cancel (phantom +54 vs merge −25), masking how wrong each is.
+
+## How Power Data Is Stored (context)
+
+One table `smart_device_samples` (`device_id`, `capability`, `data_json` TEXT, `timestamp` UTC). For `power_monitor`:
+- **Live samples** (poller, ~every 60 s): `data_json` has `current_power`/`watts`, `is_online`, etc.
+- **Imported buckets** (Tapo history import, plugin-specific but generic in storage): `data_json` additionally has `imported_from`, `bucket_interval` (hourly/daily/monthly), and **`bucket_energy_kwh`** (the bucket's own measured energy). `watts` is the bucket's *average* power. Import uses a LIVE_WINS conflict strategy, so imported and live never overlap in time for a device.
+- No rollup table — all aggregation is on-read.
+
+## Design
+
+### Constant
+
+```python
+GAP_THRESHOLD_MINUTES = 15  # live-sample gap beyond this = downtime (no bridging)
+```
+Rationale: the poller writes ~every 60 s, so a >15-min gap (≥15 missed writes) is downtime, not a missed beat. Imported buckets are handled by their own energy and are **not** subject to this cap (a 60-min hourly spacing is not a gap).
+
+### `_parse_power_from_sample` — expose import info
+
+Extend the returned dict with two fields (parsed from `data_json`):
+- `imported: bool` — `"imported_from" in data`
+- `bucket_energy_kwh: Optional[float]` — `data.get("bucket_energy_kwh")`
+
+(All existing fields unchanged.)
+
+### Core: one integration helper
+
+A single internal function computes a device's energy and cumulative curve from its parsed, online, time-sorted samples:
+
+```python
+def _integrate_samples(parsed):  # parsed: list of dicts {timestamp, watts, imported, bucket_energy_kwh}
+    """Return (data_points, total_wh).
+    data_points: [{timestamp, cumulative_kwh, cumulative_cost(later), instant_watts}]
+    """
+```
+
+Per-interval energy `(prev → cur)`:
+1. **`cur.imported` and `cur.bucket_energy_kwh is not None`** → interval energy = `cur.bucket_energy_kwh * 1000` Wh (the bucket's own measured energy; no integration).
+2. **else (live, or imported without a stored bucket energy)**:
+   - `gap_h = (cur.t − prev.t) / 3600`
+   - `gap_h * 60 > GAP_THRESHOLD_MINUTES` → interval energy = **0** (downtime; do not bridge)
+   - else → `(prev.watts + cur.watts) / 2 * gap_h`
+
+Accumulate `cumulative_wh`; emit a point per sample with `cumulative_kwh = cumulative_wh/1000` and `instant_watts = cur.watts`. The first sample contributes 0. `total_wh` is the final accumulator.
+
+`get_cumulative_energy_data` uses this helper, then applies the existing 200-point downsample to the data_points (the integration runs at full resolution first, so `total_kwh` is unaffected by downsampling) and adds `cumulative_cost`.
+
+### `get_cumulative_energy_total` — sum per-device curves (fixes #157)
+
+Replace the timestamp-merge with a **carry-forward sum of each device's cumulative curve**:
+1. For each power device, compute its full-resolution `(timestamp, cumulative_kwh, instant_watts)` series via the helper.
+2. Merge all timestamps (sorted, unique). Walk them, maintaining per device: `last_cum` (last cumulative ≤ t, 0 before its first sample), `last_watts` and `last_watts_ts`.
+3. At each t: `combined_cum = Σ last_cum[d]`; `combined_watts = Σ (last_watts[d] if (t − last_watts_ts[d]) ≤ GAP_THRESHOLD else 0)`.
+4. Emit combined points; `total_kwh = combined_cum at the last t = Σ device totals` (exact). Downsample to 200.
+
+This makes the Total **exactly** the sum of the (correct) per-device totals, and the Instant-Total reflects only devices currently online (gap → 0).
+
+### `get_period_stats` — consistent energy
+
+`get_period_stats` currently sets `total_energy_kwh = (avg_watts/1000) * period_hours` (avg×duration, also wrong over downtime). Change it to use `_integrate_samples` on the period's parsed samples so the dashboard stat cards (today/week/month) match the cumulative chart. `avg/min/max_watts`, `uptime_percentage`, `downtime_minutes` stay as-is.
+
+## Data Flow
+
+```
+samples (live + imported) ─► _parse_power_from_sample (+imported,+bucket_energy_kwh)
+  ─► _integrate_samples  (imported→own energy; live→trapezoid, gap>15min→0)
+     ├─ get_cumulative_energy_data → per-device total + curve (→ downsample, cost)
+     ├─ get_cumulative_energy_total → carry-forward sum of device curves
+     └─ get_period_stats → total_energy_kwh
+```
+
+## No Migration
+
+Everything is computed on-read; there are no stored aggregates. The fix **retroactively corrects all displayed numbers** (today/week/month/custom, per-device and Total) with no data migration.
+
+## Testing
+
+**Reproduction (TDD, `backend/tests/services/test_energy_service.py`):**
+- Two devices, offset live timestamps, a multi-hour sleep gap, and a block of imported hourly buckets. Assert:
+  - Per-device: gap energy is **0** (not bridged); imported buckets counted by `bucket_energy_kwh`.
+  - A `>15 min` live gap contributes 0; a `≤15 min` gap is trapezoid-integrated.
+  - `get_cumulative_energy_total` **equals the sum** of per-device totals (no merge under-count).
+  - `get_period_stats.total_energy_kwh` matches the cumulative total for the same range.
+- Update existing energy tests whose expected values assumed the old (bridging / avg×hours / merge) math.
+
+## Out of Scope
+
+- **Instant-chart cosmetics during gaps** (a line drawn across a >15-min gap in Instant mode). The energy/cumulative is correct; inserting synthetic 0-watt boundary points for the instant curve is a minor follow-up, not part of this fix.
+- **Backfilling real data via Tapo import** — complementary, plugin-specific, user-initiated; the calc fix does not depend on it.
+- **Device cumulative-energy-counter approach** — more exact but a larger, Tapo-specific redesign; not needed (gap-cap already matches the imported ground truth).
+- No change to retention, storage model, or the custom-range API (#156).
+
+## Expected Result (real data)
+
+Total ≈ **38.4 kWh** (was 67.7); BaluNode ≈ **24.3** (was 62.5); Sven PC ≈ **14.1** (was 29.8).


### PR DESCRIPTION
## Summary

Fixes energy/consumption being **massively over-reported**. Confirmed on real production data (BaluNode): the Total showed **67.7 kWh**, the true value is **~38.4 kWh** (over-reported ~76%). Two compounding root causes in `backend/app/services/power/energy.py`, both fixed here:

1. **Gap-bridging (dominant).** Trapezoidal integration bridged downtime gaps with no cap. When the poller is down (server asleep/off) there are no samples, so the integration assumed power flowed across the whole gap → invented energy (BaluNode +38.2 kWh, Sven PC +15.8 kWh of phantom). The Tapo history-import buckets for those same periods carry ~0 kWh, independently confirming the devices drew ≈0 while down.
2. **Total timestamp-merge (#157).** `get_cumulative_energy_total` summed `instant_watts` keyed by exact timestamp; independently-sampled devices never share a timestamp, so the overlap period was **averaged instead of summed** → under-count.

## How it works

One integration primitive, three consumers — so a device's number is consistent across the per-device chart, the Total, and the stats cards:

- **`_interval_energy_wh`** + **`GAP_THRESHOLD_MINUTES = 15`**: imported buckets contribute their own measured `bucket_energy_kwh` (exact, gap-exempt); live samples are trapezoid-integrated only within a 15-min gap; larger gaps → 0 (downtime, not bridged).
- **`get_cumulative_energy_data`** routes through `_load_parsed_online_sorted` + `_device_cumulative_series`.
- **`get_cumulative_energy_total`** rewritten as a **carry-forward sum of per-device cumulative curves** → Total = exact sum of per-device totals (closes #157); the instant-Total zeroes devices idle > 15 min.
- **`get_period_stats`** energy now uses the same integration (was `avg_watts × period_hours`).

**No migration** — everything is computed on-read, so the correction applies retroactively to today/week/month/custom, per-device and Total.

## Expected result (real data)

| | before | after |
|---|---|---|
| Total | 67.7 kWh | **~38.4** |
| BaluNode | 62.5 | **~24.3** |
| Sven PC | 29.8 | **~14.1** |

## Test Plan
- [x] `pytest tests/services/test_energy_service.py` → 27 passed (gap not bridged, imported bucket counts own energy, Total == sum of devices, period-stats == cumulative, plus the existing suite unaffected — the 5-min fixture spacing is within the cap)
- [x] `pytest tests/api/test_energy_routes.py tests/api/test_power_routes.py` → green (route layer + custom-range empty-window contracts preserved)
- [ ] Verify on the box after deploy: Total ≈ 38.4 kWh for the Jan–Jun range

Spec: `docs/superpowers/specs/2026-06-05-energy-consumption-gap-integration-design.md`
Plan: `docs/superpowers/plans/2026-06-05-energy-consumption-gap-integration.md`

Closes #159
Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)