### PR TITLE
feat(updates): Update-Page liest Neuerungen aus GitHub Releases

### DIFF
--- a/backend/app/api/routes/updates.py
+++ b/backend/app/api/routes/updates.py
@@ -12,7 +12,6 @@ from app.schemas.user import UserPublic
 from app.schemas.update import (
     UpdateCheckResponse,
     UpdateStartRequest,
-    DevUpdateStartRequest,
     UpdateStartResponse,
     UpdateProgressResponse,
     UpdateHistoryResponse,
@@ -145,62 +144,6 @@ async def start_update(
 
     if not result.success and result.blockers:
         # Return 409 Conflict if blocked
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "message": result.message,
-                "blockers": result.blockers,
-            }
-        )
-
-    return result
-
-
-@router.post("/start-dev", response_model=UpdateStartResponse)
-@user_limiter.limit(get_limit("admin_operations"))
-async def start_dev_update(
-    request: Request, response: Response,
-    body: Optional[DevUpdateStartRequest] = None,
-    current_user: UserPublic = Depends(deps.get_current_admin),
-    db: Session = Depends(get_db),
-) -> UpdateStartResponse:
-    """Start a development branch update.
-
-    Deploys the latest commit from the development branch.
-    The update runs in the background and progress can be monitored via
-    the /progress/{id} endpoint.
-
-    Requires admin privileges.
-    """
-    service = get_update_service(db)
-    audit_logger = get_audit_logger_db()
-
-    req = body or DevUpdateStartRequest()
-
-    result = await service.start_dev_update(
-        user_id=current_user.id,
-        skip_backup=req.skip_backup,
-        force=req.force,
-    )
-
-    audit_logger.log_event(
-        event_type="UPDATE",
-        action="start_dev_update",
-        user=current_user.username,
-        resource="system",
-        success=result.success,
-        details={
-            "update_id": result.update_id,
-            "channel": "development",
-            "skip_backup": req.skip_backup,
-            "force": req.force,
-            "message": result.message,
-            "blockers": result.blockers,
-        },
-        db=db,
-    )
-
-    if not result.success and result.blockers:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -34,6 +34,17 @@ class Settings(BaseSettings):
         ),
     )
 
+    update_github_repo: str = Field(
+        default="Xveyn/BaluHost",
+        validation_alias="BALUHOST_UPDATE_GITHUB_REPO",
+        description="owner/repo used to read GitHub Releases for the update page.",
+    )
+    update_changelog_path: str = Field(
+        default="CHANGELOG.md",
+        validation_alias="BALUHOST_UPDATE_CHANGELOG_PATH",
+        description="Path (repo-root-relative or absolute) to the bundled CHANGELOG.md fallback.",
+    )
+
     api_prefix: str = "/api"
     api_version: str = "1"  # Current API version
     api_min_version: str = "1"  # Minimum supported API version

--- a/backend/app/schemas/update.py
+++ b/backend/app/schemas/update.py
@@ -36,6 +36,7 @@ class ChangelogEntry(BaseModel):
     changes: list[str] = Field(default_factory=list, description="List of changes")
     breaking_changes: list[str] = Field(default_factory=list, description="Breaking changes")
     is_prerelease: bool = Field(default=False, description="Whether this is a prerelease")
+    body_markdown: Optional[str] = Field(default=None, description="Curated release notes (markdown)")
 
 
 class UpdateCheckResponse(BaseModel):
@@ -65,23 +66,6 @@ class UpdateCheckResponse(BaseModel):
         default=True,
         description="Whether update can proceed (no blockers)"
     )
-    # Dev branch info (informational only)
-    dev_version_available: bool = Field(
-        default=False,
-        description="Whether development branch has unreleased commits ahead of latest tag"
-    )
-    dev_version: Optional[VersionInfo] = Field(
-        default=None,
-        description="Development branch tip info"
-    )
-    dev_commits_ahead: Optional[int] = Field(
-        default=None,
-        description="Commits ahead of latest release"
-    )
-    dev_commits: list[CommitInfo] = Field(
-        default_factory=list,
-        description="Commit messages on dev branch since latest release"
-    )
 
 
 class UpdateStartRequest(BaseModel):
@@ -91,19 +75,6 @@ class UpdateStartRequest(BaseModel):
         default=None,
         description="Specific version to update to (default: latest)"
     )
