### PR TITLE
fix(security): restrict admin SSRF targets to LAN hosts (Posten 4)

### DIFF
--- a/backend/app/plugins/smart_device/schemas.py
+++ b/backend/app/plugins/smart_device/schemas.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from app.schemas.validators import validate_lan_host
+
 
 # ---------------------------------------------------------------------------
 # Request schemas
@@ -25,6 +27,11 @@ class SmartDeviceCreate(BaseModel):
         description="Plugin-specific config (credentials etc.) — encrypted before storage",
     )
 
+    @field_validator("address", mode="before")
+    @classmethod
+    def _validate_address(cls, v: Optional[str]) -> Optional[str]:
+        return validate_lan_host(v)
+
 
 class SmartDeviceUpdate(BaseModel):
     """Schema for updating a smart device (partial updates supported)."""
@@ -36,6 +43,11 @@ class SmartDeviceUpdate(BaseModel):
         description="If provided, re-encrypted and stored",
     )
     is_active: Optional[bool] = Field(default=None)
+
+    @field_validator("address", mode="before")
+    @classmethod
+    def _validate_address(cls, v: Optional[str]) -> Optional[str]:
+        return validate_lan_host(v)
 
 
 class DeviceCommandRequest(BaseModel):

--- a/backend/app/schemas/fritzbox.py
+++ b/backend/app/schemas/fritzbox.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
-from app.schemas.validators import validate_mac_address
+from app.schemas.validators import validate_lan_host, validate_mac_address
 
 
 class FritzBoxConfigResponse(BaseModel):
@@ -29,6 +29,11 @@ class FritzBoxConfigUpdate(BaseModel):
     @classmethod
     def _validate_mac(cls, v: Optional[str]) -> Optional[str]:
         return validate_mac_address(v)
+
+    @field_validator("host", mode="before")
+    @classmethod
+    def _validate_host(cls, v: Optional[str]) -> Optional[str]:
+        return validate_lan_host(v)
 
 
 class FritzBoxTestResponse(BaseModel):

--- a/backend/app/schemas/pihole.py
+++ b/backend/app/schemas/pihole.py
@@ -2,7 +2,9 @@
 
 from datetime import datetime
 from typing import Any, Optional, Union
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from app.schemas.validators import validate_lan_url
 
 
 # ── Status & Summary ──────────────────────────────────────────────────
@@ -248,6 +250,11 @@ class PiholeConfigUpdateRequest(BaseModel):
     dns_bogus_priv: Optional[bool] = Field(None, description="Never forward reverse lookups for private IP ranges")
     dns_domain_name: Optional[str] = Field(None, max_length=100, description="Local domain name")
     dns_expand_hosts: Optional[bool] = Field(None, description="Expand hostnames by adding domain name")
+
+    @field_validator("pihole_url", "remote_pihole_url", mode="before")
+    @classmethod
+    def _validate_url(cls, v: Optional[str]) -> Optional[str]:
+        return validate_lan_url(v)
 
 # ── Failover ─────────────────────────────────────────────────────────
 

--- a/backend/app/schemas/validators.py
+++ b/backend/app/schemas/validators.py
@@ -1,6 +1,10 @@
 """Shared Pydantic validators reusable across schemas."""
+import ipaddress
 import re
 from typing import Optional
+from urllib.parse import urlparse
+
+from app.core.network_utils import is_private_or_local_ip
 
 _USERNAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
@@ -34,6 +38,72 @@ def validate_mac_address(value: Optional[str]) -> Optional[str]:
             "Expected AA:BB:CC:DD:EE:FF or AA-BB-CC-DD-EE-FF"
         )
     return ":".join(g.upper() for g in match.groups())
+
+
+def validate_lan_host(value: Optional[str]) -> Optional[str]:
+    """Validate a host that must live on the local network (SSRF hardening).
+
+    Used for admin-configured integration targets (Fritz!Box, Tapo, Pi-hole)
+    that legitimately point at LAN devices. Prevents the configured value from
+    being abused to make the server reach an arbitrary public host.
+
+    Policy:
+    - None → None; empty/whitespace → None.
+    - IP literal → must be private/local (RFC1918, loopback, link-local,
+      IPv6-ULA), otherwise ValueError.
+    - Hostname → allowed as-is (NOT resolved — no DNS lookup here).
+
+    Returns the stripped value on success.
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+
+    try:
+        ipaddress.ip_address(stripped)
+    except ValueError:
+        # Not an IP literal → treat as a hostname and allow it through.
+        return stripped
+
+    if not is_private_or_local_ip(stripped):
+        raise ValueError(
+            f"Host '{stripped}' is a public IP address; only private/local "
+            "network addresses are allowed."
+        )
+    return stripped
+
+
+def validate_lan_url(value: Optional[str]) -> Optional[str]:
+    """Validate an http(s) URL whose host must live on the local network.
+
+    SSRF hardening for admin-configured URLs (e.g. Pi-hole remote URL).
+
+    Policy:
+    - None → None; empty/whitespace → None.
+    - Scheme must be http or https.
+    - Host must pass :func:`validate_lan_host` (private IP or hostname).
+
+    Returns the stripped value on success.
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+
+    parsed = urlparse(stripped)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(
+            f"URL must use the http or https scheme, got: '{parsed.scheme or stripped[:30]}'"
+        )
+    host = parsed.hostname
+    if not host:
+        raise ValueError("URL must include a host")
+
+    validate_lan_host(host)
+    return stripped
 
 
 def validate_username(v: str) -> str:

