### PR TITLE
fix(security): path-traversal hardening — backup tar-slip + upload filename (#1/#2)

### DIFF
--- a/backend/app/services/backup/service.py
+++ b/backend/app/services/backup/service.py
@@ -403,7 +403,14 @@ class BackupService:
 
                 # Extract tar.gz
                 with tarfile.open(filepath, "r:gz") as tar:
-                    tar.extractall(temp_path)
+                    # Security: prevent tar-slip. The ``data`` filter rejects
+                    # members with absolute paths, ".." traversal, or unsafe
+                    # links, so a tampered archive cannot write outside the
+                    # temp dir. BaluHost backups only contain regular data
+                    # files under "backup/", so this is behaviour-preserving
+                    # for legitimate archives. (tarfile filters: py3.12+,
+                    # backported to 3.11.4+.)
+                    tar.extractall(temp_path, filter="data")
                 
                 backup_root = temp_path / "backup"
                 

--- a/backend/app/services/files/operations.py
+++ b/backend/app/services/files/operations.py
@@ -418,7 +418,13 @@ async def save_uploads(
             destination = target / file_relative_path
         else:
             filename = override_filename or upload.filename or "upload.bin"
-            destination = target / filename
+            # Security: collapse to the final path component so a client-supplied
+            # name like "../other-user/evil" cannot escape the (already jailed)
+            # target dir. Mirrors chunked_upload.py's sanitization.
+            safe_name = PurePosixPath(filename.replace("\x00", "")).name
+            if not safe_name or safe_name in (".", ".."):
+                safe_name = "upload.bin"
+            destination = target / safe_name
 
         await asyncio.to_thread(ensure_dir_with_permissions, destination.parent)
         try:

--- a/backend/tests/files/test_files_operations.py
+++ b/backend/tests/files/test_files_operations.py
@@ -497,6 +497,30 @@ class TestSaveUploads:
         assert (storage_root / "test.txt").read_bytes() == b"file content"
 
     @pytest.mark.asyncio
+    async def test_save_upload_filename_traversal_is_contained(
+        self, storage_root, db_session, user_public
+    ):
+        """A client-supplied filename with ``..`` must not escape the target dir."""
+        upload = MagicMock(spec=UploadFile)
+        upload.filename = "../evil.txt"
+        upload.read = AsyncMock(return_value=b"pwned")
+        upload.close = AsyncMock()
+
+        saved = await file_ops.save_uploads(
+            relative_path="",
+            uploads=[upload],
+            user=user_public,
+            db=db_session,
+        )
+
+        # File is contained inside the storage root under its basename...
+        assert saved == ["evil.txt"]
+        assert (storage_root / "evil.txt").exists()
+        assert (storage_root / "evil.txt").read_bytes() == b"pwned"
+        # ...and did NOT escape to the parent directory.
+        assert not (storage_root.parent / "evil.txt").exists()
+
+    @pytest.mark.asyncio
     async def test_save_multiple_uploads(self, storage_root, db_session, user_public):
         """Test saving multiple uploaded files."""
         uploads = []

--- a/backend/tests/services/test_backup.py
+++ b/backend/tests/services/test_backup.py
@@ -255,6 +255,54 @@ def test_create_backup_handles_errors(backup_service: BackupService, temp_backup
             assert failed_backup.error_message == "Test error"
 
 
+def test_restore_backup_rejects_tar_slip(
+    backup_service: BackupService, temp_backup_dir: Path, db_session: Session
+):
+    """A tampered archive with a '..' member must not write outside the temp dir."""
+    import io
+    import tarfile
+
+    # Craft a malicious archive whose member escapes one level up — i.e. into
+    # backup_dir itself (the parent of the extraction temp dir).
+    malicious = temp_backup_dir / "malicious.tar.gz"
+    payload = b"escaped!"
+    with tarfile.open(malicious, "w:gz") as tar:
+        info = tarfile.TarInfo(name="../escape.txt")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+
+    backup = Backup(
+        filename="malicious.tar.gz",
+        filepath=str(malicious),
+        size_bytes=malicious.stat().st_size,
+        backup_type="full",
+        status="completed",
+        creator_id=1,
+        includes_database=False,
+        includes_files=True,
+        includes_config=False,
+    )
+    db_session.add(backup)
+    db_session.commit()
+    db_session.refresh(backup)
+
+    # The 'data' filter rejects the traversal member, so extraction raises a
+    # tarfile error (surfaced by the route as a failed restore) instead of
+    # writing outside the extraction dir.
+    with patch.object(backup_service, "backup_dir", temp_backup_dir):
+        with pytest.raises(tarfile.TarError):
+            backup_service.restore_backup(
+                backup_id=backup.id,
+                user="test_user",
+                restore_database=False,
+                restore_files=False,
+                restore_config=False,
+            )
+
+    # The traversal target was never written outside the extraction dir.
+    assert not (temp_backup_dir / "escape.txt").exists()
+
+
 def test_download_backup(backup_service: BackupService, temp_backup_dir: Path, db_session: Session):
     """Test getting backup file path for download."""
     # Create backup file


### PR DESCRIPTION
## Summary

Behebt die zwei dringendsten Befunde aus dem Security-Audit (2026-06-14) — beide
sind Path-Traversal-/Write-Primitive, die von *bösartigem Datei-Inhalt* bzw. einem
*authentifizierten Non-Admin-LAN-User* ausnutzbar sind (Threat-Model: Zugang von
außen VPN-only).

### Fix #1 — Tar-Slip im Backup-Restore (High)
`restore_backup()` entpackte Backup-Archive mit `tarfile.extractall()` **ohne
Filter**. Auf Python 3.11 (CI-Image `python:3.11-slim`) lässt der unsichere Default
ein manipuliertes Archiv außerhalb des Extraktionsverzeichnisses schreiben →
arbitrary file write als Backend-User. Backups liegen auf NAS-Storage, das ein
Non-Admin u. U. beschreiben kann → User tauscht ein Archiv, Admin restored.

→ `extractall(temp_path, filter="data")`: Member mit absoluten Pfaden oder
`..`-Traversal werden abgewiesen. Verhaltenserhaltend für legitime Backups (nur
reguläre Dateien unter `backup/`). `backend/app/services/backup/service.py`.

### Fix #2 — Cross-User-Traversal über Upload-Filename (High)
`save_uploads()` baute das Ziel als `target / upload.filename` **ohne** den
client-gelieferten Filename zu sanitisieren. Ein Name wie `"../other-user/evil"`
verließ das (bereits gejailte) Zielverzeichnis und schrieb in ein
Geschwister-/Parent-Verzeichnis, bevor `relative_to()` fehlschlug.

→ Filename auf seine finale Pfadkomponente kollabieren (`PurePosixPath(...).name`,
analog zu `chunked_upload.py`) + Nullbytes strippen.
`backend/app/services/files/operations.py`.

## Test Plan
- [x] Neuer Regressionstest `test_restore_backup_rejects_tar_slip` — manipuliertes
      `../escape.txt`-Archiv → Restore wirft `tarfile.TarError`, kein Escape.
- [x] Neuer Regressionstest `test_save_upload_filename_traversal_is_contained` —
      Filename `../evil.txt` landet als `evil.txt` im Ziel, nicht im Parent.
- [x] `tests/services/test_backup.py` + `tests/files/test_files_operations.py`:
      **87 passed, 2 skipped** (keine Regression).

## Hinweis
Der Backup-Test ist lokal auf Python 3.14 bereits durch den neuen Default-Filter
grün; die explizite `filter="data"`-Zeile ist v. a. für CI-Python-3.11 relevant,
wo sonst der unsichere Default gilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
