### PR TITLE
fix(security): tighten nginx auth_limit 10r/s -> 5r/m on /api/auth/ (audit HÄRTUNG)

### DIFF
--- a/backend/tests/test_deploy_nginx_auth_limit.py
+++ b/backend/tests/test_deploy_nginx_auth_limit.py
@@ -1,0 +1,39 @@
+"""Lock the nginx auth_limit rate (audit HÄRTUNG follow-up).
+
+The deployed nginx config (module 11 renders baluhost-nginx-http.conf) had
+`auth_limit ... rate=10r/s` (= 600/min) on /api/auth/ — effectively no brute-force
+guard at the edge. It must be the intended 5 req/min. The reference configs under
+deploy/nginx/ must not reintroduce the 10r/s value either.
+"""
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_DEPLOYED = _REPO / "deploy" / "install" / "templates" / "baluhost-nginx-http.conf"
+_REFERENCES = [
+    _REPO / "deploy" / "nginx" / "baluhost-http.conf",
+    _REPO / "deploy" / "nginx" / "baluhost-https.conf",
+]
+
+
+def test_deployed_template_auth_limit_is_5_per_min():
+    text = _DEPLOYED.read_text(encoding="utf-8")
+    assert "zone=auth_limit:10m rate=5r/m" in text, (
+        "deployed nginx auth_limit must be rate=5r/m (brute-force guard)"
+    )
+
+
+def test_deployed_template_has_no_10rs_auth_limit():
+    text = _DEPLOYED.read_text(encoding="utf-8")
+    assert "zone=auth_limit:10m rate=10r/s" not in text, (
+        "auth_limit must not be 10r/s (600/min — no real brute-force protection)"
+    )
+
+
+def test_reference_configs_do_not_reintroduce_10rs_auth_limit():
+    for cfg in _REFERENCES:
+        if not cfg.is_file():
+            continue
+        text = cfg.read_text(encoding="utf-8")
+        assert "zone=auth_limit:10m rate=10r/s" not in text, (
+            f"{cfg.name} reintroduced auth_limit rate=10r/s"
+        )

--- a/deploy/install/templates/baluhost-nginx-http.conf
+++ b/deploy/install/templates/baluhost-nginx-http.conf
@@ -5,7 +5,11 @@
 
 # Rate limiting zones
 limit_req_zone $binary_remote_addr zone=api_limit:10m rate=100r/s;
-limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=10r/s;
+# auth_limit: edge brute-force guard on /api/auth/. The FastAPI layer adds precise
+# per-endpoint per-IP limits (login 5/min, register 3/min, …) — see core/rate_limiter.py.
+# Requires uvicorn --proxy-headers so $binary_remote_addr / the app limiter see the
+# real client IP and not the nginx upstream.
+limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=5r/m;
 
 # WebSocket connection upgrade mapping
 map $http_upgrade $connection_upgrade {
@@ -106,7 +110,7 @@ server {
     location /api/auth/ {
         proxy_pass http://baluhost_backend;
 
-        # Stricter rate limiting for auth (10 req/s)
+        # Stricter rate limiting for auth (5 req/min sustained, burst 5)
         limit_req zone=auth_limit burst=5 nodelay;
 
         proxy_set_header Host $host;

--- a/deploy/nginx/baluhost-http.conf
+++ b/deploy/nginx/baluhost-http.conf
@@ -5,7 +5,7 @@
 
 # Rate limiting zones
 limit_req_zone $binary_remote_addr zone=api_limit:10m rate=100r/s;
-limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=10r/s;
+limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=5r/m;  # brute-force guard (app layer adds per-endpoint limits)
 
 # WebSocket connection upgrade mapping
 map $http_upgrade $connection_upgrade {

--- a/deploy/nginx/baluhost-https.conf
+++ b/deploy/nginx/baluhost-https.conf
@@ -10,7 +10,7 @@
 
 # Rate limiting zones
 limit_req_zone $binary_remote_addr zone=api_limit:10m rate=100r/s;
-limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=10r/s;
+limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=5r/m;  # brute-force guard (app layer adds per-endpoint limits)
 
 # WebSocket connection upgrade mapping
 map $http_upgrade $connection_upgrade {


### PR DESCRIPTION
## Was & Warum

HÄRTUNG-Folgepunkt (direkt aus #273): Die **deployte** nginx-Config (Modul 11 rendert `baluhost-nginx-http.conf` nach `/etc/nginx/sites-available/baluhost`) limitierte `/api/auth/` mit **`rate=10r/s` (= 600/min)** — praktisch **kein** Edge-Brute-Force-Schutz.

Mit dem proxy-headers-Fix (#273) wirkt der per-IP-FastAPI-Limiter jetzt präzise (login 5/min, register 3/min, …). nginx ist die **grobe, restart-überlebende** zweite Schicht — die war aber viel zu locker.

## Fix

`auth_limit`-Zone von `10r/s` → **`5r/m`** (deckt sich mit dem App-Login-Limit und der bereits korrekten `deploy/nginx/baluhost.conf`), `burst=5 nodelay` bleibt.

Geändert:
- `deploy/install/templates/baluhost-nginx-http.conf` — **die deployte** Config (greift automatisch beim nächsten Deploy: Modul 11 re-rendert + `nginx -t` + reload; kein manueller Schritt).
- `deploy/nginx/baluhost-http.conf` + `baluhost-https.conf` — Referenz/manuelle Configs, für Konsistenz angeglichen (werden nicht auto-deployt).

## Warum 5r/m sicher ist

- `/api/auth/` hat **kein** häufig gepolltes Endpoint; `/refresh` (App 10/min) passiert per-Device nur ~alle 15min.
- nginx keyt per **echter** Client-IP (`$binary_remote_addr`) — jedes VPN/LAN-Device ist eine eigene IP. Legitimer Login/Refresh bleibt klar unter 5r/m; `burst=5` fängt Spitzen ab.
- Brute-Force wird am Edge gebremst; die präzise Per-Endpoint-Sperre macht ohnehin der App-Layer.

## Tests

- Neu: `tests/test_deploy_nginx_auth_limit.py` — Regression-Lock (deploytes Template ist `5r/m`, kein `10r/s` mehr; Referenz-Configs ebenfalls nicht). 6 passed (zusammen mit dem proxy-headers-Lock).

## Hinweis

Touch in `deploy/` → **CODEOWNERS-flagged**, aber benigne (nur Rate-Limit-Wert). Damit ist der HÄRTUNG-Block bis auf **CSP (#8)** und das akzeptierte In-Memory-Limiter-Reset abgearbeitet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
