### PR TITLE
fix(security): VPN-key plaintext hard-fail in prod + widen admin-db redaction (Posten 3 #2/#4)

### DIFF
--- a/backend/app/services/audit/admin_db.py
+++ b/backend/app/services/audit/admin_db.py
@@ -9,7 +9,10 @@ from app.core import database
 from app.schemas.admin_db import AdminTableSchemaField, AdminTableRowsResponse
 
 
-REDACT_PATTERN = re.compile(r"password|secret|token|private_key|api_key", re.IGNORECASE)
+REDACT_PATTERN = re.compile(
+    r"password|secret|token|private_key|api_key|encrypted|preshared|certificate|credential",
+    re.IGNORECASE,
+)
 
 
 # Categorised table whitelist – flat _WHITELIST is derived automatically.

--- a/backend/app/services/vpn/service.py
+++ b/backend/app/services/vpn/service.py
@@ -39,10 +39,24 @@ class VPNService:
 
     @staticmethod
     def _encrypt_key(plaintext: str) -> str:
-        """Encrypt *plaintext* if VPN_ENCRYPTION_KEY is available, else return as-is."""
+        """Encrypt *plaintext* if VPN_ENCRYPTION_KEY is available.
+
+        Production hard-fails on a missing key — BaluHost must never silently
+        persist VPN/SSH key material in plaintext (OWASP Sensitive Data
+        Exposure). In dev/test the key is optional and we fall back to
+        plaintext with a warning so local development works without it.
+        """
         if not VPNService._encryption_available():
+            import os
+            is_dev = os.getenv("NAS_MODE", "dev").lower() == "dev"
+            is_test = os.getenv("SKIP_APP_INIT") == "1" or os.getenv("PYTEST_CURRENT_TEST")
+            if not (is_dev or is_test):
+                raise RuntimeError(
+                    "VPN_ENCRYPTION_KEY is not configured — refusing to store VPN/SSH "
+                    "key material in plaintext. Set VPN_ENCRYPTION_KEY in the environment."
+                )
             logger.warning(
-                "VPN_ENCRYPTION_KEY not set — storing VPN key in plaintext. "
+                "VPN_ENCRYPTION_KEY not set — storing VPN key in plaintext (dev/test). "
                 "Set VPN_ENCRYPTION_KEY in .env for production."
             )
             return plaintext

--- a/backend/tests/test_vpn_key_encryption.py
+++ b/backend/tests/test_vpn_key_encryption.py
@@ -250,6 +250,25 @@ class TestVPNKeyEncryptionDisabled:
         result = VPNService._decrypt_key(raw_key)
         assert result == raw_key
 
+    def test_encrypt_key_raises_in_prod_without_key(self, monkeypatch):
+        """Production must hard-fail rather than silently store key material in plaintext."""
+        monkeypatch.setattr(
+            VPNService, "_encryption_available", staticmethod(lambda: False)
+        )
+        monkeypatch.setenv("NAS_MODE", "prod")
+        monkeypatch.delenv("SKIP_APP_INIT", raising=False)
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        with pytest.raises(RuntimeError, match="VPN_ENCRYPTION_KEY"):
+            VPNService._encrypt_key("rawkey")
+
+    def test_encrypt_key_falls_back_to_plaintext_in_dev(self, monkeypatch):
+        """In dev mode a missing key falls back to plaintext (local-dev convenience)."""
+        monkeypatch.setattr(
+            VPNService, "_encryption_available", staticmethod(lambda: False)
+        )
+        monkeypatch.setenv("NAS_MODE", "dev")
+        assert VPNService._encrypt_key("rawkey") == "rawkey"
+
 
 # ---------------------------------------------------------------------------
 # Tests — helper methods


### PR DESCRIPTION
## Crypto-Hygiene (Posten 3) — Items #2 + #4

Zwei gekoppelte Crypto-Hygiene-Fixes aus dem Security-Audit 2026-06-14 (Posten 3). Bewusst zusammen, weil #2 die #4-Lücke erst gefährlich macht.

### Item 2 — `VPN_ENCRYPTION_KEY`: kein stiller Klartext mehr in prod

`VPNService._encrypt_key()` (`services/vpn/service.py`) speicherte VPN-/SSH-Key-Material **still im Klartext**, wenn `VPN_ENCRYPTION_KEY` fehlte — nur ein `logger.warning`. Damit landeten WireGuard-Private-Keys, PSKs, SSH-Keys und VPN-Configs unverschlüsselt in der DB.

- **Neu:** in **production** wirft `_encrypt_key()` jetzt `RuntimeError` (fail-at-use) statt Klartext zu speichern.
- **dev/test** behalten den Plaintext-Fallback (gleicher `NAS_MODE` / `PYTEST_CURRENT_TEST` / `SKIP_APP_INIT`-Guard wie die Config-Validatoren) → lokale Entwicklung ohne Key funktioniert weiter.
- Der **Read-Pfad** (`_decrypt_key`, Legacy-Plaintext-Handling) bleibt unverändert — bestehende Daten lesbar.

Bewusst **at-use** statt Startup-Validator: blockiert nicht die ganze App, wenn VPN gar nicht genutzt wird, schließt aber den eigentlichen Leak.

### Item 4 — `REDACT_PATTERN` (Admin-DB-Inspektion) erweitern

`REDACT_PATTERN` (`services/audit/admin_db.py`) matcht Spaltennamen. Das alte Pattern `password|secret|token|private_key|api_key` verfehlte mehrere verschlüsselte Spalten. Ergänzt um `encrypted|preshared|certificate|credential` → jetzt redigiert:

`server_profile.ssh_key_encrypted` · `cloud.encrypted_config` · `cloud.encrypted_client_id` · `user.totp_backup_codes_encrypted` · `vpn.preshared_key` / `preshared_key_encrypted` · `vpn_profile.config_file_encrypted` / `certificate_encrypted`.

Werte sind i. d. R. Ciphertext (Defense-in-Depth) — **aber** mit dem #2-Bug konnten sie Klartext sein, daher zusammen.

### Verifikation

- `+2` Tests (`_encrypt_key` prod-raise / dev-fallback). `test_vpn_key_encryption.py` + `test_admin_db.py` → **17 passed**.
- `ruff check` (beide Source-Dateien) → clean.
- Read-Pfad + bestehende Plaintext-Fallback-Tests unverändert grün.

### Scope / offen

Nur #2 + #4. Folgt separat: **#1** (CLOUD_ENCRYPTION_KEY von SECRET_KEY entkoppeln + Re-Encryption-Migration), **#3** (dedizierter TOTP_ENCRYPTION_KEY statt VPN-Key-Fallback). Service-Layer-Exception-Leaks → Sammelissue #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
