### PR TITLE
feat(auth): Tauri PIN login (2FA-anchored, local-channel only)

### DIFF
--- a/backend/alembic/versions/45292ba19a35_add_pin_columns_and_auth_policy.py
+++ b/backend/alembic/versions/45292ba19a35_add_pin_columns_and_auth_policy.py
@@ -1,0 +1,39 @@
+"""add pin columns and auth_policy
+
+Revision ID: 45292ba19a35
+Revises: 73861c57ef63
+Create Date: 2026-06-06 17:58:35.112596
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '45292ba19a35'
+down_revision: Union[str, Sequence[str], None] = '73861c57ef63'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    op.add_column("users", sa.Column("pin_hash", sa.String(length=255), nullable=True))
+    op.add_column("users", sa.Column("pin_grace_until", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("users", sa.Column("pin_failed_attempts", sa.Integer(), nullable=False, server_default="0"))
+    op.add_column("users", sa.Column("pin_locked_until", sa.DateTime(timezone=True), nullable=True))
+    op.create_table(
+        "auth_policy",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("pin_login_enabled", sa.Boolean(), nullable=False, server_default="1"),
+        sa.Column("pin_grace_window_seconds", sa.Integer(), nullable=False, server_default="86400"),
+    )
+
+
+def downgrade():
+    op.drop_table("auth_policy")
+    op.drop_column("users", "pin_locked_until")
+    op.drop_column("users", "pin_failed_attempts")
+    op.drop_column("users", "pin_grace_until")
+    op.drop_column("users", "pin_hash")

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -21,6 +21,7 @@ from app.api.routes import (
     docs,
     setup,
     games,
+    auth_policy,
 )
 
 api_router = APIRouter()
@@ -43,6 +44,7 @@ api_router.include_router(devices.router)
 api_router.include_router(vpn.router)
 api_router.include_router(admin_db.router)
 api_router.include_router(rate_limit_config.router, prefix="/admin", tags=["admin"])
+api_router.include_router(auth_policy.router, prefix="/admin/auth-policy", tags=["auth-policy"])
 api_router.include_router(server_profiles.router)
 api_router.include_router(vpn_profiles.router)
 api_router.include_router(metrics.router, tags=["monitoring"])

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -12,6 +12,7 @@ from app.schemas.auth import (
     TwoFactorSetupResponse, TwoFactorVerifySetupRequest,
     TwoFactorDisableRequest, TwoFactorBackupCodesResponse,
     TwoFactorStatusResponse,
+    PinLoginRequest, PinSetRequest, PinRemoveRequest, PinStatusResponse,
 )
 from app.schemas.user import UserPublic, UserCreate
 from app.services import auth as auth_service
@@ -344,6 +345,73 @@ async def get_2fa_status(
         enabled_at=user_record.totp_enabled_at,
         backup_codes_remaining=backup_remaining,
     )
+
+
+@router.get("/pin", response_model=PinStatusResponse)
+@user_limiter.limit(get_limit("user_operations"))
+async def get_pin_status(
+    request: Request, response: Response,
+    current_user=Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+) -> PinStatusResponse:
+    """Whether the current user has a desktop-app PIN configured."""
+    user_record = db.query(UserModel).filter(UserModel.id == current_user.id).first()
+    return PinStatusResponse(pin_enabled=bool(user_record and user_record.pin_hash))
+
+
+def _verify_fresh_totp(db: Session, user_id: int, code: str) -> bool:
+    """Verify a fresh TOTP or backup code for a PIN-management action."""
+    try:
+        if totp_service.verify_code(db, user_id, code):
+            return True
+    except ValueError:
+        pass
+    try:
+        return totp_service.verify_backup_code(db, user_id, code)
+    except ValueError:
+        return False
+
+
+@router.post("/pin")
+@limiter.limit(get_limit("auth_2fa_setup"))
+async def set_pin(
+    payload: PinSetRequest,
+    request: Request, response: Response,
+    current_user=Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Set/replace the desktop-app PIN. Requires 2FA enabled + a fresh TOTP code."""
+    from app.services import pin_service
+    audit_logger = get_audit_logger_db()
+    user_record = db.query(UserModel).filter(UserModel.id == current_user.id).first()
+    if not user_record or not user_record.totp_enabled:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="2FA must be enabled before setting a PIN")
+    if not _verify_fresh_totp(db, current_user.id, payload.code):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid 2FA code")
+    pin_service.set_pin(db, user_record, payload.pin)
+    audit_logger.log_security_event(action="pin_set", user=current_user.username, success=True, db=db)
+    return {"message": "PIN set"}
+
+
+@router.delete("/pin")
+@limiter.limit(get_limit("auth_2fa_setup"))
+async def remove_pin(
+    payload: PinRemoveRequest,
+    request: Request, response: Response,
+    current_user=Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Remove the desktop-app PIN. Requires a fresh TOTP code."""
+    from app.services import pin_service
+    audit_logger = get_audit_logger_db()
+    user_record = db.query(UserModel).filter(UserModel.id == current_user.id).first()
+    if not user_record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    if not _verify_fresh_totp(db, current_user.id, payload.code):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid 2FA code")
+    pin_service.clear_pin(db, user_record)
+    audit_logger.log_security_event(action="pin_removed", user=current_user.username, success=True, db=db)
+    return {"message": "PIN removed"}
 
 
 @router.post("/2fa/backup-codes", response_model=TwoFactorBackupCodesResponse)

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -175,6 +175,14 @@ async def verify_2fa(payload: TwoFactorVerifyRequest, request: Request, response
         db=db
     )
 
+    # Open the PIN grace window from this successful TOTP (only when a PIN exists).
+    if user_record.pin_hash:
+        from datetime import datetime as _dt, timezone as _tz, timedelta as _td
+        from app.services.auth_policy import get_auth_policy
+        window = get_auth_policy(db).pin_grace_window_seconds
+        user_record.pin_grace_until = _dt.now(_tz.utc) + _td(seconds=window)
+        db.commit()
+
     token = auth_service.create_access_token(user_record)
     user_public = user_service.serialize_user(user_record)
 
@@ -187,6 +195,77 @@ async def verify_2fa(payload: TwoFactorVerifyRequest, request: Request, response
     )
 
     return TokenResponse(access_token=token, user=user_public)
+
+
+@router.post("/login-pin")
+@limiter.limit(get_limit("auth_pin_login"))
+async def login_pin(payload: PinLoginRequest, request: Request, response: Response, db: Session = Depends(get_db)):
+    """PIN login — LOCAL CHANNEL ONLY.
+
+    Returns an access token when within the grace window, otherwise a
+    TwoFactorRequiredResponse (the client completes it via /verify-2fa).
+    """
+    from app.services import pin_service
+    from app.services.auth_policy import get_auth_policy
+    audit_logger = get_audit_logger_db()
+    ip_address = request.client.host if request.client else None
+    user_agent = request.headers.get("user-agent")
+
+    # Hard invariant: PIN login is only valid over the local channel.
+    if getattr(request.state, "channel", "remote") != "local":
+        audit_logger.log_security_event(
+            action="pin_login_remote_denied", user=payload.username,
+            details={"ip_address": ip_address}, success=False, db=db,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "local_channel_required",
+                "message": "PIN login is only available from the BaluHost Companion app on the server.",
+            },
+        )
+
+    if not get_auth_policy(db).pin_login_enabled:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="PIN login is disabled")
+
+    user_record = user_service.get_user_by_username(payload.username, db=db)
+    # Generic failure — never reveal which precondition failed (no enumeration).
+    if not user_record or not user_record.pin_hash or not user_record.totp_enabled:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+    if pin_service.is_pin_locked(user_record):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="PIN locked — use your password")
+
+    if not pin_service.verify_pin(payload.pin, user_record.pin_hash):
+        pin_service.register_pin_failure(db, user_record)
+        audit_logger.log_security_event(
+            action="pin_login_failed", user=user_record.username,
+            details={"ip_address": ip_address}, success=False, db=db,
+        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+    pin_service.reset_pin_failures(db, user_record)
+
+    # Within the grace window → PIN alone suffices.
+    if pin_service.in_grace_window(user_record):
+        audit_logger.log_authentication_attempt(
+            username=user_record.username, success=True,
+            ip_address=ip_address, user_agent=user_agent, db=db,
+        )
+        audit_logger.log_security_event(
+            action="pin_login_grace", user=user_record.username,
+            details={"ip_address": ip_address}, success=True, db=db,
+        )
+        token = auth_service.create_access_token(user_record)
+        return TokenResponse(access_token=token, user=user_service.serialize_user(user_record))
+
+    # Window expired → require TOTP via the existing pending flow.
+    pending_token = security.create_2fa_pending_token(user_record.id)
+    audit_logger.log_security_event(
+        action="pin_login_2fa_required", user=user_record.username,
+        details={"ip_address": ip_address}, success=True, db=db,
+    )
+    return TwoFactorRequiredResponse(pending_token=pending_token)
 
 
 @router.post("/2fa/setup", response_model=TwoFactorSetupResponse)

--- a/backend/app/api/routes/auth_policy.py
+++ b/backend/app/api/routes/auth_policy.py
@@ -1,0 +1,51 @@
+"""Admin endpoints for the system-wide auth policy."""
+from fastapi import APIRouter, Depends, Request, Response
+from sqlalchemy.orm import Session
+
+from app.api import deps
+from app.core.database import get_db
+from app.core.rate_limiter import user_limiter, get_limit
+from app.schemas.auth_policy import AuthPolicyResponse, AuthPolicyUpdate
+from app.services.auth_policy import get_auth_policy
+from app.services.audit.logger_db import get_audit_logger_db
+
+router = APIRouter()
+
+
+def _to_response(p) -> AuthPolicyResponse:
+    return AuthPolicyResponse(
+        pin_login_enabled=p.pin_login_enabled,
+        pin_grace_window_seconds=p.pin_grace_window_seconds,
+    )
+
+
+@router.get("", response_model=AuthPolicyResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def read_auth_policy(
+    request: Request, response: Response,
+    current_user=Depends(deps.get_current_admin),
+    db: Session = Depends(get_db),
+) -> AuthPolicyResponse:
+    return _to_response(get_auth_policy(db))
+
+
+@router.put("", response_model=AuthPolicyResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def update_auth_policy(
+    body: AuthPolicyUpdate,
+    request: Request, response: Response,
+    current_user=Depends(deps.get_current_admin),
+    db: Session = Depends(get_db),
+) -> AuthPolicyResponse:
+    policy = get_auth_policy(db)
+    data = body.model_dump(exclude_unset=True)
+    for field, value in data.items():
+        if value is not None:
+            setattr(policy, field, value)
+    db.commit()
+    db.refresh(policy)
+    get_audit_logger_db().log_security_event(
+        action="auth_policy_updated", user=current_user.username,
+        details=data, success=True, db=db,
+    )
+    return _to_response(policy)

--- a/backend/app/core/rate_limiter.py
+++ b/backend/app/core/rate_limiter.py
@@ -118,6 +118,7 @@ RATE_LIMITS = {
     # 2FA operations - strict limits for brute-force protection
     "auth_2fa_verify": "5/minute",
     "auth_2fa_setup": "5/minute",
+    "auth_pin_login": "5/minute",
 
     # API key management
     "api_key_operations": "30/minute",

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -100,10 +100,12 @@ from app.models.notification_routing import UserNotificationRouting
 from app.models.sync_progress import ChunkedUpload, SyncBandwidthLimit, SyncSchedule, SelectiveSync
 from app.models.sync_state import SyncState, SyncMetadata, SyncFileVersion
 from app.models.status_bar import StatusBarPillConfig, StatusBarSettings
+from app.models.auth_policy import AuthPolicy
 
 __all__ = [
     "Base",
     "User",
+    "AuthPolicy",
     "FileMetadata",
     "AuditLog",
     "FileShare",

--- a/backend/app/models/auth_policy.py
+++ b/backend/app/models/auth_policy.py
@@ -1,0 +1,21 @@
+"""Singleton auth policy: PIN-login window + global kill switch."""
+from __future__ import annotations
+
+from sqlalchemy import Integer, Boolean
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class AuthPolicy(Base):
+    """Single row (id=1) holding system-wide auth policy."""
+
+    __tablename__ = "auth_policy"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, default=1)
+    pin_login_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="1"
+    )
+    pin_grace_window_seconds: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=86400, server_default="86400"
+    )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -50,7 +50,19 @@ class User(Base):
     totp_enabled_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
-    
+
+    # PIN login (Tauri local channel) — anchored on 2FA
+    pin_hash: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    pin_grace_until: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    pin_failed_attempts: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    pin_locked_until: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # Relationships
     mobile_devices: Mapped[List["MobileDevice"]] = relationship(
         "MobileDevice", back_populates="user", cascade="all, delete-orphan"

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -137,3 +137,42 @@ class TwoFactorStatusResponse(BaseModel):
     enabled: bool
     enabled_at: datetime | None = None
     backup_codes_remaining: int = 0
+
+
+# --- PIN login schemas ---
+
+def _validate_pin(v: str) -> str:
+    """PIN policy: 4–8 digits, no all-same, no strictly sequential pattern."""
+    if not re.fullmatch(r"\d{4,8}", v):
+        raise ValueError("PIN must be 4 to 8 digits")
+    if len(set(v)) == 1:
+        raise ValueError("PIN must not be all the same digit")
+    digits = [int(c) for c in v]
+    ascending = all(digits[i + 1] - digits[i] == 1 for i in range(len(digits) - 1))
+    descending = all(digits[i] - digits[i + 1] == 1 for i in range(len(digits) - 1))
+    if ascending or descending:
+        raise ValueError("PIN must not be a sequential pattern")
+    return v
+
+
+class PinLoginRequest(BaseModel):
+    username: str
+    pin: str
+
+
+class PinSetRequest(BaseModel):
+    pin: str
+    code: str  # fresh TOTP or backup code
+
+    @field_validator("pin")
+    @classmethod
+    def _validate(cls, v: str) -> str:
+        return _validate_pin(v)
+
+
+class PinRemoveRequest(BaseModel):
+    code: str  # fresh TOTP or backup code
+
+
+class PinStatusResponse(BaseModel):
+    pin_enabled: bool

--- a/backend/app/schemas/auth_policy.py
+++ b/backend/app/schemas/auth_policy.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, Field
+
+MIN_WINDOW_SECONDS = 60
+MAX_WINDOW_SECONDS = 604800  # 7 days
+
+
+class AuthPolicyResponse(BaseModel):
+    pin_login_enabled: bool
+    pin_grace_window_seconds: int
+
+
+class AuthPolicyUpdate(BaseModel):
+    pin_login_enabled: bool | None = None
+    pin_grace_window_seconds: int | None = Field(
+        default=None, ge=MIN_WINDOW_SECONDS, le=MAX_WINDOW_SECONDS
+    )

--- a/backend/app/services/auth_policy.py
+++ b/backend/app/services/auth_policy.py
@@ -1,0 +1,17 @@
+"""Read-or-create the singleton AuthPolicy row (id=1)."""
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.auth_policy import AuthPolicy
+
+
+def get_auth_policy(db: Session) -> AuthPolicy:
+    policy = db.execute(select(AuthPolicy).where(AuthPolicy.id == 1)).scalar_one_or_none()
+    if policy is None:
+        policy = AuthPolicy(id=1)
+        db.add(policy)
+        db.commit()
+        db.refresh(policy)
+    return policy

--- a/backend/app/services/pin_service.py
+++ b/backend/app/services/pin_service.py
@@ -1,0 +1,73 @@
+"""PIN credential service for the Tauri local-channel login.
+
+PINs are hashed with the same bcrypt context as passwords. SQLite returns
+naive datetimes, so timestamps are coerced to UTC before comparison.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from app.services.users import pwd_context
+
+PIN_MAX_FAILED = 5
+PIN_LOCK_MINUTES = 15
+
+
+def _as_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    if dt is None:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def hash_pin(pin: str) -> str:
+    return pwd_context.hash(pin)
+
+
+def verify_pin(pin: str, pin_hash: str) -> bool:
+    return pwd_context.verify(pin, pin_hash)
+
+
+def in_grace_window(user: User, now: Optional[datetime] = None) -> bool:
+    now = now or datetime.now(timezone.utc)
+    until = _as_utc(user.pin_grace_until)
+    return until is not None and until > now
+
+
+def is_pin_locked(user: User, now: Optional[datetime] = None) -> bool:
+    now = now or datetime.now(timezone.utc)
+    until = _as_utc(user.pin_locked_until)
+    return until is not None and until > now
+
+
+def register_pin_failure(db: Session, user: User) -> None:
+    user.pin_failed_attempts = (user.pin_failed_attempts or 0) + 1
+    if user.pin_failed_attempts >= PIN_MAX_FAILED:
+        user.pin_locked_until = datetime.now(timezone.utc) + timedelta(minutes=PIN_LOCK_MINUTES)
+        user.pin_failed_attempts = 0
+    db.commit()
+
+
+def reset_pin_failures(db: Session, user: User) -> None:
+    if user.pin_failed_attempts or user.pin_locked_until:
+        user.pin_failed_attempts = 0
+        user.pin_locked_until = None
+        db.commit()
+
+
+def set_pin(db: Session, user: User, pin: str) -> None:
+    user.pin_hash = hash_pin(pin)
+    user.pin_failed_attempts = 0
+    user.pin_locked_until = None
+    db.commit()
+
+
+def clear_pin(db: Session, user: User) -> None:
+    user.pin_hash = None
+    user.pin_grace_until = None
+    user.pin_failed_attempts = 0
+    user.pin_locked_until = None
+    db.commit()

--- a/backend/app/services/totp_service.py
+++ b/backend/app/services/totp_service.py
@@ -215,6 +215,11 @@ def disable(db: Session, user_id: int) -> None:
     user.totp_enabled = False
     user.totp_backup_codes_encrypted = None
     user.totp_enabled_at = None
+    # PIN login is anchored on 2FA — disabling 2FA must destroy the PIN.
+    user.pin_hash = None
+    user.pin_grace_until = None
+    user.pin_failed_attempts = 0
+    user.pin_locked_until = None
     db.commit()
 
 

--- a/backend/tests/api/test_auth_policy.py
+++ b/backend/tests/api/test_auth_policy.py
@@ -1,0 +1,32 @@
+from app.core.config import settings
+
+URL = f"{settings.api_prefix}/admin/auth-policy"
+
+
+def test_get_returns_defaults(client, admin_headers):
+    r = client.get(URL, headers=admin_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["pin_login_enabled"] is True
+    assert body["pin_grace_window_seconds"] == 86400
+
+
+def test_put_updates(client, admin_headers):
+    r = client.put(URL, headers=admin_headers, json={"pin_grace_window_seconds": 3600, "pin_login_enabled": False})
+    assert r.status_code == 200
+    assert r.json()["pin_grace_window_seconds"] == 3600
+    assert r.json()["pin_login_enabled"] is False
+
+
+def test_put_rejects_over_cap(client, admin_headers):
+    r = client.put(URL, headers=admin_headers, json={"pin_grace_window_seconds": 999999999})
+    assert r.status_code == 422
+
+
+def test_put_rejects_under_min(client, admin_headers):
+    r = client.put(URL, headers=admin_headers, json={"pin_grace_window_seconds": 10})
+    assert r.status_code == 422
+
+
+def test_requires_admin(client, user_headers):
+    assert client.get(URL, headers=user_headers).status_code == 403

--- a/backend/tests/api/test_pin_login.py
+++ b/backend/tests/api/test_pin_login.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timezone, timedelta
+
+import pyotp
+from app.core.config import settings
+from app.models.user import User
+from app.services import totp_service, pin_service
+
+LOGIN_PIN = f"{settings.api_prefix}/auth/login-pin"
+VERIFY = f"{settings.api_prefix}/auth/verify-2fa"
+
+
+def _user_with_pin(db_session, username=None):
+    username = username or settings.admin_username
+    user = db_session.query(User).filter(User.username == username).first()
+    setup = totp_service.generate_setup(user)
+    secret = setup["secret"]
+    totp_service.verify_and_enable(db_session, user.id, secret, pyotp.TOTP(secret).now())
+    pin_service.set_pin(db_session, user, "4827")
+    return user, secret
+
+
+def test_login_pin_within_window_returns_token(client, admin_user, db_session):
+    user, _ = _user_with_pin(db_session)
+    user.pin_grace_until = datetime.now(timezone.utc) + timedelta(hours=1)
+    db_session.commit()
+    r = client.post(LOGIN_PIN, json={"username": user.username, "pin": "4827"})
+    assert r.status_code == 200
+    assert "access_token" in r.json()
+
+
+def test_login_pin_expired_window_requires_2fa(client, admin_user, db_session):
+    user, secret = _user_with_pin(db_session)
+    user.pin_grace_until = None
+    db_session.commit()
+    r = client.post(LOGIN_PIN, json={"username": user.username, "pin": "4827"})
+    assert r.status_code == 200
+    assert r.json().get("requires_2fa") is True
+    pending = r.json()["pending_token"]
+    # Completing TOTP returns a token AND opens the window
+    v = client.post(VERIFY, json={"pending_token": pending, "code": pyotp.TOTP(secret).now()})
+    assert v.status_code == 200 and "access_token" in v.json()
+    db_session.refresh(user)
+    assert pin_service.in_grace_window(user) is True
+
+
+def test_login_pin_wrong_pin_401(client, admin_user, db_session):
+    user, _ = _user_with_pin(db_session)
+    r = client.post(LOGIN_PIN, json={"username": user.username, "pin": "9999"})
+    assert r.status_code == 401
+
+
+def test_login_pin_no_pin_set_401(client, admin_user, db_session):
+    r = client.post(LOGIN_PIN, json={"username": settings.admin_username, "pin": "4827"})
+    assert r.status_code == 401
+
+
+def test_login_pin_lockout(client, admin_user, db_session):
+    user, _ = _user_with_pin(db_session)
+    user.pin_grace_until = datetime.now(timezone.utc) + timedelta(hours=1)
+    db_session.commit()
+    for _ in range(5):
+        client.post(LOGIN_PIN, json={"username": user.username, "pin": "9999"})
+    # Even the correct PIN is now refused (locked)
+    r = client.post(LOGIN_PIN, json={"username": user.username, "pin": "4827"})
+    assert r.status_code == 401
+
+
+def test_login_pin_disabled_by_policy(client, admin_user, db_session):
+    from app.services.auth_policy import get_auth_policy
+    user, _ = _user_with_pin(db_session)
+    user.pin_grace_until = datetime.now(timezone.utc) + timedelta(hours=1)
+    get_auth_policy(db_session).pin_login_enabled = False
+    db_session.commit()
+    r = client.post(LOGIN_PIN, json={"username": user.username, "pin": "4827"})
+    assert r.status_code == 401
+
+
+def test_login_pin_remote_channel_forbidden(remote_client, admin_user, db_session):
+    user, _ = _user_with_pin(db_session)
+    user.pin_grace_until = datetime.now(timezone.utc) + timedelta(hours=1)
+    db_session.commit()
+    r = remote_client.post(LOGIN_PIN, json={"username": user.username, "pin": "4827"})
+    assert r.status_code == 403

--- a/backend/tests/api/test_pin_management.py
+++ b/backend/tests/api/test_pin_management.py
@@ -1,0 +1,42 @@
+import pyotp
+from app.core.config import settings
+from app.models.user import User
+from app.services import totp_service
+
+PIN_URL = f"{settings.api_prefix}/auth/pin"
+
+
+def _enable_2fa(db_session, username) -> str:
+    """Enable 2FA for a user, return the plain secret."""
+    user = db_session.query(User).filter(User.username == username).first()
+    setup = totp_service.generate_setup(user)
+    secret = setup["secret"]
+    totp_service.verify_and_enable(db_session, user.id, secret, pyotp.TOTP(secret).now())
+    return secret
+
+
+def test_status_false_then_true(client, admin_headers, db_session):
+    secret = _enable_2fa(db_session, settings.admin_username)
+    assert client.get(PIN_URL, headers=admin_headers).json()["pin_enabled"] is False
+    r = client.post(PIN_URL, headers=admin_headers, json={"pin": "4827", "code": pyotp.TOTP(secret).now()})
+    assert r.status_code == 200
+    assert client.get(PIN_URL, headers=admin_headers).json()["pin_enabled"] is True
+
+
+def test_set_pin_requires_2fa_enabled(client, admin_headers):
+    r = client.post(PIN_URL, headers=admin_headers, json={"pin": "4827", "code": "000000"})
+    assert r.status_code == 400
+
+
+def test_set_pin_rejects_bad_totp(client, admin_headers, db_session):
+    _enable_2fa(db_session, settings.admin_username)
+    r = client.post(PIN_URL, headers=admin_headers, json={"pin": "4827", "code": "000000"})
+    assert r.status_code == 401
+
+
+def test_remove_pin(client, admin_headers, db_session):
+    secret = _enable_2fa(db_session, settings.admin_username)
+    client.post(PIN_URL, headers=admin_headers, json={"pin": "4827", "code": pyotp.TOTP(secret).now()})
+    r = client.request("DELETE", PIN_URL, headers=admin_headers, json={"code": pyotp.TOTP(secret).now()})
+    assert r.status_code == 200
+    assert client.get(PIN_URL, headers=admin_headers).json()["pin_enabled"] is False

--- a/backend/tests/models/test_pin_columns.py
+++ b/backend/tests/models/test_pin_columns.py
@@ -1,0 +1,17 @@
+"""Schema presence tests for PIN columns and AuthPolicy."""
+from app.models.user import User
+from app.models.auth_policy import AuthPolicy
+
+
+def test_user_has_pin_columns():
+    cols = set(User.__table__.columns.keys())
+    assert {"pin_hash", "pin_grace_until", "pin_failed_attempts", "pin_locked_until"} <= cols
+
+
+def test_auth_policy_defaults(db_session):
+    p = AuthPolicy(id=1)
+    db_session.add(p)
+    db_session.commit()
+    db_session.refresh(p)
+    assert p.pin_login_enabled is True
+    assert p.pin_grace_window_seconds == 86400

--- a/backend/tests/schemas/test_pin_validator.py
+++ b/backend/tests/schemas/test_pin_validator.py
@@ -1,0 +1,22 @@
+import pytest
+from pydantic import ValidationError
+from app.schemas.auth import PinSetRequest
+
+
+@pytest.mark.parametrize("pin", ["4827", "13905", "90218746"])
+def test_valid_pins(pin):
+    req = PinSetRequest(pin=pin, code="123456")
+    assert req.pin == pin
+
+
+@pytest.mark.parametrize("pin", [
+    "0000", "1111", "9999",     # all-same
+    "1234", "2345", "5678",     # ascending
+    "4321", "9876",             # descending
+    "123",                       # too short
+    "123456789",                 # too long
+    "12a4", "ab12",              # non-digit
+])
+def test_invalid_pins(pin):
+    with pytest.raises(ValidationError):
+        PinSetRequest(pin=pin, code="123456")

--- a/backend/tests/services/test_pin_service.py
+++ b/backend/tests/services/test_pin_service.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timezone, timedelta
+
+from app.models.user import User
+from app.services import pin_service, totp_service
+
+
+def _user(db):
+    u = User(username="pinuser", hashed_password="x", role="user", totp_enabled=True)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def test_hash_and_verify(db_session):
+    u = _user(db_session)
+    pin_service.set_pin(db_session, u, "4827")
+    assert u.pin_hash and u.pin_hash != "4827"
+    assert pin_service.verify_pin("4827", u.pin_hash) is True
+    assert pin_service.verify_pin("4828", u.pin_hash) is False
+
+
+def test_grace_window(db_session):
+    u = _user(db_session)
+    assert pin_service.in_grace_window(u) is False
+    u.pin_grace_until = datetime.now(timezone.utc) + timedelta(minutes=5)
+    assert pin_service.in_grace_window(u) is True
+    u.pin_grace_until = datetime.now(timezone.utc) - timedelta(minutes=5)
+    assert pin_service.in_grace_window(u) is False
+
+
+def test_lockout_after_5_failures(db_session):
+    u = _user(db_session)
+    for _ in range(5):
+        pin_service.register_pin_failure(db_session, u)
+    assert pin_service.is_pin_locked(u) is True
+    assert u.pin_failed_attempts == 0  # reset when lock applied
+
+
+def test_reset_failures(db_session):
+    u = _user(db_session)
+    pin_service.register_pin_failure(db_session, u)
+    pin_service.reset_pin_failures(db_session, u)
+    assert u.pin_failed_attempts == 0
+    assert u.pin_locked_until is None
+
+
+def test_disable_2fa_clears_pin(db_session):
+    u = _user(db_session)
+    pin_service.set_pin(db_session, u, "4827")
+    u.pin_grace_until = datetime.now(timezone.utc) + timedelta(hours=1)
+    db_session.commit()
+    totp_service.disable(db_session, u.id)
+    db_session.refresh(u)
+    assert u.pin_hash is None
+    assert u.pin_grace_until is None
+    assert u.totp_enabled is False

--- a/client/src/__tests__/api/pin.test.ts
+++ b/client/src/__tests__/api/pin.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/api', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), delete: vi.fn() },
+  buildApiUrl: (p: string) => p,
+}));
+
+import { apiClient } from '../../lib/api';
+import { getPinStatus, setPin, removePin } from '../../api/pin';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('pin api client', () => {
+  it('getPinStatus returns pin_enabled', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { pin_enabled: true } } as any);
+    const r = await getPinStatus();
+    expect(r.pin_enabled).toBe(true);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/auth/pin');
+  });
+
+  it('setPin posts pin + code', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { message: 'PIN set' } } as any);
+    await setPin('4827', '123456');
+    expect(apiClient.post).toHaveBeenCalledWith('/api/auth/pin', { pin: '4827', code: '123456' });
+  });
+
+  it('removePin sends code in the request body', async () => {
+    vi.mocked(apiClient.delete).mockResolvedValue({ data: { message: 'PIN removed' } } as any);
+    await removePin('123456');
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/auth/pin', { data: { code: '123456' } });
+  });
+});

