### PR TITLE
refactor(core): scrub error leaks in vpn.py routes (B3 / AP3)

### DIFF
--- a/backend/app/api/routes/vpn.py
+++ b/backend/app/api/routes/vpn.py
@@ -121,7 +121,7 @@ async def fetch_config_by_type(
             )
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=str(e),
+                detail="Failed to generate VPN configuration",
             )
 
         audit_logger.log_vpn_operation(
@@ -190,7 +190,7 @@ async def generate_vpn_config(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="Failed to generate VPN configuration"
         )
 
 
@@ -520,7 +520,7 @@ async def regenerate_client_config(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to regenerate VPN configuration",
         )
 
 
@@ -616,15 +616,10 @@ async def upload_fritzbox_config(
             public_endpoint=config_data.public_endpoint
         )
         return config
-    except ValueError as e:
+    except ValueError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid config format: {str(e)}"
-        )
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to upload config: {str(e)}"
+            detail="Invalid Fritz!Box config format"
         )
 
 
@@ -693,10 +688,10 @@ async def get_fritzbox_qr_code(
     try:
         config_base64 = VPNService.get_fritzbox_config_base64(db)
         return {"config_base64": config_base64}
-    except ValueError as e:
+    except ValueError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=str(e)
+            detail="No active Fritz!Box VPN config available"
         )
     except Exception as e:
         logger.error("Failed to generate Fritz!Box QR data: %s", e)


### PR DESCRIPTION
## AP3 — Error-Leakage Migration: `vpn.py`

Posten 2 (Error-Leakage / globaler Exception-Handler) aus dem Security-Audit 2026-06-14, Backlog-Item **B3 / GAP-10**. Folgt auf AP0 (#253), AP1 (#254, `fans.py`), AP2 (#255, `cloud.py`).

### Was — kuratierte Detail-Messages, Audit-Logging bleibt

6 client-facing Stellen, bei denen roher Exception-Text an den Client ging (OWASP *Sensitive Data Exposure*). Anders als bei `fans.py` machen die `except`-Blöcke hier teils **Audit-Logging** (context-rich → behalten); nur die client-facing `detail` wird generalisiert. **Keine Statuscode-Änderungen.**

| Stelle | Vorher | Fix |
|---|---|---|
| `fetch_config_by_type` | `RuntimeError→500 str(e)` | `detail="Failed to generate VPN configuration"`, Audit-Log bleibt |
| `generate_vpn_config` | `RuntimeError→500 str(e)` | dito |
| `regenerate_client_config` | `(ValueError,RuntimeError)→500 str(e)` | `detail="Failed to regenerate VPN configuration"`, Audit-Log bleibt |
| `upload_fritzbox_config` (ValueError) | `400 f"Invalid config format: {str(e)}"` | `detail="Invalid Fritz!Box config format"` |
| `upload_fritzbox_config` (Exception) | `500 f"Failed to upload config: {str(e)}"` | breites `except Exception` gelöscht → globaler generischer 500 |
| `get_fritzbox_qr_code` (ValueError) | `404 str(e)` | auf festen Literal angeglichen (str(e)-Fläche ganz weg) |

### Hervorzuheben: partieller PrivateKey-Leak

`upload_fritzbox_config`s `ValueError→400` surfacte `str(e)`, und der Parser (`fritzbox.py:parse_fritzbox_config`) baut einen **Debug-Dump** in die Fehlermeldung, der u. a. die **ersten 20 Zeichen des WireGuard-PrivateKey** (`{value[:20]}...`) enthält. Dieser landete damit im 400-Response-Body. Mit der Kuratierung ist das geschlossen.

> Hinweis (Nebenbefund, separat): dass `parse_fritzbox_config` überhaupt partielles Key-Material in seine Exception-Message schreibt, ist die tiefere Ursache (Service-Layer). Der Route-Fix schließt den HTTP-Leak; eine Bereinigung des Debug-Dumps im Service wäre Folgearbeit.

### Verifikation

- VPN-Suite: `test_vpn_key_encryption`, `test_vpn_local_channel_gate`, `test_mobile_token_vpn_flow` → **15 passed**
- `ruff check app/api/routes/vpn.py` → clean
- Kein Assertion-Drift (Tests treffen nur Happy-Paths/Gate, nicht die Detail-Strings).

### Scope

Nur `vpn.py`. AP4 (`plugins_marketplace.py`) folgt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