-    skip_backup: bool = Field(
-        default=False,
-        description="Skip database backup (not recommended)"
-    )
-    force: bool = Field(
-        default=False,
-        description="Force update even with non-critical blockers"
-    )
-
-
-class DevUpdateStartRequest(BaseModel):
-    """Request to start a development branch update."""
-
     skip_backup: bool = Field(
         default=False,
         description="Skip database backup (not recommended)"
@@ -304,20 +275,30 @@ class UpdateWebSocketMessage(BaseModel):
 
 
 class ReleaseNoteCategory(BaseModel):
-    """Single category of release notes (e.g. Features, Bug Fixes)."""
+    """Legacy categorized release-note group (kept for compatibility; unused by GitHub path)."""
 
-    name: str = Field(description="Category name (e.g. 'Features', 'Bug Fixes')")
-    icon: str = Field(description="Lucide icon name (e.g. 'sparkles', 'bug')")
-    changes: list[str] = Field(default_factory=list, description="List of changes in this category")
+    name: str
+    icon: str
+    changes: list[str] = Field(default_factory=list)
+
+
+class ReleaseNoteItem(BaseModel):
+    """A single release's curated notes (one GitHub release / CHANGELOG section)."""
+
+    version: str = Field(description="Version, e.g. '1.36.0' or '1.35.1-pre.3'")
+    date: Optional[datetime] = Field(default=None, description="Release date")
+    is_prerelease: bool = Field(default=False)
+    url: Optional[str] = Field(default=None, description="Release HTML URL")
+    body_markdown: str = Field(default="", description="Curated release notes (markdown)")
 
 
 class ReleaseNotesResponse(BaseModel):
-    """Response for release notes of the current version."""
+    """Release notes since the last stable, newest first."""
 
-    version: str = Field(description="Current version (e.g. '1.5.0-alpha')")
-    previous_version: Optional[str] = Field(default=None, description="Previous version (e.g. '1.1.0-alpha')")
-    date: Optional[datetime] = Field(default=None, description="Release date")
-    categories: list[ReleaseNoteCategory] = Field(default_factory=list, description="Categorized changes")
+    current_version: str
+    since_version: Optional[str] = Field(default=None, description="The last stable the notes start from")
+    source: Literal["github", "changelog"] = "github"
+    releases: list[ReleaseNoteItem] = Field(default_factory=list)
 
 
 class UpdateAvailablePayload(BaseModel):
@@ -414,13 +395,16 @@ class CommitDiffResponse(BaseModel):
 
 
 class ReleaseInfo(BaseModel):
-    """Information about a single release (git tag)."""
+    """Information about a single release (git tag or GitHub release)."""
 
-    tag: str = Field(description="Git tag (e.g., 'v1.9.0')")
+    tag: str = Field(description="Git tag (e.g., 'v1.36.0')")
     version: str = Field(description="Version string without 'v' prefix")
     date: Optional[str] = Field(default=None, description="Release date (ISO 8601)")
-    is_prerelease: bool = Field(default=False, description="True if alpha/beta/rc/etc.")
-    commit_short: str = Field(description="Short commit hash (7 chars)")
+    is_prerelease: bool = Field(default=False)
+    commit_short: Optional[str] = Field(default=None, description="Short commit hash (git path only)")
+    name: Optional[str] = Field(default=None, description="Release name")
+    html_url: Optional[str] = Field(default=None, description="Release HTML URL")
+    body_markdown: Optional[str] = Field(default=None, description="Curated release notes (markdown)")
 
 
 class ReleaseListResponse(BaseModel):

--- a/backend/app/services/update/backend.py
+++ b/backend/app/services/update/backend.py
@@ -5,7 +5,6 @@ from typing import Optional
 from app.schemas.update import (
     VersionInfo,
     ChangelogEntry,
-    CommitInfo,
     ReleaseNotesResponse,
     CommitHistoryResponse,
     CommitDiffResponse,
@@ -95,12 +94,3 @@ class UpdateBackend(ABC):
     async def get_all_releases(self) -> ReleaseListResponse:
         """Get list of all releases (git tags)."""
         pass
-
-    async def check_dev_branch(self) -> tuple[bool, Optional[VersionInfo], Optional[int], list[CommitInfo]]:
-        """Check if the development branch has unreleased commits ahead of latest tag.
-
-        Returns:
-            Tuple of (dev_available, dev_version_info, commits_ahead, commits).
-            Default implementation returns no dev version.
-        """
-        return False, None, None, []

--- a/backend/app/services/update/changelog_fallback.py
+++ b/backend/app/services/update/changelog_fallback.py
@@ -1,0 +1,72 @@
+"""Offline fallback: parse the bundled CHANGELOG.md into release-note items.
+
+Used when the GitHub Releases API is unavailable. CHANGELOG.md mainly holds
+stable sections (`## [x.y.z] - date`), so this is a degraded-but-non-empty mode.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from app.schemas.update import ReleaseNoteItem
+from app.services.update.utils import parse_version
+
+_SECTION_RE = re.compile(r"^##\s*\[(?P<ver>[^\]]+)\]\s*-\s*(?P<date>\S+)", re.MULTILINE)
+
+
+@dataclass
+class ChangelogSection:
+    version: str
+    date: Optional[str]
+    body_markdown: str
+
+
+def parse_changelog(path: str) -> list[ChangelogSection]:
+    """Parse `## [x.y.z] - date` sections (in file order = newest first)."""
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError:
+        return []
+    matches = list(_SECTION_RE.finditer(text))
+    sections: list[ChangelogSection] = []
+    for i, m in enumerate(matches):
+        body_start = m.end()
+        body_end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[body_start:body_end].strip()
+        sections.append(ChangelogSection(version=m.group("ver").strip(),
+                                         date=m.group("date").strip(), body_markdown=body))
+    return sections
+
+
+def _to_dt(date_str: Optional[str]) -> Optional[datetime]:
+    if not date_str:
+        return None
+    try:
+        return datetime.fromisoformat(date_str).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def notes_since_last_stable_from_changelog(
+    path: str, up_to_version: str
+) -> tuple[list[ReleaseNoteItem], Optional[str]]:
+    """Return CHANGELOG sections from `up_to_version` (inclusive) down to the next
+    older section, as ReleaseNoteItems. Degraded fallback (stable-only)."""
+    sections = parse_changelog(path)
+    if not sections:
+        return [], None
+    target = parse_version(up_to_version)
+    idx = next((i for i, s in enumerate(sections) if parse_version(s.version) == target), None)
+    if idx is None:
+        # Unknown current version (e.g. a pre-release not in CHANGELOG): show the newest section.
+        idx = 0
+    item = sections[idx]
+    since = sections[idx + 1].version if idx + 1 < len(sections) else None
+    return (
+        [ReleaseNoteItem(version=item.version, date=_to_dt(item.date), is_prerelease=False,
+                         url=None, body_markdown=item.body_markdown)],
+        since,
+    )

--- a/backend/app/services/update/dev_backend.py
+++ b/backend/app/services/update/dev_backend.py
@@ -8,7 +8,6 @@ from app.schemas.update import (
     VersionInfo,
     ChangelogEntry,
     ReleaseNotesResponse,
-    ReleaseNoteCategory,
     CommitInfo,
     VersionGroup,
     CommitHistoryResponse,
@@ -101,35 +100,18 @@ class DevUpdateBackend(UpdateBackend):
         ), changelog
 
     async def get_release_notes(self) -> ReleaseNotesResponse:
-        """Return mock release notes for dev mode."""
+        from app.schemas.update import ReleaseNoteItem
         return ReleaseNotesResponse(
-            version=version_to_string(self._simulated_version),
-            previous_version=version_to_string((self._simulated_version[0], self._simulated_version[1] - 1, 0, "")) if self._simulated_version[1] > 0 else "0.0.0",
-            date=datetime.now(timezone.utc),
-            categories=[
-                ReleaseNoteCategory(
-                    name="Features",
-                    icon="sparkles",
-                    changes=[
-                        "Add SSD cache management with bcache support",
-                        "Add SMB and WebDAV service discovery",
-                        "Add WSDD deployment script for Windows network discovery",
-                    ],
-                ),
-                ReleaseNoteCategory(
-                    name="Bug Fixes",
-                    icon="bug",
-                    changes=[
-                        "Skip create_all for PostgreSQL (managed by Alembic)",
-                        "Fix storage aggregation for RAID fallback path",
-                    ],
-                ),
-                ReleaseNoteCategory(
-                    name="Performance",
-                    icon="zap",
-                    changes=[
-                        "Optimize Samba config for small-file transfers",
-                    ],
+            current_version=version_to_string(self._simulated_version),
+            since_version="0.9.0",
+            source="github",
+            releases=[
+                ReleaseNoteItem(
+                    version=version_to_string(self._simulated_version),
+                    date=datetime.now(timezone.utc),
+                    is_prerelease=False,
+                    url="https://github.com/Xveyn/BaluHost/releases",
+                    body_markdown="### Added\n- SSD cache management\n- SMB/WebDAV discovery\n\n### Fixed\n- Storage aggregation",
                 ),
             ],
         )
@@ -210,29 +192,6 @@ class DevUpdateBackend(UpdateBackend):
     async def health_check(self) -> tuple[bool, list[str]]:
         """Simulate health check."""
         return True, []
-
-    async def check_dev_branch(self) -> tuple[bool, Optional[VersionInfo], Optional[int], list[CommitInfo]]:
-        """Return mock dev branch info for dev mode."""
-        base_version = version_to_string(self._simulated_version)
-        commits_ahead = 5
-        dev_version_str = f"{base_version}+dev.{commits_ahead}"
-        now = datetime.now(timezone.utc).isoformat()
-
-        dev_info = VersionInfo(
-            version=dev_version_str,
-            commit="dev9876543210abcdef9876543210abcdef98",
-            commit_short="dev9876",
-            tag=None,
-            date=datetime.now(timezone.utc),
-        )
-        dev_commits = [
-            CommitInfo(hash="aaa1111111111111111111111111111111111111", hash_short="aaa1111", message="feat(updates): add dev branch indicator", date=now, author="Dev User", type="feat", scope="updates"),
-            CommitInfo(hash="bbb2222222222222222222222222222222222222", hash_short="bbb2222", message="fix: use available memory instead of free", date=now, author="Dev User", type="fix", scope=None),
-            CommitInfo(hash="ccc3333333333333333333333333333333333333", hash_short="ccc3333", message="chore: add pytest-cov for coverage reporting", date=now, author="Dev User", type="chore", scope=None),
-            CommitInfo(hash="ddd4444444444444444444444444444444444444", hash_short="ddd4444", message="feat: add upload queue endpoint for mobile", date=now, author="Dev User", type="feat", scope=None),
-            CommitInfo(hash="eee5555555555555555555555555555555555555", hash_short="eee5555", message="fix(ci): add git identity for auto-tag", date=now, author="Dev User", type="fix", scope="ci"),
-        ]
-        return True, dev_info, commits_ahead, dev_commits
 
     async def get_commit_history(self) -> CommitHistoryResponse:
         """Return mock commit history for dev mode."""

--- a/backend/app/services/update/github_releases.py
+++ b/backend/app/services/update/github_releases.py
@@ -1,0 +1,134 @@
+"""GitHub Releases client + positional aggregation helpers for the update page.
+
+GitHub's `/releases` API returns newest-first; all range logic here is positional
+(not semver-ordered) so it is robust against `-pre.N` suffix ordering quirks.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+from app.core.config import settings
+from app.services.update.utils import parse_version
+
+GITHUB_API = "https://api.github.com"
+
+
+class GitHubUnavailable(Exception):
+    """Raised when GitHub releases cannot be fetched (network / rate-limit / HTTP error)."""
+
+
+@dataclass
+class GitHubRelease:
+    tag: str
+    name: str
+    body_markdown: str
+    prerelease: bool
+    published_at: Optional[str]
+    url: str
+
+
+class GitHubReleasesClient:
+    """Fetches the releases list with a per-instance TTL cache."""
+
+    def __init__(self, repo: Optional[str] = None, ttl_seconds: int = 900):
+        self.repo = repo or settings.update_github_repo
+        self.ttl = ttl_seconds
+        self._cache: Optional[list[GitHubRelease]] = None
+        self._cached_at: float = 0.0
+
+    async def list_releases(self, *, force: bool = False) -> list[GitHubRelease]:
+        now = time.monotonic()
+        if not force and self._cache is not None and (now - self._cached_at) < self.ttl:
+            return self._cache
+
+        url = f"{GITHUB_API}/repos/{self.repo}/releases"
+        headers = {"User-Agent": "BaluHost", "Accept": "application/vnd.github+json"}
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(url, headers=headers, params={"per_page": 100})
+            if resp.status_code != 200:
+                raise GitHubUnavailable(f"GitHub returned HTTP {resp.status_code}")
+            data = resp.json()
+        except GitHubUnavailable:
+            raise
+        except Exception as exc:  # httpx errors, JSON decode, etc.
+            raise GitHubUnavailable(str(exc)) from exc
+
+        releases = [
+            GitHubRelease(
+                tag=r.get("tag_name", ""),
+                name=r.get("name") or r.get("tag_name", ""),
+                body_markdown=r.get("body") or "",
+                prerelease=bool(r.get("prerelease")),
+                published_at=r.get("published_at"),
+                url=r.get("html_url", ""),
+            )
+            for r in (data or [])
+            if r.get("tag_name")
+        ]
+        self._cache = releases
+        self._cached_at = now
+        return releases
+
+
+def filter_channel(releases: list[GitHubRelease], channel: str) -> list[GitHubRelease]:
+    if channel == "unstable":
+        return list(releases)
+    return [r for r in releases if not r.prerelease]
+
+
+def latest_for_channel(releases: list[GitHubRelease], channel: str) -> Optional[GitHubRelease]:
+    """Newest release in the channel (the list is already newest-first)."""
+    filtered = filter_channel(releases, channel)
+    return filtered[0] if filtered else None
+
+
+def _find_index(releases: list[GitHubRelease], version: str) -> Optional[int]:
+    target = parse_version(version)
+    for i, r in enumerate(releases):
+        if parse_version(r.tag) == target:
+            return i
+    return None
+
+
+def notes_since_last_stable(
+    releases: list[GitHubRelease], up_to_version: str
+) -> tuple[list[GitHubRelease], Optional[str]]:
+    """Releases for the running version's notes "since the last stable", newest first.
+
+    - If up_to is stable: just [up_to] (its body already covers since-last-stable).
+    - If up_to is a pre-release: up_to plus older pre-releases, down to (excl.) the
+      first older stable.
+    Returns (slice, since_tag).
+    """
+    idx = _find_index(releases, up_to_version)
+    if idx is None:
+        return [], None
+    up = releases[idx]
+    # the first stable strictly older than up_to (for the since_version label)
+    since_tag = next((r.tag for r in releases[idx + 1:] if not r.prerelease), None)
+    if not up.prerelease:
+        return [up], since_tag
+    out: list[GitHubRelease] = []
+    for r in releases[idx:]:
+        if not r.prerelease:
+            break
+        out.append(r)
+    return out, since_tag
+
+
+def releases_between(
+    releases: list[GitHubRelease], newer_than: str, up_to: str
+) -> list[GitHubRelease]:
+    """Releases from up_to (inclusive) down to newer_than (exclusive), newest first."""
+    up_idx = _find_index(releases, up_to)
+    nt_idx = _find_index(releases, newer_than)
+    start = up_idx if up_idx is not None else 0
+    end = nt_idx if nt_idx is not None else len(releases)
+    if start >= end:
+        return []
+    return releases[start:end]

--- a/backend/app/services/update/github_releases.py
+++ b/backend/app/services/update/github_releases.py
@@ -128,7 +128,10 @@ def releases_between(
     up_idx = _find_index(releases, up_to)
     nt_idx = _find_index(releases, newer_than)
     start = up_idx if up_idx is not None else 0
-    end = nt_idx if nt_idx is not None else len(releases)
+    # When the running version isn't a published release (local dev build, or
+    # aged past the fetched page), don't return the whole history as the delta —
+    # show just the target release's notes.
+    end = nt_idx if nt_idx is not None else start + 1
     if start >= end:
         return []
     return releases[start:end]

--- a/backend/app/services/update/prod_backend.py
+++ b/backend/app/services/update/prod_backend.py
@@ -7,10 +7,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from app.core.config import settings
 from app.schemas.update import (
     VersionInfo,
     ChangelogEntry,
     ReleaseNotesResponse,
+    ReleaseNoteItem,
     CommitInfo,
     VersionGroup,
     CommitHistoryResponse,
@@ -20,6 +22,16 @@ from app.schemas.update import (
     ReleaseListResponse,
 )
 from app.services.update.backend import UpdateBackend
+from app.services.update.github_releases import (
+    GitHubReleasesClient,
+    GitHubRelease,
+    GitHubUnavailable,
+    filter_channel,
+    latest_for_channel,
+    notes_since_last_stable,
+    releases_between,
+)
+from app.services.update.changelog_fallback import notes_since_last_stable_from_changelog
 from app.services.update.utils import (
     ProgressCallback,
     parse_version,
@@ -40,6 +52,23 @@ class ProdUpdateBackend(UpdateBackend):
         self.repo_path = repo_path or Path(__file__).parent.parent.parent.parent.parent
         self.backend_path = self.repo_path / "backend"
         self.client_path = self.repo_path / "client"
+        self._gh = GitHubReleasesClient()
+
+    def _changelog_path(self) -> str:
+        p = Path(settings.update_changelog_path)
+        return str(p if p.is_absolute() else (self.repo_path / p))
+
+    @staticmethod
+    def _to_item(r: GitHubRelease) -> ReleaseNoteItem:
+        from datetime import datetime
+        date = None
+        if r.published_at:
+            try:
+                date = datetime.fromisoformat(r.published_at.replace("Z", "+00:00"))
+            except ValueError:
+                date = None
+        return ReleaseNoteItem(version=r.tag.lstrip("v"), date=date,
+                               is_prerelease=r.prerelease, url=r.url, body_markdown=r.body_markdown)
 
     def _run_git(self, *args: str) -> tuple[bool, str, str]:
         """Run a git command and return (success, stdout, stderr)."""
@@ -95,155 +124,52 @@ class ProdUpdateBackend(UpdateBackend):
         )
 
     async def check_for_updates(self, channel: str) -> tuple[bool, Optional[VersionInfo], list[ChangelogEntry]]:
-        """Check for updates by fetching tags and comparing versions."""
-        # Fetch tags
-        success, _, err = self._run_git("fetch", "--tags", "--force")
-        if not success:
-            logger.warning(f"Failed to fetch tags: {err}")
-            return False, None, []
-
-        # Get current version
         current = await self.get_current_version()
-        current_version = parse_version(current.version)
-
-        # Get all tags
-        success, tags_output, _ = self._run_git("tag", "-l", "--sort=-version:refname")
-        if not success or not tags_output:
+        try:
+            releases = await self._gh.list_releases()
+        except GitHubUnavailable:
             return False, None, []
 
-        tags = [t.strip() for t in tags_output.split("\n") if t.strip()]
-
-        # Filter tags based on channel
-        include_prerelease = channel == "unstable"
-        latest_tag = None
-        latest_version = current_version
-
-        for tag in tags:
-            version = parse_version(tag)
-            is_prerelease = bool(version[3])
-
-            if not include_prerelease and is_prerelease:
-                continue
-
-            if version > latest_version:
-                latest_version = version
-                latest_tag = tag
-
-        if latest_tag is None:
+        latest = latest_for_channel(releases, channel)
+        if latest is None:
             return False, None, []
 
-        # Get commit for latest tag
-        success, commit, _ = self._run_git("rev-parse", latest_tag)
-        if not success:
+        latest_v = parse_version(latest.tag)
+        current_v = parse_version(current.version)
+        if latest_v <= current_v:
             return False, None, []
 
-        # Get tag date
-        success, date_str, _ = self._run_git("log", "-1", "--format=%cI", latest_tag)
-        date = datetime.fromisoformat(date_str) if success and date_str else None
-
-        latest = VersionInfo(
-            version=version_to_string(latest_version),
-            commit=commit,
-            commit_short=commit[:7],
-            tag=latest_tag,
-            date=date,
+        latest_info = VersionInfo(
+            version=latest.tag.lstrip("v"), commit="", commit_short="",
+            tag=latest.tag, date=None, is_prerelease=latest.prerelease,
         )
-
-        # Build changelog from commit messages between versions
-        changelog = await self._build_changelog(current.commit, commit, version_to_string(latest_version))
-
-        return True, latest, changelog
-
-    async def _build_changelog(self, from_commit: str, to_commit: str, version: str = "unknown") -> list[ChangelogEntry]:
-        """Build changelog from git log between commits."""
-        success, log_output, _ = self._run_git(
-            "log", f"{from_commit}..{to_commit}",
-            "--pretty=format:%s", "--no-merges"
-        )
-
-        if not success or not log_output:
-            return []
-
-        changes = [line.strip() for line in log_output.split("\n") if line.strip()]
-
-        # Parse conventional commits for breaking changes
-        breaking = [c for c in changes if "BREAKING" in c.upper() or c.startswith("!")]
-        regular = [c for c in changes if c not in breaking]
-
-        return [
-            ChangelogEntry(
-                version=version,
-                date=datetime.now(timezone.utc),
-                changes=regular[:20],  # Limit to 20 changes
-                breaking_changes=breaking,
-                is_prerelease=False,
-            )
+        delta = releases_between(releases, newer_than=current.version, up_to=latest.tag.lstrip("v"))
+        changelog = [
+            ChangelogEntry(version=r.tag.lstrip("v"), date=None, changes=[], breaking_changes=[],
+                           is_prerelease=r.prerelease, body_markdown=r.body_markdown)
+            for r in delta
         ]
+        return True, latest_info, changelog
 
     async def get_release_notes(self) -> ReleaseNotesResponse:
-        """Get release notes by comparing current tag with the previous tag."""
-        # Get all tags sorted by semver
-        success, tags_output, _ = self._run_git("tag", "-l", "--sort=-version:refname")
-        if not success or not tags_output:
-            return ReleaseNotesResponse(version="unknown", categories=[])
-
-        tags = [t.strip() for t in tags_output.split("\n") if t.strip()]
-        if not tags:
-            return ReleaseNotesResponse(version="unknown", categories=[])
-
-        # Sort tags by semver properly
-        sorted_tags = sorted(tags, key=lambda t: parse_version(t), reverse=True)
-
-        # Get current version info
         current = await self.get_current_version()
-        current_version = parse_version(current.version)
-
-        # Find current tag and the one before it
-        current_tag: Optional[str] = None
-        previous_tag: Optional[str] = None
-
-        for i, tag in enumerate(sorted_tags):
-            if parse_version(tag) <= current_version:
-                current_tag = tag
-                if i + 1 < len(sorted_tags):
-                    previous_tag = sorted_tags[i + 1]
-                break
-
-        if not current_tag:
-            return ReleaseNotesResponse(version=current.version, categories=[])
-
-        # Get tag date
-        success, date_str, _ = self._run_git("log", "-1", "--format=%cI", current_tag)
-        tag_date = datetime.fromisoformat(date_str) if success and date_str else None
-
-        if not previous_tag:
-            # No previous tag — list all commits up to current tag
-            success, log_output, _ = self._run_git(
-                "log", current_tag, "--pretty=format:%s", "--no-merges"
-            )
-        else:
-            success, log_output, _ = self._run_git(
-                "log", f"{previous_tag}..{current_tag}",
-                "--pretty=format:%s", "--no-merges"
-            )
-
-        if not success or not log_output:
+        try:
+            releases = await self._gh.list_releases()
+            slice_, since = notes_since_last_stable(releases, current.version)
             return ReleaseNotesResponse(
-                version=current.version,
-                previous_version=previous_tag.lstrip("v") if previous_tag else None,
-                date=tag_date,
-                categories=[],
+                current_version=current.version,
+                since_version=since.lstrip("v") if since else None,
+                source="github",
+                releases=[self._to_item(r) for r in slice_],
             )
-
-        messages = [line.strip() for line in log_output.split("\n") if line.strip()]
-        categories = _parse_conventional_commits(messages)
-
-        return ReleaseNotesResponse(
-            version=current.version,
-            previous_version=previous_tag.lstrip("v") if previous_tag else None,
-            date=tag_date,
-            categories=categories,
-        )
+        except GitHubUnavailable:
+            items, since = notes_since_last_stable_from_changelog(self._changelog_path(), current.version)
+            return ReleaseNotesResponse(
+                current_version=current.version,
+                since_version=since.lstrip("v") if since else None,
+                source="changelog",
+                releases=items,
+            )
 
     async def fetch_updates(self, callback: Optional[ProgressCallback] = None) -> bool:
         if callback:
@@ -565,128 +491,17 @@ class ProdUpdateBackend(UpdateBackend):
             diff=diff_text,
         )
 
-    async def check_dev_branch(self) -> tuple[bool, Optional[VersionInfo], Optional[int], list[CommitInfo]]:
-        """Check if origin/development has unreleased commits ahead of latest tag."""
-        empty: list[CommitInfo] = []
-
-        # Fetch all refs including tags
-        success, _, err = self._run_git("fetch", "--all", "--tags", "--prune")
-        if not success:
-            logger.warning(f"Failed to fetch for dev branch check: {err}")
-            return False, None, None, empty
-
-        # Get latest tag by semver
-        success, tags_output, _ = self._run_git("tag", "-l", "--sort=-version:refname")
-        if not success or not tags_output.strip():
-            return False, None, None, empty
-
-        tags = [t.strip() for t in tags_output.split("\n") if t.strip()]
-        if not tags:
-            return False, None, None, empty
-        latest_tag = tags[0]
-
-        # Check if origin/development exists
-        success, _, _ = self._run_git("rev-parse", "--verify", "origin/development")
-        if not success:
-            return False, None, None, empty
-
-        # Count commits ahead
-        success, count_str, _ = self._run_git(
-            "rev-list", "--count", f"{latest_tag}..origin/development"
-        )
-        if not success or not count_str.strip():
-            return False, None, None, empty
-
-        commits_ahead = int(count_str.strip())
-        if commits_ahead <= 0:
-            return False, None, None, empty
-
-        # Get tip commit info
-        success, tip_output, _ = self._run_git(
-            "log", "-1", "--format=%H|%h|%aI", "origin/development"
-        )
-        if not success or not tip_output.strip():
-            return False, None, None, empty
-
-        parts = tip_output.split("|", 2)
-        if len(parts) < 3:
-            return False, None, None, empty
-
-        full_hash, short_hash, date_str = parts
-        tip_date = datetime.fromisoformat(date_str) if date_str else None
-
-        # Format version as X.Y.Z+dev.N
-        base_version = latest_tag.lstrip("v")
-        dev_version_str = f"{base_version}+dev.{commits_ahead}"
-
-        dev_info = VersionInfo(
-            version=dev_version_str,
-            commit=full_hash,
-            commit_short=short_hash,
-            tag=None,
-            date=tip_date,
-        )
-
-        # Fetch commit messages (max 50)
-        commit_list: list[CommitInfo] = []
-        success, log_output, _ = self._run_git(
-            "log", "--format=%H|%h|%s|%aI|%an",
-            f"{latest_tag}..origin/development", "--no-merges", "-50"
-        )
-        if success and log_output.strip():
-            for line in log_output.strip().split("\n"):
-                line = line.strip()
-                if not line:
-                    continue
-                log_parts = line.split("|", 4)
-                if len(log_parts) < 5:
-                    continue
-                c_hash, c_short, c_msg, c_date, c_author = log_parts
-                # Parse conventional commit type/scope
-                c_type, c_scope = None, None
-                if ":" in c_msg:
-                    prefix = c_msg.split(":", 1)[0]
-                    if "(" in prefix and prefix.endswith(")"):
-                        c_type = prefix.split("(")[0]
-                        c_scope = prefix.split("(")[1].rstrip(")")
-                    elif prefix.isalpha() or prefix.replace("!", "").isalpha():
-                        c_type = prefix.rstrip("!")
-                commit_list.append(CommitInfo(
-                    hash=c_hash, hash_short=c_short, message=c_msg,
-                    date=c_date, author=c_author, type=c_type, scope=c_scope,
-                ))
-
-        return True, dev_info, commits_ahead, commit_list
-
     async def get_all_releases(self) -> ReleaseListResponse:
-        """Get list of all releases from git tags."""
-        # Get all tags sorted by semver (newest first)
-        success, tags_output, _ = self._run_git("tag", "-l", "--sort=-version:refname")
-        if not success or not tags_output.strip():
+        try:
+            releases = await self._gh.list_releases()
+        except GitHubUnavailable:
             return ReleaseListResponse(releases=[], total=0)
-
-        tags = [t.strip() for t in tags_output.strip().split("\n") if t.strip()]
-
-        releases: list[ReleaseInfo] = []
-        for tag in tags:
-            # Get commit for this tag
-            ok, commit, _ = self._run_git("rev-parse", "--short=7", tag)
-            commit_short = commit if ok else "unknown"
-
-            # Get tag date
-            ok, date_str, _ = self._run_git("log", "-1", "--format=%aI", tag)
-            tag_date = date_str if ok and date_str else None
-
-            # Parse version to check for prerelease
-            version = tag.lstrip("v")
-            is_prerelease = bool(parse_version(tag)[3])  # tuple[3] is prerelease suffix
-
-            releases.append(ReleaseInfo(
-                tag=tag,
-                version=version,
-                date=tag_date,
-                is_prerelease=is_prerelease,
-                commit_short=commit_short,
-            ))
-
-        return ReleaseListResponse(releases=releases, total=len(releases))
+        infos = [
+            ReleaseInfo(
+                tag=r.tag, version=r.tag.lstrip("v"), date=r.published_at,
+                is_prerelease=r.prerelease, commit_short=None,
+                name=r.name, html_url=r.url, body_markdown=r.body_markdown,
+            )
+            for r in releases
+        ]
+        return ReleaseListResponse(releases=infos, total=len(infos))

--- a/backend/app/services/update/service.py
+++ b/backend/app/services/update/service.py
@@ -119,9 +119,6 @@ class UpdateService:
         # Check for updates
         available, latest, changelog = await self.backend.check_for_updates(config.channel)
 
-        # Check dev branch for unreleased commits
-        dev_available, dev_version, dev_commits_ahead, dev_commits = await self.backend.check_dev_branch()
-
         # Update last check time
         db_config = self.db.query(UpdateConfig).first()
         if db_config:
@@ -139,10 +136,6 @@ class UpdateService:
             last_checked=datetime.now(timezone.utc),
             blockers=blockers,
             can_update=available and len(blockers) == 0,
-            dev_version_available=dev_available,
-            dev_version=dev_version,
-            dev_commits_ahead=dev_commits_ahead,
-            dev_commits=dev_commits,
         )
 
     async def get_release_notes(self) -> ReleaseNotesResponse:
@@ -267,84 +260,6 @@ class UpdateService:
             success=True,
             update_id=update.id,
             message=f"Update to {target.version} started",
-        )
-
-    async def start_dev_update(
-        self,
-        user_id: int,
-        skip_backup: bool = False,
-        force: bool = False,
-    ) -> UpdateStartResponse:
-        """Start an update to the development branch tip."""
-        # Check for blockers
-        blockers = await self._check_blockers()
-        if blockers and not force:
-            return UpdateStartResponse(
-                success=False,
-                message="Update blocked",
-                blockers=blockers,
-            )
-
-        # Get current version and dev branch info
-        current = await self.backend.get_current_version()
-        dev_available, dev_version, dev_commits_ahead, dev_commits = (
-            await self.backend.check_dev_branch()
-        )
-
-        if not dev_available or not dev_version:
-            return UpdateStartResponse(
-                success=False,
-                message="No development version available",
-            )
-
-        # Create update record
-        update = UpdateHistory(
-            from_version=current.version,
-            to_version=dev_version.version,
-            channel="development",
-            from_commit=current.commit,
-            to_commit=dev_version.commit,
-            user_id=user_id,
-            status=UpdateStatus.PENDING.value,
-            changelog="\n".join(
-                f"- {c.message}" for c in dev_commits
-            ) if dev_commits else "",
-        )
-        self.db.add(update)
-        self.db.commit()
-        self.db.refresh(update)
-
-        self._current_update = update
-
-        # Production: launch detached shell script via systemd-run
-        # Dev mode: run in-process simulation via asyncio task
-        if isinstance(self.backend, ProdUpdateBackend):
-            update.status = UpdateStatus.DOWNLOADING.value
-            update.set_progress(5, "Launching dev update runner...")
-            self.db.commit()
-
-            success, error = self.backend.launch_update_script(
-                update_id=update.id,
-                from_commit=current.commit,
-                to_commit=dev_version.commit,
-                from_version=current.version,
-                to_version=dev_version.version,
-            )
-            if not success:
-                update.fail(f"Failed to launch update: {error}")
-                self.db.commit()
-                return UpdateStartResponse(
-                    success=False,
-                    message=f"Failed to launch update: {error}",
-                )
-        else:
-            task = asyncio.create_task(self._run_dev_update(update.id, skip_backup))
-            _running_tasks[update.id] = task
-
-        return UpdateStartResponse(
-            success=True,
-            update_id=update.id,
-            message=f"Dev update to {dev_version.version} started",
         )
 
     async def _run_dev_update(self, update_id: int, skip_backup: bool) -> None:

--- a/backend/app/services/update/utils.py
+++ b/backend/app/services/update/utils.py
@@ -21,9 +21,18 @@ def parse_version(tag: str) -> tuple[int, int, int, str]:
     if "-" in tag:
         tag, prerelease = tag.split("-", 1)
     parts = tag.split(".")
-    major = int(parts[0]) if len(parts) > 0 else 0
-    minor = int(parts[1]) if len(parts) > 1 else 0
-    patch = int(parts[2]) if len(parts) > 2 else 0
+
+    def _safe_int(value: str) -> int:
+        # Tolerate non-numeric headers (e.g. a "[Unreleased]" CHANGELOG section)
+        # so callers never crash — keeps the public release-notes endpoint 500-free.
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+
+    major = _safe_int(parts[0]) if len(parts) > 0 else 0
+    minor = _safe_int(parts[1]) if len(parts) > 1 else 0
+    patch = _safe_int(parts[2]) if len(parts) > 2 else 0
     return (major, minor, patch, prerelease)
 
 

--- a/backend/tests/services/test_changelog_fallback.py
+++ b/backend/tests/services/test_changelog_fallback.py
@@ -1,0 +1,39 @@
+from app.services.update.changelog_fallback import parse_changelog, notes_since_last_stable_from_changelog
+
+SAMPLE = """# Changelog
+
+---
+
+## [1.36.0] - 2026-06-06
+
+### Added
+- thing A
+
+## [1.35.0] - 2026-05-01
+
+### Fixed
+- thing B
+"""
+
+
+def test_parse_changelog(tmp_path):
+    p = tmp_path / "CHANGELOG.md"
+    p.write_text(SAMPLE, encoding="utf-8")
+    sections = parse_changelog(str(p))
+    assert sections[0].version == "1.36.0"
+    assert "thing A" in sections[0].body_markdown
+    assert sections[1].version == "1.35.0"
+
+
+def test_notes_for_current(tmp_path):
+    p = tmp_path / "CHANGELOG.md"
+    p.write_text(SAMPLE, encoding="utf-8")
+    items, since = notes_since_last_stable_from_changelog(str(p), "1.36.0")
+    assert items[0].version == "1.36.0"
+    assert "thing A" in items[0].body_markdown
+    assert since == "1.35.0"
+
+
+def test_notes_missing_file(tmp_path):
+    items, since = notes_since_last_stable_from_changelog(str(tmp_path / "nope.md"), "1.36.0")
+    assert items == [] and since is None

--- a/backend/tests/services/test_github_releases.py
+++ b/backend/tests/services/test_github_releases.py
@@ -1,0 +1,95 @@
+import pytest
+
+from app.services.update.github_releases import (
+    GitHubRelease, GitHubReleasesClient, GitHubUnavailable,
+    filter_channel, latest_for_channel, notes_since_last_stable, releases_between,
+)
+
+
+def _r(tag, prerelease, body="b"):
+    return GitHubRelease(tag=tag, name=tag, body_markdown=body, prerelease=prerelease,
+                         published_at=None, url=f"https://x/{tag}")
+
+
+# Newest-first, like the GitHub API returns.
+RELEASES = [
+    _r("v1.36.0", False),
+    _r("v1.35.1-pre.25", True),
+    _r("v1.35.1-pre.24", True),
+    _r("v1.35.0", False),
+    _r("v1.34.0", False),
+]
+
+
+def test_filter_channel():
+    assert len(filter_channel(RELEASES, "unstable")) == 5
+    assert [r.tag for r in filter_channel(RELEASES, "stable")] == ["v1.36.0", "v1.35.0", "v1.34.0"]
+
+
+def test_latest_for_channel():
+    assert latest_for_channel(RELEASES, "stable").tag == "v1.36.0"
+    assert latest_for_channel(RELEASES, "unstable").tag == "v1.36.0"
+
+
+def test_notes_since_last_stable_for_prerelease():
+    items, since = notes_since_last_stable(RELEASES, "1.35.1-pre.25")
+    # current is a pre-release: aggregate from it back to (excl.) the last stable v1.35.0
+    assert [r.tag for r in items] == ["v1.35.1-pre.25", "v1.35.1-pre.24"]
+    assert since == "v1.35.0"
+
+
+def test_notes_since_last_stable_for_stable():
+    items, since = notes_since_last_stable(RELEASES, "1.36.0")
+    # current is stable: its own body already covers since-last-stable
+    assert [r.tag for r in items] == ["v1.36.0"]
+    assert since == "v1.35.0"
+
+
+def test_releases_between_current_to_latest():
+    # what an update from a pre-release to the latest stable brings
+    items = releases_between(RELEASES, newer_than="1.35.1-pre.25", up_to="1.36.0")
+    assert [r.tag for r in items] == ["v1.36.0"]
+
+
+@pytest.mark.asyncio
+async def test_list_releases_caches_and_falls_back(monkeypatch):
+    client = GitHubReleasesClient(repo="x/y", ttl_seconds=999)
+    calls = {"n": 0}
+
+    class _Resp:
+        status_code = 200
+        def json(self):
+            return [{"tag_name": "v1.0.0", "name": "v1.0.0", "body": "hi",
+                     "prerelease": False, "published_at": "2026-01-01T00:00:00Z",
+                     "html_url": "https://x/v1.0.0"}]
+
+    class _Client:
+        def __init__(self, *a, **k): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def get(self, *a, **k):
+            calls["n"] += 1
+            return _Resp()
+
+    monkeypatch.setattr("app.services.update.github_releases.httpx.AsyncClient", _Client)
+    first = await client.list_releases()
+    second = await client.list_releases()
+    assert first[0].tag == "v1.0.0"
+    assert calls["n"] == 1  # second served from cache
+
+
+@pytest.mark.asyncio
+async def test_list_releases_raises_unavailable_on_error(monkeypatch):
+    import httpx
+    client = GitHubReleasesClient(repo="x/y")
+
+    class _Client:
+        def __init__(self, *a, **k): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def get(self, *a, **k):
+            raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr("app.services.update.github_releases.httpx.AsyncClient", _Client)
+    with pytest.raises(GitHubUnavailable):
+        await client.list_releases()

--- a/backend/tests/services/test_github_releases.py
+++ b/backend/tests/services/test_github_releases.py
@@ -6,9 +6,26 @@ from app.services.update.github_releases import (
 )
 
 
+from app.services.update.utils import parse_version
+
+
 def _r(tag, prerelease, body="b"):
     return GitHubRelease(tag=tag, name=tag, body_markdown=body, prerelease=prerelease,
                          published_at=None, url=f"https://x/{tag}")
+
+
+def test_parse_version_tolerates_non_numeric_headers():
+    # "[Unreleased]" sections must not crash the public fallback path.
+    assert parse_version("Unreleased") == (0, 0, 0, "")
+    assert parse_version("v1.2.x") == (1, 2, 0, "")
+
+
+def test_releases_between_unknown_current_returns_only_target():
+    rels = [_r("v1.36.0", False), _r("v1.35.0", False)]
+    # current "1.9.9+dev" isn't a published release → show just the target's notes,
+    # not the whole history.
+    items = releases_between(rels, newer_than="1.9.9", up_to="1.36.0")
+    assert [r.tag for r in items] == ["v1.36.0"]
 
 
 # Newest-first, like the GitHub API returns.

--- a/backend/tests/services/test_update_github.py
+++ b/backend/tests/services/test_update_github.py
@@ -16,3 +16,59 @@ def test_changelog_entry_has_body_markdown():
 def test_release_info_extended_optional_commit():
     r = ReleaseInfo(tag="v1.36.0", version="1.36.0", is_prerelease=False)
     assert r.commit_short is None and r.html_url is None
+
+
+import pytest
+from app.services.update.github_releases import GitHubRelease, GitHubUnavailable
+from app.services.update.prod_backend import ProdUpdateBackend
+
+
+def _gh(tag, pre, body="notes"):
+    return GitHubRelease(tag=tag, name=tag, body_markdown=body, prerelease=pre, published_at=None, url=f"https://x/{tag}")
+
+
+_REL = [_gh("v1.36.0", False), _gh("v1.35.1-pre.25", True), _gh("v1.35.0", False)]
+
+
+class _FakeVersion:
+    def __init__(self, v): self.version = v; self.commit = "c"; self.commit_short = "c"; self.tag = "v"+v; self.date = None
+
+
+@pytest.mark.asyncio
+async def test_get_release_notes_github(monkeypatch):
+    b = ProdUpdateBackend()
+    async def _ver(): return _FakeVersion("1.35.1-pre.25")
+    monkeypatch.setattr(b, "get_current_version", _ver)
+    async def fake_list(*a, **k): return _REL
+    monkeypatch.setattr(b._gh, "list_releases", fake_list)
+    notes = await b.get_release_notes()
+    assert notes.source == "github"
+    assert [r.version for r in notes.releases] == ["1.35.1-pre.25"]  # since v1.35.0
+
+
+@pytest.mark.asyncio
+async def test_get_release_notes_falls_back_to_changelog(monkeypatch, tmp_path):
+    cl = tmp_path / "CHANGELOG.md"
+    cl.write_text("# Changelog\n\n## [1.36.0] - 2026-06-06\n\n### Added\n- a\n", encoding="utf-8")
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "update_changelog_path", str(cl))
+    b = ProdUpdateBackend()
+    async def _ver(): return _FakeVersion("1.36.0")
+    monkeypatch.setattr(b, "get_current_version", _ver)
+    async def boom(*a, **k): raise GitHubUnavailable("down")
+    monkeypatch.setattr(b._gh, "list_releases", boom)
+    notes = await b.get_release_notes()
+    assert notes.source == "changelog"
+    assert notes.releases[0].version == "1.36.0"
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_github(monkeypatch):
+    b = ProdUpdateBackend()
+    async def _ver(): return _FakeVersion("1.35.1-pre.25")
+    monkeypatch.setattr(b, "get_current_version", _ver)
+    async def fake_list(*a, **k): return _REL
+    monkeypatch.setattr(b._gh, "list_releases", fake_list)
+    available, latest, changelog = await b.check_for_updates("stable")
+    assert available is True and latest.version == "1.36.0"
+    assert changelog and changelog[0].body_markdown == "notes"

--- a/backend/tests/services/test_update_github.py
+++ b/backend/tests/services/test_update_github.py
@@ -72,3 +72,12 @@ async def test_check_for_updates_github(monkeypatch):
     available, latest, changelog = await b.check_for_updates("stable")
     assert available is True and latest.version == "1.36.0"
     assert changelog and changelog[0].body_markdown == "notes"
+
+
+def test_dev_endpoints_and_fields_removed():
+    import app.schemas.update as u
+    assert not hasattr(u, "DevUpdateStartRequest")
+    from app.api.routes import updates as r
+    # No start-dev route registered
+    paths = [getattr(rt, "path", "") for rt in r.router.routes]
+    assert not any(p.endswith("/start-dev") for p in paths)

--- a/backend/tests/services/test_update_github.py
+++ b/backend/tests/services/test_update_github.py
@@ -1,0 +1,18 @@
+from app.schemas.update import ReleaseNoteItem, ReleaseNotesResponse, ReleaseInfo, ChangelogEntry
+
+
+def test_release_notes_response_shape():
+    item = ReleaseNoteItem(version="1.36.0", is_prerelease=False, url="u", body_markdown="### Added\n- x")
+    resp = ReleaseNotesResponse(current_version="1.36.0", since_version="1.35.0", source="github", releases=[item])
+    assert resp.source == "github"
+    assert resp.releases[0].body_markdown.startswith("### Added")
+
+
+def test_changelog_entry_has_body_markdown():
+    e = ChangelogEntry(version="1.36.0", body_markdown="- y")
+    assert e.body_markdown == "- y"
+
+
+def test_release_info_extended_optional_commit():
+    r = ReleaseInfo(tag="v1.36.0", version="1.36.0", is_prerelease=False)
+    assert r.commit_short is None and r.html_url is None

--- a/client/src/__tests__/components/updates/UpdateOverviewTab.test.tsx
+++ b/client/src/__tests__/components/updates/UpdateOverviewTab.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import UpdateOverviewTab from '../../../components/updates/UpdateOverviewTab';
-import type { UpdateCheckResponse, VersionInfo } from '../../../api/updates';
+import type {
+  UpdateCheckResponse,
+  VersionInfo,
+  ReleaseNotesResponse,
+} from '../../../api/updates';
 
 // i18n is not initialized in component tests; the component receives `t` as a
 // prop, so we pass a mock that echoes the key back.
@@ -30,34 +34,42 @@ function checkResult(current: VersionInfo): UpdateCheckResponse {
     last_checked: null,
     blockers: [],
     can_update: false,
-    dev_version_available: false,
-    dev_version: null,
-    dev_commits_ahead: null,
-    dev_commits: [],
   };
 }
 
+const baseProps = {
+  t,
+  currentUpdate: null,
+  releaseNotes: null,
+  updateLoading: false,
+  rollbackLoading: false,
+  cancelLoading: false,
+  showUpdateConfirm: false,
+  onSetShowUpdateConfirm: vi.fn(),
+  onSetShowRollbackConfirm: vi.fn(),
+  onStartUpdate: vi.fn(),
+  onCancel: vi.fn(),
+};
+
 function renderTab(current: VersionInfo) {
-  return render(
-    <UpdateOverviewTab
-      t={t}
-      checkResult={checkResult(current)}
-      currentUpdate={null}
-      releaseNotes={null}
-      updateLoading={false}
-      rollbackLoading={false}
-      cancelLoading={false}
-      devUpdateLoading={false}
-      showUpdateConfirm={false}
-      showDevUpdateConfirm={false}
-      onSetShowUpdateConfirm={vi.fn()}
-      onSetShowDevUpdateConfirm={vi.fn()}
-      onSetShowRollbackConfirm={vi.fn()}
-      onStartUpdate={vi.fn()}
-      onStartDevUpdate={vi.fn()}
-      onCancel={vi.fn()}
-    />,
-  );
+  return render(<UpdateOverviewTab {...baseProps} checkResult={checkResult(current)} />);
+}
+
+function notes(source: 'github' | 'changelog'): ReleaseNotesResponse {
+  return {
+    current_version: '1.36.0',
+    since_version: '1.35.0',
+    source,
+    releases: [
+      {
+        version: '1.36.0',
+        date: null,
+        is_prerelease: false,
+        url: 'https://gh/r',
+        body_markdown: '### Added\n- Shiny new thing',
+      },
+    ],
+  };
 }
 
 describe('UpdateOverviewTab — stability indicator', () => {
@@ -80,5 +92,18 @@ describe('UpdateOverviewTab — stability indicator', () => {
     renderTab(version({ is_dev_build: true, tag: null }));
     expect(screen.getByText('version.devBuild')).toBeInTheDocument();
     expect(screen.queryByText('version.stable')).not.toBeInTheDocument();
+  });
+});
+
+describe('UpdateOverviewTab release notes', () => {
+  it('renders the markdown body of each release', () => {
+    render(<UpdateOverviewTab {...baseProps} checkResult={null} releaseNotes={notes('github')} />);
+    expect(screen.getByText('Shiny new thing')).toBeInTheDocument();
+    expect(screen.queryByText('releaseNotes.fromChangelog')).not.toBeInTheDocument();
+  });
+
+  it('shows the CHANGELOG offline hint when source is changelog', () => {
+    render(<UpdateOverviewTab {...baseProps} checkResult={null} releaseNotes={notes('changelog')} />);
+    expect(screen.getByText('releaseNotes.fromChangelog')).toBeInTheDocument();
   });
 });

--- a/client/src/api/updates.ts
+++ b/client/src/api/updates.ts
@@ -38,6 +38,7 @@ export interface ChangelogEntry {
   changes: string[];
   breaking_changes: string[];
   is_prerelease: boolean;
+  body_markdown?: string | null;
 }
 
 // Check response
@@ -50,20 +51,11 @@ export interface UpdateCheckResponse {
   last_checked: string | null;
   blockers: string[];
   can_update: boolean;
-  dev_version_available: boolean;
-  dev_version: VersionInfo | null;
-  dev_commits_ahead: number | null;
-  dev_commits: CommitInfo[];
 }
 
 // Start request/response
 export interface UpdateStartRequest {
   target_version?: string | null;
-  skip_backup?: boolean;
-  force?: boolean;
-}
-
-export interface DevUpdateStartRequest {
   skip_backup?: boolean;
   force?: boolean;
 }
@@ -163,17 +155,19 @@ export interface UpdateConfigUpdate {
 }
 
 // Release notes
-export interface ReleaseNoteCategory {
-  name: string;
-  icon: string;
-  changes: string[];
+export interface ReleaseNoteItem {
+  version: string;
+  date: string | null;
+  is_prerelease: boolean;
+  url: string | null;
+  body_markdown: string;
 }
 
 export interface ReleaseNotesResponse {
-  version: string;
-  previous_version: string | null;
-  date: string | null;
-  categories: ReleaseNoteCategory[];
+  current_version: string;
+  since_version: string | null;
+  source: 'github' | 'changelog';
+  releases: ReleaseNoteItem[];
 }
 
 // Commit history types (Versions tab)
@@ -224,7 +218,10 @@ export interface ReleaseInfo {
   version: string;
   date: string | null;
   is_prerelease: boolean;
-  commit_short: string;
+  commit_short: string | null;
+  name: string | null;
+  html_url: string | null;
+  body_markdown: string | null;
 }
 
 export interface ReleaseListResponse {
@@ -283,14 +280,6 @@ export async function checkForUpdates(): Promise<UpdateCheckResponse> {
  */
 export async function startUpdate(request?: UpdateStartRequest): Promise<UpdateStartResponse> {
   const response = await apiClient.post<UpdateStartResponse>('/api/updates/start', request ?? {});
-  return response.data;
-}
-
-/**
- * Start a development branch update
- */
-export async function startDevUpdate(request?: DevUpdateStartRequest): Promise<UpdateStartResponse> {
-  const response = await apiClient.post<UpdateStartResponse>('/api/updates/start-dev', request ?? {});
   return response.data;
 }
 

--- a/client/src/components/updates/UpdateHistoryTab.tsx
+++ b/client/src/components/updates/UpdateHistoryTab.tsx
@@ -48,7 +48,16 @@ export default function UpdateHistoryTab({
               >
                 <div className="flex items-center gap-3">
                   <span className="font-mono text-white">{release.tag}</span>
-                  <span className="font-mono text-xs text-slate-500">{release.commit_short}</span>
+                  {release.html_url && (
+                    <a
+                      href={release.html_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-blue-400 hover:underline"
+                    >
+                      {t('releaseNotes.viewOnGitHub')}
+                    </a>
+                  )}
                 </div>
                 <div className="flex items-center gap-3">
                   {release.date && (

--- a/client/src/components/updates/UpdateOverviewTab.tsx
+++ b/client/src/components/updates/UpdateOverviewTab.tsx
@@ -6,43 +6,19 @@ import {
   Clock,
   Loader2,
   Zap,
-  Sparkles,
-  Bug,
-  Wrench,
-  Cog,
-  BookOpen,
-  TestTube,
-  Paintbrush,
-  CircleDot,
   FileText,
   Package,
 } from 'lucide-react';
+import Markdown from 'react-markdown';
 import type { UpdateCheckResponse, ReleaseNotesResponse } from '../../api/updates';
 import { isUpdateInProgress, type UpdateProgressResponse } from '../../api/updates';
 import UpdateProgress from './UpdateProgress';
 
-const CATEGORY_ICONS: Record<string, React.ReactNode> = {
-  sparkles: <Sparkles className="h-4 w-4" />,
-  bug: <Bug className="h-4 w-4" />,
-  zap: <Zap className="h-4 w-4" />,
-  wrench: <Wrench className="h-4 w-4" />,
-  cog: <Cog className="h-4 w-4" />,
-  'book-open': <BookOpen className="h-4 w-4" />,
-  'test-tube': <TestTube className="h-4 w-4" />,
-  paintbrush: <Paintbrush className="h-4 w-4" />,
-  'circle-dot': <CircleDot className="h-4 w-4" />,
-};
-
-const CATEGORY_COLORS: Record<string, string> = {
-  Features: 'text-emerald-400',
-  'Bug Fixes': 'text-rose-400',
-  Performance: 'text-amber-400',
-  Refactoring: 'text-sky-400',
-  Maintenance: 'text-slate-400',
-  Documentation: 'text-violet-400',
-  Tests: 'text-cyan-400',
-  Other: 'text-slate-400',
-};
+const PROSE =
+  'prose prose-invert prose-slate max-w-none prose-sm ' +
+  'prose-headings:text-white prose-h2:text-base prose-h3:text-sm ' +
+  'prose-p:text-slate-300 prose-li:text-slate-300 prose-strong:text-white ' +
+  'prose-a:text-blue-400 prose-code:text-cyan-400';
 
 interface UpdateOverviewTabProps {
   t: (key: string, options?: Record<string, unknown>) => string;
@@ -52,14 +28,10 @@ interface UpdateOverviewTabProps {
   updateLoading: boolean;
   rollbackLoading: boolean;
   cancelLoading: boolean;
-  devUpdateLoading: boolean;
   showUpdateConfirm: boolean;
-  showDevUpdateConfirm: boolean;
   onSetShowUpdateConfirm: (show: boolean) => void;
-  onSetShowDevUpdateConfirm: (show: boolean) => void;
   onSetShowRollbackConfirm: (show: boolean) => void;
   onStartUpdate: () => void;
-  onStartDevUpdate: () => void;
   onCancel: () => void;
 }
 
@@ -71,14 +43,10 @@ export default function UpdateOverviewTab({
   updateLoading,
   rollbackLoading,
   cancelLoading,
-  devUpdateLoading,
   showUpdateConfirm,
-  showDevUpdateConfirm,
   onSetShowUpdateConfirm,
-  onSetShowDevUpdateConfirm,
   onSetShowRollbackConfirm,
   onStartUpdate,
-  onStartDevUpdate,
   onCancel,
 }: UpdateOverviewTabProps) {
   return (
@@ -116,9 +84,7 @@ export default function UpdateOverviewTab({
               </div>
               <div className="flex items-center gap-2 text-sm text-slate-400">
                 <GitBranch className="h-4 w-4" />
-                <span className="font-mono">
-                  {checkResult.current_version.commit_short}
-                </span>
+                <span className="font-mono">{checkResult.current_version.commit_short}</span>
                 {checkResult.current_version.tag && (
                   <span className="px-2 py-0.5 bg-slate-700 rounded text-xs">
                     {checkResult.current_version.tag}
@@ -132,8 +98,6 @@ export default function UpdateOverviewTab({
                   </span>
                 </div>
               ) : !checkResult.current_version.is_prerelease ? (
-                /* Pre-releases are already flagged by the amber badge next to the
-                   version; only genuine stable builds get the "Stable" indicator. */
                 <div className="flex items-center gap-2 text-sm">
                   <span className="text-emerald-400">{t('version.stable')}</span>
                 </div>
@@ -145,18 +109,12 @@ export default function UpdateOverviewTab({
         {/* Available Update */}
         <div
           className={`bg-slate-800 rounded-lg p-5 border ${
-            checkResult?.update_available
-              ? 'border-blue-500/50 bg-blue-500/5'
-              : !checkResult?.update_available && checkResult?.dev_version_available
-                ? 'border-amber-500/30 bg-amber-500/5'
-                : 'border-slate-700'
+            checkResult?.update_available ? 'border-blue-500/50 bg-blue-500/5' : 'border-slate-700'
           }`}
         >
           <div className="flex items-center gap-2 mb-4">
             {checkResult?.update_available ? (
               <Zap className="h-5 w-5 text-blue-400" />
-            ) : !checkResult?.update_available && checkResult?.dev_version_available ? (
-              <GitBranch className="h-5 w-5 text-amber-400" />
             ) : (
               <CheckCircle className="h-5 w-5 text-emerald-400" />
             )}
@@ -169,12 +127,6 @@ export default function UpdateOverviewTab({
               <div className="text-3xl font-bold text-blue-400">
                 v{checkResult.latest_version.version}
               </div>
-              <div className="flex items-center gap-2 text-sm text-slate-400">
-                <GitBranch className="h-4 w-4" />
-                <span className="font-mono">
-                  {checkResult.latest_version.commit_short}
-                </span>
-              </div>
               {checkResult.last_checked && (
                 <div className="flex items-center gap-2 text-xs text-slate-500">
                   <Clock className="h-3 w-3" />
@@ -183,84 +135,7 @@ export default function UpdateOverviewTab({
               )}
             </div>
           ) : (
-            <div className="space-y-3">
-              <p className="text-slate-400">
-                {t('version.upToDateDesc')}
-              </p>
-              {checkResult?.dev_version_available && checkResult.dev_version && (
-                <div className="pt-2 border-t border-slate-700/50 space-y-2">
-                  <div className="flex items-center gap-2 text-sm text-amber-400">
-                    <GitBranch className="h-3.5 w-3.5" />
-                    <span className="font-medium">{t('version.devVersionAvailable')}</span>
-                  </div>
-                  <div className="flex items-center gap-3 text-xs text-slate-400">
-                    <span className="font-mono">{checkResult.dev_version.commit_short}</span>
-                    <span>{t('version.devCommitsAhead', { count: checkResult.dev_commits_ahead ?? 0 })}</span>
-                  </div>
-                  {checkResult.dev_commits && checkResult.dev_commits.length > 0 && (
-                    <div className="space-y-1 max-h-48 overflow-y-auto">
-                      {checkResult.dev_commits.map((commit) => (
-                        <div key={commit.hash_short} className="flex items-start gap-2 text-xs">
-                          <span className="font-mono text-slate-500 shrink-0">{commit.hash_short}</span>
-                          <span className="text-slate-300 break-all">
-                            {commit.type && (
-                              <span className={`font-medium ${
-                                commit.type === 'feat' ? 'text-emerald-400' :
-                                commit.type === 'fix' ? 'text-blue-400' :
-                                'text-slate-400'
-                              }`}>
-                                {commit.type}{commit.scope ? `(${commit.scope})` : ''}:
-                              </span>
-                            )}{' '}
-                            {commit.message.includes(':') ? commit.message.split(':').slice(1).join(':').trim() : commit.message}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                  {/* Dev Install Button */}
-                  <div className="pt-2">
-                    {!showDevUpdateConfirm ? (
-                      <button
-                        onClick={() => onSetShowDevUpdateConfirm(true)}
-                        disabled={devUpdateLoading || !!currentUpdate}
-                        className="flex items-center gap-2 px-3 py-1.5 bg-amber-600 hover:bg-amber-700 disabled:bg-slate-700 disabled:text-slate-500 text-white rounded-lg transition-all touch-manipulation active:scale-95 text-xs font-medium"
-                      >
-                        <Download className="h-3.5 w-3.5" />
-                        {t('buttons.installDevVersion')}
-                      </button>
-                    ) : (
-                      <div className="space-y-2">
-                        <p className="text-xs text-amber-400/80">
-                          <AlertTriangle className="h-3 w-3 inline mr-1" />
-                          {t('version.devWarning')}
-                        </p>
-                        <div className="flex items-center gap-2">
-                          <button
-                            onClick={onStartDevUpdate}
-                            disabled={devUpdateLoading}
-                            className="flex items-center gap-1.5 px-3 py-1.5 bg-amber-600 hover:bg-amber-700 text-white rounded text-xs transition-all touch-manipulation active:scale-95"
-                          >
-                            {devUpdateLoading ? (
-                              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                            ) : (
-                              <Download className="h-3.5 w-3.5" />
-                            )}
-                            {t('buttons.confirmDevInstall')}
-                          </button>
-                          <button
-                            onClick={() => onSetShowDevUpdateConfirm(false)}
-                            className="px-3 py-1.5 bg-slate-600 hover:bg-slate-500 text-white rounded text-xs transition-all touch-manipulation active:scale-95"
-                          >
-                            {t('common:cancel')}
-                          </button>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
+            <p className="text-slate-400">{t('version.upToDateDesc')}</p>
           )}
         </div>
       </div>
@@ -282,49 +157,65 @@ export default function UpdateOverviewTab({
         </div>
       )}
 
-      {/* Release Notes */}
-      {releaseNotes && releaseNotes.categories.length > 0 && (
+      {/* Release Notes (markdown, since last stable) */}
+      {releaseNotes && releaseNotes.releases.length > 0 && (
         <div className="bg-slate-800 rounded-lg p-5 border border-slate-700">
-          <div className="flex items-center gap-3 mb-1">
+          <div className="flex flex-wrap items-center gap-3 mb-1">
             <FileText className="h-5 w-5 text-blue-400" />
             <h3 className="font-medium text-white">{t('releaseNotes.title')}</h3>
-            <span className="text-sm font-mono text-slate-400">v{releaseNotes.version}</span>
+            <span className="text-sm font-mono text-slate-400">v{releaseNotes.current_version}</span>
+            {releaseNotes.source === 'changelog' && (
+              <span className="text-xs text-amber-400/80">{t('releaseNotes.fromChangelog')}</span>
+            )}
           </div>
-          {releaseNotes.previous_version && (
+          {releaseNotes.since_version && (
             <p className="text-sm text-slate-500 mb-4 ml-8">
-              {t('releaseNotes.since', { version: releaseNotes.previous_version })}
+              {t('releaseNotes.since', { version: releaseNotes.since_version })}
             </p>
           )}
-          <div className="space-y-4 ml-8">
-            {releaseNotes.categories.map((category) => (
-              <div key={category.name}>
-                <div className="flex items-center gap-2 mb-2">
-                  <span className={CATEGORY_COLORS[category.name] || 'text-slate-400'}>
-                    {CATEGORY_ICONS[category.icon] || <CircleDot className="h-4 w-4" />}
-                  </span>
-                  <h4 className={`text-sm font-medium ${CATEGORY_COLORS[category.name] || 'text-slate-400'}`}>
-                    {category.name}
-                  </h4>
+          <div className="space-y-5 ml-8">
+            {releaseNotes.releases.map((r) => (
+              <div key={r.version}>
+                <div className="flex flex-wrap items-center gap-2 mb-1">
+                  <span className="font-medium text-white">v{r.version}</span>
+                  {r.is_prerelease && (
+                    <span className="px-2 py-0.5 bg-amber-500/20 text-amber-400 text-xs rounded">
+                      {t('preRelease.badge')}
+                    </span>
+                  )}
+                  {r.date && (
+                    <span className="text-xs text-slate-500">
+                      {new Date(r.date).toLocaleDateString()}
+                    </span>
+                  )}
+                  {r.url && (
+                    <a
+                      href={r.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-blue-400 hover:underline"
+                    >
+                      {t('releaseNotes.viewOnGitHub')}
+                    </a>
+                  )}
                 </div>
-                <ul className="space-y-1 text-sm text-slate-300 ml-6">
-                  {category.changes.map((change, j) => (
-                    <li key={j}>• {change}</li>
-                  ))}
-                </ul>
+                <div className={PROSE}>
+                  <Markdown>{r.body_markdown}</Markdown>
+                </div>
               </div>
             ))}
           </div>
         </div>
       )}
 
-      {/* Changelog */}
+      {/* Changelog (what an update brings) */}
       {checkResult?.update_available && checkResult.changelog.length > 0 && (
         <div className="bg-slate-800 rounded-lg p-5 border border-slate-700">
           <h3 className="font-medium text-white mb-4">{t('changelog.title')}</h3>
           <div className="space-y-4">
             {checkResult.changelog.map((entry, i) => (
               <div key={i} className="border-l-2 border-blue-500/50 pl-4">
-                <div className="flex items-center gap-2 mb-2">
+                <div className="flex items-center gap-2 mb-1">
                   <span className="font-medium text-white">v{entry.version}</span>
                   {entry.is_prerelease && (
                     <span className="px-2 py-0.5 bg-amber-500/20 text-amber-400 text-xs rounded">
@@ -332,23 +223,9 @@ export default function UpdateOverviewTab({
                     </span>
                   )}
                 </div>
-                {entry.changes.length > 0 && (
-                  <ul className="space-y-1 text-sm text-slate-300">
-                    {entry.changes.map((change, j) => (
-                      <li key={j}>• {change}</li>
-                    ))}
-                  </ul>
-                )}
-                {entry.breaking_changes.length > 0 && (
-                  <div className="mt-2">
-                    <span className="text-rose-400 text-sm font-medium">
-                      {t('changelog.breakingChanges')}
-                    </span>
-                    <ul className="space-y-1 text-sm text-rose-300">
-                      {entry.breaking_changes.map((change, j) => (
-                        <li key={j}>• {change}</li>
-                      ))}
-                    </ul>
+                {entry.body_markdown && (
+                  <div className={PROSE}>
+                    <Markdown>{entry.body_markdown}</Markdown>
                   </div>
                 )}
               </div>
@@ -377,11 +254,7 @@ export default function UpdateOverviewTab({
                 disabled={updateLoading}
                 className="px-4 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded text-sm transition-all touch-manipulation active:scale-95"
               >
-                {updateLoading ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  t('buttons.yesUpdate')
-                )}
+                {updateLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : t('buttons.yesUpdate')}
               </button>
               <button
                 onClick={() => onSetShowUpdateConfirm(false)}

--- a/client/src/i18n/locales/de/updates.json
+++ b/client/src/i18n/locales/de/updates.json
@@ -48,7 +48,9 @@
   "releaseNotes": {
     "title": "Versionshinweise",
     "since": "Änderungen seit v{{version}}",
-    "empty": "Keine Versionshinweise verfügbar"
+    "empty": "Keine Versionshinweise verfügbar",
+    "fromChangelog": "aus CHANGELOG (offline)",
+    "viewOnGitHub": "Auf GitHub ansehen"
   },
   "history": {
     "title": "Update-Verlauf",

--- a/client/src/i18n/locales/en/updates.json
+++ b/client/src/i18n/locales/en/updates.json
@@ -48,7 +48,9 @@
   "releaseNotes": {
     "title": "Release Notes",
     "since": "Changes since v{{version}}",
-    "empty": "No release notes available"
+    "empty": "No release notes available",
+    "fromChangelog": "from CHANGELOG (offline)",
+    "viewOnGitHub": "View on GitHub"
   },
   "history": {
     "title": "Update History",

--- a/client/src/pages/UpdatePage.tsx
+++ b/client/src/pages/UpdatePage.tsx
@@ -26,7 +26,6 @@ import {
 import {
   checkForUpdates,
   startUpdate,
-  startDevUpdate,
   getUpdateProgress,
   getCurrentUpdate,
   rollbackUpdate,
@@ -88,8 +87,6 @@ export default function UpdatePage() {
 
   // Confirmation states
   const [showUpdateConfirm, setShowUpdateConfirm] = useState(false);
-  const [showDevUpdateConfirm, setShowDevUpdateConfirm] = useState(false);
-  const [devUpdateLoading, setDevUpdateLoading] = useState(false);
   const [showRollbackConfirm, setShowRollbackConfirm] = useState(false);
   const [rollbackTarget, setRollbackTarget] = useState<number | null>(null);
 
@@ -232,32 +229,6 @@ export default function UpdatePage() {
     }
   };
 
-  // Start dev update
-  const handleStartDevUpdate = async () => {
-    setDevUpdateLoading(true);
-    setShowDevUpdateConfirm(false);
-    try {
-      const result = await startDevUpdate();
-      if (result.success && result.update_id) {
-        toast.success(t('toast.devUpdateStarted'));
-        const progress = await getUpdateProgress(result.update_id);
-        setCurrentUpdate(progress);
-      } else {
-        toast.error(result.message);
-      }
-    } catch (err: unknown) {
-      const detail = (err as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail;
-      if (typeof detail === 'object' && detail !== null && 'blockers' in detail) {
-        const blockers = (detail as { blockers: string[] }).blockers;
-        toast.error(t('blockers.updateBlocked', { blockers: blockers.join(', ') }));
-      } else {
-        handleApiError(err, t('toast.updateFailed'));
-      }
-    } finally {
-      setDevUpdateLoading(false);
-    }
-  };
-
   // Rollback
   const handleRollback = async (updateId?: number) => {
     setRollbackLoading(true);
@@ -375,14 +346,10 @@ export default function UpdatePage() {
           updateLoading={updateLoading}
           rollbackLoading={rollbackLoading}
           cancelLoading={cancelLoading}
-          devUpdateLoading={devUpdateLoading}
           showUpdateConfirm={showUpdateConfirm}
-          showDevUpdateConfirm={showDevUpdateConfirm}
           onSetShowUpdateConfirm={setShowUpdateConfirm}
-          onSetShowDevUpdateConfirm={setShowDevUpdateConfirm}
           onSetShowRollbackConfirm={setShowRollbackConfirm}
           onStartUpdate={handleStartUpdate}
-          onStartDevUpdate={handleStartDevUpdate}
           onCancel={handleCancel}
         />
       )}

--- a/docs/superpowers/plans/2026-06-06-update-page-github-releases-backend.md
+++ b/docs/superpowers/plans/2026-06-06-update-page-github-releases-backend.md
@@ -894,7 +894,13 @@ In `backend/app/services/update/service.py`, in `check_for_updates`, delete the 
 
 and remove the four `dev_*=...` keyword args from the `UpdateCheckResponse(...)` return.
 
-Then delete the entire `start_dev_update(...)` method from the same file.
+Then delete the entire **`start_dev_update(...)`** method (the development-branch deploy path, ~lines
+272-348) from the same file.
+
+> **CAUTION — do NOT remove `_run_dev_update(...)`.** Despite the similar name, `_run_dev_update` is
+> the shared **dev-mode in-process update simulator** that the normal `start_update` calls
+> (`asyncio.create_task(self._run_dev_update(...))`). It must stay. Only `start_dev_update` (the
+> development-*branch* method that calls `check_dev_branch`) is removed.
 
 - [ ] **Step 5: Remove the route**
 

--- a/docs/superpowers/plans/2026-06-06-update-page-github-releases-backend.md
+++ b/docs/superpowers/plans/2026-06-06-update-page-github-releases-backend.md
@@ -1,0 +1,946 @@
+# Update Page → GitHub Releases — Backend Plan (Plan 1 of 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make GitHub Releases the source for the update page's release-notes, the "update available?" check, and the releases list (curated markdown bodies), with a CHANGELOG.md offline fallback; remove the dead `development`-branch logic. Git/systemd still applies updates.
+
+**Architecture:** A new `GitHubReleasesClient` (httpx + per-worker TTL cache) plus pure, positional helpers feed `ProdUpdateBackend.get_release_notes/check_for_updates/get_all_releases`. Notes aggregate "since the last stable" using the API's newest-first ordering (no fragile semver ordering of `-pre.N`). On any GitHub error → parse the bundled `CHANGELOG.md`.
+
+**Tech Stack:** FastAPI, httpx, Pydantic, Pytest.
+
+Spec: `docs/superpowers/specs/2026-06-06-update-page-github-releases-design.md`. Frontend (markdown rendering, dev-channel UI removal, i18n) is **Plan 2**.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `backend/app/core/config.py` | settings | +`update_github_repo`, +`update_changelog_path` |
+| `backend/app/schemas/update.py` | contracts | reshape `ReleaseNotesResponse`, +`ReleaseNoteItem`, +`ChangelogEntry.body_markdown`, extend `ReleaseInfo`, drop `DevUpdateStartRequest`, drop `UpdateCheckResponse.dev_*` |
+| `backend/app/services/update/github_releases.py` | GitHub client + positional helpers | NEW |
+| `backend/app/services/update/changelog_fallback.py` | CHANGELOG.md parser | NEW |
+| `backend/app/services/update/prod_backend.py` | release-notes/check/releases via GitHub | rework + drop `check_dev_branch` |
+| `backend/app/services/update/dev_backend.py` | mock markdown notes | rework + drop `check_dev_branch` |
+| `backend/app/services/update/backend.py` | abstract interface | drop `check_dev_branch` |
+| `backend/app/services/update/service.py` | orchestration | drop dev_* in `check_for_updates`, drop `start_dev_update` |
+| `backend/app/api/routes/updates.py` | HTTP | drop `POST /updates/start-dev` |
+| `backend/tests/services/test_github_releases.py`, `test_changelog_fallback.py`, `test_update_github.py` | tests | NEW |
+
+---
+
+## Task 1: Config + schema reshape
+
+**Files:**
+- Modify: `backend/app/core/config.py`
+- Modify: `backend/app/schemas/update.py`
+- Test: `backend/tests/services/test_update_github.py`
+
+- [ ] **Step 1: Add settings**
+
+In `backend/app/core/config.py`, inside the `Settings` class (place near other feature settings, mirroring the existing `Field(default=..., validation_alias="...")` style):
+
+```python
+    update_github_repo: str = Field(
+        default="Xveyn/BaluHost",
+        validation_alias="BALUHOST_UPDATE_GITHUB_REPO",
+        description="owner/repo used to read GitHub Releases for the update page.",
+    )
+    update_changelog_path: str = Field(
+        default="CHANGELOG.md",
+        validation_alias="BALUHOST_UPDATE_CHANGELOG_PATH",
+        description="Path (repo-root-relative or absolute) to the bundled CHANGELOG.md fallback.",
+    )
+```
+
+(If `Field` is not already imported in `config.py`, it is — the existing settings use it.)
+
+- [ ] **Step 2: Write the failing schema test**
+
+Create `backend/tests/services/test_update_github.py`:
+
+```python
+from app.schemas.update import ReleaseNoteItem, ReleaseNotesResponse, ReleaseInfo, ChangelogEntry
+
+
+def test_release_notes_response_shape():
+    item = ReleaseNoteItem(version="1.36.0", is_prerelease=False, url="u", body_markdown="### Added\n- x")
+    resp = ReleaseNotesResponse(current_version="1.36.0", since_version="1.35.0", source="github", releases=[item])
+    assert resp.source == "github"
+    assert resp.releases[0].body_markdown.startswith("### Added")
+
+
+def test_changelog_entry_has_body_markdown():
+    e = ChangelogEntry(version="1.36.0", body_markdown="- y")
+    assert e.body_markdown == "- y"
+
+
+def test_release_info_extended_optional_commit():
+    r = ReleaseInfo(tag="v1.36.0", version="1.36.0", is_prerelease=False)
+    assert r.commit_short is None and r.html_url is None
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/services/test_update_github.py -v --no-cov`
+Expected: FAIL — `ImportError: ReleaseNoteItem` / unexpected required field `commit_short`.
+
+- [ ] **Step 4: Reshape the schemas**
+
+In `backend/app/schemas/update.py`:
+
+(a) Add `ReleaseNoteItem` and reshape `ReleaseNotesResponse` — replace the existing
+`ReleaseNoteCategory` + `ReleaseNotesResponse` block with:
+
+```python
+class ReleaseNoteCategory(BaseModel):
+    """Legacy categorized release-note group (kept for compatibility; unused by GitHub path)."""
+
+    name: str
+    icon: str
+    changes: list[str] = Field(default_factory=list)
+
+
+class ReleaseNoteItem(BaseModel):
+    """A single release's curated notes (one GitHub release / CHANGELOG section)."""
+
+    version: str = Field(description="Version, e.g. '1.36.0' or '1.35.1-pre.3'")
+    date: Optional[datetime] = Field(default=None, description="Release date")
+    is_prerelease: bool = Field(default=False)
+    url: Optional[str] = Field(default=None, description="Release HTML URL")
+    body_markdown: str = Field(default="", description="Curated release notes (markdown)")
+
+
+class ReleaseNotesResponse(BaseModel):
+    """Release notes since the last stable, newest first."""
+
+    current_version: str
+    since_version: Optional[str] = Field(default=None, description="The last stable the notes start from")
+    source: Literal["github", "changelog"] = "github"
+    releases: list[ReleaseNoteItem] = Field(default_factory=list)
+```
+
+(b) In `ChangelogEntry`, add after `is_prerelease`:
+
+```python
+    body_markdown: Optional[str] = Field(default=None, description="Curated release notes (markdown)")
+```
+
+(c) In `ReleaseInfo`, replace the class body with (adds `name`/`html_url`/`body_markdown`, makes `commit_short` optional):
+
+```python
+    tag: str = Field(description="Git tag (e.g., 'v1.36.0')")
+    version: str = Field(description="Version string without 'v' prefix")
+    date: Optional[str] = Field(default=None, description="Release date (ISO 8601)")
+    is_prerelease: bool = Field(default=False)
+    commit_short: Optional[str] = Field(default=None, description="Short commit hash (git path only)")
+    name: Optional[str] = Field(default=None, description="Release name")
+    html_url: Optional[str] = Field(default=None, description="Release HTML URL")
+    body_markdown: Optional[str] = Field(default=None, description="Curated release notes (markdown)")
+```
+
+(d) Delete the `DevUpdateStartRequest` class entirely.
+
+(e) In `UpdateCheckResponse`, delete the four dev-branch fields (`dev_version_available`,
+`dev_version`, `dev_commits_ahead`, `dev_commits`) and their `CommitInfo` forward use.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/services/test_update_github.py -v --no-cov`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/core/config.py backend/app/schemas/update.py backend/tests/services/test_update_github.py
+git commit -m "feat(updates): GitHub-releases settings + reshape release-notes schemas"
+```
+
+---
+
+## Task 2: GitHub Releases client + positional helpers
+
+**Files:**
+- Create: `backend/app/services/update/github_releases.py`
+- Test: `backend/tests/services/test_github_releases.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/services/test_github_releases.py`:
+
+```python
+import pytest
+
+from app.services.update.github_releases import (
+    GitHubRelease, GitHubReleasesClient, GitHubUnavailable,
+    filter_channel, latest_for_channel, notes_since_last_stable, releases_between,
+)
+
+
+def _r(tag, prerelease, body="b"):
+    return GitHubRelease(tag=tag, name=tag, body_markdown=body, prerelease=prerelease,
+                         published_at=None, url=f"https://x/{tag}")
+
+
+# Newest-first, like the GitHub API returns.
+RELEASES = [
+    _r("v1.36.0", False),
+    _r("v1.35.1-pre.25", True),
+    _r("v1.35.1-pre.24", True),
+    _r("v1.35.0", False),
+    _r("v1.34.0", False),
+]
+
+
+def test_filter_channel():
+    assert len(filter_channel(RELEASES, "unstable")) == 5
+    assert [r.tag for r in filter_channel(RELEASES, "stable")] == ["v1.36.0", "v1.35.0", "v1.34.0"]
+
+
+def test_latest_for_channel():
+    assert latest_for_channel(RELEASES, "stable").tag == "v1.36.0"
+    assert latest_for_channel(RELEASES, "unstable").tag == "v1.36.0"
+
+
+def test_notes_since_last_stable_for_prerelease():
+    items, since = notes_since_last_stable(RELEASES, "1.35.1-pre.25")
+    # current is a pre-release: aggregate from it back to (excl.) the last stable v1.35.0
+    assert [r.tag for r in items] == ["v1.35.1-pre.25", "v1.35.1-pre.24"]
+    assert since == "v1.35.0"
+
+
+def test_notes_since_last_stable_for_stable():
+    items, since = notes_since_last_stable(RELEASES, "1.36.0")
+    # current is stable: its own body already covers since-last-stable
+    assert [r.tag for r in items] == ["v1.36.0"]
+    assert since == "v1.35.0"
+
+
+def test_releases_between_current_to_latest():
+    # what an update from a pre-release to the latest stable brings
+    items = releases_between(RELEASES, newer_than="1.35.1-pre.25", up_to="1.36.0")
+    assert [r.tag for r in items] == ["v1.36.0"]
+
+
+@pytest.mark.asyncio
+async def test_list_releases_caches_and_falls_back(monkeypatch):
+    client = GitHubReleasesClient(repo="x/y", ttl_seconds=999)
+    calls = {"n": 0}
+
+    class _Resp:
+        status_code = 200
+        def json(self):
+            return [{"tag_name": "v1.0.0", "name": "v1.0.0", "body": "hi",
+                     "prerelease": False, "published_at": "2026-01-01T00:00:00Z",
+                     "html_url": "https://x/v1.0.0"}]
+
+    class _Client:
+        def __init__(self, *a, **k): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def get(self, *a, **k):
+            calls["n"] += 1
+            return _Resp()
+
+    monkeypatch.setattr("app.services.update.github_releases.httpx.AsyncClient", _Client)
+    first = await client.list_releases()
+    second = await client.list_releases()
+    assert first[0].tag == "v1.0.0"
+    assert calls["n"] == 1  # second served from cache
+
+
+@pytest.mark.asyncio
+async def test_list_releases_raises_unavailable_on_error(monkeypatch):
+    import httpx
+    client = GitHubReleasesClient(repo="x/y")
+
+    class _Client:
+        def __init__(self, *a, **k): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def get(self, *a, **k):
+            raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr("app.services.update.github_releases.httpx.AsyncClient", _Client)
+    with pytest.raises(GitHubUnavailable):
+        await client.list_releases()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/services/test_github_releases.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError: app.services.update.github_releases`.
+
+- [ ] **Step 3: Implement the client + helpers**
+
+Create `backend/app/services/update/github_releases.py`:
+
+```python
+"""GitHub Releases client + positional aggregation helpers for the update page.
+
+GitHub's `/releases` API returns newest-first; all range logic here is positional
+(not semver-ordered) so it is robust against `-pre.N` suffix ordering quirks.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+from app.core.config import settings
+from app.services.update.utils import parse_version
+
+GITHUB_API = "https://api.github.com"
+
+
+class GitHubUnavailable(Exception):
+    """Raised when GitHub releases cannot be fetched (network / rate-limit / HTTP error)."""
+
+
+@dataclass
+class GitHubRelease:
+    tag: str
+    name: str
+    body_markdown: str
+    prerelease: bool
+    published_at: Optional[str]
+    url: str
+
+
+class GitHubReleasesClient:
+    """Fetches the releases list with a per-instance TTL cache."""
+
+    def __init__(self, repo: Optional[str] = None, ttl_seconds: int = 900):
+        self.repo = repo or settings.update_github_repo
+        self.ttl = ttl_seconds
+        self._cache: Optional[list[GitHubRelease]] = None
+        self._cached_at: float = 0.0
+
+    async def list_releases(self, *, force: bool = False) -> list[GitHubRelease]:
+        now = time.monotonic()
+        if not force and self._cache is not None and (now - self._cached_at) < self.ttl:
+            return self._cache
+
+        url = f"{GITHUB_API}/repos/{self.repo}/releases"
+        headers = {"User-Agent": "BaluHost", "Accept": "application/vnd.github+json"}
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(url, headers=headers, params={"per_page": 100})
+            if resp.status_code != 200:
+                raise GitHubUnavailable(f"GitHub returned HTTP {resp.status_code}")
+            data = resp.json()
+        except GitHubUnavailable:
+            raise
+        except Exception as exc:  # httpx errors, JSON decode, etc.
+            raise GitHubUnavailable(str(exc)) from exc
+
+        releases = [
+            GitHubRelease(
+                tag=r.get("tag_name", ""),
+                name=r.get("name") or r.get("tag_name", ""),
+                body_markdown=r.get("body") or "",
+                prerelease=bool(r.get("prerelease")),
+                published_at=r.get("published_at"),
+                url=r.get("html_url", ""),
+            )
+            for r in (data or [])
+            if r.get("tag_name")
+        ]
+        self._cache = releases
+        self._cached_at = now
+        return releases
+
+
+def filter_channel(releases: list[GitHubRelease], channel: str) -> list[GitHubRelease]:
+    if channel == "unstable":
+        return list(releases)
+    return [r for r in releases if not r.prerelease]
+
+
+def latest_for_channel(releases: list[GitHubRelease], channel: str) -> Optional[GitHubRelease]:
+    """Newest release in the channel (the list is already newest-first)."""
+    filtered = filter_channel(releases, channel)
+    return filtered[0] if filtered else None
+
+
+def _find_index(releases: list[GitHubRelease], version: str) -> Optional[int]:
+    target = parse_version(version)
+    for i, r in enumerate(releases):
+        if parse_version(r.tag) == target:
+            return i
+    return None
+
+
+def notes_since_last_stable(
+    releases: list[GitHubRelease], up_to_version: str
+) -> tuple[list[GitHubRelease], Optional[str]]:
+    """Releases for the running version's notes "since the last stable", newest first.
+
+    - If up_to is stable: just [up_to] (its body already covers since-last-stable).
+    - If up_to is a pre-release: up_to plus older pre-releases, down to (excl.) the
+      first older stable.
+    Returns (slice, since_tag).
+    """
+    idx = _find_index(releases, up_to_version)
+    if idx is None:
+        return [], None
+    up = releases[idx]
+    # the first stable strictly older than up_to (for the since_version label)
+    since_tag = next((r.tag for r in releases[idx + 1:] if not r.prerelease), None)
+    if not up.prerelease:
+        return [up], since_tag
+    out: list[GitHubRelease] = []
+    for r in releases[idx:]:
+        if not r.prerelease:
+            break
+        out.append(r)
+    return out, since_tag
+
+
+def releases_between(
+    releases: list[GitHubRelease], newer_than: str, up_to: str
+) -> list[GitHubRelease]:
+    """Releases from up_to (inclusive) down to newer_than (exclusive), newest first."""
+    up_idx = _find_index(releases, up_to)
+    nt_idx = _find_index(releases, newer_than)
+    start = up_idx if up_idx is not None else 0
+    end = nt_idx if nt_idx is not None else len(releases)
+    if start >= end:
+        return []
+    return releases[start:end]
+```
+
+- [ ] **Step 4: Add the asyncio marker dependency check**
+
+The async tests use `@pytest.mark.asyncio`. Confirm it's available (the repo already uses
+`pytest_asyncio` — see `conftest.py`). If a test errors with "async def functions are not natively
+supported", add `import pytest_asyncio` is NOT needed; the repo's `pyproject` sets asyncio mode. Run
+the tests as-is in the next step.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/test_github_releases.py -v --no-cov`
+Expected: PASS (7 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/update/github_releases.py backend/tests/services/test_github_releases.py
+git commit -m "feat(updates): GitHub Releases client + positional since-last-stable helpers"
+```
+
+---
+
+## Task 3: CHANGELOG.md fallback parser
+
+**Files:**
+- Create: `backend/app/services/update/changelog_fallback.py`
+- Test: `backend/tests/services/test_changelog_fallback.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/services/test_changelog_fallback.py`:
+
+```python
+from app.services.update.changelog_fallback import parse_changelog, notes_since_last_stable_from_changelog
+
+SAMPLE = """# Changelog
+
+---
+
+## [1.36.0] - 2026-06-06
+
+### Added
+- thing A
+
+## [1.35.0] - 2026-05-01
+
+### Fixed
+- thing B
+"""
+
+
+def test_parse_changelog(tmp_path):
+    p = tmp_path / "CHANGELOG.md"
+    p.write_text(SAMPLE, encoding="utf-8")
+    sections = parse_changelog(str(p))
+    assert sections[0].version == "1.36.0"
+    assert "thing A" in sections[0].body_markdown
+    assert sections[1].version == "1.35.0"
+
+
+def test_notes_for_current(tmp_path):
+    p = tmp_path / "CHANGELOG.md"
+    p.write_text(SAMPLE, encoding="utf-8")
+    items, since = notes_since_last_stable_from_changelog(str(p), "1.36.0")
+    assert items[0].version == "1.36.0"
+    assert items[0].source_is_changelog if hasattr(items[0], "source_is_changelog") else True
+
+
+def test_notes_missing_file(tmp_path):
+    items, since = notes_since_last_stable_from_changelog(str(tmp_path / "nope.md"), "1.36.0")
+    assert items == [] and since is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/services/test_changelog_fallback.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement the parser**
+
+Create `backend/app/services/update/changelog_fallback.py`:
+
+```python
+"""Offline fallback: parse the bundled CHANGELOG.md into release-note items.
+
+Used when the GitHub Releases API is unavailable. CHANGELOG.md mainly holds
+stable sections (`## [x.y.z] - date`), so this is a degraded-but-non-empty mode.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from app.schemas.update import ReleaseNoteItem
+from app.services.update.utils import parse_version
+
+_SECTION_RE = re.compile(r"^##\s*\[(?P<ver>[^\]]+)\]\s*-\s*(?P<date>\S+)", re.MULTILINE)
+
+
+@dataclass
+class ChangelogSection:
+    version: str
+    date: Optional[str]
+    body_markdown: str
+
+
+def parse_changelog(path: str) -> list[ChangelogSection]:
+    """Parse `## [x.y.z] - date` sections (in file order = newest first)."""
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError:
+        return []
+    matches = list(_SECTION_RE.finditer(text))
+    sections: list[ChangelogSection] = []
+    for i, m in enumerate(matches):
+        body_start = m.end()
+        body_end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[body_start:body_end].strip()
+        sections.append(ChangelogSection(version=m.group("ver").strip(),
+                                         date=m.group("date").strip(), body_markdown=body))
+    return sections
+
+
+def _to_dt(date_str: Optional[str]) -> Optional[datetime]:
+    if not date_str:
+        return None
+    try:
+        return datetime.fromisoformat(date_str).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def notes_since_last_stable_from_changelog(
+    path: str, up_to_version: str
+) -> tuple[list[ReleaseNoteItem], Optional[str]]:
+    """Return CHANGELOG sections from `up_to_version` (inclusive) down to the next
+    older section, as ReleaseNoteItems. Degraded fallback (stable-only)."""
+    sections = parse_changelog(path)
+    if not sections:
+        return [], None
+    target = parse_version(up_to_version)
+    idx = next((i for i, s in enumerate(sections) if parse_version(s.version) == target), None)
+    if idx is None:
+        # Unknown current version (e.g. a pre-release not in CHANGELOG): show the newest section.
+        idx = 0
+    item = sections[idx]
+    since = sections[idx + 1].version if idx + 1 < len(sections) else None
+    return (
+        [ReleaseNoteItem(version=item.version, date=_to_dt(item.date), is_prerelease=False,
+                         url=None, body_markdown=item.body_markdown)],
+        since,
+    )
+```
+
+- [ ] **Step 4: Simplify the over-specified test**
+
+Edit `test_changelog_fallback.py` `test_notes_for_current` to drop the speculative attribute line — replace its body with:
+
+```python
+def test_notes_for_current(tmp_path):
+    p = tmp_path / "CHANGELOG.md"
+    p.write_text(SAMPLE, encoding="utf-8")
+    items, since = notes_since_last_stable_from_changelog(str(p), "1.36.0")
+    assert items[0].version == "1.36.0"
+    assert "thing A" in items[0].body_markdown
+    assert since == "1.35.0"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/test_changelog_fallback.py -v --no-cov`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/update/changelog_fallback.py backend/tests/services/test_changelog_fallback.py
+git commit -m "feat(updates): CHANGELOG.md offline fallback parser"
+```
+
+---
+
+## Task 4: Rework ProdUpdateBackend (notes/check/releases via GitHub)
+
+**Files:**
+- Modify: `backend/app/services/update/prod_backend.py`
+- Test: `backend/tests/services/test_update_github.py`
+
+- [ ] **Step 1: Write the failing tests** (append to `test_update_github.py`)
+
+```python
+import pytest
+from app.services.update.github_releases import GitHubRelease, GitHubUnavailable
+from app.services.update.prod_backend import ProdUpdateBackend
+
+
+def _gh(tag, pre, body="notes"):
+    return GitHubRelease(tag=tag, name=tag, body_markdown=body, prerelease=pre, published_at=None, url=f"https://x/{tag}")
+
+
+_REL = [_gh("v1.36.0", False), _gh("v1.35.1-pre.25", True), _gh("v1.35.0", False)]
+
+
+class _FakeVersion:
+    def __init__(self, v): self.version = v; self.commit = "c"; self.commit_short = "c"; self.tag = "v"+v; self.date = None
+
+
+@pytest.mark.asyncio
+async def test_get_release_notes_github(monkeypatch):
+    b = ProdUpdateBackend()
+    monkeypatch.setattr(b, "get_current_version", lambda: _FakeVersion("1.35.1-pre.25"))
+    async def fake_list(*a, **k): return _REL
+    monkeypatch.setattr(b._gh, "list_releases", fake_list)
+    notes = await b.get_release_notes()
+    assert notes.source == "github"
+    assert [r.version for r in notes.releases] == ["1.35.1-pre.25"]  # since v1.35.0
+
+
+@pytest.mark.asyncio
+async def test_get_release_notes_falls_back_to_changelog(monkeypatch, tmp_path):
+    cl = tmp_path / "CHANGELOG.md"
+    cl.write_text("# Changelog\n\n## [1.36.0] - 2026-06-06\n\n### Added\n- a\n", encoding="utf-8")
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "update_changelog_path", str(cl))
+    b = ProdUpdateBackend()
+    monkeypatch.setattr(b, "get_current_version", lambda: _FakeVersion("1.36.0"))
+    async def boom(*a, **k): raise GitHubUnavailable("down")
+    monkeypatch.setattr(b._gh, "list_releases", boom)
+    notes = await b.get_release_notes()
+    assert notes.source == "changelog"
+    assert notes.releases[0].version == "1.36.0"
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_github(monkeypatch):
+    b = ProdUpdateBackend()
+    monkeypatch.setattr(b, "get_current_version", lambda: _FakeVersion("1.35.1-pre.25"))
+    async def fake_list(*a, **k): return _REL
+    monkeypatch.setattr(b._gh, "list_releases", fake_list)
+    available, latest, changelog = await b.check_for_updates("stable")
+    assert available is True and latest.version == "1.36.0"
+    assert changelog and changelog[0].body_markdown == "notes"
+```
+
+Note: `get_current_version` is async in the real code — these tests stub it with a sync lambda returning an object; since the backend awaits it, replace the stub with an async one if a test errors. Use:
+
+```python
+    async def _ver(): return _FakeVersion("1.35.1-pre.25")
+    monkeypatch.setattr(b, "get_current_version", _ver)
+```
+
+(Apply the async-stub form in all three tests.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/services/test_update_github.py -k "release_notes or check_for_updates" -v --no-cov`
+Expected: FAIL — `ProdUpdateBackend` has no `_gh`; old `get_release_notes` returns `categories`.
+
+- [ ] **Step 3: Rework prod_backend**
+
+In `backend/app/services/update/prod_backend.py`:
+
+(a) Extend the imports near the top:
+
+```python
+from app.core.config import settings
+from app.schemas.update import ReleaseNoteItem
+from app.services.update.github_releases import (
+    GitHubReleasesClient, GitHubRelease, GitHubUnavailable,
+    filter_channel, latest_for_channel, notes_since_last_stable, releases_between,
+)
+from app.services.update.changelog_fallback import notes_since_last_stable_from_changelog
+```
+
+(b) In `__init__`, add a client + a changelog-path resolver:
+
+```python
+        self._gh = GitHubReleasesClient()
+```
+
+And add this helper method to the class:
+
+```python
+    def _changelog_path(self) -> str:
+        p = Path(settings.update_changelog_path)
+        return str(p if p.is_absolute() else (self.repo_path / p))
+
+    @staticmethod
+    def _to_item(r: GitHubRelease) -> ReleaseNoteItem:
+        from datetime import datetime
+        date = None
+        if r.published_at:
+            try:
+                date = datetime.fromisoformat(r.published_at.replace("Z", "+00:00"))
+            except ValueError:
+                date = None
+        return ReleaseNoteItem(version=r.tag.lstrip("v"), date=date,
+                               is_prerelease=r.prerelease, url=r.url, body_markdown=r.body_markdown)
+```
+
+(c) Replace `get_release_notes` entirely with:
+
+```python
+    async def get_release_notes(self) -> ReleaseNotesResponse:
+        current = await self.get_current_version()
+        try:
+            releases = await self._gh.list_releases()
+            slice_, since = notes_since_last_stable(releases, current.version)
+            return ReleaseNotesResponse(
+                current_version=current.version,
+                since_version=since.lstrip("v") if since else None,
+                source="github",
+                releases=[self._to_item(r) for r in slice_],
+            )
+        except GitHubUnavailable:
+            items, since = notes_since_last_stable_from_changelog(self._changelog_path(), current.version)
+            return ReleaseNotesResponse(
+                current_version=current.version,
+                since_version=since.lstrip("v") if since else None,
+                source="changelog",
+                releases=items,
+            )
+```
+
+(d) Replace `check_for_updates` and `_build_changelog` with a GitHub-driven version (delete the old
+git-tag `check_for_updates` body and the `_build_changelog` method):
+
+```python
+    async def check_for_updates(self, channel: str) -> tuple[bool, Optional[VersionInfo], list[ChangelogEntry]]:
+        current = await self.get_current_version()
+        try:
+            releases = await self._gh.list_releases()
+        except GitHubUnavailable:
+            return False, None, []
+
+        latest = latest_for_channel(releases, channel)
+        if latest is None:
+            return False, None, []
+
+        latest_v = parse_version(latest.tag)
+        current_v = parse_version(current.version)
+        if latest_v <= current_v:
+            return False, None, []
+
+        latest_info = VersionInfo(
+            version=latest.tag.lstrip("v"), commit="", commit_short="",
+            tag=latest.tag, date=None, is_prerelease=latest.prerelease,
+        )
+        delta = releases_between(releases, newer_than=current.version, up_to=latest.tag.lstrip("v"))
+        changelog = [
+            ChangelogEntry(version=r.tag.lstrip("v"), date=None, changes=[], breaking_changes=[],
+                           is_prerelease=r.prerelease, body_markdown=r.body_markdown)
+            for r in delta
+        ]
+        return True, latest_info, changelog
+```
+
+(e) Replace `get_all_releases` with a GitHub-driven version (delete the old git-tag body):
+
+```python
+    async def get_all_releases(self) -> ReleaseListResponse:
+        try:
+            releases = await self._gh.list_releases()
+        except GitHubUnavailable:
+            return ReleaseListResponse(releases=[], total=0)
+        infos = [
+            ReleaseInfo(
+                tag=r.tag, version=r.tag.lstrip("v"), date=r.published_at,
+                is_prerelease=r.prerelease, commit_short=None,
+                name=r.name, html_url=r.url, body_markdown=r.body_markdown,
+            )
+            for r in releases
+        ]
+        return ReleaseListResponse(releases=infos, total=len(infos))
+```
+
+(f) Delete the `check_dev_branch` method from `prod_backend.py` entirely.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/test_update_github.py -v --no-cov`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/update/prod_backend.py backend/tests/services/test_update_github.py
+git commit -m "feat(updates): ProdUpdateBackend reads release-notes/check/releases from GitHub"
+```
+
+---
+
+## Task 5: Rework DevUpdateBackend
+
+**Files:**
+- Modify: `backend/app/services/update/dev_backend.py`
+
+- [ ] **Step 1: Replace `get_release_notes` with a markdown mock**
+
+In `backend/app/services/update/dev_backend.py`, replace the `get_release_notes` method body with:
+
+```python
+    async def get_release_notes(self) -> ReleaseNotesResponse:
+        from app.schemas.update import ReleaseNoteItem
+        return ReleaseNotesResponse(
+            current_version=version_to_string(self._simulated_version),
+            since_version="0.9.0",
+            source="github",
+            releases=[
+                ReleaseNoteItem(
+                    version=version_to_string(self._simulated_version),
+                    date=datetime.now(timezone.utc),
+                    is_prerelease=False,
+                    url="https://github.com/Xveyn/BaluHost/releases",
+                    body_markdown="### Added\n- SSD cache management\n- SMB/WebDAV discovery\n\n### Fixed\n- Storage aggregation",
+                ),
+            ],
+        )
+```
+
+Update the imports at the top of `dev_backend.py`: remove the now-unused `ReleaseNoteCategory`
+import if present.
+
+- [ ] **Step 2: Delete `check_dev_branch` from `dev_backend.py`** (if it overrides the base — remove the override).
+
+- [ ] **Step 3: Run dev-mode smoke**
+
+Run: `cd backend && python -c "import asyncio; from app.services.update.dev_backend import DevUpdateBackend; n=asyncio.run(DevUpdateBackend().get_release_notes()); print(n.source, n.releases[0].body_markdown[:10])"`
+Expected: prints `github ### Added`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/services/update/dev_backend.py
+git commit -m "feat(updates): DevUpdateBackend returns markdown release notes"
+```
+
+---
+
+## Task 6: Remove dead development-branch logic
+
+**Files:**
+- Modify: `backend/app/services/update/backend.py`
+- Modify: `backend/app/services/update/service.py`
+- Modify: `backend/app/api/routes/updates.py`
+- Test: `backend/tests/services/test_update_github.py`
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```python
+def test_dev_endpoints_and_fields_removed():
+    import app.schemas.update as u
+    assert not hasattr(u, "DevUpdateStartRequest")
+    from app.api.routes import updates as r
+    # No start-dev route registered
+    paths = [getattr(rt, "path", "") for rt in r.router.routes]
+    assert not any(p.endswith("/start-dev") for p in paths)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd backend && python -m pytest tests/services/test_update_github.py::test_dev_endpoints_and_fields_removed -v --no-cov`
+Expected: FAIL (route + schema still present).
+
+- [ ] **Step 3: Remove from the abstract interface**
+
+In `backend/app/services/update/backend.py`, delete the `check_dev_branch` method (lines defining
+`async def check_dev_branch...` through its `return False, None, None, []`). Remove the now-unused
+`CommitInfo` import if nothing else in the file uses it.
+
+- [ ] **Step 4: Drop dev_* from `service.check_for_updates` and remove `start_dev_update`**
+
+In `backend/app/services/update/service.py`, in `check_for_updates`, delete the line:
+
+```python
+        dev_available, dev_version, dev_commits_ahead, dev_commits = await self.backend.check_dev_branch()
+```
+
+and remove the four `dev_*=...` keyword args from the `UpdateCheckResponse(...)` return.
+
+Then delete the entire `start_dev_update(...)` method from the same file.
+
+- [ ] **Step 5: Remove the route**
+
+In `backend/app/api/routes/updates.py`, delete the entire `@router.post("/start-dev", ...)` handler
+(`start_dev_update`) and drop `DevUpdateStartRequest` from the `from app.schemas.update import (...)`
+import list.
+
+- [ ] **Step 6: Run tests to verify they pass + no import errors**
+
+Run: `cd backend && python -m pytest tests/services/test_update_github.py -v --no-cov && python -c "import app.api.routes.updates, app.services.update.service, app.services.update.backend"`
+Expected: PASS; import line prints nothing (no error).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/update/backend.py backend/app/services/update/service.py backend/app/api/routes/updates.py backend/tests/services/test_update_github.py
+git commit -m "refactor(updates): remove dead development-branch update path"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Run the new update tests**
+
+Run: `cd backend && python -m pytest tests/services/test_github_releases.py tests/services/test_changelog_fallback.py tests/services/test_update_github.py -v --no-cov`
+Expected: PASS (all).
+
+- [ ] **Step 2: Run the existing update suite (no regression)**
+
+Run: `cd backend && python -m pytest tests/services/test_update_service.py -q --no-cov`
+Expected: PASS — or, for any test that asserted on the old git-tag `get_release_notes`/`check_for_updates`/`get_all_releases` or the removed `dev_*`/`start_dev_update`, update that test to the new contract (notes carry `releases[].body_markdown`; no `dev_*`). Document each changed test in the commit.
+
+- [ ] **Step 3: Commit any test adjustments**
+
+```bash
+git add backend/tests/services/test_update_service.py
+git commit -m "test(updates): adapt update-service tests to the GitHub-releases contract"
+```
+
+---
+
+## Notes for the implementer
+
+- **Positional, not semver-ordered:** all range logic uses the GitHub newest-first order; `parse_version` is only used for *equality* (finding a release by version) and the single `latest_v <= current_v` guard. Do not reintroduce semver sorting of `-pre.N`.
+- **Public endpoint never 500s:** `get_release_notes` always returns a response (github or changelog). Keep the `try/except GitHubUnavailable` intact.
+- **Out of scope:** `get_commit_history`/`get_commit_diff` stay git-based; `apply_updates`/`launch_update_script`/`rollback` unchanged.
+- **Frontend is Plan 2:** API types, `react-markdown` rendering of `body_markdown`, removing the dev-channel UI, and i18n consume these contracts.
+```

--- a/docs/superpowers/plans/2026-06-06-update-page-github-releases-frontend.md
+++ b/docs/superpowers/plans/2026-06-06-update-page-github-releases-frontend.md
@@ -1,0 +1,633 @@
+# Update Page → GitHub Releases — Frontend Plan (Plan 2 of 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the update page's release notes + check changelog from the new curated **markdown** contracts (via `react-markdown`), show a "from CHANGELOG (offline)" hint, and remove the dead development-channel UI. Consumes the Plan-1 backend.
+
+**Architecture:** `UpdateOverviewTab` is a presentational component fed by `UpdatePage`. Swap its categorized-commit rendering for `<Markdown>{body_markdown}</Markdown>` blocks (same `prose` pattern as the manual `ArticleView`), drop the dev-update card/props, and mirror the reshaped API types.
+
+**Tech Stack:** React + TypeScript + Vite, `react-markdown` (already a dependency), Vitest.
+
+Spec: `docs/superpowers/specs/2026-06-06-update-page-github-releases-design.md`. Backend = Plan 1 (done).
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `client/src/api/updates.ts` | reshape `ReleaseNotesResponse` + `ReleaseNoteItem`; `ChangelogEntry.body_markdown`; extend `ReleaseInfo`; drop `UpdateCheckResponse.dev_*`, `DevUpdateStartRequest`, `startDevUpdate` |
+| `client/src/components/updates/UpdateOverviewTab.tsx` | markdown rendering; remove dev-channel UI + props; `source` hint |
+| `client/src/components/updates/UpdateHistoryTab.tsx` | releases list: drop now-empty `commit_short`, add GitHub link |
+| `client/src/pages/UpdatePage.tsx` | remove dev-update state/handlers/props |
+| `client/src/i18n/locales/{de,en}/updates.json` | `releaseNotes.fromChangelog` + `releaseNotes.viewOnGitHub` |
+| `client/src/__tests__/components/updates/UpdateOverviewTab.test.tsx` | NEW |
+
+---
+
+## Task 1: API types
+
+**Files:**
+- Modify: `client/src/api/updates.ts`
+
+- [ ] **Step 1: Reshape the release-notes + changelog + release types**
+
+In `client/src/api/updates.ts`:
+
+(a) Add `body_markdown` to `ChangelogEntry` (after `is_prerelease`):
+
+```typescript
+  body_markdown?: string | null;
+```
+
+(b) In `UpdateCheckResponse`, delete the four dev fields:
+
+```typescript
+  dev_version_available: boolean;
+  dev_version: VersionInfo | null;
+  dev_commits_ahead: number | null;
+  dev_commits: CommitInfo[];
+```
+
+(c) Delete the `DevUpdateStartRequest` interface and the `startDevUpdate` function (the
+`export async function startDevUpdate(...)` block).
+
+(d) Replace the `ReleaseNoteCategory` + `ReleaseNotesResponse` block with:
+
+```typescript
+export interface ReleaseNoteItem {
+  version: string;
+  date: string | null;
+  is_prerelease: boolean;
+  url: string | null;
+  body_markdown: string;
+}
+
+export interface ReleaseNotesResponse {
+  current_version: string;
+  since_version: string | null;
+  source: 'github' | 'changelog';
+  releases: ReleaseNoteItem[];
+}
+```
+
+(e) Extend `ReleaseInfo` (add fields, make `commit_short` nullable):
+
+```typescript
+export interface ReleaseInfo {
+  tag: string;
+  version: string;
+  date: string | null;
+  is_prerelease: boolean;
+  commit_short: string | null;
+  name: string | null;
+  html_url: string | null;
+  body_markdown: string | null;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: errors ONLY in `UpdateOverviewTab.tsx` / `UpdatePage.tsx` (they still reference the removed
+fields/functions) — those are fixed in Tasks 2 & 3. No errors in `updates.ts` itself.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/api/updates.ts
+git commit -m "feat(updates): mirror GitHub-releases contracts in the API client"
+```
+
+---
+
+## Task 2: UpdateOverviewTab — markdown rendering, drop dev UI
+
+**Files:**
+- Modify: `client/src/components/updates/UpdateOverviewTab.tsx`
+- Test: `client/src/__tests__/components/updates/UpdateOverviewTab.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/components/updates/UpdateOverviewTab.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import UpdateOverviewTab from '../../../components/updates/UpdateOverviewTab';
+import type { ReleaseNotesResponse } from '../../../api/updates';
+
+const t = (k: string) => k;
+
+const baseProps = {
+  t,
+  checkResult: null,
+  currentUpdate: null,
+  updateLoading: false,
+  rollbackLoading: false,
+  cancelLoading: false,
+  showUpdateConfirm: false,
+  onSetShowUpdateConfirm: vi.fn(),
+  onSetShowRollbackConfirm: vi.fn(),
+  onStartUpdate: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+function notes(source: 'github' | 'changelog'): ReleaseNotesResponse {
+  return {
+    current_version: '1.36.0',
+    since_version: '1.35.0',
+    source,
+    releases: [
+      { version: '1.36.0', date: null, is_prerelease: false, url: 'https://gh/r',
+        body_markdown: '### Added\n- Shiny new thing' },
+    ],
+  };
+}
+
+describe('UpdateOverviewTab release notes', () => {
+  it('renders the markdown body of each release', () => {
+    render(<UpdateOverviewTab {...baseProps} releaseNotes={notes('github')} />);
+    expect(screen.getByText('Shiny new thing')).toBeInTheDocument();
+    expect(screen.queryByText('releaseNotes.fromChangelog')).not.toBeInTheDocument();
+  });
+
+  it('shows the CHANGELOG offline hint when source is changelog', () => {
+    render(<UpdateOverviewTab {...baseProps} releaseNotes={notes('changelog')} />);
+    expect(screen.getByText('releaseNotes.fromChangelog')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd client && npx vitest run src/__tests__/components/updates/UpdateOverviewTab.test.tsx`
+Expected: FAIL — the component still reads `releaseNotes.categories` (type error / no markdown), and its
+props type still requires the dev props.
+
+- [ ] **Step 3: Replace `UpdateOverviewTab.tsx` entirely**
+
+Replace the **whole file** `client/src/components/updates/UpdateOverviewTab.tsx` with:
+
+```tsx
+import {
+  Download,
+  CheckCircle,
+  AlertTriangle,
+  GitBranch,
+  Clock,
+  Loader2,
+  Zap,
+  FileText,
+  Package,
+} from 'lucide-react';
+import Markdown from 'react-markdown';
+import type { UpdateCheckResponse, ReleaseNotesResponse } from '../../api/updates';
+import { isUpdateInProgress, type UpdateProgressResponse } from '../../api/updates';
+import UpdateProgress from './UpdateProgress';
+
+const PROSE =
+  'prose prose-invert prose-slate max-w-none prose-sm ' +
+  'prose-headings:text-white prose-h2:text-base prose-h3:text-sm ' +
+  'prose-p:text-slate-300 prose-li:text-slate-300 prose-strong:text-white ' +
+  'prose-a:text-blue-400 prose-code:text-cyan-400';
+
+interface UpdateOverviewTabProps {
+  t: (key: string, options?: Record<string, unknown>) => string;
+  checkResult: UpdateCheckResponse | null;
+  currentUpdate: UpdateProgressResponse | null;
+  releaseNotes: ReleaseNotesResponse | null;
+  updateLoading: boolean;
+  rollbackLoading: boolean;
+  cancelLoading: boolean;
+  showUpdateConfirm: boolean;
+  onSetShowUpdateConfirm: (show: boolean) => void;
+  onSetShowRollbackConfirm: (show: boolean) => void;
+  onStartUpdate: () => void;
+  onCancel: () => void;
+}
+
+export default function UpdateOverviewTab({
+  t,
+  checkResult,
+  currentUpdate,
+  releaseNotes,
+  updateLoading,
+  rollbackLoading,
+  cancelLoading,
+  showUpdateConfirm,
+  onSetShowUpdateConfirm,
+  onSetShowRollbackConfirm,
+  onStartUpdate,
+  onCancel,
+}: UpdateOverviewTabProps) {
+  return (
+    <div className="space-y-6">
+      {/* Current Update Progress */}
+      {currentUpdate && isUpdateInProgress(currentUpdate.status) && (
+        <UpdateProgress
+          progress={currentUpdate}
+          onRollback={() => onSetShowRollbackConfirm(true)}
+          rollbackLoading={rollbackLoading}
+          onCancel={onCancel}
+          cancelLoading={cancelLoading}
+        />
+      )}
+
+      {/* Version Info Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* Current Version */}
+        <div className="bg-slate-800 rounded-lg p-5 border border-slate-700">
+          <div className="flex items-center gap-2 mb-4">
+            <Package className="h-5 w-5 text-slate-400" />
+            <h3 className="font-medium text-white">{t('version.current')}</h3>
+          </div>
+          {checkResult && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <span className="text-3xl font-bold text-white">
+                  v{checkResult.current_version.version}
+                </span>
+                {checkResult.current_version.is_prerelease && (
+                  <span className="ml-2 inline-flex items-center rounded-md bg-amber-500/20 px-2 py-0.5 text-xs font-medium text-amber-300">
+                    {t('preRelease.badge')}
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2 text-sm text-slate-400">
+                <GitBranch className="h-4 w-4" />
+                <span className="font-mono">{checkResult.current_version.commit_short}</span>
+                {checkResult.current_version.tag && (
+                  <span className="px-2 py-0.5 bg-slate-700 rounded text-xs">
+                    {checkResult.current_version.tag}
+                  </span>
+                )}
+              </div>
+              {checkResult.current_version.is_dev_build ? (
+                <div className="flex items-center gap-2 text-sm">
+                  <span className="px-2 py-0.5 bg-amber-500/20 text-amber-400 rounded text-xs font-medium">
+                    {t('version.devBuild')}
+                  </span>
+                </div>
+              ) : !checkResult.current_version.is_prerelease ? (
+                <div className="flex items-center gap-2 text-sm">
+                  <span className="text-emerald-400">{t('version.stable')}</span>
+                </div>
+              ) : null}
+            </div>
+          )}
+        </div>
+
+        {/* Available Update */}
+        <div
+          className={`bg-slate-800 rounded-lg p-5 border ${
+            checkResult?.update_available ? 'border-blue-500/50 bg-blue-500/5' : 'border-slate-700'
+          }`}
+        >
+          <div className="flex items-center gap-2 mb-4">
+            {checkResult?.update_available ? (
+              <Zap className="h-5 w-5 text-blue-400" />
+            ) : (
+              <CheckCircle className="h-5 w-5 text-emerald-400" />
+            )}
+            <h3 className="font-medium text-white">
+              {checkResult?.update_available ? t('version.available') : t('version.upToDate')}
+            </h3>
+          </div>
+          {checkResult?.update_available && checkResult.latest_version ? (
+            <div className="space-y-3">
+              <div className="text-3xl font-bold text-blue-400">
+                v{checkResult.latest_version.version}
+              </div>
+              {checkResult.last_checked && (
+                <div className="flex items-center gap-2 text-xs text-slate-500">
+                  <Clock className="h-3 w-3" />
+                  {t('version.lastChecked')} {new Date(checkResult.last_checked).toLocaleString()}
+                </div>
+              )}
+            </div>
+          ) : (
+            <p className="text-slate-400">{t('version.upToDateDesc')}</p>
+          )}
+        </div>
+      </div>
+
+      {/* Blockers Warning */}
+      {checkResult?.blockers && checkResult.blockers.length > 0 && (
+        <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="h-5 w-5 text-amber-400 mt-0.5" />
+            <div>
+              <h4 className="font-medium text-amber-400">{t('blockers.title')}</h4>
+              <ul className="mt-2 space-y-1 text-sm text-slate-300">
+                {checkResult.blockers.map((blocker, i) => (
+                  <li key={i}>• {blocker}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Release Notes (markdown, since last stable) */}
+      {releaseNotes && releaseNotes.releases.length > 0 && (
+        <div className="bg-slate-800 rounded-lg p-5 border border-slate-700">
+          <div className="flex flex-wrap items-center gap-3 mb-1">
+            <FileText className="h-5 w-5 text-blue-400" />
+            <h3 className="font-medium text-white">{t('releaseNotes.title')}</h3>
+            <span className="text-sm font-mono text-slate-400">v{releaseNotes.current_version}</span>
+            {releaseNotes.source === 'changelog' && (
+              <span className="text-xs text-amber-400/80">{t('releaseNotes.fromChangelog')}</span>
+            )}
+          </div>
+          {releaseNotes.since_version && (
+            <p className="text-sm text-slate-500 mb-4 ml-8">
+              {t('releaseNotes.since', { version: releaseNotes.since_version })}
+            </p>
+          )}
+          <div className="space-y-5 ml-8">
+            {releaseNotes.releases.map((r) => (
+              <div key={r.version}>
+                <div className="flex flex-wrap items-center gap-2 mb-1">
+                  <span className="font-medium text-white">v{r.version}</span>
+                  {r.is_prerelease && (
+                    <span className="px-2 py-0.5 bg-amber-500/20 text-amber-400 text-xs rounded">
+                      {t('preRelease.badge')}
+                    </span>
+                  )}
+                  {r.date && (
+                    <span className="text-xs text-slate-500">
+                      {new Date(r.date).toLocaleDateString()}
+                    </span>
+                  )}
+                  {r.url && (
+                    <a
+                      href={r.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-blue-400 hover:underline"
+                    >
+                      {t('releaseNotes.viewOnGitHub')}
+                    </a>
+                  )}
+                </div>
+                <div className={PROSE}>
+                  <Markdown>{r.body_markdown}</Markdown>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Changelog (what an update brings) */}
+      {checkResult?.update_available && checkResult.changelog.length > 0 && (
+        <div className="bg-slate-800 rounded-lg p-5 border border-slate-700">
+          <h3 className="font-medium text-white mb-4">{t('changelog.title')}</h3>
+          <div className="space-y-4">
+            {checkResult.changelog.map((entry, i) => (
+              <div key={i} className="border-l-2 border-blue-500/50 pl-4">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="font-medium text-white">v{entry.version}</span>
+                  {entry.is_prerelease && (
+                    <span className="px-2 py-0.5 bg-amber-500/20 text-amber-400 text-xs rounded">
+                      {t('changelog.prerelease')}
+                    </span>
+                  )}
+                </div>
+                {entry.body_markdown && (
+                  <div className={PROSE}>
+                    <Markdown>{entry.body_markdown}</Markdown>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Update Button */}
+      {checkResult?.update_available && (
+        <div className="flex justify-end gap-3">
+          {!showUpdateConfirm ? (
+            <button
+              onClick={() => onSetShowUpdateConfirm(true)}
+              disabled={!checkResult.can_update || updateLoading || !!currentUpdate}
+              className="flex items-center gap-2 px-6 py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-slate-700 disabled:text-slate-500 text-white rounded-lg transition-all touch-manipulation active:scale-95 font-medium"
+            >
+              <Download className="h-5 w-5" />
+              {t('buttons.updateTo', { version: checkResult.latest_version?.version })}
+            </button>
+          ) : (
+            <div className="flex items-center gap-3 p-3 bg-slate-700 rounded-lg">
+              <span className="text-sm text-slate-300">{t('buttons.confirmUpdate')}</span>
+              <button
+                onClick={onStartUpdate}
+                disabled={updateLoading}
+                className="px-4 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded text-sm transition-all touch-manipulation active:scale-95"
+              >
+                {updateLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : t('buttons.yesUpdate')}
+              </button>
+              <button
+                onClick={() => onSetShowUpdateConfirm(false)}
+                className="px-4 py-1.5 bg-slate-600 hover:bg-slate-500 text-white rounded text-sm transition-all touch-manipulation active:scale-95"
+              >
+                {t('common:cancel')}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd client && npx vitest run src/__tests__/components/updates/UpdateOverviewTab.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/updates/UpdateOverviewTab.tsx client/src/__tests__/components/updates/UpdateOverviewTab.test.tsx
+git commit -m "feat(updates): render release notes as markdown; drop dev-channel UI"
+```
+
+---
+
+## Task 3: UpdatePage — remove dev-update wiring
+
+**Files:**
+- Modify: `client/src/pages/UpdatePage.tsx`
+
+- [ ] **Step 1: Drop the `startDevUpdate` import**
+
+In `client/src/pages/UpdatePage.tsx`, remove `startDevUpdate,` from the
+`from '../api/updates'` import block.
+
+- [ ] **Step 2: Remove the dev state**
+
+Delete these two state lines:
+
+```typescript
+  const [showDevUpdateConfirm, setShowDevUpdateConfirm] = useState(false);
+  const [devUpdateLoading, setDevUpdateLoading] = useState(false);
+```
+
+- [ ] **Step 3: Remove the `handleStartDevUpdate` handler**
+
+Delete the entire `// Start dev update` / `const handleStartDevUpdate = async () => { ... };` block.
+
+- [ ] **Step 4: Remove the dev props from `<UpdateOverviewTab>`**
+
+In the `<UpdateOverviewTab ... />` render, delete these four props:
+
+```tsx
+          devUpdateLoading={devUpdateLoading}
+          showDevUpdateConfirm={showDevUpdateConfirm}
+          onSetShowDevUpdateConfirm={setShowDevUpdateConfirm}
+          onStartDevUpdate={handleStartDevUpdate}
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: PASS (no errors anywhere now).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/pages/UpdatePage.tsx
+git commit -m "refactor(updates): remove dev-channel update wiring from UpdatePage"
+```
+
+---
+
+## Task 4: i18n keys
+
+**Files:**
+- Modify: `client/src/i18n/locales/de/updates.json`
+- Modify: `client/src/i18n/locales/en/updates.json`
+
+- [ ] **Step 1: Add the two new keys to the `releaseNotes` object (German)**
+
+In `client/src/i18n/locales/de/updates.json`, inside the existing `"releaseNotes"` object (next to its
+`"since"` key), add:
+
+```json
+    "fromChangelog": "aus CHANGELOG (offline)",
+    "viewOnGitHub": "Auf GitHub ansehen"
+```
+
+- [ ] **Step 2: Add them in English**
+
+In `client/src/i18n/locales/en/updates.json`, inside `"releaseNotes"`:
+
+```json
+    "fromChangelog": "from CHANGELOG (offline)",
+    "viewOnGitHub": "View on GitHub"
+```
+
+- [ ] **Step 3: Validate JSON**
+
+Run:
+```bash
+cd client && node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/de/updates.json','utf8')); JSON.parse(require('fs').readFileSync('src/i18n/locales/en/updates.json','utf8')); console.log('OK')"
+```
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/i18n/locales/de/updates.json client/src/i18n/locales/en/updates.json
+git commit -m "i18n(updates): release-notes source hint + GitHub link (de/en)"
+```
+
+---
+
+## Task 5: UpdateHistoryTab — releases list (GitHub link, null-safe)
+
+**Files:**
+- Modify: `client/src/components/updates/UpdateHistoryTab.tsx`
+
+> Context: the releases list now comes from GitHub, so `commit_short` is usually `null` (React renders
+> it as empty — no crash, but a dangling empty span). Replace it with a "View on GitHub" link.
+
+- [ ] **Step 1: Replace the release row's left block**
+
+In `client/src/components/updates/UpdateHistoryTab.tsx`, find:
+
+```tsx
+                <div className="flex items-center gap-3">
+                  <span className="font-mono text-white">{release.tag}</span>
+                  <span className="font-mono text-xs text-slate-500">{release.commit_short}</span>
+                </div>
+```
+
+and replace it with:
+
+```tsx
+                <div className="flex items-center gap-3">
+                  <span className="font-mono text-white">{release.tag}</span>
+                  {release.html_url && (
+                    <a
+                      href={release.html_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-blue-400 hover:underline"
+                    >
+                      {t('releaseNotes.viewOnGitHub')}
+                    </a>
+                  )}
+                </div>
+```
+
+(`releaseNotes.viewOnGitHub` was added in Task 4 and lives in the same `updates` namespace.)
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/components/updates/UpdateHistoryTab.tsx
+git commit -m "feat(updates): releases list links to GitHub (commit_short now nullable)"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Run the new test + full vitest suite**
+
+Run: `cd client && npx vitest run`
+Expected: all green (incl. the new `UpdateOverviewTab.test.tsx`).
+
+- [ ] **Step 2: Production build (type-check)**
+
+Run: `cd client && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Manual smoke (dev)**
+
+1. `python start_dev.py`, login as admin → Updates page → Overview.
+2. Release Notes card shows the dev backend's **markdown** body (a "Added" heading + bullet), no
+   category icons, no "Install dev version" button.
+3. (Against the public repo / prod) the notes show GitHub bodies since the last stable; if GitHub is
+   blocked, a "from CHANGELOG (offline)" hint appears.
+
+- [ ] **Step 4: No commit** (verification only).
+
+---
+
+## Notes for the implementer
+
+- **`react-markdown`** is already a dependency (used by the manual `ArticleView` as `import Markdown from 'react-markdown'`). No raw-HTML plugin → GitHub bodies render safely.
+- The dev-channel i18n strings (`version.devVersionAvailable`, `version.devCommitsAhead`, `version.devWarning`, `buttons.installDevVersion`, `buttons.confirmDevInstall`, `toast.devUpdateStarted`) become unused after this change — leave them (harmless) unless asked to prune.
+- `commit_short` on the latest version may be an empty string from the GitHub path — the Available card no longer renders it, so no "undefined" leaks.
+- The `'development'` value stays in the `UpdateChannel` TS union (matches the backend enum kept for config compatibility); only the dev-*update* path is gone.
+```

--- a/docs/superpowers/specs/2026-06-06-update-page-github-releases-design.md
+++ b/docs/superpowers/specs/2026-06-06-update-page-github-releases-design.md
@@ -1,0 +1,192 @@
+# Update Page → GitHub Releases — Design Spec
+
+**Date:** 2026-06-06
+**Status:** Approved
+**Author:** Sven (Xveyn) + Claude (via brainstorming session)
+**Branch:** `feat/update-page-github-releases`
+
+## Problem
+
+The self-hosted update mechanism (`backend/app/services/update/`) derives "what's new" entirely
+from **local git tags + commit subjects**: `get_release_notes()` shows the commits between the
+current tag and the immediately-preceding tag, `check_for_updates()` finds the highest semver tag and
+builds a changelog from raw commit messages, `get_all_releases()` lists git tags.
+
+The release/deploy flow changed (2026-05): **every merge to `main` now creates a `v<x.y.z>-pre.<n>`
+tag + a GitHub pre-release**, and stable releases are cut via `release-stable.yml`. Consequences:
+
+- `get_release_notes()`'s "previous tag" is almost always the prior `…-pre.(n-1)`, so the notes shrink
+  to a **single PR's commits** instead of meaningful "what changed since the last stable".
+- The new flow generates **curated CHANGELOG sections + GitHub Release `body`s** (the real, readable
+  notes), which the update page ignores in favour of raw commit subjects.
+- `check_dev_branch()` / `start_dev_update()` query `origin/development`, but the `development` branch
+  was **retired 2026-05-06** — dead code.
+- Channel handling is inconsistent (`check` filters pre-releases, `release-notes` does not).
+
+## Goal
+
+Make **GitHub Releases** the single source for the update page's "Neuerungen", the "update available?"
+check, and the releases list. The actual update (checkout/migrate/restart) stays git/systemd.
+
+## Decisions (from brainstorming)
+
+| Topic | Decision |
+|---|---|
+| Scope | GitHub Releases becomes the source for **release-notes + check + releases list**; git only applies updates |
+| "Neuerungen" content | **Since the last stable release** (rolls pre-release noise into one block) |
+| Fallback (GitHub down / rate-limited) | Parse the bundled **`CHANGELOG.md`** |
+| Dead `development` logic | **Remove** `start-dev` / `check_dev_branch` / `start_dev_update` + UI |
+| Repo | Public (`Xveyn/BaluHost`) → GitHub API **without token**; cache against the 60/h rate limit |
+
+## Architecture
+
+```
+GitHub Releases API  (GET /repos/{repo}/releases?per_page=100, public, no token)
+        │  httpx (5s timeout, UA + Accept headers), per-worker in-memory TTL cache (~15 min)
+        ▼
+services/update/github_releases.py   (NEW)
+  - list_releases()           -> [GitHubRelease{tag, name, body_md, prerelease, published_at, url}]
+  - latest_for_channel(ch)    -> highest-semver release (stable: prerelease=false; unstable: any)
+  - notes_since_last_stable(up_to)  -> [release bodies in (last_stable, up_to], newest first]
+        │  on httpx error / 403 rate-limit / 4xx-5xx  →  CHANGELOG.md parser (NEW)
+        ▼
+ProdUpdateBackend (reworked)
+  - get_release_notes()  -> notes since last stable, up to CURRENT          (source: github|changelog)
+  - check_for_updates()  -> latest = latest_for_channel; changelog = notes (current, latest]
+  - get_all_releases()   -> from GitHub releases (was git tags)
+  - apply_updates/rollback/launch_update_script  -> UNCHANGED (git/systemd)
+  - get_commit_history/get_commit_diff           -> UNCHANGED (git; dev Versions tab, out of scope)
+  - check_dev_branch / start_dev_update          -> REMOVED
+DevUpdateBackend -> mock returns GitHub-release-shaped markdown notes
+```
+
+**Core idea:** one source (GitHub Releases) for *display + availability*; git/systemd only *apply*.
+The repo is configurable via a new setting so forks/tests can override it.
+
+## Components
+
+### New
+
+| File | Purpose |
+|---|---|
+| `backend/app/services/update/github_releases.py` | httpx GitHub Releases client + TTL cache + `latest_for_channel` / `notes_since_last_stable` |
+| `backend/app/services/update/changelog_fallback.py` | Parse bundled `CHANGELOG.md` → release-note items since last stable |
+| `backend/tests/services/test_github_releases.py`, `test_changelog_fallback.py` | Unit tests (mocked httpx, no network) |
+
+### Modified
+
+| File | Change |
+|---|---|
+| `backend/app/services/update/prod_backend.py` | `get_release_notes`/`check_for_updates`/`get_all_releases` delegate to the GitHub client; remove `check_dev_branch` |
+| `backend/app/services/update/dev_backend.py` | mock returns markdown notes (`body_markdown`); drop `check_dev_branch` |
+| `backend/app/services/update/backend.py` | drop `check_dev_branch` from the abstract interface |
+| `backend/app/services/update/service.py` | remove `start_dev_update` |
+| `backend/app/api/routes/updates.py` | remove `POST /updates/start-dev` |
+| `backend/app/schemas/update.py` | reshape `ReleaseNotesResponse`; add `body_markdown` to `ChangelogEntry`; extend `ReleaseInfo`; drop `DevUpdateStartRequest` |
+| `backend/app/core/config.py` | `update_github_repo` (default `Xveyn/BaluHost`), `update_changelog_path` (default repo-root `CHANGELOG.md`) |
+| `client/src/api/updates.ts` | mirror schema changes |
+| `client/src/components/updates/*` | render `body_markdown` via `react-markdown`; `source` hint; remove dev-channel UI |
+| `client/src/i18n/locales/{de,en}/updates.json` | `source.changelogFallback` (+ remove dev-channel strings) |
+
+## Semantics
+
+**Channel mapping:** `stable` → releases with `prerelease=false`; `unstable` → all releases.
+**Latest available (check):** highest-semver release in the active channel (tag via existing `parse_version`).
+
+**"Since last stable" — two distinct computations** (each aggregates the curated release `body`s,
+newest first, one block per release with a version header):
+
+| Display | Range |
+|---|---|
+| `/release-notes` (Neuerungen of the running version) | release bodies in **(last stable below `current`, `current`]** |
+| `/check` changelog (what an update brings) | release bodies in **(`current`, `latest`]** |
+
+## Schemas (`backend/app/schemas/update.py`)
+
+```python
+class ReleaseNoteItem(BaseModel):
+    version: str
+    date: datetime | None = None
+    is_prerelease: bool = False
+    url: str | None = None
+    body_markdown: str = ""
+
+class ReleaseNotesResponse(BaseModel):           # reshaped
+    current_version: str
+    since_version: str | None = None             # the last stable the notes start from
+    source: Literal["github", "changelog"] = "github"
+    releases: list[ReleaseNoteItem] = []
+
+# ChangelogEntry: + body_markdown: str | None = None   (changes/breaking_changes kept, not populated here)
+# ReleaseInfo:    + name: str | None, + html_url: str | None, + body_markdown: str | None ;
+#                 commit_short becomes Optional (GitHub release has no short hash)
+# DevUpdateStartRequest: removed
+```
+
+## Caching, Fallback & Errors
+
+- **Cache:** per-worker in-memory TTL (~15 min) on the releases list. 4 workers × 4 windows/h ≈ ≤16
+  calls/h — well under 60/h. (Deliberately no DB/SHM sharing — YAGNI.)
+- **GitHub client:** `httpx` async, 5s timeout, headers `User-Agent: BaluHost` + `Accept:
+  application/vnd.github+json`; one page `per_page=100`.
+- **Fallback → `CHANGELOG.md`** on timeout / network error / HTTP 403 (rate limit) / 4xx-5xx: a small
+  parser reads the `## [x.y.z] - date` sections and returns the section(s) since the last stable as
+  markdown, `source="changelog"`. Degraded mode (CHANGELOG mainly has stable entries → a pre-release
+  box shows the last stable section offline — better than empty).
+- **Error invariants:**
+  - `/release-notes` (public, no auth) **never 500s** — total failure → `releases=[]`,
+    `source="changelog"`.
+  - `/check` (admin) degrades the same way; never a hard error.
+  - The `source` flag reaches the frontend so it can show a subtle "from CHANGELOG (offline)" note.
+
+## Frontend
+
+- `client/src/api/updates.ts` — mirror the schema changes (`ReleaseNoteItem`, reshaped
+  `ReleaseNotesResponse`, `ChangelogEntry.body_markdown?`, extended `ReleaseInfo`).
+- Release-notes display (`components/updates/`) — render each `release` block: version header + date +
+  Pre-Release badge (exists) + `<Markdown>{body_markdown}</Markdown>` with the existing `prose`
+  classes (same pattern as the manual `ArticleView`). Subtle "from CHANGELOG (offline)" hint when
+  `source === 'changelog'`; optional link to `url`.
+- Check changelog and releases list render `body_markdown` the same way (releases list collapsible +
+  `html_url`).
+- Remove the "Update from development" / dev-channel UI.
+- `react-markdown` renders **no raw HTML** (no `rehype-raw`) → GitHub bodies are safe.
+
+## Out of Scope
+
+- The git/systemd **apply/rollback** path (`apply_updates`, `launch_update_script`, `run-update.sh`).
+- `get_commit_history` / `get_commit_diff` (dev-only Versions tab; remain git-based).
+- The release/deploy **workflows** themselves (already in their final form).
+
+## Tests
+
+**Backend:**
+- `github_releases.py`: JSON→models; channel filter; `latest_for_channel`; `notes_since_last_stable`
+  aggregation; TTL cache hit/miss; fallback to CHANGELOG on httpx error/403. httpx mocked
+  (monkeypatch/`respx`) — no real network.
+- `changelog_fallback.py`: extracts the section(s) since the last stable correctly.
+- `prod_backend`: `get_release_notes` (since-last-stable up to current), `check_for_updates`
+  (current→latest), `get_all_releases` against a mocked GitHub client.
+- `dev_backend`: returns markdown notes; existing update tests stay green.
+
+**Frontend:** Vitest — the release-notes component renders `body_markdown` (react-markdown) and shows
+the `source==='changelog'` hint; types compile.
+
+## Manual Smoke (dev + prod)
+
+1. Dev: update page shows the mock markdown notes; no dev-channel button.
+2. Prod (or against the public repo): release notes show the aggregated GitHub bodies **since the last
+   stable**; `/check` shows the delta to latest for the active channel.
+3. Simulate GitHub failure (block the host / force 403) → notes fall back to CHANGELOG with the
+   "offline" hint; no 500.
+4. Switch channel stable↔unstable → latest/available and the notes range adjust accordingly.
+
+## Build Order
+
+1. Config (`update_github_repo`, `update_changelog_path`) + schema reshape.
+2. `github_releases.py` client + cache (TDD).
+3. `changelog_fallback.py` parser (TDD).
+4. Rework `prod_backend` (`get_release_notes`/`check_for_updates`/`get_all_releases`) + `dev_backend`.
+5. Remove dead `development` logic (backend + route + schema).
+6. Frontend: API types, markdown rendering, remove dev-channel UI, i18n.
+7. Tests green (backend + frontend), smoke.


### PR DESCRIPTION
## Was

Die Update-Page liest „Neuerungen", den „Update verfügbar?"-Check und die Releases-Liste jetzt aus **GitHub Releases** (kuratierte Markdown-Bodies) statt aus rohen git-Commit-Betreffzeilen zwischen Tags. Git/systemd bleibt fürs eigentliche Anwenden (Checkout/Migrate/Restart).

## Warum

Der Release-Flow erzeugt seit Mai 2025 pro Merge ein `v<x.y.z>-pre.<n>`-Tag + GitHub-Pre-Release. Die alte tag-basierte Logik zeigte dadurch nur noch die Commits **eines einzigen PRs** („previous tag" = das vorige Pre-Release) und ignorierte die kuratierten CHANGELOG-/Release-Notes. Zudem zeigte sie auf den **stillgelegten `development`-Branch**.

## Entscheidungen (aus dem Brainstorming)

- **Quelle:** GitHub Releases für Neuerungen + Check + Releases-Liste.
- **Inhalt:** „seit letztem Stable" (rollt die Pre-Release-Zwischenschritte zu einem Block zusammen).
- **Fallback:** gebündelte `CHANGELOG.md` bei GitHub-Ausfall/Rate-Limit; `source`-Flag fürs UI.
- **Cleanup:** totes `development` (start-dev / check_dev_branch / Dev-Channel-UI) entfernt.
- Repo public → **kein Token**; 15-min-TTL-Cache gegen das 60/h-Limit.

Spec: `docs/superpowers/specs/2026-06-06-update-page-github-releases-design.md`
Pläne: `docs/superpowers/plans/2026-06-06-update-page-github-releases-{backend,frontend}.md`

## Backend (Plan 1)

- `services/update/github_releases.py` — httpx-Client (TTL-Cache, `GitHubUnavailable`) + **positionale** Helfer (`since-last-stable`, `latest_for_channel`, `releases_between`) — umgeht die `-pre.N`-Ordering-Falle.
- `services/update/changelog_fallback.py` — CHANGELOG-Parser (`## [x.y.z] - date`).
- `ProdUpdateBackend` liest notes/check/releases über GitHub mit CHANGELOG-Fallback; `DevUpdateBackend` liefert Markdown-Mock.
- Settings `update_github_repo` / `update_changelog_path`; Schemas auf Markdown umgestellt (`ReleaseNoteItem`, `body_markdown`).
- Dead-`development`-Logik raus; `_run_dev_update` (vom normalen `start_update` genutzt) erhalten.

## Frontend (Plan 2)

- `UpdateOverviewTab` rendert Release-Notes + Changelog als **Markdown** (`react-markdown`, vorhandenes `prose`-Muster), „aus CHANGELOG (offline)"-Hinweis, GitHub-Links; Dev-Channel-Karte entfernt.
- `UpdatePage`/`UpdateHistoryTab`/`api/updates.ts` entsprechend angepasst (Dev-Wiring raus, `commit_short` nullable → GitHub-Link), i18n DE/EN.

## Tests & Review

- **Backend:** 19 neue + 53 bestehende Tests grün; **8 Invarianten** unabhängig belegt (public-Endpoint nie 500, positionale Ranges, `_run_dev_update` erhalten, keine kaputten Caller, httpx gemockt). Zwei latente Schwachstellen (non-numerische CHANGELOG-Header → 500; `releases_between` open-ended) direkt **abgehärtet + getestet**.
- **Frontend:** Vitest 408 grün, Build grün, Markdown safe (kein `rehype-raw`).
- Backend **und** Frontend je zweistufig (Spec + Korrektheit/Security) durch unabhängige Subagents → **APPROVED**.

## Hinweise

- `get_commit_history`/`get_commit_diff` (Dev-Versions-Tab) bleiben git-basiert (out of scope).
- `'development'` bleibt im Channel-Enum (Config-Kompatibilität); nur der Dev-*Update*-Pfad ist weg.
- Ungenutzte Dev-i18n-Strings bewusst belassen (harmlos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