--- a/client/src/api/pin.ts
+++ b/client/src/api/pin.ts
@@ -1,0 +1,58 @@
+/** PIN login + management + admin auth-policy API client. */
+import { apiClient, buildApiUrl } from '../lib/api';
+import type { User } from '../types/auth';
+
+export interface PinStatus {
+  pin_enabled: boolean;
+}
+
+export interface AuthPolicy {
+  pin_login_enabled: boolean;
+  pin_grace_window_seconds: number;
+}
+
+/** Either a finished login (access_token) or a 2FA challenge (pending_token). */
+export interface PinLoginResult {
+  access_token?: string;
+  user?: User;
+  requires_2fa?: boolean;
+  pending_token?: string;
+  detail?: string;
+}
+
+/** PIN login is pre-auth and local-channel only — mirror Login.tsx's fetch path. */
+export async function loginWithPin(username: string, pin: string): Promise<PinLoginResult> {
+  const res = await fetch(buildApiUrl('/api/auth/login-pin'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, pin }),
+  });
+  const data = (await res.json().catch(() => ({}))) as PinLoginResult;
+  if (!res.ok) {
+    throw new Error(String(data.detail || `PIN login failed (${res.status})`));
+  }
+  return data;
+}
+
+export async function getPinStatus(): Promise<PinStatus> {
+  const res = await apiClient.get<PinStatus>('/api/auth/pin');
+  return res.data;
+}
+
+export async function setPin(pin: string, code: string): Promise<void> {
+  await apiClient.post('/api/auth/pin', { pin, code });
+}
+
+export async function removePin(code: string): Promise<void> {
+  await apiClient.delete('/api/auth/pin', { data: { code } });
+}
+
+export async function getAuthPolicy(): Promise<AuthPolicy> {
+  const res = await apiClient.get<AuthPolicy>('/api/admin/auth-policy');
+  return res.data;
+}
+
+export async function updateAuthPolicy(body: Partial<AuthPolicy>): Promise<AuthPolicy> {
+  const res = await apiClient.put<AuthPolicy>('/api/admin/auth-policy', body);
+  return res.data;
+}

