### PR TITLE
fix(notifications): Desktop-Schalter persistieren (reserved pref key)

### DIFF
--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -368,11 +368,14 @@ async def update_notification_preferences(
                 detail="Invalid quiet_hours_end format. Use HH:MM",
             )
 
-    # Convert category preferences if provided
+    # Convert category preferences if provided. Values arrive as plain dicts
+    # (the field is typed dict[str, Any] so reserved keys like
+    # "desktop_notifications" round-trip), but stay tolerant of pydantic models.
     cat_prefs = None
     if body.category_preferences:
         cat_prefs = {
-            cat: pref.model_dump() for cat, pref in body.category_preferences.items()
+            cat: (pref.model_dump() if hasattr(pref, "model_dump") else pref)
+            for cat, pref in body.category_preferences.items()
         }
 
     prefs = service.update_user_preferences(

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -196,9 +196,14 @@ class NotificationPreferencesBase(BaseModel):
         le=3,
         description="Minimum priority level for notifications"
     )
-    category_preferences: Optional[dict[str, CategoryPreference]] = Field(
+    # dict[str, Any] (not dict[str, CategoryPreference]) so reserved non-category
+    # keys round-trip untouched — e.g. "desktop_notifications": {disabled, enabled}.
+    # Strict per-category validation would coerce such keys to CategoryPreference
+    # and silently drop their fields. Category shapes are read defensively in
+    # NotificationService._get_category_pref.
+    category_preferences: Optional[dict[str, Any]] = Field(
         default=None,
-        description="Per-category notification settings"
+        description="Per-category notification settings (plus reserved keys like desktop_notifications)"
     )
     trash_retention_days: int = Field(
         default=7,
@@ -217,7 +222,8 @@ class NotificationPreferencesUpdate(BaseModel):
     quiet_hours_start: Optional[str] = None
     quiet_hours_end: Optional[str] = None
     min_priority: Optional[int] = Field(default=None, ge=0, le=3)
-    category_preferences: Optional[dict[str, CategoryPreference]] = None
+    # See NotificationPreferencesBase.category_preferences for why this is Any.
+    category_preferences: Optional[dict[str, Any]] = None
     trash_retention_days: Optional[int] = Field(default=None, ge=1, le=7)
 
 

--- a/backend/tests/test_desktop_notifications.py
+++ b/backend/tests/test_desktop_notifications.py
@@ -191,3 +191,37 @@ def test_route_emit_failure_does_not_break_toggle(client, admin_headers):
         r = client.post(_DISABLE_URL, headers=admin_headers)
     assert r.status_code == 200
     assert r.json()["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Preference persistence through the real API (PUT -> GET round-trip)
+# ---------------------------------------------------------------------------
+
+_PREFS_URL = f"{settings.api_prefix}/notifications/preferences"
+
+
+def test_desktop_notifications_pref_roundtrips_via_api(client, admin_headers):
+    """The reserved 'desktop_notifications' key must survive PUT->GET unmangled.
+
+    Regression guard: when category_preferences was typed dict[str, CategoryPreference],
+    pydantic coerced this key into a CategoryPreference and dropped {disabled, enabled},
+    so the per-event admin toggles never persisted. A normal category is included to
+    prove ordinary category prefs still round-trip after the schema loosening.
+    """
+    put = client.put(
+        _PREFS_URL,
+        headers=admin_headers,
+        json={
+            "category_preferences": {
+                "raid": {"error": True, "success": False, "mobile": True, "desktop": False},
+                "desktop_notifications": {"disabled": False, "enabled": True},
+            }
+        },
+    )
+    assert put.status_code == 200, put.text
+
+    get = client.get(_PREFS_URL, headers=admin_headers)
+    assert get.status_code == 200
+    cat_prefs = get.json()["category_preferences"]
+    assert cat_prefs["desktop_notifications"] == {"disabled": False, "enabled": True}
+    assert cat_prefs["raid"] == {"error": True, "success": False, "mobile": True, "desktop": False}


### PR DESCRIPTION
## Problem

Follow-up zu #167. In Produktion bestätigt: Die Admin-Schalter „Desktop deaktiviert/reaktiviert benachrichtigen" haben **keine Wirkung** — das Deaktivieren persistiert nicht, die Notification feuert **immer**.

## Ursache

Das Notification-Preferences-Schema typisierte `category_preferences` strikt als `dict[str, CategoryPreference]`. `CategoryPreference` hat nur `error/success/mobile/desktop`. Pydantic v2 verwirft unbekannte Keys beim Parsen → der reservierte Key `desktop_notifications: {disabled, enabled}` wird sowohl bei `PUT /preferences` (Schreiben) als auch bei `GET /preferences` (Lesen) in eine `CategoryPreference` umgewandelt und **verliert** `{disabled, enabled}`.

Folge: Der Gate liest `category_preferences["desktop_notifications"].get("disabled", True)` → Key fehlt → fällt auf Default `True` zurück → Notification feuert unconditional, der Schalter ist wirkungslos.

Der Bug rutschte durch, weil die Gate-Tests mock-basiert waren und den echten Schema-/Route-Pfad (PUT→GET) nie ausgeführt haben.

## Fix

- `schemas/notification.py`: `category_preferences` auf `dict[str, Any]` gelockert (Base/Response + Update). Kategorie-Formen werden ohnehin defensiv in `NotificationService._get_category_pref` gelesen; reservierte Keys laufen jetzt unverändert durch.
- `api/routes/notifications.py`: die Wert-Serialisierung toleriert plain dicts (statt hart `pref.model_dump()`).
- **Neuer echter Round-Trip-Test** (`PUT → GET` über die API) als Regression-Guard — genau die Abdeckung, die zuvor fehlte. Eine normale Kategorie (`raid`) ist mitgetestet, um zu beweisen, dass gewöhnliche Kategorie-Prefs nach der Lockerung weiter round-trippen.

## Tests

`tests/test_desktop_notifications.py` + `tests/test_notifications_routes.py` → **grün** (inkl. neuem `test_desktop_notifications_pref_roundtrips_via_api`, der ohne den Fix fehlschlägt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
