### PR TITLE
fix(deps): vite 7.3.5 + undici 7.28.0 (Dependabot #49/#50/#51/#52)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -47,7 +47,7 @@
         "tailwindcss": "^3.4.17",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
-        "vite": "^7.3.2",
+        "vite": "^7.3.5",
         "vitest": "^4.1.0"
       }
     },
@@ -7970,9 +7970,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8181,9 +8181,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,8 @@
     "recharts": "^3.4.1"
   },
   "overrides": {
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "undici": "^7.28.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
@@ -62,7 +63,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^7.3.2",
+    "vite": "^7.3.5",
     "vitest": "^4.1.0"
   }
 }


### PR DESCRIPTION
## Summary

Closes 4 open Dependabot alerts in `client/` (npm), bundled into one PR.

| Alert | Sev | Package | Issue |
|-------|-----|---------|-------|
| #49 | high | vite | `server.fs.deny` bypass on Windows alternate paths |
| #52 | medium | vite / launch-editor | NTLMv2 hash disclosure via UNC path handling on Windows |
| #50 | high | undici | TLS cert validation bypass via dropped requestTls in SOCKS5 ProxyAgent |
| #51 | medium | undici | cross-user info disclosure via shared-cache whitespace bypass |

## Changes

- `vite` (direct devDependency): `^7.3.2` → `^7.3.5` → resolves to `7.3.5`
- `undici` (transitive via `jsdom`): pinned via `overrides` to `^7.28.0` → resolves to `7.28.0`

The Windows-specific vite / launch-editor issues are especially relevant given local Win11 development.

## Verification

- `npm ls vite` → `7.3.5`, `npm ls undici` → `7.28.0`
- Vitest suite green: **65 files, 424 tests passed**

## Out of scope (side-finding)

`npm audit` reports 5 further transitive findings (form-data high, @babel/core, brace-expansion, js-yaml, yaml) that Dependabot does **not** flag. Left untouched here to keep this PR scoped to the Dependabot alerts; can be addressed separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
