### PR TITLE
fix(api): survive FastAPI 0.137 router nesting in versioned router (#234)

### DIFF
--- a/backend/app/api/versioned/__init__.py
+++ b/backend/app/api/versioned/__init__.py
@@ -11,11 +11,19 @@ from app.api.routes import api_router as v1_router
 
 
 def create_versioned_router() -> APIRouter:
-    """Create the root API router with version-aware structure."""
-    root = APIRouter()
-    # v1 = default, no prefix (backwards-compatible)
-    root.include_router(v1_router)
-    # When v2 is needed:
-    # from app.api.versioned.v2 import v2_overrides
-    # root.include_router(v2_overrides, prefix="/v2")
-    return root
+    """Create the root API router with version-aware structure.
+
+    v1 is served without a version prefix, so it is returned directly rather
+    than re-wrapped in a prefix-less parent router. Since FastAPI 0.137,
+    ``include_router`` nests lazily and rejects an empty-prefix include whose
+    leaf routes have empty paths (``@router.get("")``) with
+    ``FastAPIError: Prefix and path cannot be both empty`` — which the prior
+    ``root.include_router(v1_router)`` wrapper triggered at startup (#234).
+
+    When v2 is introduced, mount v1 and v2 at the app level with explicit
+    prefixes instead of wrapping v1 in a prefix-less router, e.g.::
+
+        app.include_router(v1_router, prefix=settings.api_prefix)
+        app.include_router(v2_overrides, prefix=f"{settings.api_prefix}/v2")
+    """
+    return v1_router


### PR DESCRIPTION
Fixes #234

## Problem

FastAPI **0.137.0** lässt den Backend-App-Start crashen:

```
fastapi.exceptions.FastAPIError: Prefix and path cannot be both empty (path operation: read_auth_policy)
```

Crash beim Import von `app.main` → **alle** `backend-tests` fallen aus. Lokal/Prod laufen noch FastAPI 0.115.6, aber CI installiert bei jedem PR frisch (Pin `fastapi>=0.115.0,<1.0.0` ohne obere Schranke) und zieht die neue Release → CI-only-Failure, der jeden Backend-PR und den nächsten Deploy blockiert.

## Root Cause

FastAPI 0.137 hat `include_router` auf **lazy nesting** (`_IncludedRouter`) umgestellt und lehnt jetzt einen prefixlosen `include_router` ab, dessen Leaf-Routen leere Paths (`@router.get("")`) haben. Der bisherige `create_versioned_router()` wrappte `v1_router` in einen prefixlosen Parent:

```python
root = APIRouter()
root.include_router(v1_router)   # prefixlos -> bricht unter 0.137
```

`read_auth_policy` ist nur die erste der 16 betroffenen Empty-Path-Routen.

## Fix

v1 wird ohne Versions-Prefix ausgeliefert → `v1_router` direkt zurückgeben statt re-wrappen. URLs bleiben unverändert (`/api/admin/auth-policy` etc.). Docstring dokumentiert, wie v1/v2 künftig am App-Level mit explizitem Prefix gemountet werden (der prefixlose Wrapper wäre unter 0.137 auch im v2-Fall kaputt).

## Verifikation

- Crash in isoliertem `fastapi==0.137.0` venv 1:1 reproduziert; Fix baut die App dort sauber.
- Lokal: App-Import ok, `auth_policy`/`versioning`-Tests 6/6 grün, Routen lösen zu `/api/admin/auth-policy` auf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
