### PR TITLE
fix(security): trust nginx X-Forwarded-For for real client IP (audit #9 follow-up)

### DIFF
--- a/backend/tests/test_deploy_proxy_headers.py
+++ b/backend/tests/test_deploy_proxy_headers.py
@@ -1,0 +1,30 @@
+"""Lock the prod backend's uvicorn proxy-header trust config (audit #9 follow-up).
+
+Behind nginx (proxy_pass -> 127.0.0.1:8000), uvicorn must honor X-Forwarded-For
+so request.client.host is the real client IP — otherwise the per-IP rate limiter
+and audit logs all see 127.0.0.1. The trust MUST be pinned to the local nginx
+upstream to prevent X-Forwarded-For spoofing.
+"""
+from pathlib import Path
+
+_TEMPLATE = (
+    Path(__file__).resolve().parents[2]
+    / "deploy" / "install" / "templates" / "baluhost-backend.service"
+)
+
+
+def test_template_exists():
+    assert _TEMPLATE.is_file(), f"systemd template missing: {_TEMPLATE}"
+
+
+def test_proxy_headers_enabled():
+    text = _TEMPLATE.read_text(encoding="utf-8")
+    assert "--proxy-headers" in text, "uvicorn must run with --proxy-headers behind nginx"
+
+
+def test_forwarded_allow_ips_pinned_to_localhost():
+    text = _TEMPLATE.read_text(encoding="utf-8")
+    # Trust pin: only the local nginx upstream may set X-Forwarded-For.
+    assert "--forwarded-allow-ips=127.0.0.1" in text, (
+        "X-Forwarded-For trust must be pinned to 127.0.0.1 (anti-spoofing)"
+    )

--- a/deploy/install/templates/baluhost-backend.service
+++ b/deploy/install/templates/baluhost-backend.service
@@ -15,13 +15,19 @@ EnvironmentFile=@@INSTALL_DIR@@/.env.production
 # Clean up stale primary worker lock before start
 ExecStartPre=/usr/bin/rm -f /tmp/baluhost-primary.lock
 
-# Virtual environment activation and uvicorn start
+# Virtual environment activation and uvicorn start.
+# --proxy-headers + --forwarded-allow-ips=127.0.0.1: trust X-Forwarded-For ONLY
+# from the local nginx upstream, so request.client.host is the real client IP
+# (per-client rate limiting + accurate audit IPs). The trust pin to 127.0.0.1
+# prevents X-Forwarded-For spoofing, incl. direct connections to :8000.
 ExecStart=@@VENV_BIN@@/uvicorn app.main:app \
     --host 0.0.0.0 \
     --port 8000 \
     --workers 4 \
     --log-level info \
-    --no-access-log
+    --no-access-log \
+    --proxy-headers \
+    --forwarded-allow-ips=127.0.0.1
 
 # Restart policy
 Restart=always


### PR DESCRIPTION
## Was & Warum

Aus der Untersuchung von Audit **#9** (`enforce_local_only`/`registration_enabled`-Defaults) — die literal fast ein Non-Issue ist — fiel ein **echter** Gap auf:

Die App lief hinter nginx (`proxy_pass http://127.0.0.1:8000`) **ohne** `--proxy-headers`. Dadurch war `request.client.host` für **jede** Anfrage `127.0.0.1` (der Proxy), nicht die echte Client-IP. Folgen:
- Der **FastAPI-Rate-Limiter** (`get_remote_address`) keyt auf `127.0.0.1` → **alle Clients teilen einen Bucket**; der Login-Brute-Force-Limiter (5/min) wirkt global statt per-IP.
- **Audit-Logs** verlieren die echte Client-IP.

## Fix

uvicorn im prod-systemd-Unit (`baluhost-backend.service`) mit:
```
--proxy-headers --forwarded-allow-ips=127.0.0.1
```
- `--proxy-headers`: X-Forwarded-For wird ausgewertet → echte Client-IP.
- `--forwarded-allow-ips=127.0.0.1`: Vertrauen **nur** vom lokalen nginx-Upstream → kein X-Forwarded-For-Spoofing, auch nicht bei Direktzugriff auf `:8000` (dort ist der Peer nicht 127.0.0.1, also wird der Header ignoriert).

Greift automatisch beim nächsten Deploy (systemd-Templates werden in Modul 10 neu gerendert + Restart).

## Zu #9 selbst (kein Code nötig)

- **`registration_enabled`**: Default ist in prod bereits `False` → Registrierung aus, außer der Operator setzt sie *explizit* (mit Validator-Warnung). Safe-by-default, belassen.
- **`enforce_local_only`**: redundant zur **VPN-Grenze** (externer Zugang nur via WireGuard) und hinter nginx ohnehin wirkungslos (s.o.) → off gelassen.

## Tests

- Neu: `tests/test_deploy_proxy_headers.py` — Regression-Lock, dass `--proxy-headers` + `--forwarded-allow-ips=127.0.0.1` im Template stehen (3 passed). uvicorn kennt beide Flags (verifiziert).

## Folge / operativ

Mit diesem Fix greift der per-IP-FastAPI-Limiter wieder. Für vollen Login-Brute-Force-Schutz sollte zusätzlich die **deployte nginx `auth_limit`** von 600/min auf 5/min (live-Config prüfen — separater operativer Punkt aus dem HÄRTUNG-Block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
