### PR TITLE
fix(admin): make loadOwners unmount guard actually work (#247)

### DIFF
--- a/client/src/pages/AdminDatabase.tsx
+++ b/client/src/pages/AdminDatabase.tsx
@@ -44,6 +44,13 @@ export default function AdminDatabase() {
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // Mount guard for async handlers that aren't tied to an effect teardown
+  // (e.g. the manual loadOwners button). Flipped to false on unmount.
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    return () => { isMountedRef.current = false }
+  }, [])
+
   // Row detail
   const [selectedRow, setSelectedRow] = useState<Record<string, unknown> | null>(null)
 
@@ -158,14 +165,13 @@ export default function AdminDatabase() {
       return
     }
     setOwnerLoadInfo({ status: 'loading' })
-    const mounted = true
     try {
       const sizes = [2000, 1000, 500, 200, 100, 50]
       let successful = false
       for (const sz of sizes) {
         try {
           const res = await fetchRows('users', 1, sz)
-          if (!mounted) return
+          if (!isMountedRef.current) return
           const map: Record<string,string> = {}
           for (const u of res.rows || []) {
             const id = u.id ?? u.ID ?? u.user_id ?? u.userId
@@ -177,6 +183,7 @@ export default function AdminDatabase() {
           successful = true
           break
         } catch (err: unknown) {
+          if (!isMountedRef.current) return
           const status = (err as { response?: { status?: number } })?.response?.status
           if (status && status !== 422) {
             setOwnerLoadInfo({ status: 'failed', error: `HTTP ${status}` })
@@ -185,8 +192,10 @@ export default function AdminDatabase() {
           setOwnerLoadInfo({ status: 'loading', page_size: sz })
         }
       }
+      if (!isMountedRef.current) return
       if (!successful) setOwnerLoadInfo({ status: 'failed', error: 'no successful response' })
     } catch (e: unknown) {
+      if (!isMountedRef.current) return
       setOwnerLoadInfo({ status: 'failed', error: String(e) })
     }
   }


### PR DESCRIPTION
Fixes #247.

## Problem

`AdminDatabase.loadOwners` declared a `mounted` flag as an unmount guard but
never flipped it to `false` — `const mounted = true` with no teardown. The
check `if (!mounted) return` could therefore never fire. `loadOwners` is a
manual button handler (`onClick`), not a `useEffect`, so there was no effect
teardown to hook a cleanup onto. The #210 lint PR had changed `let → const`
(correct for `prefer-const`), which cemented the dead guard rather than fixing
it.

## Fix

- Add a component-level `isMountedRef = useRef(true)`, flipped to `false` in a
  `useEffect` cleanup.
- Remove the dead local `const mounted = true`.
- Check `isMountedRef.current` after **every** awaited `fetchRows` before
  applying state — including the `catch` branch inside the loop and the two
  trailing `setOwnerLoadInfo` calls, not just the single original guard point.

## Notes

- **No runtime regression existed**: React 18 dropped the
  "setState on an unmounted component" warning, so this is a correctness/cleanup
  fix with no observable behavior change (matches the issue's "no observed
  user-visible regression"). For that reason no unit test was added — an
  unmount-race test would assert nothing observable, and there is no existing
  `AdminDatabase.test.tsx`.
- Severity: Low (per issue).

## Verification

- `tsc --noEmit`: 0 errors
- `eslint AdminDatabase.tsx`: 0 errors (2 pre-existing `exhaustive-deps`
  warnings on the older loaders — out of scope, tracked in #244)
- Vitest: 64 files / 418 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
