### PR TITLE
fix(settings): Desktop-PIN entfernen — Button-Feedback, Styling & Backup-Codes

### DIFF
--- a/client/src/components/settings/DesktopPinSettings.tsx
+++ b/client/src/components/settings/DesktopPinSettings.tsx
@@ -83,9 +83,10 @@ export function DesktopPinSettings({ twoFactorEnabled }: Props) {
             </>
           )}
 
-          <input type="text" inputMode="numeric" placeholder={t('pin.codeLabel')}
+          {/* Accept a 6-digit TOTP OR an 8-char backup code (uppercase hex). */}
+          <input type="text" inputMode="text" placeholder={t('pin.codeLabel')}
             className="input" value={code}
-            onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 8))}
+            onChange={(e) => setCode(e.target.value.replace(/[^0-9a-zA-Z]/g, '').toUpperCase().slice(0, 8))}
             autoComplete="one-time-code" />
           <p className="text-xs text-slate-400">{t('pin.codeHint')}</p>
 

--- a/client/src/components/settings/DesktopPinSettings.tsx
+++ b/client/src/components/settings/DesktopPinSettings.tsx
@@ -94,7 +94,11 @@ export function DesktopPinSettings({ twoFactorEnabled }: Props) {
                 {t('pin.save')}
               </button>
             ) : (
-              <button className="btn btn-danger" disabled={busy || code.length < 6} onClick={onRemove}>
+              <button
+                className="btn border border-rose-500/40 bg-rose-500/10 text-rose-300 hover:border-rose-400/60 hover:bg-rose-500/20 hover:text-rose-200"
+                disabled={busy || code.length < 6}
+                onClick={onRemove}
+              >
                 {t('pin.remove')}
               </button>
             )}

--- a/client/src/components/settings/DesktopPinSettings.tsx
+++ b/client/src/components/settings/DesktopPinSettings.tsx
@@ -87,15 +87,20 @@ export function DesktopPinSettings({ twoFactorEnabled }: Props) {
             className="input" value={code}
             onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 8))}
             autoComplete="one-time-code" />
+          <p className="text-xs text-slate-400">{t('pin.codeHint')}</p>
 
           <div className="flex gap-2">
             {!enabled ? (
-              <button className="btn btn-primary" disabled={busy || pin.length < 4 || code.length < 6} onClick={onSave}>
+              <button
+                className="btn btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={busy || pin.length < 4 || code.length < 6}
+                onClick={onSave}
+              >
                 {t('pin.save')}
               </button>
             ) : (
               <button
-                className="btn border border-rose-500/40 bg-rose-500/10 text-rose-300 hover:border-rose-400/60 hover:bg-rose-500/20 hover:text-rose-200"
+                className="btn border border-rose-500/40 bg-rose-500/10 text-rose-300 hover:border-rose-400/60 hover:bg-rose-500/20 hover:text-rose-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-rose-500/10"
                 disabled={busy || code.length < 6}
                 onClick={onRemove}
               >

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -374,7 +374,7 @@
     "pinLabel": "PIN (4–8 Ziffern)",
     "confirmLabel": "PIN bestätigen",
     "codeLabel": "2FA-Code",
-    "codeHint": "Gib zum Bestätigen deinen aktuellen 2FA-Code aus der Authenticator-App ein.",
+    "codeHint": "Gib zum Bestätigen deinen aktuellen 2FA-Code (oder einen Backup-Code) ein.",
     "save": "PIN speichern",
     "remove": "PIN entfernen",
     "mismatch": "Die PINs stimmen nicht überein.",

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -374,6 +374,7 @@
     "pinLabel": "PIN (4–8 Ziffern)",
     "confirmLabel": "PIN bestätigen",
     "codeLabel": "2FA-Code",
+    "codeHint": "Gib zum Bestätigen deinen aktuellen 2FA-Code aus der Authenticator-App ein.",
     "save": "PIN speichern",
     "remove": "PIN entfernen",
     "mismatch": "Die PINs stimmen nicht überein.",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -374,7 +374,7 @@
     "pinLabel": "PIN (4–8 digits)",
     "confirmLabel": "Confirm PIN",
     "codeLabel": "2FA code",
-    "codeHint": "Enter your current 2FA code from your authenticator app to confirm.",
+    "codeHint": "Enter your current 2FA code (or a backup code) to confirm.",
     "save": "Save PIN",
     "remove": "Remove PIN",
     "mismatch": "The PINs do not match.",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -374,6 +374,7 @@
     "pinLabel": "PIN (4–8 digits)",
     "confirmLabel": "Confirm PIN",
     "codeLabel": "2FA code",
+    "codeHint": "Enter your current 2FA code from your authenticator app to confirm.",
     "save": "Save PIN",
     "remove": "Remove PIN",
     "mismatch": "The PINs do not match.",


### PR DESCRIPTION
## Was

Follow-up-Fixes für die „Desktop-App-PIN"-Sektion aus #170. Behebt, dass der **„PIN entfernen"-Button scheinbar nichts tut** — plus zwei verwandte UX-/Funktions-Punkte.

## Probleme & Fixes

1. **„PIN entfernen" tat nichts** — der Button ist (wie gewollt) deaktiviert, bis ein frischer 2FA-Code eingegeben ist, aber die `.btn`-Klasse des Projekts hat **keinerlei Disabled-Optik**. Der deaktivierte Button sah klickbar aus und schluckte Klicks ohne Feedback. → `disabled:opacity-50 disabled:cursor-not-allowed` auf beiden PIN-Buttons + ein Hinweistext, dass der aktuelle 2FA-Code (aus der Authenticator-App **oder** ein Backup-Code) zum Bestätigen nötig ist.

2. **„PIN entfernen" war ungestylt** — der Button nutzte `btn btn-danger`, aber das Projekt definiert nur `.btn`/`.btn-primary`/`.btn-secondary` (kein `.btn-danger`). → konsistente rosa Danger-Optik (Basis `.btn` + Tailwind-Rose-Utilities).

3. **Backup-Codes gingen nicht** — das Code-Feld filterte Nicht-Ziffern raus, also funktionierte nur der 6-stellige TOTP-Code; Backup-Codes (8-stellig, Großbuchstaben-Hex) ließen sich nicht eingeben, obwohl das Backend sie akzeptiert. → Feld erlaubt jetzt alphanumerische Eingabe, uppercased sie (Backup-Codes werden case-sensitiv geprüft).

## Test

`npm run build` grün; JSON valide. Reiner Frontend-Fix, nur `DesktopPinSettings.tsx` + settings-i18n (de/en).

Bezug: #170 (Feature, gemergt). Deckt teilweise das UX-Follow-up aus #171 ab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
