### PR TITLE
fix(mobile): push device_removed on automatic expiry/deactivation (#228)

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -318,8 +318,14 @@ async def verify_mobile_device_token(
             detail="Device has been deactivated"
         )
     
-    # Check if device token has expired
-    if device.expires_at and device.expires_at < datetime.now(timezone.utc):
+    # Check if device token has expired.
+    # expires_at is stored in a naive DateTime column, so normalize it to UTC
+    # before comparing against an aware "now" (otherwise the comparison raises
+    # "can't compare offset-naive and offset-aware datetimes").
+    device_expires_at = device.expires_at
+    if device_expires_at is not None and device_expires_at.tzinfo is None:
+        device_expires_at = device_expires_at.replace(tzinfo=timezone.utc)
+    if device_expires_at and device_expires_at < datetime.now(timezone.utc):
         audit_logger = get_audit_logger_db()
         audit_logger.log_security_event(
             action="expired_device_token",
@@ -328,7 +334,23 @@ async def verify_mobile_device_token(
             error_message=f"Device {device.device_name} token expired at {device.expires_at}",
             db=db
         )
-        
+
+        # Notify the device it has been deauthorized so the app can log out
+        # cleanly — the app handles this push identically to a manual removal.
+        # Best-effort: never let a push failure block the 401. (#228)
+        if device.push_token:
+            try:
+                from app.services.notifications.firebase import FirebaseService
+                if FirebaseService.is_available():
+                    FirebaseService.send_device_removed_notification(
+                        device_token=device.push_token,
+                        device_name=device.device_name,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to send device-removed push on auto-expiry: %s", exc
+                )
+
         # Automatically deactivate expired device
         device.is_active = False
         db.commit()

--- a/backend/tests/api/test_mobile_device_expiry_notification.py
+++ b/backend/tests/api/test_mobile_device_expiry_notification.py
@@ -1,0 +1,132 @@
+"""Push notification on automatic mobile device deactivation/expiry (#228).
+
+When a device's authorization expires, ``verify_mobile_device_token`` auto-
+deactivates it and raises 401. Previously this happened silently — the
+``device_removed`` push (which the app already handles to log out cleanly) was
+only sent on *manual* deletion. These tests pin the best-effort push on the
+automatic-expiry path.
+"""
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.api.deps import verify_mobile_device_token
+from app.models.mobile import MobileDevice
+from app.services import auth as auth_service
+
+
+def _make_request(device_id: str) -> Request:
+    """Build a minimal Starlette request carrying the X-Device-ID header."""
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/mobile/ping",
+        "headers": [(b"x-device-id", device_id.encode())],
+        "query_string": b"",
+        "client": ("127.0.0.1", 1234),
+    }
+    return Request(scope)
+
+
+def _add_device(db_session, user, *, push_token, expires_at):
+    device = MobileDevice(
+        user_id=str(user.id),
+        device_name="Expired Phone",
+        device_type="android",
+        push_token=push_token,
+        is_active=True,
+        expires_at=expires_at,
+    )
+    db_session.add(device)
+    db_session.commit()
+    db_session.refresh(device)
+    return device
+
+
+def test_expired_device_sends_removal_push(db_session, regular_user):
+    """An expired device gets a device_removed push before the 401 (#228)."""
+    device = _add_device(
+        db_session, regular_user,
+        push_token="fake-fcm-expired",
+        expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    token = auth_service.create_access_token(regular_user)
+    request = _make_request(str(device.id))
+
+    with patch(
+        "app.services.notifications.firebase.FirebaseService.is_available",
+        return_value=True,
+    ), patch(
+        "app.services.notifications.firebase.FirebaseService.send_device_removed_notification"
+    ) as mock_push:
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(
+                verify_mobile_device_token(request=request, token=token, db=db_session)
+            )
+
+    assert exc_info.value.status_code == 401
+    mock_push.assert_called_once_with(
+        device_token="fake-fcm-expired",
+        device_name="Expired Phone",
+    )
+    # Device is still auto-deactivated.
+    db_session.refresh(device)
+    assert device.is_active is False
+
+
+def test_expired_device_without_push_token_does_not_send(db_session, regular_user):
+    """No push token → no push attempt, but still 401 + deactivation."""
+    device = _add_device(
+        db_session, regular_user,
+        push_token=None,
+        expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    token = auth_service.create_access_token(regular_user)
+    request = _make_request(str(device.id))
+
+    with patch(
+        "app.services.notifications.firebase.FirebaseService.is_available",
+        return_value=True,
+    ), patch(
+        "app.services.notifications.firebase.FirebaseService.send_device_removed_notification"
+    ) as mock_push:
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(
+                verify_mobile_device_token(request=request, token=token, db=db_session)
+            )
+
+    assert exc_info.value.status_code == 401
+    mock_push.assert_not_called()
+    db_session.refresh(device)
+    assert device.is_active is False
+
+
+def test_push_failure_does_not_block_logout(db_session, regular_user):
+    """A failing push must not swallow the 401 — logout still happens (#228)."""
+    device = _add_device(
+        db_session, regular_user,
+        push_token="fake-fcm-expired",
+        expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    token = auth_service.create_access_token(regular_user)
+    request = _make_request(str(device.id))
+
+    with patch(
+        "app.services.notifications.firebase.FirebaseService.is_available",
+        return_value=True,
+    ), patch(
+        "app.services.notifications.firebase.FirebaseService.send_device_removed_notification",
+        side_effect=RuntimeError("FCM down"),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(
+                verify_mobile_device_token(request=request, token=token, db=db_session)
+            )
+
+    assert exc_info.value.status_code == 401
+    db_session.refresh(device)
+    assert device.is_active is False


### PR DESCRIPTION
## Problem (#228)

Bei automatischem Ablauf/Deaktivierung eines Mobilgeräts sendet das Backend **keine** Push-Notification — obwohl die App den `device_removed`-Pfad bereits vollständig implementiert hat (zeigt „❌ Gerät deautorisiert" + `clearAll()`). Bisher wurde `send_device_removed_notification` **nur** beim *manuellen* Löschen (`delete_device`) aufgerufen. Der automatische Kick in `verify_mobile_device_token` setzte still `is_active=False` und warf 401 — ohne Push.

## Fix

`send_device_removed_notification` wird jetzt **best-effort** auch auf dem automatischen Ablaufpfad in `verify_mobile_device_token` (`deps.py`) ausgelöst — in `try/except`, sodass ein Push-Fehler den 401 niemals blockiert. Die App behandelt diesen Push identisch zum manuellen Entfernen.

## Zusätzlich behoben: latenter naive/aware-Bug auf demselben Pfad

`MobileDevice.expires_at` liegt in einer **naiven** `DateTime`-Spalte (ohne `timezone=True`), wurde aber in `deps.py:322` gegen ein aware `datetime.now(timezone.utc)` verglichen → `TypeError: can't compare offset-naive and offset-aware datetimes` für **jedes** Gerät mit gesetztem `expires_at`. `expires_at` wird jetzt vor dem Vergleich als UTC normalisiert (analog zum bestehenden Muster in `services/mobile.py` für Registrierungs-Tokens).

> Hinweis: Die tieferliegende Ursache (Spaltentyp `DateTime` statt `DateTime(timezone=True)`, entgegen der Model-Konvention) bleibt bestehen und betrifft potenziell auch den Ablauf-Warner. Sollte separat als Issue/Migration behandelt werden.

## Änderungen

- `backend/app/api/deps.py` — Best-Effort-`device_removed`-Push auf dem Auto-Ablaufpfad + UTC-Normalisierung von `expires_at`
- `backend/tests/api/test_mobile_device_expiry_notification.py` — neue Tests: Push bei Ablauf, kein Push ohne Token, Push-Fehler blockt Logout nicht

## Tests

- `tests/api/test_mobile_device_expiry_notification.py` — 3 passed
- Regression `tests/services/test_firebase_push.py` + `tests/integration/test_mobile_registration_flow.py` — alle grün (36 passed gesamt)

## Zusammenhang mit #227

Hängt mit #227 (PR #239) zusammen: Erst durch das Angleichen der Refresh-Token-TTL an die Geräte-Autorisierung (#227) fällt der Logout überhaupt auf diesen `verify_mobile_device_token`-Ablaufpfad — den richtigen Ort für diesen Push.

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