--- a/client/src/components/admin/AuthPolicySettings.tsx
+++ b/client/src/components/admin/AuthPolicySettings.tsx
@@ -1,0 +1,68 @@
+/** Admin: system-wide PIN-login policy (grace window + kill switch). */
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { getAuthPolicy, updateAuthPolicy } from '../../api/pin';
+import { handleApiError } from '../../lib/errorHandling';
+
+const WINDOW_OPTIONS: { key: string; seconds: number }[] = [
+  { key: '1h', seconds: 3600 },
+  { key: '8h', seconds: 28800 },
+  { key: '24h', seconds: 86400 },
+  { key: '7d', seconds: 604800 },
+];
+
+export function AuthPolicySettings() {
+  const { t } = useTranslation('admin');
+  const [loading, setLoading] = useState(true);
+  const [enabled, setEnabled] = useState(true);
+  const [windowSeconds, setWindowSeconds] = useState(86400);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    getAuthPolicy()
+      .then((p) => { setEnabled(p.pin_login_enabled); setWindowSeconds(p.pin_grace_window_seconds); })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const save = async (next: { pin_login_enabled?: boolean; pin_grace_window_seconds?: number }) => {
+    setBusy(true);
+    try {
+      const p = await updateAuthPolicy(next);
+      setEnabled(p.pin_login_enabled);
+      setWindowSeconds(p.pin_grace_window_seconds);
+      toast.success(t('authPolicy.saved'));
+    } catch (err) {
+      handleApiError(err, t('authPolicy.saveError'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) return null;
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+      <h3 className="text-lg font-semibold text-slate-100">{t('authPolicy.title')}</h3>
+      <p className="mt-1 text-sm text-slate-400">{t('authPolicy.description')}</p>
+
+      <label className="mt-4 flex items-center justify-between">
+        <span className="text-sm text-slate-300">{t('authPolicy.enabled')}</span>
+        <input type="checkbox" checked={enabled} disabled={busy}
+          onChange={(e) => save({ pin_login_enabled: e.target.checked })}
+          className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-sky-500 focus:ring-sky-500/50" />
+      </label>
+
+      <label className="mt-4 block text-sm text-slate-300">
+        {t('authPolicy.window')}
+        <select className="input mt-1" value={windowSeconds} disabled={busy}
+          onChange={(e) => save({ pin_grace_window_seconds: Number(e.target.value) })}>
+          {WINDOW_OPTIONS.map((o) => (
+            <option key={o.key} value={o.seconds}>{t(`authPolicy.windows.${o.key}`)}</option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/client/src/components/settings/DesktopPinSettings.tsx
+++ b/client/src/components/settings/DesktopPinSettings.tsx
@@ -1,0 +1,106 @@
+/** Desktop-app PIN management — visible only when 2FA is enabled. */
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { getPinStatus, setPin as apiSetPin, removePin } from '../../api/pin';
+import { handleApiError } from '../../lib/errorHandling';
+
+interface Props {
+  twoFactorEnabled: boolean;
+}
+
+export function DesktopPinSettings({ twoFactorEnabled }: Props) {
+  const { t } = useTranslation('settings');
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [pin, setPinValue] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [code, setCode] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!twoFactorEnabled) { setLoading(false); return; }
+    getPinStatus()
+      .then((s) => setEnabled(s.pin_enabled))
+      .catch(() => setEnabled(false))
+      .finally(() => setLoading(false));
+  }, [twoFactorEnabled]);
+
+  const onSave = async () => {
+    if (pin !== confirm) { toast.error(t('pin.mismatch')); return; }
+    setBusy(true);
+    try {
+      await apiSetPin(pin, code);
+      setEnabled(true);
+      setPinValue(''); setConfirm(''); setCode('');
+      toast.success(t('pin.saved'));
+    } catch (err) {
+      handleApiError(err, t('pin.saveError'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onRemove = async () => {
+    setBusy(true);
+    try {
+      await removePin(code);
+      setEnabled(false);
+      setCode('');
+      toast.success(t('pin.removed'));
+    } catch (err) {
+      handleApiError(err, t('pin.removeError'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) return null;
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+      <h3 className="text-lg font-semibold text-slate-100">{t('pin.title')}</h3>
+      <p className="mt-1 text-sm text-slate-400">{t('pin.description')}</p>
+
+      {!twoFactorEnabled ? (
+        <p className="mt-4 text-sm text-amber-300">{t('pin.needs2fa')}</p>
+      ) : (
+        <div className="mt-4 space-y-3">
+          <p className="text-sm">
+            <span className={enabled ? 'text-emerald-400' : 'text-slate-400'}>
+              {enabled ? t('pin.enabled') : t('pin.disabled')}
+            </span>
+          </p>
+
+          {!enabled && (
+            <>
+              <input type="password" inputMode="numeric" placeholder={t('pin.pinLabel')}
+                className="input" value={pin}
+                onChange={(e) => setPinValue(e.target.value.replace(/\D/g, '').slice(0, 8))} />
+              <input type="password" inputMode="numeric" placeholder={t('pin.confirmLabel')}
+                className="input" value={confirm}
+                onChange={(e) => setConfirm(e.target.value.replace(/\D/g, '').slice(0, 8))} />
+            </>
+          )}
+
+          <input type="text" inputMode="numeric" placeholder={t('pin.codeLabel')}
+            className="input" value={code}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 8))}
+            autoComplete="one-time-code" />
+
+          <div className="flex gap-2">
+            {!enabled ? (
+              <button className="btn btn-primary" disabled={busy || pin.length < 4 || code.length < 6} onClick={onSave}>
+                {t('pin.save')}
+              </button>
+            ) : (
+              <button className="btn btn-danger" disabled={busy || code.length < 6} onClick={onRemove}>
+                {t('pin.remove')}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/i18n/locales/de/admin.json
+++ b/client/src/i18n/locales/de/admin.json
@@ -463,5 +463,14 @@
       "diffFailed": "Diff konnte nicht geladen werden"
     },
     "processing": "Wird verarbeitet..."
+  },
+  "authPolicy": {
+    "title": "PIN-Login-Richtlinie",
+    "description": "Steuert das Gnadenfenster, in dem die Desktop-App-PIN ohne 2FA-Code genügt.",
+    "enabled": "PIN-Login aktiviert",
+    "window": "Gnadenfenster",
+    "saved": "Richtlinie gespeichert",
+    "saveError": "Richtlinie konnte nicht gespeichert werden",
+    "windows": { "1h": "1 Stunde", "8h": "8 Stunden", "24h": "24 Stunden", "7d": "7 Tage" }
   }
 }

--- a/client/src/i18n/locales/de/login.json
+++ b/client/src/i18n/locales/de/login.json
@@ -24,6 +24,12 @@
     "backToLogin": "Zurück zum Login",
     "invalidCode": "Ungültiger Verifizierungscode"
   },
+  "pin": {
+    "label": "PIN",
+    "submit": "Mit PIN anmelden",
+    "usePin": "Stattdessen PIN verwenden",
+    "usePassword": "Passwort verwenden"
+  },
   "defaultCredentials": "Standard-Anmeldedaten",
   "systemStatus": "System-Status",
   "optimal": "Optimal",

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -364,5 +364,22 @@
     "lastUpdated": "Zuletzt aktualisiert",
     "helpGoogle": "Zugangsdaten in der Google Cloud Console unter APIs & Services > Credentials erstellen.",
     "helpOneDrive": "App im Azure Portal unter App-Registrierungen registrieren."
+  },
+  "pin": {
+    "title": "Desktop-App-PIN",
+    "description": "Melde dich in der BaluHost-Companion-App mit einer PIN statt dem Passwort an (erfordert aktives 2FA).",
+    "enabled": "PIN aktiv",
+    "disabled": "Keine PIN gesetzt",
+    "needs2fa": "Aktiviere zuerst die Zwei-Faktor-Authentifizierung.",
+    "pinLabel": "PIN (4–8 Ziffern)",
+    "confirmLabel": "PIN bestätigen",
+    "codeLabel": "2FA-Code",
+    "save": "PIN speichern",
+    "remove": "PIN entfernen",
+    "mismatch": "Die PINs stimmen nicht überein.",
+    "saved": "PIN gespeichert",
+    "removed": "PIN entfernt",
+    "saveError": "PIN konnte nicht gespeichert werden",
+    "removeError": "PIN konnte nicht entfernt werden"
   }
 }

--- a/client/src/i18n/locales/en/admin.json
+++ b/client/src/i18n/locales/en/admin.json
@@ -463,5 +463,14 @@
       "diffFailed": "Failed to load diff"
     },
     "processing": "Processing..."
+  },
+  "authPolicy": {
+    "title": "PIN login policy",
+    "description": "Controls the grace window in which the desktop-app PIN suffices without a 2FA code.",
+    "enabled": "PIN login enabled",
+    "window": "Grace window",
+    "saved": "Policy saved",
+    "saveError": "Could not save policy",
+    "windows": { "1h": "1 hour", "8h": "8 hours", "24h": "24 hours", "7d": "7 days" }
   }
 }

--- a/client/src/i18n/locales/en/login.json
+++ b/client/src/i18n/locales/en/login.json
@@ -24,6 +24,12 @@
     "backToLogin": "Back to login",
     "invalidCode": "Invalid verification code"
   },
+  "pin": {
+    "label": "PIN",
+    "submit": "Sign in with PIN",
+    "usePin": "Use a PIN instead",
+    "usePassword": "Use password"
+  },
   "defaultCredentials": "Default credentials",
   "systemStatus": "System Status",
   "optimal": "Optimal",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -364,5 +364,22 @@
     "lastUpdated": "Last Updated",
     "helpGoogle": "Create credentials in the Google Cloud Console under APIs & Services > Credentials.",
     "helpOneDrive": "Register an app in the Azure Portal under App registrations."
+  },
+  "pin": {
+    "title": "Desktop app PIN",
+    "description": "Sign in to the BaluHost Companion app with a PIN instead of your password (requires 2FA enabled).",
+    "enabled": "PIN active",
+    "disabled": "No PIN set",
+    "needs2fa": "Enable two-factor authentication first.",
+    "pinLabel": "PIN (4–8 digits)",
+    "confirmLabel": "Confirm PIN",
+    "codeLabel": "2FA code",
+    "save": "Save PIN",
+    "remove": "Remove PIN",
+    "mismatch": "The PINs do not match.",
+    "saved": "PIN saved",
+    "removed": "PIN removed",
+    "saveError": "Could not save PIN",
+    "removeError": "Could not remove PIN"
   }
 }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -16,6 +16,10 @@ const tauriApiBase =
     ? window.__BALU_API_BASE__
     : undefined;
 
+/** True when running inside the Tauri Companion shell (local channel). Read
+ *  synchronously at module load; safe to use pre-auth on the Login screen. */
+export const isTauri = Boolean(tauriApiBase);
+
 export const API_BASE_URL =
   tauriApiBase ?? (isDevelopment ? '' : (import.meta.env.VITE_API_BASE_URL || ''));
 

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -4,7 +4,8 @@ import { Eye, EyeOff } from 'lucide-react';
 import type { User } from '../types/auth';
 import logoMark from '../assets/baluhost-logo.png';
 import { localApi } from '../lib/localApi';
-import { buildApiUrl } from '../lib/api';
+import { buildApiUrl, isTauri } from '../lib/api';
+import { loginWithPin } from '../api/pin';
 import { useVersion } from '../contexts/VersionContext';
 import { DeveloperBadge } from '../components/ui/DeveloperBadge';
 import { useAuth } from '../contexts/AuthContext';
@@ -29,6 +30,8 @@ export default function Login() {
   const [totpCode, setTotpCode] = useState('');
   const totpInputRef = useRef<HTMLInputElement>(null);
   const [showPassword, setShowPassword] = useState(false);
+  const [pinMode, setPinMode] = useState(false);
+  const [pin, setPin] = useState('');
 
   // Check if local backend is available on component mount
   useEffect(() => {
@@ -138,6 +141,31 @@ export default function Login() {
       login(data.user as User, token);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePinSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      const result = await loginWithPin(username, pin);
+      if (result.requires_2fa) {
+        setPendingToken(String(result.pending_token ?? ''));
+        setTwoFactorRequired(true);
+        setLoading(false);
+        return;
+      }
+      if (typeof result.access_token === 'string' && result.user) {
+        login(result.user, result.access_token);
+        return;
+      }
+      throw new Error('PIN login did not return a token');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'PIN login failed');
+      setPin('');
     } finally {
       setLoading(false);
     }
@@ -274,6 +302,43 @@ export default function Login() {
           ) : (
             /* Regular Login Form */
             <>
+              {pinMode ? (
+                <form onSubmit={handlePinSubmit} className="mt-8 sm:mt-10 space-y-4 sm:space-y-5">
+                  {error && (
+                    <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 px-3 sm:px-4 py-2.5 sm:py-3 text-sm text-rose-200">
+                      {error}
+                    </div>
+                  )}
+                  <div className="space-y-2">
+                    <label htmlFor="pin-username" className="text-xs font-medium uppercase tracking-[0.2em] text-slate-100-tertiary">
+                      {t('form.username')}
+                    </label>
+                    <input
+                      type="text" id="pin-username" className="input"
+                      value={username} onChange={(e) => setUsername(e.target.value)}
+                      placeholder="admin" required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="pin" className="text-xs font-medium uppercase tracking-[0.2em] text-slate-100-tertiary">
+                      {t('pin.label')}
+                    </label>
+                    <input
+                      type="password" id="pin"
+                      className="input text-center text-2xl tracking-[0.5em] font-mono"
+                      value={pin}
+                      onChange={(e) => setPin(e.target.value.replace(/\D/g, '').slice(0, 8))}
+                      placeholder="••••" inputMode="numeric" autoComplete="off" required
+                    />
+                  </div>
+                  <button type="submit" className="btn btn-primary w-full mt-5 sm:mt-6 touch-manipulation active:scale-[0.98]" disabled={loading || pin.length < 4}>
+                    {loading ? t('form.loading') : t('pin.submit')}
+                  </button>
+                  <button type="button" onClick={() => { setPinMode(false); setError(''); setPin(''); }} className="w-full text-center text-sm text-slate-100-tertiary hover:text-slate-100-secondary transition-colors">
+                    {t('pin.usePassword')}
+                  </button>
+                </form>
+              ) : (
               <form onSubmit={handleSubmit} className="mt-8 sm:mt-10 space-y-4 sm:space-y-5">
                 {error && (
                   <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 px-3 sm:px-4 py-2.5 sm:py-3 text-sm text-rose-200">
@@ -330,6 +395,17 @@ export default function Login() {
                   {loading ? t('form.loading') : t('form.submit')}
                 </button>
               </form>
+              )}
+
+              {isTauri && !pinMode && (
+                <button
+                  type="button"
+                  onClick={() => { setPinMode(true); setError(''); setPassword(''); }}
+                  className="mt-3 w-full text-center text-sm text-slate-100-tertiary hover:text-slate-100-secondary transition-colors"
+                >
+                  {t('pin.usePin')}
+                </button>
+              )}
 
               {devCredentials && (
                 <div className="mt-6 sm:mt-8 rounded-xl border border-slate-800 bg-slate-950-secondary p-3 sm:p-4 text-center text-xs text-slate-100-tertiary">

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -4,6 +4,8 @@ import { useSearchParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { User, Lock, Clock, Download, Globe, GitBranch, Bell, HardDrive, Plug } from 'lucide-react';
 import TwoFactorCard from '../components/settings/TwoFactorCard';
+import { DesktopPinSettings } from '../components/settings/DesktopPinSettings';
+import { useTwoFactorStatus } from '../components/quickSettings/twoFactorStatusStore';
 import VCLTrackingPanel from '../components/vcl/VCLTrackingPanel';
 import { apiClient } from '../lib/api';
 import LanguageSettings from '../components/LanguageSettings';
@@ -38,6 +40,11 @@ export default function SettingsPage() {
     setActiveTab(tab);
     setSearchParams(tab === 'profile' ? {} : { tab });
   };
+
+  // Shared 2FA status (cached store, populated/refreshed by TwoFactorCard) —
+  // gates the Desktop-app PIN section below.
+  const twoFactorStatus = useTwoFactorStatus(true);
+  const twoFactorEnabled = twoFactorStatus?.enabled === true;
   
   // Password change
   const [currentPassword, setCurrentPassword] = useState('');
@@ -283,6 +290,9 @@ export default function SettingsPage() {
 
             {/* Two-Factor Authentication */}
             <TwoFactorCard />
+
+            {/* Desktop-app PIN (2FA-gated) */}
+            <DesktopPinSettings twoFactorEnabled={twoFactorEnabled} />
 
             {/* Active Sessions */}
             <div className="card border-slate-800/60 bg-slate-900/55">

--- a/client/src/pages/SystemControlPage.tsx
+++ b/client/src/pages/SystemControlPage.tsx
@@ -18,6 +18,7 @@ import { ServicesTab } from '../components/services';
 import VCLSettings from '../components/vcl/VCLSettings';
 import { Link } from 'react-router-dom';
 import { RateLimitsTab } from '../components/rate-limits';
+import { AuthPolicySettings } from '../components/admin/AuthPolicySettings';
 import WebdavConnectionCard from '../components/webdav/WebdavConnectionCard';
 import SambaManagementCard from '../components/samba/SambaManagementCard';
 import SleepMode from './SleepMode';
@@ -206,7 +207,12 @@ export default function SystemControlPage() {
             </Link>
           </div>
         )}
-        {activeTab === 'ratelimits' && <RateLimitsTab />}
+        {activeTab === 'ratelimits' && (
+          <div className="space-y-6">
+            <RateLimitsTab />
+            <AuthPolicySettings />
+          </div>
+        )}
         {activeTab === 'webdav' && <WebdavConnectionCard />}
         {activeTab === 'samba' && <SambaManagementCard />}
         {activeTab === 'firebase' && <FirebaseManagementCard />}

--- a/docs/superpowers/plans/2026-06-06-tauri-pin-login-backend.md
+++ b/docs/superpowers/plans/2026-06-06-tauri-pin-login-backend.md
@@ -1,0 +1,1057 @@
+# Tauri PIN Login — Backend Implementation Plan (Plan 1 of 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Backend for signing into the Tauri Companion app with a numeric PIN in place of the password — local-channel only, 2FA-anchored, with an admin-global absolute grace window during which the PIN alone suffices.
+
+**Architecture:** A new local-channel-only `POST /api/auth/login-pin` reuses the existing `2fa_pending`/`verify-2fa` flow and bcrypt (`pwd_context`). Within an admin-configured grace window (set on every successful TOTP) the PIN alone returns an access token; outside it, the PIN yields a `2fa_pending` token that the user completes with TOTP. PIN management is TOTP-gated; disabling 2FA destroys the PIN.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0 (`Mapped`/`mapped_column`), Alembic, passlib bcrypt, Pytest.
+
+Spec: `docs/superpowers/specs/2026-06-06-tauri-pin-login-design.md`. Frontend (Tauri login UI, PIN settings, admin policy UI, i18n) is **Plan 2**. Step-up 2FA is out of scope ([#169](https://github.com/Xveyn/BaluHost/issues/169)).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `backend/app/models/user.py` | User ORM | +4 PIN columns |
+| `backend/app/models/auth_policy.py` | `AuthPolicy` singleton (window + kill switch) | NEW |
+| `backend/app/models/__init__.py` | model registry | register `AuthPolicy` |
+| `backend/alembic/versions/<rev>_add_pin_and_auth_policy.py` | migration | NEW |
+| `backend/app/services/auth_policy.py` | get-or-create singleton | NEW |
+| `backend/app/services/pin_service.py` | PIN hash/verify, grace, lockout | NEW |
+| `backend/app/schemas/auth.py` | PIN request/response + validator | +schemas |
+| `backend/app/schemas/auth_policy.py` | policy schemas (cap-validated) | NEW |
+| `backend/app/services/totp_service.py` | disable 2FA | clear PIN on disable |
+| `backend/app/api/routes/auth.py` | auth routes | +`login-pin`, +`/pin` (GET/POST/DELETE), extend `verify_2fa` |
+| `backend/app/api/routes/auth_policy.py` | admin policy endpoints | NEW |
+| `backend/app/api/routes/__init__.py` | router registry | register `auth_policy` |
+| `backend/app/core/rate_limiter.py` | limits | +`auth_pin_login` |
+| `backend/tests/...` | tests | NEW per task |
+
+---
+
+## Task 1: User PIN columns + AuthPolicy model + migration
+
+**Files:**
+- Modify: `backend/app/models/user.py`
+- Create: `backend/app/models/auth_policy.py`
+- Modify: `backend/app/models/__init__.py`
+- Create: `backend/alembic/versions/<rev>_add_pin_and_auth_policy.py`
+- Test: `backend/tests/models/test_pin_columns.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/models/test_pin_columns.py`:
+
+```python
+"""Schema presence tests for PIN columns and AuthPolicy."""
+from app.models.user import User
+from app.models.auth_policy import AuthPolicy
+
+
+def test_user_has_pin_columns():
+    cols = set(User.__table__.columns.keys())
+    assert {"pin_hash", "pin_grace_until", "pin_failed_attempts", "pin_locked_until"} <= cols
+
+
+def test_auth_policy_defaults(db_session):
+    p = AuthPolicy(id=1)
+    db_session.add(p)
+    db_session.commit()
+    db_session.refresh(p)
+    assert p.pin_login_enabled is True
+    assert p.pin_grace_window_seconds == 86400
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/models/test_pin_columns.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError: app.models.auth_policy` / missing columns.
+
+- [ ] **Step 3: Add the 4 PIN columns to `User`**
+
+In `backend/app/models/user.py`, immediately after the TOTP block (after the line
+`totp_enabled_at: Mapped[Optional[datetime]] = mapped_column(\n        DateTime(timezone=True), nullable=True\n    )`):
+
+```python
+
+    # PIN login (Tauri local channel) — anchored on 2FA
+    pin_hash: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    pin_grace_until: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    pin_failed_attempts: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    pin_locked_until: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+```
+
+- [ ] **Step 4: Create the `AuthPolicy` model**
+
+Create `backend/app/models/auth_policy.py`:
+
+```python
+"""Singleton auth policy: PIN-login window + global kill switch."""
+from __future__ import annotations
+
+from sqlalchemy import Integer, Boolean
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class AuthPolicy(Base):
+    """Single row (id=1) holding system-wide auth policy."""
+
+    __tablename__ = "auth_policy"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, default=1)
+    pin_login_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="1"
+    )
+    pin_grace_window_seconds: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=86400, server_default="86400"
+    )
+```
+
+- [ ] **Step 5: Register `AuthPolicy` in the model registry**
+
+In `backend/app/models/__init__.py`, add an import alongside the other model imports and add
+`"AuthPolicy"` to `__all__` (mirror the existing entries):
+
+```python
+from app.models.auth_policy import AuthPolicy
+```
+
+- [ ] **Step 6: Run the schema test (passes without migration — in-memory `Base.metadata`)**
+
+Run: `cd backend && python -m pytest tests/models/test_pin_columns.py -v --no-cov`
+Expected: PASS (the `db_session` fixture builds tables from `Base.metadata`).
+
+- [ ] **Step 7: Generate the Alembic migration**
+
+Run: `cd backend && alembic heads`
+Note the printed head revision (call it `<HEAD>`). Then:
+Run: `cd backend && alembic revision --autogenerate -m "add pin columns and auth_policy"`
+
+- [ ] **Step 8: Review & fix the migration**
+
+Open the new file under `backend/alembic/versions/`. Confirm:
+- `down_revision` equals `<HEAD>` from Step 7 (NOT a stale dev-DB head — if it differs, set it manually).
+- `upgrade()` adds the 4 columns to `users` and creates `auth_policy`. If autogenerate missed anything, make `upgrade()` exactly:
+
+```python
+def upgrade():
+    op.add_column("users", sa.Column("pin_hash", sa.String(length=255), nullable=True))
+    op.add_column("users", sa.Column("pin_grace_until", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("users", sa.Column("pin_failed_attempts", sa.Integer(), nullable=False, server_default="0"))
+    op.add_column("users", sa.Column("pin_locked_until", sa.DateTime(timezone=True), nullable=True))
+    op.create_table(
+        "auth_policy",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("pin_login_enabled", sa.Boolean(), nullable=False, server_default="1"),
+        sa.Column("pin_grace_window_seconds", sa.Integer(), nullable=False, server_default="86400"),
+    )
+
+
+def downgrade():
+    op.drop_table("auth_policy")
+    op.drop_column("users", "pin_locked_until")
+    op.drop_column("users", "pin_failed_attempts")
+    op.drop_column("users", "pin_grace_until")
+    op.drop_column("users", "pin_hash")
+```
+
+- [ ] **Step 9: Apply + verify the migration**
+
+Run: `cd backend && alembic upgrade head && python -c "from app.core.database import engine; from sqlalchemy import inspect; i=inspect(engine); print('auth_policy' in i.get_table_names()); print('pin_hash' in [c['name'] for c in i.get_columns('users')])"`
+Expected: `True` and `True`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/app/models/user.py backend/app/models/auth_policy.py backend/app/models/__init__.py backend/alembic/versions/ backend/tests/models/test_pin_columns.py
+git commit -m "feat(auth): pin columns on users + auth_policy singleton + migration"
+```
+
+---
+
+## Task 2: PIN policy validator + PIN schemas
+
+**Files:**
+- Modify: `backend/app/schemas/auth.py`
+- Test: `backend/tests/schemas/test_pin_validator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/schemas/test_pin_validator.py`:
+
+```python
+import pytest
+from pydantic import ValidationError
+from app.schemas.auth import PinSetRequest
+
+
+@pytest.mark.parametrize("pin", ["4827", "13905", "90218746"])
+def test_valid_pins(pin):
+    req = PinSetRequest(pin=pin, code="123456")
+    assert req.pin == pin
+
+
+@pytest.mark.parametrize("pin", [
+    "0000", "1111", "9999",     # all-same
+    "1234", "2345", "5678",     # ascending
+    "4321", "9876",             # descending
+    "123",                       # too short
+    "123456789",                 # too long
+    "12a4", "ab12",              # non-digit
+])
+def test_invalid_pins(pin):
+    with pytest.raises(ValidationError):
+        PinSetRequest(pin=pin, code="123456")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/schemas/test_pin_validator.py -v --no-cov`
+Expected: FAIL — `ImportError: cannot import name 'PinSetRequest'`.
+
+- [ ] **Step 3: Add the validator + schemas**
+
+In `backend/app/schemas/auth.py`, append at the end of the file (`re` and `field_validator` are already imported):
+
+```python
+
+
+# --- PIN login schemas ---
+
+def _validate_pin(v: str) -> str:
+    """PIN policy: 4–8 digits, no all-same, no strictly sequential pattern."""
+    if not re.fullmatch(r"\d{4,8}", v):
+        raise ValueError("PIN must be 4 to 8 digits")
+    if len(set(v)) == 1:
+        raise ValueError("PIN must not be all the same digit")
+    digits = [int(c) for c in v]
+    ascending = all(digits[i + 1] - digits[i] == 1 for i in range(len(digits) - 1))
+    descending = all(digits[i] - digits[i + 1] == 1 for i in range(len(digits) - 1))
+    if ascending or descending:
+        raise ValueError("PIN must not be a sequential pattern")
+    return v
+
+
+class PinLoginRequest(BaseModel):
+    username: str
+    pin: str
+
+
+class PinSetRequest(BaseModel):
+    pin: str
+    code: str  # fresh TOTP or backup code
+
+    @field_validator("pin")
+    @classmethod
+    def _validate(cls, v: str) -> str:
+        return _validate_pin(v)
+
+
+class PinRemoveRequest(BaseModel):
+    code: str  # fresh TOTP or backup code
+
+
+class PinStatusResponse(BaseModel):
+    pin_enabled: bool
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/schemas/test_pin_validator.py -v --no-cov`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/schemas/auth.py backend/tests/schemas/test_pin_validator.py
+git commit -m "feat(auth): PIN policy validator + PIN schemas"
+```
+
+---
+
+## Task 3: PIN service + clear-PIN-on-2FA-disable
+
+**Files:**
+- Create: `backend/app/services/pin_service.py`
+- Modify: `backend/app/services/totp_service.py`
+- Test: `backend/tests/services/test_pin_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/services/test_pin_service.py`:
+
+```python
+from datetime import datetime, timezone, timedelta
+
+from app.models.user import User
+from app.services import pin_service, totp_service
+
+
+def _user(db):
+    u = User(username="pinuser", hashed_password="x", role="user", totp_enabled=True)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def test_hash_and_verify(db_session):
+    u = _user(db_session)
+    pin_service.set_pin(db_session, u, "4827")
+    assert u.pin_hash and u.pin_hash != "4827"
+    assert pin_service.verify_pin("4827", u.pin_hash) is True
+    assert pin_service.verify_pin("4828", u.pin_hash) is False
+
+
+def test_grace_window(db_session):
+    u = _user(db_session)
+    assert pin_service.in_grace_window(u) is False
+    u.pin_grace_until = datetime.now(timezone.utc) + timedelta(minutes=5)
+    assert pin_service.in_grace_window(u) is True
+    u.pin_grace_until = datetime.now(timezone.utc) - timedelta(minutes=5)
+    assert pin_service.in_grace_window(u) is False
+
+
+def test_lockout_after_5_failures(db_session):
+    u = _user(db_session)
+    for _ in range(5):
+        pin_service.register_pin_failure(db_session, u)
+    assert pin_service.is_pin_locked(u) is True
+    assert u.pin_failed_attempts == 0  # reset when lock applied
+
+
+def test_reset_failures(db_session):
+    u = _user(db_session)
+    pin_service.register_pin_failure(db_session, u)
+    pin_service.reset_pin_failures(db_session, u)
+    assert u.pin_failed_attempts == 0
+    assert u.pin_locked_until is None
+
+
+def test_disable_2fa_clears_pin(db_session):
+    u = _user(db_session)
+    pin_service.set_pin(db_session, u, "4827")
+    u.pin_grace_until = datetime.now(timezone.utc) + timedelta(hours=1)
+    db_session.commit()
+    totp_service.disable(db_session, u.id)
+    db_session.refresh(u)
+    assert u.pin_hash is None
+    assert u.pin_grace_until is None
+    assert u.totp_enabled is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/services/test_pin_service.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError: app.services.pin_service`.
+
+- [ ] **Step 3: Create `pin_service.py`**
+
+Create `backend/app/services/pin_service.py`:
+
+```python
+"""PIN credential service for the Tauri local-channel login.
+
+PINs are hashed with the same bcrypt context as passwords. SQLite returns
+naive datetimes, so timestamps are coerced to UTC before comparison.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from app.services.users import pwd_context
+
+PIN_MAX_FAILED = 5
+PIN_LOCK_MINUTES = 15
+
+
+def _as_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    if dt is None:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def hash_pin(pin: str) -> str:
+    return pwd_context.hash(pin)
+
+
+def verify_pin(pin: str, pin_hash: str) -> bool:
+    return pwd_context.verify(pin, pin_hash)
+
+
+def in_grace_window(user: User, now: Optional[datetime] = None) -> bool:
+    now = now or datetime.now(timezone.utc)
+    until = _as_utc(user.pin_grace_until)
+    return until is not None and until > now
+
+
+def is_pin_locked(user: User, now: Optional[datetime] = None) -> bool:
+    now = now or datetime.now(timezone.utc)
+    until = _as_utc(user.pin_locked_until)
+    return until is not None and until > now
+
+
+def register_pin_failure(db: Session, user: User) -> None:
+    user.pin_failed_attempts = (user.pin_failed_attempts or 0) + 1
+    if user.pin_failed_attempts >= PIN_MAX_FAILED:
+        user.pin_locked_until = datetime.now(timezone.utc) + timedelta(minutes=PIN_LOCK_MINUTES)
+        user.pin_failed_attempts = 0
+    db.commit()
+
+
+def reset_pin_failures(db: Session, user: User) -> None:
+    if user.pin_failed_attempts or user.pin_locked_until:
+        user.pin_failed_attempts = 0
+        user.pin_locked_until = None
+        db.commit()
+
+
+def set_pin(db: Session, user: User, pin: str) -> None:
+    user.pin_hash = hash_pin(pin)
+    user.pin_failed_attempts = 0
+    user.pin_locked_until = None
+    db.commit()
+
+
+def clear_pin(db: Session, user: User) -> None:
+    user.pin_hash = None
+    user.pin_grace_until = None
+    user.pin_failed_attempts = 0
+    user.pin_locked_until = None
+    db.commit()
+```
+
+- [ ] **Step 4: Clear the PIN when 2FA is disabled**
+
+In `backend/app/services/totp_service.py`, in `disable(...)`, replace the body assignment block
+(the four `user.totp_* = None/False` lines followed by `db.commit()`) with:
+
+```python
+    user.totp_secret_encrypted = None
+    user.totp_enabled = False
+    user.totp_backup_codes_encrypted = None
+    user.totp_enabled_at = None
+    # PIN login is anchored on 2FA — disabling 2FA must destroy the PIN.
+    user.pin_hash = None
+    user.pin_grace_until = None
+    user.pin_failed_attempts = 0
+    user.pin_locked_until = None
+    db.commit()
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/services/test_pin_service.py -v --no-cov`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/pin_service.py backend/app/services/totp_service.py backend/tests/services/test_pin_service.py
+git commit -m "feat(auth): pin_service (hash/grace/lockout) + clear PIN on 2FA disable"
+```
+
+---
+
+## Task 4: AuthPolicy service, schemas & admin endpoints
+
+**Files:**
+- Create: `backend/app/services/auth_policy.py`
+- Create: `backend/app/schemas/auth_policy.py`
+- Create: `backend/app/api/routes/auth_policy.py`
+- Modify: `backend/app/api/routes/__init__.py`
+- Test: `backend/tests/api/test_auth_policy.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/api/test_auth_policy.py`:
+
+```python
+from app.core.config import settings
+
+URL = f"{settings.api_prefix}/admin/auth-policy"
+
+
+def test_get_returns_defaults(client, admin_headers):
+    r = client.get(URL, headers=admin_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["pin_login_enabled"] is True
+    assert body["pin_grace_window_seconds"] == 86400
+
+
+def test_put_updates(client, admin_headers):
+    r = client.put(URL, headers=admin_headers, json={"pin_grace_window_seconds": 3600, "pin_login_enabled": False})
+    assert r.status_code == 200
+    assert r.json()["pin_grace_window_seconds"] == 3600
+    assert r.json()["pin_login_enabled"] is False
+
+
+def test_put_rejects_over_cap(client, admin_headers):
+    r = client.put(URL, headers=admin_headers, json={"pin_grace_window_seconds": 999999999})
+    assert r.status_code == 422
+
+
+def test_put_rejects_under_min(client, admin_headers):
+    r = client.put(URL, headers=admin_headers, json={"pin_grace_window_seconds": 10})
+    assert r.status_code == 422
+
+
+def test_requires_admin(client, user_headers):
+    assert client.get(URL, headers=user_headers).status_code == 403
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/api/test_auth_policy.py -v --no-cov`
+Expected: FAIL — 404 (route not registered).
+
+- [ ] **Step 3: Create the policy service**
+
+Create `backend/app/services/auth_policy.py`:
+
+```python
+"""Read-or-create the singleton AuthPolicy row (id=1)."""
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.auth_policy import AuthPolicy
+
+
+def get_auth_policy(db: Session) -> AuthPolicy:
+    policy = db.execute(select(AuthPolicy).where(AuthPolicy.id == 1)).scalar_one_or_none()
+    if policy is None:
+        policy = AuthPolicy(id=1)
+        db.add(policy)
+        db.commit()
+        db.refresh(policy)
+    return policy
+```
+
+- [ ] **Step 4: Create the policy schemas**
+
+Create `backend/app/schemas/auth_policy.py`:
+
+```python
+from pydantic import BaseModel, Field
+
+MIN_WINDOW_SECONDS = 60
+MAX_WINDOW_SECONDS = 604800  # 7 days
+
+
+class AuthPolicyResponse(BaseModel):
+    pin_login_enabled: bool
+    pin_grace_window_seconds: int
+
+
+class AuthPolicyUpdate(BaseModel):
+    pin_login_enabled: bool | None = None
+    pin_grace_window_seconds: int | None = Field(
+        default=None, ge=MIN_WINDOW_SECONDS, le=MAX_WINDOW_SECONDS
+    )
+```
+
+- [ ] **Step 5: Create the admin policy router**
+
+Create `backend/app/api/routes/auth_policy.py`:
+
+```python
+"""Admin endpoints for the system-wide auth policy."""
+from fastapi import APIRouter, Depends, Request, Response
+from sqlalchemy.orm import Session
+
+from app.api import deps
+from app.core.database import get_db
+from app.core.rate_limiter import user_limiter, get_limit
+from app.schemas.auth_policy import AuthPolicyResponse, AuthPolicyUpdate
+from app.services.auth_policy import get_auth_policy
+from app.services.audit.logger_db import get_audit_logger_db
+
+router = APIRouter()
+
+
+def _to_response(p) -> AuthPolicyResponse:
+    return AuthPolicyResponse(
+        pin_login_enabled=p.pin_login_enabled,
+        pin_grace_window_seconds=p.pin_grace_window_seconds,
+    )
+
+
+@router.get("", response_model=AuthPolicyResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def read_auth_policy(
+    request: Request, response: Response,
+    current_user=Depends(deps.get_current_admin),
+    db: Session = Depends(get_db),
+) -> AuthPolicyResponse:
+    return _to_response(get_auth_policy(db))
+
+
+@router.put("", response_model=AuthPolicyResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def update_auth_policy(
+    body: AuthPolicyUpdate,
+    request: Request, response: Response,
+    current_user=Depends(deps.get_current_admin),
+    db: Session = Depends(get_db),
+) -> AuthPolicyResponse:
+    policy = get_auth_policy(db)
+    data = body.model_dump(exclude_unset=True)
+    for field, value in data.items():
+        if value is not None:
+            setattr(policy, field, value)
+    db.commit()
+    db.refresh(policy)
+    get_audit_logger_db().log_security_event(
+        action="auth_policy_updated", user=current_user.username,
+        details=data, success=True, db=db,
+    )
+    return _to_response(policy)
+```
+
+- [ ] **Step 6: Register the router**
+
+In `backend/app/api/routes/__init__.py`, mirror an existing `api_router.include_router(...)` line and add:
+
+```python
+from app.api.routes import auth_policy
+api_router.include_router(auth_policy.router, prefix="/admin/auth-policy", tags=["auth-policy"])
+```
+
+(Place the import with the other route imports and the `include_router` with the others. Match the actual aggregator variable name used in that file — it is the same one every other route uses.)
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/api/test_auth_policy.py -v --no-cov`
+Expected: PASS (5 tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/app/services/auth_policy.py backend/app/schemas/auth_policy.py backend/app/api/routes/auth_policy.py backend/app/api/routes/__init__.py backend/tests/api/test_auth_policy.py
+git commit -m "feat(auth): admin auth-policy endpoints (pin window + kill switch)"
+```
+
+---
+
+## Task 5: PIN management endpoints (GET/POST/DELETE /pin)
+
+**Files:**
+- Modify: `backend/app/api/routes/auth.py`
+- Modify: `backend/app/core/rate_limiter.py`
+- Test: `backend/tests/api/test_pin_management.py`
+
+- [ ] **Step 1: Add the rate-limit key**
+
+In `backend/app/core/rate_limiter.py`, in the `RATE_LIMITS` dict, immediately after the
+`"auth_2fa_setup": "5/minute",` line:
+
+```python
+    "auth_pin_login": "5/minute",
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `backend/tests/api/test_pin_management.py`:
+
+```python
+import pyotp
+from app.core.config import settings
+from app.models.user import User
+from app.services import totp_service
+
+PIN_URL = f"{settings.api_prefix}/auth/pin"
+
+
+def _enable_2fa(db_session, username) -> str:
+    """Enable 2FA for a user, return the plain secret."""
+    user = db_session.query(User).filter(User.username == username).first()
+    setup = totp_service.generate_setup(user)
+    secret = setup["secret"]
+    totp_service.verify_and_enable(db_session, user.id, secret, pyotp.TOTP(secret).now())
+    return secret
+
+
+def test_status_false_then_true(client, admin_headers, db_session):
+    secret = _enable_2fa(db_session, settings.admin_username)
+    assert client.get(PIN_URL, headers=admin_headers).json()["pin_enabled"] is False
+    r = client.post(PIN_URL, headers=admin_headers, json={"pin": "4827", "code": pyotp.TOTP(secret).now()})
+    assert r.status_code == 200
+    assert client.get(PIN_URL, headers=admin_headers).json()["pin_enabled"] is True
+
+
+def test_set_pin_requires_2fa_enabled(client, admin_headers):
+    r = client.post(PIN_URL, headers=admin_headers, json={"pin": "4827", "code": "000000"})
+    assert r.status_code == 400
+
+
+def test_set_pin_rejects_bad_totp(client, admin_headers, db_session):
+    _enable_2fa(db_session, settings.admin_username)
+    r = client.post(PIN_URL, headers=admin_headers, json={"pin": "4827", "code": "000000"})
+    assert r.status_code == 401
+
+
+def test_remove_pin(client, admin_headers, db_session):
+    secret = _enable_2fa(db_session, settings.admin_username)
+    client.post(PIN_URL, headers=admin_headers, json={"pin": "4827", "code": pyotp.TOTP(secret).now()})
+    r = client.request("DELETE", PIN_URL, headers=admin_headers, json={"code": pyotp.TOTP(secret).now()})
+    assert r.status_code == 200
+    assert client.get(PIN_URL, headers=admin_headers).json()["pin_enabled"] is False
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/api/test_pin_management.py -v --no-cov`
+Expected: FAIL — 404/405 (routes missing).
+
+- [ ] **Step 4: Add the PIN-schema imports to `auth.py`**
+
+In `backend/app/api/routes/auth.py`, extend the `from app.schemas.auth import (...)` block to also import:
+
+```python
+    PinLoginRequest, PinSetRequest, PinRemoveRequest, PinStatusResponse,
+```
+
+- [ ] **Step 5: Add the three PIN-management endpoints**
+
+In `backend/app/api/routes/auth.py`, immediately after the `get_2fa_status` endpoint (after its
+`return TwoFactorStatusResponse(...)` block, before `regenerate_backup_codes`), add:
+
+```python
+@router.get("/pin", response_model=PinStatusResponse)
+@user_limiter.limit(get_limit("user_operations"))
+async def get_pin_status(
+    request: Request, response: Response,
+    current_user=Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+) -> PinStatusResponse:
+    """Whether the current user has a desktop-app PIN configured."""
+    user_record = db.query(UserModel).filter(UserModel.id == current_user.id).first()
+    return PinStatusResponse(pin_enabled=bool(user_record and user_record.pin_hash))
+
+
+def _verify_fresh_totp(db: Session, user_id: int, code: str) -> bool:
+    """Verify a fresh TOTP or backup code for a PIN-management action."""
+    try:
+        if totp_service.verify_code(db, user_id, code):
+            return True
+    except ValueError:
+        pass
+    try:
+        return totp_service.verify_backup_code(db, user_id, code)
+    except ValueError:
+        return False
+
+
+@router.post("/pin")
+@limiter.limit(get_limit("auth_2fa_setup"))
+async def set_pin(
+    payload: PinSetRequest,
+    request: Request, response: Response,
+    current_user=Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Set/replace the desktop-app PIN. Requires 2FA enabled + a fresh TOTP code."""
+    from app.services import pin_service
+    audit_logger = get_audit_logger_db()
+    user_record = db.query(UserModel).filter(UserModel.id == current_user.id).first()
+    if not user_record or not user_record.totp_enabled:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="2FA must be enabled before setting a PIN")
+    if not _verify_fresh_totp(db, current_user.id, payload.code):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid 2FA code")
+    pin_service.set_pin(db, user_record, payload.pin)
+    audit_logger.log_security_event(action="pin_set", user=current_user.username, success=True, db=db)
+    return {"message": "PIN set"}
+
+
+@router.delete("/pin")
+@limiter.limit(get_limit("auth_2fa_setup"))
+async def remove_pin(
+    payload: PinRemoveRequest,
+    request: Request, response: Response,
+    current_user=Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Remove the desktop-app PIN. Requires a fresh TOTP code."""
+    from app.services import pin_service
+    audit_logger = get_audit_logger_db()
+    user_record = db.query(UserModel).filter(UserModel.id == current_user.id).first()
+    if not user_record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    if not _verify_fresh_totp(db, current_user.id, payload.code):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid 2FA code")
+    pin_service.clear_pin(db, user_record)
+    audit_logger.log_security_event(action="pin_removed", user=current_user.username, success=True, db=db)
+    return {"message": "PIN removed"}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/api/test_pin_management.py -v --no-cov`
+Expected: PASS (4 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/api/routes/auth.py backend/app/core/rate_limiter.py backend/tests/api/test_pin_management.py
+git commit -m "feat(auth): PIN management endpoints (status/set/remove, TOTP-gated)"
+```
+
+---
+
+## Task 6: login-pin endpoint + verify-2fa grace window
+
+**Files:**
+- Modify: `backend/app/api/routes/auth.py`
+- Test: `backend/tests/api/test_pin_login.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/api/test_pin_login.py`:
+
+```python
+from datetime import datetime, timezone, timedelta
+
+import pyotp
+from app.core.config import settings
+from app.models.user import User
+from app.services import totp_service, pin_service
+
+LOGIN_PIN = f"{settings.api_prefix}/auth/login-pin"
+VERIFY = f"{settings.api_prefix}/auth/verify-2fa"
+
+
+def _user_with_pin(db_session, username=None):
+    username = username or settings.admin_username
+    user = db_session.query(User).filter(User.username == username).first()
+    setup = totp_service.generate_setup(user)
+    secret = setup["secret"]
+    totp_service.verify_and_enable(db_session, user.id, secret, pyotp.TOTP(secret).now())
+    pin_service.set_pin(db_session, user, "4827")
+    return user, secret
+
+
+def test_login_pin_within_window_returns_token(client, admin_user, db_session):
+    user, _ = _user_with_pin(db_session)
+    user.pin_grace_until = datetime.now(timezone.utc) + timedelta(hours=1)
+    db_session.commit()
+    r = client.post(LOGIN_PIN, json={"username": user.username, "pin": "4827"})
+    assert r.status_code == 200
+    assert "access_token" in r.json()
+
+
+def test_login_pin_expired_window_requires_2fa(client, admin_user, db_session):
+    user, secret = _user_with_pin(db_session)
+    user.pin_grace_until = None
+    db_session.commit()
+    r = client.post(LOGIN_PIN, json={"username": user.username, "pin": "4827"})
+    assert r.status_code == 200
+    assert r.json().get("requires_2fa") is True
+    pending = r.json()["pending_token"]
+    # Completing TOTP returns a token AND opens the window
+    v = client.post(VERIFY, json={"pending_token": pending, "code": pyotp.TOTP(secret).now()})
+    assert v.status_code == 200 and "access_token" in v.json()
+    db_session.refresh(user)
+    assert pin_service.in_grace_window(user) is True
+
+
+def test_login_pin_wrong_pin_401(client, admin_user, db_session):
+    user, _ = _user_with_pin(db_session)
+    r = client.post(LOGIN_PIN, json={"username": user.username, "pin": "9999"})
+    assert r.status_code == 401
+
+
+def test_login_pin_no_pin_set_401(client, admin_user, db_session):
+    r = client.post(LOGIN_PIN, json={"username": settings.admin_username, "pin": "4827"})
+    assert r.status_code == 401
+
+
+def test_login_pin_lockout(client, admin_user, db_session):
+    user, _ = _user_with_pin(db_session)
+    user.pin_grace_until = datetime.now(timezone.utc) + timedelta(hours=1)
+    db_session.commit()
+    for _ in range(5):
+        client.post(LOGIN_PIN, json={"username": user.username, "pin": "9999"})
+    # Even the correct PIN is now refused (locked)
+    r = client.post(LOGIN_PIN, json={"username": user.username, "pin": "4827"})
+    assert r.status_code == 401
+
+
+def test_login_pin_disabled_by_policy(client, admin_user, db_session):
+    from app.services.auth_policy import get_auth_policy
+    user, _ = _user_with_pin(db_session)
+    user.pin_grace_until = datetime.now(timezone.utc) + timedelta(hours=1)
+    get_auth_policy(db_session).pin_login_enabled = False
+    db_session.commit()
+    r = client.post(LOGIN_PIN, json={"username": user.username, "pin": "4827"})
+    assert r.status_code == 401
+
+
+def test_login_pin_remote_channel_forbidden(remote_client, admin_user, db_session):
+    user, _ = _user_with_pin(db_session)
+    user.pin_grace_until = datetime.now(timezone.utc) + timedelta(hours=1)
+    db_session.commit()
+    r = remote_client.post(LOGIN_PIN, json={"username": user.username, "pin": "4827"})
+    assert r.status_code == 403
+```
+
+> Note: the default `client` fixture runs `channel=local` (so PIN login is allowed). The
+> `remote_client` fixture is the canonical way the repo simulates `channel=remote` — mirror exactly
+> how `backend/tests/api/test_require_local_admin.py` uses it; if `remote_client` does not flip
+> `request.state.channel` on its own, re-wire `ChannelMarkerMiddleware` the same way that test does.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/api/test_pin_login.py -v --no-cov`
+Expected: FAIL — 404 (`/login-pin` missing) and the grace-window assertion in the verify test.
+
+- [ ] **Step 3: Extend `verify_2fa` to open the grace window**
+
+In `backend/app/api/routes/auth.py`, in `verify_2fa`, immediately **before** the
+`token = auth_service.create_access_token(user_record)` line (the one inside `verify_2fa`, after the
+successful-2FA audit logs), add:
+
+```python
+    # Open the PIN grace window from this successful TOTP (only when a PIN exists).
+    if user_record.pin_hash:
+        from datetime import datetime as _dt, timezone as _tz, timedelta as _td
+        from app.services.auth_policy import get_auth_policy
+        window = get_auth_policy(db).pin_grace_window_seconds
+        user_record.pin_grace_until = _dt.now(_tz.utc) + _td(seconds=window)
+        db.commit()
+```
+
+- [ ] **Step 4: Add the `login-pin` endpoint**
+
+In `backend/app/api/routes/auth.py`, immediately after the `verify_2fa` endpoint (before
+`setup_2fa`), add:
+
+```python
+@router.post("/login-pin")
+@limiter.limit(get_limit("auth_pin_login"))
+async def login_pin(payload: PinLoginRequest, request: Request, response: Response, db: Session = Depends(get_db)):
+    """PIN login — LOCAL CHANNEL ONLY.
+
+    Returns an access token when within the grace window, otherwise a
+    TwoFactorRequiredResponse (the client completes it via /verify-2fa).
+    """
+    from app.services import pin_service
+    from app.services.auth_policy import get_auth_policy
+    audit_logger = get_audit_logger_db()
+    ip_address = request.client.host if request.client else None
+    user_agent = request.headers.get("user-agent")
+
+    # Hard invariant: PIN login is only valid over the local channel.
+    if getattr(request.state, "channel", "remote") != "local":
+        audit_logger.log_security_event(
+            action="pin_login_remote_denied", user=payload.username,
+            details={"ip_address": ip_address}, success=False, db=db,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "local_channel_required",
+                "message": "PIN login is only available from the BaluHost Companion app on the server.",
+            },
+        )
+
+    if not get_auth_policy(db).pin_login_enabled:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="PIN login is disabled")
+
+    user_record = user_service.get_user_by_username(payload.username, db=db)
+    # Generic failure — never reveal which precondition failed (no enumeration).
+    if not user_record or not user_record.pin_hash or not user_record.totp_enabled:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+    if pin_service.is_pin_locked(user_record):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="PIN locked — use your password")
+
+    if not pin_service.verify_pin(payload.pin, user_record.pin_hash):
+        pin_service.register_pin_failure(db, user_record)
+        audit_logger.log_security_event(
+            action="pin_login_failed", user=user_record.username,
+            details={"ip_address": ip_address}, success=False, db=db,
+        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+    pin_service.reset_pin_failures(db, user_record)
+
+    # Within the grace window → PIN alone suffices.
+    if pin_service.in_grace_window(user_record):
+        audit_logger.log_authentication_attempt(
+            username=user_record.username, success=True,
+            ip_address=ip_address, user_agent=user_agent, db=db,
+        )
+        audit_logger.log_security_event(
+            action="pin_login_grace", user=user_record.username,
+            details={"ip_address": ip_address}, success=True, db=db,
+        )
+        token = auth_service.create_access_token(user_record)
+        return TokenResponse(access_token=token, user=user_service.serialize_user(user_record))
+
+    # Window expired → require TOTP via the existing pending flow.
+    pending_token = security.create_2fa_pending_token(user_record.id)
+    audit_logger.log_security_event(
+        action="pin_login_2fa_required", user=user_record.username,
+        details={"ip_address": ip_address}, success=True, db=db,
+    )
+    return TwoFactorRequiredResponse(pending_token=pending_token)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/api/test_pin_login.py -v --no-cov`
+Expected: PASS (7 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/api/routes/auth.py backend/tests/api/test_pin_login.py
+git commit -m "feat(auth): local-channel login-pin + grace window on verify-2fa"
+```
+
+---
+
+## Task 7: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run all new PIN/auth tests**
+
+Run: `cd backend && python -m pytest tests/models/test_pin_columns.py tests/schemas/test_pin_validator.py tests/services/test_pin_service.py tests/api/test_auth_policy.py tests/api/test_pin_management.py tests/api/test_pin_login.py -v --no-cov`
+Expected: PASS (all).
+
+- [ ] **Step 2: Run the existing auth/2FA suites (no regression)**
+
+Run: `cd backend && python -m pytest tests/api/test_2fa_endpoints.py tests/security/test_totp_2fa.py tests/auth -q --no-cov`
+Expected: PASS (all previously-passing tests still pass — especially that disabling 2FA still works).
+
+- [ ] **Step 3: No commit** (verification only).
+
+---
+
+## Notes for the implementer
+
+- **Channel in tests:** the default `client` fixture is `channel=local`, so `login-pin` is allowed; `remote_client` is the canonical remote simulation (see Task 6 note + `test_require_local_admin.py`).
+- **SQLite naive datetimes:** `pin_service._as_utc()` coerces stored timestamps before comparison — do not drop it; without it the grace/lock comparisons raise on SQLite.
+- **Migration head:** set `down_revision` to the real `alembic heads` output (not a stale dev-DB head) — this repo has hit multi-head prod failures before.
+- **Frontend is Plan 2:** Tauri login option (username + PIN, then TOTP if challenged), `DesktopPinSettings` (set/remove with TOTP, only when 2FA on), `AuthPolicySettings` (admin), and i18n consume these endpoints.
+```

--- a/docs/superpowers/plans/2026-06-06-tauri-pin-login-backend.md
+++ b/docs/superpowers/plans/2026-06-06-tauri-pin-login-backend.md
@@ -629,14 +629,17 @@ async def update_auth_policy(
 
 - [ ] **Step 6: Register the router**
 
-In `backend/app/api/routes/__init__.py`, mirror an existing `api_router.include_router(...)` line and add:
+In `backend/app/api/routes/__init__.py`:
+
+1. Add `auth_policy` to the `from app.api.routes import (...)` import tuple (e.g. on the line with `setup,`/`games,` — just add `auth_policy,`).
+2. Register it next to the other `/admin` router. After the existing line
+   `api_router.include_router(rate_limit_config.router, prefix="/admin", tags=["admin"])` add:
 
 ```python
-from app.api.routes import auth_policy
 api_router.include_router(auth_policy.router, prefix="/admin/auth-policy", tags=["auth-policy"])
 ```
 
-(Place the import with the other route imports and the `include_router` with the others. Match the actual aggregator variable name used in that file — it is the same one every other route uses.)
+The aggregator is `api_router` (an `APIRouter()`), exactly like every other route module.
 
 - [ ] **Step 7: Run test to verify it passes**
 
@@ -913,10 +916,10 @@ def test_login_pin_remote_channel_forbidden(remote_client, admin_user, db_sessio
     assert r.status_code == 403
 ```
 
-> Note: the default `client` fixture runs `channel=local` (so PIN login is allowed). The
-> `remote_client` fixture is the canonical way the repo simulates `channel=remote` — mirror exactly
-> how `backend/tests/api/test_require_local_admin.py` uses it; if `remote_client` does not flip
-> `request.state.channel` on its own, re-wire `ChannelMarkerMiddleware` the same way that test does.
+> Note: the default `client` fixture runs `channel=local` (PIN login allowed). `remote_client`
+> monkeypatches `settings.channel="remote"`, which `ChannelMarkerMiddleware` reads **per-request**
+> via its channel-provider callable — so it flips `request.state.channel` with no re-wiring needed.
+> Working example to mirror: `backend/tests/api/test_power_authority_routes.py::test_put_authority_requires_local_channel`.
 
 - [ ] **Step 2: Run tests to verify they fail**
 

--- a/docs/superpowers/plans/2026-06-06-tauri-pin-login-frontend.md
+++ b/docs/superpowers/plans/2026-06-06-tauri-pin-login-frontend.md
@@ -1,0 +1,747 @@
+# Tauri PIN Login — Frontend Implementation Plan (Plan 2 of 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Frontend for signing into the Tauri Companion app with a PIN (consuming the Plan-1 backend): a PIN login option on the Login screen (Tauri-only), a "Desktop-App PIN" management section (set/remove, TOTP-gated, only when 2FA on), and an admin auth-policy card (grace window + kill switch).
+
+**Architecture:** Reuse the existing Login 2FA step (`pending_token` → `verify-2fa`). PIN login posts to `/api/auth/login-pin` and, when the grace window has expired, falls into the **same** existing TOTP step. PIN management + admin policy use the authenticated `apiClient`. The PIN login option is shown only when running inside the Tauri shell, detected pre-auth via `window.__BALU_API_BASE__`.
+
+**Tech Stack:** React 18 + TypeScript + Vite, axios (`apiClient`), react-i18next, Vitest + Testing Library.
+
+Spec: `docs/superpowers/specs/2026-06-06-tauri-pin-login-design.md`. Backend is **Plan 1** (already implemented). Endpoints consumed: `POST /api/auth/login-pin`, `GET/POST/DELETE /api/auth/pin`, `GET/PUT /api/admin/auth-policy`, existing `POST /api/auth/verify-2fa`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `client/src/lib/api.ts` | API base + Tauri detection | export `isTauri` flag |
+| `client/src/api/pin.ts` | PIN + auth-policy API client | NEW |
+| `client/src/pages/Login.tsx` | login screen | PIN-login mode (Tauri-only) |
+| `client/src/components/settings/DesktopPinSettings.tsx` | set/remove PIN | NEW |
+| `client/src/components/admin/AuthPolicySettings.tsx` | admin window + kill switch | NEW |
+| `client/src/i18n/locales/{de,en}/login.json` | login strings | +PIN keys |
+| `client/src/i18n/locales/{de,en}/settings.json` | settings strings | +PIN keys |
+| `client/src/api/__tests__/pin.test.ts` | API client tests | NEW |
+
+---
+
+## Task 1: `isTauri` flag + PIN API client
+
+**Files:**
+- Modify: `client/src/lib/api.ts`
+- Create: `client/src/api/pin.ts`
+- Test: `client/src/api/__tests__/pin.test.ts`
+
+- [ ] **Step 1: Export an `isTauri` flag**
+
+In `client/src/lib/api.ts`, immediately after the `tauriApiBase` const (the block ending `: undefined;`), add:
+
+```typescript
+/** True when running inside the Tauri Companion shell (local channel). Read
+ *  synchronously at module load; safe to use pre-auth on the Login screen. */
+export const isTauri = Boolean(tauriApiBase);
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `client/src/api/__tests__/pin.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/api', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), delete: vi.fn() },
+  buildApiUrl: (p: string) => p,
+}));
+
+import { apiClient } from '../../lib/api';
+import { getPinStatus, setPin, removePin } from '../pin';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('pin api client', () => {
+  it('getPinStatus returns pin_enabled', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { pin_enabled: true } } as any);
+    const r = await getPinStatus();
+    expect(r.pin_enabled).toBe(true);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/auth/pin');
+  });
+
+  it('setPin posts pin + code', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { message: 'PIN set' } } as any);
+    await setPin('4827', '123456');
+    expect(apiClient.post).toHaveBeenCalledWith('/api/auth/pin', { pin: '4827', code: '123456' });
+  });
+
+  it('removePin sends code in the request body', async () => {
+    vi.mocked(apiClient.delete).mockResolvedValue({ data: { message: 'PIN removed' } } as any);
+    await removePin('123456');
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/auth/pin', { data: { code: '123456' } });
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd client && npx vitest run src/api/__tests__/pin.test.ts`
+Expected: FAIL — cannot resolve `../pin`.
+
+- [ ] **Step 4: Create the API client**
+
+Create `client/src/api/pin.ts`:
+
+```typescript
+/** PIN login + management + admin auth-policy API client. */
+import { apiClient, buildApiUrl } from '../lib/api';
+import type { User } from '../types/auth';
+
+export interface PinStatus {
+  pin_enabled: boolean;
+}
+
+export interface AuthPolicy {
+  pin_login_enabled: boolean;
+  pin_grace_window_seconds: number;
+}
+
+/** Either a finished login (access_token) or a 2FA challenge (pending_token). */
+export interface PinLoginResult {
+  access_token?: string;
+  user?: User;
+  requires_2fa?: boolean;
+  pending_token?: string;
+  detail?: string;
+}
+
+/** PIN login is pre-auth and local-channel only — mirror Login.tsx's fetch path. */
+export async function loginWithPin(username: string, pin: string): Promise<PinLoginResult> {
+  const res = await fetch(buildApiUrl('/api/auth/login-pin'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, pin }),
+  });
+  const data = (await res.json().catch(() => ({}))) as PinLoginResult;
+  if (!res.ok) {
+    throw new Error(String(data.detail || `PIN login failed (${res.status})`));
+  }
+  return data;
+}
+
+export async function getPinStatus(): Promise<PinStatus> {
+  const res = await apiClient.get<PinStatus>('/api/auth/pin');
+  return res.data;
+}
+
+export async function setPin(pin: string, code: string): Promise<void> {
+  await apiClient.post('/api/auth/pin', { pin, code });
+}
+
+export async function removePin(code: string): Promise<void> {
+  await apiClient.delete('/api/auth/pin', { data: { code } });
+}
+
+export async function getAuthPolicy(): Promise<AuthPolicy> {
+  const res = await apiClient.get<AuthPolicy>('/api/admin/auth-policy');
+  return res.data;
+}
+
+export async function updateAuthPolicy(body: Partial<AuthPolicy>): Promise<AuthPolicy> {
+  const res = await apiClient.put<AuthPolicy>('/api/admin/auth-policy', body);
+  return res.data;
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd client && npx vitest run src/api/__tests__/pin.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/lib/api.ts client/src/api/pin.ts client/src/api/__tests__/pin.test.ts
+git commit -m "feat(client): isTauri flag + PIN/auth-policy API client"
+```
+
+---
+
+## Task 2: PIN login option on the Login screen
+
+**Files:**
+- Modify: `client/src/pages/Login.tsx`
+
+> Context: `Login.tsx` already has a 2FA step (`twoFactorRequired`, `pendingToken`, `totpCode`,
+> `handleVerify2FA`). PIN login reuses it: a PIN login that returns `requires_2fa` drops into the
+> exact same TOTP step. Show the PIN option only when `isTauri`.
+
+- [ ] **Step 1: Add imports + state**
+
+In `client/src/pages/Login.tsx`:
+- Add to the import from `../lib/api`: `import { buildApiUrl, isTauri } from '../lib/api';` (replace the existing `import { buildApiUrl } from '../lib/api';`).
+- Add: `import { loginWithPin } from '../api/pin';`
+- After the line `const [showPassword, setShowPassword] = useState(false);` add:
+
+```tsx
+  const [pinMode, setPinMode] = useState(false);
+  const [pin, setPin] = useState('');
+```
+
+- [ ] **Step 2: Add the PIN submit handler**
+
+Immediately after `handleSubmit` (after its closing `};`), add:
+
+```tsx
+  const handlePinSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      const result = await loginWithPin(username, pin);
+      if (result.requires_2fa) {
+        setPendingToken(String(result.pending_token ?? ''));
+        setTwoFactorRequired(true);
+        setLoading(false);
+        return;
+      }
+      if (typeof result.access_token === 'string' && result.user) {
+        login(result.user, result.access_token);
+        return;
+      }
+      throw new Error('PIN login did not return a token');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'PIN login failed');
+      setPin('');
+    } finally {
+      setLoading(false);
+    }
+  };
+```
+
+- [ ] **Step 3: Render the PIN form + toggle**
+
+In the JSX, replace the `/* Regular Login Form */` block — i.e. the `<>...</>` that starts right after
+`) : (` (the else branch of `twoFactorRequired ? (...) : (...)`) — so it conditionally renders the PIN
+form when `pinMode`. Concretely, change the opening of that else-branch from:
+
+```tsx
+            /* Regular Login Form */
+            <>
+              <form onSubmit={handleSubmit} className="mt-8 sm:mt-10 space-y-4 sm:space-y-5">
+```
+
+to:
+
+```tsx
+            /* Regular Login Form */
+            <>
+              {pinMode ? (
+                <form onSubmit={handlePinSubmit} className="mt-8 sm:mt-10 space-y-4 sm:space-y-5">
+                  {error && (
+                    <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 px-3 sm:px-4 py-2.5 sm:py-3 text-sm text-rose-200">
+                      {error}
+                    </div>
+                  )}
+                  <div className="space-y-2">
+                    <label htmlFor="pin-username" className="text-xs font-medium uppercase tracking-[0.2em] text-slate-100-tertiary">
+                      {t('form.username')}
+                    </label>
+                    <input
+                      type="text" id="pin-username" className="input"
+                      value={username} onChange={(e) => setUsername(e.target.value)}
+                      placeholder="admin" required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="pin" className="text-xs font-medium uppercase tracking-[0.2em] text-slate-100-tertiary">
+                      {t('pin.label')}
+                    </label>
+                    <input
+                      type="password" id="pin"
+                      className="input text-center text-2xl tracking-[0.5em] font-mono"
+                      value={pin}
+                      onChange={(e) => setPin(e.target.value.replace(/\D/g, '').slice(0, 8))}
+                      placeholder="••••" inputMode="numeric" autoComplete="off" required
+                    />
+                  </div>
+                  <button type="submit" className="btn btn-primary w-full mt-5 sm:mt-6 touch-manipulation active:scale-[0.98]" disabled={loading || pin.length < 4}>
+                    {loading ? t('form.loading') : t('pin.submit')}
+                  </button>
+                  <button type="button" onClick={() => { setPinMode(false); setError(''); setPin(''); }} className="w-full text-center text-sm text-slate-100-tertiary hover:text-slate-100-secondary transition-colors">
+                    {t('pin.usePassword')}
+                  </button>
+                </form>
+              ) : (
+              <form onSubmit={handleSubmit} className="mt-8 sm:mt-10 space-y-4 sm:space-y-5">
+```
+
+Then find the **end** of that password `<form>` (the closing `</form>` right before the
+`{devCredentials && (` block) and immediately after that `</form>` add the closing of the ternary plus
+the "Use PIN" toggle (Tauri-only):
+
+```tsx
+              </form>
+              )}
+
+              {isTauri && !pinMode && (
+                <button
+                  type="button"
+                  onClick={() => { setPinMode(true); setError(''); setPassword(''); }}
+                  className="mt-3 w-full text-center text-sm text-slate-100-tertiary hover:text-slate-100-secondary transition-colors"
+                >
+                  {t('pin.usePin')}
+                </button>
+              )}
+```
+
+(That replaces the single `</form>` that preceded `{devCredentials && (`.)
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 5: Manual sanity (web build has no Tauri, so the toggle is hidden)**
+
+Run: `cd client && npm run build`
+Expected: build succeeds. (`isTauri` is `false` in the web build → PIN toggle not rendered; password login unchanged.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/pages/Login.tsx
+git commit -m "feat(client): PIN login option on the Login screen (Tauri-only)"
+```
+
+---
+
+## Task 3: Login i18n keys (DE + EN)
+
+**Files:**
+- Modify: `client/src/i18n/locales/de/login.json`
+- Modify: `client/src/i18n/locales/en/login.json`
+
+- [ ] **Step 1: Add a `pin` block to German login.json**
+
+In `client/src/i18n/locales/de/login.json`, add a top-level `"pin"` object (place it next to the
+existing `"twoFactor"` / `"form"` objects — match the file's structure):
+
+```json
+  "pin": {
+    "label": "PIN",
+    "submit": "Mit PIN anmelden",
+    "usePin": "Stattdessen PIN verwenden",
+    "usePassword": "Passwort verwenden"
+  }
+```
+
+- [ ] **Step 2: Add the same block to English login.json**
+
+In `client/src/i18n/locales/en/login.json`:
+
+```json
+  "pin": {
+    "label": "PIN",
+    "submit": "Sign in with PIN",
+    "usePin": "Use a PIN instead",
+    "usePassword": "Use password"
+  }
+```
+
+- [ ] **Step 3: Validate JSON**
+
+Run:
+```bash
+cd client && node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/de/login.json','utf8')); JSON.parse(require('fs').readFileSync('src/i18n/locales/en/login.json','utf8')); console.log('OK')"
+```
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/i18n/locales/de/login.json client/src/i18n/locales/en/login.json
+git commit -m "i18n(login): PIN login strings (de/en)"
+```
+
+---
+
+## Task 4: Desktop-App PIN settings section
+
+**Files:**
+- Create: `client/src/components/settings/DesktopPinSettings.tsx`
+- Modify: the security/2FA settings host component (located in Step 1)
+- Modify: `client/src/i18n/locales/{de,en}/settings.json`
+
+- [ ] **Step 1: Locate the 2FA settings host**
+
+Find the component that renders the 2FA management UI (it calls `/api/auth/2fa/setup` or shows
+2FA status). Use the vectordb MCP: `mcp__vectordb-search__search_files` with query
+"two factor 2FA settings component setup enable disable" and `projectPath` `D:/Programme (x86)/Baluhost`.
+Likely under `client/src/components/settings/`. Open it; note its file path and the place where the
+2FA block ends — you will mount `<DesktopPinSettings />` right after it. Note which i18n namespace it
+uses (`useTranslation('settings')` is expected).
+
+- [ ] **Step 2: Add settings i18n keys (DE + EN)**
+
+In `client/src/i18n/locales/de/settings.json`, add (match the file's nesting — top-level `"pin"` object):
+
+```json
+  "pin": {
+    "title": "Desktop-App-PIN",
+    "description": "Melde dich in der BaluHost-Companion-App mit einer PIN statt dem Passwort an (erfordert aktives 2FA).",
+    "enabled": "PIN aktiv",
+    "disabled": "Keine PIN gesetzt",
+    "needs2fa": "Aktiviere zuerst die Zwei-Faktor-Authentifizierung.",
+    "pinLabel": "PIN (4–8 Ziffern)",
+    "confirmLabel": "PIN bestätigen",
+    "codeLabel": "2FA-Code",
+    "save": "PIN speichern",
+    "remove": "PIN entfernen",
+    "mismatch": "Die PINs stimmen nicht überein.",
+    "saved": "PIN gespeichert",
+    "removed": "PIN entfernt",
+    "saveError": "PIN konnte nicht gespeichert werden",
+    "removeError": "PIN konnte nicht entfernt werden"
+  }
+```
+
+In `client/src/i18n/locales/en/settings.json`:
+
+```json
+  "pin": {
+    "title": "Desktop app PIN",
+    "description": "Sign in to the BaluHost Companion app with a PIN instead of your password (requires 2FA enabled).",
+    "enabled": "PIN active",
+    "disabled": "No PIN set",
+    "needs2fa": "Enable two-factor authentication first.",
+    "pinLabel": "PIN (4–8 digits)",
+    "confirmLabel": "Confirm PIN",
+    "codeLabel": "2FA code",
+    "save": "Save PIN",
+    "remove": "Remove PIN",
+    "mismatch": "The PINs do not match.",
+    "saved": "PIN saved",
+    "removed": "PIN removed",
+    "saveError": "Could not save PIN",
+    "removeError": "Could not remove PIN"
+  }
+```
+
+- [ ] **Step 3: Create the component**
+
+Create `client/src/components/settings/DesktopPinSettings.tsx`:
+
+```tsx
+/** Desktop-app PIN management — visible only when 2FA is enabled. */
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { getPinStatus, setPin as apiSetPin, removePin } from '../../api/pin';
+import { handleApiError } from '../../lib/errorHandling';
+
+interface Props {
+  twoFactorEnabled: boolean;
+}
+
+export function DesktopPinSettings({ twoFactorEnabled }: Props) {
+  const { t } = useTranslation('settings');
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [pin, setPinValue] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [code, setCode] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!twoFactorEnabled) { setLoading(false); return; }
+    getPinStatus()
+      .then((s) => setEnabled(s.pin_enabled))
+      .catch(() => setEnabled(false))
+      .finally(() => setLoading(false));
+  }, [twoFactorEnabled]);
+
+  const onSave = async () => {
+    if (pin !== confirm) { toast.error(t('pin.mismatch')); return; }
+    setBusy(true);
+    try {
+      await apiSetPin(pin, code);
+      setEnabled(true);
+      setPinValue(''); setConfirm(''); setCode('');
+      toast.success(t('pin.saved'));
+    } catch (err) {
+      handleApiError(err, t('pin.saveError'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onRemove = async () => {
+    setBusy(true);
+    try {
+      await removePin(code);
+      setEnabled(false);
+      setCode('');
+      toast.success(t('pin.removed'));
+    } catch (err) {
+      handleApiError(err, t('pin.removeError'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) return null;
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+      <h3 className="text-lg font-semibold text-slate-100">{t('pin.title')}</h3>
+      <p className="mt-1 text-sm text-slate-400">{t('pin.description')}</p>
+
+      {!twoFactorEnabled ? (
+        <p className="mt-4 text-sm text-amber-300">{t('pin.needs2fa')}</p>
+      ) : (
+        <div className="mt-4 space-y-3">
+          <p className="text-sm">
+            <span className={enabled ? 'text-emerald-400' : 'text-slate-400'}>
+              {enabled ? t('pin.enabled') : t('pin.disabled')}
+            </span>
+          </p>
+
+          {!enabled && (
+            <>
+              <input type="password" inputMode="numeric" placeholder={t('pin.pinLabel')}
+                className="input" value={pin}
+                onChange={(e) => setPinValue(e.target.value.replace(/\D/g, '').slice(0, 8))} />
+              <input type="password" inputMode="numeric" placeholder={t('pin.confirmLabel')}
+                className="input" value={confirm}
+                onChange={(e) => setConfirm(e.target.value.replace(/\D/g, '').slice(0, 8))} />
+            </>
+          )}
+
+          <input type="text" inputMode="numeric" placeholder={t('pin.codeLabel')}
+            className="input" value={code}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 8))}
+            autoComplete="one-time-code" />
+
+          <div className="flex gap-2">
+            {!enabled ? (
+              <button className="btn btn-primary" disabled={busy || pin.length < 4 || code.length < 6} onClick={onSave}>
+                {t('pin.save')}
+              </button>
+            ) : (
+              <button className="btn btn-danger" disabled={busy || code.length < 6} onClick={onRemove}>
+                {t('pin.remove')}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Mount it after the 2FA block**
+
+In the host component found in Step 1, import and render the section, passing the host's existing
+2FA-enabled boolean (whatever it is named there — it tracks `totp` status):
+
+```tsx
+import { DesktopPinSettings } from './DesktopPinSettings';
+// ...after the 2FA management block:
+<DesktopPinSettings twoFactorEnabled={/* the host's 2FA-enabled state */} />
+```
+
+- [ ] **Step 5: Type-check + JSON validate**
+
+Run: `cd client && npx tsc --noEmit && node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/de/settings.json','utf8')); JSON.parse(require('fs').readFileSync('src/i18n/locales/en/settings.json','utf8')); console.log('OK')"`
+Expected: no TS errors; `OK`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/components/settings/DesktopPinSettings.tsx client/src/i18n/locales/de/settings.json client/src/i18n/locales/en/settings.json <host-component-path>
+git commit -m "feat(settings): Desktop-app PIN management section (2FA-gated)"
+```
+
+---
+
+## Task 5: Admin auth-policy card
+
+**Files:**
+- Create: `client/src/components/admin/AuthPolicySettings.tsx`
+- Modify: an admin settings host (located in Step 1)
+- Modify: `client/src/i18n/locales/{de,en}/admin.json`
+
+- [ ] **Step 1: Locate an admin settings host**
+
+Find an admin-only settings page/section to host the card — e.g. where rate-limit config or other
+admin settings render. Use vectordb: `mcp__vectordb-search__search_files` query "admin settings page
+rate limit config security" (`projectPath` `D:/Programme (x86)/Baluhost`). Note the file + a sensible
+mount point and its i18n namespace (`admin` expected).
+
+- [ ] **Step 2: Add admin i18n keys (DE + EN)**
+
+`client/src/i18n/locales/de/admin.json` — add a top-level `"authPolicy"` object:
+
+```json
+  "authPolicy": {
+    "title": "PIN-Login-Richtlinie",
+    "description": "Steuert das Gnadenfenster, in dem die Desktop-App-PIN ohne 2FA-Code genügt.",
+    "enabled": "PIN-Login aktiviert",
+    "window": "Gnadenfenster",
+    "saved": "Richtlinie gespeichert",
+    "saveError": "Richtlinie konnte nicht gespeichert werden",
+    "windows": { "1h": "1 Stunde", "8h": "8 Stunden", "24h": "24 Stunden", "7d": "7 Tage" }
+  }
+```
+
+`client/src/i18n/locales/en/admin.json`:
+
+```json
+  "authPolicy": {
+    "title": "PIN login policy",
+    "description": "Controls the grace window in which the desktop-app PIN suffices without a 2FA code.",
+    "enabled": "PIN login enabled",
+    "window": "Grace window",
+    "saved": "Policy saved",
+    "saveError": "Could not save policy",
+    "windows": { "1h": "1 hour", "8h": "8 hours", "24h": "24 hours", "7d": "7 days" }
+  }
+```
+
+- [ ] **Step 3: Create the component**
+
+Create `client/src/components/admin/AuthPolicySettings.tsx`:
+
+```tsx
+/** Admin: system-wide PIN-login policy (grace window + kill switch). */
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { getAuthPolicy, updateAuthPolicy } from '../../api/pin';
+import { handleApiError } from '../../lib/errorHandling';
+
+const WINDOW_OPTIONS: { key: string; seconds: number }[] = [
+  { key: '1h', seconds: 3600 },
+  { key: '8h', seconds: 28800 },
+  { key: '24h', seconds: 86400 },
+  { key: '7d', seconds: 604800 },
+];
+
+export function AuthPolicySettings() {
+  const { t } = useTranslation('admin');
+  const [loading, setLoading] = useState(true);
+  const [enabled, setEnabled] = useState(true);
+  const [windowSeconds, setWindowSeconds] = useState(86400);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    getAuthPolicy()
+      .then((p) => { setEnabled(p.pin_login_enabled); setWindowSeconds(p.pin_grace_window_seconds); })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const save = async (next: { pin_login_enabled?: boolean; pin_grace_window_seconds?: number }) => {
+    setBusy(true);
+    try {
+      const p = await updateAuthPolicy(next);
+      setEnabled(p.pin_login_enabled);
+      setWindowSeconds(p.pin_grace_window_seconds);
+      toast.success(t('authPolicy.saved'));
+    } catch (err) {
+      handleApiError(err, t('authPolicy.saveError'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) return null;
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+      <h3 className="text-lg font-semibold text-slate-100">{t('authPolicy.title')}</h3>
+      <p className="mt-1 text-sm text-slate-400">{t('authPolicy.description')}</p>
+
+      <label className="mt-4 flex items-center justify-between">
+        <span className="text-sm text-slate-300">{t('authPolicy.enabled')}</span>
+        <input type="checkbox" checked={enabled} disabled={busy}
+          onChange={(e) => save({ pin_login_enabled: e.target.checked })}
+          className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-sky-500 focus:ring-sky-500/50" />
+      </label>
+
+      <label className="mt-4 block text-sm text-slate-300">
+        {t('authPolicy.window')}
+        <select className="input mt-1" value={windowSeconds} disabled={busy}
+          onChange={(e) => save({ pin_grace_window_seconds: Number(e.target.value) })}>
+          {WINDOW_OPTIONS.map((o) => (
+            <option key={o.key} value={o.seconds}>{t(`authPolicy.windows.${o.key}`)}</option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Mount it in the admin host**
+
+In the admin host found in Step 1, import and render `<AuthPolicySettings />` at a sensible spot:
+
+```tsx
+import { AuthPolicySettings } from '../admin/AuthPolicySettings';
+// ...
+<AuthPolicySettings />
+```
+
+(Adjust the relative import path to the host's location.)
+
+- [ ] **Step 5: Type-check + JSON validate**
+
+Run: `cd client && npx tsc --noEmit && node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/de/admin.json','utf8')); JSON.parse(require('fs').readFileSync('src/i18n/locales/en/admin.json','utf8')); console.log('OK')"`
+Expected: no TS errors; `OK`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/components/admin/AuthPolicySettings.tsx client/src/i18n/locales/de/admin.json client/src/i18n/locales/en/admin.json <host-component-path>
+git commit -m "feat(admin): PIN-login policy settings card"
+```
+
+---
+
+## Task 6: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the new unit test + full vitest suite**
+
+Run: `cd client && npx vitest run`
+Expected: all green (incl. `src/api/__tests__/pin.test.ts`).
+
+- [ ] **Step 2: Production build (type-check)**
+
+Run: `cd client && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Manual smoke (dev)**
+
+1. `python start_dev.py`; in the web UI (not Tauri) the PIN login toggle is **absent** (isTauri false) — password login unchanged.
+2. Enable 2FA for a user, then in Settings → Desktop-App PIN: set a PIN (enter a TOTP code).
+3. Admin settings → PIN login policy: set the window / toggle the kill switch.
+4. (Tauri smoke is part of the Companion app run, not this web flow.)
+
+- [ ] **Step 4: No commit** (verification only).
+
+---
+
+## Notes for the implementer
+
+- **Tauri-only gating:** the PIN login option keys off `isTauri` (`window.__BALU_API_BASE__`), so the web build never shows it. The backend additionally enforces local-channel (403), so this is defense-in-depth, not the only gate.
+- **2FA-step reuse:** a PIN login that returns `requires_2fa` flows into the **existing** `handleVerify2FA` step — do not duplicate the TOTP UI.
+- **Mount points (Tasks 4–5)** are located during implementation via vectordb (the host components aren't pinned in this plan); everything else has exact anchors.
+- `handleApiError` is in `client/src/lib/errorHandling.ts` (`handleApiError(err, fallback)` shows a toast). `User` type is in `client/src/types/auth.ts`.
+```

--- a/docs/superpowers/specs/2026-06-06-tauri-pin-login-design.md
+++ b/docs/superpowers/specs/2026-06-06-tauri-pin-login-design.md
@@ -1,0 +1,241 @@
+# Tauri PIN Login — Design Spec
+
+**Date:** 2026-06-06
+**Status:** Approved
+**Author:** Sven (Xveyn) + Claude (via brainstorming session)
+**Branch:** `feat/tauri-pin-login`
+
+## Problem
+
+Logging into the BaluHost Companion (Tauri) app — which runs **on the server** and talks to the
+backend over the local Unix socket (`channel=local`) — currently requires the full username +
+password (+ TOTP, if 2FA is enabled), every time. For a desktop app you open repeatedly on a
+trusted machine, typing a long password each time is friction.
+
+We want to let users sign in with a short **PIN instead of their password** in the Tauri app —
+but only as a hardened convenience, never a weakening.
+
+## Goals
+
+- A user may sign in to the **Tauri app** with a numeric **PIN in place of their password**.
+- Only available when the user has **2FA (TOTP) enabled** — 2FA is the security anchor.
+- A short **admin-configured grace window** during which the PIN **alone** suffices; outside it,
+  the login is genuine **PIN + TOTP**.
+- Reuse the existing auth building blocks (`2fa_pending`/`verify-2fa`, `pwd_context`/bcrypt, the
+  channel mechanism, audit logger) — minimal new surface.
+- Password login stays unchanged and remains available everywhere (incl. the Tauri app) as fallback.
+
+## Non-Goals
+
+- PIN login over the **remote/TCP** channel — hard invariant: PIN login is **local-channel only**.
+  A 4-digit PIN over the internet would be trivially brute-forced.
+- Replacing 2FA. The grace window is opened **only** by a successful TOTP verification.
+- Step-up 2FA for sensitive in-session actions — tracked separately as a future idea
+  ([#169](https://github.com/Xveyn/BaluHost/issues/169)).
+- Per-device PIN binding / multiple PINs per user — one PIN per user (v1).
+- Client-side token vault (PIN unlocking a stored refresh token) — rejected; keeps security on the
+  server auth layer rather than local storage.
+
+## Decisions (from brainstorming)
+
+| Topic | Decision |
+|---|---|
+| Factor model | PIN replaces the **password**; TOTP still required, but a grace window allows PIN-only within it |
+| Grace window length | **Admin-global policy** (one system-wide setting), default 24h, hard cap 7 days |
+| Grace reset | **Absolute** — window runs from the last successful TOTP; PIN-only logins do **not** extend it |
+| PIN policy | Numeric, 4–8 digits; reject all-same (`0000`) and ascending/descending sequences (`1234`/`9876`) |
+| Scope | Any user with 2FA enabled may set up a PIN (not admin-only) |
+| PIN management | Set/change/remove from anywhere when authenticated **+ fresh TOTP code**; only PIN *login* is local-only |
+| Policy change | Admin (`get_current_admin`) |
+| Brute-force | 5 failed PIN attempts → 15-min lockout; reset on success; rate-limited + audited |
+
+## Architecture
+
+```
+Tauri-App (channel=local)
+  │
+  ▼
+POST /api/auth/login-pin   { username, pin }     ← local channel ONLY (else 403)
+  │
+  ├─ global policy pin_login_enabled?   (else refuse → use password)
+  ├─ user found, totp_enabled, not pin-locked?
+  ├─ verify pin against pin_hash (bcrypt, constant-time)
+  │
+  ├─ now < pin_grace_until ?
+  │     YES → return access token directly            (PIN-only, within window)
+  │     NO  → return 2fa_pending token (existing)      (window expired)
+  │             │
+  │             ▼
+  │        POST /api/auth/verify-2fa { pending_token, code }   ← existing, minimally extended
+  │             ├─ verify TOTP or backup code (unchanged)
+  │             ├─ if user has pin_hash: pin_grace_until = now + policy.window   (absolute)
+  │             └─ return access token
+  └─ ...
+```
+
+**Core idea:** one new local login path; everything else is existing machinery.
+`create_2fa_pending_token` / `verify-2fa` / `pwd_context` / audit logger / `request.state.channel`
+already exist. New: `login-pin`, PIN management endpoints, an admin policy singleton, and four
+user columns.
+
+## Components
+
+### Data model — 4 new columns on `users` (one additive migration)
+
+| Column | Type | Purpose |
+|---|---|---|
+| `pin_hash` | `String(255)`, nullable | bcrypt hash of the PIN (same `pwd_context` as the password) |
+| `pin_grace_until` | `DateTime(timezone=True)`, nullable | absolute grace-window expiry; set on `verify-2fa` success when a PIN is configured |
+| `pin_failed_attempts` | `Integer`, default 0, server_default "0" | brute-force counter |
+| `pin_locked_until` | `DateTime(timezone=True)`, nullable | PIN lockout expiry |
+
+### Admin policy — new singleton model `AuthPolicy` (id=1, mirrors `monitoring_config`)
+
+| Field | Default | Constraint |
+|---|---|---|
+| `pin_login_enabled` | `true` | global kill switch |
+| `pin_grace_window_seconds` | `86400` (24h) | 60 ≤ x ≤ `604800` (7 days), enforced in the Pydantic schema |
+
+New file: `backend/app/models/auth_policy.py`, migration, schema `backend/app/schemas/auth_policy.py`,
+service helper to read-or-create the singleton.
+
+### Endpoints
+
+| Endpoint | Auth / Gate | Behavior |
+|---|---|---|
+| `POST /api/auth/login-pin` | **pre-auth, local-only** (inline `request.state.channel == "local"`, else 403 `local_channel_required`); rate-limited | `{username, pin}` → access token (within window) **or** `TwoFactorRequiredResponse` (window expired). Refuses if policy disabled, no PIN, no 2FA, or pin-locked. |
+| `POST /api/auth/verify-2fa` | existing | **extended:** on success, if user has `pin_hash`, set `pin_grace_until = now + policy.window` |
+| `GET /api/auth/pin` | `get_current_user` | `{ pin_enabled: bool }` for the UI |
+| `POST /api/auth/pin` | `get_current_user` + valid **TOTP code** + `totp_enabled` | set/replace PIN (PIN-policy validated); audit `pin_set` |
+| `DELETE /api/auth/pin` | `get_current_user` + valid **TOTP code** | remove PIN (clears `pin_hash`, grace, lock); audit `pin_removed` |
+| `GET /api/admin/auth-policy` | `get_current_admin` | read policy |
+| `PUT /api/admin/auth-policy` | `get_current_admin` | update policy (cap enforced); audit |
+
+### PIN policy validator
+
+Shared helper (in `backend/app/schemas/auth.py`, used by the `POST /api/auth/pin` body):
+
+```
+- must match ^\d{4,8}$
+- reject if all digits identical (0000, 1111, …)
+- reject if strictly ascending consecutive (1234, 2345, …, 5678)
+- reject if strictly descending consecutive (4321, 9876, …)
+```
+
+Clear `400` error messages per rule.
+
+## Data Flow / Login sequence (Tauri)
+
+```
+1. App detects local channel (existing isTauri / channel-status).
+2. User picks "Sign in with PIN" → enters username + PIN.
+3. POST /api/auth/login-pin:
+     a. channel != local  → 403  (never reachable from the Tauri UDS path)
+     b. policy.pin_login_enabled == false → 401 "PIN login disabled"
+     c. user missing / no pin_hash / not totp_enabled → 401 generic "Invalid credentials"
+        (do not reveal which)
+     d. pin_locked_until in the future → 423/401 "locked, use password"
+     e. bcrypt verify pin → wrong: failed_attempts++, maybe lock, audit pin_login_failed, 401
+     f. correct:
+          - reset failed_attempts
+          - now < pin_grace_until → access token, audit pin_login_grace
+          - else → 2fa_pending token, audit pin_login_2fa_required
+4. If 2fa_pending: user enters TOTP → POST /api/auth/verify-2fa (existing path)
+     → sets pin_grace_until = now + policy.window; returns access token.
+```
+
+## Edge Cases
+
+| Case | Handling |
+|---|---|
+| **User disables 2FA** | Clear `pin_hash`, `pin_grace_until`, `pin_locked_until`, `pin_failed_attempts` in the disable-2FA path — a PIN must never outlive its 2FA anchor |
+| Remote call to `login-pin` | 403 `local_channel_required` (audit `pin_login_remote_denied`); the Tauri UDS path is the only way in |
+| Policy `pin_login_enabled = false` | `login-pin` refuses; password login unaffected |
+| No PIN set / wrong username | Generic 401 (no user enumeration) |
+| PIN locked | Refuse PIN login until `pin_locked_until`; password+TOTP still works and is the recovery path |
+| Window expired | `2fa_pending` path; only a successful TOTP reopens the window |
+| Backup code at the TOTP step | Works unchanged (reuses `verify-2fa`) |
+| Setting PIN without 2FA | Rejected (`totp_enabled` required) |
+| Multiple Uvicorn workers / local + remote process | `pin_grace_until` is a DB column → consistent across processes; only the local process serves `login-pin` |
+
+## Security Invariants
+
+- **PIN login is local-channel only** — enforced in the endpoint, audited on violation.
+- PIN is **never logged**; stored only as a bcrypt hash; verified in constant time via `pwd_context`.
+- The grace window is **server-authoritative and absolute**, set **only** by a successful TOTP.
+- 2FA remains mandatory: no PIN exists without `totp_enabled`, and disabling 2FA destroys the PIN.
+- PIN management requires a **fresh TOTP code**, so a hijacked session cannot silently plant a PIN.
+- Rate-limiting + lockout bound the 4-digit brute-force surface; local channel bounds exposure to
+  physical presence.
+
+Cross-checked against `.claude/rules/security-agent.md`: auth dependencies present, Pydantic schemas
+(no raw dicts), audit logging for all PIN/policy events, no `shell=True`, no raw SQL, no secret
+logging, secrets validation untouched.
+
+## Components / Files
+
+### New
+
+- `backend/app/models/auth_policy.py` — `AuthPolicy` singleton model
+- `backend/alembic/versions/<rev>_add_pin_columns_and_auth_policy.py` — migration (4 user columns + `auth_policy` table)
+- `backend/app/schemas/auth_policy.py` — `AuthPolicyResponse`, `AuthPolicyUpdate` (cap-validated)
+- `backend/app/services/auth_policy.py` — read-or-create singleton, get window seconds
+- `backend/tests/api/test_pin_login.py`, `backend/tests/api/test_pin_management.py`, `backend/tests/api/test_auth_policy.py`
+- `client/src/api/pin.ts` — PIN status/set/remove + login-pin client
+- `client/src/components/settings/DesktopPinSettings.tsx` — set/change/remove PIN (TOTP-gated)
+- `client/src/components/admin/AuthPolicySettings.tsx` — admin window + kill switch
+- Vitest specs for the above
+
+### Modified
+
+- `backend/app/models/user.py` — 4 columns
+- `backend/app/api/routes/auth.py` — `login-pin`, `GET/POST/DELETE /pin`, extend `verify-2fa` to set the window
+- `backend/app/schemas/auth.py` — `PinLoginRequest`, `PinSetRequest` (+ PIN validator), `PinStatusResponse`
+- `backend/app/api/routes/` (admin router) — `GET/PUT /admin/auth-policy`
+- `backend/app/services/totp_service.py` (or the disable-2FA route) — clear PIN fields when 2FA is disabled
+- `backend/app/core/rate_limiter.py` — `auth_pin_login` limit key
+- `client/src/pages/Login.tsx` — PIN login option in the Tauri/local context (+ TOTP step reuse)
+- `client/src/i18n/locales/{de,en}/*.json` — PIN + policy strings
+
+## Build Order
+
+1. Migration + `User` columns + `AuthPolicy` model + policy service (DB foundation)
+2. PIN policy validator + `PinSetRequest`/`PinLoginRequest` schemas (TDD)
+3. PIN management endpoints (`GET/POST/DELETE /pin`) + clear-on-2FA-disable
+4. `login-pin` endpoint (local-only, lockout, window vs 2fa_pending) + `verify-2fa` window-set
+5. Admin auth-policy endpoints
+6. Frontend: PIN settings, admin policy, Tauri login option, i18n
+7. Tests green (backend + frontend), manual smoke
+
+## Tests
+
+**Backend:**
+- PIN validator: accepts `4827`; rejects `0000`, `1111`, `1234`, `9876`, `123` (too short), `abc1`.
+- `login-pin`: remote → 403; within window → access token; expired → `2fa_pending`; policy-disabled → refuse; no PIN → 401; locked → refuse.
+- `verify-2fa`: sets `pin_grace_until = now + window` when PIN present; unchanged when no PIN.
+- Lockout: 5 wrong PINs → locked; correct PIN resets counter.
+- **Disable 2FA clears PIN** fields.
+- Auth-policy: GET/PUT, cap (`> 604800` rejected, `< 60` rejected), admin-only.
+- PIN management requires valid TOTP; `totp_enabled` required.
+
+**Frontend:** Vitest for the PIN login flow (token vs TOTP-challenge branches), PIN settings (set/remove with TOTP), admin policy form; smoke that the PIN option only shows in the local/Tauri context and only when 2FA is enabled.
+
+## Manual Smoke (dev)
+
+1. Enable 2FA for a user; set a PIN in Security settings (enter TOTP).
+2. In the Tauri/local app: sign in with username + PIN + TOTP → window opens.
+3. Sign out, sign in again within the window with PIN only → straight in.
+4. Advance past the admin window (or shorten it) → PIN now prompts for TOTP again.
+5. Wrong PIN ×5 → locked; password+TOTP still works.
+6. Disable 2FA → PIN is gone; `login-pin` refuses.
+7. `curl` `login-pin` over TCP → 403 `local_channel_required`.
+
+## Risks / Trade-offs
+
+1. **PIN-only within the window is a single secret (+ local channel).** Bounded by: local-channel
+   (physical presence), admin-tunable window, absolute (non-sliding) expiry forcing periodic TOTP,
+   and lockout. The admin window length is the security/convenience dial.
+2. **Admin-global window** (not per-user) — simpler; one knob. Per-user could come later if needed.
+3. **bcrypt on a 4-digit PIN** is cheap to brute-force offline if the hash leaks — but the hash lives
+   in the same DB as password hashes; a DB compromise is already game-over. Lockout + local-only
+   bound the online attack.


### PR DESCRIPTION
## Was

Anmeldung in der **Tauri Companion-App** mit einer **PIN statt Passwort** — als gehärtete Bequemlichkeit, nie als Schwächung.

- **PIN ersetzt das Passwort** in der Companion-App; **2FA bleibt der Anker**.
- **Admin-globales, absolutes Gnadenfenster:** Nach einem erfolgreichen PIN + TOTP genügt innerhalb des Fensters die **PIN allein**; nach Ablauf wieder PIN + TOTP. PIN-only-Logins verlängern das Fenster **nicht**.
- **Hart local-channel-only:** PIN-Login über TCP/remote → `403`. Eine kurze PIN über das Internet wäre trivial brute-forcebar; der lokale Channel (physische Präsenz am Server) ist die kompensierende Kontrolle.
- **Web-UI unverändert** — der PIN-Login erscheint nur in der Tauri-App.

Spec: `docs/superpowers/specs/2026-06-06-tauri-pin-login-design.md`
Pläne: `docs/superpowers/plans/2026-06-06-tauri-pin-login-{backend,frontend}.md`

## Backend (Plan 1)

- 4 PIN-Spalten auf `users` + `AuthPolicy`-Singleton + Migration (`45292ba19a35`, chained auf realen Head).
- `POST /api/auth/login-pin` (local-only, Lockout, Fenster vs. `2fa_pending`); `verify-2fa` setzt das Fenster **nur via TOTP**.
- PIN-Verwaltung `GET/POST/DELETE /api/auth/pin` (TOTP-gegated, 2FA-Pflicht); **2FA-Disable löscht die PIN restlos**.
- Admin `GET/PUT /api/admin/auth-policy` (Fenster 60..604800 s, Kill-Switch).
- `pin_service` (bcrypt via vorhandenem `pwd_context`, SQLite-sichere Zeitvergleiche, Lockout 5×/15 min).

## Frontend (Plan 2)

- PIN-Login-Option im Login-Screen (nur in Tauri via `window.__BALU_API_BASE__`), die den **bestehenden** 2FA-Schritt wiederverwendet.
- „Desktop-App-PIN"-Sektion in den Einstellungen (setzen/entfernen, TOTP-gegated, nur bei aktivem 2FA).
- Admin-Karte „PIN-Login-Richtlinie" (Fenster-Presets + Kill-Switch).
- i18n DE/EN (login/settings/admin).

## Tests & Review

- **Backend:** 38 neue Tests + 118 bestehende 2FA/Auth-Tests grün; **8 Security-Invarianten** unabhängig belegt (local-channel-Gate zuerst, keine User-Enumeration, PIN nie geloggt/nur bcrypt, Fenster nur via TOTP, Lockout greift vor PIN-Check, 2FA-Disable löscht PIN, TOTP-gegate PIN-Verwaltung, kein Token-Type-Confusion).
- **Frontend:** 406 Vitest grün, Production-Build grün; Web-Build-Safety verifiziert (PIN-Toggle nur in Tauri, Passwort-Login unverändert).
- Backend **und** Frontend je zweistufig (Spec + Security/Qualität) durch unabhängige Subagents reviewt → **APPROVED**.

## Hinweise / Folgearbeit

- Step-up-2FA für sensible In-Session-Aktionen ist bewusst **out of scope** (Idee: #169).
- Zwei minor UX-Politur-Punkte (Sektions-Staleness bis Remount beim Frisch-Aktivieren von 2FA; Admin-Karte ohne optimistisches Revert) sind als Follow-up-Issue festgehalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
