### PR TITLE
feat(plugin-sandbox): iframe + postMessage frontend isolation (Track A, Phase 1-2)

### DIFF
--- a/.superpowers/sdd/task-6-report.md
+++ b/.superpowers/sdd/task-6-report.md
@@ -1,0 +1,94 @@
+# Task 6 Report: PluginSandboxHost component + wire PluginPage
+
+## Status
+DONE — all steps complete, tests green, tsc clean, committed.
+
+## Commit
+SHA: `06352b1b`
+Subject: `feat(plugin-sandbox): PluginSandboxHost component, wire PluginPage to the sandbox`
+
+## TDD RED → GREEN
+
+### RED (failing test)
+```
+npx vitest run src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx
+```
+Output: FAIL — `Failed to resolve import "../../components/plugins/PluginSandboxHost"` (module not found). Confirmed expected RED state.
+
+### Deviation from brief test code
+The brief's test code renders `<PluginSandboxHost>` directly without any provider wrapper. Two issues required deviation:
+1. `useNavigate()` (called in the component) throws without a Router context → wrapped renders in `<MemoryRouter>`.
+2. `vi.fn().mockImplementation(() => ({...}))` is not constructable → replaced with a proper `class` mock for `PluginBridge` (arrow functions aren't constructors; Vitest 4 enforces this).
+
+These changes preserve the exact assertions; only the test scaffolding changed.
+
+### GREEN
+```
+npx vitest run src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx
+```
+Output: 2 passed (2 tests).
+
+## All Sandbox Tests
+```
+npx vitest run src/__tests__/plugin-sandbox/
+```
+Output: **5 test files, 22 tests — all passed**.
+
+## TypeScript
+```
+npx tsc --noEmit
+```
+Output: (no output — zero errors).
+
+## granted_api_scopes Resolution
+The `enabledPlugins` array in `PluginContext` is typed as `PluginUIInfo[]` (from `client/src/api/plugins.ts`). `PluginUIInfo` does NOT have a `granted_api_scopes` field — that's a Phase 2 addition. Per the brief constraint, `grantedScopes={[]}` is used literally with a `// TODO(Phase 2): wire granted_api_scopes from pluginInfo once the field exists on PluginUIInfo` comment in `PluginPage.tsx`. tsc is clean.
+
+## Files Changed
+| File | Change |
+|---|---|
+| `client/src/components/plugins/PluginSandboxHost.tsx` | Created — opaque-origin iframe + PluginBridge wiring with start/dispose cleanup and resize/navigate handlers |
+| `client/src/components/PluginPage.tsx` | Modified — removed `loadPluginComponent`/`loadPluginStyles`/`PluginComponent` state+effect+Suspense; now renders `<PluginSandboxHost>` |
+| `client/src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx` | Created — 2 tests verifying correct `sandbox="allow-scripts"` and correct src, and verifying `allow-same-origin` is never present |
+
+## Self-Review
+- iframe has `sandbox="allow-scripts"` ONLY — no `allow-same-origin`. ✓
+- `src` is `/api/plugins/${pluginName}/ui/host.html`. ✓
+- Bridge is constructed with `iframe, pluginName, grantedScopes, user, onResize, onNavigate`. ✓
+- `bridge.start()` called on mount, `bridge.dispose()` called on unmount. ✓
+- `PluginPage.tsx` no longer imports `loadPluginComponent`, `loadPluginStyles`, or uses `PluginComponent` state/effect. ✓
+- `pluginLoader.ts` and `pluginSDK.ts` NOT deleted (per constraint). ✓
+- tsc clean. ✓
+- Tests verify real behavior (actual DOM attributes). ✓
+
+## Concerns
+None. The only deviation from the brief's test code (MemoryRouter wrapper + class-style PluginBridge mock) was necessary for the test to run at all in jsdom — the assertions themselves are unchanged.
+
+---
+
+## Review Fix: Stabilize bridge lifecycle (2026-06-22)
+
+### Finding
+The `useEffect` dep array `[pluginName, grantedScopes, user, navigate]` caused the bridge to be torn down and recreated on every parent re-render because `grantedScopes` is a new array reference each time (callers pass `[]` literals) and `user` is a new object reference. The isolation model is one bridge per plugin SESSION, not per render.
+
+### Fix
+`client/src/components/plugins/PluginSandboxHost.tsx`:
+- Derived two stable primitive keys before the effect: `scopesKey = grantedScopes.join(',')` and `userId = user.id`.
+- Changed dep array to `[pluginName, scopesKey, userId, navigate]` with `// eslint-disable-next-line react-hooks/exhaustive-deps`.
+- The actual `grantedScopes` array and `user` object are still read inside the effect body (so the bridge receives real values, not the derived keys).
+- `sandbox="allow-scripts"` (no allow-same-origin) unchanged.
+
+### Regression Test Added
+`client/src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx`:
+- Added module-level `bridgeConstructorCallCount` and `lastBridgeInstance` trackers, reset in `beforeEach`.
+- Added test: `does not recreate the bridge when parent re-renders with a new [] literal (same contents) and same user` — re-renders with a brand-new `[]` literal and asserts constructor called exactly once and `dispose()` not called.
+
+### Commands Run
+```
+cd client && npx vitest run src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx
+```
+Result: 3 passed (3 tests) — 2 existing + 1 new regression.
+
+```
+npx tsc --noEmit
+```
+Result: (no output — zero errors).

--- a/backend/alembic/versions/1ab0b6db5b1c_installed_plugins_granted_api_scopes.py
+++ b/backend/alembic/versions/1ab0b6db5b1c_installed_plugins_granted_api_scopes.py
@@ -1,0 +1,28 @@
+"""installed_plugins granted_api_scopes
+
+Revision ID: 1ab0b6db5b1c
+Revises: cu_suspend_on_exit
+Create Date: 2026-06-22 21:41:01.326755
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1ab0b6db5b1c'
+down_revision: Union[str, Sequence[str], None] = 'cu_suspend_on_exit'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('installed_plugins', sa.Column('granted_api_scopes', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('installed_plugins', 'granted_api_scopes')

--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -1,4 +1,5 @@
 """API routes for plugin management."""
+import html
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
@@ -521,14 +522,19 @@ async def serve_plugin_asset(
                 bundle_path = raw_bundle
         except Exception:
             pass
-        html = (
+        # Escape values flowing into the HTML attribute. `name` is a user-supplied
+        # path parameter and `bundle_path` derives from the plugin manifest; both are
+        # quoted into content="..." so escape them to neutralise attribute breakout / XSS.
+        safe_name = html.escape(name, quote=True)
+        safe_bundle_path = html.escape(bundle_path, quote=True)
+        html_doc = (
             '<!doctype html><html><head><meta charset="utf-8">'
-            f'<meta name="plugin-bundle" content="/api/plugins/{name}/ui/{bundle_path}">'
+            f'<meta name="plugin-bundle" content="/api/plugins/{safe_name}/ui/{safe_bundle_path}">'
             '</head><body><div id="plugin-root"></div>'
             '<script src="/plugin-runtime.js"></script></body></html>'
         )
         return Response(
-            content=html,
+            content=html_doc,
             media_type="text/html",
             headers={
                 "Access-Control-Allow-Origin": "*",

--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -234,11 +234,11 @@ async def toggle_plugin(
                 detail=f"Missing required permissions: {list(missing)}",
             )
 
-        from app.plugins.manifest import load_manifest, ManifestError
+        from app.plugins.manifest import load_manifest
         try:
             _manifest = load_manifest(plugin_manager.plugins_dir / name)
             api_scopes = list(_manifest.api_scopes)
-        except (ManifestError, Exception):
+        except Exception:
             api_scopes = []  # bundled/legacy plugins without a manifest declare no Core scopes
 
         plugin_service.enable_plugin(

--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -100,15 +100,22 @@ async def list_permissions(
 @user_limiter.limit(get_limit("admin_operations"))
 async def get_ui_manifest(
     request: Request, response: Response,
+    db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
     plugin_manager: PluginManager = Depends(get_plugin_manager),
 ) -> PluginUIManifestResponse:
     """Get UI manifest for frontend integration.
 
     Returns navigation items and bundle paths for all enabled plugins.
+    Includes granted_api_scopes from the DB record for each plugin so
+    the frontend plugin sandbox can enforce API scope restrictions.
     """
     manifest = plugin_manager.get_ui_manifest()
-    return PluginUIManifestResponse(**manifest)
+    result = PluginUIManifestResponse(**manifest)
+    for item in result.plugins:
+        record = plugin_service.get_installed_plugin(db, item.name)
+        item.granted_api_scopes = (record.granted_api_scopes or []) if record else []
+    return result
 
 
 @router.get("/{name}", response_model=PluginDetailResponse)

--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -459,6 +459,43 @@ async def serve_plugin_asset(
             detail="Plugin not found or not enabled",
         )
 
+    # Sandbox bootstrap document — generated, not read from disk.
+    if file_path == "host.html":
+        # Resolve the plugin's UI bundle name from its manifest (fall back to bundle.js).
+        # The manifest stores the bundle path relative to the plugin dir (e.g. "ui/bundle.js"),
+        # but the /ui/{file_path} route already includes the "ui/" prefix, so we strip it.
+        bundle_path = "bundle.js"
+        try:
+            from app.plugins.manifest import load_manifest
+            manifest = load_manifest(plugin_manager.plugins_dir / name)
+            if manifest.ui and manifest.ui.bundle:
+                raw_bundle = manifest.ui.bundle
+                # Strip leading "ui/" so the URL resolves correctly via this route
+                if raw_bundle.startswith("ui/"):
+                    raw_bundle = raw_bundle[len("ui/"):]
+                bundle_path = raw_bundle
+        except Exception:
+            pass
+        html = (
+            '<!doctype html><html><head><meta charset="utf-8">'
+            f'<meta name="plugin-bundle" content="/api/plugins/{name}/ui/{bundle_path}">'
+            '</head><body><div id="plugin-root"></div>'
+            '<script src="/plugin-runtime.js"></script></body></html>'
+        )
+        return Response(
+            content=html,
+            media_type="text/html",
+            headers={
+                "Access-Control-Allow-Origin": "*",
+                "Cache-Control": "no-store",
+                # Make the bootstrap framable by our own SPA. The global
+                # SecurityHeadersMiddleware would set DENY; the middleware
+                # carve-out in security_headers.py preserves these for the sandbox path.
+                "X-Frame-Options": "SAMEORIGIN",
+                "Content-Security-Policy": "frame-ancestors 'self'",
+            },
+        )
+
     # Construct file path
     plugin_path = plugin_manager.plugins_dir / name / "ui" / file_path
 
@@ -497,6 +534,7 @@ async def serve_plugin_asset(
         media_type=content_type,
         headers={
             "Cache-Control": "public, max-age=3600",
+            "Access-Control-Allow-Origin": "*",
         },
     )
 

--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -232,6 +232,13 @@ async def toggle_plugin(
                 detail=f"Missing required permissions: {list(missing)}",
             )
 
+        from app.plugins.manifest import load_manifest, ManifestError
+        try:
+            _manifest = load_manifest(plugin_manager.plugins_dir / name)
+            api_scopes = list(_manifest.api_scopes)
+        except (ManifestError, Exception):
+            api_scopes = []  # bundled/legacy plugins without a manifest declare no Core scopes
+
         plugin_service.enable_plugin(
             db,
             name=name,
@@ -240,6 +247,7 @@ async def toggle_plugin(
             permissions=permissions_to_grant,
             default_config=plugin.get_default_config(),
             installed_by=current_user.username,
+            api_scopes=api_scopes,
         )
 
         # Enable in plugin manager

--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -12,6 +12,7 @@ from app.middleware.plugin_gate import invalidate_plugin_cache
 from app.plugins.manager import PluginManager, PluginLoadError
 from app.plugins.permissions import PermissionManager
 from app.services import plugin_service
+from app.services.audit.logger_db import get_audit_logger_db
 from app.schemas.plugin import (
     DashboardPanelToggleRequest,
     PermissionInfo,
@@ -25,6 +26,7 @@ from app.schemas.plugin import (
     PluginToggleRequest,
     PluginToggleResponse,
     PluginUIManifestResponse,
+    ScopeDeniedReport,
 )
 
 
@@ -337,7 +339,6 @@ async def toggle_dashboard_panel(
     plugin_service.set_dashboard_panel_enabled(db, name, body.enabled)
 
     # Audit log
-    from app.services.audit.logger_db import get_audit_logger_db
     audit = get_audit_logger_db()
     audit.log_event(
         event_type="PLUGIN",
@@ -359,6 +360,35 @@ async def toggle_dashboard_panel(
         "dashboard_panel_enabled": body.enabled,
         "message": f"Dashboard panel {'enabled' if body.enabled else 'disabled'}",
     }
+
+
+@router.post("/{name}/_audit/scope-denied", status_code=200)
+@user_limiter.limit(get_limit("admin_operations"))
+async def report_scope_denied(
+    request: Request,
+    response: Response,
+    name: str,
+    body: ScopeDeniedReport,
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Record a plugin scope-denial event in the audit log.
+
+    Called by the host bridge (fire-and-forget) when a plugin attempts an API
+    call that its granted_api_scopes do not permit.  Any authenticated user may
+    post (the bridge runs in the user's session).  The event is written with
+    success=False so it surfaces as a security event in the admin audit log.
+    """
+    audit = get_audit_logger_db()
+    audit.log_event(
+        event_type="PLUGIN",
+        user=current_user.username,
+        action="scope_denied",
+        resource=name,
+        success=False,
+        details={"method": body.method, "url": body.url},
+        ip_address=request.client.host if request.client else None,
+    )
+    return {"recorded": True}
 
 
 @router.get("/{name}/config", response_model=PluginConfigResponse)

--- a/backend/app/middleware/plugin_gate.py
+++ b/backend/app/middleware/plugin_gate.py
@@ -26,8 +26,8 @@ CACHE_TTL_SECONDS = 5.0
 
 # Path suffixes for management routes that should NOT be gated.
 # These are the admin endpoints defined in api/routes/plugins.py.
-_MANAGEMENT_SUFFIXES = ("/toggle", "/config")
-_MANAGEMENT_PREFIXES = ("/ui/", "/_audit/")
+_MANAGEMENT_SUFFIXES = ("/toggle", "/config", "/_audit/scope-denied")
+_MANAGEMENT_PREFIXES = ("/ui/",)
 
 
 def _is_management_route(sub_path: str) -> bool:

--- a/backend/app/middleware/plugin_gate.py
+++ b/backend/app/middleware/plugin_gate.py
@@ -27,7 +27,7 @@ CACHE_TTL_SECONDS = 5.0
 # Path suffixes for management routes that should NOT be gated.
 # These are the admin endpoints defined in api/routes/plugins.py.
 _MANAGEMENT_SUFFIXES = ("/toggle", "/config")
-_MANAGEMENT_PREFIXES = ("/ui/",)
+_MANAGEMENT_PREFIXES = ("/ui/", "/_audit/")
 
 
 def _is_management_route(sub_path: str) -> bool:

--- a/backend/app/middleware/security_headers.py
+++ b/backend/app/middleware/security_headers.py
@@ -22,6 +22,12 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next) -> Response:
         response = await call_next(request)
 
+        # The plugin sandbox bootstrap must be framable by our own SPA; it sets
+        # its own X-Frame-Options/CSP frame-ancestors. Skip the global DENY/CSP
+        # for that single path so the iframe can render.
+        if request.url.path.endswith("/ui/host.html") and request.url.path.startswith("/api/plugins/"):
+            return response
+
         # Content Security Policy - Prevents inline scripts and external script injection
         # In dev mode, allow 'unsafe-inline' and 'unsafe-eval' for Vite HMR.
         # In production, only 'self' is permitted for script-src to prevent XSS.

--- a/backend/app/middleware/security_headers.py
+++ b/backend/app/middleware/security_headers.py
@@ -25,6 +25,11 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         # The plugin sandbox bootstrap must be framable by our own SPA; it sets
         # its own X-Frame-Options/CSP frame-ancestors. Skip the global DENY/CSP
         # for that single path so the iframe can render.
+        # Note: this early-return also drops the global script-src / object-src /
+        # base-uri directives for host.html. That is intentional — the bootstrap
+        # loads only the hardcoded /plugin-runtime.js script tag (no inline scripts,
+        # no eval), so the permissive absence of those directives carries no
+        # meaningful XSS risk for this document.
         if request.url.path.endswith("/ui/host.html") and request.url.path.startswith("/api/plugins/"):
             return response
 

--- a/backend/app/models/plugin.py
+++ b/backend/app/models/plugin.py
@@ -26,6 +26,9 @@ class InstalledPlugin(Base):
     granted_permissions: Mapped[Optional[List[str]]] = mapped_column(
         JSON, nullable=True, default=list
     )
+    granted_api_scopes: Mapped[Optional[List[str]]] = mapped_column(
+        JSON, nullable=True, default=list
+    )
     config: Mapped[Optional[Dict[str, Any]]] = mapped_column(
         JSON, nullable=True, default=dict
     )

--- a/backend/app/plugins/manifest.py
+++ b/backend/app/plugins/manifest.py
@@ -54,6 +54,9 @@ class PluginManifest(BaseModel):
     plugin_dependencies: List[str] = Field(default_factory=list)
     python_requirements: List[str] = Field(default_factory=list)
 
+    api_scopes: List[str] = Field(default_factory=list)
+    min_runtime_abi: Optional[int] = None
+
     entrypoint: str = "__init__.py"
     ui: Optional[PluginManifestUI] = None
 

--- a/backend/app/schemas/plugin.py
+++ b/backend/app/schemas/plugin.py
@@ -25,6 +25,7 @@ class PluginUIInfo(BaseModel):
     styles_path: Optional[str] = None
     dashboard_widgets: List[str] = []
     translations: Optional[Dict[str, Dict[str, str]]] = None
+    granted_api_scopes: List[str] = []
 
 
 class PluginUIManifestResponse(BaseModel):

--- a/backend/app/schemas/plugin.py
+++ b/backend/app/schemas/plugin.py
@@ -192,5 +192,5 @@ class DashboardPanelResponse(BaseModel):
 class ScopeDeniedReport(BaseModel):
     """Request body for reporting a plugin scope denial."""
 
-    method: str
-    url: str
+    method: str = Field(max_length=16)
+    url: str = Field(max_length=2048)

--- a/backend/app/schemas/plugin.py
+++ b/backend/app/schemas/plugin.py
@@ -187,3 +187,10 @@ class DashboardPanelResponse(BaseModel):
     accent: str
     data: Optional[Dict[str, Any]] = None
     translations: Optional[Dict[str, Dict[str, str]]] = None
+
+
+class ScopeDeniedReport(BaseModel):
+    """Request body for reporting a plugin scope denial."""
+
+    method: str
+    url: str

--- a/backend/app/services/plugin_service.py
+++ b/backend/app/services/plugin_service.py
@@ -39,8 +39,14 @@ def enable_plugin(
     permissions: list[str],
     default_config: dict,
     installed_by: str,
+    api_scopes: list[str] | None = None,
 ) -> InstalledPlugin:
     """Enable a plugin — create or update the DB record.
+
+    Args:
+        api_scopes: Declared Core API scopes from the plugin's manifest.
+                    Stored in ``granted_api_scopes``. Defaults to ``None``
+                    which is treated as an empty list (backwards-compatible).
 
     Returns the updated InstalledPlugin record (already committed).
     """
