### PR TITLE
feat(core): global exception handlers + 5xx scrubber net (B3 / GAP-10, AP0)

### DIFF
--- a/backend/app/core/exception_handlers.py
+++ b/backend/app/core/exception_handlers.py
@@ -1,0 +1,48 @@
+"""Global exception handlers — keep internal error strings out of API responses.
+
+- ServiceError       → mapped HTTP status + public_message
+- HTTPException 5xx   → scrubbed to a generic body (defense-in-depth net);
+                        4xx delegates to FastAPI's default handler
+- Exception (catch-all) → generic 500; full traceback logged server-side
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.exception_handlers import http_exception_handler
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from app.core.exceptions import ServiceError
+
+logger = logging.getLogger(__name__)
+
+
+async def _service_error_handler(request: Request, exc: ServiceError) -> JSONResponse:
+    logger.warning("ServiceError on %s %s: %s", request.method, request.url.path, exc)
+    return JSONResponse(status_code=exc.http_status, content={"detail": exc.public_message})
+
+
+async def _http_exception_handler(request: Request, exc: StarletteHTTPException):
+    # 5xx scrubber: a route that built HTTPException(500, detail=str(e)) would
+    # otherwise leak the raw message. Log it server-side, return a generic body.
+    # 4xx (often legitimately user-facing) falls through to the default handler.
+    if exc.status_code >= 500:
+        logger.error(
+            "HTTP %s on %s %s (detail scrubbed): %s",
+            exc.status_code, request.method, request.url.path, exc.detail,
+        )
+        return JSONResponse(status_code=exc.status_code, content={"detail": "Internal server error"})
+    return await http_exception_handler(request, exc)
+
+
+async def _bare_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
+    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    app.add_exception_handler(ServiceError, _service_error_handler)
+    app.add_exception_handler(StarletteHTTPException, _http_exception_handler)
+    app.add_exception_handler(Exception, _bare_exception_handler)

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -1,0 +1,50 @@
+"""Domain exceptions that map to safe HTTP responses.
+
+A ``ServiceError`` carries a client-safe ``public_message`` (never the raw
+exception text) and the HTTP status the global handler should emit. Raise these
+instead of ``HTTPException(500, detail=str(e))`` so internal details never reach
+API clients (OWASP Sensitive Data Exposure).
+"""
+from __future__ import annotations
+
+
+class ServiceError(Exception):
+    """Base domain error → mapped HTTP status + client-safe message."""
+
+    http_status: int = 500
+    public_message: str = "Internal server error"
+
+    def __init__(self, public_message: str | None = None) -> None:
+        if public_message is not None:
+            self.public_message = public_message
+        super().__init__(self.public_message)
+
+
+class NotFoundError(ServiceError):
+    http_status = 404
+    public_message = "Resource not found"
+
+
+class ForbiddenError(ServiceError):
+    http_status = 403
+    public_message = "Operation not permitted"
+
+
+class BadRequestError(ServiceError):
+    http_status = 400
+    public_message = "Invalid request"
+
+
+class ConflictError(ServiceError):
+    http_status = 409
+    public_message = "Conflict with current state"
+
+
+class UnprocessableError(ServiceError):
+    http_status = 422
+    public_message = "Invalid request"
+
+
+class ServiceUnavailableError(ServiceError):
+    http_status = 503
+    public_message = "Service temporarily unavailable"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -99,6 +99,12 @@ def create_app() -> FastAPI:
 
     app.add_exception_handler(RequestValidationError, _validation_exception_handler)  # type: ignore[arg-type]
 
+    # Global exception handlers: ServiceError → safe mapped response; HTTPException
+    # 5xx scrubber; catch-all → generic 500. Keeps internal error strings out of
+    # API responses (audit GAP-10 / B3).
+    from app.core.exception_handlers import register_exception_handlers
+    register_exception_handlers(app)
+
     # Security headers: CSP, X-Frame-Options, X-Content-Type-Options, HSTS
     app.add_middleware(SecurityHeadersMiddleware)
 

--- a/backend/tests/api/test_exception_handlers.py
+++ b/backend/tests/api/test_exception_handlers.py
@@ -33,12 +33,12 @@ def test_public_message_override_is_used():
 
 
 import pytest
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
-from app.main import app
+from app.core.exception_handlers import register_exception_handlers
 
-# Fault-injection routes registered once on the shared app (test-only, no auth).
+# Fault-injection routes mounted on a dedicated test app (test-only, no auth).
 _fault_router = APIRouter()
 
 
@@ -67,22 +67,20 @@ def _raise_http_400():
     raise HTTPException(status_code=400, detail="bad filename ../x")
 
 
-app.include_router(_fault_router)
-
-
 @pytest.fixture
 def raw_client():
-    # raise_server_exceptions=False so the catch-all 500 response is returned
-    # to the test instead of being re-raised by TestClient.
-    # app.debug=False: in debug mode Starlette's ServerErrorMiddleware bypasses
-    # custom Exception handlers and returns a traceback response instead.  The
-    # production app always runs with debug=False; we test that configuration here.
-    # The middleware stack is built lazily on the first request, so setting this
-    # before TestClient is created takes effect correctly.
-    app.debug = False
-    client = TestClient(app, raise_server_exceptions=False)
-    yield client
-    app.debug = True  # restore for other tests that may rely on dev defaults
+    # Dedicated app instance so the test does not depend on (or mutate) the
+    # global app's middleware stack — which is built lazily on the first request
+    # and cached, making any `app.debug` toggle order-dependent under xdist.
+    # A fresh FastAPI() defaults to debug=False, the production configuration in
+    # which Starlette's ServerErrorMiddleware actually routes to our custom
+    # Exception handler (in debug mode it returns a traceback instead).
+    # raise_server_exceptions=False so the catch-all 500 response is returned to
+    # the test instead of being re-raised by TestClient.
+    test_app = FastAPI()
+    register_exception_handlers(test_app)
+    test_app.include_router(_fault_router)
+    return TestClient(test_app, raise_server_exceptions=False)
 
 
 def test_service_error_maps_status_and_public_message(raw_client):

--- a/backend/tests/api/test_exception_handlers.py
+++ b/backend/tests/api/test_exception_handlers.py
@@ -30,3 +30,89 @@ def test_public_message_override_is_used():
     exc = ServiceUnavailableError("Device offline")
     assert exc.public_message == "Device offline"
     assert str(exc) == "Device offline"
+
+
+import pytest
+from fastapi import APIRouter, HTTPException
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+# Fault-injection routes registered once on the shared app (test-only, no auth).
+_fault_router = APIRouter()
+
+
+@_fault_router.get("/__test__/service-error")
+def _raise_service_error():
+    raise NotFoundError("widget 42 not found")
+
+
+@_fault_router.get("/__test__/service-unavailable")
+def _raise_unavailable():
+    raise ServiceUnavailableError("Device offline")
+
+
+@_fault_router.get("/__test__/bare")
+def _raise_bare():
+    raise RuntimeError("internal detail secret=hunter2")
+
+
+@_fault_router.get("/__test__/http-500")
+def _raise_http_500():
+    raise HTTPException(status_code=500, detail="raw db error secret=hunter2")
+
+
+@_fault_router.get("/__test__/http-400")
+def _raise_http_400():
+    raise HTTPException(status_code=400, detail="bad filename ../x")
+
+
+app.include_router(_fault_router)
+
+
+@pytest.fixture
+def raw_client():
+    # raise_server_exceptions=False so the catch-all 500 response is returned
+    # to the test instead of being re-raised by TestClient.
+    # app.debug=False: in debug mode Starlette's ServerErrorMiddleware bypasses
+    # custom Exception handlers and returns a traceback response instead.  The
+    # production app always runs with debug=False; we test that configuration here.
+    # The middleware stack is built lazily on the first request, so setting this
+    # before TestClient is created takes effect correctly.
+    app.debug = False
+    client = TestClient(app, raise_server_exceptions=False)
+    yield client
+    app.debug = True  # restore for other tests that may rely on dev defaults
+
+
+def test_service_error_maps_status_and_public_message(raw_client):
+    r = raw_client.get("/__test__/service-error")
+    assert r.status_code == 404
+    assert r.json()["detail"] == "widget 42 not found"
+
+
+def test_service_unavailable_maps_503(raw_client):
+    r = raw_client.get("/__test__/service-unavailable")
+    assert r.status_code == 503
+    assert r.json()["detail"] == "Device offline"
+
+
+def test_bare_exception_returns_generic_500_no_leak(raw_client):
+    r = raw_client.get("/__test__/bare")
+    assert r.status_code == 500
+    assert r.json()["detail"] == "Internal server error"
+    assert "hunter2" not in r.text
+    assert "secret" not in r.text
+
+
+def test_http_500_detail_is_scrubbed(raw_client):
+    r = raw_client.get("/__test__/http-500")
+    assert r.status_code == 500
+    assert r.json()["detail"] == "Internal server error"
+    assert "hunter2" not in r.text
+
+
+def test_http_400_detail_passes_through(raw_client):
+    r = raw_client.get("/__test__/http-400")
+    assert r.status_code == 400
+    assert r.json()["detail"] == "bad filename ../x"

--- a/backend/tests/api/test_exception_handlers.py
+++ b/backend/tests/api/test_exception_handlers.py
@@ -1,0 +1,32 @@
+"""Tests for the ServiceError hierarchy and global exception handlers."""
+from app.core.exceptions import (
+    ServiceError,
+    NotFoundError,
+    ForbiddenError,
+    BadRequestError,
+    ConflictError,
+    UnprocessableError,
+    ServiceUnavailableError,
+)
+
+
+def test_subclass_status_codes():
+    assert ServiceError().http_status == 500
+    assert NotFoundError().http_status == 404
+    assert ForbiddenError().http_status == 403
+    assert BadRequestError().http_status == 400
+    assert ConflictError().http_status == 409
+    assert UnprocessableError().http_status == 422
+    assert ServiceUnavailableError().http_status == 503
+
+
+def test_default_public_messages_are_generic():
+    assert ServiceError().public_message == "Internal server error"
+    assert NotFoundError().public_message == "Resource not found"
+    assert ForbiddenError().public_message == "Operation not permitted"
+
+
+def test_public_message_override_is_used():
+    exc = ServiceUnavailableError("Device offline")
+    assert exc.public_message == "Device offline"
+    assert str(exc) == "Device offline"

--- a/docs/superpowers/plans/2026-06-14-error-leakage-ap0-foundation.md
+++ b/docs/superpowers/plans/2026-06-14-error-leakage-ap0-foundation.md
@@ -1,0 +1,380 @@
+# Error-Leakage AP0 — Foundation + 5xx Net — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `ServiceError` exception hierarchy and global FastAPI exception handlers (ServiceError → mapped safe response, a 5xx `HTTPException` scrubber, and a catch-all → generic 500) so internal error strings never leak to API clients.
+
+**Architecture:** Two new modules under `backend/app/core/` plus three handler registrations in `main.py`. The 5xx scrubber centrally neutralises every `HTTPException(500, detail=str(e))` leak the moment this lands — including in route files not yet migrated — while `ServiceError` (its own handler) and 4xx responses are untouched. This is **AP0** of the error-leakage work (audit GAP-10 / backlog B3); per-file route migration (AP1..N) follows in separate plans.
+
+**Tech Stack:** FastAPI, Starlette exception handlers, pytest + Starlette `TestClient`.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-error-leakage-exception-handler-design.md`
+
+---
+
+## File Structure
+
+- Create `backend/app/core/exceptions.py` — `ServiceError` base + 6 subclasses (status + safe `public_message`). One responsibility: domain-error → safe-HTTP-shape data.
+- Create `backend/app/core/exception_handlers.py` — three handlers + `register_exception_handlers(app)`. One responsibility: turn exceptions into safe JSON responses + server-side logging.
+- Modify `backend/app/main.py` — call `register_exception_handlers(app)` in `create_app()`.
+- Create `backend/tests/api/test_exception_handlers.py` — class assertions + integration tests via fault-injection routes.
+
+---
+
+## Task 1: ServiceError hierarchy
+
+**Files:**
+- Create: `backend/app/core/exceptions.py`
+- Create (tests): `backend/tests/api/test_exception_handlers.py`
+
+- [ ] **Step 1: Write the failing class tests**
+
+Create `backend/tests/api/test_exception_handlers.py` with:
+
+```python
+"""Tests for the ServiceError hierarchy and global exception handlers."""
+from app.core.exceptions import (
+    ServiceError,
+    NotFoundError,
+    ForbiddenError,
+    BadRequestError,
+    ConflictError,
+    UnprocessableError,
+    ServiceUnavailableError,
+)
+
+
+def test_subclass_status_codes():
+    assert ServiceError().http_status == 500
+    assert NotFoundError().http_status == 404
+    assert ForbiddenError().http_status == 403
+    assert BadRequestError().http_status == 400
+    assert ConflictError().http_status == 409
+    assert UnprocessableError().http_status == 422
+    assert ServiceUnavailableError().http_status == 503
+
+
+def test_default_public_messages_are_generic():
+    assert ServiceError().public_message == "Internal server error"
+    assert NotFoundError().public_message == "Resource not found"
+    assert ForbiddenError().public_message == "Operation not permitted"
+
+
+def test_public_message_override_is_used():
+    exc = ServiceUnavailableError("Device offline")
+    assert exc.public_message == "Device offline"
+    assert str(exc) == "Device offline"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/api/test_exception_handlers.py -q -p no:warnings`
+Expected: collection/import error — `ModuleNotFoundError: No module named 'app.core.exceptions'`.
+
+- [ ] **Step 3: Create the exceptions module**
+
+Create `backend/app/core/exceptions.py`:
+
+```python
+"""Domain exceptions that map to safe HTTP responses.
+
+A ``ServiceError`` carries a client-safe ``public_message`` (never the raw
+exception text) and the HTTP status the global handler should emit. Raise these
+instead of ``HTTPException(500, detail=str(e))`` so internal details never reach
+API clients (OWASP Sensitive Data Exposure).
+"""
+from __future__ import annotations
+
+
+class ServiceError(Exception):
+    """Base domain error → mapped HTTP status + client-safe message."""
+
+    http_status: int = 500
+    public_message: str = "Internal server error"
+
+    def __init__(self, public_message: str | None = None) -> None:
+        if public_message is not None:
+            self.public_message = public_message
+        super().__init__(self.public_message)
+
+
+class NotFoundError(ServiceError):
+    http_status = 404
+    public_message = "Resource not found"
+
+
+class ForbiddenError(ServiceError):
+    http_status = 403
+    public_message = "Operation not permitted"
+
+
+class BadRequestError(ServiceError):
+    http_status = 400
+    public_message = "Invalid request"
+
+
+class ConflictError(ServiceError):
+    http_status = 409
+    public_message = "Conflict with current state"
+
+
+class UnprocessableError(ServiceError):
+    http_status = 422
+    public_message = "Invalid request"
+
+
+class ServiceUnavailableError(ServiceError):
+    http_status = 503
+    public_message = "Service temporarily unavailable"
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/api/test_exception_handlers.py -q -p no:warnings`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/core/exceptions.py backend/tests/api/test_exception_handlers.py
+git commit -m "feat(core): add ServiceError exception hierarchy (B3)"
+```
+
+---
+
+## Task 2: Global exception handlers + wiring
+
+**Files:**
+- Create: `backend/app/core/exception_handlers.py`
+- Modify: `backend/app/main.py` (after line 100, the `RequestValidationError` registration)
+- Modify (tests): `backend/tests/api/test_exception_handlers.py` (append integration tests)
+
+- [ ] **Step 1: Append the failing integration tests**
+
+Append to `backend/tests/api/test_exception_handlers.py`:
+
+```python
+import pytest
+from fastapi import APIRouter, HTTPException
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+# Fault-injection routes registered once on the shared app (test-only, no auth).
+_fault_router = APIRouter()
+
+
+@_fault_router.get("/__test__/service-error")
+def _raise_service_error():
+    raise NotFoundError("widget 42 not found")
+
+
+@_fault_router.get("/__test__/service-unavailable")
+def _raise_unavailable():
+    raise ServiceUnavailableError("Device offline")
+
+
+@_fault_router.get("/__test__/bare")
+def _raise_bare():
+    raise RuntimeError("internal detail secret=hunter2")
+
+
+@_fault_router.get("/__test__/http-500")
+def _raise_http_500():
+    raise HTTPException(status_code=500, detail="raw db error secret=hunter2")
+
+
+@_fault_router.get("/__test__/http-400")
+def _raise_http_400():
+    raise HTTPException(status_code=400, detail="bad filename ../x")
+
+
+app.include_router(_fault_router)
+
+
+@pytest.fixture
+def raw_client():
+    # raise_server_exceptions=False so the catch-all 500 response is returned
+    # to the test instead of being re-raised by TestClient.
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_service_error_maps_status_and_public_message(raw_client):
+    r = raw_client.get("/__test__/service-error")
+    assert r.status_code == 404
+    assert r.json()["detail"] == "widget 42 not found"
+
+
+def test_service_unavailable_maps_503(raw_client):
+    r = raw_client.get("/__test__/service-unavailable")
+    assert r.status_code == 503
+    assert r.json()["detail"] == "Device offline"
+
+
+def test_bare_exception_returns_generic_500_no_leak(raw_client):
+    r = raw_client.get("/__test__/bare")
+    assert r.status_code == 500
+    assert r.json()["detail"] == "Internal server error"
+    assert "hunter2" not in r.text
+    assert "secret" not in r.text
+
+
+def test_http_500_detail_is_scrubbed(raw_client):
+    r = raw_client.get("/__test__/http-500")
+    assert r.status_code == 500
+    assert r.json()["detail"] == "Internal server error"
+    assert "hunter2" not in r.text
+
+
+def test_http_400_detail_passes_through(raw_client):
+    r = raw_client.get("/__test__/http-400")
+    assert r.status_code == 400
+    assert r.json()["detail"] == "bad filename ../x"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd backend && python -m pytest tests/api/test_exception_handlers.py -q -p no:warnings`
+Expected: import error (`app.core.exception_handlers` missing) or, once that exists, the scrubber/catch-all assertions fail because handlers aren't registered yet. Either way: red.
+
+- [ ] **Step 3: Create the handlers module**
+
+Create `backend/app/core/exception_handlers.py`:
+
+```python
+"""Global exception handlers — keep internal error strings out of API responses.
+
+- ServiceError       → mapped HTTP status + public_message
+- HTTPException 5xx   → scrubbed to a generic body (defense-in-depth net);
+                        4xx delegates to FastAPI's default handler
+- Exception (catch-all) → generic 500; full traceback logged server-side
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.exception_handlers import http_exception_handler
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from app.core.exceptions import ServiceError
+
+logger = logging.getLogger(__name__)
+
+
+async def _service_error_handler(request: Request, exc: ServiceError) -> JSONResponse:
+    logger.warning("ServiceError on %s %s: %s", request.method, request.url.path, exc)
+    return JSONResponse(status_code=exc.http_status, content={"detail": exc.public_message})
+
+
+async def _http_exception_handler(request: Request, exc: StarletteHTTPException):
+    # 5xx scrubber: a route that built HTTPException(500, detail=str(e)) would
+    # otherwise leak the raw message. Log it server-side, return a generic body.
+    # 4xx (often legitimately user-facing) falls through to the default handler.
+    if exc.status_code >= 500:
+        logger.error(
+            "HTTP %s on %s %s (detail scrubbed): %s",
+            exc.status_code, request.method, request.url.path, exc.detail,
+        )
+        return JSONResponse(status_code=exc.status_code, content={"detail": "Internal server error"})
+    return await http_exception_handler(request, exc)
+
+
+async def _bare_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
+    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    app.add_exception_handler(ServiceError, _service_error_handler)
+    app.add_exception_handler(StarletteHTTPException, _http_exception_handler)
+    app.add_exception_handler(Exception, _bare_exception_handler)
+```
+
+- [ ] **Step 4: Wire it into `main.py`**
+
+In `backend/app/main.py`, immediately after the existing line 100:
+
+```python
+    app.add_exception_handler(RequestValidationError, _validation_exception_handler)  # type: ignore[arg-type]
+```
+
+insert:
+
+```python
+
+    # Global exception handlers: ServiceError → safe mapped response; HTTPException
+    # 5xx scrubber; catch-all → generic 500. Keeps internal error strings out of
+    # API responses (audit GAP-10 / B3).
+    from app.core.exception_handlers import register_exception_handlers
+    register_exception_handlers(app)
+```
+
+(The import is local to `create_app()` to avoid a circular import at module load.)
+
+- [ ] **Step 5: Run the exception-handler tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/api/test_exception_handlers.py -q -p no:warnings`
+Expected: 8 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/core/exception_handlers.py backend/app/main.py backend/tests/api/test_exception_handlers.py
+git commit -m "feat(core): global exception handlers + 5xx scrubber net (B3 / GAP-10)"
+```
+
+---
+
+## Task 3: Full-suite verification + 5xx assertion-drift fix
+
+The 5xx scrubber changes **every** 5xx response app-wide to `{"detail": "Internal server error"}`. Existing tests that asserted on a raw 5xx `detail` string will now fail. This task finds and fixes that drift. (4xx responses are unchanged, so 4xx-asserting tests are unaffected.)
+
+**Files:**
+- Modify (tests): whichever existing test files assert on raw 5xx `detail` strings (discovered by running the suite).
+
+- [ ] **Step 1: Run the full backend suite and collect failures**
+
+Run: `cd backend && python -m pytest -q -p no:warnings`
+Expected: the new exception-handler tests pass; some pre-existing tests may fail. The only **acceptable** failures here are assertion drifts where a test checked a 5xx response's `detail` text (e.g. `assert "Failed to ..." in r.json()["detail"]` or `assert r.json()["detail"] == "<raw message>"` on a 500/503). Note each failing test's file and line.
+
+- [ ] **Step 2: Fix each 5xx-detail assertion**
+
+For every failure that is a 5xx-detail drift, update the assertion to the new contract:
+- If the test asserted a substring/equality of the 5xx `detail`, change it to `assert r.json()["detail"] == "Internal server error"` (or assert only the status code if the message is irrelevant to the test's intent).
+- Do **not** change the asserted **status code** — only the detail text.
+- Do **not** "fix" a failure that is NOT a 5xx-detail drift (a genuine regression means a handler bug — stop and re-check Task 2).
+
+Example transformation:
+
+```python
+# before
+assert resp.status_code == 500
+assert "Failed to get fan status" in resp.json()["detail"]
+# after
+assert resp.status_code == 500
+assert resp.json()["detail"] == "Internal server error"
+```
+
+- [ ] **Step 3: Re-run the full suite**
+
+Run: `cd backend && python -m pytest -q -p no:warnings`
+Expected: all pass (0 failed). If a non-drift failure remains, it indicates a handler-interaction bug — investigate before proceeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests
+git commit -m "test: update 5xx detail assertions for scrubbed error responses (B3)"
+```
+
+---
+
+## Done criteria for AP0
+
+- `python -m pytest tests/api/test_exception_handlers.py -q` → 8 passed.
+- `python -m pytest -q` (full backend suite) → all pass.
+- Every 5xx response now returns `{"detail": "Internal server error"}` (verified by the scrubber test); 4xx detail unchanged; `ServiceError` maps to its `public_message`.
+
+After AP0 ships, the 5xx leak is closed centrally. AP1 (`fans.py`) and the remaining route files are migrated in follow-up plans to remove the dead `try/except` anti-pattern and convert user-actionable cases to `ServiceError`.

