### PR TITLE
feat(notifications): Benachrichtigung bei Desktop deaktivieren/reaktivieren

### DIFF
--- a/backend/app/api/routes/desktop.py
+++ b/backend/app/api/routes/desktop.py
@@ -10,6 +10,7 @@ from app.api.deps import get_current_user, require_power_toggle_desktop
 from app.core.rate_limiter import user_limiter, get_limit
 from app.schemas.desktop import DesktopStatus
 from app.services.power.desktop import get_desktop_service
+from app.services.notifications.events import emit_desktop_disabled, emit_desktop_enabled
 from app.services.audit.logger_db import get_audit_logger_db
 
 logger = logging.getLogger(__name__)
@@ -61,6 +62,11 @@ async def desktop_disable(
             details={"action": "desktop_disable"},
             success=True,
         )
+    if ok:
+        try:
+            await emit_desktop_disabled(current_user.username)
+        except Exception as exc:  # best-effort: never break the toggle
+            logger.warning("Desktop-disabled notification failed: %s", exc)
     return {"success": ok, "message": message}
 
 
@@ -95,4 +101,9 @@ async def desktop_enable(
             details={"action": "desktop_enable"},
             success=True,
         )
+    if ok:
+        try:
+            await emit_desktop_enabled(current_user.username)
+        except Exception as exc:  # best-effort: never break the toggle
+            logger.warning("Desktop-enabled notification failed: %s", exc)
     return {"success": ok, "message": message}

--- a/backend/app/services/notifications/events.py
+++ b/backend/app/services/notifications/events.py
@@ -31,6 +31,8 @@ _COOLDOWN_SECONDS: dict[str, int] = {
     "plugin.incompatible": 21600,      # 6h per plugin
     "lifecycle.suspend": 60,           # 1min — guard against rapid retries
     "lifecycle.resume": 60,            # 1min
+    "lifecycle.desktop_disabled": 30,  # 30s — swallow accidental double-toggle
+    "lifecycle.desktop_enabled": 30,
     # No cooldown for shutdown/startup — legitimate reboots must always notify
 }
 
@@ -120,6 +122,10 @@ class EventType(str, Enum):
     SYSTEM_RESUME = "lifecycle.resume"
     SYSTEM_SHUTDOWN = "lifecycle.shutdown"
     SYSTEM_STARTUP = "lifecycle.startup"
+
+    # Desktop power events
+    DESKTOP_DISABLED = "lifecycle.desktop_disabled"
+    DESKTOP_ENABLED = "lifecycle.desktop_enabled"
 
 
 @dataclass
@@ -421,6 +427,22 @@ EVENT_CONFIGS: dict[str, EventConfig] = {
         title_template="NAS hochgefahren",
         message_template="NAS ist wieder einsatzbereit. Letzter Shutdown vor {downtime_human}.",
         action_url="/",
+    ),
+    EventType.DESKTOP_DISABLED: EventConfig(
+        priority=1,
+        category="lifecycle",
+        notification_type="info",
+        title_template="Desktop deaktiviert",
+        message_template="Die Bildschirme wurden von {username} ausgeschaltet — die GPU kann in den Idle gehen.",
+        action_url="/admin/system-control?tab=sleep",
+    ),
+    EventType.DESKTOP_ENABLED: EventConfig(
+        priority=1,
+        category="lifecycle",
+        notification_type="info",
+        title_template="Desktop reaktiviert",
+        message_template="Die Bildschirme wurden von {username} wieder eingeschaltet.",
+        action_url="/admin/system-control?tab=sleep",
     ),
 }
 