@@ -53,6 +59,7 @@ def enable_plugin(
             display_name=display_name,
             is_enabled=True,
             granted_permissions=permissions,
+            granted_api_scopes=api_scopes or [],
             config=default_config,
             installed_by=installed_by,
             enabled_at=datetime.now(timezone.utc),
@@ -61,6 +68,7 @@ def enable_plugin(
     else:
         record.is_enabled = True
         record.granted_permissions = permissions
+        record.granted_api_scopes = api_scopes or []
         record.enabled_at = datetime.now(timezone.utc)
         record.disabled_at = None
 

--- a/backend/tests/api/test_plugin_sandbox_assets.py
+++ b/backend/tests/api/test_plugin_sandbox_assets.py
@@ -1,0 +1,51 @@
+"""Tests for plugin sandbox asset serving: CORS, host.html bootstrap, framable headers.
+
+TDD task: RED → GREEN for Task 5 (Plugin Frontend iframe Sandbox).
+
+The storage_analytics plugin is installed as a bundled plugin (plugins/installed/),
+but is only *enabled* when a DB record exists. In the TestClient's fresh in-memory DB
+there is no such record, so all routes return 404. The asserts are therefore
+conditional on status 200, and are reached when the plugin is enabled in the env
+(e.g. production, integration tests with a seed record).
+
+We keep the conditional form because enabling a plugin requires inserting a DB record
+via plugin_service.create_or_enable(), which in turn needs a seeded DB session — a
+non-trivial fixture that is out of scope for this focused asset-serving test.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from app.main import app
+    return TestClient(app)
+
+
+def test_ui_asset_has_permissive_cors(client, monkeypatch):
+    """ui/ assets must be loadable from the opaque-origin sandbox iframe."""
+    # A known bundled plugin is enabled in the test app's plugin manager.
+    resp = client.get("/api/plugins/storage_analytics/ui/bundle.js")
+    # Either the asset exists (200) or the plugin isn't enabled in this env (404);
+    # when served, it must carry the CORS header.
+    if resp.status_code == 200:
+        assert resp.headers.get("access-control-allow-origin") == "*"
+
+
+def test_host_html_bootstrap_served(client):
+    resp = client.get("/api/plugins/storage_analytics/ui/host.html")
+    if resp.status_code == 200:
+        body = resp.text
+        assert "plugin-runtime.js" in body
+        assert 'name="plugin-bundle"' in body
+        assert resp.headers.get("content-type", "").startswith("text/html")
+
+
+def test_host_html_is_framable_same_origin(client):
+    """The sandbox bootstrap MUST be framable by our own app — the global
+    X-Frame-Options: DENY would otherwise blank the iframe."""
+    resp = client.get("/api/plugins/storage_analytics/ui/host.html")
+    if resp.status_code == 200:
+        assert resp.headers.get("x-frame-options", "DENY").upper() != "DENY"
+        # CSP frame-ancestors must allow same-origin framing.
+        assert "frame-ancestors" in resp.headers.get("content-security-policy", "")

--- a/backend/tests/api/test_plugin_sandbox_assets.py
+++ b/backend/tests/api/test_plugin_sandbox_assets.py
@@ -1,17 +1,31 @@
 """Tests for plugin sandbox asset serving: CORS, host.html bootstrap, framable headers.
 
-TDD task: RED → GREEN for Task 5 (Plugin Frontend iframe Sandbox).
+All three tests patch the enabled-checks so the route reaches its serving branch
+and returns 200.  Assertions are UNCONDITIONAL — no ``if status == 200`` guards
+that can silently skip when the plugin has no DB record (which is always the case
+for the TestClient's fresh in-memory DB).
 
-The storage_analytics plugin is installed as a bundled plugin (plugins/installed/),
-but is only *enabled* when a DB record exists. In the TestClient's fresh in-memory DB
-there is no such record, so all routes return 404. The asserts are therefore
-conditional on status 200, and are reached when the plugin is enabled in the env
-(e.g. production, integration tests with a seed record).
+Patching strategy
+-----------------
+``serve_plugin_asset`` gates on two checks (logical OR):
 
-We keep the conditional form because enabling a plugin requires inserting a DB record
-via plugin_service.create_or_enable(), which in turn needs a seeded DB session — a
-non-trivial fixture that is out of scope for this focused asset-serving test.
+    db_record = plugin_service.get_enabled_plugin(db, name)  # DB path
+    if not db_record and not plugin_manager.is_enabled(name): raise 404
+
+Patching ``app.services.plugin_service.get_enabled_plugin`` to return a truthy
+sentinel makes the guard pass without touching the DB or the PluginManager
+singleton.
+
+For host.html the route also calls ``load_manifest`` (imported locally inside
+the handler body): ``from app.plugins.manifest import load_manifest``.  We patch
+the function at its *definition* module (``app.plugins.manifest.load_manifest``)
+so the local import picks up the stub.
+
+For the static-asset (bundle.js) test, ``storage_analytics/ui/bundle.js`` is a
+real bundled file that ships with the repo — no extra fixture needed.
 """
+from unittest.mock import MagicMock, patch
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -22,30 +36,88 @@ def client():
     return TestClient(app)
 
 
-def test_ui_asset_has_permissive_cors(client, monkeypatch):
-    """ui/ assets must be loadable from the opaque-origin sandbox iframe."""
-    # A known bundled plugin is enabled in the test app's plugin manager.
-    resp = client.get("/api/plugins/storage_analytics/ui/bundle.js")
-    # Either the asset exists (200) or the plugin isn't enabled in this env (404);
-    # when served, it must carry the CORS header.
-    if resp.status_code == 200:
-        assert resp.headers.get("access-control-allow-origin") == "*"
+# ---------------------------------------------------------------------------
+# 1. CORS header on a static UI asset
+# ---------------------------------------------------------------------------
 
+def test_ui_asset_has_permissive_cors(client):
+    """ui/ assets must carry Access-Control-Allow-Origin: * for the opaque-origin sandbox."""
+    fake_record = MagicMock()  # truthy — makes the enabled-guard pass
+    with patch("app.services.plugin_service.get_enabled_plugin", return_value=fake_record):
+        resp = client.get("/api/plugins/storage_analytics/ui/bundle.js")
+
+    # The bundle.js file ships in the repo, so the route resolves to 200.
+    assert resp.status_code == 200, (
+        f"Expected 200 from serve_plugin_asset; got {resp.status_code}. "
+        "Check that backend/app/plugins/installed/storage_analytics/ui/bundle.js exists."
+    )
+    assert resp.headers.get("access-control-allow-origin") == "*", (
+        "Static plugin assets must carry CORS: * so the opaque-origin sandbox iframe "
+        "can import them via ES dynamic import."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. host.html bootstrap document structure
+# ---------------------------------------------------------------------------
 
 def test_host_html_bootstrap_served(client):
-    resp = client.get("/api/plugins/storage_analytics/ui/host.html")
-    if resp.status_code == 200:
-        body = resp.text
-        assert "plugin-runtime.js" in body
-        assert 'name="plugin-bundle"' in body
-        assert resp.headers.get("content-type", "").startswith("text/html")
+    """host.html must contain plugin-runtime.js src, plugin-bundle meta, and be text/html."""
+    fake_record = MagicMock()
 
+    # Build a fake manifest whose ui.bundle matches what the route uses.
+    fake_ui = MagicMock()
+    fake_ui.bundle = "ui/bundle.js"
+    fake_manifest = MagicMock()
+    fake_manifest.ui = fake_ui
+
+    with patch("app.services.plugin_service.get_enabled_plugin", return_value=fake_record), \
+         patch("app.plugins.manifest.load_manifest", return_value=fake_manifest):
+        resp = client.get("/api/plugins/storage_analytics/ui/host.html")
+
+    assert resp.status_code == 200, (
+        f"Expected 200 from host.html handler; got {resp.status_code}."
+    )
+    body = resp.text
+    assert "plugin-runtime.js" in body, "host.html must include a <script src='/plugin-runtime.js'>"
+    assert 'name="plugin-bundle"' in body, "host.html must include the plugin-bundle <meta> tag"
+    assert resp.headers.get("content-type", "").startswith("text/html"), (
+        f"host.html must have content-type text/html, got: {resp.headers.get('content-type')}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. host.html security headers — framable by same-origin, not globally DENYed
+# ---------------------------------------------------------------------------
 
 def test_host_html_is_framable_same_origin(client):
-    """The sandbox bootstrap MUST be framable by our own app — the global
-    X-Frame-Options: DENY would otherwise blank the iframe."""
-    resp = client.get("/api/plugins/storage_analytics/ui/host.html")
-    if resp.status_code == 200:
-        assert resp.headers.get("x-frame-options", "DENY").upper() != "DENY"
-        # CSP frame-ancestors must allow same-origin framing.
-        assert "frame-ancestors" in resp.headers.get("content-security-policy", "")
+    """The sandbox bootstrap MUST be framable by our own SPA.
+
+    The global SecurityHeadersMiddleware sets ``X-Frame-Options: DENY`` for all
+    responses, but the middleware has a carve-out for ``/api/plugins/*/ui/host.html``
+    that preserves the route's own framability headers instead.
+    """
+    fake_record = MagicMock()
+
+    fake_ui = MagicMock()
+    fake_ui.bundle = "ui/bundle.js"
+    fake_manifest = MagicMock()
+    fake_manifest.ui = fake_ui
+
+    with patch("app.services.plugin_service.get_enabled_plugin", return_value=fake_record), \
+         patch("app.plugins.manifest.load_manifest", return_value=fake_manifest):
+        resp = client.get("/api/plugins/storage_analytics/ui/host.html")
+
+    assert resp.status_code == 200, (
+        f"Expected 200 from host.html handler; got {resp.status_code}."
+    )
+    xfo = resp.headers.get("x-frame-options", "DENY").upper()
+    assert xfo != "DENY", (
+        f"host.html must NOT carry X-Frame-Options: DENY (got {xfo!r}). "
+        "The middleware carve-out in security_headers.py must skip the global DENY."
+    )
+    csp = resp.headers.get("content-security-policy", "")
+    assert "frame-ancestors" in csp, (
+        f"host.html CSP must contain 'frame-ancestors' to allow same-origin framing. "
+        f"Got CSP: {csp!r}"
+    )

--- a/backend/tests/api/test_plugin_scope_denied_audit.py
+++ b/backend/tests/api/test_plugin_scope_denied_audit.py
@@ -1,0 +1,121 @@
+"""Tests for POST /api/plugins/{name}/_audit/scope-denied.
+
+Verifies that:
+- An authenticated user can POST a scope-denial report and receive 2xx.
+- The request body is validated (Pydantic schema — raw dict not accepted).
+- Unauthenticated requests are rejected.
+- The audit logger's log_event is called with the expected arguments.
+
+Auth pattern: uses the ``client`` and ``user_headers`` / ``admin_headers``
+fixtures from conftest.py (in-memory DB, real JWT auth flow).
+
+Assertions are UNCONDITIONAL — status code is always asserted before any
+further checks.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+ROUTE = "/api/plugins/my-plugin/_audit/scope-denied"
+VALID_BODY = {"method": "get", "url": "/api/users"}
+
+
+# ---------------------------------------------------------------------------
+# Positive path — any authenticated user can post
+# ---------------------------------------------------------------------------
+
+def test_scope_denied_audit_as_user_returns_200(client, user_headers):
+    """A regular authenticated user posting a scope-denied report gets 200."""
+    resp = client.post(ROUTE, json=VALID_BODY, headers=user_headers)
+    assert resp.status_code == 200, (
+        f"Expected 200 from POST {ROUTE}; got {resp.status_code}. Body: {resp.text[:500]}"
+    )
+    data = resp.json()
+    assert data.get("recorded") is True, (
+        f"Expected {{\"recorded\": true}} in response; got {data!r}"
+    )
+
+
+def test_scope_denied_audit_as_admin_returns_200(client, admin_headers):
+    """An admin user posting a scope-denied report also gets 200."""
+    resp = client.post(ROUTE, json=VALID_BODY, headers=admin_headers)
+    assert resp.status_code == 200, (
+        f"Expected 200 from POST {ROUTE} as admin; got {resp.status_code}. Body: {resp.text[:500]}"
+    )
+    assert resp.json().get("recorded") is True
+
+
+# ---------------------------------------------------------------------------
+# Audit logger is called with the right arguments
+# ---------------------------------------------------------------------------
+
+def test_scope_denied_audit_calls_log_event(client, user_headers):
+    """log_event must be called with event_type=PLUGIN, action=scope_denied, success=False."""
+    mock_logger = MagicMock()
+
+    # get_audit_logger_db is imported at module level in plugins.py, so we
+    # patch the name as seen by the route module.
+    with patch(
+        "app.api.routes.plugins.get_audit_logger_db",
+        return_value=mock_logger,
+    ):
+        resp = client.post(
+            "/api/plugins/weather/_audit/scope-denied",
+            json={"method": "post", "url": "/api/admin/users"},
+            headers=user_headers,
+        )
+
+    assert resp.status_code == 200, (
+        f"Expected 200; got {resp.status_code}. Body: {resp.text[:500]}"
+    )
+
+    mock_logger.log_event.assert_called_once()
+    call_kwargs = mock_logger.log_event.call_args
+
+    # Support both positional and keyword argument styles
+    kwargs = call_kwargs.kwargs if call_kwargs.kwargs else {}
+    args = call_kwargs.args if call_kwargs.args else ()
+
+    # Convert positional args to named for assertions (matches function signature)
+    # log_event(event_type, user, action, resource, success, details, ip_address)
+    # Route uses keyword args only, so check kwargs
+    assert kwargs.get("event_type") == "PLUGIN", f"event_type wrong: {kwargs}"
+    assert kwargs.get("action") == "scope_denied", f"action wrong: {kwargs}"
+    assert kwargs.get("success") is False, f"success should be False: {kwargs}"
+    assert kwargs.get("resource") == "weather", f"resource (plugin name) wrong: {kwargs}"
+    details = kwargs.get("details", {})
+    assert details.get("method") == "post", f"details.method wrong: {details}"
+    assert details.get("url") == "/api/admin/users", f"details.url wrong: {details}"
+
+
+# ---------------------------------------------------------------------------
+# Authentication enforcement
+# ---------------------------------------------------------------------------
+
+def test_scope_denied_audit_unauthenticated_returns_401(client):
+    """Unauthenticated requests must be rejected (401 or 403)."""
+    resp = client.post(ROUTE, json=VALID_BODY)
+    assert resp.status_code in (401, 403), (
+        f"Expected 401/403 for unauthenticated request; got {resp.status_code}. Body: {resp.text[:200]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Body validation — missing required fields
+# ---------------------------------------------------------------------------
+
+def test_scope_denied_audit_missing_body_returns_422(client, user_headers):
+    """Missing required fields must return 422 (Pydantic validation)."""
+    resp = client.post(ROUTE, json={}, headers=user_headers)
+    assert resp.status_code == 422, (
+        f"Expected 422 for empty body; got {resp.status_code}. Body: {resp.text[:300]}"
+    )
+
+
+def test_scope_denied_audit_missing_url_returns_422(client, user_headers):
+    """Body with only 'method' (missing 'url') must return 422."""
+    resp = client.post(ROUTE, json={"method": "get"}, headers=user_headers)
+    assert resp.status_code == 422, (
+        f"Expected 422 for body missing 'url'; got {resp.status_code}. Body: {resp.text[:300]}"
+    )

--- a/backend/tests/api/test_plugin_ui_manifest_scopes.py
+++ b/backend/tests/api/test_plugin_ui_manifest_scopes.py
@@ -1,0 +1,134 @@
+"""Tests that GET /api/plugins/ui/manifest includes granted_api_scopes per plugin.
+
+Patching strategy
+-----------------
+The endpoint calls two things we need to control:
+
+1. ``plugin_manager.get_ui_manifest()`` — patched to return a manifest dict with
+   one fake plugin entry so the response always has at least one item.
+2. ``plugin_service.get_installed_plugin`` — patched to return a MagicMock record
+   whose ``granted_api_scopes`` attribute is a known list so we can assert the
+   value end-to-end.
+
+Both patches are applied at their *definition* sites so FastAPI's dependency
+injection picks up the stub.  The ``/ui/manifest`` route sits between
+``/permissions`` and ``/{name}`` (note: ``/ui/manifest`` must be registered
+before ``/{name}`` to avoid being swallowed by the dynamic segment — it is).
+
+Assertions are UNCONDITIONAL — ``assert resp.status_code == 200`` at the top;
+never inside an ``if`` that can vacuously pass.
+
+Auth: uses the ``client`` and ``admin_headers`` fixtures from conftest.py, which
+set up an in-memory DB with an admin user and provide a valid Bearer token.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fake_manifest():
+    """Return a minimal manifest dict the endpoint can parse into PluginUIManifestResponse."""
+    return {
+        "plugins": [
+            {
+                "name": "storage_analytics",
+                "display_name": "Storage Analytics",
+                "nav_items": [],
+                "bundle_path": "ui/bundle.js",
+                "styles_path": None,
+                "dashboard_widgets": [],
+                "translations": None,
+            }
+        ]
+    }
+
+
+def _make_fake_db_record(scopes: list):
+    """Return a MagicMock InstalledPlugin with the given granted_api_scopes."""
+    record = MagicMock()
+    record.granted_api_scopes = scopes
+    return record
+
+
+# ---------------------------------------------------------------------------
+# Test: scopes from DB record land on each manifest item
+# ---------------------------------------------------------------------------
+
+def test_ui_manifest_items_have_granted_api_scopes_from_db(client, admin_headers):
+    """Each plugin in the ui/manifest response must carry granted_api_scopes (a list).
+
+    The test uses a fake manifest with one plugin and a fake DB record with two
+    known scopes.  The endpoint must merge them and return the scopes in the JSON.
+    """
+    expected_scopes = ["api:files:read", "api:system:read"]
+
+    fake_manifest = _make_fake_manifest()
+    fake_record = _make_fake_db_record(expected_scopes)
+
+    with patch(
+        "app.plugins.manager.PluginManager.get_ui_manifest",
+        return_value=fake_manifest,
+    ), patch(
+        "app.services.plugin_service.get_installed_plugin",
+        return_value=fake_record,
+    ):
+        resp = client.get("/api/plugins/ui/manifest", headers=admin_headers)
+
+    # UNCONDITIONAL — must be 200 before any other assertion
+    assert resp.status_code == 200, (
+        f"Expected 200 from GET /api/plugins/ui/manifest; got {resp.status_code}. "
+        f"Body: {resp.text[:500]}"
+    )
+
+    data = resp.json()
+    plugins = data.get("plugins", [])
+    assert len(plugins) >= 1, "Expected at least one plugin in manifest response"
+
+    for entry in plugins:
+        assert "granted_api_scopes" in entry, (
+            f"Plugin entry missing 'granted_api_scopes' key: {entry}"
+        )
+        assert isinstance(entry["granted_api_scopes"], list), (
+            f"'granted_api_scopes' must be a list, got: {type(entry['granted_api_scopes'])}"
+        )
+
+    # Verify the actual scopes flow through from the DB record
+    first_plugin = plugins[0]
+    assert first_plugin["granted_api_scopes"] == expected_scopes, (
+        f"Expected scopes {expected_scopes!r}, got {first_plugin['granted_api_scopes']!r}"
+    )
+
+
+def test_ui_manifest_items_have_empty_scopes_when_no_db_record(client, admin_headers):
+    """When no DB record exists for a plugin, granted_api_scopes must be [] (not absent/null)."""
+    fake_manifest = _make_fake_manifest()
+
+    with patch(
+        "app.plugins.manager.PluginManager.get_ui_manifest",
+        return_value=fake_manifest,
+    ), patch(
+        "app.services.plugin_service.get_installed_plugin",
+        return_value=None,
+    ):
+        resp = client.get("/api/plugins/ui/manifest", headers=admin_headers)
+
+    assert resp.status_code == 200, (
+        f"Expected 200 from GET /api/plugins/ui/manifest; got {resp.status_code}. "
+        f"Body: {resp.text[:500]}"
+    )
+
+    data = resp.json()
+    plugins = data.get("plugins", [])
+    assert len(plugins) >= 1, "Expected at least one plugin in manifest response"
+
+    for entry in plugins:
+        assert "granted_api_scopes" in entry, (
+            f"Plugin entry missing 'granted_api_scopes' key when no DB record: {entry}"
+        )
+        assert entry["granted_api_scopes"] == [], (
+            f"Expected empty list when no DB record, got: {entry['granted_api_scopes']!r}"
+        )

--- a/backend/tests/plugins/test_enable_persists_api_scopes.py
+++ b/backend/tests/plugins/test_enable_persists_api_scopes.py
@@ -1,0 +1,62 @@
+"""TDD tests: enable_plugin persists declared api_scopes into granted_api_scopes."""
+from app.services import plugin_service
+
+
+def test_enable_plugin_create_sets_api_scopes(db_session):
+    """CREATE branch: api_scopes passed to enable_plugin are stored."""
+    record = plugin_service.enable_plugin(
+        db_session,
+        name="weather",
+        version="1.0.0",
+        display_name="Weather",
+        permissions=["read:files"],
+        default_config={},
+        installed_by="admin",
+        api_scopes=["read:storage"],
+    )
+    db_session.refresh(record)
+    assert record.granted_api_scopes == ["read:storage"]
+
+
+def test_enable_plugin_update_replaces_api_scopes(db_session):
+    """UPDATE branch: calling enable_plugin again replaces granted_api_scopes."""
+    # First call — create
+    plugin_service.enable_plugin(
+        db_session,
+        name="weather",
+        version="1.0.0",
+        display_name="Weather",
+        permissions=["read:files"],
+        default_config={},
+        installed_by="admin",
+        api_scopes=["read:storage"],
+    )
+    # Second call — update with different scopes
+    record = plugin_service.enable_plugin(
+        db_session,
+        name="weather",
+        version="1.0.1",
+        display_name="Weather",
+        permissions=["read:files"],
+        default_config={},
+        installed_by="admin",
+        api_scopes=["read:power"],
+    )
+    db_session.refresh(record)
+    assert record.granted_api_scopes == ["read:power"]
+
+
+def test_enable_plugin_none_api_scopes_yields_empty_list(db_session):
+    """Default (api_scopes=None) results in granted_api_scopes == []."""
+    record = plugin_service.enable_plugin(
+        db_session,
+        name="legacy-plugin",
+        version="0.1.0",
+        display_name="Legacy",
+        permissions=[],
+        default_config={},
+        installed_by="admin",
+        # api_scopes not passed — default None
+    )
+    db_session.refresh(record)
+    assert record.granted_api_scopes == []

--- a/backend/tests/plugins/test_installed_plugin_scopes.py
+++ b/backend/tests/plugins/test_installed_plugin_scopes.py
@@ -1,0 +1,11 @@
+"""TDD test: InstalledPlugin.granted_api_scopes column roundtrip."""
+from app.models.plugin import InstalledPlugin
+
+
+def test_granted_api_scopes_roundtrip(db_session):
+    p = InstalledPlugin(name="weather", version="1.0.0", display_name="Weather",
+                        granted_api_scopes=["read:storage"])
+    db_session.add(p)
+    db_session.commit()
+    db_session.refresh(p)
+    assert p.granted_api_scopes == ["read:storage"]

--- a/backend/tests/plugins/test_manifest_api_scopes.py
+++ b/backend/tests/plugins/test_manifest_api_scopes.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+import pytest
+from app.plugins.manifest import load_manifest, PluginManifest
+
+
+def _write(tmp_path: Path, extra: dict) -> Path:
+    base = {
+        "manifest_version": 1, "name": "weather", "version": "1.0.0",
+        "display_name": "Weather", "description": "d", "author": "a",
+    }
+    base.update(extra)
+    (tmp_path / "plugin.json").write_text(json.dumps(base), encoding="utf-8")
+    return tmp_path
+
+
+def test_api_scopes_default_empty(tmp_path):
+    m = load_manifest(_write(tmp_path, {}))
+    assert m.api_scopes == []
+    assert m.min_runtime_abi is None
+
+
+def test_api_scopes_parsed(tmp_path):
+    m = load_manifest(_write(tmp_path, {"api_scopes": ["read:storage"], "min_runtime_abi": 1}))
+    assert m.api_scopes == ["read:storage"]
+    assert m.min_runtime_abi == 1

--- a/backend/tests/plugins/test_manifest_api_scopes.py
+++ b/backend/tests/plugins/test_manifest_api_scopes.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 import pytest
-from app.plugins.manifest import load_manifest, PluginManifest
+from app.plugins.manifest import load_manifest
 
 
 def _write(tmp_path: Path, extra: dict) -> Path:

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+public/plugin-runtime.js
 /scripts/fix_umlauts.py
 
 # Editor directories and files

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "test": "vitest",
+    "build:runtime": "vite build --config vite.runtime.config.ts",
+    "prebuild": "npm run build:runtime",
     "build": "tsc -b && vite build",
     "build:pi": "tsc -b && vite build --mode pi",
     "build:prod": "vite build",

--- a/client/src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx
+++ b/client/src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx
@@ -1,22 +1,36 @@
 // client/src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import PluginSandboxHost from '../../components/plugins/PluginSandboxHost';
 
 // PluginBridge listens on window.addEventListener('message') — mock it so
 // tests don't register real listeners (jsdom environment, no cleanup issue).
+// The mock tracks how many times the constructor has been called so regression
+// tests can assert "constructed once" across multiple renders.
+let bridgeConstructorCallCount = 0;
+let lastBridgeInstance: { start: ReturnType<typeof vi.fn>; dispose: ReturnType<typeof vi.fn> } | null = null;
+
 vi.mock('../../lib/plugin-sandbox/hostBridge', () => {
   class PluginBridge {
     start = vi.fn();
     dispose = vi.fn();
-    constructor() {}
+    constructor() {
+      bridgeConstructorCallCount++;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      lastBridgeInstance = this as any;
+    }
   }
   return { PluginBridge };
 });
 
 describe('PluginSandboxHost', () => {
   const user = { id: 1, username: 'admin', role: 'admin' };
+
+  beforeEach(() => {
+    bridgeConstructorCallCount = 0;
+    lastBridgeInstance = null;
+  });
 
   it('renders an opaque-origin sandbox iframe pointing at host.html', () => {
     const { container } = render(
@@ -38,5 +52,31 @@ describe('PluginSandboxHost', () => {
     );
     const sandbox = container.querySelector('iframe')!.getAttribute('sandbox')!;
     expect(sandbox.includes('allow-same-origin')).toBe(false);
+  });
+
+  it('does not recreate the bridge when parent re-renders with a new [] literal (same contents) and same user', () => {
+    // Render initially with one [] literal reference.
+    const { rerender } = render(
+      <MemoryRouter>
+        <PluginSandboxHost pluginName="weather" user={user} grantedScopes={[]} />
+      </MemoryRouter>
+    );
+
+    // Capture the bridge instance created on the initial render.
+    const bridgeAfterMount = lastBridgeInstance;
+    expect(bridgeConstructorCallCount).toBe(1);
+
+    // Re-render with a BRAND NEW [] literal — same contents, different reference.
+    // A naïve dep array with the array object would trigger dispose+reconstruct here.
+    rerender(
+      <MemoryRouter>
+        <PluginSandboxHost pluginName="weather" user={user} grantedScopes={[]} />
+      </MemoryRouter>
+    );
+
+    // The constructor must still have been called exactly once — no second bridge.
+    expect(bridgeConstructorCallCount).toBe(1);
+    // dispose() must NOT have been called between the two renders.
+    expect(bridgeAfterMount!.dispose).not.toHaveBeenCalled();
   });
 });

--- a/client/src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx
+++ b/client/src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx
@@ -1,0 +1,42 @@
+// client/src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PluginSandboxHost from '../../components/plugins/PluginSandboxHost';
+
+// PluginBridge listens on window.addEventListener('message') — mock it so
+// tests don't register real listeners (jsdom environment, no cleanup issue).
+vi.mock('../../lib/plugin-sandbox/hostBridge', () => {
+  class PluginBridge {
+    start = vi.fn();
+    dispose = vi.fn();
+    constructor() {}
+  }
+  return { PluginBridge };
+});
+
+describe('PluginSandboxHost', () => {
+  const user = { id: 1, username: 'admin', role: 'admin' };
+
+  it('renders an opaque-origin sandbox iframe pointing at host.html', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <PluginSandboxHost pluginName="weather" user={user} grantedScopes={[]} />
+      </MemoryRouter>
+    );
+    const iframe = container.querySelector('iframe')!;
+    expect(iframe).toBeTruthy();
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts');
+    expect(iframe.getAttribute('src')).toBe('/api/plugins/weather/ui/host.html');
+  });
+
+  it('never grants allow-same-origin', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <PluginSandboxHost pluginName="weather" user={user} grantedScopes={[]} />
+      </MemoryRouter>
+    );
+    const sandbox = container.querySelector('iframe')!.getAttribute('sandbox')!;
+    expect(sandbox.includes('allow-same-origin')).toBe(false);
+  });
+});

--- a/client/src/__tests__/plugin-sandbox/hostBridge.test.ts
+++ b/client/src/__tests__/plugin-sandbox/hostBridge.test.ts
@@ -98,7 +98,7 @@ describe('PluginBridge', () => {
   });
 
   it('ignores messages whose source is not the iframe window', async () => {
-    const { iframe, contentWindow, posted } = makeIframe();
+    const { iframe, posted } = makeIframe();
     const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user });
     b.start();
     const other = { postMessage: () => {} } as unknown as Window;

--- a/client/src/__tests__/plugin-sandbox/hostBridge.test.ts
+++ b/client/src/__tests__/plugin-sandbox/hostBridge.test.ts
@@ -1,0 +1,93 @@
+// client/src/__tests__/plugin-sandbox/hostBridge.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PluginBridge } from '../../lib/plugin-sandbox/hostBridge';
+
+vi.mock('../../lib/api', () => ({
+  apiClient: { request: vi.fn(async () => ({ data: { ok: true } })) },
+}));
+import { apiClient } from '../../lib/api';
+
+function makeIframe() {
+  const posted: unknown[] = [];
+  const contentWindow = { postMessage: (m: unknown) => posted.push(m) } as unknown as Window;
+  const iframe = { contentWindow } as unknown as HTMLIFrameElement;
+  return { iframe, contentWindow, posted };
+}
+
+function fireFromFrame(contentWindow: Window, data: unknown) {
+  // jsdom's MessageEvent constructor won't accept a plain object as `source`,
+  // so set it explicitly after construction for the reference-equality check.
+  const ev = new MessageEvent('message', { data });
+  Object.defineProperty(ev, 'source', { value: contentWindow });
+  window.dispatchEvent(ev);
+}
+
+describe('PluginBridge', () => {
+  const user = { id: 1, username: 'admin', role: 'admin' };
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sends init after the frame reports ready', () => {
+    const { iframe, contentWindow, posted } = makeIframe();
+    const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user });
+    b.start();
+    fireFromFrame(contentWindow, { kind: 'event', name: 'ready', payload: null });
+    const init = posted.find((m: any) => m.kind === 'push' && m.name === 'init') as any;
+    expect(init).toBeTruthy();
+    expect(init.payload.user.username).toBe('admin');
+    expect(init.payload.pluginName).toBe('weather');
+    b.dispose();
+  });
+
+  it('performs an allowed own-route api call and replies with the body', async () => {
+    const { iframe, contentWindow, posted } = makeIframe();
+    const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user });
+    b.start();
+    fireFromFrame(contentWindow, { kind: 'rpc', id: 'r1', channel: 'api', method: 'get', args: ['/api/plugins/weather/forecast'] });
+    await vi.waitFor(() => {
+      const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === 'r1');
+      expect(res).toBeTruthy();
+    });
+    const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === 'r1') as any;
+    expect(res.ok).toBe(true);
+    expect(res.value).toEqual({ ok: true });
+    expect(apiClient.request).toHaveBeenCalledOnce();
+    b.dispose();
+  });
+
+  it('rejects a denied core-route api call without calling apiClient', async () => {
+    const { iframe, contentWindow, posted } = makeIframe();
+    const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user });
+    b.start();
+    fireFromFrame(contentWindow, { kind: 'rpc', id: 'r2', channel: 'api', method: 'get', args: ['/api/users'] });
+    await vi.waitFor(() => {
+      const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === 'r2');
+      expect(res).toBeTruthy();
+    });
+    const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === 'r2') as any;
+    expect(res.ok).toBe(false);
+    expect(res.error.code).toBe('scope_denied');
+    expect(apiClient.request).not.toHaveBeenCalled();
+    b.dispose();
+  });
+
+  it('ignores messages whose source is not the iframe window', async () => {
+    const { iframe, contentWindow, posted } = makeIframe();
+    const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user });
+    b.start();
+    const other = { postMessage: () => {} } as unknown as Window;
+    fireFromFrame(other, { kind: 'rpc', id: 'r3', channel: 'api', method: 'get', args: ['/api/plugins/weather/x'] });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(posted.find((m: any) => m.id === 'r3')).toBeUndefined();
+    b.dispose();
+  });
+
+  it('routes resize events to onResize', () => {
+    const { iframe, contentWindow } = makeIframe();
+    const onResize = vi.fn();
+    const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user, onResize });
+    b.start();
+    fireFromFrame(contentWindow, { kind: 'event', name: 'resize', payload: { height: 420 } });
+    expect(onResize).toHaveBeenCalledWith(420);
+    b.dispose();
+  });
+});

--- a/client/src/__tests__/plugin-sandbox/hostBridge.test.ts
+++ b/client/src/__tests__/plugin-sandbox/hostBridge.test.ts
@@ -108,6 +108,42 @@ describe('PluginBridge', () => {
     b.dispose();
   });
 
+  it('navigate: denies a typosquatting path (/plugins/weatherEvil/x) and does not call onNavigate', async () => {
+    const { iframe, contentWindow, posted } = makeIframe();
+    const onNavigate = vi.fn();
+    const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user, onNavigate });
+    b.start();
+    fireFromFrame(contentWindow, { kind: 'rpc', id: 'nav1', channel: 'navigate', method: '', args: ['/plugins/weatherEvil/x'] });
+    await vi.waitFor(() => {
+      const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === 'nav1');
+      expect(res).toBeTruthy();
+    });
+    const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === 'nav1') as any;
+    expect(res.ok).toBe(false);
+    expect(res.error.code).toBe('navigate_denied');
+    expect(onNavigate).not.toHaveBeenCalled();
+    b.dispose();
+  });
+
+  it('navigate: allows /plugins/weather (exact prefix) and /plugins/weather/sub', async () => {
+    for (const path of ['/plugins/weather', '/plugins/weather/sub']) {
+      const { iframe, contentWindow, posted } = makeIframe();
+      const onNavigate = vi.fn();
+      const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user, onNavigate });
+      b.start();
+      const id = `nav-${path}`;
+      fireFromFrame(contentWindow, { kind: 'rpc', id, channel: 'navigate', method: '', args: [path] });
+      await vi.waitFor(() => {
+        const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === id);
+        expect(res).toBeTruthy();
+      });
+      const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === id) as any;
+      expect(res.ok).toBe(true);
+      expect(onNavigate).toHaveBeenCalledWith(path);
+      b.dispose();
+    }
+  });
+
   it('routes resize events to onResize', () => {
     const { iframe, contentWindow } = makeIframe();
     const onResize = vi.fn();

--- a/client/src/__tests__/plugin-sandbox/hostBridge.test.ts
+++ b/client/src/__tests__/plugin-sandbox/hostBridge.test.ts
@@ -3,7 +3,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PluginBridge } from '../../lib/plugin-sandbox/hostBridge';
 
 vi.mock('../../lib/api', () => ({
-  apiClient: { request: vi.fn(async () => ({ data: { ok: true } })) },
+  apiClient: {
+    request: vi.fn(async () => ({ data: { ok: true } })),
+    post: vi.fn(() => Promise.resolve({ data: {} })),
+  },
 }));
 import { apiClient } from '../../lib/api';
 
@@ -67,6 +70,30 @@ describe('PluginBridge', () => {
     expect(res.ok).toBe(false);
     expect(res.error.code).toBe('scope_denied');
     expect(apiClient.request).not.toHaveBeenCalled();
+    b.dispose();
+  });
+
+  it('fires audit POST and still rejects scope_denied without calling apiClient.request', async () => {
+    const { iframe, contentWindow, posted } = makeIframe();
+    const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user });
+    b.start();
+    fireFromFrame(contentWindow, { kind: 'rpc', id: 'r5', channel: 'api', method: 'get', args: ['/api/users'] });
+    await vi.waitFor(() => {
+      const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === 'r5');
+      expect(res).toBeTruthy();
+    });
+    const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === 'r5') as any;
+    // Bridge still rejects with scope_denied
+    expect(res.ok).toBe(false);
+    expect(res.error.code).toBe('scope_denied');
+    // apiClient.request must NOT have been called (call was denied before proxying)
+    expect(apiClient.request).not.toHaveBeenCalled();
+    // apiClient.post MUST have been called with the audit path and {method, url}
+    expect(apiClient.post).toHaveBeenCalledOnce();
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/api/plugins/weather/_audit/scope-denied',
+      { method: 'get', url: '/api/users' },
+    );
     b.dispose();
   });
 

--- a/client/src/__tests__/plugin-sandbox/protocol.test.ts
+++ b/client/src/__tests__/plugin-sandbox/protocol.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { isRpcRequest, isIframeEvent, RPC_CHANNELS } from '../../lib/plugin-sandbox/protocol';
+
+describe('protocol validators', () => {
+  it('accepts a well-formed rpc request on a known channel', () => {
+    const msg = { kind: 'rpc', id: 'a1', channel: 'api', method: 'get', args: ['/api/plugins/x/y'] };
+    expect(isRpcRequest(msg)).toBe(true);
+  });
+  it('rejects an rpc request on an unknown channel', () => {
+    const msg = { kind: 'rpc', id: 'a1', channel: 'filesystem', method: 'read', args: [] };
+    expect(isRpcRequest(msg)).toBe(false);
+  });
+  it('rejects rpc with non-string id or non-array args', () => {
+    expect(isRpcRequest({ kind: 'rpc', id: 1, channel: 'api', method: 'get', args: [] })).toBe(false);
+    expect(isRpcRequest({ kind: 'rpc', id: 'a', channel: 'api', method: 'get', args: 'x' })).toBe(false);
+  });
+  it('recognises iframe events', () => {
+    expect(isIframeEvent({ kind: 'event', name: 'ready', payload: null })).toBe(true);
+    expect(isIframeEvent({ kind: 'event', name: 'bogus', payload: null })).toBe(false);
+  });
+  it('exposes the fixed channel set', () => {
+    expect([...RPC_CHANNELS].sort()).toEqual(['api', 'navigate', 'storage', 'toast']);
+  });
+});

--- a/client/src/__tests__/plugin-sandbox/runtimeSdk.test.ts
+++ b/client/src/__tests__/plugin-sandbox/runtimeSdk.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createSandboxSdk } from '../../plugin-runtime/sdk';
+
+describe('createSandboxSdk', () => {
+  it('api.get posts an rpc and resolves on matching rpc-result', async () => {
+    const posted: any[] = [];
+    const sdk = createSandboxSdk((m) => posted.push(m));
+    const p = sdk.api.get('/api/plugins/weather/forecast');
+    const req = posted.find((m) => m.kind === 'rpc' && m.channel === 'api');
+    expect(req.method).toBe('get');
+    expect(req.args[0]).toBe('/api/plugins/weather/forecast');
+    // simulate host reply
+    sdk._receive({ kind: 'rpc-result', id: req.id, ok: true, value: { temp: 21 } });
+    await expect(p).resolves.toEqual({ temp: 21 });
+  });
+
+  it('api rejects on an error rpc-result with the error code', async () => {
+    const posted: any[] = [];
+    const sdk = createSandboxSdk((m) => posted.push(m));
+    const p = sdk.api.get('/api/users');
+    const req = posted.find((m) => m.kind === 'rpc');
+    sdk._receive({ kind: 'rpc-result', id: req.id, ok: false, error: { code: 'scope_denied', message: 'no' } });
+    await expect(p).rejects.toMatchObject({ code: 'scope_denied' });
+  });
+
+  it('times out a pending rpc', async () => {
+    vi.useFakeTimers();
+    const sdk = createSandboxSdk(() => {}, { timeoutMs: 100 });
+    const p = sdk.api.get('/api/plugins/weather/x');
+    const assertion = expect(p).rejects.toMatchObject({ code: 'timeout' });
+    await vi.advanceTimersByTimeAsync(150);
+    await assertion;
+    vi.useRealTimers();
+  });
+});

--- a/client/src/__tests__/plugin-sandbox/scopeCatalog.test.ts
+++ b/client/src/__tests__/plugin-sandbox/scopeCatalog.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { isCallAllowed } from '../../lib/plugin-sandbox/scopeCatalog';
+
+const base = { pluginName: 'weather', grantedScopes: [] as string[] };
+
+describe('isCallAllowed', () => {
+  it('always allows own plugin routes', () => {
+    expect(isCallAllowed({ ...base, method: 'get', url: '/api/plugins/weather/forecast' })).toBe(true);
+    expect(isCallAllowed({ ...base, method: 'post', url: '/api/plugins/weather/refresh' })).toBe(true);
+  });
+  it('denies another plugin\'s routes', () => {
+    expect(isCallAllowed({ ...base, method: 'get', url: '/api/plugins/other/secret' })).toBe(false);
+  });
+  it('denies core routes without a granted scope', () => {
+    expect(isCallAllowed({ ...base, method: 'get', url: '/api/system/info' })).toBe(false);
+  });
+  it('allows a core route when the matching scope is granted', () => {
+    expect(isCallAllowed({ ...base, grantedScopes: ['read:system-info'], method: 'get', url: '/api/system/info' })).toBe(true);
+  });
+  it('still denies a different core route with that scope', () => {
+    expect(isCallAllowed({ ...base, grantedScopes: ['read:system-info'], method: 'get', url: '/api/users' })).toBe(false);
+  });
+  it('denies wrong method even with the scope', () => {
+    expect(isCallAllowed({ ...base, grantedScopes: ['read:system-info'], method: 'delete', url: '/api/system/info' })).toBe(false);
+  });
+  it('denies path traversal and non-/api/ targets', () => {
+    expect(isCallAllowed({ ...base, method: 'get', url: '/api/plugins/weather/../../users' })).toBe(false);
+    expect(isCallAllowed({ ...base, method: 'get', url: 'https://evil.test/api/plugins/weather/x' })).toBe(false);
+  });
+});

--- a/client/src/__tests__/plugin-sandbox/scopeCatalog.test.ts
+++ b/client/src/__tests__/plugin-sandbox/scopeCatalog.test.ts
@@ -27,4 +27,10 @@ describe('isCallAllowed', () => {
     expect(isCallAllowed({ ...base, method: 'get', url: '/api/plugins/weather/../../users' })).toBe(false);
     expect(isCallAllowed({ ...base, method: 'get', url: 'https://evil.test/api/plugins/weather/x' })).toBe(false);
   });
+  it('denies own-prefix typosquatting (weatherEvil)', () => {
+    expect(isCallAllowed({ ...base, method: 'get', url: '/api/plugins/weatherEvil/secret', grantedScopes: [] })).toBe(false);
+  });
+  it('denies %2e%2e-encoded traversal', () => {
+    expect(isCallAllowed({ ...base, method: 'get', url: '/api/plugins/weather/%2e%2e/users', grantedScopes: [] })).toBe(false);
+  });
 });

--- a/client/src/api/plugins.ts
+++ b/client/src/api/plugins.ts
@@ -43,6 +43,7 @@ export interface PluginUIInfo {
   styles_path?: string;
   dashboard_widgets: string[];
   translations?: PluginTranslations;
+  granted_api_scopes: string[];
 }
 
 export interface PluginUIManifest {

--- a/client/src/components/PluginPage.tsx
+++ b/client/src/components/PluginPage.tsx
@@ -59,8 +59,7 @@ export default function PluginPage() {
       <PluginSandboxHost
         pluginName={pluginName!}
         user={user}
-        grantedScopes={[]}
-        // TODO(Phase 2): wire granted_api_scopes from pluginInfo once the field exists on PluginUIInfo
+        grantedScopes={pluginInfo?.granted_api_scopes ?? []}
       />
     </div>
   );

--- a/client/src/components/PluginPage.tsx
+++ b/client/src/components/PluginPage.tsx
@@ -1,26 +1,15 @@
 /**
  * Dynamic Plugin Page Component
  *
- * Renders plugin UI by dynamically loading the plugin's JavaScript bundle.
+ * Renders plugin UI inside a sandboxed iframe via PluginSandboxHost.
  */
-import { useEffect, useState, Suspense, type ComponentType } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { usePlugins } from '../contexts/PluginContext';
-import { loadPluginComponent, loadPluginStyles } from '../lib/pluginLoader';
-import { AlertTriangle, Plug } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 import { PluginBadge } from './ui/PluginBadge';
-
-interface PluginUser {
-  id: number;
-  username: string;
-  role: string;
-}
-
-interface PluginComponentProps {
-  user: PluginUser;
-}
+import PluginSandboxHost from './plugins/PluginSandboxHost';
 
 export default function PluginPage() {
   const { user } = useAuth();
@@ -30,54 +19,8 @@ export default function PluginPage() {
   const navigate = useNavigate();
   const { enabledPlugins } = usePlugins();
 
-  const [PluginComponent, setPluginComponent] = useState<ComponentType<PluginComponentProps> | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
   // Find the plugin info
   const pluginInfo = enabledPlugins.find((p) => p.name === pluginName);
-
-  useEffect(() => {
-    if (!pluginName || !pluginInfo) return;
-
-    // Load the plugin bundle
-    let mounted = true;
-
-    const loadPlugin = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-
-        // Load styles if available
-        if (pluginInfo.styles_path) {
-          loadPluginStyles(pluginName, pluginInfo.styles_path);
-        }
-
-        // Load the main component
-        const Component = await loadPluginComponent<ComponentType<PluginComponentProps>>(
-          pluginName,
-          'default',
-          pluginInfo.bundle_path
-        );
-
-        if (mounted) {
-          setPluginComponent(() => Component);
-          setLoading(false);
-        }
-      } catch (err) {
-        if (mounted) {
-          setError(err instanceof Error ? err.message : 'Failed to load plugin');
-          setLoading(false);
-        }
-      }
-    };
-
-    loadPlugin();
-
-    return () => {
-      mounted = false;
-    };
-  }, [pluginName, pluginInfo]);
 
   if (!user) return null;
 
@@ -104,67 +47,21 @@ export default function PluginPage() {
     );
   }
 
-  if (loading) {
-    return (
-      <div className="flex flex-col items-center justify-center h-64 gap-4">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-sky-500" />
-        <p className="text-sm text-slate-400">{t('loading')}</p>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex flex-col items-center justify-center h-64 gap-4">
-        <div className="p-4 rounded-full bg-red-500/10">
-          <AlertTriangle className="h-8 w-8 text-red-400" />
-        </div>
-        <div className="text-center">
-          <h3 className="text-lg font-medium text-white mb-1">{t('error')}</h3>
-          <p className="text-sm text-slate-400 max-w-md">{error}</p>
-        </div>
-        <button
-          onClick={() => navigate('/')}
-          className="px-4 py-2 text-sm font-medium rounded-lg border border-slate-700 text-slate-300 hover:border-sky-500/50"
-        >
-          {t('goToDashboard')}
-        </button>
-      </div>
-    );
-  }
-
-  if (!PluginComponent) {
-    return (
-      <div className="flex flex-col items-center justify-center h-64 gap-4">
-        <div className="p-4 rounded-full bg-slate-800">
-          <Plug className="h-8 w-8 text-slate-500" />
-        </div>
-        <div className="text-center">
-          <h3 className="text-lg font-medium text-white mb-1">{t('noContent')}</h3>
-          <p className="text-sm text-slate-400">{t('noUIComponent')}</p>
-        </div>
-      </div>
-    );
-  }
-
   const displayName = pluginInfo?.display_name ?? pluginName ?? '';
 
-  // Render the plugin component with user context
+  // Render the plugin in a sandboxed iframe via PluginSandboxHost
   return (
     <div className="plugin-container">
       <div className="mb-6 flex items-center gap-3">
         <h1 className="text-2xl font-semibold text-white">{displayName}</h1>
         <PluginBadge pluginName={displayName} size="md" className="ml-2" />
       </div>
-      <Suspense
-        fallback={
-          <div className="flex items-center justify-center h-64">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-sky-500" />
-          </div>
-        }
-      >
-        <PluginComponent user={user} />
-      </Suspense>
+      <PluginSandboxHost
+        pluginName={pluginName!}
+        user={user}
+        grantedScopes={[]}
+        // TODO(Phase 2): wire granted_api_scopes from pluginInfo once the field exists on PluginUIInfo
+      />
     </div>
   );
 }

--- a/client/src/components/plugins/PluginSandboxHost.tsx
+++ b/client/src/components/plugins/PluginSandboxHost.tsx
@@ -1,0 +1,43 @@
+// client/src/components/plugins/PluginSandboxHost.tsx
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { PluginBridge } from '../../lib/plugin-sandbox/hostBridge';
+
+interface User { id: number; username: string; role: string }
+
+interface Props {
+  pluginName: string;
+  user: User;
+  grantedScopes: string[];
+}
+
+export default function PluginSandboxHost({ pluginName, user, grantedScopes }: Props) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const navigate = useNavigate();
+  const [height, setHeight] = useState(480);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+    const bridge = new PluginBridge({
+      iframe,
+      pluginName,
+      grantedScopes,
+      user,
+      onResize: (h) => setHeight(Math.max(120, Math.ceil(h))),
+      onNavigate: (path) => navigate(path),
+    });
+    bridge.start();
+    return () => bridge.dispose();
+  }, [pluginName, grantedScopes, user, navigate]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      title={`plugin-${pluginName}`}
+      src={`/api/plugins/${pluginName}/ui/host.html`}
+      sandbox="allow-scripts"
+      style={{ width: '100%', height, border: 'none' }}
+    />
+  );
+}

