### PR TITLE
feat(activity): dashboard activity feed own-vs-all + close file-access/stats leak

### DIFF
--- a/backend/app/api/routes/activity.py
+++ b/backend/app/api/routes/activity.py
@@ -1,7 +1,7 @@
 """File activity tracking API endpoints."""
 import logging
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from sqlalchemy.orm import Session
@@ -36,7 +36,7 @@ async def get_recent_activities(
     file_type: Optional[str] = None,
     since: Optional[datetime] = None,
     path_prefix: Optional[str] = None,
-    scope: str = "mine",
+    scope: Literal["mine", "all"] = "mine",
     user: UserPublic = Depends(deps.get_current_user),
     db: Session = Depends(get_db),
 ) -> ActivityListResponse:

--- a/backend/app/api/routes/activity.py
+++ b/backend/app/api/routes/activity.py
@@ -18,6 +18,7 @@ from app.schemas.file_activity import (
 )
 from app.schemas.user import UserPublic
 from app.services.file_activity import FileActivityService
+from app.services.permissions import is_privileged
 
 logger = logging.getLogger(__name__)
 
@@ -35,10 +36,11 @@ async def get_recent_activities(
     file_type: Optional[str] = None,
     since: Optional[datetime] = None,
     path_prefix: Optional[str] = None,
+    scope: str = "mine",
     user: UserPublic = Depends(deps.get_current_user),
     db: Session = Depends(get_db),
 ) -> ActivityListResponse:
-    """Get recent file activities for the current user.
+    """Get recent file activities.
 
     Args:
         limit: Max items (1-100, default 20).
