### PR TITLE
fix(security): hardening batch — WebDAV resolve(), commit-SHA validation, Pi-hole DNS (audit #5/#6/#7)

### DIFF
--- a/backend/app/compat/webdav_provider.py
+++ b/backend/app/compat/webdav_provider.py
@@ -63,15 +63,16 @@ class BaluHostDAVProvider(FilesystemProvider):
             role = environ.get("baluhost.user_role", "")
             username = environ.get("wsgidav.auth.user_name", "")
             if role != "admin" and username:
-                user_root = os.path.join(self._storage_root, username)
-                os.makedirs(user_root, exist_ok=True)
+                user_root = (Path(self._storage_root) / username).resolve()
+                user_root.mkdir(parents=True, exist_ok=True)
                 path_parts = path.strip("/").split("/") if path.strip("/") else []
-                file_path = os.path.join(user_root, *path_parts)
-                # Prevent path traversal
-                file_path = os.path.normpath(file_path)
-                if not file_path.startswith(user_root):
+                candidate = user_root.joinpath(*path_parts) if path_parts else user_root
+                # resolve() follows symlinks and collapses '..'; is_relative_to
+                # rejects both traversal and sibling-prefix escapes (bob vs bobby).
+                resolved = candidate.resolve()
+                if resolved != user_root and not resolved.is_relative_to(user_root):
                     raise ValueError("Path traversal detected")
-                return file_path
+                return str(resolved)
         return super()._loc_to_file_path(path, environ)
 
     def get_resource_inst(self, path: str, environ: dict) -> _DAVResource | None:  # type: ignore[override]

--- a/backend/app/services/pihole/docker_backend.py
+++ b/backend/app/services/pihole/docker_backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 import secrets
 from functools import partial
@@ -25,6 +26,27 @@ _PIHOLE_BLOCKED_STATUSES = frozenset({
     "EXTERNAL_BLOCKED_IP", "EXTERNAL_BLOCKED_NULL", "EXTERNAL_BLOCKED_NXRA",
     "GRAVITY_CNAME", "REGEX_DENY_CNAME", "EXACT_DENY_CNAME",
 })
+
+
+def _build_resolv_lines(upstream_dns: str) -> str:
+    """Build resolv.conf 'nameserver <ip>' lines from a ';'-separated DNS string.
+
+    Only entries that parse as a valid IP address are included. This prevents
+    a misconfigured or malicious upstream_dns value from injecting shell
+    metacharacters into the in-container `sh -c` that writes /etc/resolv.conf.
+    """
+    lines = []
+    for raw in upstream_dns.split(";"):
+        entry = raw.strip()
+        if not entry:
+            continue
+        try:
+            ipaddress.ip_address(entry)
+        except ValueError:
+            logger.warning("Ignoring non-IP upstream DNS entry for resolv.conf: %r", entry)
+            continue
+        lines.append(f"nameserver {entry}")
+    return "\n".join(lines)
 
 
 def _normalize_status(raw: str) -> str:
@@ -181,13 +203,15 @@ class ContainerManager:
 
         # Fix container DNS — Docker may override /etc/resolv.conf even in host mode
         try:
-            dns_entries = [ip.strip() for ip in upstream_dns.split(";") if ip.strip()]
-            resolv_lines = "\\n".join(f"nameserver {ip}" for ip in dns_entries)
-            await self._run_sync(
-                container.exec_run,
-                ["sh", "-c", f"printf '{resolv_lines}\\n' > /etc/resolv.conf"],
-            )
-            logger.info("Wrote /etc/resolv.conf into container: %s", dns_entries)
+            resolv_lines = _build_resolv_lines(upstream_dns)
+            if resolv_lines:
+                await self._run_sync(
+                    container.exec_run,
+                    ["sh", "-c", f"printf '{resolv_lines}\\n' > /etc/resolv.conf"],
+                )
+                logger.info("Wrote /etc/resolv.conf into container")
+            else:
+                logger.warning("No valid upstream DNS IPs — leaving container resolv.conf untouched")
         except Exception as exc:
             logger.warning("Could not fix container resolv.conf: %s", exc)
 

--- a/backend/app/services/update/prod_backend.py
+++ b/backend/app/services/update/prod_backend.py
@@ -225,6 +225,9 @@ class ProdUpdateBackend(UpdateBackend):
 
     async def rollback(self, commit: str) -> tuple[bool, Optional[str]]:
         """Rollback to a specific commit."""
+        if not self._is_valid_commit(commit):
+            return False, f"Invalid commit identifier: {commit!r}"
+
         logger.info(f"Rolling back to {commit}")
 
         success, _, err = self._run_git("checkout", commit)

--- a/backend/app/services/update/prod_backend.py
+++ b/backend/app/services/update/prod_backend.py
@@ -41,6 +41,10 @@ from app.services.update.utils import (
 
 logger = logging.getLogger(__name__)
 
+# Update targets are always resolved commit SHAs (7-40 hex). Reject anything
+# else before it reaches `git checkout` (blocks option-injection like --force).
+_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+
 
 class ProdUpdateBackend(UpdateBackend):
     """Production backend using Git and systemctl."""
@@ -180,9 +184,16 @@ class ProdUpdateBackend(UpdateBackend):
 
         return success
 
+    @staticmethod
+    def _is_valid_commit(commit: str) -> bool:
+        return bool(commit) and bool(_COMMIT_RE.match(commit))
+
     async def apply_updates(
         self, target_commit: str, callback: Optional[ProgressCallback] = None
     ) -> tuple[bool, Optional[str]]:
+        if not self._is_valid_commit(target_commit):
+            return False, f"Invalid commit identifier: {target_commit!r}"
+
         if callback:
             callback(10, "Stashing local changes...")
 
@@ -239,6 +250,9 @@ class ProdUpdateBackend(UpdateBackend):
         The script runs as root via systemd-run and survives backend restarts.
         It writes progress to /var/lib/baluhost/update-status/<update_id>.json.
         """
+        if not self._is_valid_commit(to_commit) or not self._is_valid_commit(from_commit):
+            return False, "Invalid commit identifier for update"
+
         script_path = self.repo_path / "deploy" / "update" / "run-update.sh"
         if not script_path.exists():
             return False, f"Update script not found: {script_path}"

--- a/backend/tests/test_pihole_resolv_lines.py
+++ b/backend/tests/test_pihole_resolv_lines.py
@@ -1,0 +1,23 @@
+"""upstream_dns IP-validation for the Pi-hole container resolv.conf (audit #7)."""
+from app.services.pihole.docker_backend import _build_resolv_lines
+
+
+def test_valid_ips_become_nameserver_lines():
+    assert _build_resolv_lines("1.1.1.1;1.0.0.1") == "nameserver 1.1.1.1\nnameserver 1.0.0.1"
+
+
+def test_ipv6_allowed():
+    assert _build_resolv_lines("2606:4700:4700::1111") == "nameserver 2606:4700:4700::1111"
+
+
+def test_shell_metachar_entry_is_dropped():
+    # An injection attempt is not a valid IP → excluded entirely.
+    assert _build_resolv_lines("1.1.1.1; rm -rf /") == "nameserver 1.1.1.1"
+
+
+def test_all_invalid_yields_empty():
+    assert _build_resolv_lines("not-an-ip;$(whoami)") == ""
+
+
+def test_whitespace_and_blanks_ignored():
+    assert _build_resolv_lines(" 8.8.8.8 ; ; 8.8.4.4 ") == "nameserver 8.8.8.8\nnameserver 8.8.4.4"

--- a/backend/tests/test_update_commit_validation.py
+++ b/backend/tests/test_update_commit_validation.py
@@ -1,0 +1,47 @@
+"""Commit-identifier validation before git checkout (audit #6)."""
+import pytest
+
+from app.services.update.prod_backend import ProdUpdateBackend
+
+
+@pytest.mark.asyncio
+async def test_apply_updates_rejects_option_like_commit(tmp_path, monkeypatch):
+    backend = ProdUpdateBackend(repo_path=tmp_path)
+    called = []
+    monkeypatch.setattr(backend, "_run_git", lambda *a, **k: called.append(a) or (True, "", ""))
+    ok, err = await backend.apply_updates("--force")
+    assert ok is False
+    assert err is not None and "commit" in err.lower()
+    assert called == []  # git was never invoked
+
+
+@pytest.mark.asyncio
+async def test_apply_updates_rejects_metachar_commit(tmp_path, monkeypatch):
+    backend = ProdUpdateBackend(repo_path=tmp_path)
+    monkeypatch.setattr(backend, "_run_git", lambda *a, **k: (True, "", ""))
+    ok, err = await backend.apply_updates("abc123; rm -rf /")
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_apply_updates_accepts_valid_sha(tmp_path, monkeypatch):
+    backend = ProdUpdateBackend(repo_path=tmp_path)
+    # stash, checkout, rev-parse all "succeed"; rev-parse returns detached HEAD
+    def fake_git(*args, **kwargs):
+        if args[:1] == ("rev-parse",):
+            return True, "HEAD", ""
+        return True, "", ""
+    monkeypatch.setattr(backend, "_run_git", fake_git)
+    ok, err = await backend.apply_updates("a" * 40)
+    assert ok is True
+    assert err is None
+
+
+def test_launch_update_script_rejects_bad_commit(tmp_path):
+    backend = ProdUpdateBackend(repo_path=tmp_path)
+    ok, err = backend.launch_update_script(
+        update_id=1, from_commit="abc1234", to_commit="--exec=evil",
+        from_version="1.0.0", to_version="1.0.1",
+    )
+    assert ok is False
+    assert err is not None and "commit" in err.lower()

--- a/backend/tests/test_update_commit_validation.py
+++ b/backend/tests/test_update_commit_validation.py
@@ -45,3 +45,23 @@ def test_launch_update_script_rejects_bad_commit(tmp_path):
     )
     assert ok is False
     assert err is not None and "commit" in err.lower()
+
+
+@pytest.mark.asyncio
+async def test_rollback_rejects_bad_commit(tmp_path, monkeypatch):
+    backend = ProdUpdateBackend(repo_path=tmp_path)
+    called = []
+    monkeypatch.setattr(backend, "_run_git", lambda *a, **k: called.append(a) or (True, "", ""))
+    ok, err = await backend.rollback("--hard")
+    assert ok is False
+    assert err is not None and "commit" in err.lower()
+    assert called == []  # git never invoked
+
+
+@pytest.mark.asyncio
+async def test_rollback_accepts_valid_sha(tmp_path, monkeypatch):
+    backend = ProdUpdateBackend(repo_path=tmp_path)
+    monkeypatch.setattr(backend, "_run_git", lambda *a, **k: (True, "", ""))
+    ok, err = await backend.rollback("b" * 40)
+    assert ok is True
+    assert err is None

--- a/backend/tests/test_webdav_provider_isolation.py
+++ b/backend/tests/test_webdav_provider_isolation.py
@@ -1,0 +1,57 @@
+"""Isolation tests for BaluHostDAVProvider._loc_to_file_path (audit #5)."""
+import os
+from pathlib import Path
+
+import pytest
+
+from app.compat.webdav_provider import BaluHostDAVProvider
+
+USER_ENV = {"baluhost.user_role": "user", "wsgidav.auth.user_name": "bob"}
+
+
+def _provider(tmp_path) -> BaluHostDAVProvider:
+    return BaluHostDAVProvider(str(tmp_path))
+
+
+def test_normal_user_path_maps_into_user_root(tmp_path):
+    provider = _provider(tmp_path)
+    fp = Path(provider._loc_to_file_path("/docs/file.txt", USER_ENV))
+    expected = (tmp_path / "bob" / "docs" / "file.txt").resolve()
+    assert fp == expected
+
+
+def test_dotdot_traversal_raises(tmp_path):
+    provider = _provider(tmp_path)
+    with pytest.raises(ValueError, match="Path traversal"):
+        provider._loc_to_file_path("/../etc/passwd", USER_ENV)
+
+
+def test_username_prefix_sibling_blocked(tmp_path):
+    """user 'bob' must NOT reach a sibling dir 'bobby' via '..' (startswith bug)."""
+    (tmp_path / "bobby").mkdir()
+    provider = _provider(tmp_path)
+    with pytest.raises(ValueError, match="Path traversal"):
+        provider._loc_to_file_path("/../bobby/secret.txt", USER_ENV)
+
+
+def test_symlink_escape_blocked(tmp_path):
+    """A symlink inside the user root that points outside must be rejected."""
+    bob_root = tmp_path / "bob"
+    bob_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    try:
+        (bob_root / "evil").symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not permitted on this platform")
+    provider = _provider(tmp_path)
+    with pytest.raises(ValueError, match="Path traversal"):
+        provider._loc_to_file_path("/evil/secret.txt", USER_ENV)
+
+
+def test_admin_path_delegates_to_super(tmp_path):
+    """Admin role bypasses per-user isolation (delegates to base provider)."""
+    provider = _provider(tmp_path)
+    admin_env = {"baluhost.user_role": "admin", "wsgidav.auth.user_name": "root"}
+    fp = provider._loc_to_file_path("/file.txt", admin_env)
+    assert fp  # base provider returns a path under storage_root, no exception


### PR DESCRIPTION
## Was & Warum

Drei Medium-Items aus dem Härtungs-Backlog des Security-Audits, subagent-getrieben umgesetzt (TDD pro Task, Task-Review nach jedem Task, abschließender Whole-Branch-Review). Plus eine im Final-Review gefundene Vervollständigung.

## Änderungen

### #5 — WebDAV Per-User-Isolation via `Path.resolve()`
`_loc_to_file_path` (`compat/webdav_provider.py`) nutzte `os.path.normpath` + `str.startswith`. Zwei Bugs:
- **Symlink-Escape**: `normpath` löst Symlinks nicht auf → ein Symlink im User-Root konnte rausführen.
- **Username-Prefix-Bug**: `"…/bobby".startswith("…/bob")` ist `True` → User `bob` konnte via `../bobby/…` ins Home von `bobby`.

Fix: `Path.resolve()` (folgt Symlinks, kollabiert `..`) + `is_relative_to()` (echte Containment-Prüfung, kein String-Prefix).

### #6 — Commit-SHA-Validierung vor `git checkout`
Der Prod-Update-Backend (`services/update/prod_backend.py`) reichte `target_commit`/`to_commit` direkt an `git checkout`. Zwar List-Args (kein Shell), aber ein ungeprüfter Wert konnte eine Git-Option (`--force`) oder beliebige Ref sein. Neu: `_COMMIT_RE = ^[0-9a-fA-F]{7,40}$` + `_is_valid_commit()`-Guard in `apply_updates`, `launch_update_script` **und `rollback`**.

> `rollback` kam erst durch den Whole-Branch-Review dazu: dessen `commit` stammt **direkt** aus dem Client (`RollbackRequest.target_commit`, free-form, admin-only) → war die *exponierteste* der drei Checkout-Stellen. Audit #6 ist damit vollständig.

### #7 — Pi-hole Upstream-DNS als IPs validieren
`deploy_container` (`services/pihole/docker_backend.py`) baute `/etc/resolv.conf` im Container per `sh -c` aus einem f-string mit dem admin-gesetzten `upstream_dns` → Shell-Injection-Fläche. Neu: `_build_resolv_lines()` nimmt nur Einträge, die als IP parsen (`ipaddress.ip_address`); Ungültiges wird verworfen+geloggt. IPs enthalten keine Shell-Metazeichen → Injection unmöglich.

## Tests

- Neu: `tests/test_webdav_provider_isolation.py` (5), `tests/test_update_commit_validation.py` (6), `tests/test_pihole_resolv_lines.py` (5).
- Verifikation: `pytest test_webdav_provider_isolation.py test_update_commit_validation.py test_pihole_resolv_lines.py services/test_update_service.py` → **78 passed**.
- Ruff: clean.

## Scope-Hinweis

Dieser Batch deckt die **Medium-Items #5/#6/#7**. Aus dem Härtungs-Backlog bleiben offen: Quick Wins (is_active-Check, constant-time Service-Token, Avatar-MIME, print→logger), CSP-Tightening (#8, braucht Frontend-Verifikation), Config-Defaults (#9, Policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
