### PR TITLE
feat(presence): pause heartbeat while idle-logout warning is visible (#222)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { buildApiUrl } from './lib/api';
 import { useIdleTimeout } from './hooks/useIdleTimeout';
 import { IdleWarningDialog } from './components/ui/IdleWarningDialog';
+import { usePresenceHeartbeat } from './hooks/usePresenceHeartbeat';
 import { FEATURES, isDesktop } from './lib/features';
 import logoMark from './assets/baluhost-logo.png';
 import './App.css';
@@ -149,6 +150,8 @@ function AppRoutes() {
     onLogout: logout,
     enabled: user !== null,
   });
+
+  usePresenceHeartbeat({ paused: warningVisible, enabled: user !== null });
 
   // Show loading screen while AuthProvider is verifying the stored token
   if (loading) return <LoadingScreen backendReady={true} backendCheckAttempts={0} />;

--- a/client/src/__tests__/hooks/usePresenceHeartbeat.test.ts
+++ b/client/src/__tests__/hooks/usePresenceHeartbeat.test.ts
@@ -130,4 +130,47 @@ describe('usePresenceHeartbeat', () => {
     const ids = mockedSend.mock.calls.map((c) => c[0].client_id);
     expect(new Set(ids).size).toBe(1);
   });
+
+  it('skips heartbeats while paused (session mode, visible)', async () => {
+    mockedSend.mockResolvedValue({
+      present: true,
+      enabled: true,
+      mode: 'session',
+      heartbeat_interval_seconds: 45,
+      timeout_minutes: 3,
+    });
+    const { rerender } = renderHook(
+      ({ paused }) => usePresenceHeartbeat({ paused }),
+      { initialProps: { paused: false } },
+    );
+    await flushAsync(); // initial beat -> learns mode 'session'
+    expect(mockedSend).toHaveBeenCalledTimes(1);
+
+    rerender({ paused: true });
+    await act(async () => { vi.advanceTimersByTime(3 * 45_000); });
+    await flushAsync();
+    expect(mockedSend).toHaveBeenCalledTimes(1); // no new beats while paused
+  });
+
+  it('resumes heartbeats after un-pausing', async () => {
+    const { rerender } = renderHook(
+      ({ paused }) => usePresenceHeartbeat({ paused }),
+      { initialProps: { paused: true } },
+    );
+    await flushAsync();
+    expect(mockedSend).toHaveBeenCalledTimes(0); // paused from mount: even initial beat skipped
+
+    rerender({ paused: false });
+    await act(async () => { vi.advanceTimersByTime(45_000); });
+    await flushAsync();
+    expect(mockedSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends nothing when disabled', async () => {
+    renderHook(() => usePresenceHeartbeat({ enabled: false }));
+    await flushAsync();
+    await act(async () => { vi.advanceTimersByTime(3 * 45_000); });
+    await flushAsync();
+    expect(mockedSend).toHaveBeenCalledTimes(0);
+  });
 });

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -19,7 +19,6 @@ import { getStatusBarState } from '../api/statusBar';
 import { isPi } from '../lib/features';
 import UserMenu from './UserMenu';
 import ImpersonationBanner from './ImpersonationBanner';
