### PR TITLE
fix(security): CSP connect-src 'self' + backup_path allowlist (Audit Härtung)

### DIFF
--- a/backend/app/api/routes/backup.py
+++ b/backend/app/api/routes/backup.py
@@ -71,6 +71,13 @@ async def create_backup(
         )
 
         return BackupResponse.from_db(backup)
+    except ValueError as e:
+        # Curated validation error (e.g. backup_path outside the allowed storage
+        # roots) — the message is safe operational guidance, surface it as 400.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
     except Exception as e:
         # Emit hook for failed backup
         emit_hook(

--- a/backend/app/middleware/security_headers.py
+++ b/backend/app/middleware/security_headers.py
@@ -39,7 +39,12 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             f"style-src {style_src}; "
             "img-src 'self' data: https:; "
             "font-src 'self' data:; "
-            "connect-src 'self' https:; "
+            # connect-src restricted to same-origin: fetch/XHR/WebSocket/SSE all hit
+            # the local backend (relative /api, same-host ws/wss). Dropping the blanket
+            # `https:` closes a CSP-level exfiltration channel (e.g. a malicious plugin
+            # POSTing localStorage tokens to an attacker host). Verified no SPA code
+            # connects to a foreign origin in the production web build.
+            "connect-src 'self'; "
             "base-uri 'self'; "
             "form-action 'self'"
         )

--- a/backend/app/services/backup/service.py
+++ b/backend/app/services/backup/service.py
@@ -50,18 +50,15 @@ def _validate_backup_dir(backup_path: str) -> Path:
     Returns the resolved, validated destination ``Path``.
     Raises ``ValueError`` if the path is outside every allowed root.
     """
-    allowed_roots = [
-        Path(settings.nas_backup_path).resolve(),
-        Path(settings.nas_storage_path).resolve(),
-    ]
-    resolved = Path(backup_path).resolve()
-    # Direct per-root `is_relative_to` guard (matches the CodeQL-recognised
-    # containment-barrier form used in compat/webdav_provider.py) — resolve()
-    # collapses symlinks/`..`, is_relative_to rejects traversal and sibling
-    # prefixes (e.g. /storage-evil vs /storage).
-    for root in allowed_roots:
-        if resolved.is_relative_to(root):
-            return resolved
+    # realpath collapses symlinks and `..`; the `startswith(root + os.sep)` guard
+    # is the canonical path-injection containment barrier (CodeQL-recognised). The
+    # trailing separator stops a sibling-prefix escape (e.g. /storage-evil vs
+    # /storage); the `== root` arm allows the root directory itself.
+    resolved = os.path.realpath(backup_path)
+    for root in (settings.nas_backup_path, settings.nas_storage_path):
+        root_real = os.path.realpath(root)
+        if resolved == root_real or resolved.startswith(root_real + os.sep):
+            return Path(resolved)
     raise ValueError(
         "backup_path must be within the configured storage or backup directory"
     )

--- a/backend/app/services/backup/service.py
+++ b/backend/app/services/backup/service.py
@@ -55,8 +55,13 @@ def _validate_backup_dir(backup_path: str) -> Path:
         Path(settings.nas_storage_path).resolve(),
     ]
     resolved = Path(backup_path).resolve()
-    if any(resolved.is_relative_to(root) for root in allowed_roots):
-        return resolved
+    # Direct per-root `is_relative_to` guard (matches the CodeQL-recognised
+    # containment-barrier form used in compat/webdav_provider.py) — resolve()
+    # collapses symlinks/`..`, is_relative_to rejects traversal and sibling
+    # prefixes (e.g. /storage-evil vs /storage).
+    for root in allowed_roots:
+        if resolved.is_relative_to(root):
+            return resolved
     raise ValueError(
         "backup_path must be within the configured storage or backup directory"
     )

--- a/backend/app/services/backup/service.py
+++ b/backend/app/services/backup/service.py
@@ -36,6 +36,32 @@ _CONFIG_REDACT_RE = re.compile(
 _REDACTED_PLACEHOLDER = "***REDACTED***"
 
 
+def _validate_backup_dir(backup_path: str) -> Path:
+    """Resolve an admin-supplied backup destination, rejecting any path that escapes
+    the allowed storage roots.
+
+    Admins may legitimately target a custom directory — e.g. a different array or
+    external drive mounted under the NAS storage tree, or the configured backup
+    directory. They must NOT be able to make the backend (running as the shared
+    ``baluhost`` service user) ``mkdir -p`` and write an archive at an arbitrary
+    filesystem location like ``/etc`` or another LAN user's home. Symlinks are
+    resolved before the check so a symlinked subdir cannot be used to escape.
+
+    Returns the resolved, validated destination ``Path``.
+    Raises ``ValueError`` if the path is outside every allowed root.
+    """
+    allowed_roots = [
+        Path(settings.nas_backup_path).resolve(),
+        Path(settings.nas_storage_path).resolve(),
+    ]
+    resolved = Path(backup_path).resolve()
+    if any(resolved.is_relative_to(root) for root in allowed_roots):
+        return resolved
+    raise ValueError(
+        "backup_path must be within the configured storage or backup directory"
+    )
+
+
 class BackupService:
     """Service for managing system backups."""
     
@@ -65,8 +91,10 @@ class BackupService:
         """
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         filename = f"backup_{timestamp}.tar.gz"
-        # Use optional path from request or the service's backup_dir
-        backup_dir = Path(backup_data.backup_path) if backup_data.backup_path else self.backup_dir
+        # Use optional path from request or the service's backup_dir. A custom
+        # destination is validated against the allowed storage roots so an admin
+        # cannot make the backend write archives to arbitrary filesystem paths.
+        backup_dir = _validate_backup_dir(backup_data.backup_path) if backup_data.backup_path else self.backup_dir
         backup_dir.mkdir(parents=True, exist_ok=True)
         filepath = backup_dir / filename
         

