### PR TITLE
fix(audit): log NFS/Samba share mutations via audit logger (#195)

### DIFF
--- a/backend/app/api/routes/nfs.py
+++ b/backend/app/api/routes/nfs.py
@@ -108,6 +108,10 @@ async def create_nfs_export(
         await nfs_service.regenerate_exports_config()
         await nfs_service.apply_exports()
     except Exception as e:
+        try:
+            db.rollback()
+        except Exception:
+            pass
         audit.log_event(
             event_type="SYSTEM_CONFIG", user=current_admin.username,
             action="nfs_export_created", resource=payload.path,
@@ -164,6 +168,10 @@ async def update_nfs_export(
         await nfs_service.regenerate_exports_config()
         await nfs_service.apply_exports()
     except Exception as e:
+        try:
+            db.rollback()
+        except Exception:
+            pass
         audit.log_event(
             event_type="SYSTEM_CONFIG", user=current_admin.username,
             action="nfs_export_updated", resource=payload.path,
@@ -203,6 +211,10 @@ async def delete_nfs_export(
         await nfs_service.regenerate_exports_config()
         await nfs_service.apply_exports()
     except Exception as e:
+        try:
+            db.rollback()
+        except Exception:
+            pass
         audit.log_event(
             event_type="SYSTEM_CONFIG", user=current_admin.username,
             action="nfs_export_deleted", resource=path,

--- a/backend/app/api/routes/nfs.py
+++ b/backend/app/api/routes/nfs.py
@@ -17,6 +17,7 @@ from app.schemas.nfs import (
     NfsStatusResponse,
 )
 from app.services import nfs_service
+from app.services.audit.logger_db import get_audit_logger_db
 
 logger = logging.getLogger(__name__)
 
@@ -80,21 +81,44 @@ async def list_nfs_exports(
 async def create_nfs_export(
     request: Request, response: Response,
     payload: NfsExportCreate,
-    _admin=Depends(deps.get_current_admin),
+    current_admin=Depends(deps.get_current_admin),
     db: Session = Depends(get_db),
 ):
     """Create an NFS export (admin only)."""
+    audit = get_audit_logger_db()
     if db.query(NfsExport).filter(NfsExport.path == payload.path).first():
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_created", resource=payload.path,
+            success=False, error_message="An export for this path already exists", db=db,
+        )
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="An export for this path already exists")
     exp = NfsExport(
         path=payload.path, clients=payload.clients, read_only=payload.read_only,
         root_squash=payload.root_squash, enabled=payload.enabled, comment=payload.comment,
     )
-    db.add(exp)
-    db.commit()
-    db.refresh(exp)
-    await nfs_service.regenerate_exports_config()
-    await nfs_service.apply_exports()
+    details = {
+        "clients": payload.clients, "read_only": payload.read_only,
+        "root_squash": payload.root_squash, "enabled": payload.enabled,
+    }
+    try:
+        db.add(exp)
+        db.commit()
+        db.refresh(exp)
+        await nfs_service.regenerate_exports_config()
+        await nfs_service.apply_exports()
+    except Exception as e:
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_created", resource=payload.path,
+            success=False, error_message=str(e), db=db,
+        )
+        raise
+    audit.log_event(
+        event_type="SYSTEM_CONFIG", user=current_admin.username,
+        action="nfs_export_created", resource=exp.path,
+        success=True, details=details, db=db,
+    )
     return _to_response(exp, _get_local_ip())
 
 
@@ -104,14 +128,25 @@ async def update_nfs_export(
     request: Request, response: Response,
     export_id: int,
     payload: NfsExportUpdate,
-    _admin=Depends(deps.get_current_admin),
+    current_admin=Depends(deps.get_current_admin),
     db: Session = Depends(get_db),
 ):
     """Update an NFS export (admin only)."""
+    audit = get_audit_logger_db()
     exp = db.query(NfsExport).filter(NfsExport.id == export_id).first()
     if not exp:
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_updated", resource=str(export_id),
+            success=False, error_message="Export not found", db=db,
+        )
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Export not found")
     if payload.path != exp.path and db.query(NfsExport).filter(NfsExport.path == payload.path).first():
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_updated", resource=payload.path,
+            success=False, error_message="An export for this path already exists", db=db,
+        )
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="An export for this path already exists")
     exp.path = payload.path
     exp.clients = payload.clients
@@ -119,10 +154,27 @@ async def update_nfs_export(
     exp.root_squash = payload.root_squash
     exp.enabled = payload.enabled
     exp.comment = payload.comment
-    db.commit()
-    db.refresh(exp)
-    await nfs_service.regenerate_exports_config()
-    await nfs_service.apply_exports()
+    details = {
+        "clients": payload.clients, "read_only": payload.read_only,
+        "root_squash": payload.root_squash, "enabled": payload.enabled,
+    }
+    try:
+        db.commit()
+        db.refresh(exp)
+        await nfs_service.regenerate_exports_config()
+        await nfs_service.apply_exports()
+    except Exception as e:
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_updated", resource=payload.path,
+            success=False, error_message=str(e), db=db,
+        )
+        raise
+    audit.log_event(
+        event_type="SYSTEM_CONFIG", user=current_admin.username,
+        action="nfs_export_updated", resource=exp.path,
+        success=True, details=details, db=db,
+    )
     return _to_response(exp, _get_local_ip())
 
 
@@ -131,15 +183,35 @@ async def update_nfs_export(
 async def delete_nfs_export(
     request: Request, response: Response,
     export_id: int,
-    _admin=Depends(deps.get_current_admin),
+    current_admin=Depends(deps.get_current_admin),
     db: Session = Depends(get_db),
 ):
     """Delete an NFS export (admin only)."""
+    audit = get_audit_logger_db()
     exp = db.query(NfsExport).filter(NfsExport.id == export_id).first()
     if not exp:
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_deleted", resource=str(export_id),
+            success=False, error_message="Export not found", db=db,
+        )
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Export not found")
-    db.delete(exp)
-    db.commit()
-    await nfs_service.regenerate_exports_config()
-    await nfs_service.apply_exports()
+    path = exp.path
+    try:
+        db.delete(exp)
+        db.commit()
+        await nfs_service.regenerate_exports_config()
+        await nfs_service.apply_exports()
+    except Exception as e:
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_deleted", resource=path,
+            success=False, error_message=str(e), db=db,
+        )
+        raise
+    audit.log_event(
+        event_type="SYSTEM_CONFIG", user=current_admin.username,
+        action="nfs_export_deleted", resource=path,
+        success=True, details={"export_id": export_id}, db=db,
+    )
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/routes/samba.py
+++ b/backend/app/api/routes/samba.py
@@ -93,6 +93,11 @@ async def toggle_smb_user(
     audit = get_audit_logger_db()
     action = "smb_access_enabled" if payload.enabled else "smb_access_disabled"
 
+    # NOTE: set_smb_enabled() commits the smb_enabled flag immediately. If a Samba
+    # service call below then fails, the DB flag stays flipped (db.rollback() in the
+    # except has nothing to undo) while the daemon was never updated — so a
+    # success=False audit entry can coexist with a committed flag change. Pre-existing
+    # behavior of set_smb_enabled; documented here for audit-log readers.
     user = user_service.set_smb_enabled(user_id, payload.enabled, db=db)
     if not user:
         audit.log_event(

--- a/backend/app/api/routes/samba.py
+++ b/backend/app/api/routes/samba.py
@@ -20,6 +20,7 @@ from app.schemas.samba import (
 )
 from app.schemas.webdav import OsConnectionInfo
 from app.services import samba_service, users as user_service
+from app.services.audit.logger_db import get_audit_logger_db
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +82,7 @@ async def toggle_smb_user(
     request: Request, response: Response,
     user_id: int,
     payload: SambaUserToggleRequest,
-    _admin=Depends(deps.get_current_admin),
+    current_admin=Depends(deps.get_current_admin),
     db: Session = Depends(get_db),
 ):
     """Toggle SMB access for a user (admin only).
@@ -89,21 +90,49 @@ async def toggle_smb_user(
     When enabling, an optional password can be provided for immediate sync.
     Without a password the user must change their password for SMB to work.
     """
+    audit = get_audit_logger_db()
+    action = "smb_access_enabled" if payload.enabled else "smb_access_disabled"
+
     user = user_service.set_smb_enabled(user_id, payload.enabled, db=db)
     if not user:
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action=action, resource=str(user_id),
+            success=False, error_message="User not found", db=db,
+        )
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    if payload.enabled:
-        # Sync password if provided
-        if payload.password:
-            await samba_service.sync_smb_password(user.username, payload.password)
-        await samba_service.enable_smb_user(user.username)
-    else:
-        await samba_service.disable_smb_user(user.username)
+    password_synced = False
+    try:
+        if payload.enabled:
+            # Sync password if provided
+            if payload.password:
+                await samba_service.sync_smb_password(user.username, payload.password)
+                password_synced = True
+            await samba_service.enable_smb_user(user.username)
+        else:
+            await samba_service.disable_smb_user(user.username)
 
-    # Regenerate shares config and reload
-    await samba_service.regenerate_shares_config()
-    await samba_service.reload_samba()
+        # Regenerate shares config and reload
+        await samba_service.regenerate_shares_config()
+        await samba_service.reload_samba()
+    except Exception as e:
+        try:
+            db.rollback()
+        except Exception:
+            pass
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action=action, resource=user.username,
+            success=False, error_message=str(e), db=db,
+        )
+        raise
+
+    audit.log_event(
+        event_type="SYSTEM_CONFIG", user=current_admin.username,
+        action=action, resource=user.username,
+        success=True, details={"enabled": payload.enabled, "password_synced": password_synced}, db=db,
+    )
 
     return {
         "user_id": user.id,

--- a/backend/tests/api/test_nfs_routes.py
+++ b/backend/tests/api/test_nfs_routes.py
@@ -144,6 +144,45 @@ class TestNfsAudit:
         assert row is not None
         assert row.resource == "AuditUpd"
 
+    def test_update_missing_writes_failure(self, client, admin_headers, db_session, audit_enabled):
+        r = client.put(
+            f"{settings.api_prefix}/nfs/exports/999777",
+            json={"path": "Ghost", "clients": "192.168.1.0/24", "read_only": False,
+                  "root_squash": True, "enabled": True, "comment": None},
+            headers=admin_headers,
+        )
+        assert r.status_code == 404
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "nfs_export_updated", AuditLog.success == False)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == "999777"
+        assert row.error_message == "Export not found"
+
+    def test_update_duplicate_path_writes_failure(self, client, admin_headers, db_session, audit_enabled):
+        first_id = _create(client, admin_headers, path="UpdDupA").json()["id"]
+        _create(client, admin_headers, path="UpdDupB")
+        # Try to rename the first export onto the second's path -> 409
+        r = client.put(
+            f"{settings.api_prefix}/nfs/exports/{first_id}",
+            json={"path": "UpdDupB", "clients": "192.168.1.0/24", "read_only": False,
+                  "root_squash": True, "enabled": True, "comment": None},
+            headers=admin_headers,
+        )
+        assert r.status_code == 409
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "nfs_export_updated", AuditLog.success == False)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == "UpdDupB"
+        assert row.error_message == "An export for this path already exists"
+
     def test_delete_writes_audit(self, client, admin_headers, db_session, audit_enabled):
         export_id = _create(client, admin_headers, path="AuditDel").json()["id"]
         r = client.delete(f"{settings.api_prefix}/nfs/exports/{export_id}", headers=admin_headers)

