### PR TITLE
fix(login): make 2FA 'use backup code' work (toggle + hex input)

### DIFF
--- a/client/src/__tests__/lib/twoFactorCode.test.ts
+++ b/client/src/__tests__/lib/twoFactorCode.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeTwoFactorCode, isTwoFactorCodeComplete } from '../../lib/twoFactorCode';
+
+describe('sanitizeTwoFactorCode', () => {
+  it('strips non-digits in TOTP mode (unchanged legacy behaviour)', () => {
+    expect(sanitizeTwoFactorCode('12ab34', false)).toBe('1234');
+    expect(sanitizeTwoFactorCode('000000', false)).toBe('000000');
+  });
+
+  it('preserves hex chars and uppercases them in backup mode', () => {
+    // Backup codes are secrets.token_hex(4).upper() -> 8 uppercase hex chars.
+    // The old TOTP-only filter stripped the A-F letters, making backup codes
+    // impossible to enter. Backup mode must keep them.
+    expect(sanitizeTwoFactorCode('a3f9c2d1', true)).toBe('A3F9C2D1');
+  });
+
+  it('drops non-hex letters in backup mode', () => {
+    expect(sanitizeTwoFactorCode('A3G9Z2D1', true)).toBe('A392D1');
+  });
+
+  it('caps at 8 chars in both modes', () => {
+    expect(sanitizeTwoFactorCode('123456789', false)).toBe('12345678');
+    expect(sanitizeTwoFactorCode('A3F9C2D1FF', true)).toBe('A3F9C2D1');
+  });
+});
+
+describe('isTwoFactorCodeComplete', () => {
+  it('TOTP needs at least 6 digits', () => {
+    expect(isTwoFactorCodeComplete('12345', false)).toBe(false);
+    expect(isTwoFactorCodeComplete('123456', false)).toBe(true);
+    expect(isTwoFactorCodeComplete('12345678', false)).toBe(true);
+  });
+
+  it('backup code needs exactly 8 chars', () => {
+    expect(isTwoFactorCodeComplete('A3F9C2D', true)).toBe(false);
+    expect(isTwoFactorCodeComplete('A3F9C2D1', true)).toBe(true);
+  });
+});

--- a/client/src/i18n/locales/de/login.json
+++ b/client/src/i18n/locales/de/login.json
@@ -21,6 +21,9 @@
     "verify": "Verifizieren",
     "verifying": "Verifiziere...",
     "useBackupCode": "Backup-Code verwenden",
+    "useAuthenticatorCode": "Authenticator-Code verwenden",
+    "backupCodeLabel": "Backup-Code",
+    "backupCodePlaceholder": "A1B2C3D4",
     "backToLogin": "Zurück zum Login",
     "invalidCode": "Ungültiger Verifizierungscode"
   },

--- a/client/src/i18n/locales/en/login.json
+++ b/client/src/i18n/locales/en/login.json
@@ -21,6 +21,9 @@
     "verify": "Verify",
     "verifying": "Verifying...",
     "useBackupCode": "Use a backup code",
+    "useAuthenticatorCode": "Use authenticator code",
+    "backupCodeLabel": "Backup Code",
+    "backupCodePlaceholder": "A1B2C3D4",
     "backToLogin": "Back to login",
     "invalidCode": "Invalid verification code"
   },

