### PR TITLE
docs(readme): fix broken documentation links (#178)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ npm run dev
 
 ### Production Deployment
 
-See [Production Quickstart](docs/deployment/PRODUCTION_QUICKSTART.md) for full instructions.
+See [Production Quickstart](docs/deployment/PRODUCTION_QUICKSTART.en.md) for full instructions.
 
 ```bash
 # Fresh install (modular installer)
@@ -172,7 +172,7 @@ push to main → CI checks (GitHub-hosted) → Deploy (self-hosted on NAS)
                                             └── Health check (auto-rollback on failure)
 ```
 
-See [Infrastructure](docs/deployment/infrastructure.md) and [Emergency Runbook](docs/deployment/emergency-runbook.md) for operational details.
+See [Infrastructure](docs/deployment/infrastructure.en.md) and [Emergency Runbook](docs/deployment/emergency-runbook.en.md) for operational details.
 
 ---
 
@@ -298,14 +298,16 @@ npm run build         # Type-check + production build
 |----------|-------------|
 | [Technical Documentation](docs/TECHNICAL_DOCUMENTATION.md) | Complete feature reference |
 | [Architecture](docs/ARCHITECTURE.md) | System design & patterns |
-| [Production Readiness](docs/deployment/PRODUCTION_READINESS.md) | Deployment checklist |
-| [Production Quickstart](docs/deployment/PRODUCTION_QUICKSTART.md) | Getting started in prod |
-| [User Guide](docs/getting-started/USER_GUIDE.md) | End-user manual |
-| [API Reference](docs/api/API_REFERENCE.md) | Full API documentation |
-| [Security Policy](docs/security/SECURITY.md) | Security guidelines |
+| [Production Readiness](docs/deployment/PRODUCTION_READINESS.en.md) | Deployment checklist |
+| [Production Quickstart](docs/deployment/PRODUCTION_QUICKSTART.en.md) | Getting started in prod |
+| [User Guide](docs/getting-started/USER_GUIDE.en.md) | End-user manual |
+| [API Reference](docs/api/API_REFERENCE.en.md) | Full API documentation |
+| [Security Policy](docs/security/SECURITY.en.md) | Security guidelines |
 | [Contributing](CONTRIBUTING.md) | Contribution workflow |
 | [Changelog](CHANGELOG.md) | Version history |
 | [TODO](TODO.md) | Roadmap |
+
+<sub>Most docs under `docs/` exist in English (`.en.md`) and German (`.de.md`) — swap the suffix for the other language.</sub>
 
 ```
 docs/


### PR DESCRIPTION
## Was

Behebt die toten Doku-Links in der `README.md` (Issue #178).

Die Doku-Tabelle und der Deployment-Abschnitt verlinkten auf einfache `.md`-Dateien, die im Repo nur als sprachsuffigierte `.de.md`/`.en.md`-Paare existieren — dadurch liefen ~8 Links im GitHub-UI auf 404.

## Änderung

- Links auf die `.en.md`-Variante umgestellt (README ist englisch):
  - `PRODUCTION_QUICKSTART`, `infrastructure`, `emergency-runbook`, `PRODUCTION_READINESS`, `USER_GUIDE`, `API_REFERENCE`, `SECURITY`
- Einsprachige Docs (`TECHNICAL_DOCUMENTATION.md`, `ARCHITECTURE.md`) und Root-Dateien (`CONTRIBUTING.md`, `CHANGELOG.md`, `TODO.md`) waren bereits korrekt — unverändert.
- Kurzhinweis unter der Tabelle ergänzt, dass es zu den meisten Docs auch eine deutsche `.de.md`-Variante gibt.

## Verifikation

Alle lokalen Links in `README.md` per `Test-Path` geprüft → **13/13 OK**, kein toter Link mehr.

## Bewusst nicht enthalten

Der im Issue vorgeschlagene CI-Link-Checker (z. B. `lychee`) ist eine CI-Änderung und damit Folgearbeit — dieser PR beschränkt sich auf die reine Doku-Korrektur.

Closes #178