--- a/docs/superpowers/specs/2026-06-14-error-leakage-exception-handler-design.md
+++ b/docs/superpowers/specs/2026-06-14-error-leakage-exception-handler-design.md
@@ -91,6 +91,8 @@ client-safe string, never `str(e)`.
 import logging
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from fastapi.exception_handlers import http_exception_handler
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from app.core.exceptions import ServiceError
 
 logger = logging.getLogger(__name__)
@@ -106,12 +108,39 @@ async def _bare_exception_handler(request: Request, exc: Exception) -> JSONRespo
     return JSONResponse(status_code=500, content={"detail": "Internal server error"})
 
 
+async def _http_exception_handler(request: Request, exc: StarletteHTTPException):
+    # Defense-in-depth 5xx scrubber: a route that built `HTTPException(500,
+    # detail=str(e))` would otherwise leak the raw message. For any 5xx we log
+    # the original detail server-side and return a generic body. Sub-500 errors
+    # (4xx — often legitimately user-facing) fall through to FastAPI's default.
+    if exc.status_code >= 500:
+        logger.error(
+            "HTTP %s on %s %s (original detail scrubbed): %s",
+            exc.status_code, request.method, request.url.path, exc.detail,
+        )
+        return JSONResponse(status_code=exc.status_code, content={"detail": "Internal server error"})
+    return await http_exception_handler(request, exc)
+
+
 def register_exception_handlers(app: FastAPI) -> None:
     app.add_exception_handler(ServiceError, _service_error_handler)
