### PR TITLE
fix(files): remove dead check_active_uploads() stub (#177)

### DIFF
--- a/backend/app/services/files/ownership.py
+++ b/backend/app/services/files/ownership.py
@@ -742,17 +742,3 @@ def enforce_residency(
         violations=violations,
         fixed_count=fixed_count
     )
-
-
-def check_active_uploads(path: str) -> bool:
-    """
-    Check if there are active uploads to the given path.
-    
-    This is a placeholder - implementation depends on chunked upload tracking.
-    
-    Returns:
-        True if active uploads exist, False otherwise
-    """
-    # TODO: Integrate with chunked_upload.py to check active uploads
-    # For now, return False (allow transfer)
-    return False


### PR DESCRIPTION
## Problem

`check_active_uploads()` in `backend/app/services/files/ownership.py` was a hardcoded placeholder that always returned `False`. It suggested a guard against move/delete/overwrite during an active chunked upload, but provided none.

## Finding

The function had **zero callers** across the entire repo (verified via `git grep` over all files). There was no race condition to close — the stub only implied a safety guarantee it never delivered.

## Fix

Removed the dead stub (the alternative the issue proposes) rather than building a guard nobody calls. If move/delete/overwrite vs. in-flight chunked uploads ever needs real protection, the session management lives in `services/sync/progressive.py` and can be wired in then.

## Verification

- No references remain repo-wide.
- `app.services.files.ownership` imports cleanly.

Fixes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)
