### PR TITLE
refactor(core): scrub exception text from marketplace route details (B3 / AP4) + os_sleep_inspector CI test fix

### DIFF
--- a/backend/app/api/routes/plugins_marketplace.py
+++ b/backend/app/api/routes/plugins_marketplace.py
@@ -102,14 +102,16 @@ async def list_marketplace(
             service.invalidate_cache()
         return _serialize_index(service)
     except IndexFetchError as exc:
+        logger.warning("failed to fetch marketplace index: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"failed to fetch marketplace index: {exc}",
+            detail="failed to fetch marketplace index",
         ) from exc
     except IndexParseError as exc:
+        logger.warning("malformed marketplace index: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"malformed marketplace index: {exc}",
+            detail="malformed marketplace index",
         ) from exc
 
 
@@ -143,29 +145,34 @@ async def install_plugin(
         )
     except PluginNotFoundError as exc:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"plugin {plugin_name!r} not found in marketplace",
         ) from exc
     except ResolverConflictError as exc:
         raise _conflicts_to_http(exc) from exc
     except ChecksumError as exc:
+        logger.warning("marketplace checksum mismatch for %r: %s", plugin_name, exc)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"checksum mismatch: {exc}",
+            detail="checksum mismatch",
         ) from exc
     except (DownloadError, IndexFetchError) as exc:
+        logger.warning("marketplace download failed for %r: %s", plugin_name, exc)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"download failed: {exc}",
+            detail="download failed",
         ) from exc
     except (ArchiveError, ManifestMismatchError, IndexParseError) as exc:
+        logger.warning("invalid plugin artifact for %r: %s", plugin_name, exc)
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"invalid plugin artifact: {exc}",
+            detail="invalid plugin artifact",
         ) from exc
     except PipInstallError as exc:
+        logger.error("pip install failed for %r: %s", plugin_name, exc)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"pip install failed: {exc}",
+            detail="pip install failed",
         ) from exc
 
     logger.info(

--- a/backend/tests/services/power/test_os_sleep_inspector_integration.py
+++ b/backend/tests/services/power/test_os_sleep_inspector_integration.py
@@ -29,6 +29,16 @@ def linux_fs(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(ins, "_SLEEP_DROPIN_DIRS", (systemd / "sleep.conf.d",))
     monkeypatch.setattr(ins, "_LID_SENSOR", tmp_path / "no-lid")
     monkeypatch.setattr(ins.sys, "platform", "linux")
+    # inspect_os_sleep() also probes the KDE/GNOME auto-suspend backend, which
+    # shells out via `pgrep` (subprocess.run). Since these tests patch the
+    # shared subprocess.run and assert on its call count, that probe would leak
+    # an extra, order-dependent call (its 30s detection cache is not reset
+    # between tests). Neutralise it so the count reflects only the systemctl
+    # query under test.
+    monkeypatch.setattr(
+        "app.services.power.os_auto_suspend.detect_active_backend",
+        lambda: None,
+    )
     return systemd
 
 


### PR DESCRIPTION
## AP4 — Error-Leakage Migration: `plugins_marketplace.py`

Posten 2 (Error-Leakage / globaler Exception-Handler), Security-Audit 2026-06-14, **B3 / GAP-10**. Folgt auf AP0 (#253), AP1 (#254, merged), AP2 (#255), AP3 (#256).

### Was — kuratierte Kategorie statt rohem `{exc}`, voller Fehler ins Log

Alle 7 client-facing Stellen waren bereits **gezielte Domänen-Exceptions** auf bewusste Statuscodes gemappt (der „targeted handler"-Fall) — sie leakten nur über das `: {exc}` / `str(exc)`-Suffix. Diese Mappings (404/409/422/500/502) bleiben **unverändert**; nur die Message-Fläche wird geschlossen:

| Exception | Status | Vorher → Nachher |
|---|---|---|
| `IndexFetchError` | 502 | `f"failed to fetch marketplace index: {exc}"` → `"failed to fetch marketplace index"` + log |
| `IndexParseError` (list) | 502 | `f"malformed marketplace index: {exc}"` → `"malformed marketplace index"` + log |
| `PluginNotFoundError` | 404 | `str(exc)` → `f"plugin {plugin_name!r} not found in marketplace"` (name = caller-input, kein exc) |
| `ChecksumError` | 502 | `f"checksum mismatch: {exc}"` → `"checksum mismatch"` + log |
| `DownloadError`/`IndexFetchError` | 502 | `f"download failed: {exc}"` → `"download failed"` + log |
| `ArchiveError`/`ManifestMismatchError`/`IndexParseError` | 422 | `f"invalid plugin artifact: {exc}"` → `"invalid plugin artifact"` + log |
| `PipInstallError` | 500 | `f"pip install failed: {exc}"` → `"pip install failed"` + log |

Der volle `{exc}` (inkl. z.B. pip-stderr bei `PipInstallError`) geht per `logger.warning`/`logger.error` server-seitig ins Log → Admin-Diagnostik bleibt erhalten, ohne dass roher Exception-Text die Response erreicht. `ResolverConflictError` baut weiterhin die strukturierte 409-Antwort (kein Leak).

### Verifikation

- `ruff check app/api/routes/plugins_marketplace.py` → clean; Import OK.
- Marketplace-Service-Suite (`test_plugin_marketplace_service.py`, 16 Tests) → grün.
- Route-Tests: alle Auth-/List-/403-/401-Tests grün. **Keine Statuscode-Änderung; kein Assertion-Drift** (Tests asserten nur Status, nie die Detail-Strings).

> **Hinweis:** 4 Install/Uninstall-Route-Tests (`test_install_happy_path`, `_unknown_plugin_returns_404`, `_specific_version`, `test_uninstall_happy_path`) failen **lokal nur unter Windows** (422 aus dem Installer-Archiv-Handling) — **identisch auf cleanem `main`**, also pre-existing und unabhängig von diesem PR; in CI (Linux) grün.

### Zusätzlich: CI-Test-Fix (unrelated, auf Maintainer-Wunsch hier gebündelt)

Nach dem #256-Merge ging der `Deploy Production`-Lauf auf `main` rot — **1 failed, 3459 passed** — durch `tests/services/power/test_os_sleep_inspector_integration.py::test_cache_hit_skips_subprocess`. Das ist **unabhängig** von dieser Migration; der Fix wird auf Wunsch hier mitgenommen statt als separater PR.

**Root Cause (Test-Isolations-Bug, kein Prod-Bug):** Diese Tests patchen das *globale* `subprocess.run` und asserten auf `call_count`. `inspect_os_sleep()` probt aber zusätzlich den Auto-Suspend-Backend via `os_auto_suspend.detect_active_backend()` → `pgrep` (`subprocess.run`). Die `linux_fs`-Fixture setzt `sys.platform` prozessweit auf "linux", also läuft der Probe-Zweig immer; sein 30s-Detection-Cache wird zwischen Tests **nicht** geleert. Kalt (isoliert / nach TTL-Ablauf mitten in der 131s-Suite) zählt der pgrep-Call mit → `2 statt 1` → rot. Warm (file-lokale Reihenfolge) → grün. Daher order-/cache-abhängig.

**Fix:** `detect_active_backend` in der `linux_fs`-Fixture neutralisiert (→ `None`). Verifiziert: isoliert ✅, ganze Datei 7/7 ✅, ganzer Power-Ordner **167/167** ✅. Prod-Code unverändert.

### Scope

Nur `plugins_marketplace.py` (+ der oben genannte CI-Test-Fix). AP5 (`benchmark.py`) folgt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

