### PR TITLE
fix(ci): sync pre-release tag into /opt/baluhost after deploy tagging

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -114,3 +114,15 @@ jobs:
           git tag -a "$TAG" -m "Pre-release $TAG"
           git push "https://x-access-token:${DEPLOY_PAT}@github.com/${GITHUB_REPOSITORY}.git" "$TAG"
           echo "Tag $TAG pushed -- create-release.yml will create the GitHub pre-release"
+
+      # The tag above is pushed from this workspace checkout, not from
+      # /opt/baluhost — without a fetch, the prod clone is permanently one tag
+      # behind itself and `git describe --tags --exact-match` fails, so the UI
+      # shows "Dev Build" + the stale pyproject version (#223). Fetch here on
+      # the same runner/user that ci-deploy.sh already uses. Non-fatal: the
+      # deploy is green and tagged at this point; a fetch failure only leaves
+      # today's cosmetic display state. Also runs on the tag step's skip paths,
+      # back-filling any previously missed tag on the next deploy.
+      - name: Sync tags to production checkout
+        if: success()
+        run: git -C /opt/baluhost fetch origin --tags || echo "::warning::tag fetch into /opt/baluhost failed (display-only impact)"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -125,4 +125,9 @@ jobs:
       # back-filling any previously missed tag on the next deploy.
       - name: Sync tags to production checkout
         if: success()
+        # The `||` fallback covers exit codes, not hangs: timeout-minutes caps
+        # a hung fetch, and continue-on-error keeps the already-green, tagged
+        # deploy run from being failed by that timeout.
+        timeout-minutes: 2
+        continue-on-error: true
         run: git -C /opt/baluhost fetch origin --tags || echo "::warning::tag fetch into /opt/baluhost failed (display-only impact)"

