### PR TITLE
refactor(core): scrub error leaks in cloud.py routes (B3 / AP2)

### DIFF
--- a/backend/app/api/routes/cloud.py
+++ b/backend/app/api/routes/cloud.py
@@ -243,7 +243,7 @@ async def oauth_callback_redirect(
         )
     except Exception as e:
         logger.error("OAuth callback failed: %s", e)
-        return RedirectResponse(url=f"/cloud-import?oauth_error={quote(str(e))}")
+        return RedirectResponse(url=f"/cloud-import?oauth_error={quote('Authentication failed')}")
 
     return RedirectResponse(url="/cloud-import?oauth=success")
 
@@ -277,7 +277,7 @@ async def oauth_callback(
         )
     except Exception as e:
         logger.error("OAuth callback failed: %s", e)
-        raise HTTPException(status_code=400, detail=f"OAuth failed: {e}")
+        raise HTTPException(status_code=400, detail="OAuth authentication failed")
 
     return CloudConnectionResponse.model_validate(conn)
 
@@ -294,12 +294,9 @@ async def connect_icloud(
 ):
     """Connect an iCloud account with Apple ID credentials."""
     service = CloudService(db)
-    try:
-        conn, requires_2fa = service.connect_icloud(
-            current_user.id, body.apple_id, body.password
-        )
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+    conn, requires_2fa = service.connect_icloud(
+        current_user.id, body.apple_id, body.password
+    )
 
     return {
         "connection": CloudConnectionResponse.model_validate(conn),
@@ -366,9 +363,6 @@ async def browse_files(
         files = await service.list_files(connection_id, current_user.id, path)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        logger.error("Failed to browse cloud files: %s", e)
-        raise HTTPException(status_code=500, detail=f"Failed to list files: {e}")
 
     return [
         CloudFileResponse(


### PR DESCRIPTION
## AP2 — Error-Leakage Migration: `cloud.py`

Posten 2 (Error-Leakage / globaler Exception-Handler) aus dem Security-Audit 2026-06-14, Backlog-Item **B3 / GAP-10**. Folgt auf AP0 (#253, gemergt) und AP1 (#254, `fans.py`).

### Was — `cloud.py` ist heterogener als `fans.py`

Hier gibt es **zwei** Kategorien, nicht nur den breiten `except Exception → 500`-Antipattern. Pro Stelle bewertet (decision tree der Spec):

#### Behoben — 4 echte Leaks durch breites `except Exception`

| Stelle | Problem | Fix |
|---|---|---|
| `browse_files` | `except Exception → 500 f"…{e}"` (rclone/Adapter/Crypto-Interna) | `except Exception`-Block gelöscht → propagiert zum globalen 500-Handler. `except ValueError → 404` bleibt. |
| `oauth_callback` (POST) | `except Exception → 400 f"OAuth failed: {e}"` — Service wirft `RuntimeError(f"…{resp.text}")` → **roher Provider-Token-Endpoint-Body** würde an den Client leaken | Kuratiert: `detail="OAuth authentication failed"`. Fehler weiterhin server-seitig geloggt. |
| `oauth_callback_redirect` (GET) | `quote(str(e))` landet in der **Redirect-URL** (browser-/nginx-log-sichtbar) — derselbe Provider-Response-Leak | Kuratierter `oauth_error`-Token statt `str(e)`. |
| `connect_icloud` | `except Exception → 400 str(e)` — breit; Credentials werden nicht synchron validiert, Exceptions sind real intern (DB/Crypto) | try/except gelöscht → propagiert zu generischem **500** (semantisch korrekt; 400 war mislabelled + leaky). |

#### Unangetastet — 5 gezielte `except ValueError → 4xx str(e)`

`delete_connection` (404) · `start_oauth` (400) · `icloud_2fa` (404) · `browse_files` (404) · `start_import` (400)

Der Service wirft seine `ValueError` mit **kuratierten, client-sicheren** Messages (`f"Connection {id} not found"`, `f"OAuth not configured for {provider}"`, `"Connection is not iCloud"`, …). Das sind die „targeted handler" aus dem Decision-Tree (spezifischer Exception-Typ → sinnvoller Status) — kein Leak, daher bewusst belassen.

### Verhaltensänderung (1)

`connect_icloud` bei internem Fehler: **400 → 500**. Semantisch korrekt (interner Fehler, keine User-Schuld), kein Test hing am 400.

### Verifikation

- Cloud-Suite: `test_cloud_oauth_admin`, `test_cloud_export_routes`, `test_cloud_oauth_redirect`, `test_cloud_dev_adapter`, `test_cloud_export_service`, `test_cloud_scheduler` → **63 passed**
- `ruff check app/api/routes/cloud.py` → clean
- Kein Assertion-Drift (keine Tests asserten auf die gescrubbten Detail-Strings).

### Scope

Nur `cloud.py`. AP3 (`vpn.py`) folgt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
