### PR TITLE
docs: translate PRODUCTION_DEPLOYMENT_NOTES.de.md to German (#217)

### DIFF
--- a/docs/deployment/PRODUCTION_DEPLOYMENT_NOTES.de.md
+++ b/docs/deployment/PRODUCTION_DEPLOYMENT_NOTES.de.md
@@ -1,184 +1,184 @@
-# BaluHost Production Deployment Notes
+# BaluHost Produktions-Deployment-Notizen
 
-**Deployment Date:** January 25, 2026
-**Deployment Type:** Native Systemd (Debian 13)
-**Status:** ✅ PRODUCTION - RUNNING
+**Deployment-Datum:** 25. Januar 2026
+**Deployment-Typ:** Natives Systemd (Debian 13)
+**Status:** ✅ PRODUKTION – LÄUFT
 
 ---
 
-## 🖥️ Server Specifications
+## 🖥️ Server-Spezifikationen
 
-- **Hardware:** Ryzen 5 5600GT, 16GB DDR4 RAM
-- **Storage:** 250GB NVMe M.2 SSD (primary)
-- **Planned:** 2x 4TB NAS HDDs (RAID1) - pending setup
+- **Hardware:** Ryzen 5 5600GT, 16 GB DDR4-RAM
+- **Speicher:** 250 GB NVMe-M.2-SSD (primär)
+- **Geplant:** 2x 4 TB NAS-HDDs (RAID1) – Einrichtung ausstehend
 - **OS:** Debian 13 (Trixie), Linux 6.12.63+deb13-amd64
-- **Network:** Gigabit Ethernet, mDNS enabled
+- **Netzwerk:** Gigabit-Ethernet, mDNS aktiviert
 
 ---
 
-## 📦 Deployed Components
+## 📦 Bereitgestellte Komponenten
 
-### Backend Service
-- **Service:** `baluhost-backend.service`
-- **Status:** Active (running)
-- **Workers:** 4 Uvicorn processes
-- **Port:** 8000 (internal)
-- **Working Dir:** `/home/sven/projects/BaluHost/backend`
-- **Virtual Env:** `.venv` (Python 3.13)
+### Backend-Dienst
+- **Dienst:** `baluhost-backend.service`
+- **Status:** Aktiv (läuft)
+- **Worker:** 4 Uvicorn-Prozesse
+- **Port:** 8000 (intern)
+- **Arbeitsverzeichnis:** `/home/sven/projects/BaluHost/backend`
+- **Virtuelle Umgebung:** `.venv` (Python 3.13)
 - **Logs:** `journalctl -u baluhost-backend -f`
-- **Memory Usage:** ~480MB
-- **Auto-Start:** Enabled
+- **Speicherverbrauch:** ~480 MB
+- **Auto-Start:** Aktiviert
 
-**Environment:**
+**Umgebung:**
 - `NAS_MODE=prod`
 - `LOG_LEVEL=INFO`
 - `LOG_FORMAT=json`
 - `DATABASE_URL=postgresql://baluhost:***@localhost:5432/baluhost`
 
-### Frontend Service
-- **Service:** `baluhost-frontend.service`
-- **Status:** Inactive (not needed - Nginx serves static files)
-- **Build Output:** `/var/www/baluhost/`
-- **Permissions:** `www-data:www-data` (755)
-- **Bundle Size:** 1.1MB (gzipped: 291KB)
-- **Update Process:** `npm run build:prod` → `sudo cp -r client/dist/* /var/www/baluhost/`
+### Frontend-Dienst
+- **Dienst:** `baluhost-frontend.service`
+- **Status:** Inaktiv (nicht benötigt – Nginx liefert statische Dateien aus)
+- **Build-Ausgabe:** `/var/www/baluhost/`
+- **Berechtigungen:** `www-data:www-data` (755)
+- **Bundle-Größe:** 1,1 MB (gzip: 291 KB)
+- **Aktualisierungsprozess:** `npm run build:prod` → `sudo cp -r client/dist/* /var/www/baluhost/`
 
-### Database
+### Datenbank
 - **Engine:** PostgreSQL 17.7 (Debian 17.7-0+deb13u1)
-- **Database:** `baluhost`
-- **User:** `baluhost`
-- **Tables:** 35+ tables (all verified)
-- **Status:** Active, enabled on boot
-- **Connection:** localhost:5432
-- **Auth:** md5 (pg_hba.conf)
+- **Datenbank:** `baluhost`
+- **Benutzer:** `baluhost`
+- **Tabellen:** 35+ Tabellen (alle verifiziert)
+- **Status:** Aktiv, beim Booten aktiviert
+- **Verbindung:** localhost:5432
+- **Authentifizierung:** md5 (pg_hba.conf)
 
 ### Nginx Reverse Proxy
-- **Config:** `/etc/nginx/sites-available/baluhost`
+- **Konfiguration:** `/etc/nginx/sites-available/baluhost`
 - **Port:** 80 (HTTP)
 - **Root:** `/var/www/baluhost/`
-- **Upstream:** `127.0.0.1:8000` (backend)
-- **Features:**
-  - Rate limiting (API: 100r/s, Auth: 10r/s)
-  - Security headers (X-Frame-Options, X-XSS-Protection, etc.)
-  - Gzip compression
-  - WebSocket/SSE support
-  - 10GB max upload size
+- **Upstream:** `127.0.0.1:8000` (Backend)
+- **Funktionen:**
+  - Rate-Limiting (API: 100 r/s, Auth: 10 r/s)
+  - Security-Header (X-Frame-Options, X-XSS-Protection, etc.)
+  - Gzip-Komprimierung
+  - WebSocket/SSE-Unterstützung
+  - 10 GB maximale Upload-Größe
 - **Logs:**
-  - Access: `/var/log/nginx/baluhost-access.log`
-  - Error: `/var/log/nginx/baluhost-error.log`
+  - Zugriff: `/var/log/nginx/baluhost-access.log`
+  - Fehler: `/var/log/nginx/baluhost-error.log`
 
 ---
 
-## 🔐 Security Configuration
+## 🔐 Sicherheitskonfiguration
 
-### Secrets (Auto-Generated)
-- `SECRET_KEY`: 64-char secure token (for JWT signing)
-- `TOKEN_SECRET`: 64-char secure token (legacy auth)
-- `POSTGRES_PASSWORD`: 43-char secure token
-- `VPN_ENCRYPTION_KEY`: Fernet key for WireGuard encryption
+### Secrets (automatisch generiert)
+- `SECRET_KEY`: 64-Zeichen-Sicherheitstoken (für JWT-Signierung)
+- `TOKEN_SECRET`: 64-Zeichen-Sicherheitstoken (Legacy-Auth)
+- `POSTGRES_PASSWORD`: 43-Zeichen-Sicherheitstoken
+- `VPN_ENCRYPTION_KEY`: Fernet-Schlüssel für WireGuard-Verschlüsselung
 - `ADMIN_PASSWORD`: *(wird beim Setup vergeben)* ⚠️ **Nach erstem Login ändern**
 
-### Admin Account
-- **Username:** `admin`
-- **Email:** `admin@example.com` (fixed from `admin@baluhost.local` - Pydantic validation issue)
-- **Role:** `admin`
-- **First Login:** Change password in Settings immediately
+### Admin-Konto
+- **Benutzername:** `admin`
+- **E-Mail:** `admin@example.com` (korrigiert von `admin@baluhost.local` – Pydantic-Validierungsproblem)
+- **Rolle:** `admin`
+- **Erster Login:** Passwort umgehend in den Einstellungen ändern
 
-### Rate Limiting
-- API endpoints: 100 requests/second (burst 20)
-- Auth endpoints: 10 requests/second (burst 5)
+### Rate-Limiting
+- API-Endpunkte: 100 Anfragen/Sekunde (Burst 20)
+- Auth-Endpunkte: 10 Anfragen/Sekunde (Burst 5)
 
 ### CORS
 - Origins: `http://localhost`, `http://baluhost.local`, `http://127.0.0.1`
 
 ---
 
-## 🛠️ Deployment Steps Taken
+## 🛠️ Durchgeführte Deployment-Schritte
 
-1. **Backup Created:** `/home/sven/baluhost_backup_20260125_220931` (1.1GB)
-2. **PostgreSQL Installed:** Version 17.7, configured with dedicated user
-3. **Database Initialized:** All tables created, admin user seeded
-4. **Production .env Generated:** Secure secrets auto-generated
-5. **Systemd Services Created:**
-   - Backend service with 4 workers
-   - Frontend service (build-only, not used for serving)
-6. **Nginx Configured:**
-   - HTTP-only reverse proxy
-   - Static file serving from `/var/www/baluhost/`
-   - Security headers and rate limiting
-7. **Frontend Built:** Production build (1.1MB bundle)
-8. **Services Started:** Backend running, Nginx serving
-9. **Health Check Verified:** Login successful, API responding
-
----
-
-## ⚠️ Known Issues
-
-### 1. Monitoring Integer Overflow (Non-Critical)
-**Symptom:** Memory and network sample inserts fail with "integer out of range"
-**Cause:** `memory_samples.used_bytes` and `network_samples.bytes_sent/received` use INTEGER (max ~2GB) instead of BIGINT
-**Impact:** Telemetry/monitoring data not saved (does not affect core functionality)
-**Fix:** Alembic migration to change column types to BIGINT
-**Priority:** Medium (fix when convenient)
-
-### 2. Email Validation Issue (RESOLVED)
-**Symptom:** Login failed with 500 error
-**Cause:** Pydantic rejects `.local` TLD as invalid email
-**Fix:** Changed admin email from `admin@baluhost.local` to `admin@example.com`
-**Status:** ✅ Resolved
+1. **Backup erstellt:** `/home/sven/baluhost_backup_20260125_220931` (1,1 GB)
+2. **PostgreSQL installiert:** Version 17.7, mit dediziertem Benutzer konfiguriert
+3. **Datenbank initialisiert:** Alle Tabellen erstellt, Admin-Benutzer angelegt
+4. **Produktions-.env generiert:** Sichere Secrets automatisch erzeugt
+5. **Systemd-Dienste erstellt:**
+   - Backend-Dienst mit 4 Workern
+   - Frontend-Dienst (nur Build, nicht zum Ausliefern verwendet)
+6. **Nginx konfiguriert:**
+   - HTTP-only Reverse Proxy
+   - Auslieferung statischer Dateien aus `/var/www/baluhost/`
+   - Security-Header und Rate-Limiting
+7. **Frontend gebaut:** Produktions-Build (1,1 MB Bundle)
+8. **Dienste gestartet:** Backend läuft, Nginx liefert aus
+9. **Health-Check verifiziert:** Login erfolgreich, API antwortet
 
 ---
 
-## 📊 System Performance
+## ⚠️ Bekannte Probleme
 
-**Startup Time:**
-- Backend: ~30 seconds (4 workers + DB connection)
-- Frontend build: ~21 seconds
-- Database: <5 seconds
+### 1. Monitoring-Integer-Überlauf (unkritisch)
+**Symptom:** Einfügen von Memory- und Network-Samples schlägt mit „integer out of range" fehl
+**Ursache:** `memory_samples.used_bytes` und `network_samples.bytes_sent/received` nutzen INTEGER (max. ~2 GB) statt BIGINT
+**Auswirkung:** Telemetrie-/Monitoring-Daten werden nicht gespeichert (beeinträchtigt die Kernfunktionalität nicht)
+**Fix:** Alembic-Migration, um die Spaltentypen auf BIGINT zu ändern
+**Priorität:** Mittel (bei Gelegenheit beheben)
 
-**Memory Usage (Idle):**
-- Backend: 480MB
-- PostgreSQL: 60MB
-- Nginx: 20MB
-- Total: ~560MB
-
-**CPU Usage (Idle):** <5%
-
-**Disk Usage:**
-- Backend: 250MB
-- Frontend dist: 2MB
-- PostgreSQL data: 15MB
-- Total: ~300MB
+### 2. E-Mail-Validierungsproblem (BEHOBEN)
+**Symptom:** Login schlug mit 500-Fehler fehl
+**Ursache:** Pydantic lehnt `.local`-TLD als ungültige E-Mail ab
+**Fix:** Admin-E-Mail von `admin@baluhost.local` auf `admin@example.com` geändert
+**Status:** ✅ Behoben
 
 ---
 
-## 🔄 Maintenance Procedures
+## 📊 Systemleistung
 
-### View Logs
+**Startzeit:**
+- Backend: ~30 Sekunden (4 Worker + DB-Verbindung)
+- Frontend-Build: ~21 Sekunden
+- Datenbank: <5 Sekunden
+
+**Speicherverbrauch (Leerlauf):**
+- Backend: 480 MB
+- PostgreSQL: 60 MB
+- Nginx: 20 MB
+- Gesamt: ~560 MB
+
+**CPU-Auslastung (Leerlauf):** <5 %
+
+**Speicherplatz:**
+- Backend: 250 MB
+- Frontend-dist: 2 MB
+- PostgreSQL-Daten: 15 MB
+- Gesamt: ~300 MB
+
+---
+
+## 🔄 Wartungsprozeduren
+
+### Logs anzeigen
 ```bash
-# Backend logs (JSON format)
+# Backend-Logs (JSON-Format)
 sudo journalctl -u baluhost-backend -f
 
-# Nginx access logs
+# Nginx-Zugriffslogs
 sudo tail -f /var/log/nginx/baluhost-access.log
 
-# Nginx error logs
+# Nginx-Fehlerlogs
 sudo tail -f /var/log/nginx/baluhost-error.log
 ```
 
-### Restart Services
+### Dienste neustarten
 ```bash
-# Restart backend
+# Backend neustarten
 sudo systemctl restart baluhost-backend
 
-# Reload Nginx (no downtime)
+# Nginx neu laden (keine Ausfallzeit)
 sudo systemctl reload nginx
 
-# Full restart (brief downtime)
+# Vollständiger Neustart (kurze Ausfallzeit)
 sudo systemctl restart nginx
 ```
 
-### Update Frontend
+### Frontend aktualisieren
 ```bash
 cd /home/sven/projects/BaluHost/client
 npm run build:prod
@@ -186,12 +186,12 @@ sudo cp -r dist/* /var/www/baluhost/
 sudo systemctl reload nginx
 ```
 
-### Database Backup
+### Datenbank-Backup
 ```bash
 sudo -u postgres pg_dump baluhost > /path/to/backup/baluhost_$(date +%Y%m%d_%H%M%S).sql
 ```
 
-### Check Service Status
+### Dienststatus prüfen
 ```bash
 systemctl status baluhost-backend
 systemctl status nginx
@@ -200,64 +200,64 @@ systemctl status postgresql
 
 ---
 
-## 📋 Pending Tasks
+## 📋 Ausstehende Aufgaben
 
-### Critical
-- [ ] None - system is production-ready
+### Kritisch
+- [ ] Keine – System ist produktionsbereit
 
-### Important
-- [ ] **Task #7:** Production storage setup (2x 4TB HDDs → RAID1)
-- [ ] Fix monitoring integer overflow (BIGINT migration)
-- [ ] **Task #10:** Automated backup configuration (cronjob)
+### Wichtig
+- [ ] **Aufgabe #7:** Produktiv-Speicher-Setup (2x 4 TB HDDs → RAID1)
+- [ ] Monitoring-Integer-Überlauf beheben (BIGINT-Migration)
+- [ ] **Aufgabe #10:** Automatisierte Backup-Konfiguration (Cronjob)
 
 ### Optional
-- [ ] SSL/HTTPS setup (Let's Encrypt)
-- [ ] **Task #9:** Prometheus + Grafana monitoring
-- [ ] Frontend performance optimization (code splitting)
-- [ ] Load testing (locust, k6)
+- [ ] SSL/HTTPS-Setup (Let's Encrypt)
+- [ ] **Aufgabe #9:** Prometheus + Grafana Monitoring
+- [ ] Frontend-Performance-Optimierung (Code-Splitting)
+- [ ] Lasttests (locust, k6)
 
 ---
 
-## 🎯 Next Steps
+## 🎯 Nächste Schritte
 
-1. **Immediate (After First Login):**
-   - Change admin password in Settings
-   - Test file upload/download
-   - Verify dashboard metrics
+1. **Sofort (nach erstem Login):**
+   - Admin-Passwort in den Einstellungen ändern
+   - Datei-Upload/-Download testen
+   - Dashboard-Metriken verifizieren
 
-2. **Short Term (This Week):**
-   - Install 2x 4TB HDDs
-   - Create RAID1 array
-   - Configure storage mountpoints
-   - Fix monitoring integer overflow
+2. **Kurzfristig (diese Woche):**
+   - 2x 4 TB HDDs einbauen
+   - RAID1-Array erstellen
+   - Speicher-Mountpoints konfigurieren
+   - Monitoring-Integer-Überlauf beheben
 
-3. **Long Term (This Month):**
-   - Set up automated backups
-   - Configure SSL/HTTPS (if needed)
-   - Deploy monitoring stack (optional)
+3. **Langfristig (diesen Monat):**
+   - Automatisierte Backups einrichten
+   - SSL/HTTPS konfigurieren (falls benötigt)
+   - Monitoring-Stack bereitstellen (optional)
 
 ---
 
-## 📞 Access Information
+## 📞 Zugriffsinformationen
 
-**Web UI:**
-- Local: `http://localhost`
-- Network: `http://baluhost.local` (if mDNS configured)
-- IP: `http://<server-ip>` (check with `hostname -I`)
+**Weboberfläche:**
+- Lokal: `http://localhost`
+- Netzwerk: `http://baluhost.local` (falls mDNS konfiguriert)
+- IP: `http://<server-ip>` (mit `hostname -I` ermitteln)
 
-**API Documentation:**
+**API-Dokumentation:**
 - Swagger UI: `http://localhost/docs`
 - OpenAPI JSON: `http://localhost/openapi.json`
 
-**Admin Credentials:**
-- Username: `admin`
-- Password: *(wird beim Setup vergeben — hier nicht dokumentiert)* ⚠️ **Sofort ändern**
+**Admin-Zugangsdaten:**
+- Benutzername: `admin`
+- Passwort: *(wird beim Setup vergeben — hier nicht dokumentiert)* ⚠️ **Sofort ändern**
 
 ---
 
-**Last Updated:** January 25, 2026 23:40 CET
-**Deployment Status:** ✅ PRODUCTION - STABLE
-**Uptime Target:** 99.9%
+**Zuletzt aktualisiert:** 25. Januar 2026, 23:40 CET
+**Deployment-Status:** ✅ PRODUKTION – STABIL
+**Verfügbarkeitsziel:** 99,9 %
 
 ## Legacy-Frontend-Unit (BaluNode)
 


### PR DESCRIPTION
## Summary

`docs/deployment/PRODUCTION_DEPLOYMENT_NOTES.de.md` was an untranslated copy of the `.en.md` — English content under a `.de.md` name — which broke the bilingual pattern of `docs/deployment/` (every other `.de`/`.en` pair is a real translation). Since #207/PR #215 the file had also become mixed-language: the appended "Legacy-Frontend-Unit (BaluNode)" ops note is German.

This PR translates the file fully into German.

## Changes

- All headings translated (emojis kept), plus prose, status badges (`✅ PRODUKTION – LÄUFT/STABIL`), Known Issues, Pending Tasks and Next Steps.
- **Kept identical to `.en.md`:** code blocks/commands, paths, service names, env vars, secret names, version values, URLs.
- The already-German Legacy-Frontend ops note and the setup hints are preserved → file is no longer mixed-language.
- Structure stays 1:1 with the `.en.md`; both language versions are content-synced (no drift found during the review).

## Scope

Docs-only, no functional impact (Severity: low — as noted in the issue).

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)