--- a/backend/tests/test_lan_host_validator.py
+++ b/backend/tests/test_lan_host_validator.py
@@ -1,0 +1,155 @@
+"""Tests for the LAN-host / LAN-URL SSRF-hardening validators.
+
+Policy (Posten 4, admin-gated SSRF hardening):
+- IP literals must be private/local (RFC1918, loopback, link-local, IPv6-ULA).
+- Public IP literals are rejected.
+- Hostnames are allowed as-is (NOT resolved — no DNS in the validator).
+- None / empty → None.
+"""
+import pytest
+
+from app.schemas.validators import validate_lan_host, validate_lan_url
+
+
+class TestValidateLanHost:
+    def test_none_returns_none(self):
+        assert validate_lan_host(None) is None
+
+    def test_empty_returns_none(self):
+        assert validate_lan_host("") is None
+        assert validate_lan_host("   ") is None
+
+    def test_private_ipv4_allowed(self):
+        assert validate_lan_host("192.168.1.50") == "192.168.1.50"
+        assert validate_lan_host("10.0.0.1") == "10.0.0.1"
+        assert validate_lan_host("172.16.0.1") == "172.16.0.1"
+
+    def test_loopback_allowed(self):
+        assert validate_lan_host("127.0.0.1") == "127.0.0.1"
+
+    def test_link_local_allowed(self):
+        assert validate_lan_host("169.254.1.1") == "169.254.1.1"
+
+    def test_private_ipv6_allowed(self):
+        assert validate_lan_host("fd00::1") == "fd00::1"
+
+    def test_hostname_allowed_unresolved(self):
+        assert validate_lan_host("fritz.box") == "fritz.box"
+        assert validate_lan_host("pi.hole") == "pi.hole"
+        assert validate_lan_host("localhost") == "localhost"
+
+    def test_public_ipv4_rejected(self):
+        with pytest.raises(ValueError):
+            validate_lan_host("1.2.3.4")
+        with pytest.raises(ValueError):
+            validate_lan_host("8.8.8.8")
+
+    def test_public_ipv6_rejected(self):
+        with pytest.raises(ValueError):
+            validate_lan_host("2001:4860:4860::8888")
+
+    def test_ipv6_mapped_public_ipv4_rejected(self):
+        with pytest.raises(ValueError):
+            validate_lan_host("::ffff:1.2.3.4")
+
+    def test_whitespace_stripped(self):
+        assert validate_lan_host("  192.168.1.50  ") == "192.168.1.50"
+
+
+class TestValidateLanUrl:
+    def test_none_returns_none(self):
+        assert validate_lan_url(None) is None
+
+    def test_empty_returns_none(self):
+        assert validate_lan_url("") is None
+
+    def test_private_host_url_allowed(self):
+        assert validate_lan_url("http://192.168.1.50:80") == "http://192.168.1.50:80"
+
+    def test_hostname_url_allowed(self):
+        assert validate_lan_url("http://pi.hole") == "http://pi.hole"
+
+    def test_https_allowed(self):
+        assert validate_lan_url("https://192.168.1.50") == "https://192.168.1.50"
+
+    def test_public_host_url_rejected(self):
+        with pytest.raises(ValueError):
+            validate_lan_url("http://1.2.3.4:80")
+
+    def test_non_http_scheme_rejected(self):
+        with pytest.raises(ValueError):
+            validate_lan_url("file:///etc/passwd")
+        with pytest.raises(ValueError):
+            validate_lan_url("gopher://192.168.1.50")
+
+    def test_missing_host_rejected(self):
+        with pytest.raises(ValueError):
+            validate_lan_url("http://")
+
+
+class TestFritzBoxConfigUpdateHost:
+    def test_public_ip_host_rejected(self):
+        from app.schemas.fritzbox import FritzBoxConfigUpdate
+        with pytest.raises(ValueError):
+            FritzBoxConfigUpdate(host="1.2.3.4")
+
+    def test_private_ip_host_allowed(self):
+        from app.schemas.fritzbox import FritzBoxConfigUpdate
+        assert FritzBoxConfigUpdate(host="192.168.178.1").host == "192.168.178.1"
+
+    def test_hostname_allowed(self):
+        from app.schemas.fritzbox import FritzBoxConfigUpdate
+        assert FritzBoxConfigUpdate(host="fritz.box").host == "fritz.box"
+
+    def test_host_omitted_is_none(self):
+        from app.schemas.fritzbox import FritzBoxConfigUpdate
+        assert FritzBoxConfigUpdate().host is None
+
+
+class TestSmartDeviceAddress:
+    def test_create_public_ip_rejected(self):
+        from app.plugins.smart_device.schemas import SmartDeviceCreate
+        with pytest.raises(ValueError):
+            SmartDeviceCreate(
+                name="Plug", plugin_name="tapo_smart_plug",
+                device_type_id="p110", address="1.2.3.4",
+            )
+
+    def test_create_private_ip_allowed(self):
+        from app.plugins.smart_device.schemas import SmartDeviceCreate
+        dev = SmartDeviceCreate(
+            name="Plug", plugin_name="tapo_smart_plug",
+            device_type_id="p110", address="192.168.1.55",
+        )
+        assert dev.address == "192.168.1.55"
+
+    def test_update_public_ip_rejected(self):
+        from app.plugins.smart_device.schemas import SmartDeviceUpdate
+        with pytest.raises(ValueError):
+            SmartDeviceUpdate(address="8.8.8.8")
+
+    def test_update_address_omitted_is_none(self):
+        from app.plugins.smart_device.schemas import SmartDeviceUpdate
+        assert SmartDeviceUpdate().address is None
+
+
+class TestPiholeConfigUpdateUrls:
+    def test_public_pihole_url_rejected(self):
+        from app.schemas.pihole import PiholeConfigUpdateRequest
+        with pytest.raises(ValueError):
+            PiholeConfigUpdateRequest(pihole_url="http://1.2.3.4:80")
+
+    def test_private_pihole_url_allowed(self):
+        from app.schemas.pihole import PiholeConfigUpdateRequest
+        req = PiholeConfigUpdateRequest(pihole_url="http://192.168.1.50:80")
+        assert req.pihole_url == "http://192.168.1.50:80"
+
+    def test_public_remote_pihole_url_rejected(self):
+        from app.schemas.pihole import PiholeConfigUpdateRequest
+        with pytest.raises(ValueError):
+            PiholeConfigUpdateRequest(remote_pihole_url="http://9.9.9.9")
+
+    def test_hostname_pihole_url_allowed(self):
+        from app.schemas.pihole import PiholeConfigUpdateRequest
+        req = PiholeConfigUpdateRequest(pihole_url="http://pi.hole")
+        assert req.pihole_url == "http://pi.hole"