-    # Catch-all for genuinely unhandled exceptions. FastAPI's HTTPException is
-    # processed by the framework's own handler and never reaches here.
+    # 5xx scrubber for explicitly-built HTTPExceptions (overrides FastAPI's
+    # default HTTPException handler; delegates 4xx back to it).
+    app.add_exception_handler(StarletteHTTPException, _http_exception_handler)
+    # Catch-all for genuinely unhandled (non-HTTP) exceptions.
     app.add_exception_handler(Exception, _bare_exception_handler)
 ```
+
+**Why the scrubber AND the migration (defense-in-depth + cleanup).** The scrubber
+is the immediate net: it closes every 5xx leak the moment the foundation lands —
+including in route files not yet migrated — so the long migration doesn't leave
+leaks open meanwhile. It does **not** touch `ServiceError` responses (those use a
+separate handler, never raised as `HTTPException`), so curated 503/5xx
+`public_message`s survive. It also does **not** scrub 4xx, where `detail=str(e)`
+can still leak — those are fixed by the per-site migration. The migration then
+removes the dead `try/except` anti-pattern and converts user-actionable cases to
+`ServiceError`. Net effect: leaks closed centrally now, code cleaned thoroughly
+after.
 
 ### 3. `backend/app/main.py` — Wiring
 
@@ -147,8 +176,12 @@ For each `try: <body> except Exception as e: [log] raise HTTPException(500, …s
 ### 5. Tests
 
 - New `backend/tests/api/test_exception_handlers.py`: fault-injection routes assert
-  `ServiceError` → mapped status + `public_message`; a bare `RuntimeError("…secret…")`
-  → 500 with `{"detail": "Internal server error"}` and **no** leaked substring.
+  - `ServiceError` → mapped status + `public_message`;
+  - a bare `RuntimeError("…secret…")` → 500 with `{"detail": "Internal server error"}`
+    and **no** leaked substring;
+  - an explicit `HTTPException(500, detail="…secret…")` → scrubbed to generic 500
+    (proves the net), while `HTTPException(400, detail="bad filename")` passes through
+    unchanged (proves 4xx is untouched).
 - **Assertion-drift remediation:** existing error-path tests that assert on the old
   raw `detail` string must be updated to expect the generic 500 / curated message.
   The plan migrates **file by file** (route file → its tests → suite green) so drift
@@ -173,10 +206,26 @@ For each `try: <body> except Exception as e: [log] raise HTTPException(500, …s
   foundation (exceptions + handlers + tests) lands first and is independently
   correct, then each route file is migrated as its own commit.
 
-## Plan sequencing (preview, detailed in the plan)
+## Arbeitspakete
 
-1. `core/exceptions.py` + tests.
-2. `core/exception_handlers.py` + `main.py` wiring + `test_exception_handlers.py`.
-3. Migrate route files one per commit, descending by leak count (`fans.py` first),
-   updating each file's tests, suite green after each.
-4. Full suite + PR.
+The work splits into independently-shippable packages. **AP0 is the security
+deliverable** (foundation + 5xx net — closes the leak immediately); AP1+ are the
+thorough cleanup, each a small, reviewable unit.
+
+- **AP0 — Fundament + Netz** *(its own PR; high value, low risk)*
+  - `core/exceptions.py` (ServiceError hierarchy)
+  - `core/exception_handlers.py` (ServiceError handler + 5xx scrubber + bare catch-all)
+  - `main.py` wiring
+  - `tests/api/test_exception_handlers.py`
+  - After AP0, every 5xx leak is centrally neutralised even before migration.
+- **AP1..N — Route-Migration** *(batched by file, descending by leak count)*
+  - AP1: `fans.py` (22) · AP2: `cloud.py` (8) · AP3: `vpn.py` (6) ·
+    AP4: `plugins_marketplace.py` (6) · AP5: `benchmark.py` (4) · then the
+    remaining ~23 files (1–3 each), grouped into a few packages.
+  - Each package: drop leaky `try/except` (per the decision tree), convert
+    user-actionable cases to `ServiceError`, update that file's tests, suite green.
+  - Can ship as one PR per package or a few packages per PR — decided in the plan.
+- **AP-final — Full suite + PR(s).**
+
+Out-of-scope follow-up issue: `optical_drive` plugin (22) + `plugin_marketplace.py`
+service site (1).

--- a/docs/superpowers/specs/2026-06-14-error-leakage-exception-handler-design.md
+++ b/docs/superpowers/specs/2026-06-14-error-leakage-exception-handler-design.md
@@ -1,0 +1,182 @@
+# Globaler Exception-Handler + Error-Leakage-Elimination — Design
+
+- **Datum:** 2026-06-14
+- **Audit-Befund:** GAP-10 (Error-Leakage / kein globaler Exception-Handler),
+  Security-Audit 2026-06-14. Knüpft an Backlog-Item **B3**
+  (`docs/superpowers/plans/2026-05-08-backend-refactor-backlog.md`, Tasks 6.1–6.4).
+- **Status:** Design genehmigt.
+
+## Problem
+
+Zwei verbundene Schwächen:
+
+1. **Kein globales Sicherheitsnetz.** Eine wirklich *unhandled* Exception wird
+   zwar von FastAPI/Starlette (bei `debug=False`) generisch zu 500 ohne Body, aber
+   ohne konsistente, strukturierte JSON-Antwort und ohne garantiertes Logging.
+2. **Explizite Leakage.** **109** Stellen bauen `HTTPException(500, detail=str(e))`
+   bzw. `detail=f"…{e}"` — sie fangen die Exception ab und leaken die interne
+   Fehlermeldung an den Client (OWASP *Sensitive Data Exposure*). Davon **86 in 28
+   Dateien unter `backend/app/api/routes/`** (verifiziert per Inventur 2026-06-14;
+   `fans.py` 22, `cloud.py` 8, `plugins_marketplace.py` 6, `vpn.py` 6, `benchmark.py`
+   4, …). Diese umgehen jedes globale Sicherheitsnetz, weil sie ihre eigene Response
+   bauen — sie müssen pro Stelle angefasst werden.
+
+## Scope
+
+- **In Scope:** Fundament (ServiceError-Hierarchie + globale Handler + main.py +
+  Tests) **und** Migration **aller 86** expliziten `detail=str(e)`-Leak-Stellen in
+  `backend/app/api/routes/`.
+- **Out of Scope (Folge-Issue):** `app/plugins/installed/optical_drive/__init__.py`
+  (22 Stellen, Plugin-Code) und `app/services/plugin_marketplace.py` (1 Stelle).
+- **Bewusst NICHT angefasst:** die ~811 `except Exception`-Blöcke pauschal — nur
+  jene, die `detail=str(e)` an Clients leaken.
+
+## Design
+
+### 1. `backend/app/core/exceptions.py` — ServiceError-Hierarchie
+
+```python
+class ServiceError(Exception):
+    """Base for domain errors that map to a safe HTTP response.
+
+    Carries a client-safe ``public_message`` (never the raw exception text)
+    and the HTTP status the global handler should emit.
+    """
+    http_status: int = 500
+    public_message: str = "Internal server error"
+
+    def __init__(self, public_message: str | None = None):
+        if public_message is not None:
+            self.public_message = public_message
+        super().__init__(self.public_message)
+
+
+class NotFoundError(ServiceError):
+    http_status = 404
+    public_message = "Resource not found"
+
+
+class ForbiddenError(ServiceError):
+    http_status = 403
+    public_message = "Operation not permitted"
+
+
+class BadRequestError(ServiceError):
+    http_status = 400
+    public_message = "Invalid request"
+
+
+class ConflictError(ServiceError):
+    http_status = 409
+    public_message = "Conflict with current state"
+
+
+class UnprocessableError(ServiceError):
+    http_status = 422
+    public_message = "Invalid request"
+
+
+class ServiceUnavailableError(ServiceError):
+    http_status = 503
+    public_message = "Service temporarily unavailable"
+```
+
+The caller may override `public_message` per raise (e.g.
+`raise ServiceUnavailableError("Device offline")`) — but it must remain a curated,
+client-safe string, never `str(e)`.
+
+### 2. `backend/app/core/exception_handlers.py` — Handler
+
+```python
+import logging
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from app.core.exceptions import ServiceError
+
+logger = logging.getLogger(__name__)
+
+
+async def _service_error_handler(request: Request, exc: ServiceError) -> JSONResponse:
+    logger.warning("ServiceError on %s %s: %s", request.method, request.url.path, exc)
+    return JSONResponse(status_code=exc.http_status, content={"detail": exc.public_message})
+
+
+async def _bare_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
+    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    app.add_exception_handler(ServiceError, _service_error_handler)
+    # Catch-all for genuinely unhandled exceptions. FastAPI's HTTPException is
+    # processed by the framework's own handler and never reaches here.
+    app.add_exception_handler(Exception, _bare_exception_handler)
+```
+
+### 3. `backend/app/main.py` — Wiring
+
+After the existing `RateLimitExceeded` / `RequestValidationError` handlers are
+registered in `create_app()`, add:
+
+```python
+from app.core.exception_handlers import register_exception_handlers
+register_exception_handlers(app)
+```
+
+More specific handlers (`RateLimitExceeded`, `RequestValidationError`,
+`HTTPException`) take precedence over the `Exception` catch-all — no conflict.
+
+### 4. Migration of the 86 route leak sites (decision tree per site)
+
+For each `try: <body> except Exception as e: [log] raise HTTPException(500, …str(e)…)`:
+
+- **Generic 500-leak (the common case)** → **delete the whole `try/except`**. The
+  exception propagates to `_bare_exception_handler` → generic 500 + full trace
+  logged. This is usually a net simplification.
+- **`except HTTPException: raise` present** → preserved (or, after deleting the
+  wrapper, HTTPExceptions raised inside propagate correctly anyway).
+- **A specific exception type mapped to a meaningful status** (e.g.
+  `except FanNotFoundError: raise HTTPException(404, …)`) → **keep** the targeted
+  handler (optionally convert to the matching `ServiceError` subclass).
+- **User-actionable condition** (e.g. "device offline", "no space") → convert to a
+  `ServiceError` subclass with a curated `public_message` — **never** `str(e)`. This
+  is the part that needs per-site judgment so the frontend keeps a useful toast.
+- Redundant per-route `logger.error(...; exc_info=True)` that only duplicates the
+  global handler's logging may be dropped; context-rich logging is kept.
+
+### 5. Tests
+
+- New `backend/tests/api/test_exception_handlers.py`: fault-injection routes assert
+  `ServiceError` → mapped status + `public_message`; a bare `RuntimeError("…secret…")`
+  → 500 with `{"detail": "Internal server error"}` and **no** leaked substring.
+- **Assertion-drift remediation:** existing error-path tests that assert on the old
+  raw `detail` string must be updated to expect the generic 500 / curated message.
+  The plan migrates **file by file** (route file → its tests → suite green) so drift
+  is caught incrementally and each step stays reviewable.
+
+## Behaviour change (intentional)
+
+- Unexpected 500s now return generic `{"detail": "Internal server error"}` instead
+  of the raw exception text. Correct for genuine internal errors.
+- Genuinely user-actionable failures are preserved via `ServiceError` subclasses
+  with curated messages, so the web UI keeps meaningful feedback. Identifying these
+  is the core judgement of the migration.
+- Full tracebacks remain in the server logs (`logger.exception`).
+
+## Risks
+
+- **Test-drift** across many suites is the main risk — mitigated by the file-by-file
+  migration with a suite run after each file.
+- **Over-deletion**: dropping a `try/except` that also performed cleanup or mapped a
+  specific status. Mitigated by the decision tree (keep targeted handlers) and tests.
+- **Large change set** (28 files) — one spec, but the plan sequences it so the
+  foundation (exceptions + handlers + tests) lands first and is independently
+  correct, then each route file is migrated as its own commit.
+
+## Plan sequencing (preview, detailed in the plan)
+
+1. `core/exceptions.py` + tests.
+2. `core/exception_handlers.py` + `main.py` wiring + `test_exception_handlers.py`.
+3. Migrate route files one per commit, descending by leak count (`fans.py` first),
+   updating each file's tests, suite green after each.
+4. Full suite + PR.


### PR DESCRIPTION
Lands **AP0** (foundation) of the error-leakage / global-exception-handler work
from the 2026-06-14 security audit (finding B3 / GAP-10). Branch rebased onto
current `main` (was 14 commits behind); rebase was conflict-free.

## Problem

Numerous routes do `except Exception as e: raise HTTPException(500, detail=str(e))`,
leaking internal error strings (paths, stack context, library messages) to API
clients — OWASP Sensitive Data Exposure. There was no global safety net.

## What this adds (foundation + 5xx net)

- **`core/exceptions.py`** — a `ServiceError` hierarchy (`NotFoundError`,
  `ForbiddenError`, `BadRequestError`, `ConflictError`, `UnprocessableError`,
  `ServiceUnavailableError`). Each carries a client-safe `public_message` and a
  mapped HTTP status. Services raise these instead of hand-built
  `HTTPException(500, detail=str(e))`.
- **`core/exception_handlers.py`** — three handlers registered on the app:
  - `ServiceError` → mapped status + `public_message`
  - `HTTPException` **5xx scrubber** → logs the real detail server-side, returns
    a generic `{"detail": "Internal server error"}`; **4xx delegates** to
    FastAPI's default handler (legit user-facing messages preserved)
  - catch-all `Exception` → generic 500, full traceback logged server-side
- **`main.py`** — `register_exception_handlers(app)` wired in after the existing
  `RequestValidationError` handler.

This is the **net**: it stops leaks defensively even before individual routes
are migrated. The per-route migrations are tracked as follow-ups (AP1 `fans.py`,
AP2 `cloud.py`, AP3 `vpn.py`, AP4 `plugins_marketplace.py`, AP5 `benchmark.py`,
AP6 the long tail) — not in this PR.

Spec + plan included under `docs/superpowers/`.

## Behavior-change risk assessed

The 5xx scrubber rewrites the body of `HTTPException(5xx)` responses on the real
app. I scanned the whole test suite for `status_code == 5xx` assertions paired
with a `detail`-text check (8 hits): all are either service-level
`pytest.raises` (assert the exception object directly, not the HTTP response) or
use a test-local `_make_app()` that does not register the global handlers — none
regress. The catch-all `Exception` handler does not change `TestClient`'s
default re-raise behavior. 4xx bodies are untouched.

## Verification

- `tests/api/test_exception_handlers.py` — 8 passed
- Suspect files re-run green: `test_sync_guard.py`, `test_plugin_gate.py`,
  `test_plugin_marketplace_service.py`, `test_pihole.py` — 143 passed
- ruff clean on all changed files
- Full backend suite runs in CI (the Windows local run hangs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