--- a/backend/tests/api/test_nfs_routes.py
+++ b/backend/tests/api/test_nfs_routes.py
@@ -1,5 +1,7 @@
 """Route tests for /api/nfs (admin-only NFS export management)."""
+import pytest
 from app.core.config import settings
+from app.models.audit_log import AuditLog
 
 
 def _create(client, headers, **over):
@@ -100,3 +102,82 @@ class TestNfsCrud:
         assert _create(client, admin_headers, path="Media").status_code == 201
         # "Media/" normalizes to "Media" -> duplicate path -> 409
         assert _create(client, admin_headers, path="Media/").status_code == 409
+
+
+@pytest.fixture
+def audit_enabled():
+    """Ensure the global audit logger is enabled (a prior test may have disabled it)."""
+    from app.services.audit.logger_db import get_audit_logger_db
+    get_audit_logger_db().enable()
+
+
+class TestNfsAudit:
+    def test_create_writes_audit(self, client, admin_headers, db_session, audit_enabled):
+        r = _create(client, admin_headers, path="AuditMedia")
+        assert r.status_code == 201, r.text
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "nfs_export_created", AuditLog.success == True)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.event_type == "SYSTEM_CONFIG"
+        assert row.resource == "AuditMedia"
+        assert row.user == settings.admin_username
+
+    def test_update_writes_audit(self, client, admin_headers, db_session, audit_enabled):
+        export_id = _create(client, admin_headers, path="AuditUpd").json()["id"]
+        r = client.put(
+            f"{settings.api_prefix}/nfs/exports/{export_id}",
+            json={"path": "AuditUpd", "clients": "192.168.1.0/24", "read_only": True,
+                  "root_squash": True, "enabled": True, "comment": None},
+            headers=admin_headers,
+        )
+        assert r.status_code == 200
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "nfs_export_updated", AuditLog.success == True)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == "AuditUpd"
+
+    def test_delete_writes_audit(self, client, admin_headers, db_session, audit_enabled):
+        export_id = _create(client, admin_headers, path="AuditDel").json()["id"]
+        r = client.delete(f"{settings.api_prefix}/nfs/exports/{export_id}", headers=admin_headers)
+        assert r.status_code == 204
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "nfs_export_deleted", AuditLog.success == True)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == "AuditDel"
+
+    def test_delete_missing_writes_failure(self, client, admin_headers, db_session, audit_enabled):
+        r = client.delete(f"{settings.api_prefix}/nfs/exports/888888", headers=admin_headers)
+        assert r.status_code == 404
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "nfs_export_deleted", AuditLog.success == False)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == "888888"
+        assert row.error_message == "Export not found"
+
+    def test_duplicate_create_writes_failure(self, client, admin_headers, db_session, audit_enabled):
+        assert _create(client, admin_headers, path="AuditDup").status_code == 201
+        assert _create(client, admin_headers, path="AuditDup").status_code == 409
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "nfs_export_created", AuditLog.success == False)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == "AuditDup"