### PR DESCRIPTION
## Was & Warum

Posten 4 aus dem Security-Audit (admin-gated SSRF-Härtung). Admin-konfigurierte
Integrations-Ziele konnten den Server auf einen beliebigen **Public**-Host zeigen
lassen → der NAS ließe sich als SSRF-Proxy missbrauchen.

Betroffene Eingangs-Flächen (alle admin-only, Stored-Config):
- Fritz!Box `host` (`f"http://{host}:{port}"` für TR-064 WoL)
- Tapo / Smart-Device `address`
- Pi-hole `pihole_url` + `remote_pihole_url`

## Lösung

Geteilte Validatoren in `schemas/validators.py`:
- **`validate_lan_host()`** — IP-Literale müssen privat/lokal sein (via
  `core/network_utils.is_private_or_local_ip()`), Public-IPs → `ValueError`.
  Hostnamen werden **nicht** aufgelöst und durchgelassen (bewusster
  UX/Security-Tradeoff, damit `fritz.box` / `pi.hole` weiter funktionieren).
- **`validate_lan_url()`** — erzwingt http/https-Scheme, Host über
  `validate_lan_host()` geprüft.

Verdrahtet als Pydantic `field_validator`:

| Schema | Feld(er) |
|--------|----------|
| `FritzBoxConfigUpdate` | `host` |
| `SmartDeviceCreate` / `SmartDeviceUpdate` | `address` |
| `PiholeConfigUpdateRequest` | `pihole_url`, `remote_pihole_url` |

## Tests

- **31 neue Tests** in `tests/test_lan_host_validator.py` (TDD, RED→GREEN):
  Private/Loopback/Link-local/IPv6-ULA erlaubt, Public-IPv4/IPv6 + IPv6-mapped
  Public abgelehnt, Hostnamen erlaubt, http/https erzwungen, plus
  Schema-Integration aller drei Flächen.
- **Regression grün**: `test_fritzbox_wol.py` + `test_pihole.py` (124),
  `tests/plugins/` (444), `tests/schemas/` (15).
- **Ruff**: clean.

## Threat-Model-Hinweis

Defense-in-Depth, admin-gated. Blockt offensichtliche Public-IP-SSRF und
Nicht-http(s)-Schemes. Ein vom Admin gesetzter Hostname, der per DNS auf eine
Public-IP zeigt, wird nicht aufgelöst — bewusst gewählter Tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
