### PR TITLE
refactor(core): error-leakage migration — remaining route files (B3 / AP6, Posten 2 final)

### DIFF
--- a/backend/app/api/routes/ad_discovery.py
+++ b/backend/app/api/routes/ad_discovery.py
@@ -1,5 +1,6 @@
 """API routes for Ad Discovery feature."""
 
+import logging
 import re
 from typing import Optional
 
@@ -20,6 +21,8 @@ from app.schemas.ad_discovery import (
     AdDiscoveryStatusResponse, AdDiscoveryConfigResponse, AdDiscoveryConfigUpdate,
 )
 from app.services.audit import get_audit_logger_db
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/ad-discovery", tags=["ad-discovery"])
 
@@ -496,9 +499,10 @@ async def create_custom_list(
     try:
         lst = svc.create_list(db, name=body.name, description=body.description)
     except Exception as exc:
+        logger.warning("Could not create custom list: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=f"Could not create list: {exc}",
+            detail="Could not create list",
         )
     get_audit_logger_db().log_event(
         event_type="AD_DISCOVERY", user=current_user.username,

--- a/backend/app/api/routes/admin_db.py
+++ b/backend/app/api/routes/admin_db.py
@@ -1,5 +1,6 @@
-from typing import List, Optional
 import json
+import logging
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sqlalchemy.orm import Session
@@ -16,6 +17,8 @@ from app.schemas.admin_db import (
 )
 from app.services.audit.admin_db import AdminDBService
 from app.core.rate_limiter import user_limiter, get_limit
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -83,7 +86,8 @@ def table_rows(
             if not isinstance(parsed_filters, dict):
                 raise ValueError("filters must be a JSON object")
         except (json.JSONDecodeError, ValueError) as exc:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid filters: {exc}")
+            logger.warning("Invalid filters value: %s", exc)
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid filters")
 
     try:
         result = AdminDBService.get_table_rows(

--- a/backend/app/api/routes/backup.py
+++ b/backend/app/api/routes/backup.py
@@ -1,4 +1,6 @@
 """Backup API routes."""
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
@@ -19,6 +21,7 @@ from app.services.backup import get_backup_service
 from app.plugins.emit import emit_hook
 from app.core.rate_limiter import user_limiter, get_limit
 
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -76,9 +79,10 @@ async def create_backup(
             success=False,
             error=str(e),
         )
+        logger.error("Failed to create backup: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to create backup: {str(e)}"
+            detail="Failed to create backup"
         )
 
 
@@ -218,13 +222,16 @@ async def restore_backup(
         # If the service raised a RestoreLockedError, return 423 Locked with helpful message
         from app.services.backup import RestoreLockedError
         if isinstance(e, RestoreLockedError):
+            # Deliberate user-facing 423: the service message is curated operational
+            # guidance ("stop the app before restoring the DB"), safe to surface.
             raise HTTPException(
                 status_code=423,
                 detail=str(e)
             )
+        logger.error("Failed to restore backup: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to restore backup: {str(e)}"
+            detail="Failed to restore backup"
         )
 
 

--- a/backend/app/api/routes/balupi.py
+++ b/backend/app/api/routes/balupi.py
@@ -123,9 +123,10 @@ async def update_balupi_config(
     try:
         env_config_service.update_vars("backend", updates)
     except ValueError as e:
+        logger.error("Failed to write BaluPi config: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to write config: {e}",
+            detail="Failed to write config",
         )
 
     # Update runtime settings (take effect immediately without restart)

--- a/backend/app/api/routes/monitoring_gpu.py
+++ b/backend/app/api/routes/monitoring_gpu.py
@@ -3,6 +3,7 @@
 Kept separate from monitoring.py because that file is already large.
 Registered under the same /api/monitoring prefix in routes/__init__.py.
 """
+import logging
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
@@ -19,6 +20,8 @@ from app.schemas.monitoring import (
     TimeRangeEnum,
 )
 from app.services.monitoring.orchestrator import get_monitoring_orchestrator
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/monitoring", tags=["system-monitoring"])
 
@@ -47,7 +50,8 @@ async def get_gpu_info(
     try:
         return orch.gpu_collector.backend.device_info()
     except Exception as exc:
-        raise HTTPException(status_code=503, detail=f"GPU info unavailable: {exc}")
+        logger.error("GPU device_info failed: %s", exc)
+        raise HTTPException(status_code=503, detail="GPU info unavailable")
 
 
 @router.get("/gpu/current", response_model=CurrentGpuResponse)

--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -127,9 +127,10 @@ async def get_plugin_details(
         if plugin is None:
             plugin = plugin_manager.load_plugin(name)
     except PluginLoadError as e:
+        logger.warning("Plugin not found: %s", e)
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Plugin not found: {e}",
+            detail="Plugin not found",
         )
 
     meta = plugin.metadata
@@ -202,9 +203,10 @@ async def toggle_plugin(
         if plugin is None:
             plugin = plugin_manager.load_plugin(name)
     except PluginLoadError as e:
+        logger.warning("Plugin not found: %s", e)
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Plugin not found: {e}",
+            detail="Plugin not found",
         )
 
     meta = plugin.metadata
@@ -408,9 +410,10 @@ async def update_plugin_config(
     try:
         validated_config = plugin.validate_config(body.config)
     except ValueError as e:
+        logger.warning("Invalid plugin configuration for %s: %s", name, e)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid configuration: {e}",
+            detail="Invalid plugin configuration",
         )
 
     meta = plugin.metadata

--- a/backend/app/api/routes/power.py
+++ b/backend/app/api/routes/power.py
@@ -474,7 +474,7 @@ async def switch_power_backend(
         logger.error(f"Error checking Linux backend availability: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error checking backend availability: {str(e)}"
+            detail="Error checking backend availability"
         )
 
     if body.use_linux_backend and not linux_available:
@@ -490,7 +490,7 @@ async def switch_power_backend(
         logger.error(f"Error switching backend: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error switching backend: {str(e)}"
+            detail="Error switching backend"
         )
 
     if not success:

--- a/backend/app/api/routes/sleep.py
+++ b/backend/app/api/routes/sleep.py
@@ -248,7 +248,8 @@ async def update_sleep_config(
             )
         return result
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to update config: {e}")
+        logger.error("Failed to update sleep config: %s", e)
+        raise HTTPException(status_code=500, detail="Failed to update config")
 
 
 @router.get("/history", response_model=SleepHistoryResponse)

--- a/backend/app/api/routes/smart_devices.py
+++ b/backend/app/api/routes/smart_devices.py
@@ -161,7 +161,7 @@ async def discover_devices(
         logger.error("Discovery failed for plugin '%s': %s", plugin_name, exc)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Discovery failed: {exc}",
+            detail="Discovery failed",
         )
 
     return {

--- a/backend/app/api/routes/ssd_file_cache.py
+++ b/backend/app/api/routes/ssd_file_cache.py
@@ -1,4 +1,5 @@
 """SSD File Cache API Routes (per-array)."""
+import logging
 import shutil
 from pathlib import Path
 from typing import List
@@ -22,6 +23,8 @@ from app.schemas.ssd_file_cache import (
 from app.services.cache.ssd_file_cache import SSDFileCacheService
 from app.services.cache.eviction import EvictionManager
 from app.services.audit.logger_db import get_audit_logger_db
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -198,9 +201,10 @@ async def update_cache_config(
         try:
             Path(cache_path).mkdir(parents=True, exist_ok=True)
         except OSError as e:
+            logger.warning("Cache path not writable: %s", e)
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Cache path not writable: {e}",
+                detail="Cache path not writable",
             )
 
     service.update_config(update_values)

--- a/backend/app/api/routes/vcl.py
+++ b/backend/app/api/routes/vcl.py
@@ -1,4 +1,5 @@
 """VCL (Version Control Light) API Routes."""
+import logging
 from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy.orm import Session
@@ -21,6 +22,8 @@ from app.services.versioning.vcl import VCLService
 from app.services.audit.logger_db import get_audit_logger_db
 from app.models.vcl import VCLSettings, FileVersion
 from app.models.file_metadata import FileMetadata
+
+logger = logging.getLogger(__name__)
 
 
 def needs_cleanup(settings: VCLSettings) -> bool:
@@ -260,9 +263,10 @@ async def restore_file_version(
             error_message=str(e),
             db=db
         )
+        logger.error("Failed to restore file: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to restore file: {str(e)}"
+            detail="Failed to restore file"
         )
 
 
@@ -341,9 +345,10 @@ async def get_version_diff(
         content_old = vcl_service.get_version_content(version_old)
         content_new = vcl_service.get_version_content(version_new)
     except Exception as e:
+        logger.error("Failed to read version content: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to read version content: {str(e)}"
+            detail="Failed to read version content"
         )
 
     # Check if binary

--- a/backend/app/api/routes/vcl_admin.py
+++ b/backend/app/api/routes/vcl_admin.py
@@ -1,4 +1,5 @@
 """VCL (Version Control Light) API Routes — Admin Endpoints."""
+import logging
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy.orm import Session
@@ -31,6 +32,8 @@ from app.services.audit.logger_db import get_audit_logger_db
 from app.models.vcl import VCLSettings, VCLStats, FileVersion, VersionBlob
 from app.models.user import User
 from app.api.routes.vcl import needs_cleanup
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -470,9 +473,10 @@ async def trigger_manual_cleanup(
             error_message=str(e),
             db=db
         )
+        logger.error("VCL cleanup failed: %s", e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Cleanup failed: {str(e)}"
+            detail="Cleanup failed"
         )
 
 


### PR DESCRIPTION
## AP6 — Error-Leakage Migration: remaining route files (Posten 2 final)

Letzter Schritt von Posten 2 (Error-Leakage / globaler Exception-Handler), Security-Audit 2026-06-14, **B3 / GAP-10**. Folgt auf AP0 (#253), AP1 (#254), AP2 (#255), AP3 (#256), AP4 (#257), AP5 (#260). Ausgeführt **subagent-driven** (writing-plans → subagent-driven-development) mit Diff-Review pro Task + finalem Whole-Branch-Review.

### Inventur & Vorgehen

Frische Inventur: **23 Route-Dateien / 40 Stellen** mit `detail=str(e)` / `{e}` / `{exc}`. Jede Stelle nach dem in AP1–AP5 bewährten Decision-Tree klassifiziert:

- **CURATE (17 Stellen, 12 Dateien):** breites `except Exception` oder spezifischer Typ, der internen/untrusted Text leakt → roher Exception-Text aus `detail` entfernt, kuratierte Kategorie behalten, voller Fehler server-seitig geloggt (`logger.warning` für 4xx, `logger.error` für 5xx; Logger ergänzt wo nötig). **Keine Statuswechsel.**
  - Batch A: `power` (×2), `monitoring_gpu`, `smart_devices`, `sleep`
  - Batch B: `backup` (×2), `vcl` (×2), `vcl_admin`, `balupi`, `ssd_file_cache`, `ad_discovery`, `admin_db`, `plugins` (×3)
- **KEEP (21 Stellen, 11 Dateien):** gezielte `except ValueError`/`PermissionError → 4xx str(e)`, deren Service **verifiziert** nur kuratierte, client-sichere Messages wirft (z. B. „File not found", „You don't have permission to share this file", „VPN_ENCRYPTION_KEY not configured"). Pro Stelle die Service-Message gelesen und belegt → unverändert gelassen. Betrifft: `api_keys`, `auth` (×2), `cloud_export` (×3), `devices` (×2), `env_config` (×2), `migration` (×3), `server_profiles`, `shares` (×3), `sync`, `sync_advanced` (×2), `updates`.
- **Bewusst behalten (Borderline):** `ad_discovery.py` `re.error → f"Invalid regex pattern: {exc}"` — user-facing Validierungs-Feedback für das eigene Regex des Admins, keine Server-Internas.

### Review-Korrektur (Über-Curation verhindert)

`backup.py` `RestoreLockedError → 423`: zunächst fälschlich curatet, im Task-Review **zurückgesetzt auf `detail=str(e)`** — die Service-Message ist kuratierte, bewusst hilfreiche First-Party-Anleitung („Database file is currently locked… stop the application before restoring the database") und damit ein KEEP, kein Leak.

### Verifikation

- `ruff check app/api/routes/` → clean.
- Berührte Test-Suites (power/monitoring/smart/sleep/backup/vcl/ssd/admin_db/ad_discovery/balupi/plugins): **261 passed**.
- Finaler Whole-Branch-Review (opus): **APPROVED**, keine Critical/Important/Minor-Defekte; Statuscodes erhalten, Logging korrekt, keine zerstörte user-facing Message, Logger sauber.
- Kein Assertion-Drift (Tests asserten Status, nicht die Detail-Strings).

### Nebenbefunde (Service-Layer, out-of-AP6-scope)

Aus der KEEP-Verifikation: `migration_service.py:495` wirft `f"Destination path not writable: {e}"` mit `e`=`OSError` → OS-Fehlertext (errno+Pfad) erreicht den admin-only Client via `migration.py`. Analog #258 (fritzbox). Separat zu adressieren (Service-Datei, nicht Route). Außerdem: `backup.py` broad-except kann pre-existing einen 404 zu 500 re-wrappen.

→ **Posten 2 (Route-Migration) ist damit code-complete** (modulo `optical_drive`-Plugin (22) + `plugin_marketplace.py`-Service (1) Folge-Issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
