### PR TITLE
fix(ci): enable-linger reconciliation + self-tests for ci-runner rootless Podman (#127)

### DIFF
--- a/scripts/bootstrap-ci-runner.sh
+++ b/scripts/bootstrap-ci-runner.sh
@@ -105,6 +105,18 @@ fi
 log "Enabling systemd lingering for '$RUNNER_USER'..."
 loginctl enable-linger "$RUNNER_USER"
 
+# Reconcile rootless Podman state now that the user manager + /run/user/<uid> are
+# persistent. `loginctl enable-linger` (above) is the DURABLE fix — it keeps the
+# pause process alive across logout/reboot — but it does not retroactively repair
+# state that already went stale (e.g. from an earlier non-lingered session, which is
+# why #127 recurred even though linger was already in this script). A one-time
+# `podman system migrate` reconciles that stale pause.pid so the first `podman run`
+# does not hit 'invalid internal status ... could not find any running process'.
+# (migrate alone is only a temporary fix — linger is what makes it survive reboots.)
+# Best-effort here; the linger + `podman info` self-tests below are the gate.
+log "Reconciling rootless Podman state ('podman system migrate')..."
+as_runner bash -lc 'podman system migrate' || true
+
 # ---------- Step 5: GitHub Actions runner agent ----------
 if [[ -x "$RUNNER_DIR/config.sh" ]] && [[ -f "$RUNNER_DIR/.runner" ]]; then
   log "Runner agent already installed; skipping download. Re-registration follows."
@@ -181,6 +193,19 @@ for grp in docker sudo wheel; do
   fi
 done
 log "  [OK] ci-runner not in docker/sudo/wheel groups (current: $RUNNER_GROUPS)"
+
+# Podman base health (issue #127): linger must be active and `podman info` must
+# succeed — catches the stale rootless pause-process failure before any container
+# actually runs (clearer diagnostic than a failing `podman run`).
+if [[ "$(loginctl show-user "$RUNNER_USER" -p Linger --value 2>/dev/null)" != "yes" ]]; then
+  fail "systemd linger is not enabled for $RUNNER_USER — rootless pause process will die on idle/reboot (issue #127). Run: loginctl enable-linger $RUNNER_USER"
+fi
+log "  [OK] systemd linger enabled for $RUNNER_USER"
+
+if ! as_runner bash -lc 'podman info >/dev/null 2>&1'; then
+  fail "rootless 'podman info' failed for $RUNNER_USER — stale pause process? Run: sudo -u $RUNNER_USER -H bash -lc 'podman system migrate'"
+fi
+log "  [OK] rootless 'podman info' healthy"
 
 # 7d: rootless podman works.
 HELLO_OUT=$(as_runner podman run --rm docker.io/library/hello-world 2>&1 || true)


### PR DESCRIPTION
## Summary

Closes #127. Härtet `scripts/bootstrap-ci-runner.sh` gegen den rootless-Podman „pause process"-Fehler, der den Deploy von #125 zweimal sofort am Schritt *"Run backend tests in rootless Podman container"* killte:

```
invalid internal status, try resetting the pause process with "podman system migrate":
could not find any running process: no such process
```

## Befund

Checkbox 1 des Issues (`loginctl enable-linger ci-runner`) war **bereits** im Skript (Original-Commit `d70e0604`, vor der Issue-Erstellung). Der Fehler trat also *trotz* linger auf — die operativ fehlenden Teile sind Checkbox 2 + 3:

- **`podman system migrate`** einmalig beim Provisioning (reconciled einen bereits stale gewordenen `pause.pid`, z. B. aus einer früheren nicht-lingered Session).
- **Self-Tests**, die einen kaputten rootless-Zustand beim Bootstrap *vor* dem ersten Container abfangen.

## Changes (`scripts/bootstrap-ci-runner.sh`)

- Nach dem linger-Schritt: `as_runner bash -lc 'podman system migrate' || true` (best-effort Reconciliation), mit erklärendem Kommentar.
- Neue Self-Tests vor dem hello-world-Run:
  - **linger aktiv** (`loginctl show-user ci-runner -p Linger --value` == `yes`) — verifiziert direkt den Root-Cause-Mechanismus.
  - **`podman info` gesund** (`as_runner bash -lc 'podman info >/dev/null'`) — klarere Diagnose als ein fehlschlagender `podman run`.
- Beide `fail`-Meldungen nennen den manuellen Recovery-Befehl.

## Verifikation (Websuche, autoritativ)

Root-Cause + Fix gegen offizielle Quellen bestätigt:
- `podman system migrate` ist nur ein **temporärer** Fix — der Fehler kehrt nach Reboot zurück.
- **`loginctl enable-linger` ist der dauerhafte Fix** (hält Pause-Prozess über Logout/Reboot am Leben).

→ Aufteilung im PR: **linger = dauerhafter Mechanismus (hart als Self-Test asserted)**, **migrate = einmalige Reconciliation des Alt-Zustands (best-effort)**. Quellen:
- Red Hat: „Why am I not able to run podman commands after the host is rebooted?" (access.redhat.com/solutions/7011470)
- Red Hat: access.redhat.com/solutions/6988045
- containers/podman #19456, #20697

## Test Plan

- [x] `bash -n scripts/bootstrap-ci-runner.sh` — Syntax OK (das Skript selbst läuft nur als root auf dem Linux-Sandbox-Host).
- [ ] **Auf BaluNode:** `sudo scripts/bootstrap-ci-runner.sh --token <…>` erneut ausführen (idempotent) → neue Self-Tests „[OK] systemd linger enabled" + „[OK] rootless 'podman info' healthy" müssen grün sein; danach ein PR-`backend-tests`-Lauf startet sauber im Podman-Container.

> CODEOWNERS-relevant (`/scripts/bootstrap-ci-runner.sh`), Layer 2 in `.claude/rules/ci-cd-security.md` (Sandbox-Runner-Härtung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
