### PR TITLE
fix(security): hardening quick-wins — is_active, constant-time token, avatar MIME, no token in logs (audit #1-4)

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -156,7 +156,7 @@ async def get_current_user_optional(
     try:
         payload: TokenPayload = auth_service.decode_token(token)
         user = user_service.get_user(payload.sub, db=db)
-        if not user:
+        if not user or not user.is_active:
             return None
         return user_service.serialize_user(user)
     except auth_service.InvalidTokenError:

--- a/backend/app/api/routes/mobile.py
+++ b/backend/app/api/routes/mobile.py
@@ -101,7 +101,7 @@ async def generate_registration_token(
         server_url = f"http://{local_ip}:8000"
     
     # Debug output
-    print(f"[Mobile Token] User: {current_user.username}, Server URL: {server_url}, Token validity: {token_validity_days} days")
+    logger.debug("Mobile token generated for user %s (server_url=%s, validity=%s days)", current_user.username, server_url, token_validity_days)
     
     return MobileService.generate_registration_token(
         db=db,
@@ -176,16 +176,16 @@ async def get_devices(
     # Admin sieht alle Geräte aller Nutzer
     if current_user.role == "admin":
         devices = MobileService.get_all_devices_with_users(db=db)
-        print(f"[GET DEVICES] Admin sees all {len(devices)} device(s)")
+        logger.debug("[GET DEVICES] Admin sees all %s device(s)", len(devices))
     else:
         devices = MobileService.get_user_devices(db=db, user_id=current_user.id)
-        print(f"[GET DEVICES] User {current_user.id} has {len(devices)} device(s)")
+        logger.debug("[GET DEVICES] User %s has %s device(s)", current_user.id, len(devices))
     
     for dev in devices:
         # Für Admin: dev ist dict, für User: dev ist MobileDevice-Objekt
         device_id = dev.get('id') if isinstance(dev, dict) else dev.id
         device_name = dev.get('device_name') if isinstance(dev, dict) else dev.device_name
-        print(f"  - {device_id}: {device_name}")
+        logger.debug("  - %s: %s", device_id, device_name)
     return devices
 
 
@@ -274,7 +274,7 @@ async def delete_device(
                 )
         except Exception as e:
             # Don't block deletion if notification fails
-            print(f"[Mobile] Failed to send removal notification: {e}")
+            logger.warning("Failed to send removal notification: %s", e)
 
     MobileService.remove_device(db, device)
     return None
@@ -327,7 +327,7 @@ async def register_push_token(
     if FirebaseService.is_available():
         token_valid = FirebaseService.verify_token(push_token)
     
-    print(f"[Mobile] Registered FCM token for {device.device_name}: {push_token[:20]}... (valid: {token_valid})")
+    logger.debug("Registered FCM token for device %s (valid=%s)", device.device_name, token_valid)
     
     return {
         "success": True,

--- a/backend/app/api/routes/power.py
+++ b/backend/app/api/routes/power.py
@@ -34,7 +34,9 @@ async def _get_admin_or_service_token(
     """
     # 1. Check X-Service-Token header
     service_token = request.headers.get("X-Service-Token")
-    if service_token and secrets.compare_digest(service_token, settings.scheduler_service_token):
+    if service_token and secrets.compare_digest(
+        service_token.encode("utf-8"), settings.scheduler_service_token.encode("utf-8")
+    ):
         return  # Service token valid
 
     # 2. Fall back to normal admin JWT auth

--- a/backend/app/api/routes/power.py
+++ b/backend/app/api/routes/power.py
@@ -5,6 +5,7 @@ Provides endpoints for CPU power profile management and monitoring.
 """
 
 import logging
+import secrets
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -33,7 +34,7 @@ async def _get_admin_or_service_token(
     """
     # 1. Check X-Service-Token header
     service_token = request.headers.get("X-Service-Token")
-    if service_token and service_token == settings.scheduler_service_token:
+    if service_token and secrets.compare_digest(service_token, settings.scheduler_service_token):
         return  # Service token valid
 
     # 2. Fall back to normal admin JWT auth

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -14,6 +14,18 @@ from app.services.audit.logger_db import get_audit_logger_db
 
 router = APIRouter()
 
+_AVATAR_EXT_BY_TYPE = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+}
+
+
+def _avatar_ext(content_type: str) -> str:
+    """Return a safe file extension for a validated avatar content type."""
+    return _AVATAR_EXT_BY_TYPE[content_type]
+
 
 @router.get("/", response_model=UsersResponse)
 @user_limiter.limit(get_limit("user_operations"))
@@ -313,8 +325,9 @@ async def upload_avatar(
         except FileNotFoundError:
             pass
     
-    # Generate unique filename
-    file_ext = Path(avatar.filename or "avatar").suffix
+    # Generate unique filename — extension from the VALIDATED content type,
+    # never from the user-supplied filename (stored-XSS guard).
+    file_ext = _avatar_ext(avatar.content_type)
     unique_filename = f"{uuid.uuid4()}{file_ext}"
     file_path = avatars_dir / unique_filename
     

--- a/backend/tests/test_avatar_extension.py
+++ b/backend/tests/test_avatar_extension.py
@@ -1,0 +1,14 @@
+"""Avatar extension must come from the validated MIME, not the user filename (audit #3)."""
+from app.api.routes.users import _AVATAR_EXT_BY_TYPE, _avatar_ext
+
+
+def test_each_allowed_type_maps_to_safe_extension():
+    assert _avatar_ext("image/jpeg") == ".jpg"
+    assert _avatar_ext("image/png") == ".png"
+    assert _avatar_ext("image/gif") == ".gif"
+    assert _avatar_ext("image/webp") == ".webp"
+
+
+def test_extensions_are_image_only():
+    # No executable/markup extensions can ever be produced.
+    assert set(_AVATAR_EXT_BY_TYPE.values()) == {".jpg", ".png", ".gif", ".webp"}

--- a/backend/tests/test_get_current_user_optional_active.py
+++ b/backend/tests/test_get_current_user_optional_active.py
@@ -1,0 +1,32 @@
+"""get_current_user_optional must reject inactive users on the JWT path (audit #1)."""
+import types
+
+import pytest
+
+from app.api import deps
+
+
+class _FakeReq:
+    client = None
+    state = types.SimpleNamespace()
+
+
+@pytest.mark.asyncio
+async def test_optional_auth_returns_none_for_inactive_user(monkeypatch):
+    inactive = types.SimpleNamespace(id=1, username="u", is_active=False, role="user")
+    monkeypatch.setattr(deps.auth_service, "decode_token",
+                        lambda t: types.SimpleNamespace(sub="1"))
+    monkeypatch.setattr(deps.user_service, "get_user", lambda sub, db=None: inactive)
+    result = await deps.get_current_user_optional(_FakeReq(), token="jwt.token.here", db=None)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_optional_auth_returns_active_user(monkeypatch):
+    active = types.SimpleNamespace(id=1, username="u", is_active=True, role="user")
+    monkeypatch.setattr(deps.auth_service, "decode_token",
+                        lambda t: types.SimpleNamespace(sub="1"))
+    monkeypatch.setattr(deps.user_service, "get_user", lambda sub, db=None: active)
+    monkeypatch.setattr(deps.user_service, "serialize_user", lambda u: u)
+    result = await deps.get_current_user_optional(_FakeReq(), token="jwt.token.here", db=None)
+    assert result is active

--- a/backend/tests/test_mobile_no_token_stdout.py
+++ b/backend/tests/test_mobile_no_token_stdout.py
@@ -1,0 +1,19 @@
+"""The FCM push token must never be written to stdout (audit #4)."""
+import inspect
+
+from app.api.routes import mobile
+
+
+def test_mobile_module_has_no_print_calls():
+    """All debug output in mobile.py must go through logging, not print()."""
+    src = inspect.getsource(mobile)
+    # Ignore occurrences inside this assertion's own string by checking the
+    # source of the module file directly.
+    assert "print(" not in src, "mobile.py must not use print() (use logger)"
+
+
+def test_register_push_token_source_does_not_print_token():
+    src = inspect.getsource(mobile.register_push_token)
+    assert "print(" not in src
+    # The token value must not be interpolated into any log/print line.
+    assert "push_token[:20]" not in src

--- a/backend/tests/test_service_token_compare.py
+++ b/backend/tests/test_service_token_compare.py
@@ -1,0 +1,36 @@
+"""Service-token check must use a constant-time compare (audit #2)."""
+import types
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routes import power
+from app.core.config import settings
+
+
+def _req(token_value):
+    return types.SimpleNamespace(headers={"X-Service-Token": token_value} if token_value else {})
+
+
+@pytest.mark.asyncio
+async def test_correct_service_token_accepted(monkeypatch):
+    monkeypatch.setattr(settings, "scheduler_service_token", "s3cr3t-token-value")
+    # No JWT; a correct service token must pass without raising.
+    result = await power._get_admin_or_service_token(_req("s3cr3t-token-value"), token=None)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_wrong_service_token_falls_through_to_jwt(monkeypatch):
+    monkeypatch.setattr(settings, "scheduler_service_token", "s3cr3t-token-value")
+    # Wrong token + no JWT → 401 (falls through to the JWT branch which has no token).
+    with pytest.raises(HTTPException) as exc:
+        await power._get_admin_or_service_token(_req("wrong"), token=None)
+    assert exc.value.status_code == 401
+
+
+def test_power_module_uses_secrets_compare():
+    """Guard against regression to plain ==."""
+    import inspect
+    src = inspect.getsource(power._get_admin_or_service_token)
+    assert "compare_digest" in src

--- a/backend/tests/test_service_token_compare.py
+++ b/backend/tests/test_service_token_compare.py
@@ -34,3 +34,12 @@ def test_power_module_uses_secrets_compare():
     import inspect
     src = inspect.getsource(power._get_admin_or_service_token)
     assert "compare_digest" in src
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_service_token_falls_through_to_401(monkeypatch):
+    monkeypatch.setattr(settings, "scheduler_service_token", "s3cr3t-token-value")
+    # A non-ASCII header must NOT raise TypeError (500); it should deny -> 401.
+    with pytest.raises(HTTPException) as exc:
+        await power._get_admin_or_service_token(_req("tök\xffen"), token=None)
+    assert exc.value.status_code == 401


### PR DESCRIPTION
## Was & Warum

Vier kleine Härtungs-„Quick Wins" aus dem Security-Audit, subagent-getrieben (TDD pro Fix, abschließender Whole-Branch-Review). Plus eine vom Review gefundene Robustheits-Ergänzung.

## Änderungen

### #1 — `is_active` in `get_current_user_optional` (`api/deps.py`)
Der JWT-Pfad gab den User ohne `is_active`-Prüfung zurück (der API-Key-Pfad direkt darüber prüft es bereits). Ein deaktivierter User mit noch gültigem Access-Token kam an Optional-Auth-Endpoints. Fix: `if not user or not user.is_active: return None`.

### #2 — Constant-time Service-Token-Vergleich (`api/routes/power.py`)
`X-Service-Token` wurde mit `==` verglichen (Timing-Seitenkanal). Auf `secrets.compare_digest` umgestellt — auf **UTF-8-Bytes**, damit ein non-ASCII-Header sauber mit 401 abgelehnt wird statt `TypeError`→500 (vom Whole-Branch-Review gefunden).

### #3 — Avatar-Endung aus validiertem MIME (`api/routes/users.py`)
Der `content_type` wurde gegen eine Allow-List geprüft, die gespeicherte Dateiendung kam aber aus `avatar.filename` (User-kontrolliert) → `.svg`/`.html` als statisch ausgelieferter Avatar = Stored-XSS. Neu: `_AVATAR_EXT_BY_TYPE`/`_avatar_ext()` leiten die Endung aus dem validierten Typ ab; der User-Filename hat keinen Einfluss mehr.

### #4 — FCM-Token nicht mehr nach stdout (`api/routes/mobile.py`)
Alle 6 `print()` durch `logger` ersetzt; die FCM-Token-Zeile loggt **keinen** Token-Wert mehr (vorher `push_token[:20]` → journal/nginx-Logs). `firebase.py` (18 Prints, kein Token-Leak) bleibt bewusst out-of-scope → separater Cleanup.

## Tests

- Neu: `test_get_current_user_optional_active.py` (2), `test_service_token_compare.py` (4), `test_avatar_extension.py` (2), `test_mobile_no_token_stdout.py` (2). #2/#4 nutzen Source-Inspection-Asserts (constant-time / kein stdout sind so am robustesten lockbar); #2 hat zusätzlich echte Verhaltenstests.
- Verifikation: alle vier Suiten → **10 passed**. Ruff clean.

## Scope

Damit ist der Härtung-Block bis auf **CSP (#8, braucht Frontend-Verifikation)**, **Config-Defaults (#9, Policy)** und den `firebase.py`-Print-Cleanup abgearbeitet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