--- a/backend/tests/api/test_nfs_routes.py
+++ b/backend/tests/api/test_nfs_routes.py
@@ -220,3 +220,26 @@ class TestNfsAudit:
         )
         assert row is not None
         assert row.resource == "AuditDup"
+
+    def test_create_service_failure_writes_failure_audit(
+        self, client, admin_headers, db_session, audit_enabled, monkeypatch
+    ):
+        from app.services import nfs_service
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("apply failed")
+
+        monkeypatch.setattr(nfs_service, "apply_exports", _boom)
+
+        with pytest.raises(Exception):
+            _create(client, admin_headers, path="BoomNfs")
+
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "nfs_export_created", AuditLog.success == False)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == "BoomNfs"
+        assert "apply failed" in (row.error_message or "")

--- a/backend/tests/api/test_samba_routes.py
+++ b/backend/tests/api/test_samba_routes.py
@@ -100,3 +100,26 @@ class TestSambaToggleAudit:
         assert secret not in (row.details or "")
         assert secret not in (row.error_message or "")
         assert secret not in (row.resource or "")
+
+    def test_enable_service_failure_writes_failure_audit(
+        self, client, admin_headers, regular_user, db_session, audit_enabled, mock_samba, monkeypatch
+    ):
+        from app.services import samba_service
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("smb enable failed")
+
+        monkeypatch.setattr(samba_service, "enable_smb_user", _boom)
+
+        with pytest.raises(Exception):
+            _toggle(client, admin_headers, regular_user.id, True)
+
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "smb_access_enabled", AuditLog.success == False)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == regular_user.username
+        assert "smb enable failed" in (row.error_message or "")

--- a/backend/tests/api/test_samba_routes.py
+++ b/backend/tests/api/test_samba_routes.py
@@ -80,3 +80,23 @@ class TestSambaToggleAudit:
         assert row is not None
         assert row.resource == "999999"
         assert row.error_message == "User not found"
+
+    def test_enable_with_password_records_synced_without_leaking_password(
+        self, client, admin_headers, regular_user, db_session, audit_enabled, mock_samba
+    ):
+        secret = "SuperSecret123!"
+        r = _toggle(client, admin_headers, regular_user.id, True, password=secret)
+        assert r.status_code == 200, r.text
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "smb_access_enabled", AuditLog.success == True)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        # details must record that a password was synced...
+        assert '"password_synced": true' in (row.details or "")
+        # ...but the password value itself must NEVER be persisted anywhere on the row.
+        assert secret not in (row.details or "")
+        assert secret not in (row.error_message or "")
+        assert secret not in (row.resource or "")

--- a/backend/tests/api/test_samba_routes.py
+++ b/backend/tests/api/test_samba_routes.py
@@ -1,0 +1,82 @@
+"""Route tests for /api/samba (admin-only SMB user management)."""
+import pytest
+
+from app.core.config import settings
+from app.models.audit_log import AuditLog
+
+
+@pytest.fixture
+def audit_enabled():
+    """Ensure the global audit logger is enabled (a prior test may have disabled it)."""
+    from app.services.audit.logger_db import get_audit_logger_db
+    get_audit_logger_db().enable()
+
+
+@pytest.fixture
+def mock_samba(monkeypatch):
+    """Stub the system-touching Samba service calls so no real smbpasswd runs."""
+    async def _noop(*args, **kwargs):
+        return None
+
+    from app.services import samba_service
+    for fn in (
+        "enable_smb_user", "disable_smb_user", "sync_smb_password",
+        "regenerate_shares_config", "reload_samba",
+    ):
+        monkeypatch.setattr(samba_service, fn, _noop)
+
+
+def _toggle(client, headers, user_id, enabled, password=None):
+    body = {"enabled": enabled}
+    if password is not None:
+        body["password"] = password
+    return client.post(
+        f"{settings.api_prefix}/samba/users/{user_id}/toggle", json=body, headers=headers
+    )
+
+
+class TestSambaAuth:
+    def test_toggle_forbidden_for_regular_user(self, client, user_headers, regular_user):
+        r = _toggle(client, user_headers, regular_user.id, True)
+        assert r.status_code == 403
+
+
+class TestSambaToggleAudit:
+    def test_enable_writes_audit(self, client, admin_headers, regular_user, db_session, audit_enabled, mock_samba):
+        r = _toggle(client, admin_headers, regular_user.id, True)
+        assert r.status_code == 200, r.text
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "smb_access_enabled", AuditLog.success == True)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.event_type == "SYSTEM_CONFIG"
+        assert row.resource == regular_user.username
+        assert row.user == settings.admin_username
+
+    def test_disable_writes_audit(self, client, admin_headers, regular_user, db_session, audit_enabled, mock_samba):
+        r = _toggle(client, admin_headers, regular_user.id, False)
+        assert r.status_code == 200, r.text
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "smb_access_disabled", AuditLog.success == True)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == regular_user.username
+
+    def test_toggle_missing_user_writes_failure(self, client, admin_headers, db_session, audit_enabled, mock_samba):
+        r = _toggle(client, admin_headers, 999999, True)
+        assert r.status_code == 404
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "smb_access_enabled", AuditLog.success == False)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == "999999"
+        assert row.error_message == "User not found"

