### PR TITLE
fix(mobile): tie refresh-token TTL to device authorization validity (#227)

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -669,8 +669,10 @@ async def refresh_token(
     """
     Refresh access token using a refresh token (for mobile clients).
 
-    Mobile clients receive a long-lived refresh token (30 days) during registration.
-    This endpoint allows them to obtain new access tokens without re-authentication.
+    Mobile clients receive a refresh token during registration whose lifetime
+    matches the chosen device authorization validity (30-180 days, default 90).
+    This endpoint allows them to obtain new access tokens without re-authentication;
+    it does not rotate the refresh token, so once it expires the user re-registers.
 
     ✅ Security Fix #6: Now checks if refresh token has been revoked.
     """

--- a/backend/app/services/mobile.py
+++ b/backend/app/services/mobile.py
@@ -273,9 +273,14 @@ class MobileService:
             )
         
         # Generate auth tokens
+        # Refresh-token TTL is tied to the device authorization validity so both
+        # clocks expire together — otherwise the device would be silently logged
+        # out when the (previously hard-coded 30-day) refresh token expired while
+        # its authorization was still valid (#227). On expiry the user re-registers.
+        refresh_expires_at = device_expires_at
         access_token = auth_service.create_access_token(user=user)
         refresh_token_str, jti = security.create_refresh_token(
-            user=user, expires_delta=timedelta(days=30)
+            user=user, expires_delta=timedelta(days=token_validity_days)
         )
 
         # Store refresh token in database for revocation support
@@ -285,7 +290,7 @@ class MobileService:
             jti=jti,
             user_id=user.id,
             token=refresh_token_str,
-            expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+            expires_at=refresh_expires_at,
             device_id=str(device.id),
         )
         

--- a/backend/tests/integration/test_mobile_registration_flow.py
+++ b/backend/tests/integration/test_mobile_registration_flow.py
@@ -91,6 +91,79 @@ def test_mobile_registration_flow():
     assert any(d.get('device_name') == 'Test Phone' for d in devices), f"Devices: {devices}"
 
 
+@pytest.mark.skipif(
+    "postgresql" in _database_url_from_env(),
+    reason="Test manages its own DB engine; cannot override a live PostgreSQL connection"
+)
+def test_refresh_token_ttl_matches_device_validity():
+    """Refresh-Token-TTL must equal the chosen device authorization validity (#227).
+
+    Previously the refresh token was hard-coded to 30 days while the device
+    authorization defaulted to 90, causing a silent logout on day 30. Both
+    clocks must now expire together.
+    """
+    import jwt as pyjwt
+
+    os.environ['SKIP_APP_INIT'] = '1'
+    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+    from app.main import create_app
+    from app.core.database import init_db, SessionLocal
+    from app.services.users import create_user
+    from app.models.mobile import MobileRegistrationToken
+    from app.schemas.user import UserCreate
+
+    init_db()
+    from app.models import Base
+    from app.core.database import engine
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    db = SessionLocal()
+    user = create_user(
+        UserCreate(username='ttl_user', email='ttl@example.com', password='TestPass123!'),
+        db=db,
+    )
+    token_value = 'reg_ttl_token_67890'
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=10)
+    db.add(MobileRegistrationToken(
+        token=token_value, user_id=str(user.id), expires_at=expires_at, used=False,
+    ))
+    db.commit()
+    db.close()
+
+    app = create_app()
+    client = TestClient(app)
+
+    # Choose a validity distinct from both the old 30d hardcode and the 90d default.
+    validity_days = 45
+    payload = {
+        "token": token_value,
+        "device_info": {
+            "device_name": "TTL Phone",
+            "device_type": "android",
+            "device_model": "Pixel",
+            "os_version": "13",
+            "app_version": "1.0",
+        },
+        "token_validity_days": validity_days,
+    }
+
+    resp = client.post('/api/mobile/register', json=payload)
+    assert resp.status_code == 200, resp.text
+    refresh_token = resp.json()['refresh_token']
+
+    claims = pyjwt.decode(refresh_token, options={"verify_signature": False})
+    now = datetime.now(timezone.utc)
+    exp = datetime.fromtimestamp(claims['exp'], tz=timezone.utc)
+    ttl_days = (exp - now).total_seconds() / 86400
+
+    # Must track the chosen validity (45d), not the old 30d hardcode.
+    assert validity_days - 1 < ttl_days < validity_days + 1, (
+        f"Refresh token TTL {ttl_days:.1f}d should match device validity {validity_days}d"
+    )
+
+
 def test_token_generation_works_for_authenticated_user(client):
     """Test that any authenticated user can generate mobile tokens."""
     # Register a fresh user with a valid strong password

--- a/docs/TECHNICAL_DOCUMENTATION.md
+++ b/docs/TECHNICAL_DOCUMENTATION.md
@@ -450,7 +450,7 @@ POST /api/sync/force                          - Force sync
   - Device management and tracking
   - Multiple device support per user
   - Device naming and identification
-  - 30-day refresh tokens for long-lived sessions
+  - Refresh tokens matching the device authorization validity (30-180 days, default 90) for long-lived sessions
 
 - **Camera Backup**
   - Automatic photo/video backup


### PR DESCRIPTION
## Problem (#227)

Mobile-Geräte wurden **an Tag 30 nach Registrierung still abgemeldet**, unabhängig von der Nutzung. Ursache waren zwei nicht zusammenpassende Ablauf-Uhren pro Gerät:

| Uhr | TTL (vorher) |
|---|---|
| Refresh-Token (JWT) | hart **30 Tage** |
| Geräte-Autorisierung (`expires_at`) | **90 Tage** (default, 30–180) |

`/auth/refresh` rotiert den Refresh-Token nicht — ab Tag 30 schlug der Background-Refresh mit 401 fehl, die App rief `clearTokens()` auf einem Hintergrund-Thread, und der Nutzer war ausgeloggt, obwohl das Gerät noch ~60 Tage als „aktiv" galt.

## Fix (Option 2 — TTLs angleichen, backend-only)

Die Refresh-Token-TTL ist jetzt an `token_validity_days` der Geräte-Autorisierung gekoppelt — sowohl der JWT-`exp` als auch der gespeicherte `RefreshToken.expires_at`. Beide Uhren laufen synchron ab. **Nach Ablauf registriert sich der Nutzer neu — das ist das bewusst gewählte Verhalten.**

Kein gleitendes Fenster / keine Rotation und damit **keine App-Änderung** nötig.

## Änderungen

- `backend/app/services/mobile.py` — Refresh-TTL = `token_validity_days` (JWT exp + DB `expires_at = device_expires_at`)
- `backend/tests/integration/test_mobile_registration_flow.py` — neuer TDD-Test: Registrierung mit `tokenValidityDays=45` → Refresh-Token ~45 T (nicht 30)
- `backend/app/api/routes/auth.py`, `docs/TECHNICAL_DOCUMENTATION.md` — veraltete „30-day refresh token"-Doku korrigiert

## Tests

- `tests/integration/test_mobile_registration_flow.py` — 4 passed
- `tests/auth/test_auth_service.py` + `tests/security/test_jwt_refresh_tokens.py` — 41 passed, 1 skipped (pre-existing `@skip`)

## Folge: #228

Durch das Angleichen wandert der Logout jetzt auf den `verify_mobile_device_token`-Ablaufpfad (`deps.py`) — genau dort, wo #228 die fehlende `device_removed`-Push-Notification ergänzt. #228 wird separat angegangen.

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)
