### PR TITLE
fix(install): bind POSTGRES_PASSWORD/USER via psql vars instead of interpolating (#219)

### DIFF
--- a/deploy/install/lib/common.sh
+++ b/deploy/install/lib/common.sh
@@ -155,5 +155,7 @@ pg_db_exists() {
 }
 
 pg_user_exists() {
-    sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='$1'" 2>/dev/null | grep -q 1
+    # :'u' = psql-quoted string literal; prevents a username with special
+    # characters from breaking the query or injecting SQL (#219).
+    sudo -u postgres psql -v u="$1" -tAc "SELECT 1 FROM pg_roles WHERE rolname = :'u'" 2>/dev/null | grep -q 1
 }

--- a/deploy/install/modules/06-postgresql.sh
+++ b/deploy/install/modules/06-postgresql.sh
@@ -48,22 +48,29 @@ fi
 # --- Create PostgreSQL user ---
 if pg_user_exists "$POSTGRES_USER"; then
     log_info "PostgreSQL user '$POSTGRES_USER' already exists."
-    # Update password to ensure it matches config
-    sudo -u postgres psql -c "ALTER USER \"$POSTGRES_USER\" WITH PASSWORD '$POSTGRES_PASSWORD';" &>/dev/null
+    # Update password to ensure it matches config.
+    # psql variable binding (:'pw' / :"u") quotes value and identifier itself,
+    # so an operator-set password or username with special chars cannot break
+    # the statement or inject SQL (#219).
+    sudo -u postgres psql -v ON_ERROR_STOP=1 -v u="$POSTGRES_USER" -v pw="$POSTGRES_PASSWORD" \
+        -c "ALTER USER :\"u\" WITH PASSWORD :'pw';" &>/dev/null
     log_info "Updated password for PostgreSQL user '$POSTGRES_USER'."
 else
-    sudo -u postgres psql -c "CREATE USER \"$POSTGRES_USER\" WITH PASSWORD '$POSTGRES_PASSWORD';" &>/dev/null
+    sudo -u postgres psql -v ON_ERROR_STOP=1 -v u="$POSTGRES_USER" -v pw="$POSTGRES_PASSWORD" \
+        -c "CREATE USER :\"u\" WITH PASSWORD :'pw';" &>/dev/null
     log_info "Created PostgreSQL user '$POSTGRES_USER'."
 fi
 
 # --- Create database ---
 if pg_db_exists "$POSTGRES_DB"; then
     log_info "Database '$POSTGRES_DB' already exists."
-    # Ensure ownership is correct
-    sudo -u postgres psql -c "ALTER DATABASE \"$POSTGRES_DB\" OWNER TO \"$POSTGRES_USER\";" &>/dev/null
+    # Ensure ownership is correct (:"db" / :"u" = psql-quoted identifiers, #219)
+    sudo -u postgres psql -v ON_ERROR_STOP=1 -v db="$POSTGRES_DB" -v u="$POSTGRES_USER" \
+        -c "ALTER DATABASE :\"db\" OWNER TO :\"u\";" &>/dev/null
     log_info "Ensured database '$POSTGRES_DB' is owned by '$POSTGRES_USER'."
 else
-    sudo -u postgres psql -c "CREATE DATABASE \"$POSTGRES_DB\" OWNER \"$POSTGRES_USER\";" &>/dev/null
+    sudo -u postgres psql -v ON_ERROR_STOP=1 -v db="$POSTGRES_DB" -v u="$POSTGRES_USER" \
+        -c "CREATE DATABASE :\"db\" OWNER :\"u\";" &>/dev/null
     log_info "Created database '$POSTGRES_DB' owned by '$POSTGRES_USER'."
 fi
 


### PR DESCRIPTION
## Was

Fixes #219. `deploy/install/modules/06-postgresql.sh` interpolierte `$POSTGRES_PASSWORD` und die User-/DB-Identifier direkt in den `psql -c` SQL-String. Für generierte Passwörter (rein alphanumerisch) harmlos, aber ein **operator-gesetztes** `POSTGRES_PASSWORD` (env oder `/etc/baluhost/install.conf` — seit #212 der reguläre Transportkanal) mit Apostroph zerbricht das Statement; im schlimmsten Fall wird beliebiges SQL in der lokalen postgres-root-Session ausgeführt.

## Änderung

Umstellung auf psql-Variablen-Binding statt String-Interpolation:

- `:'pw'` / `:'u'` → psql-gequotetes String-Literal (escapet eingebettete Quotes) — Passwort, `rolname`
- `:"u"` / `:"db"` → psql-gequoteter Identifier (behandelt eingebettete Quotes) — User/DB in Identifier-Position
- `ON_ERROR_STOP=1` ergänzt, damit ein fehlerhaftes Statement nonzero zurückgibt

Betroffen: die vier User/DB-Statements (ALTER/CREATE USER, ALTER/CREATE DATABASE) in `06-postgresql.sh` und `pg_user_exists()` in `lib/common.sh`. Das Identifier-Binding macht die im Issue erwähnte separate `"`-Freiheits-Validierung überflüssig — psql quotet selbst korrekt.

Severity laut Issue: **Low** (Input ist operator-kontrolliert, kein Remote-Vektor; primär eine Korrektheitsfalle).

## Verifikation

- `bash -n` auf beiden Dateien — sauber
- `deploy/install/tests/test-install-orchestration.sh` — 24/24 grün (sourct `lib/common.sh`)
- Echte psql-Ausführung passiert nur auf dem prod-Runner zur Deploy-Zeit (kein Postgres in der CI/lokal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