--- a/docs/superpowers/plans/2026-06-09-audit-nfs-samba.md
+++ b/docs/superpowers/plans/2026-06-09-audit-nfs-samba.md
@@ -1,0 +1,506 @@
+# NFS/Samba Share-Mutation Audit Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Jede NFS-Export- und SMB-User-Mutation (Erfolg und Fehler) schreibt einen Audit-Log-Eintrag via `get_audit_logger_db().log_event(...)`.
+
+**Architecture:** Direkte `log_event(event_type="SYSTEM_CONFIG", ...)`-Aufrufe in den vier Route-Handlern; kein neuer Code im Logger. Validierungs-Ablehnungen (404/409) loggen `success=False` vor dem `raise`; Service-Calls werden in `try/except Exception` gekapselt und loggen bei Exception `success=False` + re-raise; nach erfolgreicher Mutation `success=True`.
+
+**Tech Stack:** FastAPI, SQLAlchemy, Pytest (TestClient + in-memory SQLite). Audit-Logger: `app.services.audit.logger_db.AuditLoggerDB`.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-audit-nfs-samba-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `backend/app/api/routes/nfs.py` — Import `get_audit_logger_db`; Audit-Aufrufe in `create_nfs_export`, `update_nfs_export`, `delete_nfs_export`; Parameter `_admin` → `current_admin`.
+- **Modify** `backend/app/api/routes/samba.py` — Import `get_audit_logger_db`; Audit-Aufrufe in `toggle_smb_user`; Parameter `_admin` → `current_admin`.
+- **Modify** `backend/tests/api/test_nfs_routes.py` — Neue Audit-Assertion-Tests.
+- **Create** `backend/tests/api/test_samba_routes.py` — Toggle-Audit-Tests (Samba-Service gemockt).
+
+**Hinweis zum Parameter:** Der bestehende Stil im Repo erlaubt `current_admin=Depends(deps.get_current_admin)` **ohne** Typ-Annotation (siehe `samba.py:119` `current_user=Depends(...)`). Wir nutzen diese Form — dadurch ist **kein** zusätzlicher `UserPublic`-Import nötig.
+
+---
+
+## Task 1: NFS-Export Audit-Logging
+
+**Files:**
+- Modify: `backend/app/api/routes/nfs.py`
+- Test: `backend/tests/api/test_nfs_routes.py`
+
+- [ ] **Step 1: Audit-Assertion-Tests schreiben (failing)**
+
+In `backend/tests/api/test_nfs_routes.py` oben den Import ergänzen (unter die bestehende `from app.core.config import settings`-Zeile):
+
+```python
+import pytest
+from app.models.audit_log import AuditLog
+```
+
+Am Dateiende anhängen:
+
+```python
+@pytest.fixture
+def audit_enabled():
+    """Ensure the global audit logger is enabled (a prior test may have disabled it)."""
+    from app.services.audit.logger_db import get_audit_logger_db
+    get_audit_logger_db().enable()
+
+
+class TestNfsAudit:
+    def test_create_writes_audit(self, client, admin_headers, db_session, audit_enabled):
+        r = _create(client, admin_headers, path="AuditMedia")
+        assert r.status_code == 201, r.text
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "nfs_export_created", AuditLog.success == True)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.event_type == "SYSTEM_CONFIG"
+        assert row.resource == "AuditMedia"
+        assert row.user == settings.admin_username
+
+    def test_update_writes_audit(self, client, admin_headers, db_session, audit_enabled):
+        export_id = _create(client, admin_headers, path="AuditUpd").json()["id"]
+        r = client.put(
+            f"{settings.api_prefix}/nfs/exports/{export_id}",
+            json={"path": "AuditUpd", "clients": "192.168.1.0/24", "read_only": True,
+                  "root_squash": True, "enabled": True, "comment": None},
+            headers=admin_headers,
+        )
+        assert r.status_code == 200
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "nfs_export_updated", AuditLog.success == True)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == "AuditUpd"
+
+    def test_delete_writes_audit(self, client, admin_headers, db_session, audit_enabled):
+        export_id = _create(client, admin_headers, path="AuditDel").json()["id"]
+        r = client.delete(f"{settings.api_prefix}/nfs/exports/{export_id}", headers=admin_headers)
+        assert r.status_code == 204
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "nfs_export_deleted", AuditLog.success == True)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == "AuditDel"
+
+    def test_delete_missing_writes_failure(self, client, admin_headers, db_session, audit_enabled):
+        r = client.delete(f"{settings.api_prefix}/nfs/exports/888888", headers=admin_headers)
+        assert r.status_code == 404
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "nfs_export_deleted", AuditLog.success == False)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == "888888"
+        assert row.error_message == "Export not found"
+
+    def test_duplicate_create_writes_failure(self, client, admin_headers, db_session, audit_enabled):
+        assert _create(client, admin_headers, path="AuditDup").status_code == 201
+        assert _create(client, admin_headers, path="AuditDup").status_code == 409
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "nfs_export_created", AuditLog.success == False)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == "AuditDup"
+```
+
+- [ ] **Step 2: Tests laufen lassen → fail**
+
+Run: `cd backend && python -m pytest tests/api/test_nfs_routes.py::TestNfsAudit -v`
+Expected: 5× FAIL (kein AuditLog-Row gefunden → `assert row is not None` schlägt fehl).
+
+- [ ] **Step 3: `nfs.py` implementieren**
+
+Import-Block ergänzen (nach `from app.services import nfs_service`, Zeile ~19):
+
+```python
+from app.services.audit.logger_db import get_audit_logger_db
+```
+
+`create_nfs_export` (ab `async def create_nfs_export`) vollständig ersetzen durch:
+
+```python
+async def create_nfs_export(
+    request: Request, response: Response,
+    payload: NfsExportCreate,
+    current_admin=Depends(deps.get_current_admin),
+    db: Session = Depends(get_db),
+):
+    """Create an NFS export (admin only)."""
+    audit = get_audit_logger_db()
+    if db.query(NfsExport).filter(NfsExport.path == payload.path).first():
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_created", resource=payload.path,
+            success=False, error_message="An export for this path already exists", db=db,
+        )
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="An export for this path already exists")
+    exp = NfsExport(
+        path=payload.path, clients=payload.clients, read_only=payload.read_only,
+        root_squash=payload.root_squash, enabled=payload.enabled, comment=payload.comment,
+    )
+    details = {
+        "clients": payload.clients, "read_only": payload.read_only,
+        "root_squash": payload.root_squash, "enabled": payload.enabled,
+    }
+    try:
+        db.add(exp)
+        db.commit()
+        db.refresh(exp)
+        await nfs_service.regenerate_exports_config()
+        await nfs_service.apply_exports()
+    except Exception as e:
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_created", resource=payload.path,
+            success=False, error_message=str(e), db=db,
+        )
+        raise
+    audit.log_event(
+        event_type="SYSTEM_CONFIG", user=current_admin.username,
+        action="nfs_export_created", resource=exp.path,
+        success=True, details=details, db=db,
+    )
+    return _to_response(exp, _get_local_ip())
+```
+
+`update_nfs_export` vollständig ersetzen durch:
+
+```python
+async def update_nfs_export(
+    request: Request, response: Response,
+    export_id: int,
+    payload: NfsExportUpdate,
+    current_admin=Depends(deps.get_current_admin),
+    db: Session = Depends(get_db),
+):
+    """Update an NFS export (admin only)."""
+    audit = get_audit_logger_db()
+    exp = db.query(NfsExport).filter(NfsExport.id == export_id).first()
+    if not exp:
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_updated", resource=str(export_id),
+            success=False, error_message="Export not found", db=db,
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Export not found")
+    if payload.path != exp.path and db.query(NfsExport).filter(NfsExport.path == payload.path).first():
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_updated", resource=payload.path,
+            success=False, error_message="An export for this path already exists", db=db,
+        )
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="An export for this path already exists")
+    exp.path = payload.path
+    exp.clients = payload.clients
+    exp.read_only = payload.read_only
+    exp.root_squash = payload.root_squash
+    exp.enabled = payload.enabled
+    exp.comment = payload.comment
+    details = {
+        "clients": payload.clients, "read_only": payload.read_only,
+        "root_squash": payload.root_squash, "enabled": payload.enabled,
+    }
+    try:
+        db.commit()
+        db.refresh(exp)
+        await nfs_service.regenerate_exports_config()
+        await nfs_service.apply_exports()
+    except Exception as e:
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_updated", resource=payload.path,
+            success=False, error_message=str(e), db=db,
+        )
+        raise
+    audit.log_event(
+        event_type="SYSTEM_CONFIG", user=current_admin.username,
+        action="nfs_export_updated", resource=exp.path,
+        success=True, details=details, db=db,
+    )
+    return _to_response(exp, _get_local_ip())
+```
+
+`delete_nfs_export` vollständig ersetzen durch:
+
+```python
+async def delete_nfs_export(
+    request: Request, response: Response,
+    export_id: int,
+    current_admin=Depends(deps.get_current_admin),
+    db: Session = Depends(get_db),
+):
+    """Delete an NFS export (admin only)."""
+    audit = get_audit_logger_db()
+    exp = db.query(NfsExport).filter(NfsExport.id == export_id).first()
+    if not exp:
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_deleted", resource=str(export_id),
+            success=False, error_message="Export not found", db=db,
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Export not found")
+    path = exp.path
+    try:
+        db.delete(exp)
+        db.commit()
+        await nfs_service.regenerate_exports_config()
+        await nfs_service.apply_exports()
+    except Exception as e:
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action="nfs_export_deleted", resource=path,
+            success=False, error_message=str(e), db=db,
+        )
+        raise
+    audit.log_event(
+        event_type="SYSTEM_CONFIG", user=current_admin.username,
+        action="nfs_export_deleted", resource=path,
+        success=True, details={"export_id": export_id}, db=db,
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+```
+
+- [ ] **Step 4: Tests laufen lassen → pass**
+
+Run: `cd backend && python -m pytest tests/api/test_nfs_routes.py -v`
+Expected: PASS (alle alten + 5 neue `TestNfsAudit`-Tests grün).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes/nfs.py backend/tests/api/test_nfs_routes.py
+git commit -m "feat(audit): log NFS export mutations via audit logger (#195)"
+```
+
+---
+
+## Task 2: Samba SMB-Toggle Audit-Logging
+
+**Files:**
+- Modify: `backend/app/api/routes/samba.py`
+- Create: `backend/tests/api/test_samba_routes.py`
+
+- [ ] **Step 1: Test-Datei schreiben (failing)**
+
+Neue Datei `backend/tests/api/test_samba_routes.py`:
+
+```python
+"""Route tests for /api/samba (admin-only SMB user management)."""
+import pytest
+
+from app.core.config import settings
+from app.models.audit_log import AuditLog
+
+
+@pytest.fixture
+def audit_enabled():
+    """Ensure the global audit logger is enabled (a prior test may have disabled it)."""
+    from app.services.audit.logger_db import get_audit_logger_db
+    get_audit_logger_db().enable()
+
+
+@pytest.fixture
+def mock_samba(monkeypatch):
+    """Stub the system-touching Samba service calls so no real smbpasswd runs."""
+    async def _noop(*args, **kwargs):
+        return None
+
+    from app.services import samba_service
+    for fn in (
+        "enable_smb_user", "disable_smb_user", "sync_smb_password",
+        "regenerate_shares_config", "reload_samba",
+    ):
+        monkeypatch.setattr(samba_service, fn, _noop)
+
+
+def _toggle(client, headers, user_id, enabled, password=None):
+    body = {"enabled": enabled}
+    if password is not None:
+        body["password"] = password
+    return client.post(
+        f"{settings.api_prefix}/samba/users/{user_id}/toggle", json=body, headers=headers
+    )
+
+
+class TestSambaAuth:
+    def test_toggle_forbidden_for_regular_user(self, client, user_headers, regular_user):
+        r = _toggle(client, user_headers, regular_user.id, True)
+        assert r.status_code == 403
+
+
+class TestSambaToggleAudit:
+    def test_enable_writes_audit(self, client, admin_headers, regular_user, db_session, audit_enabled, mock_samba):
+        r = _toggle(client, admin_headers, regular_user.id, True)
+        assert r.status_code == 200, r.text
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "smb_access_enabled", AuditLog.success == True)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.event_type == "SYSTEM_CONFIG"
+        assert row.resource == regular_user.username
+        assert row.user == settings.admin_username
+
+    def test_disable_writes_audit(self, client, admin_headers, regular_user, db_session, audit_enabled, mock_samba):
+        r = _toggle(client, admin_headers, regular_user.id, False)
+        assert r.status_code == 200, r.text
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "smb_access_disabled", AuditLog.success == True)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == regular_user.username
+
+    def test_toggle_missing_user_writes_failure(self, client, admin_headers, db_session, audit_enabled, mock_samba):
+        r = _toggle(client, admin_headers, 999999, True)
+        assert r.status_code == 404
+        row = (
+            db_session.query(AuditLog)
+            .filter(AuditLog.action == "smb_access_enabled", AuditLog.success == False)  # noqa: E712
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert row is not None
+        assert row.resource == "999999"
+        assert row.error_message == "User not found"
+```
+
+- [ ] **Step 2: Tests laufen lassen → fail**
+
+Run: `cd backend && python -m pytest tests/api/test_samba_routes.py -v`
+Expected: `TestSambaToggleAudit` 3× FAIL (kein AuditLog-Row). `TestSambaAuth::test_toggle_forbidden_for_regular_user` darf bereits PASS sein (Auth existiert schon).
+
+- [ ] **Step 3: `samba.py` implementieren**
+
+Import-Block ergänzen (nach `from app.services import samba_service, users as user_service`, Zeile ~22):
+
+```python
+from app.services.audit.logger_db import get_audit_logger_db
+```
+
+`toggle_smb_user` (ab `async def toggle_smb_user`) vollständig ersetzen durch:
+
+```python
+async def toggle_smb_user(
+    request: Request, response: Response,
+    user_id: int,
+    payload: SambaUserToggleRequest,
+    current_admin=Depends(deps.get_current_admin),
+    db: Session = Depends(get_db),
+):
+    """Toggle SMB access for a user (admin only).
+
+    When enabling, an optional password can be provided for immediate sync.
+    Without a password the user must change their password for SMB to work.
+    """
+    audit = get_audit_logger_db()
+    action = "smb_access_enabled" if payload.enabled else "smb_access_disabled"
+
+    user = user_service.set_smb_enabled(user_id, payload.enabled, db=db)
+    if not user:
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action=action, resource=str(user_id),
+            success=False, error_message="User not found", db=db,
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    password_synced = False
+    try:
+        if payload.enabled:
+            # Sync password if provided
+            if payload.password:
+                await samba_service.sync_smb_password(user.username, payload.password)
+                password_synced = True
+            await samba_service.enable_smb_user(user.username)
+        else:
+            await samba_service.disable_smb_user(user.username)
+
+        # Regenerate shares config and reload
+        await samba_service.regenerate_shares_config()
+        await samba_service.reload_samba()
+    except Exception as e:
+        audit.log_event(
+            event_type="SYSTEM_CONFIG", user=current_admin.username,
+            action=action, resource=user.username,
+            success=False, error_message=str(e), db=db,
+        )
+        raise
+
+    audit.log_event(
+        event_type="SYSTEM_CONFIG", user=current_admin.username,
+        action=action, resource=user.username,
+        success=True, details={"enabled": payload.enabled, "password_synced": password_synced}, db=db,
+    )
+
+    return {
+        "user_id": user.id,
+        "username": user.username,
+        "smb_enabled": user.smb_enabled,
+    }
+```
+
+**Sicherheitshinweis:** Das Passwort selbst landet **nie** im `details`-Dict — nur der boolean `password_synced`.
+
+- [ ] **Step 4: Tests laufen lassen → pass**
+
+Run: `cd backend && python -m pytest tests/api/test_samba_routes.py -v`
+Expected: PASS (4 Tests grün).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes/samba.py backend/tests/api/test_samba_routes.py
+git commit -m "feat(audit): log SMB user toggle via audit logger (#195)"
+```
+
+---
+
+## Task 3: Gesamt-Verifikation
+
+**Files:** (keine Änderung — nur Verifikation)
+
+- [ ] **Step 1: Beide Test-Dateien zusammen laufen lassen**
+
+Run: `cd backend && python -m pytest tests/api/test_nfs_routes.py tests/api/test_samba_routes.py -v`
+Expected: PASS (alle Tests grün, inkl. der bereits bestehenden NFS-CRUD/Auth-Tests — bestätigt, dass die Signatur-/Verhaltensänderung nichts gebrochen hat).
+
+- [ ] **Step 2: Audit-Logger-Regression prüfen**
+
+Run: `cd backend && python -m pytest tests/logging -v`
+Expected: PASS (keine Regression im Audit-System).
+
+- [ ] **Step 3: Security-Self-Check (manuell)**
+
+Sicherstellen: In `nfs.py` und `samba.py` enthält **kein** `details`-Dict ein Passwort/Secret. Bei Samba nur `{"enabled": ..., "password_synced": <bool>}`. `event_type` ist überall `"SYSTEM_CONFIG"` (admin-only Sichtbarkeit). Kein neuer Endpoint ohne Auth/Rate-Limit (es wurden keine Endpoints hinzugefügt).
+
+- [ ] **Step 4: Kein Commit nötig** (reine Verifikation; Code-Commits erfolgten in Task 1 & 2).
+
+---
+
+## Notes
+
+- **Branch:** `fix/195-audit-nfs-samba` (bereits von `origin/main` erstellt, Spec-Commit `04098baa` liegt vor).
+- **PR-Ziel:** `main` (siehe `.claude/rules/production.md` — Feature/Fix-Branches PRen direkt nach `main`).
+- **Windows/CRLF:** Repo läuft mit `core.autocrlf=true`; die `git commit`-Warnung „LF will be replaced by CRLF" ist erwartbar und unkritisch.

--- a/docs/superpowers/specs/2026-06-09-audit-nfs-samba-design.md
+++ b/docs/superpowers/specs/2026-06-09-audit-nfs-samba-design.md
@@ -1,0 +1,148 @@
+# Spec: Audit-Logging für NFS/Samba-Share-Mutationen (#195)
+
+**Datum:** 2026-06-09
+**Branch:** `fix/195-audit-nfs-samba` (von `origin/main`)
+**Issue:** #195 — *audit: log NFS/Samba share mutations via `get_audit_logger_db()`*
+**Tracking-Ursprung:** Finaler Review von PR #194 (NFS-Feature #183)
+
+## Problem
+
+Share-Mutationen für **NFS** und **Samba** werden nicht ins Audit-Log geschrieben.
+Admin-Operationen, die Netzwerk-Exporte anlegen/ändern/löschen (Exposition von
+Verzeichnissen ins Netz), hinterlassen damit keine nachvollziehbare Spur — entgegen
+der Projektregel (`.claude/rules/security-agent.md` → ALWAYS: „Log security-relevant
+actions … (login, password change, admin ops …)").
+
+Betroffene Handler ohne Audit-Aufruf:
+- `backend/app/api/routes/nfs.py` — `create_nfs_export`, `update_nfs_export`, `delete_nfs_export`
+- `backend/app/api/routes/samba.py` — `toggle_smb_user`
+
+Beide Endpoints sind admin-gated, rate-limited und validiert — **kein akutes Loch**,
+sondern eine Lücke in der Audit-Nachvollziehbarkeit. Severity: niedrig–mittel.
+
+## Ziel
+
+Jede erfolgreiche **und** fehlgeschlagene Share-Mutation an NFS-Exports und SMB-User-Zugriff
+erzeugt einen Audit-Log-Eintrag über `get_audit_logger_db().log_event(...)`.
+
+## Nicht-Ziel (Out of Scope)
+
+- Kein Redesign des bestehenden Fehlerverhaltens „DB committed, aber `apply_exports()`
+  fehlgeschlagen → 500" (Inkonsistenz-Fenster). Der Audit-Eintrag spiegelt diesen Zustand
+  nur wider; das Verhalten selbst bleibt unverändert. Falls relevant: eigenes Issue.
+- Keine neuen Helper-Methoden in `AuditLoggerDB` (bewusste Entscheidung: `log_event` direkt).
+- Keine Frontend-Änderungen.
+
+## Designentscheidungen
+
+1. **`log_event` direkt, `event_type="SYSTEM_CONFIG"`.** Kein neuer Code im Logger.
+   `SYSTEM_CONFIG` ist bereits in `ADMIN_ONLY_EVENTS` (`logger_db.py:19`) → Einträge sind
+   für Nicht-Admins in der Audit-Ansicht verborgen. Entspricht dem Issue-Vorschlag.
+2. **Erfolg + Fehler loggen** (wie VPN-Routes in `vpn.py`):
+   - Validierungs-Ablehnungen (404/409) → `success=False` vor dem `raise`.
+   - Service-Fehler (`regenerate_*`/`apply_*`/`reload_*`) → `try/except Exception`,
+     `success=False` + re-raise.
+3. **Signatur-Anpassung:** Das verworfene `_admin=Depends(deps.get_current_admin)` wird in
+   allen vier Handlern zu `current_admin: UserPublic = Depends(deps.get_current_admin)`,
+   damit `current_admin.username` für `user=` verfügbar ist.
+4. **Keine `ip_address`/`user_agent`** — konsistent mit `log_system_config_change` und den
+   VPN-Aufrufen.
+5. **Keine Secrets in `details`** — bei Samba nur boolean `password_synced`, nie das Passwort.
+
+## Audit-Eintrag pro Handler
+
+Alle Aufrufe: `event_type="SYSTEM_CONFIG"`, `user=current_admin.username`, `db=db`.
+
+| Handler | action (Erfolg) | resource | details (secret-frei) |
+|---|---|---|---|
+| `create_nfs_export` | `nfs_export_created` | `payload.path` | `clients`, `read_only`, `root_squash`, `enabled` |
+| `update_nfs_export` | `nfs_export_updated` | `exp.path` | `clients`, `read_only`, `root_squash`, `enabled` |
+| `delete_nfs_export` | `nfs_export_deleted` | `exp.path` | `{"export_id": export_id}` |
+| `toggle_smb_user` | `smb_access_enabled` / `smb_access_disabled` | `user.username` | `{"enabled": bool, "password_synced": bool}` |
+
+**Fehler-Actions:** Bei Validierungs-Ablehnungen und Service-Exceptions wird dieselbe
+`action` mit `success=False` und gesetztem `error_message` geloggt. Für die 404/409-Fälle,
+in denen die Zielressource noch nicht aufgelöst ist:
+- `create_nfs_export` 409 → action `nfs_export_created`, resource `payload.path`,
+  `error_message="An export for this path already exists"`.
+- `update_nfs_export` 404 → action `nfs_export_updated`, resource `str(export_id)`,
+  `error_message="Export not found"`.
+- `update_nfs_export` 409 → action `nfs_export_updated`, resource `payload.path`,
+  `error_message="An export for this path already exists"`.
+- `delete_nfs_export` 404 → action `nfs_export_deleted`, resource `str(export_id)`,
+  `error_message="Export not found"`.
+- `toggle_smb_user` 404 → action je nach `payload.enabled`, resource `str(user_id)`,
+  `error_message="User not found"`.
+
+## Kontroll-Fluss (Beispiel `delete_nfs_export`)
+
+```python
+audit = get_audit_logger_db()
+exp = db.query(NfsExport).filter(NfsExport.id == export_id).first()
+if not exp:
+    audit.log_event(
+        event_type="SYSTEM_CONFIG", user=current_admin.username,
+        action="nfs_export_deleted", resource=str(export_id),
+        success=False, error_message="Export not found", db=db,
+    )
+    raise HTTPException(status_code=404, detail="Export not found")
+
+path = exp.path
+try:
+    db.delete(exp)
+    db.commit()
+    await nfs_service.regenerate_exports_config()
+    await nfs_service.apply_exports()
+except Exception as e:
+    audit.log_event(
+        event_type="SYSTEM_CONFIG", user=current_admin.username,
+        action="nfs_export_deleted", resource=path,
+        success=False, error_message=str(e), db=db,
+    )
+    raise
+
+audit.log_event(
+    event_type="SYSTEM_CONFIG", user=current_admin.username,
+    action="nfs_export_deleted", resource=path,
+    success=True, details={"export_id": export_id}, db=db,
+)
+return Response(status_code=204)
+```
+
+Die anderen Handler folgen demselben Muster (validate → log-fail-on-reject → try/mutate+apply →
+log-fail-on-exception → log-success).
+
+## Betroffene Dateien
+
+- `backend/app/api/routes/nfs.py` — Import `get_audit_logger_db`, `UserPublic`; drei Handler.
+- `backend/app/api/routes/samba.py` — Import `get_audit_logger_db`, `UserPublic`; `toggle_smb_user`.
+- `backend/tests/api/test_nfs_routes.py` — Audit-Assertions erweitern.
+- `backend/tests/api/test_samba_routes.py` — **neu**: Toggle-Audit-Tests (Samba-Service gemockt).
+
+## Tests
+
+Vorbild für AuditLog-Assertions: `tests/api/test_require_local_admin.py:63`
+(`db_session.query(AuditLog).filter(AuditLog.action == ...)`).
+
+**NFS (`test_nfs_routes.py`):**
+- create → genau ein `AuditLog`-Row `action="nfs_export_created"`, `success=True`,
+  `user == admin`, `resource == "Media"`.
+- update → Row `nfs_export_updated`, `success=True`.
+- delete → Row `nfs_export_deleted`, `success=True`.
+- delete 404 → Row `nfs_export_deleted`, `success=False`.
+- create 409 (Duplikat) → Row `nfs_export_created`, `success=False`.
+
+**Samba (neu `test_samba_routes.py`):**
+- Samba-Service-Calls mocken (`enable_smb_user`, `disable_smb_user`, `sync_smb_password`,
+  `regenerate_shares_config`, `reload_samba`) — kein echtes `smbpasswd`.
+- enable → Row `smb_access_enabled`, `success=True`, `resource == username`,
+  `details.enabled is True`.
+- disable → Row `smb_access_disabled`, `success=True`.
+- toggle auf nicht-existenten User (404) → Row mit `success=False`.
+- (Auth-Smoke: regulärer User → 403, wie in `test_nfs_routes.py`.)
+
+## Verifikation
+
+- `python -m pytest tests/api/test_nfs_routes.py tests/api/test_samba_routes.py -v`
+- Sicherstellen, dass keine bestehenden NFS-Tests brechen (Signatur-/Verhaltensänderung).
+- Sicherheits-Check: kein Passwort in irgendeinem `details`-Dict.


### PR DESCRIPTION
## Summary

Closes #195. NFS- und Samba-Share-Mutationen schreiben jetzt Audit-Log-Einträge via `get_audit_logger_db().log_event(...)` — vorher hinterließen diese admin-gated Netzwerk-Export-Operationen keine nachvollziehbare Spur (Verstoß gegen `.claude/rules/security-agent.md` → „Log security-relevant actions … admin ops").

Betroffene Handler (je Erfolg **und** Fehler geloggt):
- `backend/app/api/routes/nfs.py` — `create_nfs_export`, `update_nfs_export`, `delete_nfs_export`
- `backend/app/api/routes/samba.py` — `toggle_smb_user`

## Design

- **`log_event` direkt** mit `event_type="SYSTEM_CONFIG"` (bereits in `ADMIN_ONLY_EVENTS` → für Nicht-Admins in der Audit-Ansicht verborgen). Kein neuer Code im Logger.
- **Erfolg + Fehler**: Validierungs-Ablehnungen (404/409) loggen `success=False` vor dem `raise`; Service-Fehler werden in `try/except Exception` gekapselt, loggen `success=False` (mit vorgeschaltetem `db.rollback()`, damit ein fehlgeschlagener `db.commit()` die Audit-Schreibung auf PostgreSQL nicht in einer aborted-Transaction verschluckt) und re-raisen.
- **Keine Secrets**: Bei Samba steht nur der boolean `password_synced` in `details` — nie das Passwort selbst (per Test abgesichert).
- Verworfenes `_admin=Depends(...)` → `current_admin=Depends(...)`, um `current_admin.username` zu loggen.

Actions: `nfs_export_created|updated|deleted`, `smb_access_enabled|disabled`. Resource = Export-Pfad bzw. Username.

Spec & Plan: `docs/superpowers/specs/2026-06-09-audit-nfs-samba-design.md`, `docs/superpowers/plans/2026-06-09-audit-nfs-samba.md`.

## Test Plan

- [x] `pytest tests/api/test_nfs_routes.py` — 21 passed (inkl. neue `TestNfsAudit`: create/update/delete success + delete-404 / create-409 / update-404 / update-409 failures + service-failure-Pfad)
- [x] `pytest tests/api/test_samba_routes.py` — 6 passed (enable/disable success, 404 failure, service-failure, **Passwort-Nicht-Leak-Test**)
- [x] `pytest tests/logging` — keine Regression im Audit-System
- [x] Security-Check: kein Passwort/Secret in irgendeinem `details`/`error_message`
- [x] Spec-Review + Code-Quality-Review je Task + finaler Gesamt-Review → READY TO MERGE

🤖 Generated with [Claude Code](https://claude.com/claude-code)
