### PR TITLE
refactor(core): drop detail=str(e) leak wrappers in benchmark.py (B3 / AP5)

### DIFF
--- a/backend/app/api/routes/benchmark.py
+++ b/backend/app/api/routes/benchmark.py
@@ -132,11 +132,6 @@ async def start_benchmark(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to start benchmark: {str(e)}",
-        )
 
 
 @router.post("/prepare", response_model=BenchmarkPrepareResponse)
@@ -232,11 +227,6 @@ async def start_confirmed_benchmark(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
-        )
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to start benchmark: {str(e)}",
         )
 
 


### PR DESCRIPTION
## AP5 — Error-Leakage Migration: `benchmark.py`

Posten 2 (Error-Leakage / globaler Exception-Handler), Security-Audit 2026-06-14, **B3 / GAP-10**. Folgt auf AP0 (#253), AP1 (#254), AP2 (#255), AP3 (#256), AP4 (#257).

### Was

Entfernt die 2 breiten `except Exception → HTTPException(500, detail=f"Failed to start benchmark: {str(e)}")`-Wrapper in `start_benchmark` und `start_confirmed_benchmark`. Unerwartete Fehler propagieren jetzt zum globalen `_bare_exception_handler` (generischer 500, voller Traceback im Server-Log).

Die gezielten `except ValueError → 400 str(e)`-Handler **bleiben** — der Benchmark-Service wirft `ValueError` nur mit kuratierten, client-sicheren Messages:
- `f"Disk '{disk_name}' not found"`
- `f"Disk '{disk_name}' cannot be benchmarked: {disk_info.warning}"`
- `"No job results in fio output"`

Gleiche Aufteilung wie `cloud.py` (AP2): targeted `ValueError`-Handler behalten, breites `except Exception` weg.

### Verifikation

- `ruff check app/api/routes/benchmark.py` → clean; Import OK.
- **Keine Statuscode-Änderung.**
- `benchmark.py` hat **keine Test-Abdeckung** (kein Test referenziert die Routen/den Service) → kein Assertion-Drift. *(Test-Lücke ist pre-existing und out-of-scope für diese Migration.)*

### Scope

Nur `benchmark.py`. AP6 (restliche ~23 Route-Dateien mit je 1–3 Stellen, gebündelt) ist der letzte Schritt von Posten 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
