### PR TITLE
fix(deploy): provision baluhost-power sudoers on deploy + clear stale workaround (#126)

### DIFF
--- a/deploy/install/templates/baluhost-deploy-sudoers
+++ b/deploy/install/templates/baluhost-deploy-sudoers
@@ -17,6 +17,8 @@
 @@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/bash /opt/baluhost/deploy/scripts/install-amd-gpu-permissions.sh
 @@BALUHOST_USER@@ ALL=(root) NOPASSWD: /bin/bash /opt/baluhost/deploy/scripts/install-hardware-sudoers.sh
 @@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/bash /opt/baluhost/deploy/scripts/install-hardware-sudoers.sh
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /bin/bash /opt/baluhost/deploy/scripts/install-power-sudoers.sh
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/bash /opt/baluhost/deploy/scripts/install-power-sudoers.sh
 
 # Companion (Tauri) install — only invoked when INSTALL_COMPANION=1 in
 # ci-deploy.sh; off by default. The script installs ONLY the .deb staged by

--- a/deploy/scripts/ci-deploy.sh
+++ b/deploy/scripts/ci-deploy.sh
@@ -458,6 +458,26 @@ if [[ "${SYNC_PERMISSIONS:-0}" == "1" || "${SYNC_PERMISSIONS,,}" == "true" ]]; t
         log_warn "Hardware sudoers script not found at $HARDWARE_SUDOERS_SCRIPT (skipping)."
     fi
 
+    # Power sudoers: power-profiles-daemon stop/start/mask/unmask + logind idle
+    # helper + sddm desktop-toggle grants. The installer renders @@BALUHOST_USER@@
+    # from the running service user and validates with visudo before replacing the
+    # live file. This is the path by which sudoers-baluhost-power template changes
+    # reach an installed box; it also clears the obsolete /etc/sudoers.d/baluhost-ppd
+    # workaround once superseded. Invoked with no env vars (like the others): the
+    # deploy sudoers rule whitelists this exact `bash <abs-path>` invocation, and the
+    # script's internal TEMPLATE default (/opt/baluhost/...) matches the prod INSTALL_DIR.
+    POWER_SUDOERS_SCRIPT="$INSTALL_DIR/deploy/scripts/install-power-sudoers.sh"
+    if [[ -f "$POWER_SUDOERS_SCRIPT" ]]; then
+        log_info "Re-applying power sudoers..."
+        if sudo bash "$POWER_SUDOERS_SCRIPT"; then
+            log_info "Power sudoers sync OK."
+        else
+            log_warn "Power sudoers sync failed (non-fatal — deploy continues)."
+        fi
+    else
+        log_warn "Power sudoers script not found at $POWER_SUDOERS_SCRIPT (skipping)."
+    fi
+
     # Future permission scripts go here following the same pattern:
     # if [[ -f "$INSTALL_DIR/deploy/scripts/install-<thing>-permissions.sh" ]]; then ...
 else

--- a/deploy/scripts/install-power-sudoers.sh
+++ b/deploy/scripts/install-power-sudoers.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Re-install (or update) the baluhost-power sudoers file on an existing host.
+#
+# Why: the power sudoers template (logind idle helper, power-profiles-daemon
+# stop/start/mask/unmask for the CPU power-authority feature, and sddm desktop
+# toggle) is rendered once at install time by module 13, but ci-deploy.sh does
+# NOT re-run installer modules on a routine deploy. Template fixes therefore
+# never reach an already-installed box — e.g. the four power-profiles-daemon
+# rules (#123) left the CPU power authority returning HTTP 500 on prod, and a
+# stale pre-@@-token file left the literal placeholder in the live sudoers file
+# (#126). Operators run this script — or a SYNC_PERMISSIONS=1 deploy, which
+# calls it — to push template changes onto /etc/sudoers.d/baluhost-power.
+#
+# It also clears the obsolete /etc/sudoers.d/baluhost-ppd workaround (manual
+# four-line PPD grant) once the regular baluhost-power file supersedes it.
+#
+# Safe by construction:
+#   - renders @@BALUHOST_USER@@ from the actual service user,
+#   - validates with `visudo -cf` BEFORE replacing the live file,
+#   - keeps a timestamped backup of the previous live file,
+#   - installs -m 0440 -o root -g root,
+#   - removes baluhost-ppd ONLY after baluhost-power is validated + installed.
+#
+# Run as root.
+
+set -euo pipefail
+
+TEMPLATE="${TEMPLATE:-/opt/baluhost/deploy/install/templates/sudoers-baluhost-power}"
+TARGET="/etc/sudoers.d/baluhost-power"
+SERVICE="${SERVICE:-baluhost-backend.service}"
+WORKAROUND="/etc/sudoers.d/baluhost-ppd"
+
+if [[ "$EUID" -ne 0 ]]; then
+    echo "ERROR: must run as root (use sudo)." >&2
+    exit 1
+fi
+
+if [[ ! -f "$TEMPLATE" ]]; then
+    echo "ERROR: template not found: $TEMPLATE" >&2
+    echo "Did you 'git pull' /opt/baluhost first?" >&2
+    exit 1
+fi
+
+# Derive the service user from baluhost-backend.service 'User=' so the sudoers
+# rules are granted to whoever actually runs the backend — not a hardcoded name.
+# Order: explicit BALUHOST_USER override > systemd 'User=' > error out.
+SERVICE_USER="$(systemctl show -p User --value "$SERVICE" 2>/dev/null || true)"
+BALUHOST_USER="${BALUHOST_USER:-${SERVICE_USER:-}}"
+if [[ -z "$BALUHOST_USER" ]]; then
+    echo "ERROR: could not determine the service user from '$SERVICE' (User=)" >&2
+    echo "       and BALUHOST_USER is unset. Set BALUHOST_USER explicitly." >&2
+    exit 1
+fi
+echo "  ..  rendering power sudoers for user: $BALUHOST_USER"
+
+# Substitute @@BALUHOST_USER@@ placeholder into a temp file.
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+sed "s|@@BALUHOST_USER@@|$BALUHOST_USER|g" "$TEMPLATE" >"$TMP"
+
+# Validate BEFORE touching the live file — never leave an invalid sudoers file.
+if ! visudo -cf "$TMP" >/dev/null 2>&1; then
+    echo "ERROR: generated sudoers file fails visudo syntax check; live file untouched." >&2
+    visudo -cf "$TMP" || true
+    exit 1
+fi
+
+# Timestamped backup of the existing live file (if any), so a bad change can be
+# rolled back by hand.
+if [[ -f "$TARGET" ]]; then
+    BACKUP="${TARGET}.bak.$(date +%Y%m%d%H%M%S)"
+    cp -p "$TARGET" "$BACKUP"
+    echo "  OK  backed up existing file to: $BACKUP"
+fi
+
+install -m 0440 -o root -g root "$TMP" "$TARGET"
+echo "  OK  installed: $TARGET"
+visudo -cf "$TARGET" >/dev/null && echo "  OK  visudo syntax check passed"
+
+# Clear the obsolete manual PPD workaround ONLY now that the regular
+# baluhost-power file is validated and live — never leave a gap without rules.
+if [[ -f "$WORKAROUND" ]]; then
+    WB="${WORKAROUND}.bak.$(date +%Y%m%d%H%M%S)"
+    cp -p "$WORKAROUND" "$WB"
+    rm -f "$WORKAROUND"
+    echo "  OK  removed obsolete workaround $WORKAROUND (backed up to $WB)"
+fi

--- a/docs/superpowers/plans/2026-06-07-ppd-sudoers-deploy-provisioning.md
+++ b/docs/superpowers/plans/2026-06-07-ppd-sudoers-deploy-provisioning.md
@@ -1,0 +1,294 @@
+# PPD-Sudoers Deploy-Provisioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ci-deploy.sh` (under `SYNC_PERMISSIONS=1`) provision `/etc/sudoers.d/baluhost-power` idempotently from the repo template, rendered with the real service user, and clear the obsolete `baluhost-ppd` workaround.
+
+**Architecture:** A new standalone installer script `install-power-sudoers.sh` mirrors the existing `install-hardware-sudoers.sh` (derive user from systemd → `sed @@BALUHOST_USER@@` → `visudo -cf` before replace → backup → install 0440 root:root → cleanup `baluhost-ppd`). `ci-deploy.sh` calls it in the `SYNC_PERMISSIONS` block. The `baluhost-deploy-sudoers` template whitelists the new script's pinned absolute path.
+
+**Tech Stack:** Bash, sudoers/visudo, systemd. No application code, no pytest. Verification via `bash -n` and template-render inspection.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-ppd-sudoers-deploy-provisioning-design.md`
+
+**Reference file (clone source):** `deploy/scripts/install-hardware-sudoers.sh`
+
+---
+
+## File Structure
+
+- **Create:** `deploy/scripts/install-power-sudoers.sh` — standalone idempotent power-sudoers installer + `baluhost-ppd` cleanup.
+- **Modify:** `deploy/scripts/ci-deploy.sh` — add power-sudoers hook in the `SYNC_PERMISSIONS` block (replace the `# Future permission scripts go here` placeholder, currently lines 461-462).
+- **Modify:** `deploy/install/templates/baluhost-deploy-sudoers` — add two pinned whitelist lines after the hardware block (currently after line 19).
+
+All three live under `/deploy/` → CODEOWNERS-tagged `@Xveyn`.
+
+---
+
+### Task 1: Create `install-power-sudoers.sh`
+
+**Files:**
+- Create: `deploy/scripts/install-power-sudoers.sh`
+
+- [ ] **Step 1: Write the script**
+
+Create `deploy/scripts/install-power-sudoers.sh` with exactly this content:
+
+```bash
+#!/bin/bash
+# Re-install (or update) the baluhost-power sudoers file on an existing host.
+#
+# Why: the power sudoers template (logind idle helper, power-profiles-daemon
+# stop/start/mask/unmask for the CPU power-authority feature, and sddm desktop
+# toggle) is rendered once at install time by module 13, but ci-deploy.sh does
+# NOT re-run installer modules on a routine deploy. Template fixes therefore
+# never reach an already-installed box — e.g. the four power-profiles-daemon
+# rules (#123) left the CPU power authority returning HTTP 500 on prod, and a
+# stale pre-@@-token file left the literal placeholder in the live sudoers file
+# (#126). Operators run this script — or a SYNC_PERMISSIONS=1 deploy, which
+# calls it — to push template changes onto /etc/sudoers.d/baluhost-power.
+#
+# It also clears the obsolete /etc/sudoers.d/baluhost-ppd workaround (manual
+# four-line PPD grant) once the regular baluhost-power file supersedes it.
+#
+# Safe by construction:
+#   - renders @@BALUHOST_USER@@ from the actual service user,
+#   - validates with `visudo -cf` BEFORE replacing the live file,
+#   - keeps a timestamped backup of the previous live file,
+#   - installs -m 0440 -o root -g root,
+#   - removes baluhost-ppd ONLY after baluhost-power is validated + installed.
+#
+# Run as root.
+
+set -euo pipefail
+
+TEMPLATE="${TEMPLATE:-/opt/baluhost/deploy/install/templates/sudoers-baluhost-power}"
+TARGET="/etc/sudoers.d/baluhost-power"
+SERVICE="${SERVICE:-baluhost-backend.service}"
+WORKAROUND="/etc/sudoers.d/baluhost-ppd"
+
+if [[ "$EUID" -ne 0 ]]; then
+    echo "ERROR: must run as root (use sudo)." >&2
+    exit 1
+fi
+
+if [[ ! -f "$TEMPLATE" ]]; then
+    echo "ERROR: template not found: $TEMPLATE" >&2
+    echo "Did you 'git pull' /opt/baluhost first?" >&2
+    exit 1
+fi
+
+# Derive the service user from baluhost-backend.service 'User=' so the sudoers
+# rules are granted to whoever actually runs the backend — not a hardcoded name.
+# Order: explicit BALUHOST_USER override > systemd 'User=' > error out.
+SERVICE_USER="$(systemctl show -p User --value "$SERVICE" 2>/dev/null || true)"
+BALUHOST_USER="${BALUHOST_USER:-${SERVICE_USER:-}}"
+if [[ -z "$BALUHOST_USER" ]]; then
+    echo "ERROR: could not determine the service user from '$SERVICE' (User=)" >&2
+    echo "       and BALUHOST_USER is unset. Set BALUHOST_USER explicitly." >&2
+    exit 1
+fi
+echo "  ..  rendering power sudoers for user: $BALUHOST_USER"
+
+# Substitute @@BALUHOST_USER@@ placeholder into a temp file.
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+sed "s|@@BALUHOST_USER@@|$BALUHOST_USER|g" "$TEMPLATE" >"$TMP"
+
+# Validate BEFORE touching the live file — never leave an invalid sudoers file.
+if ! visudo -cf "$TMP" >/dev/null 2>&1; then
+    echo "ERROR: generated sudoers file fails visudo syntax check; live file untouched." >&2
+    visudo -cf "$TMP" || true
+    exit 1
+fi
+
+# Timestamped backup of the existing live file (if any), so a bad change can be
+# rolled back by hand.
+if [[ -f "$TARGET" ]]; then
+    BACKUP="${TARGET}.bak.$(date +%Y%m%d%H%M%S)"
+    cp -p "$TARGET" "$BACKUP"
+    echo "  OK  backed up existing file to: $BACKUP"
+fi
+
+install -m 0440 -o root -g root "$TMP" "$TARGET"
+echo "  OK  installed: $TARGET"
+visudo -cf "$TARGET" >/dev/null && echo "  OK  visudo syntax check passed"
+
+# Clear the obsolete manual PPD workaround ONLY now that the regular
+# baluhost-power file is validated and live — never leave a gap without rules.
+if [[ -f "$WORKAROUND" ]]; then
+    WB="${WORKAROUND}.bak.$(date +%Y%m%d%H%M%S)"
+    cp -p "$WORKAROUND" "$WB"
+    rm -f "$WORKAROUND"
+    echo "  OK  removed obsolete workaround $WORKAROUND (backed up to $WB)"
+fi
+```
+
+- [ ] **Step 2: Verify shell syntax**
+
+Run: `bash -n deploy/scripts/install-power-sudoers.sh`
+Expected: no output, exit code 0 (a syntax error would print a line/message).
+
+- [ ] **Step 3: Verify the template renders to a valid sudoers body**
+
+This mimics exactly what the script's `sed` does, without needing root/visudo. Run:
+
+```bash
+sed 's|@@BALUHOST_USER@@|sven|g' deploy/install/templates/sudoers-baluhost-power > /tmp/power-sudoers.rendered
+```
+
+Then Read `/tmp/power-sudoers.rendered` and confirm:
+- It contains the four lines `sven ALL=(root) NOPASSWD: /usr/bin/systemctl {stop,start,mask,unmask} power-profiles-daemon`.
+- No literal `@@BALUHOST_USER@@` remains anywhere.
+
+Expected: four PPD lines present, zero `@@` occurrences.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/scripts/install-power-sudoers.sh
+git commit -m "feat(deploy): install-power-sudoers.sh — idempotent baluhost-power provisioning (#126)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Wire the hook into `ci-deploy.sh`
+
+**Files:**
+- Modify: `deploy/scripts/ci-deploy.sh` (replace the placeholder comment at lines 461-462)
+
+- [ ] **Step 1: Replace the placeholder block**
+
+Find this exact block in `deploy/scripts/ci-deploy.sh` (currently lines 461-462, inside the `if [[ "${SYNC_PERMISSIONS:-0}" == "1" ... ]]` branch, right after the hardware-sudoers block closes):
+
+```bash
+    # Future permission scripts go here following the same pattern:
+    # if [[ -f "$INSTALL_DIR/deploy/scripts/install-<thing>-permissions.sh" ]]; then ...
+```
+
+Replace it with:
+
+```bash
+    # Power sudoers: power-profiles-daemon stop/start/mask/unmask + logind idle
+    # helper + sddm desktop-toggle grants. The installer renders @@BALUHOST_USER@@
+    # from the running service user and validates with visudo before replacing the
+    # live file. This is the path by which sudoers-baluhost-power template changes
+    # reach an installed box; it also clears the obsolete /etc/sudoers.d/baluhost-ppd
+    # workaround once superseded. Invoked with no env vars (like the others): the
+    # deploy sudoers rule whitelists this exact `bash <abs-path>` invocation, and the
+    # script's internal TEMPLATE default (/opt/baluhost/...) matches the prod INSTALL_DIR.
+    POWER_SUDOERS_SCRIPT="$INSTALL_DIR/deploy/scripts/install-power-sudoers.sh"
+    if [[ -f "$POWER_SUDOERS_SCRIPT" ]]; then
+        log_info "Re-applying power sudoers..."
+        if sudo bash "$POWER_SUDOERS_SCRIPT"; then
+            log_info "Power sudoers sync OK."
+        else
+            log_warn "Power sudoers sync failed (non-fatal — deploy continues)."
+        fi
+    else
+        log_warn "Power sudoers script not found at $POWER_SUDOERS_SCRIPT (skipping)."
+    fi
+
+    # Future permission scripts go here following the same pattern:
+    # if [[ -f "$INSTALL_DIR/deploy/scripts/install-<thing>-permissions.sh" ]]; then ...
+```
+
+(The trailing `# Future permission scripts go here` comment is kept so the extension point survives for the next script.)
+
+- [ ] **Step 2: Verify shell syntax**
+
+Run: `bash -n deploy/scripts/ci-deploy.sh`
+Expected: no output, exit code 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/scripts/ci-deploy.sh
+git commit -m "feat(deploy): call install-power-sudoers.sh in SYNC_PERMISSIONS block (#126)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Whitelist the new script in the deploy-sudoers template
+
+**Files:**
+- Modify: `deploy/install/templates/baluhost-deploy-sudoers` (add two lines after line 19)
+
+- [ ] **Step 1: Add the pinned whitelist lines**
+
+Find this exact block (lines 18-19) in `deploy/install/templates/baluhost-deploy-sudoers`:
+
+```
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /bin/bash /opt/baluhost/deploy/scripts/install-hardware-sudoers.sh
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/bash /opt/baluhost/deploy/scripts/install-hardware-sudoers.sh
+```
+
+Replace it with (appends the two power lines immediately after):
+
+```
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /bin/bash /opt/baluhost/deploy/scripts/install-hardware-sudoers.sh
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/bash /opt/baluhost/deploy/scripts/install-hardware-sudoers.sh
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /bin/bash /opt/baluhost/deploy/scripts/install-power-sudoers.sh
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/bash /opt/baluhost/deploy/scripts/install-power-sudoers.sh
+```
+
+- [ ] **Step 2: Verify the rendered template is valid sudoers syntax (no root needed)**
+
+Render with the real-user substitution and inspect:
+
+```bash
+sed 's|@@BALUHOST_USER@@|sven|g' deploy/install/templates/baluhost-deploy-sudoers > /tmp/deploy-sudoers.rendered
+```
+
+Read `/tmp/deploy-sudoers.rendered` and confirm both `install-power-sudoers.sh` lines are present (one `/bin/bash`, one `/usr/bin/bash`) and no `@@` remains.
+Expected: two new power lines present, zero `@@` occurrences.
+
+> Note: a full `visudo -cf` check requires a Linux box; it runs for real during the bootstrap step on BaluNode (see spec). The render inspection is the local gate.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/install/templates/baluhost-deploy-sudoers
+git commit -m "feat(deploy): whitelist install-power-sudoers.sh in deploy sudoers (#126)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Final verification + PR
+
+- [ ] **Step 1: Re-run both syntax checks together**
+
+```bash
+bash -n deploy/scripts/install-power-sudoers.sh && bash -n deploy/scripts/ci-deploy.sh && echo "OK: both scripts parse"
+```
+Expected: `OK: both scripts parse`
+
+- [ ] **Step 2: Confirm the working tree is clean and on the feature branch**
+
+```bash
+git status
+git log --oneline -4
+```
+Expected: branch `fix/ppd-sudoers-deploy-provisioning`, clean tree, the three feature commits (+ spec commit) present.
+
+- [ ] **Step 3: Open the PR**
+
+Per project rule (`feedback_pr_body_quoting`): write the PR body with the Write tool to a temp file, then `gh pr create --body-file`. The PR description must:
+- Reference issue #126 ("Closes #126").
+- Summarize the three changes.
+- Flag the CI/CD-security-sensitive whitelist change for the CODEOWNERS reviewer.
+- Include the BaluNode bootstrap steps from the spec (one-time `install-deploy-sudoers.sh` + `SYNC_PERMISSIONS=1` deploy) and the three verification commands.
+
+---
+
+## Notes for the executor
+
+- **No application/pytest changes** — this is deploy/shell only. Do not invent tests beyond the syntax + render checks above.
+- **CRLF:** repo runs `core.autocrlf=true`; the new `.sh` file will be stored LF and that warning is expected/harmless.
+- **Bootstrap reality:** the whitelist lines only become live on BaluNode after `/etc/sudoers.d/baluhost-deploy` is re-rendered (`install-deploy-sudoers.sh`). That is an operator step documented in the spec, NOT part of these repo commits.
+- **Do not** modify `process_template` or fold power rules into the hardware sudoers file — both explicitly out of scope (see spec).

--- a/docs/superpowers/specs/2026-06-07-ppd-sudoers-deploy-provisioning-design.md
+++ b/docs/superpowers/specs/2026-06-07-ppd-sudoers-deploy-provisioning-design.md
@@ -1,0 +1,181 @@
+# PPD-Sudoers Deploy-Provisioning + Workaround-Cleanup
+
+**Datum:** 2026-06-07
+**Issue:** [#126](https://github.com/Xveyn/BaluHost/issues/126) — *deploy: PPD-sudoers automatisch ausspielen + %BALUHOST_USER%-Substitution fixen*
+**Scope:** `deploy/` (CODEOWNERS-relevant, CI/CD-Security)
+
+---
+
+## Problem
+
+Das CPU-Power-Authority-Feature (#123) braucht eine sudoers-Regel, damit der Backend-Service
+`power-profiles-daemon` stoppen/maskieren darf (`backend/app/services/power/ppd_authority.py`).
+Ohne sie → HTTP 500 beim Aktivieren (*"could not stop/mask power-profiles-daemon (check sudoers
+provisioning)"*).
+
+Beim Live-Schalten auf der BaluNode sind zwei Deploy-Lücken aufgefallen:
+
+1. **Routine-Deploy spielt die Power-Sudoers-Vorlage nicht aus.** Die vier
+   `power-profiles-daemon`-Zeilen stehen in `deploy/install/templates/sudoers-baluhost-power`,
+   installiert werden sie aber nur vom Voll-Install-Modul
+   `deploy/install/modules/13-power-helpers.sh`. `ci-deploy.sh` zieht das nicht nach — ein reiner
+   Code-Deploy bekommt die Regel nie.
+
+2. **`%BALUHOST_USER%` steht wörtlich in `/etc/sudoers.d/baluhost-power`** auf der BaluNode — die
+   Datei ist funktionslos, auch die bestehende logind-Helper-Regel. Zusätzlich läuft der Service
+   dort als **`sven`**, nicht `baluhost`.
+
+### Korrektur zur Issue-Diagnose (To-Do #2)
+
+Das Issue vermutet einen `process_template`/`%BALUHOST_USER%`-Substitutions-Bug. **Den gibt es im
+Code nicht (mehr).** Befund:
+
+- `process_template()` (`deploy/install/lib/common.sh:115`) ersetzt `@@KEY@@`-Tokens und funktioniert.
+- Das aktuelle Template `sudoers-baluhost-power` nutzt korrekt `@@BALUHOST_USER@@`.
+- Commit `b1cffc10` (*"fix(deploy): use @@BALUHOST_USER@@ token in power sudoers template"*) hat das
+  Token bereits gefixt.
+
+Das literale `%BALUHOST_USER%` auf der BaluNode ist eine **veraltete Datei von vor `b1cffc10`**, die
+nie neu substituiert wurde (weil Lücke #1: ci-deploy zieht Modul 13 nicht nach). Es ist **kein**
+Code-Change an `process_template` nötig — der neue Standalone-Installer rendert die Datei mit dem
+echten Service-User neu und behebt damit beide Symptome.
+
+---
+
+## Lösung (Approach A)
+
+Spiegelt das bereits etablierte Muster von `deploy/scripts/install-hardware-sudoers.sh` — ein
+eigenständiger, idempotenter Sudoers-Installer, der von `ci-deploy.sh` im `SYNC_PERMISSIONS`-Block
+aufgerufen wird.
+
+### Verworfene Alternativen
+
+- **B — Power-Regeln in `baluhost-hardware-sudoers` falten.** `/etc/sudoers.d/baluhost-power` ist
+  bewusst getrennt und wird namentlich in `.claude/rules/ci-cd-security.md` (Known Gap #9) und
+  `13-power-helpers.sh` referenziert. Bricht Konventionen.
+- **C — `process_template` umbauen.** Basiert auf der oben widerlegten Fehldiagnose; kein
+  Substitutions-Bug vorhanden.
+
+---
+
+## Komponenten
+
+### 1. Neues Script: `deploy/scripts/install-power-sudoers.sh`
+
+1:1-Adaption von `install-hardware-sudoers.sh`. Verhalten:
+
+| Aspekt | Wert |
+|---|---|
+| `TEMPLATE` (default) | `/opt/baluhost/deploy/install/templates/sudoers-baluhost-power` |
+| `TARGET` | `/etc/sudoers.d/baluhost-power` |
+| `SERVICE` (default) | `baluhost-backend.service` |
+| User-Ableitung | `BALUHOST_USER` override → `systemctl show -p User --value "$SERVICE"` → sonst Fehler `exit 1` |
+
+Ablauf (Reihenfolge sicherheitsrelevant):
+
+1. `require_root` (EUID-Check).
+2. Template-Existenz prüfen.
+3. Service-User ableiten (auf BaluNode automatisch `sven`).
+4. `sed "s|@@BALUHOST_USER@@|$BALUHOST_USER|g"` → `mktemp` (trap-cleanup).
+5. **`visudo -cf "$TMP"` VOR dem Ersetzen** — bei Fehler `exit 1`, Live-Datei unangetastet.
+6. Timestamped Backup der bestehenden `$TARGET` (falls vorhanden).
+7. `install -m 0440 -o root -g root "$TMP" "$TARGET"`; finaler `visudo -cf "$TARGET"`.
+8. **Workaround-Cleanup — erst NACH erfolgreichem Schritt 7:** Falls
+   `/etc/sudoers.d/baluhost-ppd` existiert → timestamped sichern (`.bak.<ts>`) + entfernen, mit
+   Log-Hinweis. Die Reihenfolge garantiert, dass die gültigen Power-Regeln bereits live sind, bevor
+   der Workaround verschwindet — keine Lücke ohne Regeln.
+
+### 2. `deploy/scripts/ci-deploy.sh` — Power-Sudoers-Hook
+
+Im `SYNC_PERMISSIONS`-Block an der Stelle *"Future permission scripts go here following the same
+pattern"* (aktuell Z. 461), nach dem Hardware-Sudoers-Block, ein analoger Block:
+
+```bash
+# Power sudoers: power-profiles-daemon stop/start/mask/unmask + logind idle +
+# sddm toggle grants. Renders @@BALUHOST_USER@@ from the running service user and
+# validates with visudo before replacing the live file. This is the path by which
+# sudoers-baluhost-power template changes reach an installed box, and it also
+# clears the obsolete /etc/sudoers.d/baluhost-ppd workaround once superseded.
+POWER_SUDOERS_SCRIPT="$INSTALL_DIR/deploy/scripts/install-power-sudoers.sh"
+if [[ -f "$POWER_SUDOERS_SCRIPT" ]]; then
+    log_info "Re-applying power sudoers..."
+    if sudo bash "$POWER_SUDOERS_SCRIPT"; then
+        log_info "Power sudoers sync OK."
+    else
+        log_warn "Power sudoers sync failed (non-fatal — deploy continues)."
+    fi
+else
+    log_warn "Power sudoers script not found at $POWER_SUDOERS_SCRIPT (skipping)."
+fi
+```
+
+- Nur unter `SYNC_PERMISSIONS=1` / `true` (wahrt die Invariante *"Routine-Deploy fasst `/etc` nie an"*).
+- Kein env-var-Passing (wie der Hardware-Block); der Template-Default matcht den prod `INSTALL_DIR`.
+- Fehler ist non-fatal (`log_warn`), bricht keinen gesunden Deploy ab.
+
+### 3. `deploy/install/templates/baluhost-deploy-sudoers` — Whitelist
+
+Zwei Zeilen nach dem Hardware-Block (aktuell Z. 19), beide bash-Pfade gepinnt:
+
+```
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /bin/bash /opt/baluhost/deploy/scripts/install-power-sudoers.sh
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/bin/bash /opt/baluhost/deploy/scripts/install-power-sudoers.sh
+```
+
+Gepinnter absoluter Pfad auf ein versioniertes Script → der Deploy-User kann kein beliebiges Script
+als root ausführen, nur dieses. Erweitert den Blast-Radius nicht über das etablierte Muster hinaus.
+
+---
+
+## Security-Betrachtung (CI/CD)
+
+- **CODEOWNERS:** Alle drei Änderungen liegen unter `/deploy/` → owner-tagged auf `@Xveyn`.
+- **Reviewer-Checklist (`ci-cd-security.md`):** Kein neuer `runs-on: self-hosted`, kein neuer
+  PR-/`pull_request_target`-Trigger, kein `DEPLOY_PAT`-Gebrauch, keine Workflow-Änderung. Die neue
+  Sudoers-Whitelist-Zeile ist auf eine spezifische, versionierte Binary mit explizitem Pfad
+  begrenzt — kein `ALL`, keine user-controlled Globs.
+- **Known Gap #9 (`ci-cd-security.md`):** Bezieht sich auf genau diese vier
+  `systemctl … power-profiles-daemon`-Verben. Dieses Design ändert die Verben nicht, sondern stellt
+  nur ihre korrekte Provisionierung sicher. Doku bleibt gültig.
+
+---
+
+## Bootstrap & Verifikation (Live-Box, kein Repo-Change)
+
+Die neuen Whitelist-Zeilen in `baluhost-deploy-sudoers` sind erst dann live, wenn
+`/etc/sudoers.d/baluhost-deploy` neu gerendert wird (gleiche Bootstrap-Eigenheit, die Hardware
+hatte). Einmalig auf BaluNode als root:
+
+```bash
+cd /opt/baluhost && git pull
+sudo bash /opt/baluhost/deploy/scripts/install-deploy-sudoers.sh   # erneuert die Whitelist
+SYNC_PERMISSIONS=1 ./deploy/scripts/ci-deploy.sh                    # spielt baluhost-power aus
+```
+
+Danach verifizieren (To-Do #3 aus dem Issue):
+
+```bash
+sudo cat /etc/sudoers.d/baluhost-power     # vier systemctl … power-profiles-daemon-Zeilen, User=sven
+sudo visudo -cf /etc/sudoers.d/baluhost-power   # OK
+test ! -e /etc/sudoers.d/baluhost-ppd && echo "workaround entfernt"
+```
+
+---
+
+## Tests
+
+Reine Shell/Deploy-Änderung, keine pytest-Abdeckung. Verifikation:
+
+- `bash -n deploy/scripts/install-power-sudoers.sh` (Syntaxcheck).
+- `bash -n deploy/scripts/ci-deploy.sh` (Syntaxcheck nach Edit).
+- Manuelle Review der gepinnten Pfade in `baluhost-deploy-sudoers`.
+- (Optional, falls vorhanden) `shellcheck` auf das neue Script.
+
+---
+
+## Out of Scope
+
+- `process_template`-Änderungen (kein Bug, siehe Korrektur oben).
+- Unconditional-Provisioning bei jedem Deploy (bewusst verworfen zugunsten der
+  `SYNC_PERMISSIONS`-Invariante).
+- Manuelles Entfernen von `baluhost-ppd` per Hand — übernimmt jetzt das Script.


### PR DESCRIPTION
Closes #126.

## Problem

The CPU power-authority feature (#123) needs a sudoers rule so the backend service may stop/mask `power-profiles-daemon` (`backend/app/services/power/ppd_authority.py`). Two deploy gaps left it broken on the BaluNode:

1. **Routine deploy never provisioned the power sudoers.** The four `power-profiles-daemon` lines live in `deploy/install/templates/sudoers-baluhost-power`, but they were only installed by the full-install module `13-power-helpers.sh`. `ci-deploy.sh` does not re-run installer modules, so a code-only deploy never got the rule → HTTP 500 on activation.
2. **Stale `%BALUHOST_USER%` in the live file.** `/etc/sudoers.d/baluhost-power` still held the literal placeholder from before commit `b1cffc10` (which switched the token to `@@BALUHOST_USER@@`), so even the logind helper rule was inert. The service on that box runs as `sven`, not `baluhost`.

> Note on the issue's To-Do #2: there is **no** `process_template` substitution bug. `process_template()` and the current template (`@@BALUHOST_USER@@`) are correct; the live `%...%` is just a pre-`b1cffc10` file that was never re-rendered (gap #1). No code change to `process_template` — the new standalone installer re-renders the file with the real service user and fixes both symptoms.

## Changes

All under `/deploy/` (CODEOWNERS-tagged), following the existing `install-hardware-sudoers.sh` pattern:

1. **New `deploy/scripts/install-power-sudoers.sh`** — idempotent installer: derives the service user from `systemctl show -p User --value baluhost-backend.service`, renders `@@BALUHOST_USER@@` via sed, validates with `visudo -cf` **before** replacing the live file, keeps a timestamped backup, installs `-m 0440 -o root -g root`. After a successful install it also removes the obsolete `/etc/sudoers.d/baluhost-ppd` workaround (backed up first) — only once the regular file is live, so there is never a window without valid rules.
2. **`deploy/scripts/ci-deploy.sh`** — calls the new script in the `SYNC_PERMISSIONS` block (after the hardware-sudoers call), non-fatal on failure. Stays gated behind `SYNC_PERMISSIONS=1`, preserving the "routine deploy never touches /etc" invariant.
3. **`deploy/install/templates/baluhost-deploy-sudoers`** — two pinned-path whitelist lines for the new script (`/bin/bash` + `/usr/bin/bash`), matching the amd-gpu/hardware/companion entries.

## ⚠️ CI/CD-security note for the CODEOWNERS reviewer

The whitelist change adds NOPASSWD sudo for a new script. It is scoped to a pinned absolute path on a version-controlled script — no `ALL`, no wildcards — identical in shape to the existing entries. No workflow/trigger/runner/gate changes. Known Gap #9 in `ci-cd-security.md` (the four `systemctl … power-profiles-daemon` verbs) is unchanged; this PR only fixes their provisioning.

## Verification

Local: `bash -n` passes on both scripts; template renders with no remaining `@@` tokens.

One-time bootstrap on BaluNode (the new whitelist lines only go live once `/etc/sudoers.d/baluhost-deploy` is re-rendered — same bootstrap quirk hardware had):

```bash
cd /opt/baluhost && git pull
sudo bash /opt/baluhost/deploy/scripts/install-deploy-sudoers.sh
SYNC_PERMISSIONS=1 ./deploy/scripts/ci-deploy.sh
```

Then verify:

```bash
sudo cat /etc/sudoers.d/baluhost-power        # four systemctl … power-profiles-daemon lines, User=sven
sudo visudo -cf /etc/sudoers.d/baluhost-power # OK
test ! -e /etc/sudoers.d/baluhost-ppd && echo "workaround removed"
```

Spec: `docs/superpowers/specs/2026-06-07-ppd-sudoers-deploy-provisioning-design.md`
Plan: `docs/superpowers/plans/2026-06-07-ppd-sudoers-deploy-provisioning.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