--- a/docs/superpowers/plans/2026-06-11-deploy-tag-fetch.md
+++ b/docs/superpowers/plans/2026-06-11-deploy-tag-fetch.md
@@ -1,0 +1,119 @@
+# Deploy Tag Fetch Fix (#223) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After `deploy-production.yml` pushes the pre-release tag, fetch tags into `/opt/baluhost` so `git describe --tags --exact-match` succeeds and the UI stops showing "Dev Build".
+
+**Architecture:** Single additive workflow step on the prod runner (same machine/user as `ci-deploy.sh`). Non-fatal by design — a fetch failure must never fail an already-green deploy. No backend changes; `get_current_version()` re-runs `git describe` per request, so the display self-heals.
+
+**Tech Stack:** GitHub Actions YAML only.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-updater-version-fixes-design.md`
+
+**Branch:** `fix/deploy-tag-fetch` (already exists, branched from `origin/main`, spec + plans committed).
+
+---
+
+### Task 1: Add "Sync tags to production checkout" step to the deploy workflow
+
+**Files:**
+- Modify: `.github/workflows/deploy-production.yml` (append after the "Auto-tag pre-release" step, which currently ends the file at line 116)
+
+- [ ] **Step 1: Append the new step**
+
+The file currently ends with the "Auto-tag pre-release" step (last line: `echo "Tag $TAG pushed -- create-release.yml will create the GitHub pre-release"`). Append this step at the same indentation level as the other steps (6 spaces for `- name:`):
+
+```yaml
+      # The tag above is pushed from this workspace checkout, not from
+      # /opt/baluhost — without a fetch, the prod clone is permanently one tag
+      # behind itself and `git describe --tags --exact-match` fails, so the UI
+      # shows "Dev Build" + the stale pyproject version (#223). Fetch here on
+      # the same runner/user that ci-deploy.sh already uses. Non-fatal: the
+      # deploy is green and tagged at this point; a fetch failure only leaves
+      # today's cosmetic display state. Also runs on the tag step's skip paths,
+      # back-filling any previously missed tag on the next deploy.
+      - name: Sync tags to production checkout
+        if: success()
+        run: git -C /opt/baluhost fetch origin --tags || echo "::warning::tag fetch into /opt/baluhost failed (display-only impact)"
+```
+
+- [ ] **Step 2: Validate the YAML parses**
+
+Run (PowerShell, repo root — PyYAML is available in the backend venv; plain `python` works too if PyYAML is installed globally):
+
+```powershell
+python -c "import yaml, io; yaml.safe_load(io.open('.github/workflows/deploy-production.yml', encoding='utf-8')); print('YAML OK')"
+```
+
+Expected: `YAML OK`. If PyYAML is not importable, fall back to a careful visual diff review (`git diff`) — indentation of `- name:` must match the sibling steps.
+
+- [ ] **Step 3: CI/CD security checklist self-review**
+
+Verify against `.claude/rules/ci-cd-security.md` Reviewer Checklist (this file is CODEOWNERS-owned):
+- No new runner targets, no new triggers, actor gate (`github.actor == 'Xveyn'`) untouched, `environment: production` untouched.
+- New step uses no secrets (public-repo fetch); `DEPLOY_PAT` still confined to the tag-push step env.
+
+Expected: all checks pass (the step is purely additive).
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add .github/workflows/deploy-production.yml
+git commit -m "fix(ci): sync pre-release tag into /opt/baluhost after deploy tagging (#223)" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Push branch and open PR
+
+**Files:** none (git/gh only)
+
+- [ ] **Step 1: Push the branch**
+
+```powershell
+git push -u origin fix/deploy-tag-fetch
+```
+
+- [ ] **Step 2: Write the PR body with the Write tool** (NOT a here-string on the gh command line — known quoting pitfall)
+
+Write to `.claude\tmp-pr-body.md`:
+
+```markdown
+## Summary
+
+After `deploy-production.yml` pushes the `v…-pre.N` tag (from its workspace checkout), the new
+"Sync tags to production checkout" step runs `git -C /opt/baluhost fetch origin --tags` so the
+prod clone finally sees the tag for its own HEAD. Fixes the permanent "Dev Build" + stale
+version display (`get_current_version()` exact-match fallback).
+
+Closes #223.
+
+## Design
+
+- Non-fatal (`|| echo ::warning::`): the deploy is already green and tagged; a fetch failure
+  must not fail the run (display-only impact).
+- Same runner/user that already writes `/opt/baluhost`; public repo → no credentials,
+  `DEPLOY_PAT` stays confined to the tag-push step. CI/CD layers 1-4 unchanged (additive step
+  in a CODEOWNERS-owned file; no new triggers/runners/secrets).
+- Also runs on the tag step's skip paths, back-filling a previously missed tag — self-heals the
+  current prod state on the next deploy.
+
+Spec: `docs/superpowers/specs/2026-06-11-updater-version-fixes-design.md` (committed here).
+
+## Verification
+
+Workflows can't run locally: YAML parse check + security-checklist review. Post-merge on the
+box: `git tag --points-at HEAD` non-empty, update page shows `v1.36.1-pre.N` instead of
+"Dev Build".
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+- [ ] **Step 3: Create the PR**
+
+```powershell
+gh pr create --base main --title "fix(ci): sync pre-release tag into /opt/baluhost after deploy tagging" --body-file ".claude\tmp-pr-body.md"
+Remove-Item ".claude\tmp-pr-body.md" -Confirm:$false
+```
+
+Expected: PR URL printed. Report the PR number back to the user.