--- a/client/src/lib/twoFactorCode.ts
+++ b/client/src/lib/twoFactorCode.ts
@@ -1,0 +1,28 @@
+/**
+ * Sanitisation + completeness helpers for the 2FA login code input.
+ *
+ * Two code kinds are entered through the same field on the login screen:
+ *  - TOTP codes: 6-8 digits from the authenticator app.
+ *  - Backup codes: 8 uppercase hex chars (backend: `secrets.token_hex(4).upper()`).
+ *
+ * The original input filter stripped every non-digit, so a backup code's A-F
+ * letters were silently removed and a backup code could never be entered. These
+ * helpers make the filter mode-aware.
+ */
+
+const BACKUP_CODE_LENGTH = 8;
+const TOTP_MIN_LENGTH = 6;
+const MAX_LENGTH = 8;
+
+/** Filter raw keystrokes for the active mode. */
+export function sanitizeTwoFactorCode(raw: string, backupMode: boolean): string {
+  if (backupMode) {
+    return raw.replace(/[^0-9a-fA-F]/g, '').toUpperCase().slice(0, MAX_LENGTH);
+  }
+  return raw.replace(/\D/g, '').slice(0, MAX_LENGTH);
+}
+
+/** Whether the entered code is long enough to allow submitting. */
+export function isTwoFactorCodeComplete(code: string, backupMode: boolean): boolean {
+  return backupMode ? code.length === BACKUP_CODE_LENGTH : code.length >= TOTP_MIN_LENGTH;
+}

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -5,6 +5,7 @@ import type { User } from '../types/auth';
 import logoMark from '../assets/baluhost-logo.png';
 import { localApi } from '../lib/localApi';
 import { buildApiUrl, isTauri } from '../lib/api';
+import { sanitizeTwoFactorCode, isTwoFactorCodeComplete } from '../lib/twoFactorCode';
 import { loginWithPin } from '../api/pin';
 import { useVersion } from '../contexts/VersionContext';
 import { DeveloperBadge } from '../components/ui/DeveloperBadge';
