### PR TITLE
fix(scheduler): Sync-Tab-Button verlinkt korrekt auf /sync

### DIFF
--- a/client/src/i18n/locales/de/scheduler.json
+++ b/client/src/i18n/locales/de/scheduler.json
@@ -54,8 +54,8 @@
   },
   "syncTab": {
     "title": "Sync-Zeitpläne",
-    "description": "Benutzerdefinierte Sync-Zeitpläne können auf der Einstellungsseite unter dem Tab Sync konfiguriert werden. Dieser Bereich wird in einem zukünftigen Update erweitert.",
-    "goToSettings": "Zu Einstellungen"
+    "description": "Benutzerdefinierte Sync-Zeitpläne können auf der Sync-Seite konfiguriert werden. Dieser Bereich wird in einem zukünftigen Update erweitert.",
+    "goToSettings": "Zur Sync-Seite"
   },
   "buttons": {
     "refresh": "Aktualisieren",

--- a/client/src/i18n/locales/en/scheduler.json
+++ b/client/src/i18n/locales/en/scheduler.json
@@ -54,8 +54,8 @@
   },
   "syncTab": {
     "title": "Sync Schedules",
-    "description": "User-defined sync schedules can be configured in the Settings page under the Sync tab. This section will be enhanced with direct schedule management in a future update.",
-    "goToSettings": "Go to Settings"
+    "description": "User-defined sync schedules can be configured on the Sync page. This section will be enhanced with direct schedule management in a future update.",
+    "goToSettings": "Go to Sync"
   },
   "buttons": {
     "refresh": "Refresh",

--- a/client/src/pages/SchedulerDashboard.tsx
+++ b/client/src/pages/SchedulerDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Calendar, Clock, History, Settings, Wrench, RefreshCw, Loader2, BarChart3, AlertTriangle } from 'lucide-react';
 import { useSchedulers, useSchedulerHistory } from '../hooks/useSchedulers';
@@ -254,13 +255,13 @@ export default function SchedulerDashboard() {
             <p className="text-sm text-slate-400 mb-6">
               {t('syncTab.description')}
             </p>
-            <a
-              href="/settings"
+            <Link
+              to="/sync"
               className="inline-flex items-center gap-2 rounded-md bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-700 transition-colors"
             >
               <Settings className="h-4 w-4" />
               {t('syncTab.goToSettings')}
-            </a>
+            </Link>
           </div>
         )}
 


### PR DESCRIPTION
## Problem

Im Scheduler-Dashboard (`/schedulers` → Tab **Sync Schedules**) verlinkte der Button "Go to Settings" auf `/settings`. Dort gibt es aber **keinen Sync-Tab** (Tabs: profile, security, storage, vcl, language, notifications, integrations). Die eigentliche Sync-Zeitplan-Verwaltung (`SyncSettings` → `ScheduleList`/`RegisteredDevicesPanel`/`ScheduleFormFields`) hängt an der Route **`/sync`** (`App.tsx:215`).

→ Klick landete auf dem Profile-Tab — ohne jeden Sync-Bezug. Der Beschreibungstext ("...under the Sync tab") war ebenfalls veralteter Altbestand.

Zusätzlich nutzte der Button ein rohes `<a href>` statt React-Router → voller Page-Reload (Bundle neu laden, React-State verworfen).

## Fix

- `<a href="/settings">` → `<Link to="/sync">` (Client-Navigation, konsistent mit dem Rest der App)
- `syncTab.description` + `syncTab.goToSettings` in `de`/`en` korrigiert (Verweis auf die Sync-Seite statt nicht-existentem Settings-Sync-Tab)

## Verifikation

- `npx tsc --noEmit` ohne Fehler
- JSON beider Locale-Dateien valide

🤖 Generated with [Claude Code](https://claude.com/claude-code)