--- a/client/src/components/plugins/PluginSandboxHost.tsx
+++ b/client/src/components/plugins/PluginSandboxHost.tsx
@@ -16,9 +16,17 @@ export default function PluginSandboxHost({ pluginName, user, grantedScopes }: P
   const navigate = useNavigate();
   const [height, setHeight] = useState(480);
 
+  // Derive stable primitive keys so the bridge is only recreated when the
+  // plugin, user identity, or scope-list CONTENTS change — not on every
+  // parent re-render that passes a new `[]` literal or a new user object ref.
+  const scopesKey = grantedScopes.join(',');
+  const userId = user.id;
+
   useEffect(() => {
     const iframe = iframeRef.current;
     if (!iframe) return;
+    // Read the CURRENT grantedScopes/user arrays/objects at effect-run time
+    // (not the derived keys) so the bridge receives the real values.
     const bridge = new PluginBridge({
       iframe,
       pluginName,
@@ -29,7 +37,8 @@ export default function PluginSandboxHost({ pluginName, user, grantedScopes }: P
     });
     bridge.start();
     return () => bridge.dispose();
-  }, [pluginName, grantedScopes, user, navigate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pluginName, scopesKey, userId, navigate]);
 
   return (
     <iframe

--- a/client/src/lib/plugin-sandbox/hostBridge.ts
+++ b/client/src/lib/plugin-sandbox/hostBridge.ts
@@ -66,7 +66,7 @@ export class PluginBridge {
     if (channel === 'navigate') {
       const path = String(args[0] ?? '');
       const prefix = `/plugins/${this.opts.pluginName}`;
-      if (!path.startsWith(prefix)) throw { code: 'navigate_denied', message: 'Out-of-plugin navigation blocked' };
+      if (path !== prefix && !path.startsWith(prefix + '/')) throw { code: 'navigate_denied', message: 'Out-of-plugin navigation blocked' };
       this.opts.onNavigate?.(path);
       return null;
     }

--- a/client/src/lib/plugin-sandbox/hostBridge.ts
+++ b/client/src/lib/plugin-sandbox/hostBridge.ts
@@ -1,0 +1,85 @@
+// client/src/lib/plugin-sandbox/hostBridge.ts
+import { apiClient } from '../api';
+import { isRpcRequest, isIframeEvent, type RpcResult, type HostPush } from './protocol';
+import { isCallAllowed } from './scopeCatalog';
+
+interface User { id: number; username: string; role: string }
+
+export interface PluginBridgeOpts {
+  iframe: HTMLIFrameElement;
+  pluginName: string;
+  grantedScopes: string[];
+  user: User;
+  onResize?: (height: number) => void;
+  onNavigate?: (path: string) => void;
+  timeoutMs?: number;
+}
+
+export class PluginBridge {
+  private listener = (ev: MessageEvent) => this.handleMessage(ev);
+  constructor(private opts: PluginBridgeOpts) {}
+
+  start(): void {
+    window.addEventListener('message', this.listener);
+  }
+  dispose(): void {
+    window.removeEventListener('message', this.listener);
+  }
+
+  private post(msg: RpcResult | HostPush): void {
+    this.opts.iframe.contentWindow?.postMessage(msg, '*');
+  }
+
+  private async handleMessage(ev: MessageEvent): Promise<void> {
+    // Opaque-origin frames post origin "null" — trust the window reference only.
+    if (ev.source !== this.opts.iframe.contentWindow) return;
+    const data = ev.data;
+
+    if (isIframeEvent(data)) {
+      if (data.name === 'ready') {
+        this.post({
+          kind: 'push', name: 'init',
+          payload: { user: this.opts.user, pluginName: this.opts.pluginName },
+        });
+      } else if (data.name === 'resize') {
+        const h = (data.payload as { height?: unknown })?.height;
+        if (typeof h === 'number') this.opts.onResize?.(h);
+      }
+      return;
+    }
+
+    if (!isRpcRequest(data)) return;
+    try {
+      const value = await this.dispatch(data.channel, data.method, data.args);
+      this.post({ kind: 'rpc-result', id: data.id, ok: true, value });
+    } catch (err) {
+      const e = err as { code?: string; message?: string };
+      this.post({
+        kind: 'rpc-result', id: data.id, ok: false,
+        error: { code: e.code ?? 'error', message: e.message ?? 'Plugin call failed' },
+      });
+    }
+  }
+
+  private async dispatch(channel: string, method: string, args: unknown[]): Promise<unknown> {
+    if (channel === 'api') return this.apiCall(method, args);
+    if (channel === 'navigate') {
+      const path = String(args[0] ?? '');
+      const prefix = `/plugins/${this.opts.pluginName}`;
+      if (!path.startsWith(prefix)) throw { code: 'navigate_denied', message: 'Out-of-plugin navigation blocked' };
+      this.opts.onNavigate?.(path);
+      return null;
+    }
+    throw { code: 'unknown_channel', message: `Unknown channel ${channel}` };
+  }
+
+  private async apiCall(method: string, args: unknown[]): Promise<unknown> {
+    const url = String(args[0] ?? '');
+    const body = args[1];
+    if (!isCallAllowed({ pluginName: this.opts.pluginName, method, url, grantedScopes: this.opts.grantedScopes })) {
+      throw { code: 'scope_denied', message: `Plugin not permitted to call ${method.toUpperCase()} ${url}` };
+    }
+    const res = await apiClient.request({ url, method, data: body });
+    return res.data;
+  }
+}

--- a/client/src/lib/plugin-sandbox/hostBridge.ts
+++ b/client/src/lib/plugin-sandbox/hostBridge.ts
@@ -17,7 +17,10 @@ export interface PluginBridgeOpts {
 
 export class PluginBridge {
   private listener = (ev: MessageEvent) => this.handleMessage(ev);
-  constructor(private opts: PluginBridgeOpts) {}
+  private opts: PluginBridgeOpts;
+  constructor(opts: PluginBridgeOpts) {
+    this.opts = opts;
+  }
 
   start(): void {
     window.addEventListener('message', this.listener);

--- a/client/src/lib/plugin-sandbox/hostBridge.ts
+++ b/client/src/lib/plugin-sandbox/hostBridge.ts
@@ -77,6 +77,8 @@ export class PluginBridge {
     const url = String(args[0] ?? '');
     const body = args[1];
     if (!isCallAllowed({ pluginName: this.opts.pluginName, method, url, grantedScopes: this.opts.grantedScopes })) {
+      console.warn('[plugin:' + this.opts.pluginName + '] scope_denied', method, url);
+      apiClient.post('/api/plugins/' + this.opts.pluginName + '/_audit/scope-denied', { method, url }).catch(() => {});
       throw { code: 'scope_denied', message: `Plugin not permitted to call ${method.toUpperCase()} ${url}` };
     }
     const res = await apiClient.request({ url, method, data: body });

--- a/client/src/lib/plugin-sandbox/protocol.ts
+++ b/client/src/lib/plugin-sandbox/protocol.ts
@@ -1,0 +1,50 @@
+export const RPC_CHANNELS = ['api', 'toast', 'navigate', 'storage'] as const;
+export type RpcChannel = (typeof RPC_CHANNELS)[number];
+
+export const IFRAME_EVENTS = ['ready', 'resize', 'error'] as const;
+export type IframeEventName = (typeof IFRAME_EVENTS)[number];
+
+export const HOST_PUSHES = ['init', 'theme-changed', 'visibility'] as const;
+export type HostPushName = (typeof HOST_PUSHES)[number];
+
+export interface RpcRequest {
+  kind: 'rpc';
+  id: string;
+  channel: RpcChannel;
+  method: string;
+  args: unknown[];
+}
+export interface RpcResult {
+  kind: 'rpc-result';
+  id: string;
+  ok: boolean;
+  value?: unknown;
+  error?: { code: string; message: string };
+}
+export interface IframeEvent {
+  kind: 'event';
+  name: IframeEventName;
+  payload: unknown;
+}
+export interface HostPush {
+  kind: 'push';
+  name: HostPushName;
+  payload: unknown;
+}
+
+function isObj(m: unknown): m is Record<string, unknown> {
+  return typeof m === 'object' && m !== null;
+}
+export function isRpcRequest(m: unknown): m is RpcRequest {
+  return (
+    isObj(m) && m.kind === 'rpc' && typeof m.id === 'string' &&
+    typeof m.method === 'string' && Array.isArray(m.args) &&
+    typeof m.channel === 'string' && (RPC_CHANNELS as readonly string[]).includes(m.channel)
+  );
+}
+export function isIframeEvent(m: unknown): m is IframeEvent {
+  return (
+    isObj(m) && m.kind === 'event' && typeof m.name === 'string' &&
+    (IFRAME_EVENTS as readonly string[]).includes(m.name)
+  );
+}

--- a/client/src/lib/plugin-sandbox/scopeCatalog.ts
+++ b/client/src/lib/plugin-sandbox/scopeCatalog.ts
@@ -1,0 +1,43 @@
+/** Core scope → concrete allowed (method, path) patterns. Curated; start small.
+ *  NO write:* scopes on sensitive Core routes in v1. /api/users, /api/auth etc.
+ *  appear in no entry, so no scope can ever open them. */
+export const SCOPE_CATALOG: Record<string, { method: string; pattern: RegExp }[]> = {
+  'read:system-info': [{ method: 'get', pattern: /^\/api\/system\/info\/?$/ }],
+  'read:storage': [
+    { method: 'get', pattern: /^\/api\/files\/storage(\/.*)?$/ },
+    { method: 'get', pattern: /^\/api\/system\/storage(\/.*)?$/ },
+  ],
+  'read:power': [{ method: 'get', pattern: /^\/api\/power\/.*$/ }],
+};
+
+/** A plugin's own routes are always allowed; everything else needs a granted scope. */
+export function isCallAllowed(opts: {
+  pluginName: string;
+  method: string;
+  url: string;
+  grantedScopes: string[];
+}): boolean {
+  const { pluginName, grantedScopes } = opts;
+  const method = opts.method.toLowerCase();
+
+  // Reject anything that isn't a clean same-origin /api/ path.
+  if (!opts.url.startsWith('/api/')) return false;
+  // Normalise and reject traversal.
+  const path = new URL(opts.url, 'http://x').pathname;
+  if (path !== opts.url.split('?')[0]) return false; // query allowed, traversal/host not
+  if (path.includes('/../') || path.includes('..')) return false;
+
+  // Own routes: /api/plugins/{thisPlugin}/...
+  const ownPrefix = `/api/plugins/${pluginName}/`;
+  if (path.startsWith(ownPrefix)) return true;
+
+  // Core route: must match a granted scope's pattern.
+  for (const scope of grantedScopes) {
+    const entries = SCOPE_CATALOG[scope];
+    if (!entries) continue;
+    for (const e of entries) {
+      if (e.method === method && e.pattern.test(path)) return true;
+    }
+  }
+  return false;
+}

--- a/client/src/lib/plugin-sandbox/scopeCatalog.ts
+++ b/client/src/lib/plugin-sandbox/scopeCatalog.ts
@@ -25,7 +25,7 @@ export function isCallAllowed(opts: {
   // Normalise and reject traversal.
   const path = new URL(opts.url, 'http://x').pathname;
   if (path !== opts.url.split('?')[0]) return false; // query allowed, traversal/host not
-  if (path.includes('/../') || path.includes('..')) return false;
+  if (path.includes('..')) return false;
 
   // Own routes: /api/plugins/{thisPlugin}/...
   const ownPrefix = `/api/plugins/${pluginName}/`;

--- a/client/src/plugin-runtime/index.ts
+++ b/client/src/plugin-runtime/index.ts
@@ -1,0 +1,28 @@
+// Boots inside the sandbox iframe: wires postMessage, exposes window.BaluHost,
+// then loads the plugin bundle. (UI lib + React are added in Phase 3; here we
+// expose the proxy SDK and announce readiness so the host sends `init`.)
+import { createSandboxSdk } from './sdk';
+
+const sdk = createSandboxSdk((msg) => window.parent.postMessage(msg, '*'));
+
+window.addEventListener('message', (ev) => {
+  const data = ev.data;
+  if (data && data.kind === 'rpc-result') sdk._receive(data);
+  if (data && data.kind === 'push' && data.name === 'init') {
+    (window as unknown as { BaluHost: unknown }).BaluHost = {
+      api: sdk.api, toast: sdk.toast, navigate: sdk.navigate,
+      user: (data.payload as { user: unknown }).user,
+    };
+    void loadPluginBundle();
+  }
+});
+
+async function loadPluginBundle(): Promise<void> {
+  // The plugin bundle path is injected via a <meta name="plugin-bundle"> tag in host.html.
+  const meta = document.querySelector('meta[name="plugin-bundle"]') as HTMLMetaElement | null;
+  if (!meta) return;
+  await import(/* @vite-ignore */ meta.content);
+}
+
+// Announce readiness so the host responds with `init`.
+window.parent.postMessage({ kind: 'event', name: 'ready', payload: null }, '*');

--- a/client/src/plugin-runtime/sdk.ts
+++ b/client/src/plugin-runtime/sdk.ts
@@ -1,0 +1,46 @@
+import { type RpcChannel } from '../lib/plugin-sandbox/protocol';
+
+interface Pending { resolve: (v: unknown) => void; reject: (e: unknown) => void; timer: ReturnType<typeof setTimeout> }
+
+export function createSandboxSdk(post: (msg: unknown) => void, opts: { timeoutMs?: number } = {}) {
+  const timeoutMs = opts.timeoutMs ?? 30000;
+  const pending = new Map<string, Pending>();
+  let counter = 0;
+
+  function call(channel: RpcChannel, method: string, args: unknown[]): Promise<unknown> {
+    const id = `rpc-${++counter}`;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject({ code: 'timeout', message: `RPC ${channel}.${method} timed out` });
+      }, timeoutMs);
+      pending.set(id, { resolve, reject, timer });
+      post({ kind: 'rpc', id, channel, method, args });
+    });
+  }
+
+  function _receive(msg: { kind?: string; id?: string; ok?: boolean; value?: unknown; error?: unknown }): void {
+    if (msg.kind !== 'rpc-result' || typeof msg.id !== 'string') return;
+    const p = pending.get(msg.id);
+    if (!p) return;
+    clearTimeout(p.timer);
+    pending.delete(msg.id);
+    if (msg.ok) p.resolve(msg.value);
+    else p.reject(msg.error ?? { code: 'error', message: 'failed' });
+  }
+
+  const api = {
+    get: (url: string) => call('api', 'get', [url]),
+    post: (url: string, data?: unknown) => call('api', 'post', [url, data]),
+    put: (url: string, data?: unknown) => call('api', 'put', [url, data]),
+    patch: (url: string, data?: unknown) => call('api', 'patch', [url, data]),
+    delete: (url: string) => call('api', 'delete', [url]),
+  };
+  const toast = {
+    success: (m: string) => post({ kind: 'rpc', id: `t-${++counter}`, channel: 'toast', method: 'success', args: [m] }),
+    error: (m: string) => post({ kind: 'rpc', id: `t-${++counter}`, channel: 'toast', method: 'error', args: [m] }),
+  };
+  const navigate = (path: string) => call('navigate', 'go', [path]);
+
+  return { api, toast, navigate, _receive };
+}

--- a/client/vite.runtime.config.ts
+++ b/client/vite.runtime.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+
+// Builds the in-iframe runtime as a single IIFE asset into `public/`, so Vite
+// serves it at `/plugin-runtime.js` in BOTH dev (public is served at root) and
+// prod (public is copied into dist). host.html references it absolutely.
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    outDir: 'public',
+    lib: {
+      entry: 'src/plugin-runtime/index.ts',
+      name: 'BaluHostPluginRuntime',
+      formats: ['iife'],
+      fileName: () => 'plugin-runtime.js',
+    },
+    rollupOptions: { output: { entryFileNames: 'plugin-runtime.js' } },
+  },
+});

--- a/docs/superpowers/plans/2026-06-22-plugin-frontend-iframe-sandbox.md
+++ b/docs/superpowers/plans/2026-06-22-plugin-frontend-iframe-sandbox.md
@@ -1,0 +1,1209 @@
+# Plugin Frontend iframe Sandbox — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run plugin frontend code inside a browser-enforced opaque-origin sandbox iframe, talking to the host only through a `postMessage` RPC bridge with default-deny, scope-gated API access — so a malicious plugin can no longer read the JWT, call arbitrary endpoints, or touch the host DOM.
+
+**Architecture:** `PluginPage` renders a `PluginSandboxHost` that mounts `<iframe sandbox="allow-scripts">` (no `allow-same-origin` → opaque origin). A host-built `plugin-runtime.js` runs inside the frame, exposes `window.BaluHost`, and proxies `api`/`toast`/`navigate`/`storage` over `postMessage`. The host bridge holds the real token and enforces a per-call API policy (own routes always; Core routes only via manifest-declared, admin-granted scopes).
+
+**Tech Stack:** React 18 + TypeScript + Vite (client), Vitest (frontend tests), FastAPI + SQLAlchemy 2.0 + Alembic (backend), Pytest (backend tests).
+
+**Spec:** `docs/superpowers/specs/2026-06-22-plugin-frontend-iframe-sandbox-design.md`
+
+## Global Constraints
+
+- **Scope of this plan:** Phases 1–2 of the spec (bridge foundation + API policy). Phases 3–5 (runtime UI lib/theme/storage, migrate 3 bundled plugins + remove legacy, E2E/docs) are outlined at the end and expanded into a follow-up plan.
+- **Opaque origin:** the iframe MUST use `sandbox="allow-scripts"` WITHOUT `allow-same-origin`. Never add `allow-same-origin`.
+- **Origin check:** validate inbound messages by `event.source === iframe.contentWindow` reference equality, never by `event.origin` (opaque origin posts `"null"`).
+- **No token to the plugin:** the runtime SDK exposes no token, no `apiClient`, no `localStorage`. The only egress is `postMessage`.
+- **RPC timeout:** 30000 ms.
+- **Frontend tests** live under `client/src/__tests__/**/*.test.{ts,tsx}` (vitest config in `client/vite.config.ts`), run with `npx vitest run`.
+- **Backend tests** live under `backend/tests/`, run with `python -m pytest`.
+- **Repo runs `core.autocrlf=true`** — let git handle line endings; don't fight CRLF.
+- **Windows:** the full backend suite hangs on Windows; run targeted test files locally, full suite in CI.
+- **Alembic:** new migrations chain onto the real `alembic heads`, not the stale dev-DB head.
+
+## File Structure
+
+**New (frontend):**
+- `client/src/lib/plugin-sandbox/protocol.ts` — message envelope types + runtime validators (shared host↔runtime).
+- `client/src/lib/plugin-sandbox/hostBridge.ts` — `PluginBridge` class: owns the iframe window, sends `init`, routes RPC, enforces API policy, times out.
+- `client/src/lib/plugin-sandbox/scopeCatalog.ts` — the Core scope→pattern catalog + `isCallAllowed()`.
+- `client/src/components/plugins/PluginSandboxHost.tsx` — React wrapper: renders the iframe, wires a `PluginBridge`, handles resize/loading/error.
+- `client/src/plugin-runtime/index.ts` — runtime entry built separately; boots the in-iframe SDK and renders the plugin.
+- `client/src/plugin-runtime/sdk.ts` — builds the in-iframe `window.BaluHost` (proxies over `postMessage`).
+- `client/vite.runtime.config.ts` — separate Vite lib build for the runtime → single IIFE asset.
+
+**Modified (frontend):**
+- `client/src/components/PluginPage.tsx` — render `<PluginSandboxHost>` instead of the dynamically-imported component.
+- `client/package.json` — add `build:runtime` script.
+
+**New/Modified (backend):**
+- `backend/app/api/routes/plugins.py` — add `GET /{name}/ui/host.html`, add the runtime asset route, add permissive CORS to the `ui/` asset response.
+- `backend/app/plugins/manifest.py` — add `api_scopes` + `min_runtime_abi` to `PluginManifest`.
+- `backend/app/models/plugin.py` — add `granted_api_scopes` column to `InstalledPlugin`.
+- `backend/alembic/versions/<rev>_installed_plugins_granted_api_scopes.py` — migration.
+- `backend/app/services/plugin_marketplace.py` (or the install route) — persist granted scopes at install.
+
+**New tests:**
+- `client/src/__tests__/plugin-sandbox/protocol.test.ts`
+- `client/src/__tests__/plugin-sandbox/hostBridge.test.ts`
+- `client/src/__tests__/plugin-sandbox/scopeCatalog.test.ts`
+- `client/src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx`
+- `backend/tests/plugins/test_manifest_api_scopes.py`
+- `backend/tests/api/test_plugin_sandbox_assets.py`
+
+---
+
+## Phase 1 — Bridge Foundation
+
+### Task 1: Message envelope protocol + validators
+
+**Files:**
+- Create: `client/src/lib/plugin-sandbox/protocol.ts`
+- Test: `client/src/__tests__/plugin-sandbox/protocol.test.ts`
+
+**Interfaces:**
+- Produces: `RpcRequest`, `RpcResult`, `IframeEvent`, `HostPush` types; `RPC_CHANNELS` const; `isRpcRequest(msg): msg is RpcRequest`; `isIframeEvent(msg): msg is IframeEvent`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// client/src/__tests__/plugin-sandbox/protocol.test.ts
+import { describe, it, expect } from 'vitest';
+import { isRpcRequest, isIframeEvent, RPC_CHANNELS } from '../../lib/plugin-sandbox/protocol';
+
+describe('protocol validators', () => {
+  it('accepts a well-formed rpc request on a known channel', () => {
+    const msg = { kind: 'rpc', id: 'a1', channel: 'api', method: 'get', args: ['/api/plugins/x/y'] };
+    expect(isRpcRequest(msg)).toBe(true);
+  });
+  it('rejects an rpc request on an unknown channel', () => {
+    const msg = { kind: 'rpc', id: 'a1', channel: 'filesystem', method: 'read', args: [] };
+    expect(isRpcRequest(msg)).toBe(false);
+  });
+  it('rejects rpc with non-string id or non-array args', () => {
+    expect(isRpcRequest({ kind: 'rpc', id: 1, channel: 'api', method: 'get', args: [] })).toBe(false);
+    expect(isRpcRequest({ kind: 'rpc', id: 'a', channel: 'api', method: 'get', args: 'x' })).toBe(false);
+  });
+  it('recognises iframe events', () => {
+    expect(isIframeEvent({ kind: 'event', name: 'ready', payload: null })).toBe(true);
+    expect(isIframeEvent({ kind: 'event', name: 'bogus', payload: null })).toBe(false);
+  });
+  it('exposes the fixed channel set', () => {
+    expect([...RPC_CHANNELS].sort()).toEqual(['api', 'navigate', 'storage', 'toast']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && npx vitest run src/__tests__/plugin-sandbox/protocol.test.ts`
+Expected: FAIL — cannot resolve `../../lib/plugin-sandbox/protocol`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// client/src/lib/plugin-sandbox/protocol.ts
+export const RPC_CHANNELS = ['api', 'toast', 'navigate', 'storage'] as const;
+export type RpcChannel = (typeof RPC_CHANNELS)[number];
+
+export const IFRAME_EVENTS = ['ready', 'resize', 'error'] as const;
+export type IframeEventName = (typeof IFRAME_EVENTS)[number];
+
+export const HOST_PUSHES = ['init', 'theme-changed', 'visibility'] as const;
+export type HostPushName = (typeof HOST_PUSHES)[number];
+
+export interface RpcRequest {
+  kind: 'rpc';
+  id: string;
+  channel: RpcChannel;
+  method: string;
+  args: unknown[];
+}
+export interface RpcResult {
+  kind: 'rpc-result';
+  id: string;
+  ok: boolean;
+  value?: unknown;
+  error?: { code: string; message: string };
+}
+export interface IframeEvent {
+  kind: 'event';
+  name: IframeEventName;
+  payload: unknown;
+}
+export interface HostPush {
+  kind: 'push';
+  name: HostPushName;
+  payload: unknown;
+}
+
+function isObj(m: unknown): m is Record<string, unknown> {
+  return typeof m === 'object' && m !== null;
+}
+export function isRpcRequest(m: unknown): m is RpcRequest {
+  return (
+    isObj(m) && m.kind === 'rpc' && typeof m.id === 'string' &&
+    typeof m.method === 'string' && Array.isArray(m.args) &&
+    typeof m.channel === 'string' && (RPC_CHANNELS as readonly string[]).includes(m.channel)
+  );
+}
+export function isIframeEvent(m: unknown): m is IframeEvent {
+  return (
+    isObj(m) && m.kind === 'event' && typeof m.name === 'string' &&
+    (IFRAME_EVENTS as readonly string[]).includes(m.name)
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client && npx vitest run src/__tests__/plugin-sandbox/protocol.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/lib/plugin-sandbox/protocol.ts client/src/__tests__/plugin-sandbox/protocol.test.ts
+git commit -m "feat(plugin-sandbox): message envelope protocol + validators"
+```
+
+---
+
+### Task 2: Scope catalog + API policy matcher
+
+**Files:**
+- Create: `client/src/lib/plugin-sandbox/scopeCatalog.ts`
+- Test: `client/src/__tests__/plugin-sandbox/scopeCatalog.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `SCOPE_CATALOG: Record<string, { method: string; pattern: RegExp }[]>`; `isCallAllowed(opts: { pluginName: string; method: string; url: string; grantedScopes: string[] }): boolean`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// client/src/__tests__/plugin-sandbox/scopeCatalog.test.ts
+import { describe, it, expect } from 'vitest';
+import { isCallAllowed } from '../../lib/plugin-sandbox/scopeCatalog';
+
+const base = { pluginName: 'weather', grantedScopes: [] as string[] };
+
+describe('isCallAllowed', () => {
+  it('always allows own plugin routes', () => {
+    expect(isCallAllowed({ ...base, method: 'get', url: '/api/plugins/weather/forecast' })).toBe(true);
+    expect(isCallAllowed({ ...base, method: 'post', url: '/api/plugins/weather/refresh' })).toBe(true);
+  });
+  it('denies another plugin\'s routes', () => {
+    expect(isCallAllowed({ ...base, method: 'get', url: '/api/plugins/other/secret' })).toBe(false);
+  });
+  it('denies core routes without a granted scope', () => {
+    expect(isCallAllowed({ ...base, method: 'get', url: '/api/system/info' })).toBe(false);
+  });
+  it('allows a core route when the matching scope is granted', () => {
+    expect(isCallAllowed({ ...base, grantedScopes: ['read:system-info'], method: 'get', url: '/api/system/info' })).toBe(true);
+  });
+  it('still denies a different core route with that scope', () => {
+    expect(isCallAllowed({ ...base, grantedScopes: ['read:system-info'], method: 'get', url: '/api/users' })).toBe(false);
+  });
+  it('denies wrong method even with the scope', () => {
+    expect(isCallAllowed({ ...base, grantedScopes: ['read:system-info'], method: 'delete', url: '/api/system/info' })).toBe(false);
+  });
+  it('denies path traversal and non-/api/ targets', () => {
+    expect(isCallAllowed({ ...base, method: 'get', url: '/api/plugins/weather/../../users' })).toBe(false);
+    expect(isCallAllowed({ ...base, method: 'get', url: 'https://evil.test/api/plugins/weather/x' })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && npx vitest run src/__tests__/plugin-sandbox/scopeCatalog.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// client/src/lib/plugin-sandbox/scopeCatalog.ts
+
+/** Core scope → concrete allowed (method, path) patterns. Curated; start small.
+ *  NO write:* scopes on sensitive Core routes in v1. /api/users, /api/auth etc.
+ *  appear in no entry, so no scope can ever open them. */
+export const SCOPE_CATALOG: Record<string, { method: string; pattern: RegExp }[]> = {
+  'read:system-info': [{ method: 'get', pattern: /^\/api\/system\/info\/?$/ }],
+  'read:storage': [
+    { method: 'get', pattern: /^\/api\/files\/storage(\/.*)?$/ },
+    { method: 'get', pattern: /^\/api\/system\/storage(\/.*)?$/ },
+  ],
+  'read:power': [{ method: 'get', pattern: /^\/api\/power\/.*$/ }],
+};
+
+/** A plugin's own routes are always allowed; everything else needs a granted scope. */
+export function isCallAllowed(opts: {
+  pluginName: string;
+  method: string;
+  url: string;
+  grantedScopes: string[];
+}): boolean {
+  const { pluginName, grantedScopes } = opts;
+  const method = opts.method.toLowerCase();
+
+  // Reject anything that isn't a clean same-origin /api/ path.
+  if (!opts.url.startsWith('/api/')) return false;
+  // Normalise and reject traversal.
+  const path = new URL(opts.url, 'http://x').pathname;
+  if (path !== opts.url.split('?')[0]) return false; // query allowed, traversal/host not
+  if (path.includes('/../') || path.includes('..')) return false;
+
+  // Own routes: /api/plugins/{thisPlugin}/...
+  const ownPrefix = `/api/plugins/${pluginName}/`;
+  if (path.startsWith(ownPrefix)) return true;
+
+  // Core route: must match a granted scope's pattern.
+  for (const scope of grantedScopes) {
+    const entries = SCOPE_CATALOG[scope];
+    if (!entries) continue;
+    for (const e of entries) {
+      if (e.method === method && e.pattern.test(path)) return true;
+    }
+  }
+  return false;
+}
+```
+
+- [ ] **Step 3a: Reconcile the traversal assertion**
+
+The test `'/api/plugins/weather/../../users'` must return false. `new URL('/api/plugins/weather/../../users', 'http://x').pathname` collapses to `/users`, which `!== '/api/plugins/weather/../../users'`, so the `path !== opts.url.split('?')[0]` check catches it. Verify this branch is hit (not the `..` substring check) by keeping both guards.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client && npx vitest run src/__tests__/plugin-sandbox/scopeCatalog.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/lib/plugin-sandbox/scopeCatalog.ts client/src/__tests__/plugin-sandbox/scopeCatalog.test.ts
+git commit -m "feat(plugin-sandbox): scope catalog + default-deny api policy matcher"
+```
+
+---
+
+### Task 3: Host bridge controller
+
+**Files:**
+- Create: `client/src/lib/plugin-sandbox/hostBridge.ts`
+- Test: `client/src/__tests__/plugin-sandbox/hostBridge.test.ts`
+
+**Interfaces:**
+- Consumes: `protocol.ts` (types/validators), `scopeCatalog.ts` (`isCallAllowed`), `apiClient` from `client/src/lib/api`.
+- Produces: `class PluginBridge` with constructor `(opts: { iframe: HTMLIFrameElement; pluginName: string; grantedScopes: string[]; user: { id: number; username: string; role: string }; onResize?: (h: number) => void; onNavigate?: (path: string) => void; timeoutMs?: number })`, methods `start()`, `dispose()`, and internal `handleMessage(ev: MessageEvent)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// client/src/__tests__/plugin-sandbox/hostBridge.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PluginBridge } from '../../lib/plugin-sandbox/hostBridge';
+
+vi.mock('../../lib/api', () => ({
+  apiClient: { request: vi.fn(async () => ({ data: { ok: true } })) },
+}));
+import { apiClient } from '../../lib/api';
+
+function makeIframe() {
+  const posted: unknown[] = [];
+  const contentWindow = { postMessage: (m: unknown) => posted.push(m) } as unknown as Window;
+  const iframe = { contentWindow } as unknown as HTMLIFrameElement;
+  return { iframe, contentWindow, posted };
+}
+
+function fireFromFrame(contentWindow: Window, data: unknown) {
+  window.dispatchEvent(new MessageEvent('message', { source: contentWindow, data }));
+}
+
+describe('PluginBridge', () => {
+  const user = { id: 1, username: 'admin', role: 'admin' };
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sends init after the frame reports ready', () => {
+    const { iframe, contentWindow, posted } = makeIframe();
+    const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user });
+    b.start();
+    fireFromFrame(contentWindow, { kind: 'event', name: 'ready', payload: null });
+    const init = posted.find((m: any) => m.kind === 'push' && m.name === 'init') as any;
+    expect(init).toBeTruthy();
+    expect(init.payload.user.username).toBe('admin');
+    expect(init.payload.pluginName).toBe('weather');
+    b.dispose();
+  });
+
+  it('performs an allowed own-route api call and replies with the body', async () => {
+    const { iframe, contentWindow, posted } = makeIframe();
+    const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user });
+    b.start();
+    fireFromFrame(contentWindow, { kind: 'rpc', id: 'r1', channel: 'api', method: 'get', args: ['/api/plugins/weather/forecast'] });
+    await vi.waitFor(() => {
+      const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === 'r1');
+      expect(res).toBeTruthy();
+    });
+    const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === 'r1') as any;
+    expect(res.ok).toBe(true);
+    expect(res.value).toEqual({ ok: true });
+    expect(apiClient.request).toHaveBeenCalledOnce();
+    b.dispose();
+  });
+
+  it('rejects a denied core-route api call without calling apiClient', async () => {
+    const { iframe, contentWindow, posted } = makeIframe();
+    const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user });
+    b.start();
+    fireFromFrame(contentWindow, { kind: 'rpc', id: 'r2', channel: 'api', method: 'get', args: ['/api/users'] });
+    await vi.waitFor(() => {
+      const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === 'r2');
+      expect(res).toBeTruthy();
+    });
+    const res = posted.find((m: any) => m.kind === 'rpc-result' && m.id === 'r2') as any;
+    expect(res.ok).toBe(false);
+    expect(res.error.code).toBe('scope_denied');
+    expect(apiClient.request).not.toHaveBeenCalled();
+    b.dispose();
+  });
+
+  it('ignores messages whose source is not the iframe window', async () => {
+    const { iframe, contentWindow, posted } = makeIframe();
+    const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user });
+    b.start();
+    const other = { postMessage: () => {} } as unknown as Window;
+    fireFromFrame(other, { kind: 'rpc', id: 'r3', channel: 'api', method: 'get', args: ['/api/plugins/weather/x'] });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(posted.find((m: any) => m.id === 'r3')).toBeUndefined();
+    b.dispose();
+  });
+
+  it('routes resize events to onResize', () => {
+    const { iframe, contentWindow } = makeIframe();
+    const onResize = vi.fn();
+    const b = new PluginBridge({ iframe, pluginName: 'weather', grantedScopes: [], user, onResize });
+    b.start();
+    fireFromFrame(contentWindow, { kind: 'event', name: 'resize', payload: { height: 420 } });
+    expect(onResize).toHaveBeenCalledWith(420);
+    b.dispose();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && npx vitest run src/__tests__/plugin-sandbox/hostBridge.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// client/src/lib/plugin-sandbox/hostBridge.ts
+import { apiClient } from '../api';
+import { isRpcRequest, isIframeEvent, type RpcResult, type HostPush } from './protocol';
+import { isCallAllowed } from './scopeCatalog';
+
+interface User { id: number; username: string; role: string }
+
+export interface PluginBridgeOpts {
+  iframe: HTMLIFrameElement;
+  pluginName: string;
+  grantedScopes: string[];
+  user: User;
+  onResize?: (height: number) => void;
+  onNavigate?: (path: string) => void;
+  timeoutMs?: number;
+}
+
+export class PluginBridge {
+  private listener = (ev: MessageEvent) => this.handleMessage(ev);
+  constructor(private opts: PluginBridgeOpts) {}
+
+  start(): void {
+    window.addEventListener('message', this.listener);
+  }
+  dispose(): void {
+    window.removeEventListener('message', this.listener);
+  }
+
+  private post(msg: RpcResult | HostPush): void {
+    this.opts.iframe.contentWindow?.postMessage(msg, '*');
+  }
+
+  private async handleMessage(ev: MessageEvent): Promise<void> {
+    // Opaque-origin frames post origin "null" — trust the window reference only.
+    if (ev.source !== this.opts.iframe.contentWindow) return;
+    const data = ev.data;
+
+    if (isIframeEvent(data)) {
+      if (data.name === 'ready') {
+        this.post({
+          kind: 'push', name: 'init',
+          payload: { user: this.opts.user, pluginName: this.opts.pluginName },
+        });
+      } else if (data.name === 'resize') {
+        const h = (data.payload as { height?: unknown })?.height;
+        if (typeof h === 'number') this.opts.onResize?.(h);
+      }
+      return;
+    }
+
+    if (!isRpcRequest(data)) return;
+    try {
+      const value = await this.dispatch(data.channel, data.method, data.args);
+      this.post({ kind: 'rpc-result', id: data.id, ok: true, value });
+    } catch (err) {
+      const e = err as { code?: string; message?: string };
+      this.post({
+        kind: 'rpc-result', id: data.id, ok: false,
+        error: { code: e.code ?? 'error', message: e.message ?? 'Plugin call failed' },
+      });
+    }
+  }
+
+  private async dispatch(channel: string, method: string, args: unknown[]): Promise<unknown> {
+    if (channel === 'api') return this.apiCall(method, args);
+    if (channel === 'navigate') {
+      const path = String(args[0] ?? '');
+      const prefix = `/plugins/${this.opts.pluginName}`;
+      if (!path.startsWith(prefix)) throw { code: 'navigate_denied', message: 'Out-of-plugin navigation blocked' };
+      this.opts.onNavigate?.(path);
+      return null;
+    }
+    throw { code: 'unknown_channel', message: `Unknown channel ${channel}` };
+  }
+
+  private async apiCall(method: string, args: unknown[]): Promise<unknown> {
+    const url = String(args[0] ?? '');
+    const body = args[1];
+    if (!isCallAllowed({ pluginName: this.opts.pluginName, method, url, grantedScopes: this.opts.grantedScopes })) {
+      throw { code: 'scope_denied', message: `Plugin not permitted to call ${method.toUpperCase()} ${url}` };
+    }
+    const res = await apiClient.request({ url, method, data: body });
+    return res.data;
+  }
+}
+```
+
+(`toast` and `storage` channels arrive in Phase 2/3; `dispatch` throws `unknown_channel` for them until then, which is correct.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client && npx vitest run src/__tests__/plugin-sandbox/hostBridge.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/lib/plugin-sandbox/hostBridge.ts client/src/__tests__/plugin-sandbox/hostBridge.test.ts
+git commit -m "feat(plugin-sandbox): host bridge controller with policy-enforced api channel"
+```
+
+---
+
+### Task 4: In-iframe runtime SDK + entry, separate Vite build
+
+**Files:**
+- Create: `client/src/plugin-runtime/sdk.ts`
+- Create: `client/src/plugin-runtime/index.ts`
+- Create: `client/vite.runtime.config.ts`
+- Modify: `client/package.json` (add `build:runtime`)
+- Test: `client/src/__tests__/plugin-sandbox/runtimeSdk.test.ts`
+
+**Interfaces:**
+- Consumes: `protocol.ts` types.
+- Produces: `createSandboxSdk(post: (msg: unknown) => void): { api; toast; navigate; setOnInit(cb) }` from `sdk.ts`; a self-booting `index.ts` that wires `window.parent.postMessage` + `window.addEventListener('message')`.
+
+- [ ] **Step 1: Write the failing test** (unit-test the SDK proxy logic, not the DOM boot)
+
+```ts
+// client/src/__tests__/plugin-sandbox/runtimeSdk.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { createSandboxSdk } from '../../plugin-runtime/sdk';
+
+describe('createSandboxSdk', () => {
+  it('api.get posts an rpc and resolves on matching rpc-result', async () => {
+    const posted: any[] = [];
+    const sdk = createSandboxSdk((m) => posted.push(m));
+    const p = sdk.api.get('/api/plugins/weather/forecast');
+    const req = posted.find((m) => m.kind === 'rpc' && m.channel === 'api');
+    expect(req.method).toBe('get');
+    expect(req.args[0]).toBe('/api/plugins/weather/forecast');
+    // simulate host reply
+    sdk._receive({ kind: 'rpc-result', id: req.id, ok: true, value: { temp: 21 } });
+    await expect(p).resolves.toEqual({ temp: 21 });
+  });
+
+  it('api rejects on an error rpc-result with the error code', async () => {
+    const posted: any[] = [];
+    const sdk = createSandboxSdk((m) => posted.push(m));
+    const p = sdk.api.get('/api/users');
+    const req = posted.find((m) => m.kind === 'rpc');
+    sdk._receive({ kind: 'rpc-result', id: req.id, ok: false, error: { code: 'scope_denied', message: 'no' } });
+    await expect(p).rejects.toMatchObject({ code: 'scope_denied' });
+  });
+
+  it('times out a pending rpc', async () => {
+    vi.useFakeTimers();
+    const sdk = createSandboxSdk(() => {}, { timeoutMs: 100 });
+    const p = sdk.api.get('/api/plugins/weather/x');
+    const assertion = expect(p).rejects.toMatchObject({ code: 'timeout' });
+    await vi.advanceTimersByTimeAsync(150);
+    await assertion;
+    vi.useRealTimers();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && npx vitest run src/__tests__/plugin-sandbox/runtimeSdk.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// client/src/plugin-runtime/sdk.ts
+import { type RpcChannel } from '../lib/plugin-sandbox/protocol';
+
+interface Pending { resolve: (v: unknown) => void; reject: (e: unknown) => void; timer: ReturnType<typeof setTimeout> }
+
+export function createSandboxSdk(post: (msg: unknown) => void, opts: { timeoutMs?: number } = {}) {
+  const timeoutMs = opts.timeoutMs ?? 30000;
+  const pending = new Map<string, Pending>();
+  let counter = 0;
+
+  function call(channel: RpcChannel, method: string, args: unknown[]): Promise<unknown> {
+    const id = `rpc-${++counter}`;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject({ code: 'timeout', message: `RPC ${channel}.${method} timed out` });
+      }, timeoutMs);
+      pending.set(id, { resolve, reject, timer });
+      post({ kind: 'rpc', id, channel, method, args });
+    });
+  }
+
+  function _receive(msg: { kind?: string; id?: string; ok?: boolean; value?: unknown; error?: unknown }): void {
+    if (msg.kind !== 'rpc-result' || typeof msg.id !== 'string') return;
+    const p = pending.get(msg.id);
+    if (!p) return;
+    clearTimeout(p.timer);
+    pending.delete(msg.id);
+    if (msg.ok) p.resolve(msg.value);
+    else p.reject(msg.error ?? { code: 'error', message: 'failed' });
+  }
+
+  const api = {
+    get: (url: string) => call('api', 'get', [url]),
+    post: (url: string, data?: unknown) => call('api', 'post', [url, data]),
+    put: (url: string, data?: unknown) => call('api', 'put', [url, data]),
+    patch: (url: string, data?: unknown) => call('api', 'patch', [url, data]),
+    delete: (url: string) => call('api', 'delete', [url]),
+  };
+  const toast = {
+    success: (m: string) => post({ kind: 'rpc', id: `t-${++counter}`, channel: 'toast', method: 'success', args: [m] }),
+    error: (m: string) => post({ kind: 'rpc', id: `t-${++counter}`, channel: 'toast', method: 'error', args: [m] }),
+  };
+  const navigate = (path: string) => call('navigate', 'go', [path]);
+
+  return { api, toast, navigate, _receive };
+}
+```
+
+```ts
+// client/src/plugin-runtime/index.ts
+// Boots inside the sandbox iframe: wires postMessage, exposes window.BaluHost,
+// then loads the plugin bundle. (UI lib + React are added in Phase 3; here we
+// expose the proxy SDK and announce readiness so the host sends `init`.)
+import { createSandboxSdk } from './sdk';
+
+const sdk = createSandboxSdk((msg) => window.parent.postMessage(msg, '*'));
+
+window.addEventListener('message', (ev) => {
+  const data = ev.data;
+  if (data && data.kind === 'rpc-result') sdk._receive(data);
+  if (data && data.kind === 'push' && data.name === 'init') {
+    (window as unknown as { BaluHost: unknown }).BaluHost = {
+      api: sdk.api, toast: sdk.toast, navigate: sdk.navigate,
+      user: (data.payload as { user: unknown }).user,
+    };
+    void loadPluginBundle();
+  }
+});
+
+async function loadPluginBundle(): Promise<void> {
+  // The plugin bundle path is injected via a <meta name="plugin-bundle"> tag in host.html.
+  const meta = document.querySelector('meta[name="plugin-bundle"]') as HTMLMetaElement | null;
+  if (!meta) return;
+  await import(/* @vite-ignore */ meta.content);
+}
+
+// Announce readiness so the host responds with `init`.
+window.parent.postMessage({ kind: 'event', name: 'ready', payload: null }, '*');
+```
+
+```ts
+// client/vite.runtime.config.ts
+import { defineConfig } from 'vite';
+
+// Builds the in-iframe runtime as a single IIFE asset, output into the main
+// client dist so the backend can serve it at a stable path.
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    outDir: 'dist',
+    lib: {
+      entry: 'src/plugin-runtime/index.ts',
+      name: 'BaluHostPluginRuntime',
+      formats: ['iife'],
+      fileName: () => 'plugin-runtime.js',
+    },
+    rollupOptions: { output: { entryFileNames: 'plugin-runtime.js' } },
+  },
+});
+```
+
+In `client/package.json` scripts, add:
+```json
+"build:runtime": "vite build --config vite.runtime.config.ts"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client && npx vitest run src/__tests__/plugin-sandbox/runtimeSdk.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Verify the runtime builds**
+
+Run: `cd client && npm run build:runtime`
+Expected: emits `client/dist/plugin-runtime.js`, no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/plugin-runtime client/vite.runtime.config.ts client/package.json client/src/__tests__/plugin-sandbox/runtimeSdk.test.ts
+git commit -m "feat(plugin-sandbox): in-iframe runtime SDK + separate vite runtime build"
+```
+
+---
+
+### Task 5: Backend — serve `host.html`, runtime asset, permissive CORS
+
+**Files:**
+- Modify: `backend/app/api/routes/plugins.py` (the `serve_plugin_asset` route region, ~438–500)
+- Test: `backend/tests/api/test_plugin_sandbox_assets.py`
+
+**Interfaces:**
+- Produces: `GET /api/plugins/{name}/ui/host.html` → HTML bootstrap referencing `/plugin-runtime.js` + a `<meta name="plugin-bundle">` pointing at the plugin's bundle; existing `ui/{file}` responses gain `Access-Control-Allow-Origin: *`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/api/test_plugin_sandbox_assets.py
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from app.main import app
+    return TestClient(app)
+
+
+def test_ui_asset_has_permissive_cors(client, monkeypatch):
+    """ui/ assets must be loadable from the opaque-origin sandbox iframe."""
+    # A known bundled plugin is enabled in the test app's plugin manager.
+    resp = client.get("/api/plugins/storage_analytics/ui/bundle.js")
+    # Either the asset exists (200) or the plugin isn't enabled in this env (404);
+    # when served, it must carry the CORS header.
+    if resp.status_code == 200:
+        assert resp.headers.get("access-control-allow-origin") == "*"
+
+
+def test_host_html_bootstrap_served(client):
+    resp = client.get("/api/plugins/storage_analytics/ui/host.html")
+    if resp.status_code == 200:
+        body = resp.text
+        assert "plugin-runtime.js" in body
+        assert 'name="plugin-bundle"' in body
+        assert resp.headers.get("content-type", "").startswith("text/html")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/api/test_plugin_sandbox_assets.py -v`
+Expected: FAIL — `host.html` route returns 404 / no CORS header.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `serve_plugin_asset`, before the generic file handling, special-case `host.html`, and add the CORS header to the returned `FileResponse`. Add near the top of the function body (after the enabled-check):
+
+```python
+    # Sandbox bootstrap document — generated, not read from disk.
+    if file_path == "host.html":
+        bundle_path = "bundle.js"  # convention; manifest UI bundle name
+        html = (
+            "<!doctype html><html><head><meta charset='utf-8'>"
+            f"<meta name='plugin-bundle' content='/api/plugins/{name}/ui/{bundle_path}'>"
+            "</head><body><div id='plugin-root'></div>"
+            "<script src='/plugin-runtime.js'></script></body></html>"
+        )
+        return Response(
+            content=html,
+            media_type="text/html",
+            headers={"Access-Control-Allow-Origin": "*", "Cache-Control": "no-store"},
+        )
+```
+
+Then change the final `FileResponse(...)` headers dict to include CORS:
+
+```python
+    return FileResponse(
+        plugin_path,
+        media_type=content_type,
+        headers={
+            "Cache-Control": "public, max-age=3600",
+            "Access-Control-Allow-Origin": "*",
+        },
+    )
+```
+
+(Ensure `Response` is imported: `from fastapi import Response` — it already is in this module.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/api/test_plugin_sandbox_assets.py -v`
+Expected: PASS (2 tests; assertions are conditional on the plugin being enabled in the test env).
+
+- [ ] **Step 5: Serve the runtime asset**
+
+The static frontend (`client/dist`) is served by nginx/Vite; `plugin-runtime.js` lands in `dist/` from `build:runtime`, so `/plugin-runtime.js` resolves via the existing static mount. Confirm the deploy build runs `build:runtime` — add it to the client build pipeline in a later infra task (tracked in Phase 5). For dev, Vite serves `src/plugin-runtime/index.ts`; add a dev-only alias note in the migration guide.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/api/routes/plugins.py backend/tests/api/test_plugin_sandbox_assets.py
+git commit -m "feat(plugin-sandbox): serve host.html bootstrap + permissive CORS on ui assets"
+```
+
+---
+
+### Task 6: `PluginSandboxHost` component + wire `PluginPage`
+
+**Files:**
+- Create: `client/src/components/plugins/PluginSandboxHost.tsx`
+- Modify: `client/src/components/PluginPage.tsx` (replace dynamic-import render with `<PluginSandboxHost>`)
+- Test: `client/src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx`
+
+**Interfaces:**
+- Consumes: `PluginBridge` from `hostBridge.ts`.
+- Produces: `<PluginSandboxHost pluginName user grantedScopes />` rendering `<iframe sandbox="allow-scripts" src="/api/plugins/{name}/ui/host.html">`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// client/src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import PluginSandboxHost from '../../components/plugins/PluginSandboxHost';
+
+describe('PluginSandboxHost', () => {
+  const user = { id: 1, username: 'admin', role: 'admin' };
+  it('renders an opaque-origin sandbox iframe pointing at host.html', () => {
+    const { container } = render(
+      <PluginSandboxHost pluginName="weather" user={user} grantedScopes={[]} />
+    );
+    const iframe = container.querySelector('iframe')!;
+    expect(iframe).toBeTruthy();
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts');
+    expect(iframe.getAttribute('src')).toBe('/api/plugins/weather/ui/host.html');
+  });
+
+  it('never grants allow-same-origin', () => {
+    const { container } = render(
+      <PluginSandboxHost pluginName="weather" user={user} grantedScopes={[]} />
+    );
+    const sandbox = container.querySelector('iframe')!.getAttribute('sandbox')!;
+    expect(sandbox.includes('allow-same-origin')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && npx vitest run src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+// client/src/components/plugins/PluginSandboxHost.tsx
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { PluginBridge } from '../../lib/plugin-sandbox/hostBridge';
+
+interface User { id: number; username: string; role: string }
+interface Props {
+  pluginName: string;
+  user: User;
+  grantedScopes: string[];
+}
+
+export default function PluginSandboxHost({ pluginName, user, grantedScopes }: Props) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const navigate = useNavigate();
+  const [height, setHeight] = useState(480);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+    const bridge = new PluginBridge({
+      iframe, pluginName, grantedScopes, user,
+      onResize: (h) => setHeight(Math.max(120, Math.ceil(h))),
+      onNavigate: (path) => navigate(path),
+    });
+    bridge.start();
+    return () => bridge.dispose();
+  }, [pluginName, grantedScopes, user, navigate]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      title={`plugin-${pluginName}`}
+      src={`/api/plugins/${pluginName}/ui/host.html`}
+      sandbox="allow-scripts"
+      style={{ width: '100%', height, border: 'none' }}
+    />
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client && npx vitest run src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire `PluginPage`**
+
+In `client/src/components/PluginPage.tsx`: remove the `loadPluginComponent`/`loadPluginStyles` usage and the `PluginComponent` state/effect; render the sandbox host in the return block instead of `<PluginComponent user={user} />`:
+
+```tsx
+// imports: drop loadPluginComponent/loadPluginStyles; add:
+import PluginSandboxHost from './plugins/PluginSandboxHost';
+// ... in the final return, replace <Suspense>…<PluginComponent/></Suspense> with:
+<PluginSandboxHost
+  pluginName={pluginName!}
+  user={user}
+  grantedScopes={pluginInfo?.granted_api_scopes ?? []}
+/>
+```
+
+(`granted_api_scopes` is added to the plugin info type in Phase 2, Task 9/10; until then pass `[]`.)
+
+- [ ] **Step 6: Run the frontend suite + typecheck**
+
+Run: `cd client && npx vitest run src/__tests__/plugin-sandbox/ && npx tsc --noEmit`
+Expected: all sandbox tests PASS; no type errors (use `grantedScopes={[]}` literal if the field isn't on the type yet).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add client/src/components/plugins/PluginSandboxHost.tsx client/src/components/PluginPage.tsx client/src/__tests__/plugin-sandbox/PluginSandboxHost.test.tsx
+git commit -m "feat(plugin-sandbox): PluginSandboxHost component, wire PluginPage to the sandbox"
+```
+
+---
+
+## Phase 2 — API Policy: manifest scopes, grant, audit
+
+### Task 7: Manifest `api_scopes` + `min_runtime_abi`
+
+**Files:**
+- Modify: `backend/app/plugins/manifest.py:37-58` (`PluginManifest`)
+- Test: `backend/tests/plugins/test_manifest_api_scopes.py`
+
+**Interfaces:**
+- Produces: `PluginManifest.api_scopes: list[str]` (default `[]`), `PluginManifest.min_runtime_abi: int | None`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/plugins/test_manifest_api_scopes.py
+import json
+from pathlib import Path
+import pytest
+from app.plugins.manifest import load_manifest, PluginManifest
+
+
+def _write(tmp_path: Path, extra: dict) -> Path:
+    base = {
+        "manifest_version": 1, "name": "weather", "version": "1.0.0",
+        "display_name": "Weather", "description": "d", "author": "a",
+    }
+    base.update(extra)
+    (tmp_path / "plugin.json").write_text(json.dumps(base), encoding="utf-8")
+    return tmp_path
+
+
+def test_api_scopes_default_empty(tmp_path):
+    m = load_manifest(_write(tmp_path, {}))
+    assert m.api_scopes == []
+    assert m.min_runtime_abi is None
+
+
+def test_api_scopes_parsed(tmp_path):
+    m = load_manifest(_write(tmp_path, {"api_scopes": ["read:storage"], "min_runtime_abi": 1}))
+    assert m.api_scopes == ["read:storage"]
+    assert m.min_runtime_abi == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/test_manifest_api_scopes.py -v`
+Expected: FAIL — `api_scopes` not an attribute.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `backend/app/plugins/manifest.py`, add to `PluginManifest` (after `python_requirements`):
+
+```python
+    api_scopes: List[str] = Field(default_factory=list)
+    min_runtime_abi: Optional[int] = None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/plugins/test_manifest_api_scopes.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/plugins/manifest.py backend/tests/plugins/test_manifest_api_scopes.py
+git commit -m "feat(plugin-sandbox): manifest api_scopes + min_runtime_abi fields"
+```
+
+---
+
+### Task 8: `InstalledPlugin.granted_api_scopes` column + migration
+
+**Files:**
+- Modify: `backend/app/models/plugin.py` (add column after `granted_permissions`)
+- Create: `backend/alembic/versions/<rev>_installed_plugins_granted_api_scopes.py`
+- Test: `backend/tests/plugins/test_installed_plugin_scopes.py`
+
+**Interfaces:**
+- Produces: `InstalledPlugin.granted_api_scopes: list[str] | None` (JSON, default `[]`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/plugins/test_installed_plugin_scopes.py
+from app.models.plugin import InstalledPlugin
+
+
+def test_granted_api_scopes_roundtrip(db_session):
+    p = InstalledPlugin(name="weather", version="1.0.0", display_name="Weather",
+                        granted_api_scopes=["read:storage"])
+    db_session.add(p)
+    db_session.commit()
+    db_session.refresh(p)
+    assert p.granted_api_scopes == ["read:storage"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/test_installed_plugin_scopes.py -v`
+Expected: FAIL — unexpected keyword `granted_api_scopes`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `backend/app/models/plugin.py`, after `granted_permissions` (line ~26-28):
+
+```python
+    granted_api_scopes: Mapped[Optional[List[str]]] = mapped_column(
+        JSON, nullable=True, default=list
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/plugins/test_installed_plugin_scopes.py -v`
+Expected: PASS (the test DB is created from models, so the column exists).
+
+- [ ] **Step 5: Generate the migration against the real head**
+
+```bash
+cd backend
+alembic heads          # note the current head revision
+alembic revision --autogenerate -m "installed_plugins granted_api_scopes"
+```
+
+Verify the generated file's `down_revision` equals the `alembic heads` output (see `project_alembic_migration_head_pitfall`). The `upgrade()` should `op.add_column('installed_plugins', sa.Column('granted_api_scopes', sa.JSON(), nullable=True))` and `downgrade()` drop it.
+
+- [ ] **Step 6: Apply + verify**
+
+Run: `cd backend && alembic upgrade head`
+Expected: applies cleanly; `alembic current` shows the new head.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/models/plugin.py backend/alembic/versions/*granted_api_scopes*.py backend/tests/plugins/test_installed_plugin_scopes.py
+git commit -m "feat(plugin-sandbox): InstalledPlugin.granted_api_scopes column + migration"
+```
+
+---
+
+### Task 9: Expose granted scopes to the frontend plugin info
+
+**Files:**
+- Modify: the plugin-list endpoint + response schema in `backend/app/api/routes/plugins.py` (the enabled/installed plugin response that the frontend `PluginContext` consumes) to include `granted_api_scopes`.
+- Modify: `client/src/api/plugins.ts` (the plugin info type) + `client/src/contexts/PluginContext` consumers to carry `granted_api_scopes`.
+- Test: extend an existing plugins-route test (or add `backend/tests/api/test_plugins_list_scopes.py`).
+
+**Interfaces:**
+- Produces: each plugin entry returned to the SPA carries `granted_api_scopes: string[]`. `PluginSandboxHost` reads it (Task 6, Step 5).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/api/test_plugins_list_scopes.py
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    from app.main import app
+    return TestClient(app)
+
+
+def test_plugin_list_includes_granted_api_scopes(client, admin_auth_headers):
+    resp = client.get("/api/plugins", headers=admin_auth_headers)
+    assert resp.status_code == 200
+    for entry in resp.json().get("plugins", []):
+        assert "granted_api_scopes" in entry
+        assert isinstance(entry["granted_api_scopes"], list)
+```
+
+(Use the project's existing admin-auth fixture; match the real list endpoint path/shape — adjust `"/api/plugins"` and `["plugins"]` to the actual response in `plugins.py`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/api/test_plugins_list_scopes.py -v`
+Expected: FAIL — key absent.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `granted_api_scopes` to the plugin-list response model/dict in `plugins.py`, sourced from `InstalledPlugin.granted_api_scopes or []`. Mirror the field in `client/src/api/plugins.ts`'s plugin interface, and ensure `PluginContext`'s `enabledPlugins` carries it through.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/api/test_plugins_list_scopes.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Frontend typecheck**
+
+Run: `cd client && npx tsc --noEmit`
+Expected: no errors; `PluginSandboxHost` now reads `pluginInfo.granted_api_scopes`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/api/routes/plugins.py client/src/api/plugins.ts client/src/contexts backend/tests/api/test_plugins_list_scopes.py
+git commit -m "feat(plugin-sandbox): expose granted_api_scopes to the SPA plugin list"
+```
+
+---
+
+### Task 10: Grant scopes at install + scope_denied audit log
+
+**Files:**
+- Modify: the install flow in `backend/app/services/plugin_marketplace.py` (or the install route) to persist `manifest.api_scopes` into `InstalledPlugin.granted_api_scopes` (admin-confirmed — store declared scopes as granted on install).
+- Modify: install-dialog UI to display declared scopes (the marketplace install component).
+- Modify: `client/src/lib/plugin-sandbox/hostBridge.ts` — on `scope_denied`, emit a one-line `console.warn` and (optionally) POST a lightweight audit event to `/api/plugins/{name}/_audit/scope-denied` (rate-limited backend route).
+- Test: `backend/tests/plugins/test_install_grants_scopes.py`
+
+**Interfaces:**
+- Consumes: `PluginManifest.api_scopes`, `InstalledPlugin.granted_api_scopes`.
+- Produces: install persists granted scopes; denied calls are audit-logged.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/plugins/test_install_grants_scopes.py
+def test_install_persists_declared_scopes(db_session, fake_marketplace_index):
+    """After install, the InstalledPlugin row carries the manifest's api_scopes."""
+    from app.models.plugin import InstalledPlugin
+    # ... arrange a fake index entry whose manifest declares api_scopes=["read:storage"]
+    # ... call the installer used by the marketplace install route
+    row = db_session.query(InstalledPlugin).filter_by(name="weather").one()
+    assert row.granted_api_scopes == ["read:storage"]
+```
+
+(Wire to the existing installer test harness in `backend/tests/plugins/`; reuse the `fake_marketplace_index` / temp-index fixtures already used by installer tests.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/test_install_grants_scopes.py -v`
+Expected: FAIL — `granted_api_scopes` stays empty after install.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In the install path, after creating/updating the `InstalledPlugin` row, set `row.granted_api_scopes = list(manifest.api_scopes)`. Add the scope list to the install-dialog payload so the admin sees what they grant. Add a rate-limited `POST /api/plugins/{name}/_audit/scope-denied` route that calls `get_audit_logger_db()` with event_type `"PLUGIN"`, action `"scope_denied"`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/plugins/test_install_grants_scopes.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Frontend — surface denials**
+
+In `hostBridge.ts` `apiCall`, when `isCallAllowed` is false, before throwing, `console.warn('[plugin:'+pluginName+'] scope_denied', method, url)` and fire-and-forget `apiClient.post('/api/plugins/'+pluginName+'/_audit/scope-denied', { method, url }).catch(()=>{})`.
+
+- [ ] **Step 6: Run targeted suites**
+
+Run: `cd backend && python -m pytest tests/plugins/ -q` and `cd client && npx vitest run src/__tests__/plugin-sandbox/`
+Expected: green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/plugin_marketplace.py backend/app/api/routes/plugins.py client/src backend/tests/plugins/test_install_grants_scopes.py
+git commit -m "feat(plugin-sandbox): grant scopes at install + scope_denied audit logging"
+```
+
+---
+
+## Phase 1–2 Verification
+
+- [ ] Run the full sandbox frontend suite: `cd client && npx vitest run src/__tests__/plugin-sandbox/` → all green.
+- [ ] Run backend plugin + sandbox tests: `cd backend && python -m pytest tests/plugins/ tests/api/test_plugin_sandbox_assets.py tests/api/test_plugins_list_scopes.py -q` → all green.
+- [ ] Typecheck: `cd client && npx tsc --noEmit` → clean.
+- [ ] Manual smoke (dev): enable a plugin, open its page, confirm it renders inside an iframe (`sandbox="allow-scripts"`, no `allow-same-origin`), confirm an own-route call succeeds and a `/api/users` call is denied in the console.
+- [ ] Confirm the main window no longer defines `window.BaluHost` (DevTools console: `window.BaluHost` → `undefined`) once Phase 4 removes the legacy SDK; until then it still exists and is removed in the follow-up plan.
+
+---
+
+## Future Phases (follow-up plan)
+
+These are the remaining spec phases. They get their own detailed TDD plan (`2026-XX-XX-plugin-frontend-iframe-sandbox-phase3-5.md`) when Phases 1–2 land. Outline only:
+
+- **Phase 3 — Runtime UI lib + theme + storage.** Bundle React + the existing UI component library (`Button`/`Card`/`Modal`/…) + compiled Tailwind/theme CSS into `plugin-runtime.js`; inject theme tokens from the `init` handshake; add the `storage` channel (decide server-side per-plugin table vs. bounded client prefix). Re-export `BaluHost.React`/`hooks`/`ui`/`icons`/`utils` inside the iframe.
+- **Phase 4 — Migrate the 3 bundled plugins + remove legacy.** Convert `optical_drive`, `storage_analytics`, `tapo_smart_plug` to the externals/runtime-ABI build, add `api_scopes` + `min_runtime_abi` to each `plugin.json`, re-point Core calls. Then DELETE `client/src/lib/pluginLoader.ts` and the main-context `client/src/lib/pluginSDK.ts` (`initPluginSDK`), and remove its call site so `window.BaluHost` no longer exists in the host context.
+- **Phase 5 — E2E + docs.** Playwright test: a test plugin loads in the iframe, makes one allowed + one denied call, asserts the main context exposes no `window.BaluHost`. Plugin-author migration guide; `min_runtime_abi` / ABI versioning doc; ensure the deploy frontend build runs `build:runtime`.
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage (Phases 1–2):** opaque-origin iframe (Task 6), reference-equality origin check (Task 3), envelope/channels (Task 1), default-deny scope policy + own-routes (Task 2/3), no-token runtime SDK (Task 4), `host.html` + CORS (Task 5), manifest scopes (Task 7), grant column + migration (Task 8/9), install grant + audit (Task 10). Phases 3–5 explicitly deferred to a follow-up plan.
+- **Placeholder scan:** none — every code step carries real code; Task 9/10 note where to match existing fixtures/paths rather than inventing them.
+- **Type consistency:** `RpcRequest`/`RpcResult`/`IframeEvent` shared from `protocol.ts`; `PluginBridge` ctor matches `PluginSandboxHost` usage; `isCallAllowed` signature identical across Task 2 and Task 3; `granted_api_scopes` consistent across model/migration/route/frontend.

--- a/docs/superpowers/plans/2026-06-22-plugin-frontend-iframe-sandbox.md
+++ b/docs/superpowers/plans/2026-06-22-plugin-frontend-iframe-sandbox.md
@@ -39,7 +39,8 @@
 - `client/package.json` — add `build:runtime` script.
 
 **New/Modified (backend):**
-- `backend/app/api/routes/plugins.py` — add `GET /{name}/ui/host.html`, add the runtime asset route, add permissive CORS to the `ui/` asset response.
+- `backend/app/api/routes/plugins.py` — add `GET /{name}/ui/host.html` (framable bootstrap), add permissive CORS to the `ui/` asset response.
+- `backend/app/middleware/security_headers.py` — carve-out so the `host.html` bootstrap keeps `X-Frame-Options: SAMEORIGIN` + CSP `frame-ancestors 'self'` (the global `DENY` would blank the iframe).
 - `backend/app/plugins/manifest.py` — add `api_scopes` + `min_runtime_abi` to `PluginManifest`.
 - `backend/app/models/plugin.py` — add `granted_api_scopes` column to `InstalledPlugin`.
 - `backend/alembic/versions/<rev>_installed_plugins_granted_api_scopes.py` — migration.
@@ -320,7 +321,11 @@ function makeIframe() {
 }
 
 function fireFromFrame(contentWindow: Window, data: unknown) {
-  window.dispatchEvent(new MessageEvent('message', { source: contentWindow, data }));
+  // jsdom's MessageEvent constructor won't accept a plain object as `source`,
+  // so set it explicitly after construction for the reference-equality check.
+  const ev = new MessageEvent('message', { data });
+  Object.defineProperty(ev, 'source', { value: contentWindow });
+  window.dispatchEvent(ev);
 }
 
 describe('PluginBridge', () => {
@@ -652,12 +657,13 @@ window.parent.postMessage({ kind: 'event', name: 'ready', payload: null }, '*');
 // client/vite.runtime.config.ts
 import { defineConfig } from 'vite';
 
-// Builds the in-iframe runtime as a single IIFE asset, output into the main
-// client dist so the backend can serve it at a stable path.
+// Builds the in-iframe runtime as a single IIFE asset into `public/`, so Vite
+// serves it at `/plugin-runtime.js` in BOTH dev (public is served at root) and
+// prod (public is copied into dist). host.html references it absolutely.
 export default defineConfig({
   build: {
     emptyOutDir: false,
-    outDir: 'dist',
+    outDir: 'public',
     lib: {
       entry: 'src/plugin-runtime/index.ts',
       name: 'BaluHostPluginRuntime',
@@ -669,10 +675,18 @@ export default defineConfig({
 });
 ```
 
-In `client/package.json` scripts, add:
+In `client/package.json` scripts, add `build:runtime` and run it before the main build:
 ```json
-"build:runtime": "vite build --config vite.runtime.config.ts"
+"build:runtime": "vite build --config vite.runtime.config.ts",
+"prebuild": "npm run build:runtime"
 ```
+
+Add the generated artifact to `client/.gitignore` (it's a build output, not source):
+```
+public/plugin-runtime.js
+```
+
+For dev: `npm run build:runtime` once after pulling (document this in the migration guide); the file is then served at `/plugin-runtime.js` by the Vite dev server.
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -682,7 +696,7 @@ Expected: PASS (3 tests).
 - [ ] **Step 5: Verify the runtime builds**
 
 Run: `cd client && npm run build:runtime`
-Expected: emits `client/dist/plugin-runtime.js`, no errors.
+Expected: emits `client/public/plugin-runtime.js`, no errors. Add `public/plugin-runtime.js` to `client/.gitignore`.
 
 - [ ] **Step 6: Commit**
 
@@ -693,10 +707,11 @@ git commit -m "feat(plugin-sandbox): in-iframe runtime SDK + separate vite runti
 
 ---
 
-### Task 5: Backend — serve `host.html`, runtime asset, permissive CORS
+### Task 5: Backend — serve framable `host.html`, permissive CORS, middleware carve-out
 
 **Files:**
 - Modify: `backend/app/api/routes/plugins.py` (the `serve_plugin_asset` route region, ~438–500)
+- Modify: `backend/app/middleware/security_headers.py` (carve-out so the bootstrap stays framable)
 - Test: `backend/tests/api/test_plugin_sandbox_assets.py`
 
 **Interfaces:**
@@ -733,6 +748,16 @@ def test_host_html_bootstrap_served(client):
         assert "plugin-runtime.js" in body
         assert 'name="plugin-bundle"' in body
         assert resp.headers.get("content-type", "").startswith("text/html")
+
+
+def test_host_html_is_framable_same_origin(client):
+    """The sandbox bootstrap MUST be framable by our own app — the global
+    X-Frame-Options: DENY would otherwise blank the iframe."""
+    resp = client.get("/api/plugins/storage_analytics/ui/host.html")
+    if resp.status_code == 200:
+        assert resp.headers.get("x-frame-options", "DENY").upper() != "DENY"
+        # CSP frame-ancestors must allow same-origin framing.
+        assert "frame-ancestors" in resp.headers.get("content-security-policy", "")
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -747,7 +772,15 @@ In `serve_plugin_asset`, before the generic file handling, special-case `host.ht
 ```python
     # Sandbox bootstrap document — generated, not read from disk.
     if file_path == "host.html":
-        bundle_path = "bundle.js"  # convention; manifest UI bundle name
+        # Resolve the plugin's UI bundle name from its manifest (fall back to bundle.js).
+        bundle_path = "bundle.js"
+        try:
+            from app.plugins.manifest import load_manifest
+            manifest = load_manifest(plugin_manager.plugins_dir / name)
+            if manifest.ui and manifest.ui.bundle:
+                bundle_path = manifest.ui.bundle
+        except Exception:
+            pass
         html = (
             "<!doctype html><html><head><meta charset='utf-8'>"
             f"<meta name='plugin-bundle' content='/api/plugins/{name}/ui/{bundle_path}'>"
@@ -757,7 +790,15 @@ In `serve_plugin_asset`, before the generic file handling, special-case `host.ht
         return Response(
             content=html,
             media_type="text/html",
-            headers={"Access-Control-Allow-Origin": "*", "Cache-Control": "no-store"},
+            headers={
+                "Access-Control-Allow-Origin": "*",
+                "Cache-Control": "no-store",
+                # Make the bootstrap framable by our own SPA. The global
+                # SecurityHeadersMiddleware would set DENY; the middleware
+                # carve-out (Step 4) preserves these for the sandbox path.
+                "X-Frame-Options": "SAMEORIGIN",
+                "Content-Security-Policy": "frame-ancestors 'self'",
+            },
         )
 ```
 
@@ -776,20 +817,36 @@ Then change the final `FileResponse(...)` headers dict to include CORS:
 
 (Ensure `Response` is imported: `from fastapi import Response` — it already is in this module.)
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 4: Carve out the sandbox bootstrap in SecurityHeadersMiddleware**
+
+The middleware runs after the route and unconditionally sets `X-Frame-Options: DENY`, which would clobber the framable header and blank the iframe. Modify `backend/app/middleware/security_headers.py` so the sandbox bootstrap keeps its own framing headers.
+
+In `SecurityHeadersMiddleware.dispatch`, right after `response = await call_next(request)`, add:
+
+```python
+        # The plugin sandbox bootstrap must be framable by our own SPA; it sets
+        # its own X-Frame-Options/CSP frame-ancestors. Skip the global DENY/CSP
+        # for that single path so the iframe can render.
+        if request.url.path.endswith("/ui/host.html") and request.url.path.startswith("/api/plugins/"):
+            return response
+```
+
+This returns before the global header block overwrites the route's headers. (All other plugin asset paths still get the standard headers.)
+
+- [ ] **Step 5: Run test to verify it passes**
 
 Run: `cd backend && python -m pytest tests/api/test_plugin_sandbox_assets.py -v`
-Expected: PASS (2 tests; assertions are conditional on the plugin being enabled in the test env).
+Expected: PASS (3 tests; assertions are conditional on the plugin being enabled in the test env).
 
-- [ ] **Step 5: Serve the runtime asset**
+- [ ] **Step 7: Confirm runtime asset serving**
 
-The static frontend (`client/dist`) is served by nginx/Vite; `plugin-runtime.js` lands in `dist/` from `build:runtime`, so `/plugin-runtime.js` resolves via the existing static mount. Confirm the deploy build runs `build:runtime` — add it to the client build pipeline in a later infra task (tracked in Phase 5). For dev, Vite serves `src/plugin-runtime/index.ts`; add a dev-only alias note in the migration guide.
+`plugin-runtime.js` is emitted into `client/public/` by `build:runtime` (Task 4), so the `prebuild` hook makes `npm run build` copy it into `dist/` and `/plugin-runtime.js` resolves via the existing static mount in prod, and via the Vite dev server in dev. No backend route needed for the runtime itself. Verify `/plugin-runtime.js` is reachable in a dev session after `npm run build:runtime`.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
-git add backend/app/api/routes/plugins.py backend/tests/api/test_plugin_sandbox_assets.py
-git commit -m "feat(plugin-sandbox): serve host.html bootstrap + permissive CORS on ui assets"
+git add backend/app/api/routes/plugins.py backend/app/middleware/security_headers.py backend/tests/api/test_plugin_sandbox_assets.py
+git commit -m "feat(plugin-sandbox): serve framable host.html bootstrap + CORS, middleware carve-out"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-06-22-plugin-frontend-iframe-sandbox-design.md
+++ b/docs/superpowers/specs/2026-06-22-plugin-frontend-iframe-sandbox-design.md
@@ -189,7 +189,7 @@ Deliberately excluded in v1: write Core scopes, wildcard scopes, plugin-to-plugi
 
 ## Backend Changes (small)
 
-- New route `GET /api/plugins/{name}/ui/host.html` (sandbox bootstrap) + permissive CORS on the `ui/` asset routes.
+- New route `GET /api/plugins/{name}/ui/host.html` (sandbox bootstrap) + permissive CORS on the `ui/` asset routes. The bootstrap must be **framable by our own SPA**: it sets `X-Frame-Options: SAMEORIGIN` + CSP `frame-ancestors 'self'`, and `SecurityHeadersMiddleware` gets a carve-out for that path (the global `X-Frame-Options: DENY` would otherwise blank the iframe).
 - Route serving the versioned `plugin-runtime.js`.
 - `plugin.json` schema + `PluginManifest` model gain `api_scopes` / `min_runtime_abi`; `InstalledPlugin` gains granted scopes (Alembic migration, chained onto the real `alembic heads` — see `project_alembic_migration_head_pitfall`).
 - Scope catalog as a Core constant; `scope_denied` audit logging.

--- a/docs/superpowers/specs/2026-06-22-plugin-frontend-iframe-sandbox-design.md
+++ b/docs/superpowers/specs/2026-06-22-plugin-frontend-iframe-sandbox-design.md
@@ -1,0 +1,225 @@
+# Plugin Frontend Sandbox — iframe + postMessage Bridge
+
+**Status:** Spec
+**Date:** 2026-06-22
+**Track:** A (Frontend JS isolation) of the Plugin-Sandboxing program. Tracks B (backend Python isolation) and C (supply-chain signing) are separate specs.
+**Audit origin:** `SECURITY_AUDIT_2026-06-14.md` — "Plugin-System = größtes Architektur-Risiko". Closes the deferred Non-Goal "Frontend SDK changes / sandboxing" from `2026-04-13-plugin-marketplace-design.md`.
+
+## Problem
+
+Today a plugin's `ui/bundle.js` is loaded via `import(/* @vite-ignore */ bundleUrl)` directly into the **main browsing context** (`client/src/lib/pluginLoader.ts:41`, consumed only by `client/src/components/PluginPage.tsx:57`). The plugin's default export is a React component rendered into the host React tree. Plugins receive the full `window.BaluHost` SDK (`client/src/lib/pluginSDK.ts`), which exposes `api` — a wrapper over `apiClient` that auto-attaches the user's Bearer token from `localStorage`.
+
+Consequences for **untrusted, third-party** plugin code (the agreed trust model — a real third-party ecosystem):
+
+- A malicious plugin can read `localStorage` (the JWT), call **any** `/api/*` endpoint as the logged-in user, manipulate the host DOM, and exfiltrate data. This is a stored-XSS / account-takeover equivalent.
+- The plugin runs in **every** user's browser that opens its page, with that user's privileges.
+- `window.BaluHost` is a writable global (`pluginSDK.ts:237`); `loadPluginStyles` injects an unrestricted `<link>` (`pluginLoader.ts:122`).
+
+Goal of this spec: run plugin frontend code in a **browser-enforced sandbox** with no access to the host token, host storage, host DOM, or arbitrary API endpoints — while keeping the existing plugin authoring experience (`window.BaluHost` with React + UI components) largely intact.
+
+## Trust Model & Scope
+
+- **Threat model** (from the audit): VPN-only access, single-admin home NAS, potentially multiple non-admin LAN users. Plugin **install** is admin-only; plugin **UI** executes in any user's browser who opens it. Plugins are untrusted third-party code.
+- **The entire untrusted-JS surface in the frontend is one component**: `PluginPage.tsx` (verified — sole consumer of the bundle loader). Everything else is in scope only as it touches that path.
+- **Dashboard panels are already safe** and out of scope: a plugin supplies a declarative `PanelSpec` (`gauge`/`stat`/`status`/`chart` + data) and the **host** renders it with built-in renderers (`client/src/components/dashboard/PluginDashboardPanel.tsx` + `panels/*`). No plugin JS executes.
+
+### Non-Goals (explicit)
+
+- **Backend Python isolation** — plugin `__init__.py` keeps running in-process. That is Track B.
+- **Supply-chain signing / provenance** — Track C.
+- **Separate-origin iframe** (real distinct domain/port) — a future hardening over the opaque-origin sandbox chosen here; needs DNS/cert/port plumbing on the LAN/VPN box.
+- **Write access to sensitive Core endpoints from plugins** — no `write:*` or wildcard API scopes in v1.
+- **Plugin-to-plugin calls.**
+
+## Approach Selection
+
+For untrusted code, three isolation strategies were weighed:
+
+1. **Soft-sandbox in the main context** (SES/`lockdown`, Proxy-hidden globals) — JS soft-sandboxes are bypassable; does not meet the untrusted-code bar. Rejected.
+2. **Web Worker** — strong isolation but no DOM access; would require a full declarative-UI protocol (a custom renderer over `postMessage`). Too heavy for UI plugins. Rejected.
+3. **Sandboxed `<iframe>` + `postMessage` RPC** — browser-enforced isolation, DOM rendering preserved inside the frame. **Chosen.**
+
+## Architecture
+
+```
+PluginPage  (host chrome: title + PluginBadge + loading/error states)
+└── PluginSandboxHost  (owns the iframe + the bridge)
+        └── <iframe sandbox="allow-scripts">          ← NO allow-same-origin → opaque (null) origin
+                host.html            (backend-served sandbox bootstrap)
+                ├── plugin-runtime.js (host-built: React + UI lib + theme CSS + bridge SDK)
+                └── bundle.js         (plugin, built against window.BaluHost externals)
+                         │
+                         │  postMessage RPC  (the ONLY channel out)
+                         ▼
+                Host bridge  (holds the real token; enforces API policy)
+```
+
+### Why this isolates (browser-enforced, not hand-rolled)
+
+- `sandbox="allow-scripts"` **without** `allow-same-origin` gives the iframe document an **opaque origin**. It cannot reach `parent`/host DOM, host `localStorage`, or host cookies. (It also cannot use its own `localStorage` — fine; plugin persistence goes through the `storage` bridge channel.)
+- The plugin holds **no token**. A direct `fetch('/api/...')` from the null-origin iframe is cross-origin **without** credentials → 401, and CORS blocks reading the response. The **only** way out is `postMessage`.
+- **Origin check on the host:** a null-origin frame posts with `event.origin === "null"`, so the host validates by **reference equality** `event.source === iframe.contentWindow`, not by origin string.
+
+### Asset loading
+
+`host.html`, `plugin-runtime.js`, and `bundle.js` are not secret. The plugin `ui/` asset routes serve them with permissive CORS (`Access-Control-Allow-Origin: *`) so the opaque-origin iframe can load them via `<script>` / `import()`. No credentials are involved in these requests.
+
+## The Bridge (postMessage RPC protocol)
+
+`PluginSandboxHost` (new, `client/src/components/plugins/`) replaces the `loadPluginComponent` path. It renders the iframe, holds its `contentWindow` reference, and mediates every message.
+
+### Lifecycle / handshake
+
+```
+1. Host renders <iframe sandbox="allow-scripts" src="/api/plugins/{name}/ui/host.html">
+2. runtime.js loads → postMessage(parent, {kind:'event', name:'ready'})      [iframe→host]
+3. Host replies {kind:'push', name:'init', payload:{user, pluginName, theme, locale, i18n}}
+4. runtime builds window.BaluHost, loads bundle.js, renders the default export
+5. Running: RPC calls + events (below)
+6. Unmount: host removes the iframe → all pending RPCs reject
+```
+
+### Message envelope (one shape for everything)
+
+```ts
+// iframe → host (request, expects a reply)
+{ kind:'rpc', id:string, channel:'api'|'toast'|'navigate'|'storage', method:string, args:unknown[] }
+// host → iframe (reply)
+{ kind:'rpc-result', id:string, ok:boolean, value?:unknown, error?:{code:string, message:string} }
+// iframe → host (fire-and-forget)
+{ kind:'event', name:'resize'|'ready'|'error', payload:unknown }
+// host → iframe (push)
+{ kind:'push', name:'init'|'theme-changed'|'visibility', payload:unknown }
+```
+
+### Mediated channels — the entire plugin capability surface (deliberately small)
+
+| Channel | What the plugin may do | Host enforcement |
+|---|---|---|
+| `api` | `get/post/put/patch/delete(url, data)` | **API policy** (below), then fetch with the real token |
+| `toast` | success/error/loading/dismiss | forwarded to `react-hot-toast` |
+| `navigate` | navigation **only within** `/plugins/{name}` | host validates target path prefix |
+| `storage` | get/set/del — namespaced key-value | host persists under the plugin's own scope (backend route, or a bounded host-localStorage prefix) |
+| `resize` (event) | reports content height | host sets iframe height (no inner scrollbar) |
+
+Anything not in this set does not exist for plugins.
+
+### Robustness
+
+- Every RPC carries an `id` + a timeout (30 s) → no hanging promises.
+- The host **whitelists** `channel`+`method`; unknown values reject (no dynamic dispatch).
+- Args cross the boundary as plain JSON (structured clone) — no functions/prototypes.
+- A message flood is rate-limited / dropped to protect the host thread (DoS guard).
+
+## In-iframe Runtime & SDK (`window.BaluHost`, new)
+
+`plugin-runtime.js` is **built and served by the host** and runs inside the iframe. It presents the same `window.BaluHost` shape as today, but the security-sensitive parts are now bridge proxies.
+
+```ts
+window.BaluHost = {
+  React, hooks,                          // real React instance INSIDE the iframe (bundled in the runtime)
+  ui: { Button, Card, Modal, … },        // existing UI lib, rendered standalone in the iframe
+  icons,                                 // lucide
+  utils: { formatBytes, cn, … },         // pure functions, unchanged
+  toast,                                 // → postMessage proxy (channel 'toast')
+  api:   { get,post,put,patch,delete },  // → postMessage proxy (channel 'api'), NO token
+  storage,                               // → postMessage proxy (channel 'storage'), namespaced
+  navigate,                              // → postMessage proxy (channel 'navigate'), prefix-bounded
+  user,                                  // from init handshake (id/username/role, read-only)
+}
+```
+
+### Differences from today (= the plugin-author migration cost)
+
+- `api` is async-identical to today (`await BaluHost.api.get(url)`) → plugin JSX/logic mostly unchanged. No direct `apiClient`/`localStorage`/`window` access (never officially in the SDK anyway).
+- React is the iframe's **own** instance (bundled in the runtime), not the host's. Transparent for plugins that take React from `BaluHost.React`/`hooks` (the documented path).
+- Styling: the runtime ships the host's compiled Tailwind/theme CSS into the iframe and applies theme tokens (CSS variables) from the `init` handshake → native look & dark mode.
+
+### Build / distribution
+
+- The runtime is a separate client-build entry (`vite` lib mode), versioned (`runtime_abi: 1`), served from a host route.
+- Plugin `bundle.js` is built with React/ui as **externals** (`window.BaluHost`) — small bundles, no duplicate React (unchanged from today).
+- ABI check: the runtime reports `runtime_abi`; a manifest may declare `min_runtime_abi` → a clean error instead of a cryptic break.
+
+## API Mediation & Permission Scopes (default-deny)
+
+The `api` channel is the only path to data; least-privilege lives here.
+
+### Per-call policy (host bridge)
+
+```
+1. Normalize the target URL (resolve, no '..', must start with /api/).
+2. Own routes:  /api/plugins/{thisPlugin}/...   → ALWAYS allowed.
+3. Otherwise (Core route) → allowed only if a plugin-declared AND admin-granted
+   scope matches it (allowlist lookup). Else → reject {code:'scope_denied'}.
+4. Allowed → host fetches with the real Bearer token, returns only the JSON
+   body (no headers / token leak).
+```
+
+### Scope model
+
+- `plugin.json` gains `api_scopes: ["read:storage", "read:system-info", …]` (separate from the existing backend `required_permissions`).
+- A **fixed, Core-maintained catalog** maps each scope → concrete allowed method + path pattern:
+  ```
+  read:system-info  → GET /api/system/info
+  read:storage      → GET /api/files/storage*, GET /api/system/storage*
+  read:power        → GET /api/power/*
+  …  (start small, curate additively; NO write:* scopes on sensitive Core routes in v1)
+  ```
+  Plugins can never invent a scope that opens `/api/users` or `/api/auth` — those appear in no catalog entry.
+- **Admin grant at install:** declared scopes are shown in the install dialog ("This plugin wants: read storage info") and stored as granted/denied on the `InstalledPlugin` row. Ungranted scopes are blocked even if declared.
+- **Audit:** `scope_denied` calls are logged (rate-limited) → visible when a plugin reaches beyond its grant.
+
+Deliberately excluded in v1: write Core scopes, wildcard scopes, plugin-to-plugin calls. Plugins needing Core writes encapsulate them behind their **own** backend route (isolated under Track B).
+
+## Host Integration
+
+- New `PluginSandboxHost` (`client/src/components/plugins/`) wraps iframe + bridge. `PluginPage` keeps the chrome (title / `PluginBadge` / error states) and renders `<PluginSandboxHost pluginName … user … />` instead of `<PluginComponent>`.
+- `client/src/lib/pluginLoader.ts` (the `import()` path) and `client/src/lib/pluginSDK.ts` (`initPluginSDK` in the main context) are **removed** — the main context no longer exposes `window.BaluHost`, directly closing the audit gap.
+- iframe height driven by the `resize` event; loading / error / timeout states owned by the host.
+
+## Migration of the 3 Bundled Plugins (part of this track)
+
+`optical_drive`, `storage_analytics`, `tapo_smart_plug`:
+
+- Switch the build target to externals / runtime ABI.
+- Add `api_scopes` + `min_runtime_abi` to each `plugin.json`.
+- Re-point any calls that hit Core endpoints onto their own routes or declared scopes. JSX stays largely as-is.
+- They double as the **reference implementation** and an end-to-end smoke test of the whole chain.
+
+## Backend Changes (small)
+
+- New route `GET /api/plugins/{name}/ui/host.html` (sandbox bootstrap) + permissive CORS on the `ui/` asset routes.
+- Route serving the versioned `plugin-runtime.js`.
+- `plugin.json` schema + `PluginManifest` model gain `api_scopes` / `min_runtime_abi`; `InstalledPlugin` gains granted scopes (Alembic migration, chained onto the real `alembic heads` — see `project_alembic_migration_head_pitfall`).
+- Scope catalog as a Core constant; `scope_denied` audit logging.
+
+## Error Handling
+
+- Bridge RPC timeout (30 s) → reject with `{code:'timeout'}`; surfaced in-plugin via the rejected promise.
+- Unknown channel/method → `{code:'unknown_channel'}`.
+- `scope_denied` → returned to the plugin and audit-logged.
+- Runtime ABI mismatch (`min_runtime_abi` > runtime) → host shows a clean "plugin needs a newer BaluHost" message, does not load `bundle.js`.
+- iframe load failure / bundle parse error → host error state (mirrors today's `PluginPage` error UI).
+
+## Testing
+
+- **Bridge RPC unit tests:** envelope handling, timeout, unknown channel → reject.
+- **Policy tests:** own route allowed; Core route without scope denied; `/api/users` never reachable; `..` / non-`/api/` denied; granted-but-not-declared and declared-but-not-granted both denied.
+- **Vitest** for `PluginSandboxHost`: handshake, resize, unmount rejects pending RPCs.
+- **E2E (Playwright):** a test plugin loads in the iframe, makes one allowed + one denied call, observes the expected outcome; asserts the main context exposes no `window.BaluHost`.
+- **Migration smoke:** the 3 bundled plugins load and function under the new model.
+
+## Implementation Phases (each shippable)
+
+1. **Bridge core + envelope** — `PluginSandboxHost` + in-iframe runtime skeleton, handshake, `toast`/`navigate`/`resize` channels. A trivial test plugin renders in the sandbox.
+2. **API channel + policy** — own-routes-only first, then the scope catalog + manifest `api_scopes` + `InstalledPlugin` grant + install-dialog UI + audit.
+3. **Runtime UI lib + theme CSS** — ship React + UI components + Tailwind theme into the iframe; `storage` channel.
+4. **Migrate the 3 bundled plugins** + remove `pluginLoader.ts` / main-context `pluginSDK.ts`.
+5. **E2E + docs** — Playwright coverage, plugin-author migration guide, `min_runtime_abi`/ABI versioning.
+
+## Open Questions / Future Hardening
+
+- Separate-origin iframe (real domain/port) as defense-in-depth over the opaque origin.
+- Per-plugin Content-Security-Policy on the sandbox document (tighten `connect-src`/`script-src` inside the frame).
+- Whether `storage` persists server-side (per-plugin table) or client-side (bounded prefix) — decided in Phase 3.


### PR DESCRIPTION
## Was

**Plugin-Frontend-Sandboxing — Track A, Phase 1–2** (Brainstorm → Spec → Plan → subagent-getriebene Umsetzung). Schließt das größte offene Architektur-Risiko aus dem Security-Audit: Plugin-Frontend-Code lief bisher **unsandboxed im Haupt-Browsing-Context** mit Vollzugriff auf `window.BaluHost` → `apiClient` (JWT), `localStorage`, Host-DOM (Stored-XSS-/Account-Takeover-äquivalent).

Plugin-UI läuft jetzt in einem **opaque-origin `<iframe sandbox="allow-scripts">`** (kein `allow-same-origin`) und spricht ausschließlich über eine **`postMessage`-RPC-Bridge** mit dem Host. Der Host hält den Token und erzwingt eine **default-deny API-Policy**: eigene `/api/plugins/{name}/...`-Routen immer erlaubt, Core-Routen nur über im Manifest deklarierte, admin-gewährte Scopes aus einem festen Katalog.

Spec: `docs/superpowers/specs/2026-06-22-plugin-frontend-iframe-sandbox-design.md`
Plan: `docs/superpowers/plans/2026-06-22-plugin-frontend-iframe-sandbox.md`

## Inhalt (10 Tasks, TDD, je task- + whole-branch-reviewed)

**Phase 1 — Bridge-Fundament**
- Shared Message-Envelope-Protokoll + Validatoren (`protocol.ts`)
- Default-deny Scope-Katalog + `isCallAllowed` (`scopeCatalog.ts`)
- Host-Bridge-Controller (`hostBridge.ts`) — `event.source`-Referenz-Check, Policy-Enforcement, RPC
- In-iframe-Runtime-SDK + separater Vite-Build (`plugin-runtime/`, `vite.runtime.config.ts`)
- Framable `host.html`-Bootstrap-Route + permissives CORS + `SecurityHeadersMiddleware`-Carve-out (sonst würde `X-Frame-Options: DENY` das iframe leeren)
- `PluginSandboxHost`-Komponente + `PluginPage`-Verdrahtung

**Phase 2 — API-Policy**
- Manifest `api_scopes` + `min_runtime_abi`
- `InstalledPlugin.granted_api_scopes`-Spalte + Alembic-Migration (`1ab0b6db5b1c`, chained auf echten Head)
- Exposure via `/api/plugins/ui/manifest` → `PluginUIInfo` → Bridge
- Scope-Persistenz beim Enable + `scope_denied`-Audit-Route + Bridge-Firing

## Sicherheits-Boundary (vom finalen Whole-Branch-Review bestätigt)
Kein Pfad von einem Sandbox-Plugin zum Host-Token, Host-`localStorage`, Host-DOM oder einem nicht-erlaubten API-Call. Backend-Carve-outs (host.html-Framing, `/_audit/scope-denied` exact-match Gate, CORS `*` auf öffentlichen Asset-Routen) sind eng begrenzt.

## Tests
- Frontend Sandbox-Suite: **28 Tests grün** (Vitest), `tsc --noEmit` clean
- Backend Plugin/Sandbox-Aggregat: **461 Tests grün** (pytest, targeted — volle Suite hängt auf Windows → CI)
- Jeder Task: Implementer + Task-Review (Spec + Quality); finales Opus-Whole-Branch-Review: **Ready to merge**

## Bewusst NICHT in diesem PR (dokumentierte Follow-ups)
- **Phase 3–5**: In-iframe-UI-Lib/Theme/Storage, Migration der 3 gebundelten Plugins, **Entfernung des Haupt-Kontext-`initPluginSDK()`/`window.BaluHost`** (vom Review als nach Phase 2 weiterhin offen markiert — Sandbox-Plugins erreichen es nicht, aber der Convenience-Global bleibt bis Phase 4), E2E + Autoren-Doku.
- **Track B** (Backend-Python-Isolation), **Track C** (Supply-Chain-Signing) — eigene Specs/PRs.
- Akzeptierte Minors (host-seitiger `timeoutMs`, `_receive` vs `setOnInit`, N+1-Lookups bei kleiner Plugin-Zahl, `publicDir:false`) — als Follow-up notiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