--- a/backend/tests/security/test_security_headers.py
+++ b/backend/tests/security/test_security_headers.py
@@ -34,6 +34,16 @@ class TestSecurityHeaders:
         assert "default-src 'self'" in csp
         assert "script-src" in csp
 
+    def test_connect_src_restricted_to_self(self, client):
+        """connect-src must be same-origin only — no blanket `https:` exfil channel."""
+        response = client.get("/api/health")
+
+        headers = {k.lower(): v for k, v in response.headers.items()}
+        csp = headers["content-security-policy"]
+        assert "connect-src 'self'" in csp
+        # The blanket `https:` source (any external HTTPS host) must be gone.
+        assert "connect-src 'self' https:" not in csp
+
     def test_x_content_type_options_header_set(self, client):
         """Verify X-Content-Type-Options: nosniff header."""
         response = client.get("/api/health")

--- a/backend/tests/services/test_backup.py
+++ b/backend/tests/services/test_backup.py
@@ -407,3 +407,58 @@ class TestConfigBackup:
         ref_dirs = list(temp_backup_dir.glob("restored-config-*"))
         assert len(ref_dirs) == 1
         assert (ref_dirs[0] / "settings.snapshot.json").exists()
+
+
+class TestValidateBackupDir:
+    """A custom backup_path must stay within the allowed storage roots so an admin
+    cannot make the backend write archives to arbitrary filesystem locations."""
+
+    @pytest.fixture
+    def roots(self, tmp_path, monkeypatch):
+        from app.services.backup import service as backup_module
+
+        storage = tmp_path / "storage"
+        backups = tmp_path / "backups"
+        storage.mkdir()
+        backups.mkdir()
+        monkeypatch.setattr(backup_module.settings, "nas_storage_path", str(storage))
+        monkeypatch.setattr(backup_module.settings, "nas_backup_path", str(backups))
+        return storage, backups
+
+    def test_accepts_path_within_backup_root(self, roots):
+        from app.services.backup.service import _validate_backup_dir
+
+        storage, backups = roots
+        target = backups / "weekly"
+        result = _validate_backup_dir(str(target))
+        assert result == target.resolve()
+
+    def test_accepts_path_within_storage_root(self, roots):
+        from app.services.backup.service import _validate_backup_dir
+
+        storage, backups = roots
+        target = storage / "array2" / "backups"
+        result = _validate_backup_dir(str(target))
+        assert result == target.resolve()
+
+    def test_accepts_root_itself(self, roots):
+        from app.services.backup.service import _validate_backup_dir
+
+        storage, backups = roots
+        assert _validate_backup_dir(str(backups)) == backups.resolve()
+
+    def test_rejects_arbitrary_absolute_path(self, roots):
+        from app.services.backup.service import _validate_backup_dir
+
+        with pytest.raises(ValueError):
+            _validate_backup_dir(str(Path(os.sep) / "etc" / "baluhost-evil"))
+
+    def test_rejects_traversal_escape(self, roots):
+        from app.services.backup.service import _validate_backup_dir
+
+        storage, backups = roots
+        # Escape the allowed root via '..' — resolve() collapses it, so the check
+        # sees the real (outside) destination and rejects it.
+        escape = backups / ".." / ".." / "outside"
+        with pytest.raises(ValueError):
+            _validate_backup_dir(str(escape))


