### PR TITLE
fix(security): DoS hardening — chunked size bound, WS cap, dev-in-prod guard, upload limit (Posten 5)

### DIFF
--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -598,9 +598,15 @@ async def notification_websocket(
         logger.error(f"WebSocket: Failed to accept connection - {e}")
         return
 
-    # Register with WebSocket manager
+    # Register with WebSocket manager (enforce per-user connection cap)
+    from app.services.websocket_manager import ConnectionLimitExceeded
     manager = get_websocket_manager()
-    await manager.connect(websocket, user_id, is_admin=is_admin)
+    try:
+        await manager.connect(websocket, user_id, is_admin=is_admin)
+    except ConnectionLimitExceeded as e:
+        logger.warning(f"WebSocket: connection cap reached - {e}")
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return
 
     try:
         # Send initial unread count with fresh db session

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -307,6 +307,15 @@ class Settings(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def _block_dev_mode_in_production(self) -> "Settings":
+        if str(self.environment).lower() in ("production", "prod") and self.is_dev_mode:
+            raise ValueError(
+                "NAS_MODE=dev is not allowed when ENVIRONMENT=production — dev mode "
+                "relaxes rate limits and enables mock backends. Set NAS_MODE=prod."
+            )
+        return self
+
+    @model_validator(mode="after")
     def _validate_loopback_fallback_only_in_dev(self) -> "Settings":
         if self.local_loopback_fallback and not self.is_dev_mode:
             raise ValueError(

--- a/backend/app/core/rate_limiter.py
+++ b/backend/app/core/rate_limiter.py
@@ -72,7 +72,7 @@ RATE_LIMITS = {
     "auth_refresh": "10/minute",  # ✅ Security Fix #5
     
     # File operations - moderate limits
-    "file_upload": "50000/minute",
+    "file_upload": "300/minute",
     "file_download": "500/minute",
     "file_list": "200/minute",
     "file_delete": "30/minute",

--- a/backend/app/services/files/chunked_upload.py
+++ b/backend/app/services/files/chunked_upload.py
@@ -131,6 +131,14 @@ class ChunkedUploadManager:
                     f"Expected chunk {session.next_chunk_index}, got {chunk_index}"
                 )
 
+        # Overflow guard: outside the lock so abort_session can acquire it.
+        if session.received_bytes + len(data) > session.total_size:
+            await self.abort_session(upload_id)
+            raise ValueError(
+                "Upload exceeds declared total_size "
+                f"({session.total_size} bytes) for session {upload_id}"
+            )
+
         # Write + hash outside the lock in a thread — avoids blocking the event loop.
         def _write_and_hash() -> None:
             with open(session.temp_file_path, "ab") as f:
@@ -176,6 +184,15 @@ class ChunkedUploadManager:
         parts: list[bytes] = []
         async for part in stream:
             parts.append(part)
+
+        # Overflow guard: outside the lock so abort_session can acquire it.
+        incoming = sum(len(p) for p in parts)
+        if session.received_bytes + incoming > session.total_size:
+            await self.abort_session(upload_id)
+            raise ValueError(
+                "Upload exceeds declared total_size "
+                f"({session.total_size} bytes) for session {upload_id}"
+            )
 
         def _write_and_hash() -> int:
             written = 0

--- a/backend/app/services/websocket_manager.py
+++ b/backend/app/services/websocket_manager.py
@@ -12,6 +12,14 @@ from fastapi import WebSocket
 
 logger = logging.getLogger(__name__)
 
+# Max simultaneous WebSocket connections per user (DoS guard, Posten 5 #2).
+# Covers a desktop client + phone + a couple of browser tabs.
+MAX_CONNECTIONS_PER_USER = 5
+
+
+class ConnectionLimitExceeded(Exception):
+    """Raised when a user exceeds MAX_CONNECTIONS_PER_USER active connections."""
+
 
 @dataclass
 class Connection:
@@ -56,6 +64,10 @@ class WebSocketManager:
         )
 
         async with self._lock:
+            if len(self._user_connections.get(user_id, [])) >= MAX_CONNECTIONS_PER_USER:
+                raise ConnectionLimitExceeded(
+                    f"user {user_id} exceeded {MAX_CONNECTIONS_PER_USER} connections"
+                )
             if user_id not in self._user_connections:
                 self._user_connections[user_id] = []
             self._user_connections[user_id].append(connection)

--- a/backend/tests/files/test_chunked_upload.py
+++ b/backend/tests/files/test_chunked_upload.py
@@ -341,3 +341,48 @@ class TestShutdown:
         await manager.shutdown()
 
         assert len(manager._sessions) == 0
+
+
+# ============================================================================
+# Overflow Guard (DoS hardening — Posten 5 #3)
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_write_chunk_rejects_overflow_beyond_total_size(tmp_path, monkeypatch):
+    """A chunk that pushes received_bytes past the declared total_size is rejected
+    and the session is aborted (disk-fill DoS guard)."""
+    import app.services.files.chunked_upload as cu
+    monkeypatch.setattr(cu, "TMP_UPLOAD_DIR", tmp_path)
+
+    mgr = ChunkedUploadManager()
+    session = await mgr.create_session(
+        target_path="x", filename="f.bin", total_size=4,
+        user_id=1, username="u",
+    )
+    # First chunk fits exactly (4 bytes == total_size).
+    await mgr.write_chunk(session.upload_id, 0, b"AAAA")
+    # Second chunk overflows.
+    with pytest.raises(ValueError, match="exceeds declared total_size"):
+        await mgr.write_chunk(session.upload_id, 1, b"B")
+    # Session was aborted → temp file gone, session unknown.
+    assert mgr.get_session(session.upload_id) is None
+
+
+@pytest.mark.asyncio
+async def test_write_chunk_stream_rejects_overflow(tmp_path, monkeypatch):
+    """Streaming variant also rejects overflow before writing to disk."""
+    import app.services.files.chunked_upload as cu
+    monkeypatch.setattr(cu, "TMP_UPLOAD_DIR", tmp_path)
+
+    async def _stream(*fragments):
+        for fr in fragments:
+            yield fr
+
+    mgr = ChunkedUploadManager()
+    session = await mgr.create_session(
+        target_path="x", filename="f.bin", total_size=3,
+        user_id=1, username="u",
+    )
+    with pytest.raises(ValueError, match="exceeds declared total_size"):
+        await mgr.write_chunk_stream(session.upload_id, 0, _stream(b"AA", b"BB"))
+    assert mgr.get_session(session.upload_id) is None

--- a/backend/tests/services/test_websocket_manager.py
+++ b/backend/tests/services/test_websocket_manager.py
@@ -172,3 +172,34 @@ class TestGetWebSocketManagerSingleton:
         a = get_websocket_manager()
         b = get_websocket_manager()
         assert a is b
+
+
+# ---------------------------------------------------------------------------
+# Task 2: per-user WebSocket connection cap (Posten 5 #2)
+# ---------------------------------------------------------------------------
+
+import pytest
+from app.services.websocket_manager import (
+    ConnectionLimitExceeded,
+    MAX_CONNECTIONS_PER_USER,
+)
+
+
+class _FakeWS:
+    async def send_json(self, _):  # pragma: no cover - not exercised here
+        pass
+
+
+@pytest.mark.asyncio
+async def test_connect_caps_connections_per_user():
+    mgr = WebSocketManager()
+    # Fill up to the cap for one user.
+    for _ in range(MAX_CONNECTIONS_PER_USER):
+        await mgr.connect(_FakeWS(), user_id=7)
+    # The next one is rejected.
+    with pytest.raises(ConnectionLimitExceeded):
+        await mgr.connect(_FakeWS(), user_id=7)
+    # A different user is unaffected.
+    await mgr.connect(_FakeWS(), user_id=8)
+    assert mgr.get_connection_count(7) == MAX_CONNECTIONS_PER_USER
+    assert mgr.get_connection_count(8) == 1

--- a/backend/tests/test_admin_password_validation.py
+++ b/backend/tests/test_admin_password_validation.py
@@ -74,12 +74,20 @@ class TestAdminPasswordValidation:
 
     def test_dev_mode_accepts_default_password(self, monkeypatch):
         """Dev mode should accept the default 'DevMode2024' password without error."""
-        settings = self._build_settings(monkeypatch, NAS_MODE="dev", ADMIN_PASSWORD="DevMode2024")
+        # A real dev build runs ENVIRONMENT=development; pairing it with
+        # ENVIRONMENT=production is rejected by _block_dev_mode_in_production.
+        settings = self._build_settings(
+            monkeypatch, NAS_MODE="dev", ENVIRONMENT="development",
+            ADMIN_PASSWORD="DevMode2024",
+        )
         assert settings.admin_password == "DevMode2024"
 
     def test_dev_mode_accepts_short_password(self, monkeypatch):
         """Dev mode should accept any password, even short ones."""
-        settings = self._build_settings(monkeypatch, NAS_MODE="dev", ADMIN_PASSWORD="abc")
+        settings = self._build_settings(
+            monkeypatch, NAS_MODE="dev", ENVIRONMENT="development",
+            ADMIN_PASSWORD="abc",
+        )
         assert settings.admin_password == "abc"
 
     def test_validation_skipped_during_testing(self, monkeypatch):

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -1,0 +1,27 @@
+import pytest
+from app.core.config import Settings
+
+
+def test_dev_mode_in_production_environment_is_rejected():
+    """environment=production together with NAS_MODE=dev must fail fast.
+
+    The new validator reads the INSTANCE fields (self.environment,
+    self.is_dev_mode), so the nas_mode="dev" kwarg genuinely trips it.
+    """
+    with pytest.raises(ValueError, match="not allowed when ENVIRONMENT=production"):
+        Settings(environment="production", nas_mode="dev")
+
+
+def test_prod_mode_in_production_environment_is_allowed():
+    # NOTE: the existing SECRET_KEY/token_secret/admin_password validators detect
+    # prod via os.getenv("NAS_MODE") and are skipped under pytest (conftest sets
+    # NAS_MODE=dev + SKIP_APP_INIT=1), so this constructs fine without strong
+    # secrets. The new validator reads instance fields and does NOT fire here
+    # (is_dev_mode is False for nas_mode="prod").
+    s = Settings(environment="production", nas_mode="prod")
+    assert s.is_dev_mode is False
+
+
+def test_dev_mode_in_development_environment_is_allowed():
+    s = Settings(environment="development", nas_mode="dev")
+    assert s.is_dev_mode is True

--- a/backend/tests/test_rate_limit_values.py
+++ b/backend/tests/test_rate_limit_values.py
@@ -1,0 +1,13 @@
+from app.core.rate_limiter import RATE_LIMITS
+
+
+def test_file_upload_limit_is_realistic():
+    """50000/min was effectively unlimited (DoS path). 300/min is plenty for the
+    web file manager while bounding abuse."""
+    assert RATE_LIMITS["file_upload"] == "300/minute"
+
+
+def test_file_chunked_stays_high_for_per_chunk_puts():
+    """file_chunked gates every chunk PUT, so it must stay high — do not slash it."""
+    count = int(RATE_LIMITS["file_chunked"].split("/")[0])
+    assert count >= 10000

--- a/deploy/install/templates/env.production
+++ b/deploy/install/templates/env.production
@@ -8,6 +8,9 @@
 # Application Mode
 # ===================================
 NAS_MODE=prod
+# Independent production marker. Cross-checked against NAS_MODE at startup:
+# ENVIRONMENT=production + NAS_MODE=dev fails fast (config.py).
+ENVIRONMENT=production
 
 # ===================================
 # Security Keys


### PR DESCRIPTION
## Was & Warum

Posten 5 aus dem Security-Audit (DoS-Härtung). Vier unabhängige Backend-Fixes, subagent-getrieben umgesetzt (TDD pro Task, Task-Review nach jedem Task, abschließender Whole-Branch-Review).

## Änderungen

### 1. Chunked-Upload `total_size`-Bound *(echte Lücke — höchster Wert)*
`write_chunk` / `write_chunk_stream` (`services/files/chunked_upload.py`) erzwingten bisher nur die Chunk-Reihenfolge, **nicht** `received_bytes <= total_size`. Ein Client konnte eine kleine `total_size` deklarieren (besteht den 507-Space-Check beim Init), dann beliebig viele Chunks streamen → unbegrenzter Disk-Write, umgeht Quota/Space-Check = **Disk-Fill-DoS**. Fix: `received_bytes > total_size` → `ValueError` + `abort_session` (Temp-File-Cleanup). Guard liegt bewusst *außerhalb* des `asyncio.Lock` (`abort_session` lockt selbst → sonst Deadlock).

### 2. WebSocket Per-User-Connection-Cap = 5
`WebSocketManager.connect()` (`services/websocket_manager.py`) nahm unbegrenzt Verbindungen pro User an. Neu: `MAX_CONNECTIONS_PER_USER = 5` + `ConnectionLimitExceeded`; die WS-Route (`api/routes/notifications.py`) fängt die Exception und schließt mit `WS_1008_POLICY_VIOLATION`. 5 deckt Desktop + Handy + ein paar Tabs ab.

### 3. Fail-fast bei `NAS_MODE=dev` in Produktion
`core/config.py`: neuer `model_validator` — `ENVIRONMENT=production` **und** `is_dev_mode` → `ValueError` beim Start (dev mode relaxt Rate-Limits + aktiviert Mock-Backends). Plus `ENVIRONMENT=production`-Marker im `deploy/install/templates/env.production` (sonst feuert der Validator nie, da `environment` sonst auf `development` bliebe).

### 4. `file_upload`-Rate-Limit realistisch
`core/rate_limiter.py`: `file_upload` 50000→**300/min** (war praktisch unlimitiert). `file_chunked` **bewusst hoch gelassen** — gated jeden Chunk-PUT, Senken würde große Uploads drosseln.

### Bereits erledigt (kein Code)
Audit #4 (Monitoring-History Row-Limit): alle History-Endpoints haben schon `limit ... le=10000` — nur verifiziert.

## Tests

- Neue Tests: `tests/files/test_chunked_upload.py` (2 Overflow-Guards), `tests/services/test_websocket_manager.py` (Cap), `tests/test_config_validation.py` (3), `tests/test_rate_limit_values.py` (2).
- Verifikation: `python -m pytest tests/files/test_chunked_upload.py tests/services/test_websocket_manager.py tests/test_websocket_auth.py tests/test_config_validation.py tests/test_rate_limit_values.py` → **58 passed**.
- Ruff: clean.

## Operativer Follow-up (nach Merge, nicht aus Code)

Die Live-`BaluNode` hat ein generiertes `.env.production` ohne `ENVIRONMENT=production`. Damit der dev-in-prod-Guard dort greift: `ENVIRONMENT=production` an `/opt/baluhost/.env.production` anhängen + Backend-Restart. (Nicht über CI ändern.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