@@ -28,6 +29,7 @@ export default function Login() {
   const [twoFactorRequired, setTwoFactorRequired] = useState(false);
   const [pendingToken, setPendingToken] = useState('');
   const [totpCode, setTotpCode] = useState('');
+  const [backupMode, setBackupMode] = useState(false);
   const totpInputRef = useRef<HTMLInputElement>(null);
   const [showPassword, setShowPassword] = useState(false);
   const [pinMode, setPinMode] = useState(false);
@@ -208,6 +210,7 @@ export default function Login() {
     setTwoFactorRequired(false);
     setPendingToken('');
     setTotpCode('');
+    setBackupMode(false);
     setError('');
   };
 
@@ -261,7 +264,7 @@ export default function Login() {
 
               <div className="space-y-2">
                 <label htmlFor="totp-code" className="text-xs font-medium uppercase tracking-[0.2em] text-slate-100-tertiary">
-                  {t('twoFactor.codeLabel')}
+                  {backupMode ? t('twoFactor.backupCodeLabel') : t('twoFactor.codeLabel')}
                 </label>
                 <input
                   ref={totpInputRef}
@@ -269,24 +272,26 @@ export default function Login() {
                   id="totp-code"
                   className="input text-center text-2xl tracking-[0.5em] font-mono"
                   value={totpCode}
-                  onChange={(e) => {
-                    const val = e.target.value.replace(/\D/g, '').slice(0, 8);
-                    setTotpCode(val);
-                  }}
-                  placeholder={t('twoFactor.codePlaceholder')}
-                  autoComplete="one-time-code"
-                  inputMode="numeric"
+                  onChange={(e) => setTotpCode(sanitizeTwoFactorCode(e.target.value, backupMode))}
+                  placeholder={backupMode ? t('twoFactor.backupCodePlaceholder') : t('twoFactor.codePlaceholder')}
+                  autoComplete={backupMode ? 'off' : 'one-time-code'}
+                  inputMode={backupMode ? 'text' : 'numeric'}
+                  maxLength={8}
                   required
                 />
-                <p className="text-xs text-slate-100-tertiary text-center mt-1">
-                  {t('twoFactor.useBackupCode')}
-                </p>
+                <button
+                  type="button"
+                  onClick={() => { setBackupMode((v) => !v); setTotpCode(''); setError(''); }}
+                  className="w-full text-center text-xs text-slate-100-tertiary hover:text-slate-100-secondary transition-colors mt-1"
+                >
+                  {backupMode ? t('twoFactor.useAuthenticatorCode') : t('twoFactor.useBackupCode')}
+                </button>
               </div>
 
               <button
                 type="submit"
                 className="btn btn-primary w-full mt-5 sm:mt-6 touch-manipulation active:scale-[0.98]"
-                disabled={loading || totpCode.length < 6}
+                disabled={loading || !isTwoFactorCodeComplete(totpCode, backupMode)}
               >
                 {loading ? t('twoFactor.verifying') : t('twoFactor.verify')}
               </button>


### PR DESCRIPTION
## Summary

Behebt den 2FA-Login-Bug: Auf dem 2FA-Screen (nach Username/Passwort) stand „Use a backup code" / „Backup-Code verwenden", aber weder Klick auf den Text noch „Verify" taten etwas — Backup-Codes waren über den Login praktisch unbenutzbar.

## Root Cause (komplett im Frontend, `client/src/pages/Login.tsx`)

Der 2FA-Screen war nur für numerische TOTP-Codes gebaut. „Use a backup code" war auf zwei Ebenen kaputt:

1. **Kein Button:** Der Hinweis war ein statisches `<p>` ohne `onClick`/State — der Text liest sich wie eine Aktion, war aber Deko. → Klick passiert nichts.
2. **Backup-Codes nicht eingebbar:** Das Eingabefeld filterte via `value.replace(/\D/g, '')` **alle Nicht-Ziffern** weg (+ `inputMode="numeric"`). Backup-Codes sind aber **8-stellig HEX, großgeschrieben** (`secrets.token_hex(4).upper()`, enthält A–F) → die Buchstaben wurden beim Tippen gestrippt. Der Verify-Button (`disabled={… totpCode.length < 6}`) blieb dadurch grau bzw. ein verstümmelter Ziffern-String wurde abgelehnt.

**Backend war bereits korrekt:** `/api/auth/verify-2fa` probiert TOTP, dann `verify_backup_code` über dasselbe `code`-Feld — kein Backend-Fix nötig.

## Fix

- „Use a backup code" ist jetzt ein echter Toggle-Button (Label wechselt zu „Use authenticator code"), schaltet das Feld in den Backup-Modus (Hex-Filter, `inputMode="text"`, eigenes Label/Placeholder) und leert Feld + Fehler beim Umschalten.
- Die Eingabe-Sanitization in eine reine, getestete Helper-Funktion `client/src/lib/twoFactorCode.ts` ausgelagert:
  - `sanitizeTwoFactorCode(raw, backupMode)` — TOTP: nur Ziffern (unverändertes Legacy-Verhalten); Backup: Hex, uppercased, max 8.
  - `isTwoFactorCodeComplete(code, backupMode)` — TOTP: ≥6; Backup: exakt 8.
- `handleVerify2FA` unverändert — das Backend-Fallback verarbeitet beide Code-Typen.
- i18n-Keys `useAuthenticatorCode` / `backupCodeLabel` / `backupCodePlaceholder` in `en` + `de` ergänzt.

Der TOTP-Pfad ist verhaltensgleich (Filter + disabled-Bedingung identisch zu vorher).

## Test Plan

- [x] **TDD:** neue Unit-Tests `client/src/__tests__/lib/twoFactorCode.test.ts` (6 Tests) — zuerst rot (Modul fehlte), dann grün. Kodieren den Kern-Defekt (Hex-Buchstaben im Backup-Modus erhalten, in TOTP gestrippt; Längen-Gates).
- [x] Volle Vitest-Suite: **407 passed**, keine Regression.
- [x] `npm run build` (Typecheck + Bundle): ✓.
- [ ] Manuell: 2FA-Login → „Use a backup code" klicken → 8-stelligen Backup-Code eintippen → Verify loggt ein; Toggle zurück zu Authenticator-Code funktioniert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