### PR DESCRIPTION
## Was

Zwei unabhängige Härtungs-Fixes aus dem Security-Audit (Block „HÄRTUNG", die beiden offenen *mittleren* Punkte):

### 1. CSP `connect-src 'self'` (Audit Härtung #8)
`connect-src` enthielt ein blankes `https:` → fetch/XHR/WebSocket/SSE durften zu **beliebigem** HTTPS-Host. Das ist ein CSP-Exfiltrations-Kanal (z. B. ein bösartiges Plugin, das `localStorage`-Token an einen Angreifer-Host POSTet — das unsandboxed Plugin-System ist der größte offene Audit-Befund).

**Verifiziert**, dass im Prod-Web-Build jede Connect-Quelle same-origin ist:
- axios `apiClient` → relative `/api` (`buildApiUrl`, Base `''` in prod)
- WebSocket (notifications / plugin-dashboard / smart-devices) → `${host}/api/...`
- EventSource (backend-logs) → relative `/api/...`
- `chunkedUpload` fetch → `buildApiUrl`
- `localApi` fetch → Base `''` im prod Web-Build

Die Nicht-same-origin-Basen (`127.0.0.1:8000` in Dev, `__BALU_API_BASE__` in Tauri) werden von Vite bzw. der Tauri-Shell ausgeliefert und unterliegen **nicht** diesem FastAPI-CSP-Header. nginx setzt kein eigenes CSP → Single source of truth ist die Middleware.

*Bewusst nicht angefasst:* `style-src 'unsafe-inline'` (Tailwind/Recharts brauchen es, würde UI brechen) und CSP-Reporting (optionales Follow-up).

### 2. `backup_path`-Validierung
Der admin-only Create-Backup-Endpoint nahm ein **ungeprüftes** `backup_path` entgegen und reichte es direkt an `mkdir -p` + Archiv-Write weiter. Ein Admin konnte das Backend (läuft als geteilter `baluhost`-Service-User) Verzeichnisse anlegen + ein tar.gz an **beliebigem** Pfad schreiben lassen (fremdes LAN-User-Home auf dem Storage, Disk-Fill in fremde Partition).

Neuer `_validate_backup_dir()`: resolved den Pfad (löst Symlinks + `..` auf) und verlangt, dass er innerhalb `nas_backup_path` **oder** `nas_storage_path` bleibt. Custom-Ziele unter dem Storage-Tree (anderes Array / gemountete Platte) bleiben unterstützt; alles außerhalb → `ValueError` → **400** (kuratiert, kein 500-Leak — konsistent mit Posten 2).

## Tests
- `tests/security/test_security_headers.py`: neuer `test_connect_src_restricted_to_self`
- `tests/services/test_backup.py`: neue `TestValidateBackupDir` (accept backup/storage-root + root selbst; reject arbitrary absolute + traversal-escape)
- `python -m pytest tests/services/test_backup.py tests/security/test_security_headers.py` → **26 passed, 9 skipped**
- `ruff check` über alle geänderten Dateien → clean

## Threat-Model-Einordnung
Beide sind Defense-in-Depth/Least-Privilege-Härtung (CSP = Anti-Exfil-Layer; backup_path = admin-gated, daher Low). Keine Verhaltensänderung für legitime Nutzung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