--- a/backend/app/services/notifications/events.py
+++ b/backend/app/services/notifications/events.py
@@ -709,6 +709,38 @@ class EventEmitter:
         """
         self.emit_sync(event_type, user_id=None, cooldown_entity=cooldown_entity, **kwargs)
 
+    def any_admin_wants_desktop_event(self, which: str) -> bool:
+        """Return True if at least one active admin wants the desktop *which* event.
+
+        *which* is "disabled" or "enabled". Reads each admin's
+        category_preferences["desktop_notifications"][which]; default True.
+        Returns True if no DB session factory is configured (e.g. very early
+        startup) so notifications are never silently lost.
+        """
+        if not self._db_session_factory:
+            return True
+        db = self._db_session_factory()
+        try:
+            from app.services.notifications.service import get_notification_service
+            from app.models.user import User
+
+            svc = get_notification_service()
+            admin_ids = [
+                uid for (uid,) in db.query(User.id).filter(
+                    User.role == "admin",
+                    User.is_active == True,
+                ).all()
+            ]
+            for admin_id in admin_ids:
+                prefs = svc.get_user_preferences(db, admin_id)
+                cat_prefs = (prefs.category_preferences or {}) if prefs else {}
+                desktop_prefs = cat_prefs.get("desktop_notifications", {})
+                if desktop_prefs.get(which, True):
+                    return True
+            return False
+        finally:
+            db.close()
+
     def _send_push_sync(
         self,
         db,
@@ -1300,3 +1332,44 @@ async def emit_system_shutdown(trigger: str) -> None:
 async def emit_system_startup(downtime_seconds: Optional[float]) -> None:
     """Async wrapper — used in `_startup()`."""
     emit_system_startup_sync(downtime_seconds)
+
+
+# ---------------------------------------------------------------------------
+# Desktop power event helpers
+# ---------------------------------------------------------------------------
+
+
+def emit_desktop_disabled_sync(username: str) -> None:
+    """Emit lifecycle.desktop_disabled (sync) — fired after a successful disable."""
+    emitter = get_event_emitter()
+    if not emitter.any_admin_wants_desktop_event("disabled"):
+        logger.debug("Desktop-disabled event suppressed: no admin wants it")
+        return
+    emitter.emit_for_admins_sync(
+        EventType.DESKTOP_DISABLED,
+        cooldown_entity="desktop",
+        username=username,
+    )
+
+
+def emit_desktop_enabled_sync(username: str) -> None:
+    """Emit lifecycle.desktop_enabled (sync) — fired after a successful enable."""
+    emitter = get_event_emitter()
+    if not emitter.any_admin_wants_desktop_event("enabled"):
+        logger.debug("Desktop-enabled event suppressed: no admin wants it")
+        return
+    emitter.emit_for_admins_sync(
+        EventType.DESKTOP_ENABLED,
+        cooldown_entity="desktop",
+        username=username,
+    )
+
+
+async def emit_desktop_disabled(username: str) -> None:
+    """Async wrapper — used in the desktop route handler."""
+    emit_desktop_disabled_sync(username)
+
+
+async def emit_desktop_enabled(username: str) -> None:
+    """Async wrapper — used in the desktop route handler."""
+    emit_desktop_enabled_sync(username)

--- a/backend/tests/test_desktop_notifications.py
+++ b/backend/tests/test_desktop_notifications.py
@@ -27,3 +27,120 @@ def test_desktop_event_configs_present():
 def test_desktop_event_cooldowns_present():
     assert _COOLDOWN_SECONDS["lifecycle.desktop_disabled"] == 30
     assert _COOLDOWN_SECONDS["lifecycle.desktop_enabled"] == 30
+
+
+# ---------------------------------------------------------------------------
+# Gate: any_admin_wants_desktop_event
+# ---------------------------------------------------------------------------
+
+def _emitter_with_db(db: MagicMock) -> EventEmitter:
+    emitter = EventEmitter()
+    emitter.set_db_session_factory(lambda: db)
+    return emitter
+
+
+def _db_with_admins(*ids: int) -> MagicMock:
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = [(i,) for i in ids]
+    return db
+
+
+def _svc_with_prefs(category_preferences):
+    svc = MagicMock()
+    prefs = MagicMock()
+    prefs.category_preferences = category_preferences
+    svc.get_user_preferences.return_value = prefs
+    return svc
+
+
+def test_gate_default_true_when_no_pref():
+    db = _db_with_admins(1)
+    emitter = _emitter_with_db(db)
+    svc = _svc_with_prefs(None)
+    with patch.object(_notification_service_mod, "get_notification_service", lambda: svc):
+        assert emitter.any_admin_wants_desktop_event("disabled") is True
+        assert emitter.any_admin_wants_desktop_event("enabled") is True
+
+
+def test_gate_per_event_independent():
+    db = _db_with_admins(1)
+    emitter = _emitter_with_db(db)
+    svc = _svc_with_prefs({"desktop_notifications": {"disabled": False, "enabled": True}})
+    with patch.object(_notification_service_mod, "get_notification_service", lambda: svc):
+        assert emitter.any_admin_wants_desktop_event("disabled") is False
+        assert emitter.any_admin_wants_desktop_event("enabled") is True
+
+
+def test_gate_false_when_no_admins():
+    db = _db_with_admins()  # no admins
+    emitter = _emitter_with_db(db)
+    svc = _svc_with_prefs({"desktop_notifications": {"disabled": True}})
+    with patch.object(_notification_service_mod, "get_notification_service", lambda: svc):
+        assert emitter.any_admin_wants_desktop_event("disabled") is False
+
+
+def test_gate_true_when_factory_missing():
+    """No DB factory configured (e.g. early startup) -> do not suppress."""
+    emitter = EventEmitter()  # no set_db_session_factory
+    assert emitter.any_admin_wants_desktop_event("disabled") is True
+
+
+# ---------------------------------------------------------------------------
+# Emit helpers
+# ---------------------------------------------------------------------------
+
+def test_emit_desktop_disabled_calls_emit_when_wanted():
+    from app.services.notifications.events import emit_desktop_disabled_sync, get_event_emitter
+    emitter = get_event_emitter()
+    with patch.object(emitter, "any_admin_wants_desktop_event", return_value=True), \
+         patch.object(emitter, "emit_for_admins_sync") as mock_emit:
+        emit_desktop_disabled_sync("alice")
+    mock_emit.assert_called_once()
+    args, kwargs = mock_emit.call_args
+    assert args[0] == EventType.DESKTOP_DISABLED
+    assert kwargs.get("username") == "alice"
+    assert kwargs.get("cooldown_entity") == "desktop"
+
+
+def test_emit_desktop_enabled_calls_emit_when_wanted():
+    from app.services.notifications.events import emit_desktop_enabled_sync, get_event_emitter
+    emitter = get_event_emitter()
+    with patch.object(emitter, "any_admin_wants_desktop_event", return_value=True), \
+         patch.object(emitter, "emit_for_admins_sync") as mock_emit:
+        emit_desktop_enabled_sync("bob")
+    mock_emit.assert_called_once()
+    args, kwargs = mock_emit.call_args
+    assert args[0] == EventType.DESKTOP_ENABLED
+    assert kwargs.get("username") == "bob"
+
+
+def test_emit_desktop_disabled_suppressed_when_not_wanted():
+    from app.services.notifications.events import emit_desktop_disabled_sync, get_event_emitter
+    emitter = get_event_emitter()
+    with patch.object(emitter, "any_admin_wants_desktop_event", return_value=False), \
+         patch.object(emitter, "emit_for_admins_sync") as mock_emit:
+        emit_desktop_disabled_sync("alice")
+    mock_emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Cooldown
+# ---------------------------------------------------------------------------
+
+def test_cooldown_suppresses_second_disable_within_window():
+    from app.services.notifications.events import _cooldown_cache
+    _cooldown_cache.clear()
+    db = _db_with_admins(1)
+    notif = MagicMock()
+    notif.id = 1
+    emitter = _emitter_with_db(db)
+    svc = MagicMock()
+    svc.get_user_preferences.return_value = None
+    svc._get_category_pref.return_value = {"error": True, "success": False, "mobile": False, "desktop": False}
+    with patch.object(_notification_service_mod, "get_notification_service", lambda: svc), \
+         patch("app.services.notifications.events.EventEmitter._send_push_sync"), \
+         patch("app.models.notification.Notification", return_value=notif), \
+         patch("app.services.notification_routing.get_routed_user_ids", return_value=[]):
+        emitter.emit_for_admins_sync(EventType.DESKTOP_DISABLED, cooldown_entity="desktop", username="admin")
+        emitter.emit_for_admins_sync(EventType.DESKTOP_DISABLED, cooldown_entity="desktop", username="admin")
+    db.add.assert_called_once()  # second suppressed by 30s cooldown

--- a/backend/tests/test_desktop_notifications.py
+++ b/backend/tests/test_desktop_notifications.py
@@ -144,3 +144,50 @@ def test_cooldown_suppresses_second_disable_within_window():
         emitter.emit_for_admins_sync(EventType.DESKTOP_DISABLED, cooldown_entity="desktop", username="admin")
         emitter.emit_for_admins_sync(EventType.DESKTOP_DISABLED, cooldown_entity="desktop", username="admin")
     db.add.assert_called_once()  # second suppressed by 30s cooldown
+
+
+# ---------------------------------------------------------------------------
+# Route wiring (uses TestClient + admin auth)
+# ---------------------------------------------------------------------------
+
+from app.core.config import settings
+
+_DISABLE_URL = f"{settings.api_prefix}/system/sleep/desktop/disable"
+_ENABLE_URL = f"{settings.api_prefix}/system/sleep/desktop/enable"
+
+
+def test_route_emits_on_disable_success(client, admin_headers):
+    with patch("app.api.routes.desktop.emit_desktop_disabled", new=AsyncMock()) as m:
+        r = client.post(_DISABLE_URL, headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["success"] is True
+    m.assert_awaited_once()
+    assert m.await_args.args[0] == settings.admin_username
+
+
+def test_route_emits_on_enable_success(client, admin_headers):
+    with patch("app.api.routes.desktop.emit_desktop_enabled", new=AsyncMock()) as m:
+        r = client.post(_ENABLE_URL, headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["success"] is True
+    m.assert_awaited_once()
+    assert m.await_args.args[0] == settings.admin_username
+
+
+def test_route_no_emit_on_disable_failure(client, admin_headers):
+    svc = MagicMock()
+    svc.disable = AsyncMock(return_value=(False, "boom"))
+    with patch("app.api.routes.desktop.get_desktop_service", return_value=svc), \
+         patch("app.api.routes.desktop.emit_desktop_disabled", new=AsyncMock()) as m:
+        r = client.post(_DISABLE_URL, headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["success"] is False
+    m.assert_not_awaited()
+
+
+def test_route_emit_failure_does_not_break_toggle(client, admin_headers):
+    with patch("app.api.routes.desktop.emit_desktop_disabled",
+               new=AsyncMock(side_effect=RuntimeError("push down"))):
+        r = client.post(_DISABLE_URL, headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["success"] is True

--- a/backend/tests/test_desktop_notifications.py
+++ b/backend/tests/test_desktop_notifications.py
@@ -1,0 +1,29 @@
+"""Tests for desktop disable/enable notifications."""
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+import app.services.notifications.service as _notification_service_mod
+from app.services.notifications.events import (
+    EventEmitter,
+    EVENT_CONFIGS,
+    EventType,
+    _COOLDOWN_SECONDS,
+)
+
+
+def test_desktop_event_configs_present():
+    assert EventType.DESKTOP_DISABLED.value == "lifecycle.desktop_disabled"
+    assert EventType.DESKTOP_ENABLED.value == "lifecycle.desktop_enabled"
+    for et in (EventType.DESKTOP_DISABLED, EventType.DESKTOP_ENABLED):
+        cfg = EVENT_CONFIGS[et]
+        assert cfg.category == "lifecycle"
+        assert cfg.priority == 1
+        assert cfg.notification_type == "info"
+        assert "{username}" in cfg.message_template
+        assert cfg.action_url == "/admin/system-control?tab=sleep"
+
+
+def test_desktop_event_cooldowns_present():
+    assert _COOLDOWN_SECONDS["lifecycle.desktop_disabled"] == 30
+    assert _COOLDOWN_SECONDS["lifecycle.desktop_enabled"] == 30

--- a/client/src/api/notifications.ts
+++ b/client/src/api/notifications.ts
@@ -49,6 +49,11 @@ export interface CategoryPreference {
   desktop: boolean;
 }
 
+export interface DesktopEventsPref {
+  disabled: boolean;
+  enabled: boolean;
+}
+
 export interface DeliveryStatus {
   has_mobile_devices: boolean;
   has_desktop_clients: boolean;
@@ -75,7 +80,7 @@ export interface NotificationPreferencesUpdate {
   quiet_hours_end?: string | null;
   min_priority?: number;
   trash_retention_days?: number;
-  category_preferences?: Record<string, CategoryPreference>;
+  category_preferences?: Record<string, CategoryPreference | DesktopEventsPref>;
 }
 
 /**

--- a/client/src/i18n/locales/de/notifications.json
+++ b/client/src/i18n/locales/de/notifications.json
@@ -33,6 +33,12 @@
     "desktopClientDimmed": "Kein Desktop Client verbunden",
     "noneAssigned": "Dir wurden noch keine System-Benachrichtigungen zugewiesen. Wende dich an einen Administrator."
   },
+  "desktopEvents": {
+    "title": "Desktop-Benachrichtigungen",
+    "description": "Benachrichtigen, wenn der Desktop deaktiviert oder reaktiviert wird",
+    "onDisable": "Bei Deaktivierung benachrichtigen",
+    "onEnable": "Bei Reaktivierung benachrichtigen"
+  },
   "buttons": {
     "save": "Speichern",
     "back": "Zurück",

--- a/client/src/i18n/locales/en/notifications.json
+++ b/client/src/i18n/locales/en/notifications.json
@@ -33,6 +33,12 @@
     "desktopClientDimmed": "No desktop client connected",
     "noneAssigned": "No system notifications have been assigned to you yet. Please contact an administrator."
   },
+  "desktopEvents": {
+    "title": "Desktop notifications",
+    "description": "Notify when the desktop is disabled or re-enabled",
+    "onDisable": "Notify on disable",
+    "onEnable": "Notify on re-enable"
+  },
   "buttons": {
     "save": "Save",
     "back": "Back",

--- a/client/src/pages/NotificationPreferencesPage.tsx
+++ b/client/src/pages/NotificationPreferencesPage.tsx
@@ -69,6 +69,10 @@ export default function NotificationPreferencesPage({ embedded = false }: { embe
   const [minPriority, setMinPriority] = useState(0);
   const [trashRetentionDays, setTrashRetentionDays] = useState<number>(7);
   const [categoryPrefs, setCategoryPrefs] = useState<Record<string, CategoryPreference>>({});
+  const [desktopEvents, setDesktopEvents] = useState<{ disabled: boolean; enabled: boolean }>({
+    disabled: true,
+    enabled: true,
+  });
   const [routing, setRouting] = useState<MyNotificationRouting | null>(null);
   const [deliveryStatus, setDeliveryStatus] = useState<DeliveryStatus>({ has_mobile_devices: false, has_desktop_clients: false });
 
@@ -128,6 +132,11 @@ export default function NotificationPreferencesPage({ embedded = false }: { embe
         }
       }
       setCategoryPrefs(migrated);
+      const de = (rawPrefs as any)?.desktop_notifications;
+      setDesktopEvents({
+        disabled: de?.disabled ?? true,
+        enabled: de?.enabled ?? true,
+      });
     } catch {
       toast.error(t('common:toast.loadFailed'));
     } finally {
@@ -143,7 +152,10 @@ export default function NotificationPreferencesPage({ embedded = false }: { embe
         quiet_hours_start: quietHoursEnabled ? quietHoursStart : null,
         quiet_hours_end: quietHoursEnabled ? quietHoursEnd : null,
         min_priority: minPriority,
-        category_preferences: categoryPrefs,
+        category_preferences: {
+          ...categoryPrefs,
+          desktop_notifications: desktopEvents,
+        },
         trash_retention_days: trashRetentionDays,
       });
       toast.success(t('common:toast.saved'));
@@ -451,6 +463,45 @@ export default function NotificationPreferencesPage({ embedded = false }: { embe
                 })}
               </tbody>
             </table>
+          </div>
+        </div>
+      )}
+
+      {/* Desktop power notifications (admin only) */}
+      {isAdmin && (
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+          <div className="mb-4 flex items-center gap-3">
+            <Monitor className="h-5 w-5 text-slate-400" />
+            <div>
+              <h2 className="text-lg font-semibold text-slate-100">{t('desktopEvents.title')}</h2>
+              <p className="text-sm text-slate-400">{t('desktopEvents.description')}</p>
+            </div>
+          </div>
+          <div className="space-y-3">
+            <label className="flex items-center justify-between">
+              <span className="text-sm text-slate-300">{t('desktopEvents.onDisable')}</span>
+              <span className="relative inline-flex cursor-pointer items-center">
+                <input
+                  type="checkbox"
+                  checked={desktopEvents.disabled}
+                  onChange={(e) => setDesktopEvents((p) => ({ ...p, disabled: e.target.checked }))}
+                  className="peer sr-only"
+                />
+                <span className="peer h-6 w-11 rounded-full bg-slate-700 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-slate-600 after:bg-slate-400 after:transition-all after:content-[''] peer-checked:bg-sky-500 peer-checked:after:translate-x-full peer-checked:after:border-white" />
+              </span>
+            </label>
+            <label className="flex items-center justify-between">
+              <span className="text-sm text-slate-300">{t('desktopEvents.onEnable')}</span>
+              <span className="relative inline-flex cursor-pointer items-center">
+                <input
+                  type="checkbox"
+                  checked={desktopEvents.enabled}
+                  onChange={(e) => setDesktopEvents((p) => ({ ...p, enabled: e.target.checked }))}
+                  className="peer sr-only"
+                />
+                <span className="peer h-6 w-11 rounded-full bg-slate-700 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-slate-600 after:bg-slate-400 after:transition-all after:content-[''] peer-checked:bg-sky-500 peer-checked:after:translate-x-full peer-checked:after:border-white" />
+              </span>
+            </label>
           </div>
         </div>
       )}

--- a/client/src/pages/NotificationPreferencesPage.tsx
+++ b/client/src/pages/NotificationPreferencesPage.tsx
@@ -487,7 +487,7 @@ export default function NotificationPreferencesPage({ embedded = false }: { embe
                   onChange={(e) => setDesktopEvents((p) => ({ ...p, disabled: e.target.checked }))}
                   className="peer sr-only"
                 />
-                <span className="peer h-6 w-11 rounded-full bg-slate-700 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-slate-600 after:bg-slate-400 after:transition-all after:content-[''] peer-checked:bg-sky-500 peer-checked:after:translate-x-full peer-checked:after:border-white" />
+                <span className="peer h-6 w-11 rounded-full bg-slate-700 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-slate-600 after:bg-slate-400 after:transition-all after:content-[''] peer-checked:bg-sky-500 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none" />
               </span>
             </label>
             <label className="flex items-center justify-between">
@@ -499,7 +499,7 @@ export default function NotificationPreferencesPage({ embedded = false }: { embe
                   onChange={(e) => setDesktopEvents((p) => ({ ...p, enabled: e.target.checked }))}
                   className="peer sr-only"
                 />
-                <span className="peer h-6 w-11 rounded-full bg-slate-700 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-slate-600 after:bg-slate-400 after:transition-all after:content-[''] peer-checked:bg-sky-500 peer-checked:after:translate-x-full peer-checked:after:border-white" />
+                <span className="peer h-6 w-11 rounded-full bg-slate-700 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-slate-600 after:bg-slate-400 after:transition-all after:content-[''] peer-checked:bg-sky-500 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none" />
               </span>
             </label>
           </div>

--- a/docs/superpowers/plans/2026-06-06-desktop-disable-notification.md
+++ b/docs/superpowers/plans/2026-06-06-desktop-disable-notification.md
@@ -1,0 +1,767 @@
+# Desktop-Disable Notifications Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eine Push-/In-App-Notification erzeugen, wenn der KDE-Desktop deaktiviert oder reaktiviert wird, pro Event durch Admins an-/abschaltbar (beide default an).
+
+**Architecture:** Wiederverwendung der bestehenden `EventEmitter`-Pipeline. Zwei neue `EventType`-Werte in der `lifecycle`-Kategorie (priority=1/info, immer-an wie Suspend/Resume). Ein neuer „any-admin-wants-it"-Gate als `EventEmitter`-Methode liest pro-Event-Präferenzen aus `category_preferences["desktop_notifications"]` (JSON, keine Migration). Best-effort-Emit aus den Desktop-Routen nach erfolgreichem Toggle. Frontend bekommt eine Admin-only Toggle-Sektion.
+
+**Tech Stack:** FastAPI / SQLAlchemy / Pytest (Backend), React + TypeScript + Vite / Vitest / i18next (Frontend).
+
+Spec: `docs/superpowers/specs/2026-06-06-desktop-disable-notification-design.md`. i18n der Notification-**Inhalte** ist Non-Goal (siehe [#166](https://github.com/Xveyn/BaluHost/issues/166)).
+
+---
+
+## File Structure
+
+| File | Verantwortung | Änderung |
+|---|---|---|
+| `backend/app/services/notifications/events.py` | Event-Definitionen, Cooldowns, Gate, Emit-Helfer | 2 EventTypes, 2 EVENT_CONFIGS, 2 Cooldowns, `EventEmitter.any_admin_wants_desktop_event`, 4 Emit-Helfer |
+| `backend/app/api/routes/desktop.py` | HTTP-Routen Desktop-Toggle | best-effort Emit nach `ok==True` |
+| `backend/tests/test_desktop_notifications.py` | Unit-Tests | NEU |
+| `client/src/api/notifications.ts` | API-Typen | Typ `category_preferences` um Desktop-Shape erweitern |
+| `client/src/pages/NotificationPreferencesPage.tsx` | Notification-Einstellungen | Admin-only Toggle-Sektion + State + Load/Merge |
+| `client/src/i18n/locales/de/notifications.json` | DE-i18n | `desktopEvents.*` Keys |
+| `client/src/i18n/locales/en/notifications.json` | EN-i18n | `desktopEvents.*` Keys |
+
+---
+
+## Task 1: EventTypes, EVENT_CONFIGS & Cooldowns
+
+**Files:**
+- Create: `backend/tests/test_desktop_notifications.py`
+- Modify: `backend/app/services/notifications/events.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_desktop_notifications.py`:
+
+```python
+"""Tests for desktop disable/enable notifications."""
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+import app.services.notifications.service as _notification_service_mod
+from app.services.notifications.events import (
+    EventEmitter,
+    EVENT_CONFIGS,
+    EventType,
+    _COOLDOWN_SECONDS,
+)
+
+
+def test_desktop_event_configs_present():
+    assert EventType.DESKTOP_DISABLED.value == "lifecycle.desktop_disabled"
+    assert EventType.DESKTOP_ENABLED.value == "lifecycle.desktop_enabled"
+    for et in (EventType.DESKTOP_DISABLED, EventType.DESKTOP_ENABLED):
+        cfg = EVENT_CONFIGS[et]
+        assert cfg.category == "lifecycle"
+        assert cfg.priority == 1
+        assert cfg.notification_type == "info"
+        assert "{username}" in cfg.message_template
+        assert cfg.action_url == "/admin/system-control?tab=sleep"
+
+
+def test_desktop_event_cooldowns_present():
+    assert _COOLDOWN_SECONDS["lifecycle.desktop_disabled"] == 30
+    assert _COOLDOWN_SECONDS["lifecycle.desktop_enabled"] == 30
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_desktop_notifications.py -v`
+Expected: FAIL — `AttributeError: DESKTOP_DISABLED` (enum member missing).
+
+- [ ] **Step 3: Add the two EventType values**
+
+In `backend/app/services/notifications/events.py`, in the `EventType` enum, immediately after the line `SYSTEM_STARTUP = "lifecycle.startup"`:
+
+```python
+    # Desktop power events
+    DESKTOP_DISABLED = "lifecycle.desktop_disabled"
+    DESKTOP_ENABLED = "lifecycle.desktop_enabled"
+```
+
+- [ ] **Step 4: Add the two cooldown entries**
+
+In `_COOLDOWN_SECONDS`, immediately after the line `"lifecycle.resume": 60,` and before the `# No cooldown for shutdown/startup` comment:
+
+```python
+    "lifecycle.desktop_disabled": 30,  # 30s — swallow accidental double-toggle
+    "lifecycle.desktop_enabled": 30,
+```
+
+- [ ] **Step 5: Add the two EVENT_CONFIGS entries**
+
+In `EVENT_CONFIGS`, immediately after the `EventType.SYSTEM_STARTUP: EventConfig(...)` block (the last entry, ending in `action_url="/",\n    ),`) and before the closing `}` of the dict:
+
+```python
+    EventType.DESKTOP_DISABLED: EventConfig(
+        priority=1,
+        category="lifecycle",
+        notification_type="info",
+        title_template="Desktop deaktiviert",
+        message_template="Die Bildschirme wurden von {username} ausgeschaltet — die GPU kann in den Idle gehen.",
+        action_url="/admin/system-control?tab=sleep",
+    ),
+    EventType.DESKTOP_ENABLED: EventConfig(
+        priority=1,
+        category="lifecycle",
+        notification_type="info",
+        title_template="Desktop reaktiviert",
+        message_template="Die Bildschirme wurden von {username} wieder eingeschaltet.",
+        action_url="/admin/system-control?tab=sleep",
+    ),
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/test_desktop_notifications.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/notifications/events.py backend/tests/test_desktop_notifications.py
+git commit -m "feat(notifications): add desktop_disabled/enabled event types, configs, cooldowns"
+```
+
+---
+
+## Task 2: Gate method & emit helpers
+
+**Files:**
+- Modify: `backend/app/services/notifications/events.py`
+- Modify: `backend/tests/test_desktop_notifications.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/test_desktop_notifications.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Gate: any_admin_wants_desktop_event
+# ---------------------------------------------------------------------------
+
+def _emitter_with_db(db: MagicMock) -> EventEmitter:
+    emitter = EventEmitter()
+    emitter.set_db_session_factory(lambda: db)
+    return emitter
+
+
+def _db_with_admins(*ids: int) -> MagicMock:
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = [(i,) for i in ids]
+    return db
+
+
+def _svc_with_prefs(category_preferences):
+    svc = MagicMock()
+    prefs = MagicMock()
+    prefs.category_preferences = category_preferences
+    svc.get_user_preferences.return_value = prefs
+    return svc
+
+
+def test_gate_default_true_when_no_pref():
+    db = _db_with_admins(1)
+    emitter = _emitter_with_db(db)
+    svc = _svc_with_prefs(None)
+    with patch.object(_notification_service_mod, "get_notification_service", lambda: svc):
+        assert emitter.any_admin_wants_desktop_event("disabled") is True
+        assert emitter.any_admin_wants_desktop_event("enabled") is True
+
+
+def test_gate_per_event_independent():
+    db = _db_with_admins(1)
+    emitter = _emitter_with_db(db)
+    svc = _svc_with_prefs({"desktop_notifications": {"disabled": False, "enabled": True}})
+    with patch.object(_notification_service_mod, "get_notification_service", lambda: svc):
+        assert emitter.any_admin_wants_desktop_event("disabled") is False
+        assert emitter.any_admin_wants_desktop_event("enabled") is True
+
+
+def test_gate_false_when_no_admins():
+    db = _db_with_admins()  # no admins
+    emitter = _emitter_with_db(db)
+    svc = _svc_with_prefs({"desktop_notifications": {"disabled": True}})
+    with patch.object(_notification_service_mod, "get_notification_service", lambda: svc):
+        assert emitter.any_admin_wants_desktop_event("disabled") is False
+
+
+def test_gate_true_when_factory_missing():
+    """No DB factory configured (e.g. early startup) -> do not suppress."""
+    emitter = EventEmitter()  # no set_db_session_factory
+    assert emitter.any_admin_wants_desktop_event("disabled") is True
+
+
+# ---------------------------------------------------------------------------
+# Emit helpers
+# ---------------------------------------------------------------------------
+
+def test_emit_desktop_disabled_calls_emit_when_wanted():
+    from app.services.notifications.events import emit_desktop_disabled_sync, get_event_emitter
+    emitter = get_event_emitter()
+    with patch.object(emitter, "any_admin_wants_desktop_event", return_value=True), \
+         patch.object(emitter, "emit_for_admins_sync") as mock_emit:
+        emit_desktop_disabled_sync("alice")
+    mock_emit.assert_called_once()
+    args, kwargs = mock_emit.call_args
+    assert args[0] == EventType.DESKTOP_DISABLED
+    assert kwargs.get("username") == "alice"
+    assert kwargs.get("cooldown_entity") == "desktop"
+
+
+def test_emit_desktop_enabled_calls_emit_when_wanted():
+    from app.services.notifications.events import emit_desktop_enabled_sync, get_event_emitter
+    emitter = get_event_emitter()
+    with patch.object(emitter, "any_admin_wants_desktop_event", return_value=True), \
+         patch.object(emitter, "emit_for_admins_sync") as mock_emit:
+        emit_desktop_enabled_sync("bob")
+    mock_emit.assert_called_once()
+    args, kwargs = mock_emit.call_args
+    assert args[0] == EventType.DESKTOP_ENABLED
+    assert kwargs.get("username") == "bob"
+
+
+def test_emit_desktop_disabled_suppressed_when_not_wanted():
+    from app.services.notifications.events import emit_desktop_disabled_sync, get_event_emitter
+    emitter = get_event_emitter()
+    with patch.object(emitter, "any_admin_wants_desktop_event", return_value=False), \
+         patch.object(emitter, "emit_for_admins_sync") as mock_emit:
+        emit_desktop_disabled_sync("alice")
+    mock_emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Cooldown
+# ---------------------------------------------------------------------------
+
+def test_cooldown_suppresses_second_disable_within_window():
+    from app.services.notifications.events import _cooldown_cache
+    _cooldown_cache.clear()
+    db = _db_with_admins(1)
+    notif = MagicMock()
+    notif.id = 1
+    emitter = _emitter_with_db(db)
+    svc = MagicMock()
+    svc.get_user_preferences.return_value = None
+    svc._get_category_pref.return_value = {"error": True, "success": False, "mobile": False, "desktop": False}
+    with patch.object(_notification_service_mod, "get_notification_service", lambda: svc), \
+         patch("app.services.notifications.events.EventEmitter._send_push_sync"), \
+         patch("app.models.notification.Notification", return_value=notif), \
+         patch("app.services.notification_routing.get_routed_user_ids", return_value=[]):
+        emitter.emit_for_admins_sync(EventType.DESKTOP_DISABLED, cooldown_entity="desktop", username="admin")
+        emitter.emit_for_admins_sync(EventType.DESKTOP_DISABLED, cooldown_entity="desktop", username="admin")
+    db.add.assert_called_once()  # second suppressed by 30s cooldown
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_desktop_notifications.py -v`
+Expected: FAIL — `AttributeError: 'EventEmitter' object has no attribute 'any_admin_wants_desktop_event'` and `ImportError: cannot import name 'emit_desktop_disabled_sync'`.
+
+- [ ] **Step 3: Add the gate method to EventEmitter**
+
+In `backend/app/services/notifications/events.py`, inside `class EventEmitter`, immediately after the `emit_for_admins_sync` method (after its final line `self.emit_sync(event_type, user_id=None, cooldown_entity=cooldown_entity, **kwargs)`) and before `_send_push_sync`:
+
+```python
+    def any_admin_wants_desktop_event(self, which: str) -> bool:
+        """Return True if at least one active admin wants the desktop *which* event.
+
+        *which* is "disabled" or "enabled". Reads each admin's
+        category_preferences["desktop_notifications"][which]; default True.
+        Returns True if no DB session factory is configured (e.g. very early
+        startup) so notifications are never silently lost.
+        """
+        if not self._db_session_factory:
+            return True
+        db = self._db_session_factory()
+        try:
+            from app.services.notifications.service import get_notification_service
+            from app.models.user import User
+
+            svc = get_notification_service()
+            admin_ids = [
+                uid for (uid,) in db.query(User.id).filter(
+                    User.role == "admin",
+                    User.is_active == True,
+                ).all()
+            ]
+            for admin_id in admin_ids:
+                prefs = svc.get_user_preferences(db, admin_id)
+                cat_prefs = (prefs.category_preferences or {}) if prefs else {}
+                desktop_prefs = cat_prefs.get("desktop_notifications", {})
+                if desktop_prefs.get(which, True):
+                    return True
+            return False
+        finally:
+            db.close()
+```
+
+- [ ] **Step 4: Add the emit helpers at the end of the file**
+
+Append to the end of `backend/app/services/notifications/events.py` (after the `emit_system_startup` async helper):
+
+```python
+# ---------------------------------------------------------------------------
+# Desktop power event helpers
+# ---------------------------------------------------------------------------
+
+
+def emit_desktop_disabled_sync(username: str) -> None:
+    """Emit lifecycle.desktop_disabled (sync) — fired after a successful disable."""
+    emitter = get_event_emitter()
+    if not emitter.any_admin_wants_desktop_event("disabled"):
+        logger.debug("Desktop-disabled event suppressed: no admin wants it")
+        return
+    emitter.emit_for_admins_sync(
+        EventType.DESKTOP_DISABLED,
+        cooldown_entity="desktop",
+        username=username,
+    )
+
+
+def emit_desktop_enabled_sync(username: str) -> None:
+    """Emit lifecycle.desktop_enabled (sync) — fired after a successful enable."""
+    emitter = get_event_emitter()
+    if not emitter.any_admin_wants_desktop_event("enabled"):
+        logger.debug("Desktop-enabled event suppressed: no admin wants it")
+        return
+    emitter.emit_for_admins_sync(
+        EventType.DESKTOP_ENABLED,
+        cooldown_entity="desktop",
+        username=username,
+    )
+
+
+async def emit_desktop_disabled(username: str) -> None:
+    """Async wrapper — used in the desktop route handler."""
+    emit_desktop_disabled_sync(username)
+
+
+async def emit_desktop_enabled(username: str) -> None:
+    """Async wrapper — used in the desktop route handler."""
+    emit_desktop_enabled_sync(username)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/test_desktop_notifications.py -v`
+Expected: PASS (all gate, emit-helper and cooldown tests green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/notifications/events.py backend/tests/test_desktop_notifications.py
+git commit -m "feat(notifications): add desktop event gate + emit helpers"
+```
+
+---
+
+## Task 3: Wire emit into the desktop routes
+
+**Files:**
+- Modify: `backend/app/api/routes/desktop.py`
+- Modify: `backend/tests/test_desktop_notifications.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/test_desktop_notifications.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Route wiring (uses TestClient + admin auth)
+# ---------------------------------------------------------------------------
+
+from app.core.config import settings
+
+_DISABLE_URL = f"{settings.api_prefix}/system/sleep/desktop/disable"
+_ENABLE_URL = f"{settings.api_prefix}/system/sleep/desktop/enable"
+
+
+def test_route_emits_on_disable_success(client, admin_headers):
+    with patch("app.api.routes.desktop.emit_desktop_disabled", new=AsyncMock()) as m:
+        r = client.post(_DISABLE_URL, headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["success"] is True
+    m.assert_awaited_once()
+    assert m.await_args.args[0] == settings.admin_username
+
+
+def test_route_emits_on_enable_success(client, admin_headers):
+    with patch("app.api.routes.desktop.emit_desktop_enabled", new=AsyncMock()) as m:
+        r = client.post(_ENABLE_URL, headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["success"] is True
+    m.assert_awaited_once()
+    assert m.await_args.args[0] == settings.admin_username
+
+
+def test_route_no_emit_on_disable_failure(client, admin_headers):
+    svc = MagicMock()
+    svc.disable = AsyncMock(return_value=(False, "boom"))
+    with patch("app.api.routes.desktop.get_desktop_service", return_value=svc), \
+         patch("app.api.routes.desktop.emit_desktop_disabled", new=AsyncMock()) as m:
+        r = client.post(_DISABLE_URL, headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["success"] is False
+    m.assert_not_awaited()
+
+
+def test_route_emit_failure_does_not_break_toggle(client, admin_headers):
+    with patch("app.api.routes.desktop.emit_desktop_disabled",
+               new=AsyncMock(side_effect=RuntimeError("push down"))):
+        r = client.post(_DISABLE_URL, headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["success"] is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_desktop_notifications.py -k route -v`
+Expected: FAIL — `emit_desktop_disabled` not awaited (route does not emit yet) / `AttributeError` on the patch target (name not imported in `desktop.py`).
+
+- [ ] **Step 3: Import the emit helpers in the route module**
+
+In `backend/app/api/routes/desktop.py`, immediately after the line `from app.services.power.desktop import get_desktop_service`:
+
+```python
+from app.services.notifications.events import emit_desktop_disabled, emit_desktop_enabled
+```
+
+- [ ] **Step 4: Emit on success in `desktop_disable`**
+
+In `backend/app/api/routes/desktop.py`, in `desktop_disable`, replace the final `return` block. Find:
+
+```python
+    if current_user.role != "admin":
+        # Mirror the sleep routes: record that a delegated (non-admin) user
+        # invoked a privileged power action, for the security-audit trail.
+        audit_logger.log_security_event(
+            action="delegated_power_action",
+            user=current_user.username,
+            resource="toggle_desktop",
+            details={"action": "desktop_disable"},
+            success=True,
+        )
+    return {"success": ok, "message": message}
+```
+
+Replace with (keep everything identical, add the `if ok:` block before `return`):
+
+```python
+    if current_user.role != "admin":
+        # Mirror the sleep routes: record that a delegated (non-admin) user
+        # invoked a privileged power action, for the security-audit trail.
+        audit_logger.log_security_event(
+            action="delegated_power_action",
+            user=current_user.username,
+            resource="toggle_desktop",
+            details={"action": "desktop_disable"},
+            success=True,
+        )
+    if ok:
+        try:
+            await emit_desktop_disabled(current_user.username)
+        except Exception as exc:  # best-effort: never break the toggle
+            logger.warning("Desktop-disabled notification failed: %s", exc)
+    return {"success": ok, "message": message}
+```
+
+- [ ] **Step 5: Emit on success in `desktop_enable`**
+
+In `desktop_enable`, find:
+
+```python
+    if current_user.role != "admin":
+        # Mirror the sleep routes: record that a delegated (non-admin) user
+        # invoked a privileged power action, for the security-audit trail.
+        audit_logger.log_security_event(
+            action="delegated_power_action",
+            user=current_user.username,
+            resource="toggle_desktop",
+            details={"action": "desktop_enable"},
+            success=True,
+        )
+    return {"success": ok, "message": message}
+```
+
+Replace with:
+
+```python
+    if current_user.role != "admin":
+        # Mirror the sleep routes: record that a delegated (non-admin) user
+        # invoked a privileged power action, for the security-audit trail.
+        audit_logger.log_security_event(
+            action="delegated_power_action",
+            user=current_user.username,
+            resource="toggle_desktop",
+            details={"action": "desktop_enable"},
+            success=True,
+        )
+    if ok:
+        try:
+            await emit_desktop_enabled(current_user.username)
+        except Exception as exc:  # best-effort: never break the toggle
+            logger.warning("Desktop-enabled notification failed: %s", exc)
+    return {"success": ok, "message": message}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/test_desktop_notifications.py -v`
+Expected: PASS (all tests, incl. route tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/api/routes/desktop.py backend/tests/test_desktop_notifications.py
+git commit -m "feat(desktop): emit desktop disabled/enabled notification on success"
+```
+
+---
+
+## Task 4: Frontend API type
+
+**Files:**
+- Modify: `client/src/api/notifications.ts`
+
+- [ ] **Step 1: Add the `DesktopEventsPref` interface**
+
+In `client/src/api/notifications.ts`, immediately after the `CategoryPreference` interface (the block ending with `desktop: boolean;\n}`):
+
+```typescript
+export interface DesktopEventsPref {
+  disabled: boolean;
+  enabled: boolean;
+}
+```
+
+- [ ] **Step 2: Widen the update type**
+
+In the `NotificationPreferencesUpdate` interface, replace the line:
+
+```typescript
+  category_preferences?: Record<string, CategoryPreference>;
+```
+
+with:
+
+```typescript
+  category_preferences?: Record<string, CategoryPreference | DesktopEventsPref>;
+```
+
+- [ ] **Step 3: Verify the client still type-checks**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: No new errors from `notifications.ts` (a pre-existing clean tree stays clean).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/api/notifications.ts
+git commit -m "feat(notifications): type desktop_notifications pref in update payload"
+```
+
+---
+
+## Task 5: Frontend toggle section
+
+**Files:**
+- Modify: `client/src/pages/NotificationPreferencesPage.tsx`
+
+- [ ] **Step 1: Add the `desktopEvents` state**
+
+In `client/src/pages/NotificationPreferencesPage.tsx`, immediately after the line:
+
+```typescript
+  const [categoryPrefs, setCategoryPrefs] = useState<Record<string, CategoryPreference>>({});
+```
+
+add:
+
+```typescript
+  const [desktopEvents, setDesktopEvents] = useState<{ disabled: boolean; enabled: boolean }>({
+    disabled: true,
+    enabled: true,
+  });
+```
+
+- [ ] **Step 2: Load `desktopEvents` in `loadPreferences`**
+
+In `loadPreferences`, immediately after `setCategoryPrefs(migrated);`:
+
+```typescript
+      const de = (rawPrefs as any)?.desktop_notifications;
+      setDesktopEvents({
+        disabled: de?.disabled ?? true,
+        enabled: de?.enabled ?? true,
+      });
+```
+
+- [ ] **Step 3: Merge `desktopEvents` into the save payload**
+
+In `handleSave`, replace the line:
+
+```typescript
+        category_preferences: categoryPrefs,
+```
+
+with:
+
+```typescript
+        category_preferences: {
+          ...categoryPrefs,
+          desktop_notifications: desktopEvents,
+        },
+```
+
+- [ ] **Step 4: Add the Admin-only toggle section**
+
+In the returned JSX, immediately after the Category Settings block — i.e. after the closing `)}` of the `{!isAdmin && visibleCategories.length === 0 ? (...) : (...)}` ternary and before the final `</div>` that closes the page wrapper — insert:
+
+```tsx
+      {/* Desktop power notifications (admin only) */}
+      {isAdmin && (
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+          <div className="mb-4 flex items-center gap-3">
+            <Monitor className="h-5 w-5 text-slate-400" />
+            <div>
+              <h2 className="text-lg font-semibold text-slate-100">{t('desktopEvents.title')}</h2>
+              <p className="text-sm text-slate-400">{t('desktopEvents.description')}</p>
+            </div>
+          </div>
+          <div className="space-y-3">
+            <label className="flex items-center justify-between">
+              <span className="text-sm text-slate-300">{t('desktopEvents.onDisable')}</span>
+              <span className="relative inline-flex cursor-pointer items-center">
+                <input
+                  type="checkbox"
+                  checked={desktopEvents.disabled}
+                  onChange={(e) => setDesktopEvents((p) => ({ ...p, disabled: e.target.checked }))}
+                  className="peer sr-only"
+                />
+                <span className="peer h-6 w-11 rounded-full bg-slate-700 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-slate-600 after:bg-slate-400 after:transition-all after:content-[''] peer-checked:bg-sky-500 peer-checked:after:translate-x-full peer-checked:after:border-white" />
+              </span>
+            </label>
+            <label className="flex items-center justify-between">
+              <span className="text-sm text-slate-300">{t('desktopEvents.onEnable')}</span>
+              <span className="relative inline-flex cursor-pointer items-center">
+                <input
+                  type="checkbox"
+                  checked={desktopEvents.enabled}
+                  onChange={(e) => setDesktopEvents((p) => ({ ...p, enabled: e.target.checked }))}
+                  className="peer sr-only"
+                />
+                <span className="peer h-6 w-11 rounded-full bg-slate-700 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-slate-600 after:bg-slate-400 after:transition-all after:content-[''] peer-checked:bg-sky-500 peer-checked:after:translate-x-full peer-checked:after:border-white" />
+              </span>
+            </label>
+          </div>
+        </div>
+      )}
+```
+
+> `Monitor` is already imported from `lucide-react` at the top of this file — no new import needed.
+
+- [ ] **Step 5: Verify the client type-checks**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: No new errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/pages/NotificationPreferencesPage.tsx
+git commit -m "feat(notifications): admin toggles for desktop disable/enable notifications"
+```
+
+---
+
+## Task 6: i18n keys (DE + EN)
+
+**Files:**
+- Modify: `client/src/i18n/locales/de/notifications.json`
+- Modify: `client/src/i18n/locales/en/notifications.json`
+
+- [ ] **Step 1: German keys**
+
+In `client/src/i18n/locales/de/notifications.json`, immediately before the top-level `"buttons": {` object, insert:
+
+```json
+  "desktopEvents": {
+    "title": "Desktop-Benachrichtigungen",
+    "description": "Benachrichtigen, wenn der Desktop deaktiviert oder reaktiviert wird",
+    "onDisable": "Bei Deaktivierung benachrichtigen",
+    "onEnable": "Bei Reaktivierung benachrichtigen"
+  },
+```
+
+- [ ] **Step 2: English keys**
+
+In `client/src/i18n/locales/en/notifications.json`, immediately before the top-level `"buttons": {` object, insert:
+
+```json
+  "desktopEvents": {
+    "title": "Desktop notifications",
+    "description": "Notify when the desktop is disabled or re-enabled",
+    "onDisable": "Notify on disable",
+    "onEnable": "Notify on re-enable"
+  },
+```
+
+- [ ] **Step 3: Verify both JSON files are valid**
+
+Run:
+```bash
+cd client && node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/de/notifications.json','utf8')); JSON.parse(require('fs').readFileSync('src/i18n/locales/en/notifications.json','utf8')); console.log('OK')"
+```
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/i18n/locales/de/notifications.json client/src/i18n/locales/en/notifications.json
+git commit -m "i18n(notifications): desktopEvents toggle labels (de/en)"
+```
+
+---
+
+## Task 7: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the new backend tests**
+
+Run: `cd backend && python -m pytest tests/test_desktop_notifications.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 2: Run the related notification suites (no regression)**
+
+Run: `cd backend && python -m pytest tests/services/test_notification_events.py tests/test_lifecycle_notifications.py -q`
+Expected: PASS (all previously-passing tests still pass).
+
+- [ ] **Step 3: Run the frontend unit suite + build typecheck**
+
+Run: `cd client && npx vitest run && npm run build`
+Expected: Vitest green; production build (tsc + vite) succeeds.
+
+- [ ] **Step 4: Manual smoke (dev mode)**
+
+1. `python start_dev.py`, login as admin.
+2. PowerMenu → „Desktop deaktivieren" → Glocke zeigt „Desktop deaktiviert … von admin".
+3. System Control → Sleep → Desktop reaktivieren → „Desktop reaktiviert … von admin".
+4. Notification-Einstellungen → „Bei Deaktivierung benachrichtigen" aus, speichern → erneut deaktivieren → **keine** Notification.
+5. Zwei schnelle Deaktivierungen < 30 s → nur eine Notification (Cooldown).
+
+- [ ] **Step 5: No commit** (verification only).
+
+---
+
+## Notes for the implementer
+
+- **Dev mode:** `DevDesktopBackend.disable/enable` return `(True, ...)`, so the emit fires in dev — good for the manual smoke and route tests.
+- **Single-admin reality:** the gate's „any admin wants it" is effectively a personal switch (BaluHost has one admin). With multiple admins, the shared system notification appears in every admin's bell; per-admin bell muting is out of scope (see spec).
+- **No migration:** prefs live in the existing `category_preferences` JSON column under the reserved key `desktop_notifications`.
+- **Notification text stays German** (backend templates), consistent with the whole system — see [#166](https://github.com/Xveyn/BaluHost/issues/166).

--- a/docs/superpowers/specs/2026-06-06-desktop-disable-notification-design.md
+++ b/docs/superpowers/specs/2026-06-06-desktop-disable-notification-design.md
@@ -1,0 +1,215 @@
+# Desktop-Disable Notifications — Design Spec
+
+**Date:** 2026-06-06
+**Status:** Approved
+**Author:** Sven (Xveyn) + Claude (via brainstorming session)
+**Branch:** `feat/desktop-disable-notification`
+
+## Problem
+
+Das KDE-Desktop-Deaktivieren/-Aktivieren (Bildschirme via DPMS aus-/einschalten, damit
+die dGPU von ~78W auf ~18W deep-idlen kann) ist seit Kurzem als Schnellaktion im PowerMenu
+sowie im `DesktopTogglePanel` (System Control → Sleep) verfügbar
+(`POST /api/system/sleep/desktop/disable|enable`). Anders als bei Suspend/Resume/Shutdown/Startup
+gibt es dafür **keine Benachrichtigung** — der Admin (und ggf. ein delegierter User) bekommt
+keinen nachvollziehbaren Hinweis, dass der Desktop-Zustand gewechselt wurde.
+
+## Goals
+
+- Push-/In-App-Notification beim **Deaktivieren** und **Reaktivieren** des Desktops.
+- Den **auslösenden Benutzer** im Text nennen (Nachvollziehbarkeit bei mehreren Admins / delegierten Usern).
+- **Pro-Event** durch Admins konfigurierbar (beide standardmäßig an).
+- Bestehende `EventEmitter`-Pipeline 1:1 wiederverwenden (keine Parallel-Pipeline).
+
+## Non-Goals
+
+- **Lokalisierung der Notification-Inhalte** — der gesamte Bestand erzeugt Notification-Titel/-Texte
+  hart auf Deutsch (siehe [Issue #166](https://github.com/Xveyn/BaluHost/issues/166)). Dieses Feature
+  folgt demselben Muster; i18n der Inhalte ist hier explizit ausgeklammert.
+- Neue Notification-Kategorie (`desktop`) oder neues DB-Table — unnötig, siehe Decisions.
+- Änderungen am PowerMenu, am `DesktopTogglePanel` oder an den Desktop-Backends.
+- Notifications für automatische/Idle-Auslöser — es gibt **keine**; Desktop-Toggle ist rein manuell.
+- Pro-Admin-Stummschaltung in der Glocke (technisch nicht möglich für geteilte System-Notifications,
+  siehe Decisions / Edge Cases).
+
+## Decisions (from brainstorming)
+
+| Topic | Decision |
+|---|---|
+| Events | Beide: `desktop_disabled` + `desktop_enabled` |
+| Kategorie | Bestehende `lifecycle`-Kategorie (kein neues Table, keine Migration) |
+| Default-Lautstärke | Immer an für Admins (priority=1, `info` — wie Suspend/Resume) |
+| Wer-Kontext | Auslösender Benutzer (`current_user.username`) im Text |
+| Konfigurierbarkeit | Pro-Event-Schalter (neu), beide default an; „any-admin-wants-it"-Gate |
+| Persistenz der Prefs | `category_preferences["desktop_notifications"]` (JSON, keine Migration) |
+| Cooldown | 30 s pro Event (`cooldown_entity="desktop"`) gegen Doppelauslösung |
+| Trigger-Punkt | `desktop.py` Route-Handler, nur bei `ok==True`, best-effort |
+
+## Architecture
+
+```
+desktop.py: desktop_disable() / desktop_enable()   [async route, beliebiger Worker]
+  └─ nach erfolgreichem Toggle (ok==True):
+       emit_desktop_disabled(username)  bzw.  emit_desktop_enabled(username)
+            │
+            ├─ Gate (NEU): "will mind. ein aktiver Admin dieses Event?"
+            │     │  SessionLocal → category_preferences["desktop_notifications"]
+            │     ├─ nein  → still (keine DB-Zeile, kein Push)
+            │     └─ ja    → emit_for_admins_sync(EventType.DESKTOP_*, username=...)
+            │
+            └─ ab hier bestehende Mechanik 1:1:
+                 emit_sync()  (priority=1/info passiert den generischen Gate ohnehin durch)
+                 ├─ System-Notification (user_id=NULL) → Glocke (alle Admins)
+                 ├─ 30 s-Cooldown
+                 └─ _send_push_sync → Mobile-Push, respektiert lifecycle-`mobile`-Flag pro Admin
+```
+
+**Kernidee:** Der Pro-Event-Gate lebt isoliert im neuen Emit-Helfer; `emit_sync` bleibt unverändert.
+Bei genau einem Admin (reale Lage) wirkt „any-admin-wants-it" wie ein persönlicher Schalter.
+
+## Components
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `backend/app/services/notifications/events.py` | 2 neue `EventType` (`DESKTOP_DISABLED`, `DESKTOP_ENABLED`); 2 `EVENT_CONFIGS` (category `lifecycle`, priority=1, `info`); 2 Cooldown-Einträge (30 s); neue Emit-Helfer `emit_desktop_disabled_sync/_async`, `emit_desktop_enabled_sync/_async` inkl. „any-admin-wants-it"-Gate |
+| `backend/app/api/routes/desktop.py` | In `desktop_disable` / `desktop_enable` nach `ok==True`: best-effort Emit mit `current_user.username` (try/except, bricht Toggle nie ab) |
+| `client/src/pages/NotificationPreferencesPage.tsx` | Neue Admin-only Sektion „Desktop-Benachrichtigungen" mit 2 Toggles; State `desktopEvents`; Load aus `category_preferences.desktop_notifications` (Default beide `true`); Merge in `handleSave`-Payload |
+| `client/src/api/notifications.ts` | Typ `NotificationPreferencesUpdate.category_preferences` minimal lockern (Union mit `{disabled:boolean; enabled:boolean}`-Shape); optional `DesktopEventsPref`-Interface |
+| `client/src/i18n/locales/de/notifications.json` | Neue Keys `desktopEvents.*` |
+| `client/src/i18n/locales/en/notifications.json` | Neue Keys `desktopEvents.*` |
+
+### New files
+
+| File | Purpose |
+|---|---|
+| `backend/tests/test_desktop_notifications.py` | Unit-Tests (Gate, Texte, Route-on-success-only, best-effort, Cooldown) |
+
+> Kein neues Model, keine Migration, keine neue API-Route.
+
+## Event-Templates (Deutsch, konsistent mit Bestand)
+
+```
+DESKTOP_DISABLED:  title   "Desktop deaktiviert"
+                   message "Die Bildschirme wurden von {username} ausgeschaltet — die GPU kann in den Idle gehen."
+                   action_url "/admin/system-control?tab=sleep"
+                   priority 1, type info
+
+DESKTOP_ENABLED:   title   "Desktop reaktiviert"
+                   message "Die Bildschirme wurden von {username} wieder eingeschaltet."
+                   action_url "/admin/system-control?tab=sleep"
+                   priority 1, type info
+```
+
+`EventType`-Werte: `DESKTOP_DISABLED = "lifecycle.desktop_disabled"`, `DESKTOP_ENABLED = "lifecycle.desktop_enabled"`.
+Cooldown: `"lifecycle.desktop_disabled": 30`, `"lifecycle.desktop_enabled": 30`.
+
+## Preference-Speicherung & Gate
+
+**Befund:** `NotificationPreferencesPage.loadPreferences()` normalisiert jede Kategorie auf exakt
+`{error,success,mobile,desktop}` und `handleSave()` speichert nur `categoryPrefs` — **jeder Zusatz-Key
+in `category_preferences` würde beim nächsten Speichern verworfen.** Speicherung erfordert daher bewusste
+Frontend-Behandlung (separater State + explizites Load/Merge).
+
+**Speicherort:** `category_preferences["desktop_notifications"] = {"disabled": true, "enabled": true}`
+(reservierter Key, JSON-Feld → keine Migration). Wird vom Backend `update_user_preferences` wholesale
+persistiert; `_get_category_pref` wird damit **nie** aufgerufen (Events emittieren unter `lifecycle`),
+also keine Interferenz.
+
+**Gate-Helfer** (neu, in `events.py`): öffnet `SessionLocal`, iteriert aktive Admins
+(`User.role == "admin", is_active == True`), liest je Admin
+`prefs.category_preferences.get("desktop_notifications", {})` und prüft `.get(which, True)`
+(`which ∈ {"disabled","enabled"}`). Wenn **mind. ein** Admin das jeweilige Event will →
+`emit_for_admins_sync(...)`, sonst still zurück. Spiegelt die vorhandene „any-admin-wants-it"-Logik
+aus `emit_sync`.
+
+## Frontend (UI) & i18n
+
+- Neue **Admin-only** Karte „Desktop-Benachrichtigungen" in `NotificationPreferencesPage.tsx`,
+  platziert unter der Kategorie-Tabelle. Zwei Toggle-Switches (gleicher Stil wie Quiet-Hours):
+  „Bei Deaktivierung benachrichtigen" / „Bei Reaktivierung benachrichtigen", beide default an.
+- **State:** `const [desktopEvents, setDesktopEvents] = useState({disabled: true, enabled: true})`.
+  - Load: aus `prefs.category_preferences?.desktop_notifications` (Default beide `true`).
+  - Save: in `handleSave` als `{...categoryPrefs, desktop_notifications: desktopEvents}` mergen.
+- **i18n-Keys** (DE + EN, `notifications`-Namespace):
+
+| Key | Deutsch | English |
+|---|---|---|
+| `desktopEvents.title` | „Desktop-Benachrichtigungen" | "Desktop notifications" |
+| `desktopEvents.description` | „Benachrichtigen, wenn der Desktop deaktiviert oder reaktiviert wird" | "Notify when the desktop is disabled or re-enabled" |
+| `desktopEvents.onDisable` | „Bei Deaktivierung benachrichtigen" | "Notify on disable" |
+| `desktopEvents.onEnable` | „Bei Reaktivierung benachrichtigen" | "Notify on re-enable" |
+
+> Notification-**Inhalte** bleiben deutsch (Backend-Templates), siehe Non-Goals / Issue #166.
+> Kategorie-Anzeigename (`getCategoryName`) ist bereits hardcodiert `Lifecycle` (unverändert).
+
+## Data Flow
+
+```
+User klickt "Desktop deaktivieren" (PowerMenu / DesktopTogglePanel)
+  │
+  ▼
+POST /api/system/sleep/desktop/disable   (require_power_toggle_desktop)
+  │  ok, message = await get_desktop_service().disable()
+  │  audit_logger.log_event(...)                         [bestehend, unverändert]
+  │
+  ├─ if ok:                                              [NEU]
+  │     try:
+  │         emit_desktop_disabled(current_user.username)
+  │     except Exception: log.warning(...)               # best-effort
+  │
+  └─ return {"success": ok, "message": message}
+```
+
+Reaktivierung (`/enable`) analog mit `emit_desktop_enabled`.
+
+## Edge Cases
+
+| Fall | Verhalten |
+|---|---|
+| `disable()`/`enable()` schlägt fehl (`ok==False`) | Keine Notification (kein Zustandswechsel); Route gibt `{success:false}` |
+| Emit wirft Exception | `try/except` → Toggle bricht nie ab, nur Log-Warnung |
+| Kein Admin will das Event | Gate unterdrückt Erzeugung komplett (keine DB-Zeile, kein Push) |
+| Pro-Event unabhängig | `disabled=false, enabled=true` → nur Enable feuert |
+| Dev-Mode (`DevDesktopBackend`) | `ok==True` → Notification wird erzeugt (Tests/Konsistenz) |
+| FCM nicht konfiguriert | `_send_push_sync` no-op; Glocken-Eintrag bleibt |
+| Quiet Hours | priority=1 < 3 → aktive Zustellung unterdrückt, Eintrag gespeichert (bestehend) |
+| Doppelklick / API-Doppelaufruf | 30 s-Cooldown pro Event schluckt die zweite Meldung |
+| Mehrere Worker | Ein Emit pro Request, beliebiger Worker → kein Primary-Worker-Guard, keine Duplikate |
+| Mehrere Admins | Geteilte System-Notification ist in der Glocke für alle Admins sichtbar (Mobile-Push pro Admin via lifecycle-`mobile`-Flag). Pro-Admin-Glockenfilter ist out of scope |
+
+## Tests
+
+`backend/tests/test_desktop_notifications.py`:
+
+| Test | Prüft |
+|---|---|
+| `test_emit_desktop_disabled_creates_notification_when_admin_wants` | Default-Prefs → Notification mit `event_type=lifecycle.desktop_disabled`, `username` im Text |
+| `test_emit_desktop_enabled_creates_notification` | Analog für Reaktivierung |
+| `test_gate_suppresses_when_no_admin_wants` | `desktop_notifications.disabled=false` → keine Notification |
+| `test_gate_per_event_independent` | `disabled=false, enabled=true` → nur Enable feuert |
+| `test_route_emits_on_success_only` | `ok=True` → emit aufgerufen; `ok=False` → nicht |
+| `test_emit_failure_does_not_break_toggle` | Emit wirft → Route liefert trotzdem `{success:true}` |
+| `test_cooldown_suppresses_second_within_30s` | Zwei Disable-Emits < 30 s → zweiter unterdrückt |
+
+Frontend: Smoke-Check, dass die zwei Toggles laden/speichern (bestehende
+`NotificationPreferencesPage`-Tests erweitern, falls vorhanden). PowerMenu-Tests bleiben unberührt
+(kein PowerMenu-Change).
+
+## Build Order
+
+1. `events.py`: 2 EventTypes + 2 EVENT_CONFIGS + 2 Cooldowns + Emit-Helfer mit Gate
+2. Tests (`test_desktop_notifications.py`) — TDD, zuerst rot
+3. `desktop.py`: best-effort Emit nach `ok==True` in beiden Routen
+4. Frontend: `NotificationPreferencesPage` Sektion + State + Load/Merge; `notifications.ts` Typ
+5. i18n-Keys DE + EN
+6. Backend-Tests grün + Frontend-Smoke
+
+## Manual Smoketest (post-deploy)
+
+1. PowerMenu → „Desktop deaktivieren" → Glocke zeigt „Desktop deaktiviert … von <user>"; Mobile-Push (falls FCM)
+2. System Control → Sleep → Desktop reaktivieren → „Desktop reaktiviert … von <user>"
+3. Notification-Einstellungen → „Bei Deaktivierung benachrichtigen" aus → erneut deaktivieren → keine Notification
+4. Beide Toggles aus → kein Event; beide an (Default) → beide Events
+5. Zwei schnelle Deaktivierungen < 30 s → nur eine Notification (Cooldown)


### PR DESCRIPTION
## Was

Benachrichtigungen, wenn der **KDE-Desktop deaktiviert oder reaktiviert** wird (DPMS-Toggle über PowerMenu / `DesktopTogglePanel`). Bisher gab es dafür — anders als bei Suspend/Resume/Shutdown/Startup — keine Notification.

Zwei neue Events in der bestehenden `lifecycle`-Kategorie:
- `lifecycle.desktop_disabled` → *„Desktop deaktiviert — Die Bildschirme wurden von &lt;user&gt; ausgeschaltet …"*
- `lifecycle.desktop_enabled` → *„Desktop reaktiviert — … von &lt;user&gt; wieder eingeschaltet."*

Beide priority=1/info (immer-an wie Suspend/Resume), mit **auslösendem Benutzer** im Text, **pro Event** durch Admins an-/abschaltbar (beide default an).

## Design / Entscheidungen

- **Wiederverwendung der `EventEmitter`-Pipeline** — keine Parallel-Pipeline, kein neues DB-Table, **keine Migration**.
- **Pro-Event-Gate:** neuer `EventEmitter.any_admin_wants_desktop_event(...)` mit „any-admin-wants-it"-Logik (spiegelt die bestehende Erfolg/Fehler-Gate-Mechanik). Bei BaluHosts Einzel-Admin = effektiv persönlicher Schalter.
- **Präferenzen migrationsfrei** in `category_preferences["desktop_notifications"] = {disabled, enabled}` (JSON-Feld; Frontend lädt/merged bewusst, da die Page sonst Fremd-Keys verwirft).
- **Best-effort Emit** aus den Desktop-Routen, nur bei `ok==True`, in `try/except` — ein Push-Fehler bricht den Toggle nie ab.
- **30 s Cooldown** pro Event gegen Doppelauslösung.

Spec: `docs/superpowers/specs/2026-06-06-desktop-disable-notification-design.md`
Plan: `docs/superpowers/plans/2026-06-06-desktop-disable-notification.md`

## Änderungen

**Backend**
- `services/notifications/events.py` — 2 EventTypes, 2 EVENT_CONFIGS, 2 Cooldowns, `any_admin_wants_desktop_event` + 4 Emit-Helfer.
- `api/routes/desktop.py` — best-effort Emit nach erfolgreichem disable/enable (Username aus `current_user`).

**Frontend**
- `pages/NotificationPreferencesPage.tsx` — Admin-only Karte „Desktop-Benachrichtigungen" mit zwei Toggles; State + Load/Merge in `category_preferences.desktop_notifications`.
- `api/notifications.ts` — `DesktopEventsPref`-Typ + erweiterter Update-Typ.
- `i18n/locales/{de,en}/notifications.json` — `desktopEvents.*` Keys.

## Tests

- **Backend:** 14 neue Tests (`tests/test_desktop_notifications.py`) — Configs/Cooldowns, Gate (Default-an, pro-Event unabhängig, keine Admins → still, kein Factory → an), Emit-Helfer-Wiring, Cooldown-Suppression, Route emittiert nur bei Erfolg, Emit-Fehler bricht Toggle nicht. Verwandte Suiten (`test_notification_events.py`, `test_lifecycle_notifications.py`) ohne Regression → **38 passed**.
- **Frontend:** Vitest **403 passed**, Production-Build (tsc + vite) grün.

## Hinweise

- Notification-**Inhalte** bleiben Deutsch (Backend-Templates) — konsistent mit dem gesamten Bestand; echte i18n der Inhalte ist separat als **#166** erfasst.
- Mehrere Admins teilen sich System-Notifications in der Glocke (Mobile-Push pro Admin über das lifecycle-`mobile`-Flag); pro-Admin-Glockenfilter ist bewusst out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
