### PR TITLE
fix(deploy): use @@BALUHOST_USER@@ in NFS/Samba sudoers instead of hardcoded user (#196)

### DIFF
--- a/deploy/nfs/baluhost-nfs-sudoers
+++ b/deploy/nfs/baluhost-nfs-sudoers
@@ -1,6 +1,8 @@
 # BaluHost NFS sudoers rules
-# Install: sudo cp baluhost-nfs-sudoers /etc/sudoers.d/baluhost-nfs
-# Verify:  sudo visudo -c
+# Installed by setup-nfs.sh, which substitutes the service-user placeholder on
+# each rule line with the actual service user, validates the result with
+# `visudo -cf`, then installs it to /etc/sudoers.d/baluhost-nfs (mode 440).
+# Verify: sudo visudo -cf /etc/sudoers.d/baluhost-nfs
 
-sven ALL=(ALL) NOPASSWD: /usr/sbin/exportfs -ra
-sven ALL=(ALL) NOPASSWD: /usr/sbin/exportfs -r
+@@BALUHOST_USER@@ ALL=(ALL) NOPASSWD: /usr/sbin/exportfs -ra
+@@BALUHOST_USER@@ ALL=(ALL) NOPASSWD: /usr/sbin/exportfs -r

--- a/deploy/nfs/setup-nfs.sh
+++ b/deploy/nfs/setup-nfs.sh
@@ -24,9 +24,18 @@ chown "$SERVICE_USER:$STORAGE_GROUP" "$EXPORTS_CONF"
 chmod 644 "$EXPORTS_CONF"
 
 echo "[3/4] Installing sudoers rules..."
-cp "$SCRIPT_DIR/baluhost-nfs-sudoers" /etc/sudoers.d/baluhost-nfs
-chmod 440 /etc/sudoers.d/baluhost-nfs
-visudo -c
+# Substitute the @@BALUHOST_USER@@ placeholder, validate in isolation, then
+# install — never write an unvalidated file into /etc/sudoers.d (a malformed
+# drop-in can break sudo system-wide).
+SUDOERS_TMP=$(mktemp)
+trap 'rm -f "$SUDOERS_TMP"' EXIT
+sed "s|@@BALUHOST_USER@@|$SERVICE_USER|g" "$SCRIPT_DIR/baluhost-nfs-sudoers" > "$SUDOERS_TMP"
+if ! visudo -cf "$SUDOERS_TMP" >/dev/null 2>&1; then
+    echo "ERROR: generated sudoers file fails visudo syntax check." >&2
+    visudo -cf "$SUDOERS_TMP" || true
+    exit 1
+fi
+install -m 440 -o root -g root "$SUDOERS_TMP" /etc/sudoers.d/baluhost-nfs
 
 echo "[4/4] Enabling nfs-server..."
 systemctl enable --now nfs-server

--- a/deploy/samba/baluhost-samba-sudoers
+++ b/deploy/samba/baluhost-samba-sudoers
@@ -1,9 +1,11 @@
 # BaluHost Samba sudoers rules
-# Install: sudo cp baluhost-samba-sudoers /etc/sudoers.d/baluhost-samba
-# Verify:  sudo visudo -c
+# Installed by setup-samba.sh, which substitutes the service-user placeholder on
+# each rule line with the actual service user, validates the result with
+# `visudo -cf`, then installs it to /etc/sudoers.d/baluhost-samba (mode 440).
+# Verify: sudo visudo -cf /etc/sudoers.d/baluhost-samba
 
-sven ALL=(ALL) NOPASSWD: /usr/bin/smbpasswd
-sven ALL=(ALL) NOPASSWD: /usr/bin/smbcontrol
-sven ALL=(ALL) NOPASSWD: /usr/bin/smbstatus
-sven ALL=(ALL) NOPASSWD: /usr/sbin/useradd
-sven ALL=(ALL) NOPASSWD: /usr/sbin/userdel
+@@BALUHOST_USER@@ ALL=(ALL) NOPASSWD: /usr/bin/smbpasswd
+@@BALUHOST_USER@@ ALL=(ALL) NOPASSWD: /usr/bin/smbcontrol
+@@BALUHOST_USER@@ ALL=(ALL) NOPASSWD: /usr/bin/smbstatus
+@@BALUHOST_USER@@ ALL=(ALL) NOPASSWD: /usr/sbin/useradd
+@@BALUHOST_USER@@ ALL=(ALL) NOPASSWD: /usr/sbin/userdel

--- a/deploy/samba/setup-samba.sh
+++ b/deploy/samba/setup-samba.sh
@@ -33,9 +33,18 @@ chmod 644 "$SHARES_CONF"
 
 # 4. Install sudoers
 echo "[4/5] Installing sudoers rules..."
-cp "$SCRIPT_DIR/baluhost-samba-sudoers" /etc/sudoers.d/baluhost-samba
-chmod 440 /etc/sudoers.d/baluhost-samba
-visudo -c
+# Substitute the @@BALUHOST_USER@@ placeholder, validate in isolation, then
+# install — never write an unvalidated file into /etc/sudoers.d (a malformed
+# drop-in can break sudo system-wide).
+SUDOERS_TMP=$(mktemp)
+trap 'rm -f "$SUDOERS_TMP"' EXIT
+sed "s|@@BALUHOST_USER@@|$SERVICE_USER|g" "$SCRIPT_DIR/baluhost-samba-sudoers" > "$SUDOERS_TMP"
+if ! visudo -cf "$SUDOERS_TMP" >/dev/null 2>&1; then
+    echo "ERROR: generated sudoers file fails visudo syntax check." >&2
+    visudo -cf "$SUDOERS_TMP" || true
+    exit 1
+fi
+install -m 440 -o root -g root "$SUDOERS_TMP" /etc/sudoers.d/baluhost-samba
 
 # 5. Enable and start smbd
 echo "[5/5] Starting Samba..."


### PR DESCRIPTION
## Summary

Closes #196. Die sudoers-Dateien für NFS und Samba verdrahteten den Service-User hart als `sven`. Auf einer Installation mit anderem Service-User griffen die Regeln nicht (`exportfs`/`smbpasswd` schlugen mit „password required" fehl), bis die Datei manuell angepasst wurde.

Beide Dateien nutzen jetzt den etablierten `@@BALUHOST_USER@@`-Platzhalter (wie `deploy/install/templates/`), der beim Install durch die Setup-Skripte mit dem tatsächlichen Service-User ersetzt wird.

## Changes

- `deploy/nfs/baluhost-nfs-sudoers`, `deploy/samba/baluhost-samba-sudoers`: `sven` → `@@BALUHOST_USER@@` auf jeder Regelzeile; Header-Kommentar an den neuen Install-Weg angepasst.
- `deploy/nfs/setup-nfs.sh`, `deploy/samba/setup-samba.sh`: der sudoers-Install-Schritt ersetzt das `cp` durch `sed "s|@@BALUHOST_USER@@|$SERVICE_USER|g"` → Temp-Datei → **`visudo -cf` Validierung** → `install -m 440 -o root -g root`.

Dabei gleich das sichere Muster aus `deploy/scripts/install-deploy-sudoers.sh` übernommen: vorher wurde die sudoers-Datei per `cp` **unvalidiert** nach `/etc/sudoers.d/` geschrieben und erst danach `visudo -c` aufgerufen — ein kaputtes Drop-in wäre also bereits live gewesen. Jetzt wird in Isolation validiert, bevor installiert wird.

Scope bleibt unverändert eng: konkrete Binaries mit expliziten Args (`exportfs -ra/-r`, `smbpasswd`, `smbcontrol`, `smbstatus`, `useradd`, `userdel`) — kein `ALL`, keine Globs, keine Rechteausweitung. Nur der User wird parametrisiert.

## Test Plan

- [x] `bash -n` auf beiden Setup-Skripten — Syntax OK
- [x] `sed`-Trockenlauf (`SERVICE_USER=baluhost`): Regelzeilen erhalten den echten User, keine Restplatzhalter, Kommentare bleiben konsistent
- [ ] Auf Prod-Host (Service-User `sven`): `sudo bash deploy/nfs/setup-nfs.sh` bzw. `setup-samba.sh` erneut ausführen → `visudo -cf /etc/sudoers.d/baluhost-nfs` / `…-samba` grün, `sudo -n -u $SERVICE_USER /usr/sbin/exportfs -ra` ohne Passwort-Prompt

> Hinweis: `deploy/` ist CODEOWNERS-geschützt (@Xveyn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