-import { usePresenceHeartbeat } from '../hooks/usePresenceHeartbeat';
 
 interface LayoutProps {
   children: ReactNode;
@@ -120,7 +119,6 @@ export default function Layout({ children }: LayoutProps) {
   const location = useLocation();
   const { t } = useTranslation('common');
   const { user, logout, isAdmin, isImpersonating } = useAuth();
-  usePresenceHeartbeat();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState<'shutdown' | 'restart' | null>(null);
   const [pendingMessage, setPendingMessage] = useState<string | null>(null);

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -37,7 +37,7 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useNetworkStatus.ts` | Online/offline detection |
 | `useNotificationSocket.ts` | WebSocket connection for real-time notifications |
 | `useNextMaintenance.ts` | Next scheduled maintenance window |
-| `usePresenceHeartbeat.ts` | Presence heartbeat to `/api/system/sleep/presence` while tab visible (blocks auto true-suspend, #214); fire-and-forget, mounted once in Layout |
+| `usePresenceHeartbeat.ts` | Presence heartbeat to `/api/system/sleep/presence` while tab visible (blocks auto true-suspend, #214); fire-and-forget, mounted once in `AppRoutes` (auth-gated via `enabled`); paused while the idle-logout warning is visible (#222) |
 
 ## Conventions
 

--- a/client/src/hooks/usePresenceHeartbeat.ts
+++ b/client/src/hooks/usePresenceHeartbeat.ts
@@ -45,10 +45,14 @@ function getClientId(): string {
 export function usePresenceHeartbeat(options: UsePresenceHeartbeatOptions = {}): void {
   const { paused = false, enabled = true } = options;
 
-  // `paused` flips on every idle warning; keep it in a ref so toggling it does
-  // not re-run the effect (which would tear down and recreate the interval).
+  // `paused` flips on every idle warning; keep it in a ref so the main effect
+  // (which owns the interval) does not re-run and tear down/recreate the timer
+  // on every toggle. Sync the ref from a dedicated effect — writing it during
+  // render trips the react-hooks/refs lint rule.
   const pausedRef = useRef(paused);
-  pausedRef.current = paused;
+  useEffect(() => {
+    pausedRef.current = paused;
+  }, [paused]);
 
   useEffect(() => {
     if (!enabled) return;

--- a/client/src/hooks/usePresenceHeartbeat.ts
+++ b/client/src/hooks/usePresenceHeartbeat.ts
@@ -1,5 +1,5 @@
 /**
- * Presence heartbeat (issue #214).
+ * Presence heartbeat (issue #214, idle-pause #222).
  *
  * Sends POST /api/system/sleep/presence on an interval so the backend knows
  * a user is actively present and will not auto-escalate to true suspend.
@@ -9,15 +9,29 @@
  *   background tab does not keep the server awake.
  * - 'session': beats while the tab is open, regardless of visibility.
  *
+ * Options:
+ * - `paused`  — when true, no beats are sent (e.g. the idle-logout warning is
+ *   showing: the user has been inactive ≥4 min, so the tab must stop signalling
+ *   presence). Changes often, so it is read through a ref and never tears down
+ *   the interval.
+ * - `enabled` — when false, the heartbeat is fully off (e.g. no user logged in).
+ *
  * Best-effort by design: all errors are swallowed; the hook must never
- * disturb the UI. Mount it once in the authenticated layout — unmounting
- * (logout) stops the heartbeat.
+ * disturb the UI. Mount it once at the authenticated app root (AppRoutes),
+ * gated on auth via `enabled` — unmounting/disabling stops the heartbeat.
  */
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { sendPresenceHeartbeat, type PresenceMode } from '../api/sleep';
 
 const DEFAULT_INTERVAL_MS = 45_000;
 const CLIENT_ID_KEY = 'baluhost_presence_client_id';
+
+interface UsePresenceHeartbeatOptions {
+  /** When true, skip sending heartbeats (idle-logout warning visible). */
+  paused?: boolean;
+  /** When false, the heartbeat is fully disabled (no user logged in). */
+  enabled?: boolean;
+}
 
 function getClientId(): string {
   let id = sessionStorage.getItem(CLIENT_ID_KEY);
@@ -28,14 +42,24 @@ function getClientId(): string {
   return id;
 }
 
-export function usePresenceHeartbeat(): void {
+export function usePresenceHeartbeat(options: UsePresenceHeartbeatOptions = {}): void {
+  const { paused = false, enabled = true } = options;
+
+  // `paused` flips on every idle warning; keep it in a ref so toggling it does
+  // not re-run the effect (which would tear down and recreate the interval).
+  const pausedRef = useRef(paused);
+  pausedRef.current = paused;
+
   useEffect(() => {
+    if (!enabled) return;
+
     let timer: ReturnType<typeof setInterval> | null = null;
     let intervalMs = DEFAULT_INTERVAL_MS;
     let mode: PresenceMode = 'active';
     const clientId = getClientId();
 
     const beat = async () => {
+      if (pausedRef.current) return;
       if (mode === 'active' && document.visibilityState !== 'visible') return;
       try {
         const res = await sendPresenceHeartbeat({ client_id: clientId, client_type: 'web' });
@@ -67,5 +91,5 @@ export function usePresenceHeartbeat(): void {
       if (timer) clearInterval(timer);
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };
-  }, []);
+  }, [enabled]);
 }


### PR DESCRIPTION
## Summary

Pause the presence heartbeat while the idle-auto-logout warning dialog is visible (#222).

In the presence `session` mode ("every open tab counts", #214), `usePresenceHeartbeat` sent beats independently of tab visibility. Because background tabs throttle timers, the 60 s idle-logout countdown could stretch to ~1 h, during which the throttled heartbeat kept the 3-min presence timeout alive — so a forgotten background tab could block True Suspend for roughly an hour instead of the intended ~5 min + 3 min timeout. Default `active` mode was never affected.

Fix: a visible idle-logout warning means "user inactive ≥4 min" by definition, so the tab should stop signalling presence. The heartbeat now pauses while the warning is up.

### Changes
- **`usePresenceHeartbeat`** gains `{ paused?, enabled? }` options. `paused` is read through a ref (synced in its own effect) so toggling it never tears down the interval; `enabled` gates the whole effect. Existing visibility/mode/interval/error-swallow behavior is unchanged.
- **Wiring moved** from `Layout` up into `AppRoutes`, next to `useIdleTimeout` (whose `warningVisible` it now consumes): `usePresenceHeartbeat({ paused: warningVisible, enabled: user !== null })`. Mount is now a single auth-gated instance; behavior on login/logout is equivalent to the old Layout mount.
- **Docs**: `hooks/CLAUDE.md` row updated (mount location + idle-pause).

### Not included (deliberate)
- Issue point 3 (immediate beat on "stay logged in"): on un-pause the interval is still running, so beats resume within ≤45 s — harmless against a 3-min timeout. Skipped to keep the hook's single-effect structure.

## Test Plan
- [x] `npx vitest run` — 418/418 (3 new presence tests: skip-while-paused, resume-after-unpause, nothing-when-disabled)
- [x] `npx tsc -b` — clean
- [x] `npx eslint` on touched files — clean (the one `react-hooks/refs` finding was fixed; remaining frontend lint debt is pre-existing, tracked in #210)
- [ ] Manual (dev): `session` mode, idle warning appears → `POST /api/system/sleep/presence` stops; "Stay logged in" → resumes within one interval

Closes #222.
