### PR TITLE
fix(security): urgent audit fixes #3-#5 (plugin homepage XSS, SSH SSRF, WS token leak)

### DIFF
--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -530,7 +530,9 @@ async def notification_websocket(
     """WebSocket endpoint for real-time notification delivery.
 
     Requires a scoped WS token (from POST /ws-token) as query parameter.
-    Also accepts full access tokens for backwards compatibility (deprecated).
+    The full access token is intentionally NOT accepted here: passing it as a
+    query parameter would leak the broadly-scoped token into proxy/nginx access
+    logs. Clients must exchange their access token for a short-lived ws token.
     """
     import logging
     from app.services.websocket_manager import get_websocket_manager
@@ -554,19 +556,13 @@ async def notification_websocket(
     try:
         db = SessionLocal()
 
-        # First try to decode as a scoped WS token
+        # Only a scoped WS token (type="ws") is accepted. Full access tokens are
+        # rejected fail-closed so they can never be leaked via the ?token= query
+        # parameter into proxy logs.
         try:
             payload = decode_raw_token(token, token_type="ws")
         except pyjwt.InvalidTokenError:
-            # Fall back to access token for backwards compatibility
-            try:
-                payload = decode_raw_token(token, token_type="access")
-                logger.warning(
-                    "WebSocket: client used access token instead of scoped ws token "
-                    "(deprecated, use POST /api/notifications/ws-token)"
-                )
-            except pyjwt.InvalidTokenError:
-                raise auth_service.InvalidTokenError("Invalid WebSocket token")
+            raise auth_service.InvalidTokenError("Invalid WebSocket token")
 
         user_sub = payload.get("sub")
         if not user_sub:

--- a/backend/app/api/routes/server_profiles.py
+++ b/backend/app/api/routes/server_profiles.py
@@ -246,9 +246,14 @@ async def check_ssh_connection(
     response: Response,
     profile_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.get_current_admin),
 ) -> SSHConnectionTest:
-    """Test SSH connectivity to server."""
+    """Test SSH connectivity to server.
+
+    Admin-only: this opens an outbound TCP/SSH connection to an arbitrary,
+    profile-supplied host:port. Allowing any authenticated user would turn the
+    server into an SSRF/port-scan oracle against the internal network (audit #4).
+    """
     profile = server_profile_service.get_user_profile(db, profile_id, current_user.id)
     if not profile:
         raise HTTPException(
@@ -292,9 +297,14 @@ async def start_remote_server(
     response: Response,
     profile_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(deps.get_current_user),
+    current_user: User = Depends(deps.get_current_admin),
 ) -> ServerStartResponse:
-    """Start remote BaluHost server."""
+    """Start remote BaluHost server.
+
+    Admin-only: this opens an outbound SSH connection to a profile-supplied
+    host:port and executes the stored power-on command there. Same SSRF /
+    arbitrary-egress surface as check-connectivity (audit #4).
+    """
     profile = server_profile_service.get_user_profile(db, profile_id, current_user.id)
     if not profile:
         raise HTTPException(

--- a/backend/tests/integration/test_remote_server_start.py
+++ b/backend/tests/integration/test_remote_server_start.py
@@ -187,17 +187,17 @@ MIIEpAIBAAKCAQEA0Z+4rqGr1+...truncated...
         assert response.status_code == 404
     
     @patch("app.services.ssh_service.SSHService.test_connection")
-    def test_check_ssh_connection_success(self, mock_ssh, client_with_user, db_session, test_user):
-        """Test SSH connectivity check endpoint."""
+    def test_check_ssh_connection_success(self, mock_ssh, client, db_session, admin_user, admin_headers):
+        """Test SSH connectivity check endpoint (admin-only, audit #4)."""
         mock_ssh.return_value = (True, None)
-        
+
         ssh_key = """-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEA0Z+4rqGr1+...truncated...
 -----END RSA PRIVATE KEY-----"""
-        
+
         encrypted_key = VPNEncryption.encrypt_ssh_private_key(ssh_key)
         profile = ServerProfile(
-            user_id=test_user.id,
+            user_id=admin_user.id,
             name="Test",
             ssh_host="10.0.0.1",
             ssh_port=22,
@@ -206,24 +206,51 @@ MIIEpAIBAAKCAQEA0Z+4rqGr1+...truncated...
         )
         db_session.add(profile)
         db_session.commit()
-        
-        response = client_with_user.post(f"/api/server-profiles/{profile.id}/check-connectivity")
-        
+
+        response = client.post(
+            f"/api/server-profiles/{profile.id}/check-connectivity", headers=admin_headers
+        )
+
         assert response.status_code == 200
         data = response.json()
         assert data["ssh_reachable"] is True
         assert data["error_message"] is None
-    
+
     @patch("app.services.ssh_service.SSHService.test_connection")
-    def test_check_ssh_connection_failure(self, mock_ssh, client_with_user, db_session, test_user):
-        """Test SSH connectivity check with failure."""
+    def test_check_ssh_connection_failure(self, mock_ssh, client, db_session, admin_user, admin_headers):
+        """Test SSH connectivity check with failure (admin-only, audit #4)."""
         mock_ssh.return_value = (False, "Connection refused")
-        
+
         ssh_key = """-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEA0Z+4rqGr1+...truncated...
 -----END RSA PRIVATE KEY-----"""
-        
+
         encrypted_key = VPNEncryption.encrypt_ssh_private_key(ssh_key)
+        profile = ServerProfile(
+            user_id=admin_user.id,
+            name="Test",
+            ssh_host="10.0.0.1",
+            ssh_port=22,
+            ssh_username="user",
+            ssh_key_encrypted=encrypted_key,
+        )
+        db_session.add(profile)
+        db_session.commit()
+
+        response = client.post(
+            f"/api/server-profiles/{profile.id}/check-connectivity", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ssh_reachable"] is False
+        assert "Connection refused" in data["error_message"]
+
+    def test_check_connectivity_forbidden_for_regular_user(self, client_with_user, db_session, test_user):
+        """A non-admin must NOT be able to trigger an outbound SSH probe (audit #4)."""
+        encrypted_key = VPNEncryption.encrypt_ssh_private_key(
+            "-----BEGIN RSA PRIVATE KEY-----\nx\n-----END RSA PRIVATE KEY-----"
+        )
         profile = ServerProfile(
             user_id=test_user.id,
             name="Test",
@@ -234,24 +261,46 @@ MIIEpAIBAAKCAQEA0Z+4rqGr1+...truncated...
         )
         db_session.add(profile)
         db_session.commit()
-        
+
         response = client_with_user.post(f"/api/server-profiles/{profile.id}/check-connectivity")
-        
-        assert response.status_code == 200
-        data = response.json()
-        assert data["ssh_reachable"] is False
-        assert "Connection refused" in data["error_message"]
-    
+        assert response.status_code == 403
+
     @patch("app.services.ssh_service.SSHService.start_server")
-    def test_start_remote_server(self, mock_start, client_with_user, db_session, test_user):
-        """Test remote server startup endpoint."""
+    def test_start_remote_server(self, mock_start, client, db_session, admin_user, admin_headers):
+        """Test remote server startup endpoint (admin-only, audit #4)."""
         mock_start.return_value = (True, "Server startup initiated")
-        
+
         ssh_key = """-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEA0Z+4rqGr1+...truncated...
 -----END RSA PRIVATE KEY-----"""
-        
+
         encrypted_key = VPNEncryption.encrypt_ssh_private_key(ssh_key)
+        profile = ServerProfile(
+            user_id=admin_user.id,
+            name="Test",
+            ssh_host="10.0.0.1",
+            ssh_port=22,
+            ssh_username="user",
+            ssh_key_encrypted=encrypted_key,
+            power_on_command="systemctl start baluhost-backend",
+        )
+        db_session.add(profile)
+        db_session.commit()
+
+        response = client.post(
+            f"/api/server-profiles/{profile.id}/start", headers=admin_headers
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["profile_id"] == profile.id
+        assert data["status"] == "starting"
+
+    def test_start_forbidden_for_regular_user(self, client_with_user, db_session, test_user):
+        """A non-admin must NOT be able to start a remote server over SSH (audit #4)."""
+        encrypted_key = VPNEncryption.encrypt_ssh_private_key(
+            "-----BEGIN RSA PRIVATE KEY-----\nx\n-----END RSA PRIVATE KEY-----"
+        )
         profile = ServerProfile(
             user_id=test_user.id,
             name="Test",
@@ -263,13 +312,9 @@ MIIEpAIBAAKCAQEA0Z+4rqGr1+...truncated...
         )
         db_session.add(profile)
         db_session.commit()
-        
+
         response = client_with_user.post(f"/api/server-profiles/{profile.id}/start")
-        
-        assert response.status_code == 200
-        data = response.json()
-        assert data["profile_id"] == profile.id
-        assert data["status"] == "starting"
+        assert response.status_code == 403
 
 
 class TestVPNProfileAPI:

--- a/backend/tests/test_websocket_auth.py
+++ b/backend/tests/test_websocket_auth.py
@@ -9,6 +9,7 @@ Verifies that:
 
 import jwt
 import pytest
+from fastapi import WebSocketDisconnect
 from app.core.config import settings
 from app.core.security import create_ws_token
 
@@ -78,3 +79,47 @@ class TestWsTokenEndpoint:
         # Decode to verify it's a valid WS token
         payload = jwt.decode(data["token"], settings.SECRET_KEY, algorithms=["HS256"])
         assert payload["type"] == "ws"
+
+
+class TestWsEndpointRejectsAccessToken:
+    """The /ws endpoint must only accept scoped ws tokens, never the broad
+    access token (which would leak into proxy logs via ?token=)."""
+
+    def test_ws_rejects_access_token(self, client, admin_headers):
+        """Connecting with a full access token must be refused (fail-closed)."""
+        access_token = admin_headers["Authorization"].split()[1]
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect(
+                f"/api/notifications/ws?token={access_token}"
+            ) as ws:
+                ws.receive_text()
+
+    def test_ws_rejects_missing_token(self, client):
+        """Connecting without a token must be refused."""
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect("/api/notifications/ws") as ws:
+                ws.receive_text()
+
+    def test_ws_rejects_expired_or_wrong_type_token(self, client):
+        """A token without type='ws' (e.g. a forged 'sse' token) is refused."""
+        import jwt as pyjwt
+        from datetime import datetime, timezone, timedelta
+
+        now = datetime.now(timezone.utc)
+        # A syntactically valid JWT but with the wrong type claim.
+        bad = pyjwt.encode(
+            {
+                "sub": "1",
+                "username": "admin",
+                "type": "sse",
+                "exp": now + timedelta(minutes=5),
+                "iat": now,
+            },
+            settings.SECRET_KEY,
+            algorithm="HS256",
+        )
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect(
+                f"/api/notifications/ws?token={bad}"
+            ) as ws:
+                ws.receive_text()

--- a/client/src/__tests__/lib/safeUrl.test.ts
+++ b/client/src/__tests__/lib/safeUrl.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { safeExternalUrl } from '../../lib/safeUrl'
+
+describe('safeExternalUrl', () => {
+  it('accepts http and https URLs', () => {
+    expect(safeExternalUrl('https://example.com/plugin')).toBe('https://example.com/plugin')
+    expect(safeExternalUrl('http://example.com')).toBe('http://example.com/')
+  })
+
+  it('rejects javascript: URLs (JWT exfiltration vector)', () => {
+    expect(safeExternalUrl('javascript:alert(document.cookie)')).toBeNull()
+    expect(safeExternalUrl('JavaScript:void(0)')).toBeNull()
+  })
+
+  it('rejects data:, vbscript:, file: and other non-http(s) schemes', () => {
+    expect(safeExternalUrl('data:text/html,<script>alert(1)</script>')).toBeNull()
+    expect(safeExternalUrl('vbscript:msgbox(1)')).toBeNull()
+    expect(safeExternalUrl('file:///etc/passwd')).toBeNull()
+  })
+
+  it('rejects whitespace/control-char obfuscation around the scheme', () => {
+    expect(safeExternalUrl('\tjavascript:alert(1)')).toBeNull()
+    expect(safeExternalUrl('  javascript:alert(1)')).toBeNull()
+  })
+
+  it('rejects relative URLs (no absolute scheme)', () => {
+    expect(safeExternalUrl('/local/path')).toBeNull()
+    expect(safeExternalUrl('example.com')).toBeNull()
+  })
+
+  it('returns null for empty/nullish input', () => {
+    expect(safeExternalUrl(null)).toBeNull()
+    expect(safeExternalUrl(undefined)).toBeNull()
+    expect(safeExternalUrl('')).toBeNull()
+    expect(safeExternalUrl('   ')).toBeNull()
+  })
+})

--- a/client/src/components/plugins/MarketplaceTab.tsx
+++ b/client/src/components/plugins/MarketplaceTab.tsx
@@ -8,6 +8,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
+import { safeExternalUrl } from '../../lib/safeUrl';
 import {
   AlertTriangle,
   Download,
@@ -253,11 +254,11 @@ export default function MarketplaceTab() {
                           <span>{formatBytes(latest.size_bytes)}</span>
                         </>
                       )}
-                      {plugin.homepage && (
+                      {safeExternalUrl(plugin.homepage) && (
                         <>
                           <span>•</span>
                           <a
-                            href={plugin.homepage}
+                            href={safeExternalUrl(plugin.homepage)!}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-blue-400 hover:underline inline-flex items-center gap-1"

--- a/client/src/hooks/useNotificationSocket.ts
+++ b/client/src/hooks/useNotificationSocket.ts
@@ -74,13 +74,15 @@ export function useNotificationSocket(options: UseNotificationSocketOptions = {}
     }
 
     try {
-      // Fetch a short-lived, scoped WS token instead of passing the access token
+      // Always use a short-lived, scoped WS token — never the broad access
+      // token (which would leak into proxy logs via the ?token= query param).
+      // If the ws-token exchange fails, abort and let the reconnect logic retry
+      // rather than falling back to the access token.
       let wsToken: string;
       try {
         wsToken = await getWsToken();
       } catch {
-        // If ws-token endpoint is unavailable (e.g. older backend), fall back to access token
-        wsToken = tokenRef.current;
+        throw new Error('ws-token exchange failed');
       }
       const url = getWebSocketUrl(wsToken);
       const ws = new WebSocket(url);
@@ -186,6 +188,19 @@ export function useNotificationSocket(options: UseNotificationSocketOptions = {}
         connected: false,
         error: 'Connection failed',
       }));
+      // No WebSocket was created (e.g. the ws-token exchange failed), so no
+      // onclose handler will fire to drive reconnection. Schedule the retry
+      // here with the same bounded backoff.
+      if (
+        enabledRef.current &&
+        reconnectAttemptsRef.current < maxReconnectAttemptsRef.current
+      ) {
+        reconnectAttemptsRef.current++;
+        const delay = reconnectDelayRef.current * reconnectAttemptsRef.current;
+        reconnectTimeoutRef.current = setTimeout(() => {
+          connect();
+        }, delay);
+      }
     }
   }, []); // Stable identity — reads everything from refs
 

--- a/client/src/lib/safeUrl.ts
+++ b/client/src/lib/safeUrl.ts
@@ -1,0 +1,22 @@
+/**
+ * URL sanitization for user/plugin-supplied links rendered as <a href>.
+ *
+ * A plugin's `homepage` (and similar untrusted fields) is attacker-controlled.
+ * Rendering it directly into an href allows `javascript:` (and `data:`/`vbscript:`)
+ * URLs that execute on click in the app's origin — enough to read the JWT from
+ * localStorage and exfiltrate it (account takeover). `rel="noopener"` does NOT
+ * protect against this.
+ */
+export function safeExternalUrl(url: string | null | undefined): string | null {
+  if (!url) return null
+  try {
+    const parsed = new URL(url.trim())
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.href
+    }
+    return null
+  } catch {
+    // Relative URLs / malformed input throw — treat as unsafe.
+    return null
+  }
+}

--- a/client/src/pages/PluginsPage.tsx
+++ b/client/src/pages/PluginsPage.tsx
@@ -5,6 +5,7 @@
  */
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { safeExternalUrl } from '../lib/safeUrl';
 import { usePlugins } from '../contexts/PluginContext';
 import type {
   PluginDetail,
@@ -321,12 +322,12 @@ export default function PluginsPage() {
                     <dt className="text-slate-500">{t('details.category')}</dt>
                     <dd className="text-white capitalize">{selectedPlugin.category}</dd>
                   </div>
-                  {selectedPlugin.homepage && (
+                  {safeExternalUrl(selectedPlugin.homepage) && (
                     <div className="flex justify-between">
                       <dt className="text-slate-500">{t('details.homepage')}</dt>
                       <dd>
                         <a
-                          href={selectedPlugin.homepage}
+                          href={safeExternalUrl(selectedPlugin.homepage)!}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="text-blue-400 hover:underline flex items-center gap-1"


### PR DESCRIPTION
Closes the three remaining "urgent" findings from the 2026-06-14 security audit
(#1/#2 were already fixed in #249). One commit per fix for clean review.

## #3 — `javascript:` URL in `plugin.homepage` (Medium, impact High)

A plugin's `homepage` is attacker-controlled and was rendered straight into an
`<a href>` in both the installed-plugin detail view (`PluginsPage`) and the
marketplace listing (`MarketplaceTab`). A `javascript:` / `data:` / `vbscript:`
URL there executes in the app origin on click — enough to read the JWT from
localStorage and exfiltrate it (account takeover). `rel="noopener"` does not
protect against this.

- New `lib/safeUrl.ts#safeExternalUrl()` parses via `URL` and returns the link
  only for `http`/`https`, else `null`. Both call sites render the link only
  when safe.
- Unit-tested (`__tests__/lib/safeUrl.test.ts`): `javascript:`/`data:`/
  `vbscript:`/`file:`, whitespace obfuscation, relative URLs, nullish input.

## #4 — SSH connectivity-test / start endpoints reachable by any user (Medium)

`POST /server-profiles/{id}/check-connectivity` and `.../start` both open an
outbound TCP/SSH connection to a profile-supplied `host:port` (and `start`
executes the stored power-on command there). They were gated on
`get_current_user`, so any non-admin could register a profile with an arbitrary
`host:port` and use the server as an SSRF / internal-port-scan oracle.

- Both switched to `get_current_admin`. `is_private_or_local_ip()` is
  **deliberately not** used: the threat is probing *internal* (private) hosts,
  which a private-only allowlist would permit — restricting the trigger to the
  trusted admin is what addresses it. Pure-CRUD endpoints stay on
  `get_current_user`.
- `RemoteServersPage` is not wired into the frontend router, so there is no
  user-facing regression — this only closes the raw-API surface.
- Happy-path tests now run as admin; added two regression tests asserting a
  regular user gets `403` on both endpoints.

## #5 — WS endpoint accepted the full access token via `?token=` (Medium)

The notification WebSocket accepted a full access token as a "backwards compat"
fallback. Query params land in nginx/proxy access logs, leaking a broadly-scoped
token (valid until rotation) and defeating the 60s-scoped ws token.

- **Backend:** only a `type="ws"` token is accepted now; anything else is
  refused before `accept()`. Regression tests assert an access token, a missing
  token, and a wrong-type (`sse`) token are all rejected.
- **Frontend:** `useNotificationSocket` had its own access-token fallback when
  the ws-token exchange failed — which, against a fail-closed backend, would
  silently break notifications. It now never sends the access token; if the
  exchange fails it aborts and the bounded-backoff reconnect retries (a retry is
  scheduled in the `catch` too, since no WebSocket — hence no `onclose` — exists
  to drive reconnection there).

## Verification

- Backend: `tests/test_websocket_auth.py` (11 passed),
  `tests/integration/test_remote_server_start.py` (21 passed); ruff clean on all
  changed files.
- Frontend: `tsc --noEmit` 0 errors; eslint 0 errors on changed files; full
  Vitest suite **65 files / 424 tests passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