@@ -47,9 +49,15 @@ async def get_recent_activities(
         file_type: Filter by type: file, directory, image, video, document.
         since: ISO timestamp — only activities after this time.
         path_prefix: Only activities within this directory.
+        scope: ``mine`` (own activity, default) or ``all`` (admin only — every
+            user's activity, with the acting username populated).
     """
     limit = max(1, min(limit, 100))
     offset = max(0, offset)
+
+    all_users = scope == "all"
+    if all_users and not is_privileged(user):
+        raise HTTPException(status_code=403, detail="Admin access required")
 
     parsed_types: Optional[List[str]] = None
     if action_types:
@@ -64,6 +72,7 @@ async def get_recent_activities(
         file_type=file_type,
         since=since,
         path_prefix=path_prefix,
+        all_users=all_users,
     )
 
     return ActivityListResponse(

--- a/backend/app/api/routes/logging.py
+++ b/backend/app/api/routes/logging.py
@@ -178,7 +178,7 @@ async def get_file_access_logs(
         limit: Maximum number of logs to return (default: 100)
         days: Number of days to look back (default: 1)
         action: Filter by action type (optional)
-        user: Filter by username (optional)
+        user: Filter by username (optional). For non-privileged callers this is always overridden to the caller's own username.
         current_user: Current authenticated user
         db: Database session
 
@@ -204,6 +204,8 @@ async def get_file_access_logs(
     # In dev mode, if no real logs exist, return mock data
     if settings.is_dev_mode and len(logs) == 0:
         mock_logs = _generate_mock_file_access_logs(days=days, limit=limit)
+        if not is_privileged(current_user):
+            mock_logs = [m for m in mock_logs if m["user"] == current_user.username]
         return {"dev_mode": True, "total": len(mock_logs), "logs": mock_logs}
 
     return {"dev_mode": settings.is_dev_mode, "total": len(logs), "logs": logs}

--- a/backend/app/api/routes/logging.py
+++ b/backend/app/api/routes/logging.py
@@ -231,13 +231,18 @@ async def get_logging_stats(
     Returns:
         Statistics about disk I/O and file access
     """
-    # Get audit logs from database
+    # Non-admins only see statistics derived from their own activity.
+    scoped_user = None if is_privileged(current_user) else current_user.username
     audit = get_audit_logger_db()
-    logs = audit.get_logs(limit=10000, event_type="FILE_ACCESS", days=days, db=db)
+    logs = audit.get_logs(
+        limit=10000, event_type="FILE_ACCESS", user=scoped_user, days=days, db=db
+    )
 
     # If no real logs exist in dev mode, return mock statistics
     if settings.is_dev_mode and len(logs) == 0:
         mock_logs = _generate_mock_file_access_logs(days=days, limit=100)
+        if scoped_user is not None:
+            mock_logs = [m for m in mock_logs if m["user"] == scoped_user]
         total_ops = len(mock_logs)
         by_action = {}
         by_user = {}

--- a/backend/app/api/routes/logging.py
+++ b/backend/app/api/routes/logging.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user, get_db
+from app.services.permissions import is_privileged
 from app.core.config import settings
 from app.schemas.user import UserPublic
 from app.schemas.audit_log import AuditLogResponse
@@ -184,6 +185,11 @@ async def get_file_access_logs(
     Returns:
         File access log entries
     """
+    # Non-admins may only ever see their own file-access entries — prevent the
+    # widget (and any direct caller) from reading other users' paths/usernames.
+    if not is_privileged(current_user):
+        user = current_user.username
+
     # Get audit logs from database
     audit = get_audit_logger_db()
     logs = audit.get_logs(

--- a/backend/app/schemas/file_activity.py
+++ b/backend/app/schemas/file_activity.py
@@ -33,6 +33,8 @@ class ActivityItem(BaseModel):
     """Single activity entry in API responses."""
 
     id: int
+    user_id: int
+    username: Optional[str] = None
     action_type: str
     file_path: str
     file_name: str

--- a/backend/app/services/file_activity.py
+++ b/backend/app/services/file_activity.py
@@ -17,6 +17,7 @@ from sqlalchemy import desc, func, and_, delete
 from sqlalchemy.orm import Session
 
 from app.models.file_activity import FileActivity
+from app.models.user import User
 from app.schemas.file_activity import (
     VALID_ACTION_TYPES,
     SHORT_RETENTION_ACTIONS,
@@ -144,12 +145,11 @@ class FileActivityService:
         """Query recent activities.
 
         When ``all_users`` is True, returns activities across every user and
-        populates ``ActivityItem.username`` (admin view). Otherwise scoped to
-        ``user_id`` with ``username`` left as None.
+        populates ``ActivityItem.username`` (admin view); ``user_id`` is ignored
+        in this mode. Otherwise scoped to ``user_id`` with ``username`` left as None.
 
         Returns (items, total_count).
         """
-        from app.models.user import User
 
         if all_users:
             query = self.db.query(FileActivity, User.username).join(

--- a/backend/app/services/file_activity.py
+++ b/backend/app/services/file_activity.py
@@ -139,14 +139,26 @@ class FileActivityService:
         file_type: Optional[str] = None,
         since: Optional[datetime] = None,
         path_prefix: Optional[str] = None,
+        all_users: bool = False,
     ) -> tuple[List[ActivityItem], int]:
-        """Query recent activities for a user.
+        """Query recent activities.
+
+        When ``all_users`` is True, returns activities across every user and
+        populates ``ActivityItem.username`` (admin view). Otherwise scoped to
+        ``user_id`` with ``username`` left as None.
 
         Returns (items, total_count).
         """
-        query = self.db.query(FileActivity).filter(
-            FileActivity.user_id == user_id
-        )
+        from app.models.user import User
+
+        if all_users:
+            query = self.db.query(FileActivity, User.username).join(
+                User, User.id == FileActivity.user_id
+            )
+        else:
+            query = self.db.query(FileActivity).filter(
+                FileActivity.user_id == user_id
+            )
 
         if action_types:
             query = query.filter(FileActivity.action_type.in_(action_types))
@@ -170,7 +182,13 @@ class FileActivityService:
             .all()
         )
 
-        items = [self._to_activity_item(r) for r in rows]
+        if all_users:
+            items = [
+                self._to_activity_item(row, username=username)
+                for (row, username) in rows
+            ]
+        else:
+            items = [self._to_activity_item(r) for r in rows]
         return items, total
 
     def get_recent_files(
@@ -275,7 +293,9 @@ class FileActivityService:
     # Helpers
     # ------------------------------------------------------------------
     @staticmethod
-    def _to_activity_item(row: FileActivity) -> ActivityItem:
+    def _to_activity_item(
+        row: FileActivity, username: Optional[str] = None
+    ) -> ActivityItem:
         metadata = None
         if row.metadata_json:
             try:
@@ -285,6 +305,8 @@ class FileActivityService:
 
         return ActivityItem(
             id=row.id,
+            user_id=row.user_id,
+            username=username,
             action_type=row.action_type,
             file_path=row.file_path,
             file_name=row.file_name,

--- a/backend/tests/test_file_activity.py
+++ b/backend/tests/test_file_activity.py
@@ -202,6 +202,40 @@ class TestFileActivityService:
         assert items[0].source == "client"
         assert items[0].device_id == "pixel-7-abc"
 
+    def test_get_recent_activities_sets_user_id_and_no_username_for_mine(self, db_session: Session):
+        svc = self._make_service(db_session)
+        svc.record(7, "file.upload", "u7/a.txt", "a.txt")
+        db_session.commit()
+
+        items, total = svc.get_recent_activities(user_id=7, limit=10)
+        assert total == 1
+        assert items[0].user_id == 7
+        assert items[0].username is None
+
+    def test_get_recent_activities_all_users_returns_cross_user_with_username(self, db_session: Session):
+        from app.models.user import User
+
+        alice = User(username="alice", email="alice@example.com", hashed_password="x", role="user")
+        bob = User(username="bob", email="bob@example.com", hashed_password="x", role="user")
+        db_session.add_all([alice, bob])
+        db_session.commit()
+
+        svc = self._make_service(db_session)
+        svc.record(alice.id, "file.upload", "alice/a.txt", "a.txt")
+        svc.record(bob.id, "file.download", "bob/b.txt", "b.txt")
+        db_session.commit()
+
+        # Scoped: alice sees only her own
+        mine, mine_total = svc.get_recent_activities(user_id=alice.id, limit=10)
+        assert mine_total == 1
+        assert {i.file_name for i in mine} == {"a.txt"}
+
+        # All users: both, each with the acting username populated
+        everyone, total = svc.get_recent_activities(user_id=alice.id, limit=10, all_users=True)
+        assert total == 2
+        names = {i.file_name: i.username for i in everyone}
+        assert names == {"a.txt": "alice", "b.txt": "bob"}
+
 
 # ---------------------------------------------------------------------------
 # API-level tests

--- a/backend/tests/test_file_activity.py
+++ b/backend/tests/test_file_activity.py
@@ -416,3 +416,56 @@ class TestActivityEndpoints:
             json={"activities": []},
         )
         assert res.status_code == 422  # Pydantic validation: min_length=1
+
+
+# ---------------------------------------------------------------------------
+# Route-level scope tests
+# ---------------------------------------------------------------------------
+
+from app.core.config import settings as app_settings
+
+
+class TestActivityRouteScope:
+    """Route-level tests for scope=mine|all on /api/activity/recent."""
+
+    def _seed_two_users_activity(self, db_session):
+        from app.models.user import User
+        from app.services.file_activity import FileActivityService
+
+        admin = db_session.query(User).filter(User.username == app_settings.admin_username).first()
+        testuser = db_session.query(User).filter(User.username == "testuser").first()
+
+        svc = FileActivityService(db_session)
+        svc.record(admin.id, "file.upload", "admin/admin.txt", "admin.txt")
+        svc.record(testuser.id, "file.upload", "testuser/user.txt", "user.txt")
+        db_session.commit()
+
+    def test_scope_mine_returns_only_own(self, client, db_session, user_headers):
+        self._seed_two_users_activity(db_session)
+        resp = client.get(
+            f"{app_settings.api_prefix}/activity/recent?scope=mine&limit=50",
+            headers=user_headers,
+        )
+        assert resp.status_code == 200
+        names = {a["file_name"] for a in resp.json()["activities"]}
+        assert names == {"user.txt"}
+
+    def test_scope_all_forbidden_for_regular_user(self, client, db_session, user_headers):
+        self._seed_two_users_activity(db_session)
+        resp = client.get(
+            f"{app_settings.api_prefix}/activity/recent?scope=all&limit=50",
+            headers=user_headers,
+        )
+        assert resp.status_code == 403
+
+    def test_scope_all_returns_cross_user_for_admin(self, client, db_session, admin_headers):
+        self._seed_two_users_activity(db_session)
+        resp = client.get(
+            f"{app_settings.api_prefix}/activity/recent?scope=all&limit=50",
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        activities = resp.json()["activities"]
+        names = {a["file_name"] for a in activities}
+        assert names == {"admin.txt", "user.txt"}
+        assert all(a["username"] for a in activities)

--- a/backend/tests/test_file_activity.py
+++ b/backend/tests/test_file_activity.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from sqlalchemy.orm import Session
 
+from app.core.config import settings as app_settings
 from app.models.file_activity import FileActivity
 from app.schemas.file_activity import VALID_ACTION_TYPES
 from app.services.file_activity import FileActivityService
@@ -422,9 +423,6 @@ class TestActivityEndpoints:
 # Route-level scope tests
 # ---------------------------------------------------------------------------
 
-from app.core.config import settings as app_settings
-
-
 class TestActivityRouteScope:
     """Route-level tests for scope=mine|all on /api/activity/recent."""
 
@@ -434,6 +432,7 @@ class TestActivityRouteScope:
 
         admin = db_session.query(User).filter(User.username == app_settings.admin_username).first()
         testuser = db_session.query(User).filter(User.username == "testuser").first()
+        assert admin is not None and testuser is not None
 
         svc = FileActivityService(db_session)
         svc.record(admin.id, "file.upload", "admin/admin.txt", "admin.txt")
@@ -451,7 +450,6 @@ class TestActivityRouteScope:
         assert names == {"user.txt"}
 
     def test_scope_all_forbidden_for_regular_user(self, client, db_session, user_headers):
-        self._seed_two_users_activity(db_session)
         resp = client.get(
             f"{app_settings.api_prefix}/activity/recent?scope=all&limit=50",
             headers=user_headers,

--- a/backend/tests/test_logging_file_access_scope.py
+++ b/backend/tests/test_logging_file_access_scope.py
@@ -38,6 +38,18 @@ def test_regular_user_cannot_widen_with_user_param(client, db_session, user_head
     assert users <= {"testuser"}  # empty or only own — never the admin's
 
 
+def test_regular_user_devmode_mock_is_scoped(client, db_session, user_headers):
+    # No seeding: forces the dev-mode mock fallback (real logs == 0).
+    resp = client.get(
+        f"{settings.api_prefix}/logging/file-access?days=1&limit=100",
+        headers=user_headers,
+    )
+    assert resp.status_code == 200
+    users = {log["user"] for log in resp.json()["logs"]}
+    # Non-admin must never see other users' (mock) rows.
+    assert users <= {"testuser"}
+
+
 def test_admin_sees_all_file_access(client, db_session, admin_headers):
     _seed_file_access(db_session)
     resp = client.get(

--- a/backend/tests/test_logging_file_access_scope.py
+++ b/backend/tests/test_logging_file_access_scope.py
@@ -1,0 +1,49 @@
+"""Regression test: /api/logging/file-access must not leak other users' activity."""
+from app.core.config import settings
+from app.services.audit.logger_db import get_audit_logger_db
+
+
+def _seed_file_access(db_session):
+    audit = get_audit_logger_db()
+    audit.log_event(
+        event_type="FILE_ACCESS", user=settings.admin_username,
+        action="download", resource="/admin/secret.pdf", db=db_session,
+    )
+    audit.log_event(
+        event_type="FILE_ACCESS", user="testuser",
+        action="upload", resource="/testuser/note.txt", db=db_session,
+    )
+    db_session.commit()
+
+
+def test_regular_user_only_sees_own_file_access(client, db_session, user_headers):
+    _seed_file_access(db_session)
+    resp = client.get(
+        f"{settings.api_prefix}/logging/file-access?days=1&limit=100",
+        headers=user_headers,
+    )
+    assert resp.status_code == 200
+    users = {log["user"] for log in resp.json()["logs"]}
+    assert users == {"testuser"}
+
+
+def test_regular_user_cannot_widen_with_user_param(client, db_session, user_headers):
+    _seed_file_access(db_session)
+    resp = client.get(
+        f"{settings.api_prefix}/logging/file-access?days=1&limit=100&user={settings.admin_username}",
+        headers=user_headers,
+    )
+    assert resp.status_code == 200
+    users = {log["user"] for log in resp.json()["logs"]}
+    assert users <= {"testuser"}  # empty or only own — never the admin's
+
+
+def test_admin_sees_all_file_access(client, db_session, admin_headers):
+    _seed_file_access(db_session)
+    resp = client.get(
+        f"{settings.api_prefix}/logging/file-access?days=1&limit=100",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    users = {log["user"] for log in resp.json()["logs"]}
+    assert {settings.admin_username, "testuser"} <= users

--- a/backend/tests/test_logging_file_access_scope.py
+++ b/backend/tests/test_logging_file_access_scope.py
@@ -59,3 +59,19 @@ def test_admin_sees_all_file_access(client, db_session, admin_headers):
     assert resp.status_code == 200
     users = {log["user"] for log in resp.json()["logs"]}
     assert {settings.admin_username, "testuser"} <= users
+
+
+def test_regular_user_stats_only_counts_own(client, db_session, user_headers):
+    _seed_file_access(db_session)
+    resp = client.get(f"{settings.api_prefix}/logging/stats?days=1", headers=user_headers)
+    assert resp.status_code == 200
+    by_user = resp.json()["file_access"]["by_user"]
+    assert set(by_user.keys()) <= {"testuser"}
+
+
+def test_admin_stats_counts_all_users(client, db_session, admin_headers):
+    _seed_file_access(db_session)
+    resp = client.get(f"{settings.api_prefix}/logging/stats?days=1", headers=admin_headers)
+    assert resp.status_code == 200
+    by_user = resp.json()["file_access"]["by_user"]
+    assert {settings.admin_username, "testuser"} <= set(by_user.keys())

--- a/client/src/__tests__/components/dashboard/ActivityFeed.test.tsx
+++ b/client/src/__tests__/components/dashboard/ActivityFeed.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ActivityFeed } from '../../../components/dashboard/ActivityFeed';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+const mockUseAuth = vi.fn();
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const mockUseActivityFeed = vi.fn();
+vi.mock('../../../hooks/useActivityFeed', () => ({
+  useActivityFeed: (opts: unknown) => mockUseActivityFeed(opts),
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+function setup(isAdmin: boolean) {
+  mockUseAuth.mockReturnValue({ isAdmin });
+  mockUseActivityFeed.mockReturnValue({ activities: [], loading: false, error: null });
+  render(<ActivityFeed limit={5} />);
+}
+
+describe('ActivityFeed admin gating', () => {
+  it('passes allUsers=true and shows the system-logs button for admins', () => {
+    setup(true);
+    expect(mockUseActivityFeed).toHaveBeenCalledWith(
+      expect.objectContaining({ allUsers: true }),
+    );
+    expect(screen.getByText('dashboard:activity.viewSystemLogs')).toBeInTheDocument();
+  });
+
+  it('passes allUsers=false and hides the system-logs button for regular users', () => {
+    setup(false);
+    expect(mockUseActivityFeed).toHaveBeenCalledWith(
+      expect.objectContaining({ allUsers: false }),
+    );
+    expect(screen.queryByText('dashboard:activity.viewSystemLogs')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/hooks/useActivityFeed.helpers.test.ts
+++ b/client/src/__tests__/hooks/useActivityFeed.helpers.test.ts
@@ -1,82 +1,53 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-  getActionIcon,
-  getActionTitle,
-  formatRelativeTime,
-  transformLog,
-} from '../../hooks/useActivityFeed';
-import type { FileAccessLog } from '../../api/logging';
-import { setByteUnitMode } from '../../lib/byteUnits';
+import { mapActionType, formatRelativeTime } from '../../hooks/useActivityFeed';
 
-describe('getActionIcon', () => {
-  it('maps upload to "upload"', () => {
-    expect(getActionIcon('upload')).toBe('upload');
+describe('mapActionType', () => {
+  it('maps file.upload to upload/upload', () => {
+    expect(mapActionType('file.upload')).toEqual({ icon: 'upload', titleKey: 'upload' });
   });
 
-  it('maps download to "download"', () => {
-    expect(getActionIcon('download')).toBe('download');
+  it('maps file.download to download/download', () => {
+    expect(mapActionType('file.download')).toEqual({ icon: 'download', titleKey: 'download' });
   });
 
-  it('maps delete to "delete"', () => {
-    expect(getActionIcon('delete')).toBe('delete');
+  it('maps file.delete to delete/delete', () => {
+    expect(mapActionType('file.delete')).toEqual({ icon: 'delete', titleKey: 'delete' });
   });
 
-  it('maps create to "create"', () => {
-    expect(getActionIcon('create')).toBe('create');
+  it('maps folder.create to create/create', () => {
+    expect(mapActionType('folder.create')).toEqual({ icon: 'create', titleKey: 'create' });
   });
 
-  it('maps mkdir to "create"', () => {
-    expect(getActionIcon('mkdir')).toBe('create');
+  it('maps file.move to move/move', () => {
+    expect(mapActionType('file.move')).toEqual({ icon: 'move', titleKey: 'move' });
   });
 
-  it('maps login to "user"', () => {
-    expect(getActionIcon('login')).toBe('user');
+  it('maps file.rename to move/rename', () => {
+    expect(mapActionType('file.rename')).toEqual({ icon: 'move', titleKey: 'rename' });
   });
 
-  it('maps auth to "user"', () => {
-    expect(getActionIcon('auth')).toBe('user');
+  it('maps file.share to share/share', () => {
+    expect(mapActionType('file.share')).toEqual({ icon: 'share', titleKey: 'share' });
   });
 
-  it('maps move to "move"', () => {
-    expect(getActionIcon('move')).toBe('move');
+  it('maps file.permission to share/permission', () => {
+    expect(mapActionType('file.permission')).toEqual({ icon: 'share', titleKey: 'permission' });
   });
 
-  it('maps rename to "move"', () => {
-    expect(getActionIcon('rename')).toBe('move');
+  it('maps file.edit to file/edit', () => {
+    expect(mapActionType('file.edit')).toEqual({ icon: 'file', titleKey: 'edit' });
   });
 
-  it('maps copy to "copy"', () => {
-    expect(getActionIcon('copy')).toBe('copy');
+  it('maps file.open to file/open', () => {
+    expect(mapActionType('file.open')).toEqual({ icon: 'file', titleKey: 'open' });
   });
 
-  it('maps share to "share"', () => {
-    expect(getActionIcon('share')).toBe('share');
+  it('maps sync.triggered to file/sync', () => {
+    expect(mapActionType('sync.triggered')).toEqual({ icon: 'file', titleKey: 'sync' });
   });
 
-  it('returns "file" for unknown actions', () => {
-    expect(getActionIcon('something-unknown')).toBe('file');
-  });
-});
-
-describe('getActionTitle', () => {
-  it('maps upload to "File Uploaded"', () => {
-    expect(getActionTitle('upload')).toBe('File Uploaded');
-  });
-
-  it('maps download to "File Downloaded"', () => {
-    expect(getActionTitle('download')).toBe('File Downloaded');
-  });
-
-  it('maps delete to "File Deleted"', () => {
-    expect(getActionTitle('delete')).toBe('File Deleted');
-  });
-
-  it('maps login to "User Login"', () => {
-    expect(getActionTitle('login')).toBe('User Login');
-  });
-
-  it('capitalizes unknown actions', () => {
-    expect(getActionTitle('custom')).toBe('Custom');
+  it('falls back to file/default for unknown action types', () => {
+    expect(mapActionType('something.unknown')).toEqual({ icon: 'file', titleKey: 'default' });
   });
 });
 
@@ -91,110 +62,36 @@ describe('formatRelativeTime', () => {
   });
 
   it('returns "just now" for < 60 seconds ago', () => {
-    const date = new Date('2026-02-07T11:59:30Z');
-    expect(formatRelativeTime(date)).toBe('just now');
+    expect(formatRelativeTime(new Date('2026-02-07T11:59:30Z'))).toBe('just now');
   });
 
   it('returns minutes for < 60 minutes ago', () => {
-    const date = new Date('2026-02-07T11:55:00Z');
-    expect(formatRelativeTime(date)).toBe('5 minutes ago');
+    expect(formatRelativeTime(new Date('2026-02-07T11:55:00Z'))).toBe('5 minutes ago');
   });
 
   it('returns singular minute', () => {
-    const date = new Date('2026-02-07T11:59:00Z');
-    expect(formatRelativeTime(date)).toBe('1 minute ago');
+    expect(formatRelativeTime(new Date('2026-02-07T11:59:00Z'))).toBe('1 minute ago');
   });
 
   it('returns hours for < 24 hours ago', () => {
-    const date = new Date('2026-02-07T09:00:00Z');
-    expect(formatRelativeTime(date)).toBe('3 hours ago');
+    expect(formatRelativeTime(new Date('2026-02-07T09:00:00Z'))).toBe('3 hours ago');
   });
 
   it('returns singular hour', () => {
-    const date = new Date('2026-02-07T11:00:00Z');
-    expect(formatRelativeTime(date)).toBe('1 hour ago');
+    expect(formatRelativeTime(new Date('2026-02-07T11:00:00Z'))).toBe('1 hour ago');
   });
 
   it('returns days for < 7 days ago', () => {
-    const date = new Date('2026-02-05T12:00:00Z');
-    expect(formatRelativeTime(date)).toBe('2 days ago');
+    expect(formatRelativeTime(new Date('2026-02-05T12:00:00Z'))).toBe('2 days ago');
   });
 
   it('returns singular day', () => {
-    const date = new Date('2026-02-06T12:00:00Z');
-    expect(formatRelativeTime(date)).toBe('1 day ago');
+    expect(formatRelativeTime(new Date('2026-02-06T12:00:00Z'))).toBe('1 day ago');
   });
 
-  it('returns date string for >= 7 days ago', () => {
-    const date = new Date('2026-01-20T12:00:00Z');
-    const result = formatRelativeTime(date);
-    // Should be a date string, not a relative time
+  it('returns a date string for >= 7 days ago', () => {
+    const result = formatRelativeTime(new Date('2026-01-20T12:00:00Z'));
     expect(result).not.toContain('ago');
     expect(result).not.toBe('just now');
-  });
-});
-
-describe('transformLog', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-02-07T12:00:00Z'));
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it('transforms a FileAccessLog to an ActivityItem', () => {
-    const log: FileAccessLog = {
-      timestamp: '2026-02-07T11:55:00Z',
-      event_type: 'file_access',
-      user: 'admin',
-      action: 'upload',
-      resource: '/documents/report.pdf',
-      success: true,
-      details: { size_bytes: 2048 },
-    };
-
-    const item = transformLog(log, 0);
-
-    expect(item.id).toBe('2026-02-07T11:55:00Z-0');
-    expect(item.title).toBe('File Uploaded');
-    expect(item.icon).toBe('upload');
-    expect(item.success).toBe(true);
-    expect(item.detail).toContain('admin');
-    expect(item.detail).toContain('report.pdf');
-    expect(item.detail).toContain('KiB');
-    expect(item.ago).toBe('5 minutes ago');
-  });
-
-  it('handles logs without user or unknown user', () => {
-    const log: FileAccessLog = {
-      timestamp: '2026-02-07T11:55:00Z',
-      event_type: 'file_access',
-      user: 'unknown',
-      action: 'download',
-      resource: '/file.txt',
-      success: true,
-    };
-
-    const item = transformLog(log, 1);
-    // "unknown" user should not appear in detail
-    expect(item.detail).not.toContain('unknown');
-    expect(item.detail).toContain('file.txt');
-  });
-
-  it('handles logs without details.size_bytes', () => {
-    const log: FileAccessLog = {
-      timestamp: '2026-02-07T11:55:00Z',
-      event_type: 'file_access',
-      user: 'admin',
-      action: 'delete',
-      resource: '/old.txt',
-      success: false,
-    };
-
-    const item = transformLog(log, 2);
-    expect(item.success).toBe(false);
-    expect(item.detail).not.toContain('KB');
   });
 });

--- a/client/src/__tests__/hooks/useActivityFeed.test.ts
+++ b/client/src/__tests__/hooks/useActivityFeed.test.ts
@@ -1,121 +1,81 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, waitFor, act } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { useActivityFeed } from '../../hooks/useActivityFeed';
+import type { ActivityListResponse } from '../../api/activity';
 
-const mockLogsResponse = {
-  dev_mode: true,
+const tFn = (key: string) => key;
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: tFn }),
+}));
+
+vi.mock('../../lib/errorHandling', () => ({
+  getApiErrorMessage: (_e: unknown, fallback: string) => fallback,
+}));
+
+vi.mock('../../lib/formatters', () => ({
+  formatBytes: (n: number) => `${n} B`,
+}));
+
+vi.mock('../../api/activity', () => ({
+  getRecentActivities: vi.fn(),
+}));
+
+import { getRecentActivities } from '../../api/activity';
+
+const adminResponse: ActivityListResponse = {
   total: 2,
-  logs: [
+  has_more: false,
+  activities: [
     {
-      timestamp: '2026-02-07T11:55:00Z',
-      event_type: 'file_access',
-      user: 'admin',
-      action: 'upload',
-      resource: '/docs/report.pdf',
-      success: true,
-      details: { size_bytes: 4096 },
+      id: 1, user_id: 5, username: 'alice', action_type: 'file.upload',
+      file_path: 'alice/report.pdf', file_name: 'report.pdf', is_directory: false,
+      file_size: 2048, mime_type: 'application/pdf', source: 'server',
+      device_id: null, metadata: null, created_at: new Date().toISOString(),
     },
     {
-      timestamp: '2026-02-07T11:50:00Z',
-      event_type: 'file_access',
-      user: 'user1',
-      action: 'download',
-      resource: '/images/photo.jpg',
-      success: true,
+      id: 2, user_id: 6, username: 'bob', action_type: 'folder.create',
+      file_path: 'bob/photos', file_name: 'photos', is_directory: true,
+      file_size: null, mime_type: null, source: 'server',
+      device_id: null, metadata: null, created_at: new Date().toISOString(),
     },
   ],
 };
 
-vi.mock('../../api/logging', () => ({
-  loggingApi: {
-    getFileAccessLogs: vi.fn(),
-  },
-}));
-
-import { loggingApi } from '../../api/logging';
-
 describe('useActivityFeed', () => {
   beforeEach(() => {
-    vi.mocked(loggingApi.getFileAccessLogs).mockReset();
-    vi.mocked(loggingApi.getFileAccessLogs).mockResolvedValue(mockLogsResponse);
+    vi.mocked(getRecentActivities).mockResolvedValue(adminResponse);
   });
+  afterEach(() => vi.restoreAllMocks());
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+  it('requests scope=all when allUsers is true and maps action types', async () => {
+    const { result } = renderHook(() => useActivityFeed({ limit: 5, allUsers: true }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
 
-  it('loads and transforms logs into activity items', async () => {
-    const { result } = renderHook(() =>
-      useActivityFeed({ refreshInterval: 0 })
-    );
-
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false);
-    });
-
+    expect(getRecentActivities).toHaveBeenCalledWith({ limit: 5, scope: 'all' });
     expect(result.current.activities).toHaveLength(2);
-    expect(result.current.activities[0].title).toBe('File Uploaded');
     expect(result.current.activities[0].icon).toBe('upload');
-    expect(result.current.activities[1].title).toBe('File Downloaded');
-    expect(result.current.error).toBeNull();
+    expect(result.current.activities[1].icon).toBe('create');
+    expect(result.current.activities[0].title).toBe('activity.actions.upload');
+    expect(result.current.activities[1].title).toBe('activity.actions.create');
+    expect(result.current.activities[0].detail).toContain('alice');
   });
 
-  it('uses default options (limit=5, days=1)', async () => {
-    renderHook(() => useActivityFeed({ refreshInterval: 0 }));
-
-    await waitFor(() => {
-      expect(loggingApi.getFileAccessLogs).toHaveBeenCalled();
+  it('requests scope=mine when allUsers is false and omits username in detail', async () => {
+    vi.mocked(getRecentActivities).mockResolvedValue({
+      total: 1, has_more: false,
+      activities: [{
+        id: 9, user_id: 5, username: null, action_type: 'file.download',
+        file_path: 'me/a.txt', file_name: 'a.txt', is_directory: false,
+        file_size: null, mime_type: null, source: 'server',
+        device_id: null, metadata: null, created_at: new Date().toISOString(),
+      }],
     });
 
-    expect(loggingApi.getFileAccessLogs).toHaveBeenCalledWith({ limit: 5, days: 1 });
-  });
+    const { result } = renderHook(() => useActivityFeed({ limit: 5 }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
 
-  it('passes custom options to API', async () => {
-    renderHook(() =>
-      useActivityFeed({ limit: 10, days: 7, refreshInterval: 0 })
-    );
-
-    await waitFor(() => {
-      expect(loggingApi.getFileAccessLogs).toHaveBeenCalled();
-    });
-
-    expect(loggingApi.getFileAccessLogs).toHaveBeenCalledWith({ limit: 10, days: 7 });
-  });
-
-  it('auto-refreshes with interval', async () => {
-    vi.useFakeTimers();
-
-    renderHook(() =>
-      useActivityFeed({ refreshInterval: 10000 })
-    );
-
-    // Initial call
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(10);
-    });
-    expect(loggingApi.getFileAccessLogs).toHaveBeenCalledTimes(1);
-
-    // After 10s
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(10000);
-    });
-    expect(loggingApi.getFileAccessLogs).toHaveBeenCalledTimes(2);
-
-    vi.useRealTimers();
-  });
-
-  it('handles errors', async () => {
-    vi.mocked(loggingApi.getFileAccessLogs).mockRejectedValue(new Error('Server error'));
-
-    const { result } = renderHook(() =>
-      useActivityFeed({ refreshInterval: 0 })
-    );
-
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false);
-    });
-
-    expect(result.current.error).toBe('Server error');
-    expect(result.current.activities).toEqual([]);
+    expect(getRecentActivities).toHaveBeenCalledWith({ limit: 5, scope: 'mine' });
+    expect(result.current.activities[0].icon).toBe('download');
+    expect(result.current.activities[0].detail).toBe('a.txt');
   });
 });

--- a/client/src/__tests__/hooks/useActivityFeed.test.ts
+++ b/client/src/__tests__/hooks/useActivityFeed.test.ts
@@ -78,4 +78,12 @@ describe('useActivityFeed', () => {
     expect(result.current.activities[0].icon).toBe('download');
     expect(result.current.activities[0].detail).toBe('a.txt');
   });
+
+  it('sets error and leaves activities empty when the request fails', async () => {
+    vi.mocked(getRecentActivities).mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => useActivityFeed({ limit: 5 }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('Failed to load activity feed');
+    expect(result.current.activities).toEqual([]);
+  });
 });

--- a/client/src/api/activity.ts
+++ b/client/src/api/activity.ts
@@ -1,0 +1,39 @@
+import { apiClient } from '../lib/api';
+
+export interface ActivityItem {
+  id: number;
+  user_id: number;
+  username?: string | null;
+  action_type: string;
+  file_path: string;
+  file_name: string;
+  is_directory: boolean;
+  file_size?: number | null;
+  mime_type?: string | null;
+  source: string;
+  device_id?: string | null;
+  metadata?: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface ActivityListResponse {
+  activities: ActivityItem[];
+  total: number;
+  has_more: boolean;
+}
+
+export interface GetRecentActivitiesParams {
+  limit?: number;
+  offset?: number;
+  scope?: 'mine' | 'all';
+}
+
+export async function getRecentActivities(
+  params: GetRecentActivitiesParams = {},
+): Promise<ActivityListResponse> {
+  const { limit = 20, offset = 0, scope = 'mine' } = params;
+  const { data } = await apiClient.get<ActivityListResponse>('/api/activity/recent', {
+    params: { limit, offset, scope },
+  });
+  return data;
+}

--- a/client/src/components/dashboard/ActivityFeed.tsx
+++ b/client/src/components/dashboard/ActivityFeed.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useActivityFeed } from '../../hooks/useActivityFeed';
+import { useAuth } from '../../contexts/AuthContext';
 import {
   Upload,
   Download,
@@ -45,7 +46,8 @@ function ActivityIcon({ type, success }: { type: string; success: boolean }) {
 export const ActivityFeed: React.FC<ActivityFeedProps> = ({ limit = 5 }) => {
   const { t } = useTranslation(['dashboard', 'common']);
   const navigate = useNavigate();
-  const { activities, loading, error } = useActivityFeed({ limit, days: 1 });
+  const { isAdmin } = useAuth();
+  const { activities, loading, error } = useActivityFeed({ limit, allUsers: isAdmin });
 
   const handleViewLogs = () => {
     navigate('/logging');
@@ -58,12 +60,14 @@ export const ActivityFeed: React.FC<ActivityFeedProps> = ({ limit = 5 }) => {
           <p className="text-xs uppercase tracking-[0.28em] text-slate-500">{t('dashboard:activity.title')}</p>
           <h2 className="mt-2 text-xl font-semibold text-white">{t('dashboard:activity.liveOperations')}</h2>
         </div>
-        <button
-          onClick={handleViewLogs}
-          className="rounded-full border border-slate-700/70 px-3 py-1 text-xs text-slate-400 transition hover:border-slate-500 hover:text-white"
-        >
-          {t('dashboard:activity.viewSystemLogs')}
-        </button>
+        {isAdmin && (
+          <button
+            onClick={handleViewLogs}
+            className="rounded-full border border-slate-700/70 px-3 py-1 text-xs text-slate-400 transition hover:border-slate-500 hover:text-white"
+          >
+            {t('dashboard:activity.viewSystemLogs')}
+          </button>
+        )}
       </div>
 
       <div className="mt-6 space-y-4">

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -17,7 +17,7 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useDeviceManagement.ts` | `api/devices` | Device list, pairing, removal |
 | `useMobile.ts` | `api/mobile` | Mobile device management |
 | `useRemoteServers.ts` | `api/remote-servers` | Remote server profiles |
-| `useActivityFeed.ts` | `api/files` | Recent file activity stream |
+| `useActivityFeed.ts` | `api/activity` | Dashboard activity feed (own / admin all-users) |
 | `useLiveActivities.ts` | — | Real-time activity via polling |
 | `useDocsIndex.ts` | `api/docs` | Documentation article index |
 | `useDocsArticle.ts` | `api/docs` | Single documentation article content |

--- a/client/src/hooks/useActivityFeed.ts
+++ b/client/src/hooks/useActivityFeed.ts
@@ -1,8 +1,10 @@
 /**
- * Hook for fetching activity feed from audit logs
+ * Hook for fetching the dashboard activity feed from the user-scoped
+ * /api/activity API. Admins may request all users' activity (scope=all).
  */
 import { useState, useEffect, useCallback } from 'react';
-import { loggingApi, type FileAccessLog } from '../api/logging';
+import { useTranslation } from 'react-i18next';
+import { getRecentActivities, type ActivityItem as ApiActivityItem } from '../api/activity';
 import { formatBytes } from '../lib/formatters';
 import { getApiErrorMessage } from '../lib/errorHandling';
 
@@ -18,7 +20,7 @@ export interface ActivityItem {
 
 interface UseActivityFeedOptions {
   limit?: number;
-  days?: number;
+  allUsers?: boolean;
   refreshInterval?: number;
 }
 
@@ -29,60 +31,24 @@ interface UseActivityFeedReturn {
   refetch: () => Promise<void>;
 }
 
-// Map action to icon
-export function getActionIcon(action: string): string {
-  switch (action.toLowerCase()) {
-    case 'upload':
-      return 'upload';
-    case 'download':
-      return 'download';
-    case 'delete':
-      return 'delete';
-    case 'create':
-    case 'mkdir':
-      return 'create';
-    case 'login':
-    case 'auth':
-      return 'user';
-    case 'move':
-    case 'rename':
-      return 'move';
-    case 'copy':
-      return 'copy';
-    case 'share':
-      return 'share';
-    default:
-      return 'file';
-  }
-}
+// Map a dotted action_type (e.g. "file.upload", "folder.create") to an icon key
+// understood by ActivityFeed's ActivityIcon and to an i18n title sub-key.
+const ACTION_MAP: Record<string, { icon: string; titleKey: string }> = {
+  'file.upload': { icon: 'upload', titleKey: 'upload' },
+  'file.download': { icon: 'download', titleKey: 'download' },
+  'file.delete': { icon: 'delete', titleKey: 'delete' },
+  'file.edit': { icon: 'file', titleKey: 'edit' },
+  'file.open': { icon: 'file', titleKey: 'open' },
+  'file.move': { icon: 'move', titleKey: 'move' },
+  'file.rename': { icon: 'move', titleKey: 'rename' },
+  'file.share': { icon: 'share', titleKey: 'share' },
+  'file.permission': { icon: 'share', titleKey: 'permission' },
+  'folder.create': { icon: 'create', titleKey: 'create' },
+  'sync.triggered': { icon: 'file', titleKey: 'sync' },
+};
 
-// Map action to human-readable title
-export function getActionTitle(action: string): string {
-  switch (action.toLowerCase()) {
-    case 'upload':
-      return 'File Uploaded';
-    case 'download':
-      return 'File Downloaded';
-    case 'delete':
-      return 'File Deleted';
-    case 'create':
-    case 'mkdir':
-      return 'Created';
-    case 'login':
-      return 'User Login';
-    case 'auth':
-      return 'Authentication';
-    case 'move':
-      return 'File Moved';
-    case 'rename':
-      return 'File Renamed';
-    case 'copy':
-      return 'File Copied';
-    case 'share':
-      return 'File Shared';
-    default:
-      return action.charAt(0).toUpperCase() + action.slice(1);
-  }
+export function mapActionType(actionType: string): { icon: string; titleKey: string } {
+  return ACTION_MAP[actionType] ?? { icon: 'file', titleKey: 'default' };
 }
 
 // Format relative time
@@ -94,82 +60,63 @@ export function formatRelativeTime(date: Date): string {
   const diffHours = Math.floor(diffMinutes / 60);
   const diffDays = Math.floor(diffHours / 24);
 
-  if (diffSeconds < 60) {
-    return 'just now';
-  }
-  if (diffMinutes < 60) {
-    return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
-  }
-  if (diffHours < 24) {
-    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
-  }
-  if (diffDays < 7) {
-    return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
-  }
+  if (diffSeconds < 60) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
+  if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
   return date.toLocaleDateString();
 }
 
-// Transform log to activity item
-export function transformLog(log: FileAccessLog, index: number): ActivityItem {
-  const timestamp = new Date(log.timestamp);
-  const resourcePath = log.resource || '';
-  const fileName = resourcePath.split('/').pop() || resourcePath;
-
-  let detail = fileName || log.resource;
-  if (log.user && log.user !== 'unknown') {
-    detail = `${log.user} • ${detail}`;
-  }
-  if (log.details?.size_bytes) {
-    detail += ` (${formatBytes(log.details.size_bytes)})`;
-  }
-
-  return {
-    id: `${log.timestamp}-${index}`,
-    title: getActionTitle(log.action),
-    detail,
-    ago: formatRelativeTime(timestamp),
-    icon: getActionIcon(log.action),
-    timestamp,
-    success: log.success,
-  };
-}
-
 export function useActivityFeed(options: UseActivityFeedOptions = {}): UseActivityFeedReturn {
-  const { limit = 5, days = 1, refreshInterval = 30000 } = options;
+  const { limit = 5, allUsers = false, refreshInterval = 30000 } = options;
+  const { t } = useTranslation('dashboard');
 
   const [activities, setActivities] = useState<ActivityItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const toViewItem = useCallback(
+    (item: ApiActivityItem): ActivityItem => {
+      const { icon, titleKey } = mapActionType(item.action_type);
+      const timestamp = new Date(item.created_at);
+
+      let detail = item.file_name;
+      if (item.username) detail = `${item.username} • ${detail}`;
+      if (item.file_size) detail += ` (${formatBytes(item.file_size)})`;
+
+      return {
+        id: String(item.id),
+        title: t(`activity.actions.${titleKey}`),
+        detail,
+        ago: formatRelativeTime(timestamp),
+        icon,
+        timestamp,
+        success: true,
+      };
+    },
+    [t],
+  );
+
   const loadData = useCallback(async () => {
     try {
-      const response = await loggingApi.getFileAccessLogs({ limit, days });
-      const items = response.logs.map((log, idx) => transformLog(log, idx));
-      setActivities(items);
+      const response = await getRecentActivities({ limit, scope: allUsers ? 'all' : 'mine' });
+      setActivities(response.activities.map(toViewItem));
       setError(null);
     } catch (err: unknown) {
       setError(getApiErrorMessage(err, 'Failed to load activity feed'));
     }
-  }, [limit, days]);
+  }, [limit, allUsers, toViewItem]);
 
-  // Initial load
   useEffect(() => {
     setLoading(true);
     loadData().finally(() => setLoading(false));
   }, [loadData]);
 
-  // Auto-refresh
   useEffect(() => {
     if (refreshInterval <= 0) return;
-
     const interval = setInterval(loadData, refreshInterval);
     return () => clearInterval(interval);
   }, [refreshInterval, loadData]);
 
-  return {
-    activities,
-    loading,
-    error,
-    refetch: loadData,
-  };
+  return { activities, loading, error, refetch: loadData };
 }

--- a/client/src/hooks/useActivityFeed.ts
+++ b/client/src/hooks/useActivityFeed.ts
@@ -82,7 +82,7 @@ export function useActivityFeed(options: UseActivityFeedOptions = {}): UseActivi
 
       let detail = item.file_name;
       if (item.username) detail = `${item.username} • ${detail}`;
-      if (item.file_size) detail += ` (${formatBytes(item.file_size)})`;
+      if (item.file_size != null) detail += ` (${formatBytes(item.file_size)})`;
 
       return {
         id: String(item.id),
@@ -91,6 +91,8 @@ export function useActivityFeed(options: UseActivityFeedOptions = {}): UseActivi
         ago: formatRelativeTime(timestamp),
         icon,
         timestamp,
+        // The activity API records only successful operations, so this is
+        // always true (the failure-state styling in ActivityFeed is unused here).
         success: true,
       };
     },

--- a/client/src/i18n/locales/de/dashboard.json
+++ b/client/src/i18n/locales/de/dashboard.json
@@ -56,7 +56,21 @@
     "viewSystemLogs": "System-Logs anzeigen",
     "failedToLoad": "Aktivitäten konnten nicht geladen werden: {{error}}",
     "noRecentActivity": "Keine aktuellen Aktivitäten",
-    "operationsAppearHere": "Dateioperationen werden hier angezeigt"
+    "operationsAppearHere": "Dateioperationen werden hier angezeigt",
+    "actions": {
+      "upload": "Datei hochgeladen",
+      "download": "Datei heruntergeladen",
+      "delete": "Datei gelöscht",
+      "edit": "Datei bearbeitet",
+      "open": "Datei geöffnet",
+      "move": "Datei verschoben",
+      "rename": "Datei umbenannt",
+      "share": "Datei geteilt",
+      "permission": "Berechtigungen geändert",
+      "create": "Ordner erstellt",
+      "sync": "Synchronisierung gestartet",
+      "default": "Aktivität"
+    }
   },
   "alerts": {
     "dismiss": "Verwerfen",

--- a/client/src/i18n/locales/en/dashboard.json
+++ b/client/src/i18n/locales/en/dashboard.json
@@ -56,7 +56,21 @@
     "viewSystemLogs": "View system logs",
     "failedToLoad": "Failed to load activity: {{error}}",
     "noRecentActivity": "No recent activity",
-    "operationsAppearHere": "File operations will appear here"
+    "operationsAppearHere": "File operations will appear here",
+    "actions": {
+      "upload": "File Uploaded",
+      "download": "File Downloaded",
+      "delete": "File Deleted",
+      "edit": "File Edited",
+      "open": "File Opened",
+      "move": "File Moved",
+      "rename": "File Renamed",
+      "share": "File Shared",
+      "permission": "Permissions Changed",
+      "create": "Folder Created",
+      "sync": "Sync Triggered",
+      "default": "Activity"
+    }
   },
   "alerts": {
     "dismiss": "Dismiss",

--- a/docs/superpowers/plans/2026-06-06-activity-feed-own-vs-all.md
+++ b/docs/superpowers/plans/2026-06-06-activity-feed-own-vs-all.md
@@ -1,0 +1,986 @@
+# Activity Feed own-vs-all + leak-fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-point the Dashboard "Recent Activity" widget from the leaky audit-log endpoint to the user-scoped `/api/activity` API, give admins an all-users view, and close the existing data-disclosure in `/api/logging/file-access`.
+
+**Architecture:** Backend — add an `all_users` branch to `FileActivityService.get_recent_activities` (joins `users` for attribution) exposed via a `scope=mine|all` query param on `GET /api/activity/recent` (admin-gated for `all`); harden `GET /api/logging/file-access` so non-admins are forced to their own username. Frontend — a new typed `api/activity.ts` client, `useActivityFeed` re-pointed at it with action-type→icon/i18n-title mapping, and `ActivityFeed.tsx` passing `allUsers={isAdmin}` plus admin-gating the "View System Logs" button.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2.0 + Pytest (backend); React + TypeScript + axios + Vitest + i18next (frontend).
+
+**Reference spec:** `docs/superpowers/specs/2026-06-06-activity-feed-own-vs-all-design.md`
+
+---
+
+## File Structure
+
+Backend:
+- `backend/app/schemas/file_activity.py` — add `user_id`, `username` to `ActivityItem`.
+- `backend/app/services/file_activity.py` — `all_users` branch + join + `_to_activity_item(username=…)`.
+- `backend/app/api/routes/activity.py` — `scope` param + admin gate.
+- `backend/app/api/routes/logging.py` — non-admin self-scoping in `get_file_access_logs`.
+- `backend/tests/test_file_activity.py` — service + route admin-scope tests.
+- `backend/tests/test_logging_file_access_scope.py` (new) — leak-fix test.
+
+Frontend:
+- `client/src/api/activity.ts` (new) — typed client.
+- `client/src/i18n/locales/de/dashboard.json`, `client/src/i18n/locales/en/dashboard.json` — action titles.
+- `client/src/hooks/useActivityFeed.ts` — re-point + mapping + i18n.
+- `client/src/components/dashboard/ActivityFeed.tsx` — `allUsers` + admin-gated button.
+- `client/src/__tests__/hooks/useActivityFeed.test.ts` (new) — mapping tests.
+- `client/src/__tests__/components/dashboard/ActivityFeed.test.tsx` (new) — admin-button gating.
+
+---
+
+## Task 1: Backend — extend `ActivityItem` + service `all_users` branch
+
+**Files:**
+- Modify: `backend/app/schemas/file_activity.py` (class `ActivityItem`, ~line 32-47)
+- Modify: `backend/app/services/file_activity.py` (`get_recent_activities` ~line 132-174, `_to_activity_item` ~line 277-298)
+- Test: `backend/tests/test_file_activity.py`
+
+- [ ] **Step 1: Write the failing service tests**
+
+Append to `backend/tests/test_file_activity.py` (inside `class TestFileActivityService`):
+
+```python
+    def test_get_recent_activities_sets_user_id_and_no_username_for_mine(self, db_session: Session):
+        svc = self._make_service(db_session)
+        svc.record(7, "file.upload", "u7/a.txt", "a.txt")
+        db_session.commit()
+
+        items, total = svc.get_recent_activities(user_id=7, limit=10)
+        assert total == 1
+        assert items[0].user_id == 7
+        assert items[0].username is None
+
+    def test_get_recent_activities_all_users_returns_cross_user_with_username(self, db_session: Session):
+        from app.models.user import User
+
+        alice = User(username="alice", email="alice@example.com", hashed_password="x", role="user")
+        bob = User(username="bob", email="bob@example.com", hashed_password="x", role="user")
+        db_session.add_all([alice, bob])
+        db_session.commit()
+
+        svc = self._make_service(db_session)
+        svc.record(alice.id, "file.upload", "alice/a.txt", "a.txt")
+        svc.record(bob.id, "file.download", "bob/b.txt", "b.txt")
+        db_session.commit()
+
+        # Scoped: alice sees only her own
+        mine, mine_total = svc.get_recent_activities(user_id=alice.id, limit=10)
+        assert mine_total == 1
+        assert {i.file_name for i in mine} == {"a.txt"}
+
+        # All users: both, each with the acting username populated
+        everyone, total = svc.get_recent_activities(user_id=alice.id, limit=10, all_users=True)
+        assert total == 2
+        names = {i.file_name: i.username for i in everyone}
+        assert names == {"a.txt": "alice", "b.txt": "bob"}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_file_activity.py -k "all_users or user_id_and_no_username" -v`
+Expected: FAIL — `TypeError: get_recent_activities() got an unexpected keyword argument 'all_users'` (and `ActivityItem` has no `user_id`/`username`).
+
+- [ ] **Step 3: Add the schema fields**
+
+In `backend/app/schemas/file_activity.py`, change `ActivityItem` to add the two fields (keep the rest):
+
+```python
+class ActivityItem(BaseModel):
+    """Single activity entry in API responses."""
+
+    id: int
+    user_id: int
+    username: Optional[str] = None
+    action_type: str
+    file_path: str
+    file_name: str
+    is_directory: bool
+    file_size: Optional[int] = None
+    mime_type: Optional[str] = None
+    source: str
+    device_id: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+```
+
+- [ ] **Step 4: Implement the `all_users` branch in the service**
+
+In `backend/app/services/file_activity.py`, replace `get_recent_activities` (the whole method) with:
+
+```python
+    def get_recent_activities(
+        self,
+        user_id: int,
+        *,
+        limit: int = 20,
+        offset: int = 0,
+        action_types: Optional[List[str]] = None,
+        file_type: Optional[str] = None,
+        since: Optional[datetime] = None,
+        path_prefix: Optional[str] = None,
+        all_users: bool = False,
+    ) -> tuple[List[ActivityItem], int]:
+        """Query recent activities.
+
+        When ``all_users`` is True, returns activities across every user and
+        populates ``ActivityItem.username`` (admin view). Otherwise scoped to
+        ``user_id`` with ``username`` left as None.
+
+        Returns (items, total_count).
+        """
+        from app.models.user import User
+
+        if all_users:
+            query = self.db.query(FileActivity, User.username).join(
+                User, User.id == FileActivity.user_id
+            )
+        else:
+            query = self.db.query(FileActivity).filter(
+                FileActivity.user_id == user_id
+            )
+
+        if action_types:
+            query = query.filter(FileActivity.action_type.in_(action_types))
+
+        if since:
+            query = query.filter(FileActivity.created_at >= since)
+
+        if path_prefix:
+            prefix = path_prefix.rstrip("/") + "/"
+            query = query.filter(FileActivity.file_path.like(f"{prefix}%"))
+
+        if file_type:
+            query = self._apply_file_type_filter(query, file_type)
+
+        total = query.count()
+
+        rows = (
+            query.order_by(desc(FileActivity.created_at))
+            .offset(offset)
+            .limit(limit)
+            .all()
+        )
+
+        if all_users:
+            items = [
+                self._to_activity_item(row, username=username)
+                for (row, username) in rows
+            ]
+        else:
+            items = [self._to_activity_item(r) for r in rows]
+        return items, total
+```
+
+- [ ] **Step 5: Update `_to_activity_item` to carry user_id + username**
+
+In `backend/app/services/file_activity.py`, replace `_to_activity_item` with:
+
+```python
+    @staticmethod
+    def _to_activity_item(
+        row: FileActivity, username: Optional[str] = None
+    ) -> ActivityItem:
+        metadata = None
+        if row.metadata_json:
+            try:
+                metadata = json.loads(row.metadata_json)
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        return ActivityItem(
+            id=row.id,
+            user_id=row.user_id,
+            username=username,
+            action_type=row.action_type,
+            file_path=row.file_path,
+            file_name=row.file_name,
+            is_directory=row.is_directory,
+            file_size=row.file_size,
+            mime_type=row.mime_type,
+            source=row.source,
+            device_id=row.device_id,
+            metadata=metadata,
+            created_at=row.created_at,
+        )
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/test_file_activity.py -v`
+Expected: PASS (new tests + all pre-existing ones).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/schemas/file_activity.py backend/app/services/file_activity.py backend/tests/test_file_activity.py
+git commit -m "feat(activity): service all_users view + user attribution on ActivityItem"
+```
+
+---
+
+## Task 2: Backend — `scope` param + admin gate on `/api/activity/recent`
+
+**Files:**
+- Modify: `backend/app/api/routes/activity.py` (`get_recent_activities` ~line 27-73)
+- Test: `backend/tests/test_file_activity.py` (route-level tests)
+
+- [ ] **Step 1: Write the failing route tests**
+
+Append to `backend/tests/test_file_activity.py` (module level, outside the service class):
+
+```python
+from app.core.config import settings as app_settings
+
+
+class TestActivityRouteScope:
+    """Route-level tests for scope=mine|all on /api/activity/recent."""
+
+    def _seed_two_users_activity(self, db_session):
+        from app.models.user import User
+        from app.services.file_activity import FileActivityService
+
+        admin = db_session.query(User).filter(User.username == app_settings.admin_username).first()
+        testuser = db_session.query(User).filter(User.username == "testuser").first()
+
+        svc = FileActivityService(db_session)
+        svc.record(admin.id, "file.upload", "admin/admin.txt", "admin.txt")
+        svc.record(testuser.id, "file.upload", "testuser/user.txt", "user.txt")
+        db_session.commit()
+
+    def test_scope_mine_returns_only_own(self, client, db_session, user_headers):
+        self._seed_two_users_activity(db_session)
+        resp = client.get(
+            f"{app_settings.api_prefix}/activity/recent?scope=mine&limit=50",
+            headers=user_headers,
+        )
+        assert resp.status_code == 200
+        names = {a["file_name"] for a in resp.json()["activities"]}
+        assert names == {"user.txt"}
+
+    def test_scope_all_forbidden_for_regular_user(self, client, db_session, user_headers):
+        self._seed_two_users_activity(db_session)
+        resp = client.get(
+            f"{app_settings.api_prefix}/activity/recent?scope=all&limit=50",
+            headers=user_headers,
+        )
+        assert resp.status_code == 403
+
+    def test_scope_all_returns_cross_user_for_admin(self, client, db_session, admin_headers):
+        self._seed_two_users_activity(db_session)
+        resp = client.get(
+            f"{app_settings.api_prefix}/activity/recent?scope=all&limit=50",
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        activities = resp.json()["activities"]
+        names = {a["file_name"] for a in activities}
+        assert names == {"admin.txt", "user.txt"}
+        # username is populated in the all-users view
+        assert all(a["username"] for a in activities)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_file_activity.py::TestActivityRouteScope -v`
+Expected: FAIL — `scope=all` returns 200 for a regular user (no gate yet) / `scope` is ignored.
+
+- [ ] **Step 3: Implement the `scope` param + admin gate**
+
+In `backend/app/api/routes/activity.py`, add the import near the other imports (after line 20):
+
+```python
+from app.services.permissions import is_privileged
+```
+
+Then replace the `get_recent_activities` handler signature and body up to the service call. The new signature adds `scope`, and the body gates `all`:
+
+```python
+@router.get("/recent", response_model=ActivityListResponse)
+@user_limiter.limit(get_limit("file_list"))
+async def get_recent_activities(
+    request: Request,
+    response: Response,
+    limit: int = 20,
+    offset: int = 0,
+    action_types: Optional[str] = None,
+    file_type: Optional[str] = None,
+    since: Optional[datetime] = None,
+    path_prefix: Optional[str] = None,
+    scope: str = "mine",
+    user: UserPublic = Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+) -> ActivityListResponse:
+    """Get recent file activities.
+
+    Args:
+        limit: Max items (1-100, default 20).
+        offset: Pagination offset.
+        action_types: Comma-separated filter, e.g. ``file.open,file.download``.
+        file_type: Filter by type: file, directory, image, video, document.
+        since: ISO timestamp — only activities after this time.
+        path_prefix: Only activities within this directory.
+        scope: ``mine`` (own activity, default) or ``all`` (admin only — every
+            user's activity, with the acting username populated).
+    """
+    limit = max(1, min(limit, 100))
+    offset = max(0, offset)
+
+    all_users = scope == "all"
+    if all_users and not is_privileged(user):
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    parsed_types: Optional[List[str]] = None
+    if action_types:
+        parsed_types = [t.strip() for t in action_types.split(",") if t.strip()]
+
+    svc = FileActivityService(db)
+    items, total = svc.get_recent_activities(
+        user_id=user.id,
+        limit=limit,
+        offset=offset,
+        action_types=parsed_types,
+        file_type=file_type,
+        since=since,
+        path_prefix=path_prefix,
+        all_users=all_users,
+    )
+
+    return ActivityListResponse(
+        activities=items,
+        total=total,
+        has_more=(offset + limit) < total,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/test_file_activity.py::TestActivityRouteScope -v`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes/activity.py backend/tests/test_file_activity.py
+git commit -m "feat(activity): scope=all admin view on /api/activity/recent"
+```
+
+---
+
+## Task 3: Backend — close the data leak in `/api/logging/file-access`
+
+**Files:**
+- Modify: `backend/app/api/routes/logging.py` (`get_file_access_logs` ~line 161-203)
+- Test: `backend/tests/test_logging_file_access_scope.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_logging_file_access_scope.py`:
+
+```python
+"""Regression test: /api/logging/file-access must not leak other users' activity."""
+from app.core.config import settings
+from app.services.audit.logger_db import get_audit_logger_db
+
+
+def _seed_file_access(db_session):
+    audit = get_audit_logger_db()
+    audit.log_event(
+        event_type="FILE_ACCESS", user=settings.admin_username,
+        action="download", resource="/admin/secret.pdf", db=db_session,
+    )
+    audit.log_event(
+        event_type="FILE_ACCESS", user="testuser",
+        action="upload", resource="/testuser/note.txt", db=db_session,
+    )
+    db_session.commit()
+
+
+def test_regular_user_only_sees_own_file_access(client, db_session, user_headers):
+    _seed_file_access(db_session)
+    resp = client.get(
+        f"{settings.api_prefix}/logging/file-access?days=1&limit=100",
+        headers=user_headers,
+    )
+    assert resp.status_code == 200
+    users = {log["user"] for log in resp.json()["logs"]}
+    assert users == {"testuser"}
+
+
+def test_regular_user_cannot_widen_with_user_param(client, db_session, user_headers):
+    _seed_file_access(db_session)
+    resp = client.get(
+        f"{settings.api_prefix}/logging/file-access?days=1&limit=100&user={settings.admin_username}",
+        headers=user_headers,
+    )
+    assert resp.status_code == 200
+    users = {log["user"] for log in resp.json()["logs"]}
+    assert users <= {"testuser"}  # empty or only own — never the admin's
+
+
+def test_admin_sees_all_file_access(client, db_session, admin_headers):
+    _seed_file_access(db_session)
+    resp = client.get(
+        f"{settings.api_prefix}/logging/file-access?days=1&limit=100",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    users = {log["user"] for log in resp.json()["logs"]}
+    assert {settings.admin_username, "testuser"} <= users
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_logging_file_access_scope.py -v`
+Expected: FAIL — `test_regular_user_only_sees_own_file_access` sees `{"admin", "testuser"}` (leak).
+
+- [ ] **Step 3: Implement the self-scoping**
+
+In `backend/app/api/routes/logging.py`, add the import after line 10 (`from app.api.deps import get_current_user, get_db`):
+
+```python
+from app.services.permissions import is_privileged
+```
+
+In `get_file_access_logs`, immediately before `audit = get_audit_logger_db()` (~line 188), insert:
+
+```python
+    # Non-admins may only ever see their own file-access entries — prevent the
+    # widget (and any direct caller) from reading other users' paths/usernames.
+    if not is_privileged(current_user):
+        user = current_user.username
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/test_logging_file_access_scope.py -v`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes/logging.py backend/tests/test_logging_file_access_scope.py
+git commit -m "fix(logging): scope file-access logs to own user for non-admins"
+```
+
+---
+
+## Task 4: Frontend — new typed `api/activity.ts` client
+
+**Files:**
+- Create: `client/src/api/activity.ts`
+
+- [ ] **Step 1: Create the client module**
+
+Create `client/src/api/activity.ts`:
+
+```typescript
+import { apiClient } from '../lib/api';
+
+export interface ActivityItem {
+  id: number;
+  user_id: number;
+  username?: string | null;
+  action_type: string;
+  file_path: string;
+  file_name: string;
+  is_directory: boolean;
+  file_size?: number | null;
+  mime_type?: string | null;
+  source: string;
+  device_id?: string | null;
+  metadata?: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface ActivityListResponse {
+  activities: ActivityItem[];
+  total: number;
+  has_more: boolean;
+}
+
+export interface GetRecentActivitiesParams {
+  limit?: number;
+  offset?: number;
+  scope?: 'mine' | 'all';
+}
+
+export async function getRecentActivities(
+  params: GetRecentActivitiesParams = {},
+): Promise<ActivityListResponse> {
+  const { limit = 20, offset = 0, scope = 'mine' } = params;
+  const { data } = await apiClient.get<ActivityListResponse>('/api/activity/recent', {
+    params: { limit, offset, scope },
+  });
+  return data;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: no errors from `api/activity.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/api/activity.ts
+git commit -m "feat(activity): typed api/activity client for /api/activity/recent"
+```
+
+---
+
+## Task 5: Frontend — i18n action-title keys (de/en)
+
+**Files:**
+- Modify: `client/src/i18n/locales/de/dashboard.json`
+- Modify: `client/src/i18n/locales/en/dashboard.json`
+
+- [ ] **Step 1: Add the keys to the English locale**
+
+In `client/src/i18n/locales/en/dashboard.json`, locate the existing `"activity"` object and add an `"actions"` sub-object inside it (alongside `title`, `liveOperations`, etc.):
+
+```json
+    "actions": {
+      "upload": "File Uploaded",
+      "download": "File Downloaded",
+      "delete": "File Deleted",
+      "edit": "File Edited",
+      "open": "File Opened",
+      "move": "File Moved",
+      "rename": "File Renamed",
+      "share": "File Shared",
+      "permission": "Permissions Changed",
+      "create": "Folder Created",
+      "sync": "Sync Triggered",
+      "default": "Activity"
+    }
+```
+
+- [ ] **Step 2: Add the keys to the German locale**
+
+In `client/src/i18n/locales/de/dashboard.json`, add the same `"actions"` sub-object inside `"activity"`:
+
+```json
+    "actions": {
+      "upload": "Datei hochgeladen",
+      "download": "Datei heruntergeladen",
+      "delete": "Datei gelöscht",
+      "edit": "Datei bearbeitet",
+      "open": "Datei geöffnet",
+      "move": "Datei verschoben",
+      "rename": "Datei umbenannt",
+      "share": "Datei geteilt",
+      "permission": "Berechtigungen geändert",
+      "create": "Ordner erstellt",
+      "sync": "Synchronisierung gestartet",
+      "default": "Aktivität"
+    }
+```
+
+- [ ] **Step 3: Validate JSON**
+
+Run: `cd client && node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/de/dashboard.json','utf8')); JSON.parse(require('fs').readFileSync('src/i18n/locales/en/dashboard.json','utf8')); console.log('ok')"`
+Expected: prints `ok` (both files parse).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/i18n/locales/de/dashboard.json client/src/i18n/locales/en/dashboard.json
+git commit -m "i18n(activity): action-title keys for the dashboard activity feed (de/en)"
+```
+
+---
+
+## Task 6: Frontend — re-point `useActivityFeed` + action mapping
+
+**Files:**
+- Modify: `client/src/hooks/useActivityFeed.ts` (full rewrite of data source + mapping)
+- Test: `client/src/__tests__/hooks/useActivityFeed.test.ts` (new)
+
+Note: confirm `ActivityFeed.tsx` is the only importer before rewriting. Run a vectordb search for `useActivityFeed` usages (`mcp__vectordb-search__search_code`, query "useActivityFeed import usage", `projectPath D:/Programme (x86)/Baluhost`). Only `components/dashboard/ActivityFeed.tsx` should consume it; Task 7 updates that caller.
+
+- [ ] **Step 1: Write the failing hook test**
+
+Create `client/src/__tests__/hooks/useActivityFeed.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useActivityFeed } from '../../hooks/useActivityFeed';
+import type { ActivityListResponse } from '../../api/activity';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../lib/errorHandling', () => ({
+  getApiErrorMessage: (_e: unknown, fallback: string) => fallback,
+}));
+
+vi.mock('../../api/activity', () => ({
+  getRecentActivities: vi.fn(),
+}));
+
+import { getRecentActivities } from '../../api/activity';
+
+const adminResponse: ActivityListResponse = {
+  total: 2,
+  has_more: false,
+  activities: [
+    {
+      id: 1, user_id: 5, username: 'alice', action_type: 'file.upload',
+      file_path: 'alice/report.pdf', file_name: 'report.pdf', is_directory: false,
+      file_size: 2048, mime_type: 'application/pdf', source: 'server',
+      device_id: null, metadata: null, created_at: new Date().toISOString(),
+    },
+    {
+      id: 2, user_id: 6, username: 'bob', action_type: 'folder.create',
+      file_path: 'bob/photos', file_name: 'photos', is_directory: true,
+      file_size: null, mime_type: null, source: 'server',
+      device_id: null, metadata: null, created_at: new Date().toISOString(),
+    },
+  ],
+};
+
+describe('useActivityFeed', () => {
+  beforeEach(() => {
+    vi.mocked(getRecentActivities).mockResolvedValue(adminResponse);
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('requests scope=all when allUsers is true and maps action types', async () => {
+    const { result } = renderHook(() => useActivityFeed({ limit: 5, allUsers: true }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(getRecentActivities).toHaveBeenCalledWith({ limit: 5, scope: 'all' });
+    expect(result.current.activities).toHaveLength(2);
+    // action_type → icon key (prefix stripped; folder.create → create)
+    expect(result.current.activities[0].icon).toBe('upload');
+    expect(result.current.activities[1].icon).toBe('create');
+    // title resolved via i18n key (mocked t returns the key)
+    expect(result.current.activities[0].title).toBe('activity.actions.upload');
+    expect(result.current.activities[1].title).toBe('activity.actions.create');
+    // admin view includes the acting username in the detail line
+    expect(result.current.activities[0].detail).toContain('alice');
+  });
+
+  it('requests scope=mine when allUsers is false and omits username in detail', async () => {
+    vi.mocked(getRecentActivities).mockResolvedValue({
+      total: 1, has_more: false,
+      activities: [{
+        id: 9, user_id: 5, username: null, action_type: 'file.download',
+        file_path: 'me/a.txt', file_name: 'a.txt', is_directory: false,
+        file_size: null, mime_type: null, source: 'server',
+        device_id: null, metadata: null, created_at: new Date().toISOString(),
+      }],
+    });
+
+    const { result } = renderHook(() => useActivityFeed({ limit: 5 }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(getRecentActivities).toHaveBeenCalledWith({ limit: 5, scope: 'mine' });
+    expect(result.current.activities[0].icon).toBe('download');
+    expect(result.current.activities[0].detail).toBe('a.txt');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd client && npx vitest run src/__tests__/hooks/useActivityFeed.test.ts`
+Expected: FAIL — current hook calls `loggingApi.getFileAccessLogs`, not `getRecentActivities`; `allUsers` option unsupported.
+
+- [ ] **Step 3: Rewrite the hook**
+
+Replace the entire contents of `client/src/hooks/useActivityFeed.ts` with:
+
+```typescript
+/**
+ * Hook for fetching the dashboard activity feed from the user-scoped
+ * /api/activity API. Admins may request all users' activity (scope=all).
+ */
+import { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getRecentActivities, type ActivityItem as ApiActivityItem } from '../api/activity';
+import { formatBytes } from '../lib/formatters';
+import { getApiErrorMessage } from '../lib/errorHandling';
+
+export interface ActivityItem {
+  id: string;
+  title: string;
+  detail: string;
+  ago: string;
+  icon: string;
+  timestamp: Date;
+  success: boolean;
+}
+
+interface UseActivityFeedOptions {
+  limit?: number;
+  allUsers?: boolean;
+  refreshInterval?: number;
+}
+
+interface UseActivityFeedReturn {
+  activities: ActivityItem[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+// Map a dotted action_type (e.g. "file.upload", "folder.create") to an icon key
+// understood by ActivityFeed's ActivityIcon and to an i18n title sub-key.
+const ACTION_MAP: Record<string, { icon: string; titleKey: string }> = {
+  'file.upload': { icon: 'upload', titleKey: 'upload' },
+  'file.download': { icon: 'download', titleKey: 'download' },
+  'file.delete': { icon: 'delete', titleKey: 'delete' },
+  'file.edit': { icon: 'file', titleKey: 'edit' },
+  'file.open': { icon: 'file', titleKey: 'open' },
+  'file.move': { icon: 'move', titleKey: 'move' },
+  'file.rename': { icon: 'move', titleKey: 'rename' },
+  'file.share': { icon: 'share', titleKey: 'share' },
+  'file.permission': { icon: 'share', titleKey: 'permission' },
+  'folder.create': { icon: 'create', titleKey: 'create' },
+  'sync.triggered': { icon: 'file', titleKey: 'sync' },
+};
+
+export function mapActionType(actionType: string): { icon: string; titleKey: string } {
+  return ACTION_MAP[actionType] ?? { icon: 'file', titleKey: 'default' };
+}
+
+// Format relative time
+export function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSeconds < 60) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
+  if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+  return date.toLocaleDateString();
+}
+
+export function useActivityFeed(options: UseActivityFeedOptions = {}): UseActivityFeedReturn {
+  const { limit = 5, allUsers = false, refreshInterval = 30000 } = options;
+  const { t } = useTranslation('dashboard');
+
+  const [activities, setActivities] = useState<ActivityItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const toViewItem = useCallback(
+    (item: ApiActivityItem): ActivityItem => {
+      const { icon, titleKey } = mapActionType(item.action_type);
+      const timestamp = new Date(item.created_at);
+
+      let detail = item.file_name;
+      if (item.username) detail = `${item.username} • ${detail}`;
+      if (item.file_size) detail += ` (${formatBytes(item.file_size)})`;
+
+      return {
+        id: String(item.id),
+        title: t(`activity.actions.${titleKey}`),
+        detail,
+        ago: formatRelativeTime(timestamp),
+        icon,
+        timestamp,
+        success: true,
+      };
+    },
+    [t],
+  );
+
+  const loadData = useCallback(async () => {
+    try {
+      const response = await getRecentActivities({ limit, scope: allUsers ? 'all' : 'mine' });
+      setActivities(response.activities.map(toViewItem));
+      setError(null);
+    } catch (err: unknown) {
+      setError(getApiErrorMessage(err, 'Failed to load activity feed'));
+    }
+  }, [limit, allUsers, toViewItem]);
+
+  useEffect(() => {
+    setLoading(true);
+    loadData().finally(() => setLoading(false));
+  }, [loadData]);
+
+  useEffect(() => {
+    if (refreshInterval <= 0) return;
+    const interval = setInterval(loadData, refreshInterval);
+    return () => clearInterval(interval);
+  }, [refreshInterval, loadData]);
+
+  return { activities, loading, error, refetch: loadData };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd client && npx vitest run src/__tests__/hooks/useActivityFeed.test.ts`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/hooks/useActivityFeed.ts client/src/__tests__/hooks/useActivityFeed.test.ts
+git commit -m "feat(activity): re-point useActivityFeed to /api/activity with action mapping"
+```
+
+---
+
+## Task 7: Frontend — wire `ActivityFeed.tsx` (allUsers + admin button gate)
+
+**Files:**
+- Modify: `client/src/components/dashboard/ActivityFeed.tsx` (~line 1-67)
+- Test: `client/src/__tests__/components/dashboard/ActivityFeed.test.tsx` (new)
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `client/src/__tests__/components/dashboard/ActivityFeed.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ActivityFeed } from '../../../components/dashboard/ActivityFeed';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+const mockUseAuth = vi.fn();
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const mockUseActivityFeed = vi.fn();
+vi.mock('../../../hooks/useActivityFeed', () => ({
+  useActivityFeed: (opts: unknown) => mockUseActivityFeed(opts),
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+function setup(isAdmin: boolean) {
+  mockUseAuth.mockReturnValue({ isAdmin });
+  mockUseActivityFeed.mockReturnValue({ activities: [], loading: false, error: null });
+  render(<ActivityFeed limit={5} />);
+}
+
+describe('ActivityFeed admin gating', () => {
+  it('passes allUsers=true and shows the system-logs button for admins', () => {
+    setup(true);
+    expect(mockUseActivityFeed).toHaveBeenCalledWith(
+      expect.objectContaining({ allUsers: true }),
+    );
+    expect(screen.getByText('dashboard:activity.viewSystemLogs')).toBeInTheDocument();
+  });
+
+  it('passes allUsers=false and hides the system-logs button for regular users', () => {
+    setup(false);
+    expect(mockUseActivityFeed).toHaveBeenCalledWith(
+      expect.objectContaining({ allUsers: false }),
+    );
+    expect(screen.queryByText('dashboard:activity.viewSystemLogs')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd client && npx vitest run src/__tests__/components/dashboard/ActivityFeed.test.tsx`
+Expected: FAIL — component does not use `useAuth`, button is always rendered, and `allUsers` is not passed.
+
+- [ ] **Step 3: Update the component**
+
+In `client/src/components/dashboard/ActivityFeed.tsx`:
+
+(a) Add the `useAuth` import after the existing `useActivityFeed` import (after line 8):
+
+```typescript
+import { useAuth } from '../../contexts/AuthContext';
+```
+
+(b) Replace the hook wiring (the `const { activities, loading, error } = ...` line, ~line 48) with:
+
+```typescript
+  const { isAdmin } = useAuth();
+  const { activities, loading, error } = useActivityFeed({ limit, allUsers: isAdmin });
+```
+
+(c) Gate the "View System Logs" button (the `<button onClick={handleViewLogs} ...>...</button>` block, ~line 61-66) by wrapping it so it only renders for admins:
+
+```tsx
+        {isAdmin && (
+          <button
+            onClick={handleViewLogs}
+            className="rounded-full border border-slate-700/70 px-3 py-1 text-xs text-slate-400 transition hover:border-slate-500 hover:text-white"
+          >
+            {t('dashboard:activity.viewSystemLogs')}
+          </button>
+        )}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd client && npx vitest run src/__tests__/components/dashboard/ActivityFeed.test.tsx`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/dashboard/ActivityFeed.tsx client/src/__tests__/components/dashboard/ActivityFeed.test.tsx
+git commit -m "feat(activity): admin all-users feed + admin-only system-logs link"
+```
+
+---
+
+## Task 8: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Backend — run the touched test modules**
+
+Run: `cd backend && python -m pytest tests/test_file_activity.py tests/test_logging_file_access_scope.py -v`
+Expected: all PASS.
+
+- [ ] **Step 2: Frontend — type-check + full unit suite**
+
+Run: `cd client && npx tsc --noEmit && npx vitest run`
+Expected: no TS errors; all Vitest tests pass (new activity tests included).
+
+- [ ] **Step 3: Frontend — production build sanity**
+
+Run: `cd client && npm run build`
+Expected: build succeeds (no unresolved imports from the removed `loggingApi` usage in the hook).
+
+- [ ] **Step 4: Manual smoke (dev mode)**
+
+Start `python start_dev.py`. Log in as `admin/DevMode2024` → Dashboard "Recent Activity" shows activity for all users with usernames, and the "View System Logs" link is present. Log in as `user/User123` → the widget shows only that user's activity, no other users' paths, and no "View System Logs" link. (If the feed is empty, perform a file upload/download in the File Manager first to generate activity.)
+
+- [ ] **Step 5: Confirm no stale importers**
+
+Verify nothing else still calls the old hook signature: vectordb search for `getFileAccessLogs` should show it only in `api/logging.ts` and any logging-page code — not in `hooks/useActivityFeed.ts`.
+
+---
+
+## Notes for the implementer
+
+- Repo uses `core.autocrlf=true` on Windows — let Git handle line endings; don't fight CRLF warnings.
+- Run backend tests from the `backend/` dir; frontend from `client/`.
+- Keep commits as laid out (one per task) — the branch is `feat/activity-feed-own-vs-all`.
+- The spec is the source of truth: `docs/superpowers/specs/2026-06-06-activity-feed-own-vs-all-design.md`.
+</content>

--- a/docs/superpowers/specs/2026-06-06-activity-feed-own-vs-all-design.md
+++ b/docs/superpowers/specs/2026-06-06-activity-feed-own-vs-all-design.md
@@ -1,0 +1,178 @@
+# Activity Feed: own-vs-all + data-leak fix — Design
+
+> Status: approved (2026-06-06). Next step: implementation plan via writing-plans.
+
+## Goal
+
+The Dashboard already shows a "Recent Activity" widget, but it is wired to the
+**wrong data source** and leaks data:
+
+- `components/dashboard/ActivityFeed.tsx` → `hooks/useActivityFeed.ts` →
+  `loggingApi.getFileAccessLogs()` → `GET /api/logging/file-access` (the audit
+  log), **not** the purpose-built `/api/activity/*` (file-activity) API.
+- That logging endpoint is `Depends(get_current_user)` (any authenticated user)
+  and calls the non-filtering `AuditLoggerDB.get_logs()` with no user scoping.
+  The widget passes no `user` filter, so **every authenticated user sees every
+  other user's file activity** — real usernames and full file paths
+  (e.g. `alice • /private/steuer2025.pdf downloaded`).
+
+Desired behaviour:
+
+- **Normal user** → sees only their **own** recent file activity.
+- **Admin** → sees **all users'** activity, with the acting user shown per entry.
+
+The dedicated `file_activity` service is already user-scoped and built for exactly
+this (retention, dedup, client reporting). Re-pointing the widget at it both
+delivers the feature and removes the widget's dependency on the leaky endpoint.
+We additionally harden the logging endpoint itself so the leak is closed for any
+direct caller, not just hidden from the widget.
+
+Decision (2026-06-06): do it properly — include the endpoint hardening and the
+i18n cleanup; no separate GitHub issue (the leak is fixed within this work).
+
+## Scope
+
+In scope:
+
+1. Make `GET /api/activity/recent` admin-capable (`scope=mine|all`).
+2. Harden `GET /api/logging/file-access` so non-admins only see their own entries.
+3. Re-point the Dashboard widget to `/api/activity/recent`.
+4. Move the hard-coded English action titles into i18n (de/en).
+5. Backend + frontend tests.
+
+Out of scope (YAGNI):
+
+- No dedicated `/activity` page, no filter UI on the widget.
+- No avatars — acting user shown as plain username text.
+- `GET /api/activity/recent-files` stays user-scoped (unchanged).
+- No change to `get_logs_paginated` / the `/logging` page (already role-filtered).
+
+## Design
+
+### 1. Backend — `/api/activity/recent` admin-capable
+
+**Schema** (`backend/app/schemas/file_activity.py`)
+- `ActivityItem` gains:
+  - `user_id: int` — always populated.
+  - `username: Optional[str] = None` — populated only in the admin/all view.
+
+**Service** (`backend/app/services/file_activity.py`)
+- `get_recent_activities(..., all_users: bool = False)`:
+  - `all_users=False` (default): unchanged — filtered by `user_id`,
+    `username` left `None`.
+  - `all_users=True`: drop the `user_id == ...` filter; `JOIN users` to fetch
+    `username`; all other filters (action_types, file_type, since, path_prefix),
+    ordering, pagination and `total` count behave identically.
+- `_to_activity_item` carries `user_id`; an `all_users` path also sets `username`
+  from the joined row.
+
+**Route** (`backend/app/api/routes/activity.py`)
+- `get_recent_activities` gains `scope: str = "mine"` query param.
+  - `scope == "all"`: require admin. If the caller is not privileged → `403`.
+    Calls the service with `all_users=True`.
+  - `scope == "mine"` (default) or any other value: current behaviour
+    (service called with the caller's `user.id`, `all_users=False`).
+- Admin check uses the existing privilege helper / role check used elsewhere in
+  routes (consistent with `get_current_admin` semantics) without changing the
+  default dependency (endpoint stays `get_current_user` so `scope=mine` works for
+  everyone).
+
+### 2. Backend — leak fix in `/api/logging/file-access`
+
+**Route** (`backend/app/api/routes/logging.py:get_file_access_logs`)
+- Determine whether `current_user` is privileged (admin).
+- Non-admin: force `user = current_user.username` before calling
+  `audit.get_logs(...)`, so a non-admin only ever receives their own
+  FILE_ACCESS entries (and cannot widen it via the `user` query param).
+- Admin: unchanged (may see all, may filter by `user`).
+- This closes the disclosure for direct API callers regardless of the widget.
+
+### 3. Frontend — re-point the widget
+
+**New** `client/src/api/activity.ts`
+- Interfaces mirroring the backend: `ActivityItem` (incl. `user_id`,
+  `username`, `action_type`, `file_path`, `file_name`, `is_directory`,
+  `file_size`, `mime_type`, `source`, `device_id`, `created_at`),
+  `ActivityListResponse` (`activities`, `total`, `has_more`).
+- `getRecentActivities({ limit, offset?, scope? })` → `GET /api/activity/recent`.
+- Follows `api/CLAUDE.md` conventions (typed funcs, `apiClient`, return `res.data`).
+
+**Hook** `client/src/hooks/useActivityFeed.ts`
+- Fetches from `getRecentActivities` instead of `loggingApi.getFileAccessLogs`.
+- Accepts an `allUsers?: boolean` option; passes `scope = allUsers ? 'all' : 'mine'`.
+- Maps the dotted `action_type` (`file.upload`, `folder.create`, `sync.triggered`,
+  …) → existing icon keys (strip `file.` / `folder.` prefix, map `sync.triggered`).
+- Builds `detail` = `file_name` (+ `username • ` prefix when present) (+ size).
+- Keeps the existing returned `ActivityItem` view-shape
+  (`{ id, title, detail, ago, icon, timestamp, success }`) so the component
+  barely changes. `success` defaults to `true` (file_activity has no failure state).
+- Action titles come from i18n (see §4), not hard-coded English.
+
+**Component** `client/src/components/dashboard/ActivityFeed.tsx`
+- Passes `allUsers={isAdmin}` (from `useAuth`) into the hook.
+- "View System Logs" button rendered **only for admins** (the `/logging` route is
+  admin-only). Non-admins see the feed without that button.
+
+### 4. i18n
+
+- Add action-title keys to the `dashboard` namespace in
+  `client/src/i18n/locales/{de,en}/dashboard.json`
+  (upload, download, delete, create/folder.create, move, rename, copy, share,
+  edit/open, permission, sync.triggered, generic fallback).
+- Hook resolves titles via these keys instead of the hard-coded
+  `getActionTitle` English strings.
+
+## Data flow
+
+```
+User opens Dashboard
+  → ActivityFeed (knows isAdmin via useAuth)
+    → useActivityFeed({ limit, allUsers: isAdmin })
+      → getRecentActivities({ limit, scope: isAdmin ? 'all' : 'mine' })
+        → GET /api/activity/recent?scope=...
+          → route: scope=all ⇒ admin-gate ⇒ service(all_users=True)  [join users → username]
+                   scope=mine ⇒ service(user.id, all_users=False)
+      ← {activities[], total, has_more}
+    ← mapped view items (icon, i18n title, detail incl. username for admins, ago)
+```
+
+## Error handling
+
+- `scope=all` by a non-admin → `403` (route-level), surfaced by the hook's
+  existing error path (`setError`); the widget already renders an error state.
+- Empty result → existing empty state ("no recent activity").
+- Network/other errors → existing error state via `getApiErrorMessage`.
+
+## Testing
+
+**Backend** (`backend/tests/`)
+- Service: `get_recent_activities(all_users=True)` returns entries across users
+  with `username` populated; `all_users=False` stays user-scoped with
+  `username=None`; existing filters still apply in both modes.
+- Route: `scope=all` as admin → cross-user; `scope=all` as normal user → `403`;
+  `scope=mine` (and default) → only caller's entries.
+- Logging leak fix: a non-admin calling `/api/logging/file-access` receives only
+  their own FILE_ACCESS entries even when other users have activity and even when
+  passing a `user=` query param; admin still sees all.
+
+**Frontend** (Vitest)
+- `useActivityFeed` maps `action_type` → icon + i18n title correctly; admin mode
+  includes `username` in `detail`, non-admin does not; `api/activity` mocked.
+
+## Files touched
+
+Backend:
+- `app/schemas/file_activity.py` (extend `ActivityItem`)
+- `app/services/file_activity.py` (`all_users` branch + join)
+- `app/api/routes/activity.py` (`scope` param + admin gate)
+- `app/api/routes/logging.py` (non-admin self-scoping)
+- `tests/…` (activity admin-scope tests, logging leak-fix test)
+
+Frontend:
+- `client/src/api/activity.ts` (new)
+- `client/src/hooks/useActivityFeed.ts` (re-point + mapping + i18n)
+- `client/src/components/dashboard/ActivityFeed.tsx` (admin button gating, pass allUsers)
+- `client/src/i18n/locales/de/dashboard.json`, `…/en/dashboard.json` (action titles)
+- `client/src/**/__tests__/…` (useActivityFeed test)
+</content>
+</invoke>


### PR DESCRIPTION
## Summary

Re-points the Dashboard **"Recent Activity"** widget from the audit-log endpoint to the purpose-built, user-scoped `/api/activity` API, adds an **admin all-users view**, and closes a pre-existing **data-disclosure** in the logging endpoints found along the way.

Behaviour:
- **Regular user** → sees only their **own** recent file activity (widget + API).
- **Admin** → sees **all users'** activity, with the acting username shown per entry; the "View system logs" link is admin-only.

### Backend
- `ActivityItem` schema gains `user_id` + optional `username`.
- `FileActivityService.get_recent_activities(all_users=…)` — admin cross-user view via a `users` join (default path unchanged, user-scoped).
- `GET /api/activity/recent?scope=mine|all` — `scope=all` gated by `is_privileged` (403 otherwise); `scope` typed as a `Literal`.

### Security fix (pre-existing leak, fixed in this PR)
`GET /api/logging/file-access` and `GET /api/logging/stats` are reachable by any authenticated user but queried the audit log **unscoped**, exposing every user's file paths / usernames / per-user op counts to non-admins (incl. a `?user=` bypass and the dev-mode mock fallback). Non-admins are now forced to their own username on both endpoints and both real + dev-mock paths; admins unchanged.

> Note: this leak was pre-existing (not introduced here). Surfaced during the widget re-point and fixed in-scope per maintainer request.

### Frontend
- New typed `api/activity.ts` client.
- `useActivityFeed` re-pointed at `/api/activity/recent`, with `action_type → icon + i18n title` mapping; passes `scope=all` for admins.
- `ActivityFeed.tsx` passes `allUsers={isAdmin}` and gates the system-logs button to admins.
- i18n action-title keys added (de + en).

## Test Plan
- [x] Backend: `pytest tests/test_file_activity.py tests/test_logging_file_access_scope.py` → 35 passed (service all_users, route scope=mine/all + 403, file-access & stats leak regressions incl. `?user=` bypass and dev-mock).
- [x] Frontend: `npx vitest run` → 400 passed (hook mapping/scope/error-path, helper mapping, component admin-gating).
- [x] `npx tsc --noEmit` clean; `npm run build` succeeds.
- [ ] Manual dev-mode smoke (admin sees all + logs link; user sees only own, no link) — not run in CI; behaviour covered by the automated tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