--- a/docs/superpowers/plans/2026-06-11-updater-semver-120.md
+++ b/docs/superpowers/plans/2026-06-11-updater-semver-120.md
@@ -1,0 +1,333 @@
+# Updater SemVer Ordering Fix (#120) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Version ordering treats a stable release as newer than its own pre-releases (`1.33.1 > 1.33.1-pre.3`) and sorts numeric pre-release counters numerically (`pre.10 > pre.2`).
+
+**Architecture:** `parse_version` keeps its `(major, minor, patch, prerelease_str)` shape — it is the round-trip format for `version_to_string`/`get_installed_version`/`dev_backend` and is used for equality checks. A new `version_sort_key()` in `backend/app/services/update/utils.py` provides SemVer-correct ordering; the only ordering call site (`prod_backend.check_for_updates`) switches to it.
+
+**Tech Stack:** Python (stdlib only), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-updater-version-fixes-design.md`
+
+**Branch:** `fix/updater-semver-120` — create from `origin/main` first:
+
+```powershell
+git fetch origin
+git checkout -b fix/updater-semver-120 origin/main
+```
+
+Note: working directory is `D:\Programme (x86)\Baluhost`; run pytest from `backend\`.
+
+---
+
+### Task 1: `version_sort_key` (TDD)
+
+**Files:**
+- Modify: `backend/app/services/update/utils.py` (new function after `parse_version`, ends line 36)
+- Modify: `backend/app/services/update/__init__.py` (export)
+- Test: `backend/tests/services/test_update_service.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `backend/tests/services/test_update_service.py`, extend the import at line 16 with `version_sort_key`:
+
+```python
+from app.services.update import (
+    parse_version,
+    version_to_string,
+    version_sort_key,
+    DevUpdateBackend,
+    UpdateService,
+    get_update_backend,
+)
+```
+
+Then REPLACE the existing `test_version_comparison` method (lines 64-73 — it asserts the buggy
+`stable < beta` ordering as documented behavior) with this test class content, keeping it inside
+`TestVersionParsing` as a method plus adding a new class after `TestVersionParsing`:
+
+```python
+    def test_version_comparison(self):
+        """Major/minor/patch ordering via version_sort_key."""
+        assert version_sort_key("1.6.0") > version_sort_key("1.5.0")
+
+
+class TestVersionSortKey:
+    """SemVer-correct ordering (issue #120) — parse_version tuples are NOT ordering-safe."""
+
+    def test_stable_ranks_above_its_prerelease(self):
+        assert version_sort_key("1.33.1") > version_sort_key("1.33.1-pre.3")
+
+    def test_numeric_prerelease_counters_sort_numerically(self):
+        assert version_sort_key("1.33.1-pre.10") > version_sort_key("1.33.1-pre.2")
+
+    def test_alphanumeric_identifiers_compare_lexically(self):
+        # "pre" < "rc" lexically
+        assert version_sort_key("1.33.1-pre.2") < version_sort_key("1.33.1-rc.1")
+
+    def test_numeric_identifier_ranks_below_alphanumeric(self):
+        # SemVer: numeric identifiers always have lower precedence
+        assert version_sort_key("1.0.0-1") < version_sort_key("1.0.0-alpha")
+
+    def test_fewer_identifiers_rank_lower(self):
+        # SemVer: 1.0.0-alpha < 1.0.0-alpha.1
+        assert version_sort_key("1.0.0-alpha") < version_sort_key("1.0.0-alpha.1")
+
+    def test_equal_stables_and_v_prefix(self):
+        assert version_sort_key("v1.36.0") == version_sort_key("1.36.0")
+
+    def test_tolerates_non_numeric_header(self):
+        # parity with parse_version's CHANGELOG "[Unreleased]" tolerance
+        assert version_sort_key("Unreleased") == version_sort_key("0.0.0")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```powershell
+cd backend
+python -m pytest tests/services/test_update_service.py -v --no-cov
+```
+
+Expected: collection FAILS with `ImportError: cannot import name 'version_sort_key'`.
+
+- [ ] **Step 3: Implement `version_sort_key`**
+
+In `backend/app/services/update/utils.py`, insert after `parse_version` (after line 36). Also
+extend `parse_version`'s docstring (line 16) with the ordering warning:
+
+```python
+def parse_version(tag: str) -> tuple[int, int, int, str]:
+    """Parse semver tag (e.g., 'v1.5.0' or '1.5.0-beta') into comparable tuple.
+
+    WARNING: the returned tuple is NOT ordering-safe across pre-releases —
+    tuple comparison ranks '' below 'pre.N', i.e. a stable BELOW its own
+    pre-releases (issue #120). Use version_sort_key() for ordering; this
+    shape is for round-trips (version_to_string) and equality checks.
+    """
+```
+
+(keep the existing function body unchanged), then add:
+
+```python
+def version_sort_key(version: str) -> tuple:
+    """SemVer-correct ordering key: stable > its own pre-releases, pre.10 > pre.2.
+
+    Finals sort as (major, minor, patch, 1, ()); pre-releases as
+    (major, minor, patch, 0, identifiers) where each identifier is
+    (0, int, "") if numeric else (1, 0, str) — numeric identifiers compare
+    numerically and rank below alphanumeric ones, per SemVer precedence.
+    """
+    major, minor, patch, prerelease = parse_version(version)
+    if not prerelease:
+        return (major, minor, patch, 1, ())
+    ids = tuple(
+        (0, int(p), "") if p.isdigit() else (1, 0, p)
+        for p in prerelease.split(".")
+    )
+    return (major, minor, patch, 0, ids)
+```
+
+In `backend/app/services/update/__init__.py`, add `version_sort_key` to the `utils` import block
+(after `version_to_string` on line 13) and to `__all__` (after `"version_to_string"` on line 33):
+
+```python
+from app.services.update.utils import (
+    ProgressCallback,
+    parse_version,
+    version_to_string,
+    version_sort_key,
+    COMMIT_TYPE_MAP,
+    _CONVENTIONAL_RE,
+    _parse_conventional_commits,
+)
+```
+
+```python
+    "parse_version",
+    "version_to_string",
+    "version_sort_key",
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```powershell
+python -m pytest tests/services/test_update_service.py -v --no-cov
+```
+
+Expected: PASS (all of `TestVersionSortKey` + the rewritten `test_version_comparison` + all pre-existing tests).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add backend/app/services/update/utils.py backend/app/services/update/__init__.py backend/tests/services/test_update_service.py
+git commit -m "fix(updates): SemVer-correct version_sort_key; stable ranks above its pre-releases (#120)" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Switch `check_for_updates` to `version_sort_key` (TDD)
+
+**Files:**
+- Modify: `backend/app/services/update/prod_backend.py:34-40` (import) and `:135-137` (comparison)
+- Test: `backend/tests/services/test_update_github.py`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Append to `backend/tests/services/test_update_github.py` (file uses module-level helpers
+`_gh()` and `_FakeVersion` defined at lines 26-34; reuse them):
+
+```python
+@pytest.mark.asyncio
+async def test_check_for_updates_offers_stable_over_running_prerelease(monkeypatch):
+    """#120 regression: box runs vX.Y.Z-pre.N, matching stable vX.Y.Z exists -> offer it."""
+    rel = [_gh("v1.36.1", False), _gh("v1.36.1-pre.19", True), _gh("v1.36.0", False)]
+    b = ProdUpdateBackend()
+    async def _ver(): return _FakeVersion("1.36.1-pre.19")
+    monkeypatch.setattr(b, "get_current_version", _ver)
+    async def fake_list(*a, **k): return rel
+    monkeypatch.setattr(b._gh, "list_releases", fake_list)
+    available, latest, changelog = await b.check_for_updates("stable")
+    assert available is True and latest.version == "1.36.1"
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_no_update_when_on_latest_stable(monkeypatch):
+    rel = [_gh("v1.36.1", False), _gh("v1.36.1-pre.19", True), _gh("v1.36.0", False)]
+    b = ProdUpdateBackend()
+    async def _ver(): return _FakeVersion("1.36.1")
+    monkeypatch.setattr(b, "get_current_version", _ver)
+    async def fake_list(*a, **k): return rel
+    monkeypatch.setattr(b._gh, "list_releases", fake_list)
+    available, latest, changelog = await b.check_for_updates("stable")
+    assert available is False
+```
+
+- [ ] **Step 2: Run tests to verify the regression test fails**
+
+```powershell
+python -m pytest tests/services/test_update_github.py -v --no-cov
+```
+
+Expected: `test_check_for_updates_offers_stable_over_running_prerelease` FAILS
+(`available is False` — buggy compare ranks `1.36.1 <= 1.36.1-pre.19`);
+`test_check_for_updates_no_update_when_on_latest_stable` PASSES already.
+
+- [ ] **Step 3: Switch the comparison**
+
+In `backend/app/services/update/prod_backend.py`, replace the utils import (lines 34-40):
+`version_sort_key` comes in, `parse_version` goes out — after this task the comparison below is
+the file's only `parse_version` use, and a stale import would trip ruff F401:
+
+```python
+from app.services.update.utils import (
+    ProgressCallback,
+    version_sort_key,
+    version_to_string,
+    get_installed_version,
+    _CONVENTIONAL_RE,
+)
+```
+
+Replace lines 135-137:
+
+```python
+        latest_v = parse_version(latest.tag)
+        current_v = parse_version(current.version)
+        if latest_v <= current_v:
+            return False, None, []
+```
+
+with:
+
+```python
+        latest_v = version_sort_key(latest.tag)
+        current_v = version_sort_key(current.version)
+        if latest_v <= current_v:
+            return False, None, []
+```
+
+Verify nothing else in the file still references `parse_version`:
+
+```powershell
+git grep -n "parse_version" -- backend/app/services/update/prod_backend.py
+```
+
+Expected: no matches.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```powershell
+python -m pytest tests/services/test_update_github.py -v --no-cov
+```
+
+Expected: PASS (all tests including both new ones).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add backend/app/services/update/prod_backend.py backend/tests/services/test_update_github.py
+git commit -m "fix(updates): check_for_updates compares via version_sort_key (#120)" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Full targeted suite, push, PR
+
+**Files:** none (verification + git/gh only)
+
+- [ ] **Step 1: Run all updater-related tests**
+
+```powershell
+python -m pytest tests/services/test_update_service.py tests/services/test_update_github.py tests/services/test_github_releases.py tests/services/test_changelog_fallback.py -v --no-cov
+```
+
+Expected: ALL PASS (file existence of all four test modules verified during planning).
+
+- [ ] **Step 2: Push the branch**
+
+```powershell
+git push -u origin fix/updater-semver-120
+```
+
+- [ ] **Step 3: Write the PR body with the Write tool** (NOT a here-string on the gh command line)
+
+Write to `.claude\tmp-pr-body.md`:
+
+```markdown
+## Summary
+
+`parse_version` tuples rank a stable release BELOW its own pre-releases (`"" < "pre.3"`), so a
+box running `vX.Y.Z-pre.N` was never offered the matching stable `vX.Y.Z` on the stable channel.
+String compare also mis-sorted numeric counters (`pre.10 < pre.2`).
+
+New `version_sort_key()` implements SemVer precedence (finals above pre-releases; numeric
+identifiers numeric and below alphanumeric); `check_for_updates` — the only remaining ordering
+call site — switches to it. `parse_version` keeps its shape (round-trip format for
+`version_to_string` and equality checks) and now carries an ordering warning in its docstring.
+
+Closes #120. Note: the `get_release_notes`/`get_all_releases` ordering mentioned in the issue is
+no longer affected — positional GitHub API order since the 2026-06-06 GitHub-Releases rework.
+
+## Tests
+
+- `TestVersionSortKey`: stable > pre, `pre.10 > pre.2`, lexical identifiers, numeric < alphanumeric,
+  fewer identifiers rank lower, v-prefix, `Unreleased` tolerance.
+- `check_for_updates` regression: running `1.36.1-pre.19` + stable `v1.36.1` published → update offered;
+  running `1.36.1` → no self-offer.
+- Full updater suite green locally (`test_update_service`, `test_update_github`, `test_github_releases`,
+  `test_changelog_fallback`).
+
+Spec: `docs/superpowers/specs/2026-06-11-updater-version-fixes-design.md` (committed with #223 PR).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+- [ ] **Step 4: Create the PR**
+
+```powershell
+gh pr create --base main --title "fix(updates): SemVer-correct ordering - stable ranks above its pre-releases" --body-file ".claude\tmp-pr-body.md"
+Remove-Item ".claude\tmp-pr-body.md" -Confirm:$false
+```
+
+Expected: PR URL printed. Report the PR number back to the user.

--- a/docs/superpowers/specs/2026-06-11-updater-version-fixes-design.md
+++ b/docs/superpowers/specs/2026-06-11-updater-version-fixes-design.md
@@ -1,0 +1,133 @@
+# Updater Version Fixes — Design Spec
+
+**Date:** 2026-06-11
+**Status:** Approved
+**Author:** Sven (Xveyn) + Claude (via brainstorming session)
+**Issues:** #223 (deploy tag never reaches prod checkout), #120 (parse_version ranks pre-release above stable)
+**Branches:** `fix/deploy-tag-fetch` (#223), `fix/updater-semver-120` (#120) — two separate PRs against `main`
+
+## Problem
+
+Two independent defects in the updater's version handling:
+
+### 1. Deploy pre-release tag never reaches `/opt/baluhost` (#223)
+
+The deploy flow has a chicken-and-egg ordering: `ci-deploy.sh` fetches + resets `/opt/baluhost`
+to `origin/main` (`deploy/scripts/ci-deploy.sh:394-396`), services restart, and only **then** does
+`deploy-production.yml` create and push the `v…-pre.N` tag — from a separate workspace checkout.
+`/opt/baluhost` never fetches that tag, so the box is permanently one tag behind itself:
+
+- `git describe --tags --exact-match` fails on every deployed HEAD →
+  `get_current_version()` (`backend/app/services/update/prod_backend.py:87`) falls back to
+  `pyproject.toml` with `is_dev_build=True`.
+- UI shows "Dev Build" + the stale pyproject version (`1.36.0`) instead of `v1.36.1-pre.19`.
+- `check_for_updates` compares against the fallback `1.36.0`, so the `unstable` channel offers
+  the box its own running commit as an "update".
+
+Since the GitHub-Releases rework (2026-06-06) nothing in the check path runs `git fetch --tags`
+anymore, so the state no longer self-heals. Verified on prod 2026-06-11 (HEAD `dbcd9f6`, local
+tags end at `pre.18`, pyproject `1.36.0`).
+
+### 2. `parse_version` ranks a pre-release above its final stable (#120)
+
+`parse_version` (`backend/app/services/update/utils.py:15`) returns
+`(major, minor, patch, prerelease_str)` with `""` for finals. Tuple comparison then yields
+`(1,33,1,"") < (1,33,1,"pre.3")` — backwards per SemVer. String compare also mis-sorts numeric
+counters (`pre.10 < pre.2`).
+
+Since the GitHub-Releases rework, the only **ordering** consumer left is
+`prod_backend.check_for_updates:135-137` (`latest_v <= current_v`). All other uses are
+equality checks (`github_releases._find_index`, `changelog_fallback:61-62`) or rely on the
+4-tuple round-trip shape (`version_to_string`, `get_installed_version`, `dev_backend`).
+The `get_release_notes`/`get_all_releases` ordering mentioned in the issue text is no longer
+affected (positional GitHub API order) — note this when closing #120.
+
+## Decisions
+
+| Topic | Decision |
+|---|---|
+| #223 fix | Workflow-only: fetch tags into `/opt/baluhost` after the tag push (Option A) |
+| #223 alternatives rejected | Tag-before-restart (breaks "tag only after successful deploy" invariant, ghost-tag cleanup on rollback); backend self-healing fetch (display path mutating repo state, fetch storms across 4 workers, latency) |
+| #120 fix | Keep `parse_version` shape (round-trip + equality stay valid); add a dedicated `version_sort_key()` for ordering |
+| Delivery | Two separate branches/PRs; spec rides with PR 1 |
+
+## Fix 1: `fix/deploy-tag-fetch` (#223)
+
+New step in `.github/workflows/deploy-production.yml`, directly after "Auto-tag pre-release":
+
+```yaml
+- name: Sync tags to production checkout
+  if: success()
+  run: git -C /opt/baluhost fetch origin --tags || echo "::warning::tag fetch into /opt/baluhost failed (display-only impact)"
+```
+
+Properties:
+
+- **Non-fatal** (`|| echo ::warning::`): the deploy is already green and tagged at this point; a
+  fetch failure must not fail the run — the impact would only be today's cosmetic display state.
+- Runs on the same runner/user that already writes `/opt/baluhost` via `ci-deploy.sh`; the repo
+  is public, so the fetch needs no credentials — `DEPLOY_PAT` stays confined to the tag-push
+  step. CI/CD security layers 1–4 unchanged (additive step only in a CODEOWNERS-owned file).
+- Also runs on the tag step's skip paths (tag already exists), fetching any previously missed
+  tag — self-heals the current prod state on the next deploy.
+- No backend change: `get_current_version()` runs `git describe` per request, so the display
+  corrects itself on the next page load.
+
+**Verification:** workflows cannot run locally — `actionlint` + review; after merge, on the box:
+`git tag --points-at HEAD` non-empty and UI shows `v1.36.1-pre.N` instead of "Dev Build".
+
+## Fix 2: `fix/updater-semver-120` (#120)
+
+New function in `backend/app/services/update/utils.py`:
+
+```python
+def version_sort_key(version: str) -> tuple:
+    """SemVer ordering: stable > its own pre-releases, pre.10 > pre.2."""
+    major, minor, patch, prerelease = parse_version(version)
+    if not prerelease:
+        return (major, minor, patch, 1, ())
+    ids = tuple(
+        (0, int(p), "") if p.isdigit() else (1, 0, p)
+        for p in prerelease.split(".")
+    )
+    return (major, minor, patch, 0, ids)
+```
+
+This implements SemVer precedence: finals above all pre-releases of the same version
+(`1, ()` > `0, …`); within pre-releases, numeric identifiers compare numerically and rank
+below alphanumeric ones (SemVer rule), so `pre.10 > pre.2` and `pre.2 < rc.1`.
+
+Changes:
+
+- `prod_backend.check_for_updates:135-137` switches from `parse_version` to `version_sort_key`
+  for the `latest <= current` comparison — the only ordering call site.
+- `parse_version` gets a docstring warning: not ordering-safe across pre-releases — use
+  `version_sort_key`.
+- Export `version_sort_key` from `services/update/__init__.py` alongside the existing utils.
+
+**Tests (TDD, in `backend/tests/services/test_update_service.py`):**
+
+- `1.33.1 > 1.33.1-pre.3` (stable above its pre-release)
+- `pre.10 > pre.2` (numeric identifier ordering)
+- `pre.2 < rc.1` for the same base version (lexical identifier comparison, `"pre" < "rc"`)
+- `1.0.0-1 < 1.0.0-alpha` (SemVer: numeric identifiers rank below alphanumeric)
+- `1.0.0-alpha < 1.0.0-alpha.1` (fewer identifiers rank lower — falls out of tuple prefix compare)
+- equal stables compare equal; `v`-prefix tolerated
+- non-numeric headers (`Unreleased`) don't crash (parity with `parse_version` tolerance)
+- review existing comparison test (`test_update_service.py:66-68`, uses `1.6.0-beta`) and fix
+  its expectation if it encodes the buggy ordering
+
+Run before PR: `python -m pytest tests/services/test_update_service.py tests/services/test_github_releases.py -v`
+
+## Out of Scope
+
+- `get_release_notes` / `get_all_releases` ordering (positional since the GitHub rework)
+- Making `get_current_version()`'s fallback smarter (e.g. `git describe` without
+  `--exact-match`) — optional polish, not required once Fix 1 lands
+- Any change to tag-numbering logic or deploy ordering
+
+## Build Order
+
+1. PR 1 (`fix/deploy-tag-fetch`): workflow step + this spec. Closes #223.
+2. PR 2 (`fix/updater-semver-120`): `version_sort_key` + tests + consumer switch. Closes #120
+   (with a note about the no-longer-affected ordering paths).


### PR DESCRIPTION
## Summary

After `deploy-production.yml` pushes the `v…-pre.N` tag (from its workspace checkout), the new
"Sync tags to production checkout" step runs `git -C /opt/baluhost fetch origin --tags` so the
prod clone finally sees the tag for its own HEAD. Fixes the permanent "Dev Build" + stale
version display (`get_current_version()` exact-match fallback).

Closes #223.

## Design

- Non-fatal by construction: `|| echo ::warning::` covers exit-code failures,
  `timeout-minutes: 2` + `continue-on-error: true` cover hangs — a tag-sync problem can never
  fail an already-green, tagged deploy run (display-only impact).
- Same runner/user that already writes `/opt/baluhost`; public repo → no credentials,
  `DEPLOY_PAT` stays confined to the tag-push step. CI/CD layers 1-4 unchanged (additive step
  in a CODEOWNERS-owned file; no new triggers/runners/secrets).
- Also runs on the tag step's skip paths, back-filling a previously missed tag — self-heals the
  current prod state on the next deploy.

Spec: `docs/superpowers/specs/2026-06-11-updater-version-fixes-design.md` (committed here).

## Verification

Workflows can't run locally: YAML parse check + CI/CD security-checklist review (two
independent review passes). Post-merge on the box: `git tag --points-at HEAD` non-empty,
update page shows `v1.36.1-pre.N` instead of "Dev Build".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
