### PR TITLE
Plugin-Sandboxing Track B: Backend-Isolation — Phase 1 (RPC) + Phase 2a (Transport + Worker)

### DIFF
--- a/backend/app/plugins/sandbox/__init__.py
+++ b/backend/app/plugins/sandbox/__init__.py
@@ -1,0 +1,1 @@
+"""Plugin sandbox: isolated RPC runtime for external plugins (Track B)."""

--- a/backend/app/plugins/sandbox/channel.py
+++ b/backend/app/plugins/sandbox/channel.py
@@ -77,14 +77,7 @@ class RpcChannel:
                     break
                 if msg is None:
                     break  # clean EOF
-                # Route the message: responses resolve pending calls, requests dispatch
-                # to handlers. Bidirectional types (like LIFECYCLE) work as responses
-                # only if there's a matching pending call.
-                if msg.type in RESPONSE_TYPES and msg.id in self._pending:
-                    self._resolve(msg)
-                elif msg.type == MsgType.LIFECYCLE and msg.id in self._pending:
-                    # LIFECYCLE can be both request and response; if there's a pending
-                    # call, treat it as a response.
+                if msg.type in RESPONSE_TYPES:
                     self._resolve(msg)
                 elif msg.type in REQUEST_TYPES:
                     task = asyncio.create_task(self._dispatch(msg))

--- a/backend/app/plugins/sandbox/channel.py
+++ b/backend/app/plugins/sandbox/channel.py
@@ -77,7 +77,14 @@ class RpcChannel:
                     break
                 if msg is None:
                     break  # clean EOF
-                if msg.type in RESPONSE_TYPES:
+                # Route the message: responses resolve pending calls, requests dispatch
+                # to handlers. Bidirectional types (like LIFECYCLE) work as responses
+                # only if there's a matching pending call.
+                if msg.type in RESPONSE_TYPES and msg.id in self._pending:
+                    self._resolve(msg)
+                elif msg.type == MsgType.LIFECYCLE and msg.id in self._pending:
+                    # LIFECYCLE can be both request and response; if there's a pending
+                    # call, treat it as a response.
                     self._resolve(msg)
                 elif msg.type in REQUEST_TYPES:
                     task = asyncio.create_task(self._dispatch(msg))
@@ -124,6 +131,15 @@ class RpcChannel:
             if not fut.done():
                 fut.set_exception(exc)
         self._pending.clear()
+
+    async def wait_closed(self) -> None:
+        """Block until the read loop ends (peer closed the connection or a
+        frame error tore it down). Returns immediately if never started."""
+        if self._read_task is not None:
+            try:
+                await self._read_task
+            except (asyncio.CancelledError, Exception):
+                pass
 
     async def close(self) -> None:
         """Cancel the read loop + in-flight dispatch tasks, close the writer,

--- a/backend/app/plugins/sandbox/channel.py
+++ b/backend/app/plugins/sandbox/channel.py
@@ -126,14 +126,21 @@ class RpcChannel:
         self._pending.clear()
 
     async def close(self) -> None:
-        """Cancel the read loop, close the writer, fail pending calls."""
+        """Cancel the read loop + in-flight dispatch tasks, close the writer,
+        fail pending calls."""
         self._closed = True
         if self._read_task is not None:
             self._read_task.cancel()
             try:
                 await self._read_task
-            except asyncio.CancelledError:
+            except (asyncio.CancelledError, Exception):
                 pass
+        # Cancel any in-flight request-dispatch tasks (e.g. a slow handler) so
+        # they don't linger past event-loop teardown.
+        for task in list(self._dispatch_tasks):
+            task.cancel()
+        if self._dispatch_tasks:
+            await asyncio.gather(*self._dispatch_tasks, return_exceptions=True)
         try:
             self._writer.close()
             await self._writer.wait_closed()

--- a/backend/app/plugins/sandbox/channel.py
+++ b/backend/app/plugins/sandbox/channel.py
@@ -1,0 +1,142 @@
+"""Full-duplex RPC channel over a paired StreamReader/StreamWriter.
+
+Both ends are symmetric: each can issue ``call()`` (outbound request → awaited
+response) and each may serve inbound requests via a ``request_handler``. Inbound
+requests are dispatched in their own task, so a handler may itself issue a
+``call()`` back to the peer while the original request is still in flight
+(reentrancy) — required for an http_request handler that needs a cap_call.
+"""
+import asyncio
+import itertools
+import logging
+from typing import Awaitable, Callable, Optional
+
+from app.plugins.sandbox.protocol import (
+    FrameError,
+    Message,
+    MsgType,
+    REQUEST_TYPES,
+    RESPONSE_TYPES,
+    read_frame,
+    write_frame,
+)
+
+logger = logging.getLogger(__name__)
+
+RequestHandler = Callable[[Message], Awaitable[Message]]
+
+
+class RpcChannel:
+    """A symmetric, reentrant RPC channel."""
+
+    def __init__(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        *,
+        request_handler: Optional[RequestHandler] = None,
+    ) -> None:
+        self._reader = reader
+        self._writer = writer
+        self._request_handler = request_handler
+        self._ids = itertools.count(1)
+        self._pending: dict[int, asyncio.Future] = {}
+        self._read_task: Optional[asyncio.Task] = None
+        self._dispatch_tasks: set[asyncio.Task] = set()
+        self._closed = False
+
+    def start(self) -> None:
+        """Start the read loop (idempotent)."""
+        if self._read_task is None:
+            self._read_task = asyncio.create_task(self._read_loop())
+
+    async def call(
+        self, type: str, body: dict, *, timeout: Optional[float] = None
+    ) -> Message:
+        """Send a request and await the correlated response."""
+        if self._closed:
+            raise ConnectionError("channel closed")
+        msg_id = next(self._ids)
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[msg_id] = fut
+        try:
+            await write_frame(self._writer, Message(id=msg_id, type=type, body=body))
+            if timeout is not None:
+                return await asyncio.wait_for(fut, timeout)
+            return await fut
+        finally:
+            self._pending.pop(msg_id, None)
+
+    async def _read_loop(self) -> None:
+        try:
+            while True:
+                try:
+                    msg = await read_frame(self._reader)
+                except (FrameError, OSError) as exc:
+                    logger.warning("rpc: dropping connection: %s", exc)
+                    break
+                if msg is None:
+                    break  # clean EOF
+                if msg.type in RESPONSE_TYPES:
+                    self._resolve(msg)
+                elif msg.type in REQUEST_TYPES:
+                    task = asyncio.create_task(self._dispatch(msg))
+                    self._dispatch_tasks.add(task)
+                    task.add_done_callback(self._dispatch_tasks.discard)
+                else:
+                    logger.warning("rpc: unknown message type %r", msg.type)
+        finally:
+            self._closed = True
+            self._fail_all(ConnectionError("channel closed"))
+
+    def _resolve(self, msg: Message) -> None:
+        fut = self._pending.get(msg.id)
+        if fut is None or fut.done():
+            logger.warning("rpc: response for unknown/settled id %s", msg.id)
+            return
+        fut.set_result(msg)
+
+    async def _dispatch(self, msg: Message) -> None:
+        if self._request_handler is None:
+            await self._safe_write(
+                Message(id=msg.id, type=MsgType.ERROR, body={"error": "no_handler"})
+            )
+            return
+        try:
+            response = await self._request_handler(msg)
+        except Exception:
+            logger.exception("rpc: request handler failed")
+            await self._safe_write(
+                Message(id=msg.id, type=MsgType.ERROR, body={"error": "handler_failed"})
+            )
+            return
+        response.id = msg.id  # always correlate to the request id
+        await self._safe_write(response)
+
+    async def _safe_write(self, msg: Message) -> None:
+        try:
+            await write_frame(self._writer, msg)
+        except Exception:
+            logger.exception("rpc: failed to write frame")
+
+    def _fail_all(self, exc: Exception) -> None:
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.set_exception(exc)
+        self._pending.clear()
+
+    async def close(self) -> None:
+        """Cancel the read loop, close the writer, fail pending calls."""
+        self._closed = True
+        if self._read_task is not None:
+            self._read_task.cancel()
+            try:
+                await self._read_task
+            except asyncio.CancelledError:
+                pass
+        try:
+            self._writer.close()
+            await self._writer.wait_closed()
+        except Exception:
+            pass
+        self._fail_all(ConnectionError("channel closed"))

--- a/backend/app/plugins/sandbox/protocol.py
+++ b/backend/app/plugins/sandbox/protocol.py
@@ -1,0 +1,97 @@
+"""Frame codec and message envelope for the plugin sandbox RPC layer.
+
+A frame on the wire is a 4-byte big-endian length prefix followed by a
+msgpack-encoded envelope ``{"id": int, "type": str, "body": dict}``. The same
+codec is used by both ends of the channel (host and sandbox worker).
+"""
+import asyncio
+import struct
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import msgpack
+
+# Hard cap on a single frame's payload to bound memory and reject malformed
+# length prefixes from an untrusted peer.
+MAX_FRAME_BYTES: int = 16 * 1024 * 1024  # 16 MiB
+
+_LENGTH_PREFIX = struct.Struct(">I")  # 4-byte big-endian unsigned length
+
+
+class MsgType:
+    """Envelope ``type`` values. Requests expect a correlated response."""
+
+    HTTP_REQUEST = "http_request"
+    HTTP_RESPONSE = "http_response"
+    CAP_CALL = "cap_call"
+    CAP_RESULT = "cap_result"
+    LIFECYCLE = "lifecycle"
+    ERROR = "error"
+
+
+# A side routes inbound frames by category: request types go to the request
+# handler, response types resolve a pending outbound call.
+REQUEST_TYPES = frozenset({MsgType.HTTP_REQUEST, MsgType.CAP_CALL, MsgType.LIFECYCLE})
+RESPONSE_TYPES = frozenset({MsgType.HTTP_RESPONSE, MsgType.CAP_RESULT, MsgType.ERROR})
+
+
+class FrameError(Exception):
+    """Raised when a frame is malformed, truncated, or exceeds MAX_FRAME_BYTES."""
+
+
+@dataclass
+class Message:
+    """A single RPC envelope."""
+
+    id: int
+    type: str
+    body: dict[str, Any] = field(default_factory=dict)
+
+
+def encode_frame(msg: Message) -> bytes:
+    """Serialize a Message to a length-prefixed msgpack frame."""
+    payload = msgpack.packb(
+        {"id": msg.id, "type": msg.type, "body": msg.body},
+        use_bin_type=True,
+    )
+    if len(payload) > MAX_FRAME_BYTES:
+        raise FrameError(f"frame too large: {len(payload)} > {MAX_FRAME_BYTES}")
+    return _LENGTH_PREFIX.pack(len(payload)) + payload
+
+
+def decode_payload(payload: bytes) -> Message:
+    """Decode a msgpack payload (without length prefix) into a Message."""
+    obj = msgpack.unpackb(payload, raw=False)
+    if not isinstance(obj, dict) or "id" not in obj or "type" not in obj:
+        raise FrameError("malformed envelope")
+    body = obj.get("body") or {}
+    if not isinstance(body, dict):
+        raise FrameError("envelope body must be a map")
+    return Message(id=int(obj["id"]), type=str(obj["type"]), body=body)
+
+
+async def read_frame(reader: asyncio.StreamReader) -> Optional[Message]:
+    """Read one frame. Returns None on a clean EOF (peer closed cleanly)."""
+    try:
+        prefix = await reader.readexactly(4)
+    except asyncio.IncompleteReadError as exc:
+        if not exc.partial:
+            return None  # clean EOF at a frame boundary
+        raise FrameError("truncated length prefix") from exc
+
+    (length,) = _LENGTH_PREFIX.unpack(prefix)
+    if length > MAX_FRAME_BYTES:
+        raise FrameError(f"frame too large: {length} > {MAX_FRAME_BYTES}")
+
+    try:
+        payload = await reader.readexactly(length)
+    except asyncio.IncompleteReadError as exc:
+        raise FrameError("truncated frame body") from exc
+
+    return decode_payload(payload)
+
+
+async def write_frame(writer: asyncio.StreamWriter, msg: Message) -> None:
+    """Serialize and write one frame, flushing the transport."""
+    writer.write(encode_frame(msg))
+    await writer.drain()

--- a/backend/app/plugins/sandbox/protocol.py
+++ b/backend/app/plugins/sandbox/protocol.py
@@ -60,14 +60,27 @@ def encode_frame(msg: Message) -> bytes:
 
 
 def decode_payload(payload: bytes) -> Message:
-    """Decode a msgpack payload (without length prefix) into a Message."""
-    obj = msgpack.unpackb(payload, raw=False)
+    """Decode a msgpack payload (without length prefix) into a Message.
+
+    Any corruption — bad msgpack, wrong envelope shape, or non-coercible
+    fields — is normalized to FrameError so the read loop can drop the
+    connection cleanly instead of crashing on an untrusted peer's garbage.
+    """
+    try:
+        obj = msgpack.unpackb(payload, raw=False)
+    except Exception as exc:  # msgpack FormatError/StackError/ExtraData/etc.
+        raise FrameError("invalid msgpack payload") from exc
     if not isinstance(obj, dict) or "id" not in obj or "type" not in obj:
         raise FrameError("malformed envelope")
-    body = obj.get("body") or {}
-    if not isinstance(body, dict):
+    body = obj.get("body")
+    if body is None:
+        body = {}
+    elif not isinstance(body, dict):
         raise FrameError("envelope body must be a map")
-    return Message(id=int(obj["id"]), type=str(obj["type"]), body=body)
+    try:
+        return Message(id=int(obj["id"]), type=str(obj["type"]), body=body)
+    except (TypeError, ValueError) as exc:
+        raise FrameError("invalid envelope fields") from exc
 
 
 async def read_frame(reader: asyncio.StreamReader) -> Optional[Message]:

--- a/backend/app/plugins/sandbox/protocol.py
+++ b/backend/app/plugins/sandbox/protocol.py
@@ -26,13 +26,14 @@ class MsgType:
     CAP_CALL = "cap_call"
     CAP_RESULT = "cap_result"
     LIFECYCLE = "lifecycle"
+    LIFECYCLE_RESULT = "lifecycle_result"
     ERROR = "error"
 
 
 # A side routes inbound frames by category: request types go to the request
 # handler, response types resolve a pending outbound call.
 REQUEST_TYPES = frozenset({MsgType.HTTP_REQUEST, MsgType.CAP_CALL, MsgType.LIFECYCLE})
-RESPONSE_TYPES = frozenset({MsgType.HTTP_RESPONSE, MsgType.CAP_RESULT, MsgType.ERROR})
+RESPONSE_TYPES = frozenset({MsgType.HTTP_RESPONSE, MsgType.CAP_RESULT, MsgType.LIFECYCLE_RESULT, MsgType.ERROR})
 
 
 class FrameError(Exception):

--- a/backend/app/plugins/sandbox/transport.py
+++ b/backend/app/plugins/sandbox/transport.py
@@ -1,0 +1,90 @@
+"""Cross-platform host<->worker socket transport for the plugin sandbox.
+
+Prod (Linux): a Unix-domain socket whose path lives in the worker's working
+directory, so it works across a network-namespace boundary (the worker needs
+no host-loopback access — only the bind-mounted socket file). Dev (Windows, or
+any platform without AF_UNIX in asyncio): a loopback-TCP socket on 127.0.0.1.
+
+Either way the result is an (asyncio.StreamReader, asyncio.StreamWriter) pair
+that an RpcChannel wraps; the channel itself is transport-agnostic.
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+def _use_unix_socket() -> bool:
+    """True iff asyncio AF_UNIX servers are available (Linux/macOS, not Windows)."""
+    return hasattr(asyncio, "start_unix_server") and sys.platform != "win32"
+
+
+class WorkerListener:
+    """Host side: listen for the worker's callback connection and accept one.
+
+    The worker is spawned with the string returned by ``start()`` and connects
+    back exactly once. ``accept()`` resolves with that single connection.
+    """
+
+    def __init__(self, socket_dir: "str | os.PathLike[str]") -> None:
+        self._socket_dir = Path(socket_dir)
+        self._server: Optional[asyncio.AbstractServer] = None
+        self._accepted: Optional[asyncio.Future] = None
+        self.connect_address: str = ""
+
+    async def start(self) -> str:
+        loop = asyncio.get_running_loop()
+        self._accepted = loop.create_future()
+
+        def _on_conn(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            # Accept only the first connection; ignore any extras defensively.
+            if self._accepted is not None and not self._accepted.done():
+                self._accepted.set_result((reader, writer))
+            else:
+                writer.close()
+
+        if _use_unix_socket():
+            path = str(self._socket_dir / "plugin.sock")
+            # Stale socket file from a crashed prior worker would block bind.
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+            self._server = await asyncio.start_unix_server(_on_conn, path=path)
+            self.connect_address = f"unix:{path}"
+        else:
+            self._server = await asyncio.start_server(_on_conn, "127.0.0.1", 0)
+            host, port = self._server.sockets[0].getsockname()[:2]
+            self.connect_address = f"tcp:{host}:{port}"
+
+        return self.connect_address
+
+    async def accept(
+        self, *, timeout: float
+    ) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        if self._accepted is None:
+            raise RuntimeError("WorkerListener.accept() called before start()")
+        return await asyncio.wait_for(asyncio.shield(self._accepted), timeout)
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            try:
+                await self._server.wait_closed()
+            except Exception:
+                pass
+            self._server = None
+
+
+async def connect_to_host(
+    address: str,
+) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Worker side: connect back to the host using a ``start()`` address."""
+    scheme, _, rest = address.partition(":")
+    if scheme == "unix":
+        return await asyncio.open_unix_connection(path=rest)
+    if scheme == "tcp":
+        host, _, port = rest.rpartition(":")
+        return await asyncio.open_connection(host, int(port))
+    raise ValueError(f"unknown connect address scheme: {address!r}")

--- a/backend/app/plugins/sandbox/worker.py
+++ b/backend/app/plugins/sandbox/worker.py
@@ -1,0 +1,75 @@
+"""Plugin sandbox worker entry point — runs inside the isolated child process.
+
+Phase 2 ships a minimal built-in request handler (health + echo) so the
+host<->worker round-trip can be exercised end-to-end. Real plugin loading and
+the capability SDK arrive in Phase 3, which replaces build_worker_handler().
+"""
+import argparse
+import asyncio
+from typing import List, Optional
+
+from app.plugins.sandbox.channel import RequestHandler, RpcChannel
+from app.plugins.sandbox.protocol import Message, MsgType
+from app.plugins.sandbox.transport import connect_to_host
+
+
+def build_worker_handler() -> RequestHandler:
+    """Return the Phase-2 placeholder handler: health pings + request echo."""
+
+    async def handler(msg: Message) -> Message:
+        if msg.type == MsgType.LIFECYCLE:
+            action = msg.body.get("action")
+            if action == "health":
+                return Message(id=msg.id, type=MsgType.LIFECYCLE, body={"status": "ok"})
+            if action == "shutdown":
+                return Message(
+                    id=msg.id, type=MsgType.LIFECYCLE, body={"status": "stopping"}
+                )
+            return Message(
+                id=msg.id, type=MsgType.LIFECYCLE, body={"status": "unknown_action"}
+            )
+        if msg.type == MsgType.HTTP_REQUEST:
+            # Phase-2 echo: prove the request contract round-trips intact.
+            return Message(
+                id=msg.id,
+                type=MsgType.HTTP_RESPONSE,
+                body={
+                    "status": 200,
+                    "headers": {},
+                    "echo": {
+                        "method": msg.body.get("method"),
+                        "path": msg.body.get("path"),
+                        "body": msg.body.get("body"),
+                        "context": msg.body.get("context"),
+                    },
+                },
+            )
+        return Message(id=msg.id, type=MsgType.ERROR, body={"error": "unsupported"})
+
+    return handler
+
+
+async def run_worker(address: str) -> None:
+    """Connect back to the host, serve requests until the connection closes."""
+    reader, writer = await connect_to_host(address)
+    channel = RpcChannel(reader, writer, request_handler=build_worker_handler())
+    channel.start()
+    try:
+        await channel.wait_closed()
+    finally:
+        await channel.close()
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(prog="plugin-sandbox-worker")
+    parser.add_argument(
+        "--connect",
+        required=True,
+        help="host callback address: 'unix:<path>' or 'tcp:<host>:<port>'",
+    )
+    args = parser.parse_args(argv)
+    asyncio.run(run_worker(args.connect))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/plugins/sandbox/worker.py
+++ b/backend/app/plugins/sandbox/worker.py
@@ -20,13 +20,13 @@ def build_worker_handler() -> RequestHandler:
         if msg.type == MsgType.LIFECYCLE:
             action = msg.body.get("action")
             if action == "health":
-                return Message(id=msg.id, type=MsgType.LIFECYCLE, body={"status": "ok"})
+                return Message(id=msg.id, type=MsgType.LIFECYCLE_RESULT, body={"status": "ok"})
             if action == "shutdown":
                 return Message(
-                    id=msg.id, type=MsgType.LIFECYCLE, body={"status": "stopping"}
+                    id=msg.id, type=MsgType.LIFECYCLE_RESULT, body={"status": "stopping"}
                 )
             return Message(
-                id=msg.id, type=MsgType.LIFECYCLE, body={"status": "unknown_action"}
+                id=msg.id, type=MsgType.LIFECYCLE_RESULT, body={"status": "unknown_action"}
             )
         if msg.type == MsgType.HTTP_REQUEST:
             # Phase-2 echo: prove the request contract round-trips intact.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -43,7 +43,8 @@ dependencies = [
   "apscheduler>=3.10.0,<4.0.0",
   "docker>=7.0.0,<8.0.0",
   "qrcode>=7.0.0",
-  "dbus-next>=0.2.3,<1.0.0"
+  "dbus-next>=0.2.3,<1.0.0",
+  "msgpack>=1.0.0,<2.0.0"
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/plugins/sandbox/__init__.py
+++ b/backend/tests/plugins/sandbox/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the plugin sandbox RPC layer."""

--- a/backend/tests/plugins/sandbox/test_channel.py
+++ b/backend/tests/plugins/sandbox/test_channel.py
@@ -1,5 +1,7 @@
 """Tests for the duplex RpcChannel (happy path)."""
 import asyncio
+import socket
+import struct
 
 import pytest
 
@@ -58,3 +60,71 @@ async def test_call_times_out_when_handler_is_slow():
     finally:
         await ch_a.close()
         await ch_b.close()
+
+
+async def test_reentrant_cap_call_during_request():
+    # Host answers cap_call; plugin issues a cap_call while serving http_request.
+    async def host_handler(msg: Message) -> Message:
+        assert msg.type == MsgType.CAP_CALL
+        return Message(id=msg.id, type=MsgType.CAP_RESULT, body={"value": "42"})
+
+    channels: dict[str, RpcChannel] = {}
+
+    async def plugin_handler(msg: Message) -> Message:
+        result = await channels["plugin"].call(
+            MsgType.CAP_CALL, {"capability": "storage.get"}, timeout=5
+        )
+        return Message(id=msg.id, type=MsgType.HTTP_RESPONSE, body={"got": result.body["value"]})
+
+    ch_a, ch_b = await _connect(handler_a=host_handler, handler_b=plugin_handler)
+    channels["plugin"] = ch_b
+    try:
+        resp = await ch_a.call(MsgType.HTTP_REQUEST, {}, timeout=5)
+        assert resp.body == {"got": "42"}
+    finally:
+        await ch_a.close()
+        await ch_b.close()
+
+
+async def test_malformed_frame_drops_connection():
+    # Ein roher Loopback-Client schickt ein bogus Oversize-Längenpräfix; der
+    # RpcChannel auf der Server-Seite muss FrameError auslösen und abbauen
+    # (statt 4 GiB zu allokieren). Loopback-TCP wie im _connect-Helper.
+    accepted: dict[str, tuple] = {}
+    ready = asyncio.Event()
+
+    async def _on_client(reader, writer):
+        accepted["pair"] = (reader, writer)
+        ready.set()
+
+    server = await asyncio.start_server(_on_client, "127.0.0.1", 0)
+    host, port = server.sockets[0].getsockname()[:2]
+    raw = socket.create_connection((host, port))
+    await ready.wait()
+    s_reader, s_writer = accepted["pair"]
+    server.close()
+
+    ch = RpcChannel(s_reader, s_writer)
+    ch.start()
+    try:
+        raw.sendall(struct.pack(">I", 0xFFFFFFFF))
+        await asyncio.sleep(0.1)
+        with pytest.raises(ConnectionError):
+            await ch.call(MsgType.HTTP_REQUEST, {}, timeout=2)
+    finally:
+        await ch.close()
+        raw.close()
+
+
+async def test_close_fails_inflight_call():
+    async def never(msg: Message) -> Message:
+        await asyncio.sleep(100)
+        return Message(id=msg.id, type=MsgType.HTTP_RESPONSE, body={})
+
+    ch_a, ch_b = await _connect(handler_b=never)
+    task = asyncio.create_task(ch_a.call(MsgType.HTTP_REQUEST, {}))
+    await asyncio.sleep(0.05)
+    await ch_a.close()
+    with pytest.raises(ConnectionError):
+        await task
+    await ch_b.close()

--- a/backend/tests/plugins/sandbox/test_channel.py
+++ b/backend/tests/plugins/sandbox/test_channel.py
@@ -116,6 +116,38 @@ async def test_malformed_frame_drops_connection():
         raw.close()
 
 
+async def test_garbage_msgpack_body_drops_connection():
+    # A raw loopback client sends a VALID small length prefix + invalid msgpack
+    # body (0xc1).  The RpcChannel read loop must decode_payload → FrameError →
+    # drop the connection cleanly (no escaped exception); a pending call then
+    # raises ConnectionError.
+    accepted: dict[str, tuple] = {}
+    ready = asyncio.Event()
+
+    async def _on_client(reader, writer):
+        accepted["pair"] = (reader, writer)
+        ready.set()
+
+    server = await asyncio.start_server(_on_client, "127.0.0.1", 0)
+    host, port = server.sockets[0].getsockname()[:2]
+    raw = socket.create_connection((host, port))
+    await ready.wait()
+    s_reader, s_writer = accepted["pair"]
+    server.close()
+
+    ch = RpcChannel(s_reader, s_writer)
+    ch.start()
+    try:
+        # Valid 4-byte length prefix (1 byte payload) + 1 invalid msgpack byte.
+        raw.sendall(struct.pack(">I", 1) + b"\xc1")
+        await asyncio.sleep(0.1)
+        with pytest.raises(ConnectionError):
+            await ch.call(MsgType.HTTP_REQUEST, {}, timeout=2)
+    finally:
+        await ch.close()
+        raw.close()
+
+
 async def test_close_fails_inflight_call():
     async def never(msg: Message) -> Message:
         await asyncio.sleep(100)

--- a/backend/tests/plugins/sandbox/test_channel.py
+++ b/backend/tests/plugins/sandbox/test_channel.py
@@ -1,0 +1,60 @@
+"""Tests for the duplex RpcChannel (happy path)."""
+import asyncio
+
+import pytest
+
+from app.plugins.sandbox.channel import RpcChannel
+from app.plugins.sandbox.protocol import Message, MsgType
+
+
+async def _connect(handler_a=None, handler_b=None):
+    # Loopback-TCP-Paar statt socket.socketpair()+open_connection(sock=…):
+    # portabel über Linux UND Windows (ProactorEventLoop akzeptiert ein
+    # vorab-connectetes `sock=` nicht zuverlässig); kein Subprozess nötig.
+    accepted: dict[str, tuple] = {}
+    ready = asyncio.Event()
+
+    async def _on_client(reader, writer):
+        accepted["pair"] = (reader, writer)
+        ready.set()
+
+    server = await asyncio.start_server(_on_client, "127.0.0.1", 0)
+    host, port = server.sockets[0].getsockname()[:2]
+    a_reader, a_writer = await asyncio.open_connection(host, port)
+    await ready.wait()
+    b_reader, b_writer = accepted["pair"]
+    server.close()
+
+    ch_a = RpcChannel(a_reader, a_writer, request_handler=handler_a)
+    ch_b = RpcChannel(b_reader, b_writer, request_handler=handler_b)
+    ch_a.start()
+    ch_b.start()
+    return ch_a, ch_b
+
+
+async def test_call_returns_handler_response():
+    async def handler(msg: Message) -> Message:
+        return Message(id=msg.id, type=MsgType.HTTP_RESPONSE, body={"echo": msg.body["v"]})
+
+    ch_a, ch_b = await _connect(handler_b=handler)
+    try:
+        resp = await ch_a.call(MsgType.HTTP_REQUEST, {"v": "hi"}, timeout=5)
+        assert resp.type == MsgType.HTTP_RESPONSE
+        assert resp.body == {"echo": "hi"}
+    finally:
+        await ch_a.close()
+        await ch_b.close()
+
+
+async def test_call_times_out_when_handler_is_slow():
+    async def slow(msg: Message) -> Message:
+        await asyncio.sleep(10)
+        return Message(id=msg.id, type=MsgType.HTTP_RESPONSE, body={})
+
+    ch_a, ch_b = await _connect(handler_b=slow)
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await ch_a.call(MsgType.HTTP_REQUEST, {}, timeout=0.1)
+    finally:
+        await ch_a.close()
+        await ch_b.close()

--- a/backend/tests/plugins/sandbox/test_protocol.py
+++ b/backend/tests/plugins/sandbox/test_protocol.py
@@ -52,3 +52,24 @@ def test_request_response_type_partition():
     assert REQUEST_TYPES.isdisjoint(RESPONSE_TYPES)
     assert MsgType.HTTP_REQUEST in REQUEST_TYPES
     assert MsgType.HTTP_RESPONSE in RESPONSE_TYPES
+
+
+def test_decode_payload_rejects_invalid_msgpack():
+    with pytest.raises(FrameError):
+        decode_payload(b"\xc1")  # 0xc1 is an unused/invalid msgpack byte
+
+
+def test_decode_payload_rejects_non_numeric_id():
+    with pytest.raises(FrameError):
+        decode_payload(msgpack.packb({"id": "abc", "type": "x", "body": {}}, use_bin_type=True))
+
+
+def test_decode_payload_rejects_falsy_non_dict_body():
+    with pytest.raises(FrameError):
+        decode_payload(msgpack.packb({"id": 1, "type": "x", "body": 0}, use_bin_type=True))
+
+
+async def test_read_frame_wraps_garbage_body_as_frameerror():
+    reader = _reader(_LENGTH_PREFIX.pack(1) + b"\xc1")
+    with pytest.raises(FrameError):
+        await read_frame(reader)

--- a/backend/tests/plugins/sandbox/test_protocol.py
+++ b/backend/tests/plugins/sandbox/test_protocol.py
@@ -52,6 +52,8 @@ def test_request_response_type_partition():
     assert REQUEST_TYPES.isdisjoint(RESPONSE_TYPES)
     assert MsgType.HTTP_REQUEST in REQUEST_TYPES
     assert MsgType.HTTP_RESPONSE in RESPONSE_TYPES
+    assert MsgType.LIFECYCLE in REQUEST_TYPES
+    assert MsgType.LIFECYCLE_RESULT in RESPONSE_TYPES
 
 
 def test_decode_payload_rejects_invalid_msgpack():

--- a/backend/tests/plugins/sandbox/test_protocol.py
+++ b/backend/tests/plugins/sandbox/test_protocol.py
@@ -1,0 +1,54 @@
+"""Tests for the sandbox RPC frame codec and message types."""
+import asyncio
+
+import msgpack
+import pytest
+
+from app.plugins.sandbox.protocol import (
+    FrameError,
+    MAX_FRAME_BYTES,
+    Message,
+    MsgType,
+    REQUEST_TYPES,
+    RESPONSE_TYPES,
+    _LENGTH_PREFIX,
+    decode_payload,
+    encode_frame,
+    read_frame,
+)
+
+
+def _reader(data: bytes) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader()
+    reader.feed_data(data)
+    reader.feed_eof()
+    return reader
+
+
+async def test_frame_roundtrip():
+    msg = Message(id=7, type=MsgType.HTTP_REQUEST, body={"method": "GET", "path": "x"})
+    out = await read_frame(_reader(encode_frame(msg)))
+    assert out == msg
+
+
+async def test_read_frame_returns_none_on_clean_eof():
+    reader = asyncio.StreamReader()
+    reader.feed_eof()
+    assert await read_frame(reader) is None
+
+
+async def test_read_frame_rejects_oversize_length():
+    reader = _reader(_LENGTH_PREFIX.pack(MAX_FRAME_BYTES + 1))
+    with pytest.raises(FrameError):
+        await read_frame(reader)
+
+
+async def test_decode_payload_rejects_non_envelope():
+    with pytest.raises(FrameError):
+        decode_payload(msgpack.packb([1, 2, 3], use_bin_type=True))
+
+
+def test_request_response_type_partition():
+    assert REQUEST_TYPES.isdisjoint(RESPONSE_TYPES)
+    assert MsgType.HTTP_REQUEST in REQUEST_TYPES
+    assert MsgType.HTTP_RESPONSE in RESPONSE_TYPES

--- a/backend/tests/plugins/sandbox/test_transport.py
+++ b/backend/tests/plugins/sandbox/test_transport.py
@@ -1,0 +1,50 @@
+"""Tests for the cross-platform host<->worker transport."""
+import asyncio
+
+import pytest
+
+from app.plugins.sandbox.protocol import Message, MsgType, read_frame, write_frame
+from app.plugins.sandbox.transport import (
+    WorkerListener,
+    _use_unix_socket,
+    connect_to_host,
+)
+
+
+async def test_connect_address_scheme_matches_platform(tmp_path):
+    listener = WorkerListener(tmp_path)
+    address = await listener.start()
+    try:
+        expected = "unix:" if _use_unix_socket() else "tcp:"
+        assert address.startswith(expected)
+    finally:
+        await listener.close()
+
+
+async def test_accept_roundtrip_carries_a_frame(tmp_path):
+    listener = WorkerListener(tmp_path)
+    address = await listener.start()
+    try:
+        # Worker side connects back; host accepts the one connection.
+        w_reader, w_writer = await connect_to_host(address)
+        h_reader, h_writer = await listener.accept(timeout=5)
+
+        # Worker -> host
+        await write_frame(w_writer, Message(id=1, type=MsgType.LIFECYCLE, body={"ping": True}))
+        got = await read_frame(h_reader)
+        assert got == Message(id=1, type=MsgType.LIFECYCLE, body={"ping": True})
+
+        # Host -> worker
+        await write_frame(h_writer, Message(id=2, type=MsgType.HTTP_RESPONSE, body={"ok": 1}))
+        back = await read_frame(w_reader)
+        assert back == Message(id=2, type=MsgType.HTTP_RESPONSE, body={"ok": 1})
+
+        w_writer.close()
+        h_writer.close()
+    finally:
+        await listener.close()
+
+
+async def test_connect_to_host_rejects_unknown_scheme():
+    with pytest.raises(ValueError):
+        await connect_to_host("carrierpigeon:/nope")

--- a/backend/tests/plugins/sandbox/test_worker.py
+++ b/backend/tests/plugins/sandbox/test_worker.py
@@ -1,0 +1,71 @@
+"""In-process tests for the sandbox worker entry point (no real subprocess)."""
+import asyncio
+
+import pytest
+
+from app.plugins.sandbox.channel import RpcChannel
+from app.plugins.sandbox.protocol import Message, MsgType
+from app.plugins.sandbox.transport import WorkerListener
+from app.plugins.sandbox.worker import build_worker_handler, main, run_worker
+
+
+async def _host_and_worker(tmp_path):
+    """Start a host listener + an in-process run_worker; return (host_channel,
+    worker_task, listener) wired and ready."""
+    listener = WorkerListener(tmp_path)
+    address = await listener.start()
+    worker_task = asyncio.create_task(run_worker(address))
+    reader, writer = await listener.accept(timeout=5)
+    host = RpcChannel(reader, writer)
+    host.start()
+    return host, worker_task, listener
+
+
+async def test_worker_answers_health(tmp_path):
+    host, worker_task, listener = await _host_and_worker(tmp_path)
+    try:
+        resp = await host.call(MsgType.LIFECYCLE, {"action": "health"}, timeout=5)
+        assert resp.type == MsgType.LIFECYCLE
+        assert resp.body == {"status": "ok"}
+    finally:
+        await host.close()
+        await asyncio.wait_for(worker_task, timeout=5)
+        await listener.close()
+
+
+async def test_worker_echoes_http_request(tmp_path):
+    host, worker_task, listener = await _host_and_worker(tmp_path)
+    try:
+        resp = await host.call(
+            MsgType.HTTP_REQUEST,
+            {"method": "GET", "path": "ping", "body": b"", "context": {"user_id": 7}},
+            timeout=5,
+        )
+        assert resp.type == MsgType.HTTP_RESPONSE
+        assert resp.body["status"] == 200
+        assert resp.body["echo"]["method"] == "GET"
+        assert resp.body["echo"]["path"] == "ping"
+        assert resp.body["echo"]["context"] == {"user_id": 7}
+    finally:
+        await host.close()
+        await asyncio.wait_for(worker_task, timeout=5)
+        await listener.close()
+
+
+async def test_worker_run_returns_when_host_closes(tmp_path):
+    host, worker_task, listener = await _host_and_worker(tmp_path)
+    await host.close()
+    # run_worker must observe the closed connection and return on its own.
+    await asyncio.wait_for(worker_task, timeout=5)
+    assert worker_task.done() and worker_task.exception() is None
+    await listener.close()
+
+
+def test_main_requires_connect_arg():
+    with pytest.raises(SystemExit):
+        main([])
+
+
+def test_build_worker_handler_is_async_callable():
+    handler = build_worker_handler()
+    assert asyncio.iscoroutinefunction(handler)

--- a/backend/tests/plugins/sandbox/test_worker.py
+++ b/backend/tests/plugins/sandbox/test_worker.py
@@ -25,7 +25,7 @@ async def test_worker_answers_health(tmp_path):
     host, worker_task, listener = await _host_and_worker(tmp_path)
     try:
         resp = await host.call(MsgType.LIFECYCLE, {"action": "health"}, timeout=5)
-        assert resp.type == MsgType.LIFECYCLE
+        assert resp.type == MsgType.LIFECYCLE_RESULT
         assert resp.body == {"status": "ok"}
     finally:
         await host.close()

--- a/docs/superpowers/plans/2026-06-26-plugin-backend-isolation-phase1-rpc.md
+++ b/docs/superpowers/plans/2026-06-26-plugin-backend-isolation-phase1-rpc.md
@@ -304,7 +304,6 @@ Create `backend/tests/plugins/sandbox/test_channel.py`:
 ```python
 """Tests for the duplex RpcChannel (happy path)."""
 import asyncio
-import socket
 
 import pytest
 
@@ -313,9 +312,23 @@ from app.plugins.sandbox.protocol import Message, MsgType
 
 
 async def _connect(handler_a=None, handler_b=None):
-    a_sock, b_sock = socket.socketpair()
-    a_reader, a_writer = await asyncio.open_connection(sock=a_sock)
-    b_reader, b_writer = await asyncio.open_connection(sock=b_sock)
+    # Loopback-TCP-Paar statt socket.socketpair()+open_connection(sock=…):
+    # portabel über Linux UND Windows (ProactorEventLoop akzeptiert ein
+    # vorab-connectetes `sock=` nicht zuverlässig); kein Subprozess nötig.
+    accepted: dict[str, tuple] = {}
+    ready = asyncio.Event()
+
+    async def _on_client(reader, writer):
+        accepted["pair"] = (reader, writer)
+        ready.set()
+
+    server = await asyncio.start_server(_on_client, "127.0.0.1", 0)
+    host, port = server.sockets[0].getsockname()[:2]
+    a_reader, a_writer = await asyncio.open_connection(host, port)
+    await ready.wait()
+    b_reader, b_writer = accepted["pair"]
+    server.close()
+
     ch_a = RpcChannel(a_reader, a_writer, request_handler=handler_a)
     ch_b = RpcChannel(b_reader, b_writer, request_handler=handler_b)
     ch_a.start()
@@ -532,7 +545,7 @@ Begründung: Reentranz, Malformed-Drop und Pending-Fail sind bereits in der `Rpc
 
 - [ ] **Step 1: Failing tests schreiben**
 
-An `backend/tests/plugins/sandbox/test_channel.py` anhängen (`import struct` oben im File ergänzen; `pytest` ist seit Task 2 bereits importiert):
+An `backend/tests/plugins/sandbox/test_channel.py` anhängen (`import socket` und `import struct` oben im File ergänzen; `pytest` ist seit Task 2 bereits importiert):
 
 ```python
 async def test_reentrant_cap_call_during_request():
@@ -560,20 +573,33 @@ async def test_reentrant_cap_call_during_request():
 
 
 async def test_malformed_frame_drops_connection():
-    a_sock, b_sock = socket.socketpair()
-    a_reader, a_writer = await asyncio.open_connection(sock=a_sock)
-    ch_a = RpcChannel(a_reader, a_writer)
-    ch_a.start()
+    # Ein roher Loopback-Client schickt ein bogus Oversize-Längenpräfix; der
+    # RpcChannel auf der Server-Seite muss FrameError auslösen und abbauen
+    # (statt 4 GiB zu allokieren). Loopback-TCP wie im _connect-Helper.
+    accepted: dict[str, tuple] = {}
+    ready = asyncio.Event()
+
+    async def _on_client(reader, writer):
+        accepted["pair"] = (reader, writer)
+        ready.set()
+
+    server = await asyncio.start_server(_on_client, "127.0.0.1", 0)
+    host, port = server.sockets[0].getsockname()[:2]
+    raw = socket.create_connection((host, port))
+    await ready.wait()
+    s_reader, s_writer = accepted["pair"]
+    server.close()
+
+    ch = RpcChannel(s_reader, s_writer)
+    ch.start()
     try:
-        # An oversize length prefix from the raw peer must trip FrameError and
-        # tear the channel down (rather than allocate 4 GiB).
-        b_sock.sendall(struct.pack(">I", 0xFFFFFFFF))
+        raw.sendall(struct.pack(">I", 0xFFFFFFFF))
         await asyncio.sleep(0.1)
         with pytest.raises(ConnectionError):
-            await ch_a.call(MsgType.HTTP_REQUEST, {}, timeout=2)
+            await ch.call(MsgType.HTTP_REQUEST, {}, timeout=2)
     finally:
-        await ch_a.close()
-        b_sock.close()
+        await ch.close()
+        raw.close()
 
 
 async def test_close_fails_inflight_call():

--- a/docs/superpowers/plans/2026-06-26-plugin-backend-isolation-phase1-rpc.md
+++ b/docs/superpowers/plans/2026-06-26-plugin-backend-isolation-phase1-rpc.md
@@ -1,0 +1,637 @@
+# Plugin-Backend-Isolation — Phase 1: RPC-Fundament — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Baue die isolierte, voll-duplexe RPC-Transportschicht (msgpack-Framing über UDS/Socket + `RpcChannel` mit Correlation-IDs und reentranter Request-Dispatch), auf der alle weiteren Track-B-Phasen aufsetzen.
+
+**Architecture:** Zwei kleine, FastAPI-/Subprozess-freie Module unter `backend/app/plugins/sandbox/`: `protocol.py` (Frame-Codec + Nachrichtentypen) und `channel.py` (`RpcChannel`: asynchroner Lese-Loop, Pending-Future-Map, reentrante Handler-Dispatch). Beide Seiten (Host und späterer Sandbox-Worker) nutzen denselben `RpcChannel` spiegelbildlich. Vollständig in-process über `socket.socketpair()` testbar — keine echten Subprozesse in dieser Phase.
+
+**Tech Stack:** Python 3.11, asyncio, `msgpack` (neue Dependency), pytest + pytest-asyncio (`asyncio_mode=auto`).
+
+## Global Constraints
+
+- Python `>=3.11`; async/await für alle I/O; Type-Hints auf allen Funktionen (Backend-Coding-Style).
+- Tests: pytest, `asyncio_mode="auto"` → async-Tests sind schlicht `async def test_...`, **kein** `@pytest.mark.asyncio`-Decorator.
+- Test-DB-Fixture heißt `db_session` (für spätere Phasen; Phase 1 braucht keine DB).
+- Keine `shell=True`, keine rohen SQL mit User-Input (Security-Invarianten) — in dieser Phase ohnehin nicht berührt.
+- Repo läuft mit `core.autocrlf=true` auf Windows; neue Dateien werden als LF geschrieben (Git normalisiert).
+- Branch: `feat/plugin-backend-isolation` (existiert bereits, enthält die Spec).
+- Commit-Message-Stil: `feat(plugin-sandbox): …` / `test(plugin-sandbox): …`.
+- Spec: `docs/superpowers/specs/2026-06-26-plugin-backend-isolation-design.md` (Abschnitt „RPC-Protokoll").
+
+---
+
+## Phasen-Roadmap (Kontext — nur Phase 1 ist in diesem Plan)
+
+Track B ist eine sequenzielle Schichtung; jede Phase bekommt einen eigenen Plan:
+
+1. **Phase 1 — RPC-Fundament** ← *dieser Plan*. Frame-Codec + `RpcChannel`. Deliverable: getestete Transportschicht, standalone.
+2. Phase 2 — Sandbox-Worker + `SandboxSupervisor` (Low-Priv-Subprozess-Spawn, UDS, Health-Handshake, Restart-Budget, Primary-Worker-Ownership).
+3. Phase 3 — Capability-Layer + Plugin-SDK (`CapabilityRouter` default-deny, `storage.*` via `plugin_storage_service`, `core.*`-Startkatalog, request-gebundener User-Kontext).
+4. Phase 4 — Request-Proxy + `PluginManager`-Dual-Path (FastAPI-Catch-all, Auth/Gating, Header-Allowlist, Error-Scrubbing, Manifest/Scope-Wiring).
+5. Phase 5 — Deploy-Härtung (OS-User-Provisioning, Netzwerk-Namespace) + Frontend-Doku-Update (`PluginDocumentation.tsx` + `plugins`-Locales).
+
+---
+
+## File Structure (Phase 1)
+
+| Datei | Verantwortung |
+|---|---|
+| `backend/app/plugins/sandbox/__init__.py` (neu) | Package-Marker, kurzer Modul-Docstring. |
+| `backend/app/plugins/sandbox/protocol.py` (neu) | `Message`-Dataclass, `MsgType`-Konstanten, `REQUEST_TYPES`/`RESPONSE_TYPES`, `FrameError`, `MAX_FRAME_BYTES`, `encode_frame`/`decode_payload`/`read_frame`/`write_frame`. |
+| `backend/app/plugins/sandbox/channel.py` (neu) | `RpcChannel`: Lese-Loop, `call()`, reentrante Dispatch, Pending-Map, `close()`. |
+| `backend/tests/plugins/sandbox/__init__.py` (neu) | Test-Package-Marker. |
+| `backend/tests/plugins/sandbox/test_protocol.py` (neu) | Frame-Roundtrip, EOF, Oversize, Malformed-Envelope. |
+| `backend/tests/plugins/sandbox/test_channel.py` (neu) | Happy-Path call/response, Timeout, Reentranz, Malformed-Drop, Close-fails-pending. |
+| `backend/pyproject.toml` (modify) | `msgpack`-Dependency hinzufügen. |
+
+---
+
+## Task 1: Frame-Codec & Nachrichtentypen (`protocol.py`)
+
+**Files:**
+- Modify: `backend/pyproject.toml` (dependencies-Block, nach `"dbus-next>=0.2.3,<1.0.0"`)
+- Create: `backend/app/plugins/sandbox/__init__.py`
+- Create: `backend/app/plugins/sandbox/protocol.py`
+- Create: `backend/tests/plugins/sandbox/__init__.py`
+- Test: `backend/tests/plugins/sandbox/test_protocol.py`
+
+**Interfaces:**
+- Consumes: nichts (Fundament).
+- Produces:
+  - `Message(id: int, type: str, body: dict)` — Dataclass (Gleichheit per Value).
+  - `class MsgType` mit `HTTP_REQUEST`, `HTTP_RESPONSE`, `CAP_CALL`, `CAP_RESULT`, `LIFECYCLE`, `ERROR` (alle `str`).
+  - `REQUEST_TYPES: frozenset[str]`, `RESPONSE_TYPES: frozenset[str]`.
+  - `MAX_FRAME_BYTES: int`, `FrameError(Exception)`.
+  - `encode_frame(msg: Message) -> bytes`
+  - `decode_payload(payload: bytes) -> Message`
+  - `async read_frame(reader: asyncio.StreamReader) -> Message | None` (None bei sauberem EOF)
+  - `async write_frame(writer: asyncio.StreamWriter, msg: Message) -> None`
+
+- [ ] **Step 1: msgpack-Dependency hinzufügen**
+
+In `backend/pyproject.toml` im `dependencies = [ ... ]`-Block die letzte Zeile
+`"dbus-next>=0.2.3,<1.0.0"` um ein Komma ergänzen und eine Zeile anhängen:
+
+```toml
+  "dbus-next>=0.2.3,<1.0.0",
+  "msgpack>=1.0.0,<2.0.0"
+```
+
+Dann installieren:
+
+Run: `pip install -e ".[dev]"` (aus `backend/`)
+Expected: Installation erfolgreich, `msgpack` vorhanden.
+
+- [ ] **Step 2: Failing test schreiben**
+
+Create `backend/tests/plugins/sandbox/__init__.py` mit einer einzigen Zeile:
+
+```python
+"""Tests for the plugin sandbox RPC layer."""
+```
+
+Create `backend/tests/plugins/sandbox/test_protocol.py`:
+
+```python
+"""Tests for the sandbox RPC frame codec and message types."""
+import asyncio
+
+import msgpack
+import pytest
+
+from app.plugins.sandbox.protocol import (
+    FrameError,
+    MAX_FRAME_BYTES,
+    Message,
+    MsgType,
+    REQUEST_TYPES,
+    RESPONSE_TYPES,
+    _LENGTH_PREFIX,
+    decode_payload,
+    encode_frame,
+    read_frame,
+)
+
+
+def _reader(data: bytes) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader()
+    reader.feed_data(data)
+    reader.feed_eof()
+    return reader
+
+
+async def test_frame_roundtrip():
+    msg = Message(id=7, type=MsgType.HTTP_REQUEST, body={"method": "GET", "path": "x"})
+    out = await read_frame(_reader(encode_frame(msg)))
+    assert out == msg
+
+
+async def test_read_frame_returns_none_on_clean_eof():
+    reader = asyncio.StreamReader()
+    reader.feed_eof()
+    assert await read_frame(reader) is None
+
+
+async def test_read_frame_rejects_oversize_length():
+    reader = _reader(_LENGTH_PREFIX.pack(MAX_FRAME_BYTES + 1))
+    with pytest.raises(FrameError):
+        await read_frame(reader)
+
+
+async def test_decode_payload_rejects_non_envelope():
+    with pytest.raises(FrameError):
+        decode_payload(msgpack.packb([1, 2, 3], use_bin_type=True))
+
+
+def test_request_response_type_partition():
+    assert REQUEST_TYPES.isdisjoint(RESPONSE_TYPES)
+    assert MsgType.HTTP_REQUEST in REQUEST_TYPES
+    assert MsgType.HTTP_RESPONSE in RESPONSE_TYPES
+```
+
+- [ ] **Step 3: Test ausführen, Fehlschlag verifizieren**
+
+Run: `python -m pytest tests/plugins/sandbox/test_protocol.py -v` (aus `backend/`)
+Expected: FAIL mit `ModuleNotFoundError: No module named 'app.plugins.sandbox'`.
+
+- [ ] **Step 4: Minimal-Implementierung schreiben**
+
+Create `backend/app/plugins/sandbox/__init__.py`:
+
+```python
+"""Plugin sandbox: isolated RPC runtime for external plugins (Track B)."""
+```
+
+Create `backend/app/plugins/sandbox/protocol.py`:
+
+```python
+"""Frame codec and message envelope for the plugin sandbox RPC layer.
+
+A frame on the wire is a 4-byte big-endian length prefix followed by a
+msgpack-encoded envelope ``{"id": int, "type": str, "body": dict}``. The same
+codec is used by both ends of the channel (host and sandbox worker).
+"""
+import asyncio
+import struct
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import msgpack
+
+# Hard cap on a single frame's payload to bound memory and reject malformed
+# length prefixes from an untrusted peer.
+MAX_FRAME_BYTES: int = 16 * 1024 * 1024  # 16 MiB
+
+_LENGTH_PREFIX = struct.Struct(">I")  # 4-byte big-endian unsigned length
+
+
+class MsgType:
+    """Envelope ``type`` values. Requests expect a correlated response."""
+
+    HTTP_REQUEST = "http_request"
+    HTTP_RESPONSE = "http_response"
+    CAP_CALL = "cap_call"
+    CAP_RESULT = "cap_result"
+    LIFECYCLE = "lifecycle"
+    ERROR = "error"
+
+
+# A side routes inbound frames by category: request types go to the request
+# handler, response types resolve a pending outbound call.
+REQUEST_TYPES = frozenset({MsgType.HTTP_REQUEST, MsgType.CAP_CALL, MsgType.LIFECYCLE})
+RESPONSE_TYPES = frozenset({MsgType.HTTP_RESPONSE, MsgType.CAP_RESULT, MsgType.ERROR})
+
+
+class FrameError(Exception):
+    """Raised when a frame is malformed, truncated, or exceeds MAX_FRAME_BYTES."""
+
+
+@dataclass
+class Message:
+    """A single RPC envelope."""
+
+    id: int
+    type: str
+    body: dict[str, Any] = field(default_factory=dict)
+
+
+def encode_frame(msg: Message) -> bytes:
+    """Serialize a Message to a length-prefixed msgpack frame."""
+    payload = msgpack.packb(
+        {"id": msg.id, "type": msg.type, "body": msg.body},
+        use_bin_type=True,
+    )
+    if len(payload) > MAX_FRAME_BYTES:
+        raise FrameError(f"frame too large: {len(payload)} > {MAX_FRAME_BYTES}")
+    return _LENGTH_PREFIX.pack(len(payload)) + payload
+
+
+def decode_payload(payload: bytes) -> Message:
+    """Decode a msgpack payload (without length prefix) into a Message."""
+    obj = msgpack.unpackb(payload, raw=False)
+    if not isinstance(obj, dict) or "id" not in obj or "type" not in obj:
+        raise FrameError("malformed envelope")
+    body = obj.get("body") or {}
+    if not isinstance(body, dict):
+        raise FrameError("envelope body must be a map")
+    return Message(id=int(obj["id"]), type=str(obj["type"]), body=body)
+
+
+async def read_frame(reader: asyncio.StreamReader) -> Optional[Message]:
+    """Read one frame. Returns None on a clean EOF (peer closed cleanly)."""
+    try:
+        prefix = await reader.readexactly(4)
+    except asyncio.IncompleteReadError as exc:
+        if not exc.partial:
+            return None  # clean EOF at a frame boundary
+        raise FrameError("truncated length prefix") from exc
+
+    (length,) = _LENGTH_PREFIX.unpack(prefix)
+    if length > MAX_FRAME_BYTES:
+        raise FrameError(f"frame too large: {length} > {MAX_FRAME_BYTES}")
+
+    try:
+        payload = await reader.readexactly(length)
+    except asyncio.IncompleteReadError as exc:
+        raise FrameError("truncated frame body") from exc
+
+    return decode_payload(payload)
+
+
+async def write_frame(writer: asyncio.StreamWriter, msg: Message) -> None:
+    """Serialize and write one frame, flushing the transport."""
+    writer.write(encode_frame(msg))
+    await writer.drain()
+```
+
+- [ ] **Step 5: Test ausführen, Erfolg verifizieren**
+
+Run: `python -m pytest tests/plugins/sandbox/test_protocol.py -v` (aus `backend/`)
+Expected: PASS (5 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/pyproject.toml backend/app/plugins/sandbox/__init__.py backend/app/plugins/sandbox/protocol.py backend/tests/plugins/sandbox/__init__.py backend/tests/plugins/sandbox/test_protocol.py
+git commit -m "feat(plugin-sandbox): add RPC frame codec + message envelope (Track B Phase 1)"
+```
+
+---
+
+## Task 2: Voll-duplexer `RpcChannel` (Happy-Path)
+
+**Files:**
+- Create: `backend/app/plugins/sandbox/channel.py`
+- Test: `backend/tests/plugins/sandbox/test_channel.py`
+
+**Interfaces:**
+- Consumes: `Message`, `MsgType`, `REQUEST_TYPES`, `RESPONSE_TYPES`, `FrameError`, `read_frame`, `write_frame` aus `protocol.py`.
+- Produces:
+  - `RequestHandler = Callable[[Message], Awaitable[Message]]`
+  - `class RpcChannel`:
+    - `__init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter, *, request_handler: RequestHandler | None = None)`
+    - `start(self) -> None` — startet den Lese-Loop (idempotent).
+    - `async call(self, type: str, body: dict, *, timeout: float | None = None) -> Message` — sendet eine neue Nachricht mit frischer ID, wartet auf die korrelierte Antwort. Wirft `asyncio.TimeoutError` bei Timeout, `ConnectionError` wenn Kanal geschlossen.
+    - `async close(self) -> None` — Lese-Loop abbrechen, Writer schließen, alle Pending-Futures mit `ConnectionError` failen.
+
+Dispatch-Semantik: Eingehende **Request-Typen** werden an `request_handler` übergeben (in eigener Task → erlaubt Reentranz); dessen zurückgegebene `Message` wird mit der **ID des Requests** zurückgeschickt. Eingehende **Response-Typen** lösen das Pending-Future mit der passenden ID.
+
+- [ ] **Step 1: Failing test schreiben**
+
+Create `backend/tests/plugins/sandbox/test_channel.py`:
+
+```python
+"""Tests for the duplex RpcChannel (happy path)."""
+import asyncio
+import socket
+
+import pytest
+
+from app.plugins.sandbox.channel import RpcChannel
+from app.plugins.sandbox.protocol import Message, MsgType
+
+
+async def _connect(handler_a=None, handler_b=None):
+    a_sock, b_sock = socket.socketpair()
+    a_reader, a_writer = await asyncio.open_connection(sock=a_sock)
+    b_reader, b_writer = await asyncio.open_connection(sock=b_sock)
+    ch_a = RpcChannel(a_reader, a_writer, request_handler=handler_a)
+    ch_b = RpcChannel(b_reader, b_writer, request_handler=handler_b)
+    ch_a.start()
+    ch_b.start()
+    return ch_a, ch_b
+
+
+async def test_call_returns_handler_response():
+    async def handler(msg: Message) -> Message:
+        return Message(id=msg.id, type=MsgType.HTTP_RESPONSE, body={"echo": msg.body["v"]})
+
+    ch_a, ch_b = await _connect(handler_b=handler)
+    try:
+        resp = await ch_a.call(MsgType.HTTP_REQUEST, {"v": "hi"}, timeout=5)
+        assert resp.type == MsgType.HTTP_RESPONSE
+        assert resp.body == {"echo": "hi"}
+    finally:
+        await ch_a.close()
+        await ch_b.close()
+
+
+async def test_call_times_out_when_handler_is_slow():
+    async def slow(msg: Message) -> Message:
+        await asyncio.sleep(10)
+        return Message(id=msg.id, type=MsgType.HTTP_RESPONSE, body={})
+
+    ch_a, ch_b = await _connect(handler_b=slow)
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await ch_a.call(MsgType.HTTP_REQUEST, {}, timeout=0.1)
+    finally:
+        await ch_a.close()
+        await ch_b.close()
+```
+
+- [ ] **Step 2: Test ausführen, Fehlschlag verifizieren**
+
+Run: `python -m pytest tests/plugins/sandbox/test_channel.py -v` (aus `backend/`)
+Expected: FAIL mit `ModuleNotFoundError: No module named 'app.plugins.sandbox.channel'`.
+
+- [ ] **Step 3: Implementierung schreiben**
+
+Create `backend/app/plugins/sandbox/channel.py`:
+
+```python
+"""Full-duplex RPC channel over a paired StreamReader/StreamWriter.
+
+Both ends are symmetric: each can issue ``call()`` (outbound request → awaited
+response) and each may serve inbound requests via a ``request_handler``. Inbound
+requests are dispatched in their own task, so a handler may itself issue a
+``call()`` back to the peer while the original request is still in flight
+(reentrancy) — required for an http_request handler that needs a cap_call.
+"""
+import asyncio
+import itertools
+import logging
+from typing import Awaitable, Callable, Optional
+
+from app.plugins.sandbox.protocol import (
+    FrameError,
+    Message,
+    MsgType,
+    REQUEST_TYPES,
+    RESPONSE_TYPES,
+    read_frame,
+    write_frame,
+)
+
+logger = logging.getLogger(__name__)
+
+RequestHandler = Callable[[Message], Awaitable[Message]]
+
+
+class RpcChannel:
+    """A symmetric, reentrant RPC channel."""
+
+    def __init__(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        *,
+        request_handler: Optional[RequestHandler] = None,
+    ) -> None:
+        self._reader = reader
+        self._writer = writer
+        self._request_handler = request_handler
+        self._ids = itertools.count(1)
+        self._pending: dict[int, asyncio.Future] = {}
+        self._read_task: Optional[asyncio.Task] = None
+        self._dispatch_tasks: set[asyncio.Task] = set()
+        self._closed = False
+
+    def start(self) -> None:
+        """Start the read loop (idempotent)."""
+        if self._read_task is None:
+            self._read_task = asyncio.create_task(self._read_loop())
+
+    async def call(
+        self, type: str, body: dict, *, timeout: Optional[float] = None
+    ) -> Message:
+        """Send a request and await the correlated response."""
+        if self._closed:
+            raise ConnectionError("channel closed")
+        msg_id = next(self._ids)
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[msg_id] = fut
+        try:
+            await write_frame(self._writer, Message(id=msg_id, type=type, body=body))
+            if timeout is not None:
+                return await asyncio.wait_for(fut, timeout)
+            return await fut
+        finally:
+            self._pending.pop(msg_id, None)
+
+    async def _read_loop(self) -> None:
+        try:
+            while True:
+                try:
+                    msg = await read_frame(self._reader)
+                except (FrameError, OSError) as exc:
+                    logger.warning("rpc: dropping connection: %s", exc)
+                    break
+                if msg is None:
+                    break  # clean EOF
+                if msg.type in RESPONSE_TYPES:
+                    self._resolve(msg)
+                elif msg.type in REQUEST_TYPES:
+                    task = asyncio.create_task(self._dispatch(msg))
+                    self._dispatch_tasks.add(task)
+                    task.add_done_callback(self._dispatch_tasks.discard)
+                else:
+                    logger.warning("rpc: unknown message type %r", msg.type)
+        finally:
+            self._closed = True
+            self._fail_all(ConnectionError("channel closed"))
+
+    def _resolve(self, msg: Message) -> None:
+        fut = self._pending.get(msg.id)
+        if fut is None or fut.done():
+            logger.warning("rpc: response for unknown/settled id %s", msg.id)
+            return
+        fut.set_result(msg)
+
+    async def _dispatch(self, msg: Message) -> None:
+        if self._request_handler is None:
+            await self._safe_write(
+                Message(id=msg.id, type=MsgType.ERROR, body={"error": "no_handler"})
+            )
+            return
+        try:
+            response = await self._request_handler(msg)
+        except Exception:
+            logger.exception("rpc: request handler failed")
+            await self._safe_write(
+                Message(id=msg.id, type=MsgType.ERROR, body={"error": "handler_failed"})
+            )
+            return
+        response.id = msg.id  # always correlate to the request id
+        await self._safe_write(response)
+
+    async def _safe_write(self, msg: Message) -> None:
+        try:
+            await write_frame(self._writer, msg)
+        except Exception:
+            logger.exception("rpc: failed to write frame")
+
+    def _fail_all(self, exc: Exception) -> None:
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.set_exception(exc)
+        self._pending.clear()
+
+    async def close(self) -> None:
+        """Cancel the read loop, close the writer, fail pending calls."""
+        self._closed = True
+        if self._read_task is not None:
+            self._read_task.cancel()
+            try:
+                await self._read_task
+            except asyncio.CancelledError:
+                pass
+        try:
+            self._writer.close()
+            await self._writer.wait_closed()
+        except Exception:
+            pass
+        self._fail_all(ConnectionError("channel closed"))
+```
+
+- [ ] **Step 4: Test ausführen, Erfolg verifizieren**
+
+Run: `python -m pytest tests/plugins/sandbox/test_channel.py -v` (aus `backend/`)
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/plugins/sandbox/channel.py backend/tests/plugins/sandbox/test_channel.py
+git commit -m "feat(plugin-sandbox): add duplex RpcChannel with correlation IDs (Track B Phase 1)"
+```
+
+---
+
+## Task 3: Reentranz & Robustheit (Adversarial-Tests)
+
+**Files:**
+- Test: `backend/tests/plugins/sandbox/test_channel.py` (erweitern)
+
+**Interfaces:**
+- Consumes: `RpcChannel`, `_connect`-Helper (aus Task 2), `Message`, `MsgType`.
+- Produces: keine neuen Symbole — verifiziert das in Task 2 gebaute Verhalten unter Reentranz, Malformed-Input und Teardown.
+
+Begründung: Reentranz, Malformed-Drop und Pending-Fail sind bereits in der `RpcChannel`-Implementierung (Task 2) angelegt (Dispatch in eigener Task, `FrameError`-Bruch, `_fail_all`). Diese Task verifiziert sie adversarial — ein Reviewer kann diese Garantien unabhängig vom Happy-Path freigeben.
+
+- [ ] **Step 1: Failing tests schreiben**
+
+An `backend/tests/plugins/sandbox/test_channel.py` anhängen (`import struct` oben im File ergänzen; `pytest` ist seit Task 2 bereits importiert):
+
+```python
+async def test_reentrant_cap_call_during_request():
+    # Host answers cap_call; plugin issues a cap_call while serving http_request.
+    async def host_handler(msg: Message) -> Message:
+        assert msg.type == MsgType.CAP_CALL
+        return Message(id=msg.id, type=MsgType.CAP_RESULT, body={"value": "42"})
+
+    channels: dict[str, RpcChannel] = {}
+
+    async def plugin_handler(msg: Message) -> Message:
+        result = await channels["plugin"].call(
+            MsgType.CAP_CALL, {"capability": "storage.get"}, timeout=5
+        )
+        return Message(id=msg.id, type=MsgType.HTTP_RESPONSE, body={"got": result.body["value"]})
+
+    ch_a, ch_b = await _connect(handler_a=host_handler, handler_b=plugin_handler)
+    channels["plugin"] = ch_b
+    try:
+        resp = await ch_a.call(MsgType.HTTP_REQUEST, {}, timeout=5)
+        assert resp.body == {"got": "42"}
+    finally:
+        await ch_a.close()
+        await ch_b.close()
+
+
+async def test_malformed_frame_drops_connection():
+    a_sock, b_sock = socket.socketpair()
+    a_reader, a_writer = await asyncio.open_connection(sock=a_sock)
+    ch_a = RpcChannel(a_reader, a_writer)
+    ch_a.start()
+    try:
+        # An oversize length prefix from the raw peer must trip FrameError and
+        # tear the channel down (rather than allocate 4 GiB).
+        b_sock.sendall(struct.pack(">I", 0xFFFFFFFF))
+        await asyncio.sleep(0.1)
+        with pytest.raises(ConnectionError):
+            await ch_a.call(MsgType.HTTP_REQUEST, {}, timeout=2)
+    finally:
+        await ch_a.close()
+        b_sock.close()
+
+
+async def test_close_fails_inflight_call():
+    async def never(msg: Message) -> Message:
+        await asyncio.sleep(100)
+        return Message(id=msg.id, type=MsgType.HTTP_RESPONSE, body={})
+
+    ch_a, ch_b = await _connect(handler_b=never)
+    task = asyncio.create_task(ch_a.call(MsgType.HTTP_REQUEST, {}))
+    await asyncio.sleep(0.05)
+    await ch_a.close()
+    with pytest.raises(ConnectionError):
+        await task
+    await ch_b.close()
+```
+
+- [ ] **Step 2: Tests ausführen, Fehlschlag/Status prüfen**
+
+Run: `python -m pytest tests/plugins/sandbox/test_channel.py -v` (aus `backend/`)
+Expected: Die drei neuen Tests laufen durch (PASS), da `RpcChannel` aus Task 2 das Verhalten bereits implementiert. Falls einer fehlschlägt → Bug in Task 2, dort fixen (nicht den Test aufweichen).
+
+> Hinweis: Diese Task ist test-getrieben gegen bereits existierenden Code (Reentranz/Robustheit waren Designziel von Task 2). Sollte ein Test rot sein, ist das ein echter Defekt in `channel.py` — beheben und erst dann fortfahren.
+
+- [ ] **Step 3: Gesamte Sandbox-Suite grün verifizieren**
+
+Run: `python -m pytest tests/plugins/sandbox/ -v` (aus `backend/`)
+Expected: PASS (alle Protocol- + Channel-Tests, 10 passed).
+
+- [ ] **Step 4: Lint**
+
+Run: `ruff check app/plugins/sandbox/ tests/plugins/sandbox/` (aus `backend/`)
+Expected: `All checks passed!`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tests/plugins/sandbox/test_channel.py
+git commit -m "test(plugin-sandbox): reentrancy + malformed-frame + teardown robustness (Track B Phase 1)"
+```
+
+---
+
+## Definition of Done (Phase 1)
+
+- `backend/app/plugins/sandbox/{__init__,protocol,channel}.py` existieren und sind lint-clean.
+- `python -m pytest tests/plugins/sandbox/ -v` ist grün (Protocol + Channel, inkl. Reentranz-, Malformed- und Teardown-Tests).
+- `msgpack` ist in `backend/pyproject.toml` deklariert und installiert.
+- Keine FastAPI-/Subprozess-/DB-Abhängigkeit in dieser Phase (reine Transportschicht).
+- Phase 2 kann `RpcChannel` + `protocol`-Symbole konsumieren, ohne Phase-1-Interna zu kennen.
+
+---
+
+## Self-Review (gegen Spec-Abschnitt „RPC-Protokoll")
+
+- **Längen-präfixierte msgpack-Frames** → Task 1 (`encode_frame`/`read_frame`, `_LENGTH_PREFIX` + msgpack). ✓
+- **Voll-Duplex, reentrant, Correlation-IDs, Pending-Map** → Task 2 (`call`/`_pending`/`_dispatch` in eigener Task) + Task 3 (Reentranz-Test). ✓
+- **Request-/Response-Typ-Partition** (Routing nach Kategorie) → Task 1 (`REQUEST_TYPES`/`RESPONSE_TYPES`) + Test. ✓
+- **Malformed Frame → Connection-Drop** → Task 2 (`FrameError`-Bruch im Lese-Loop) + Task 3 (Oversize-Prefix-Test). ✓
+- **Body-Size-Cap** → Task 1 (`MAX_FRAME_BYTES`, geprüft in `encode_frame` und `read_frame`) + Oversize-Test. ✓
+- **Per-Request-Timeout** → Task 2 (`call(..., timeout=)` → `asyncio.TimeoutError`) + Timeout-Test. ✓
+- Nicht in Phase 1 (bewusst, spätere Phasen): kuratierter Request-Contract/Header-Allowlist (Phase 4), `cap_call`-Dispatch-Gating (Phase 3), Subprozess-Spawn/Health/Restart (Phase 2). Diese Phase liefert nur den generischen Transport, auf dem sie aufsetzen.

--- a/docs/superpowers/plans/2026-06-26-plugin-backend-isolation-phase2a-transport-worker.md
+++ b/docs/superpowers/plans/2026-06-26-plugin-backend-isolation-phase2a-transport-worker.md
@@ -1,0 +1,480 @@
+# Plugin-Backend-Isolation — Phase 2a: Transport + Worker-Runner — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Baue die cross-plattform Host↔Worker-Socket-Transportschicht und den Sandbox-Worker-Entry-Point (mit einem minimalen Echo/Health-Handler), sodass ein Worker-Prozess sich an den Host zurückverbinden, einen `RpcChannel` aufspannen und Requests beantworten kann — alles in-process deterministisch testbar, noch ohne echten Subprozess-Spawn (der kommt in Phase 2b: Supervisor).
+
+**Architecture:** Zwei neue Module unter `backend/app/plugins/sandbox/`: `transport.py` (Host-seitiger `WorkerListener` der genau eine Worker-Verbindung akzeptiert + Worker-seitiges `connect_to_host`; UDS auf Linux/prod, Loopback-TCP auf Windows/dev) und `worker.py` (Entry-Point: verbindet, baut `RpcChannel` mit einem Phase-2-Echo/Health-Handler, läuft bis Verbindungsschluss). Eine kleine Ergänzung an `channel.py` (`wait_closed()`). Der `RpcChannel` aus Phase 1 bleibt transport-agnostisch — Transport liefert nur ein `(StreamReader, StreamWriter)`-Paar.
+
+**Tech Stack:** Python 3.11, asyncio (Streams + UDS/TCP), argparse, pytest + pytest-asyncio (`asyncio_mode=auto`). Keine neuen Dependencies.
+
+## Global Constraints
+
+- Python `>=3.11`; async/await für alle I/O; Type-Hints auf allen Funktionen.
+- Tests: pytest `asyncio_mode="auto"` → async-Tests sind `async def test_...`, **kein** `@pytest.mark.asyncio`.
+- **Transport-Wahl ist plattformbasiert, NICHT konfigurierbar durch Plugin-Daten:** UDS gdw. `hasattr(asyncio, "start_unix_server") and sys.platform != "win32"`, sonst Loopback-TCP `127.0.0.1`. UDS ist der Prod-Pfad (funktioniert über eine Netzwerk-Namespace-Grenze via Socket-Datei im Arbeitsverzeichnis); Loopback-TCP ist der Dev-Fallback (asyncio hat `open_unix_connection` auf Windows nicht).
+- Connect-Adress-Format (Host→Worker, ein String): `unix:<path>` ODER `tcp:<host>:<port>`.
+- `RpcChannel` (Phase 1, `app/plugins/sandbox/channel.py`) ist transport-agnostisch und wird **nicht** in seinem Kern verändert — nur eine additive `wait_closed()`-Methode kommt hinzu.
+- Phase-2-Worker-Handler ist ein **Platzhalter** (Health + Echo) — echtes Plugin-Loading + Capability-SDK kommen in Phase 3 und ersetzen `build_worker_handler()`. NICHT mehr bauen als Health + Echo (YAGNI).
+- Repo `core.autocrlf=true` auf Windows; LF schreiben.
+- Branch: `feat/plugin-backend-isolation` (enthält Phase 1, merge-reif). Commit-Stil: `feat(plugin-sandbox): …` / `test(plugin-sandbox): …`.
+- Spec: `docs/superpowers/specs/2026-06-26-plugin-backend-isolation-design.md` (Abschnitte „Prozess-Topologie & Lifecycle", „RPC-Protokoll").
+
+## Konsumiert aus Phase 1 (bereits auf dem Branch, getestet)
+
+`app/plugins/sandbox/protocol.py`: `Message(id:int, type:str, body:dict)`, `MsgType` (HTTP_REQUEST/HTTP_RESPONSE/CAP_CALL/CAP_RESULT/LIFECYCLE/ERROR), `read_frame`/`write_frame`.
+`app/plugins/sandbox/channel.py`: `RpcChannel(reader, writer, *, request_handler=None)` mit `start()`, `async call(type, body, *, timeout=None)`, `async close()`, internem `self._read_task`.
+
+## Phasen-Roadmap (Kontext — nur Phase 2a ist in diesem Plan)
+
+1. ✅ Phase 1 — RPC-Fundament (protocol.py + RpcChannel), merge-reif auf dem Branch.
+2. **Phase 2a — Transport + Worker-Runner** ← *dieser Plan*. In-process testbar, kein Subprozess.
+3. Phase 2b — `SandboxSupervisor`: echter Subprozess-Spawn (`asyncio.create_subprocess_exec`), Health-Handshake, Exit-Detection, bounded Restart→auto-disable, graceful+hard shutdown. Spawn-Hook für Low-Priv-User/netns ist Stub (echte OS-Härtung = Phase 5).
+4. Phase 3 — Capability-Layer + Plugin-SDK; ersetzt den Phase-2-Echo-Handler durch echtes Plugin-Loading + `core.*`/`storage.*`-Dispatch.
+5. Phase 4 — Request-Proxy + `PluginManager`-Dual-Path (FastAPI-Wiring, Auth/Gating).
+6. Phase 5 — Deploy-Härtung (OS-User/netns Spawn-Hook) + Frontend-Doku.
+
+---
+
+## File Structure (Phase 2a)
+
+| Datei | Verantwortung |
+|---|---|
+| `backend/app/plugins/sandbox/transport.py` (neu) | `_use_unix_socket()`, Host-seitiger `WorkerListener` (listen+accept-one), Worker-seitiges `connect_to_host(address)`. Plattform-Wahl UDS/TCP. |
+| `backend/app/plugins/sandbox/worker.py` (neu) | `build_worker_handler()` (Phase-2 Health+Echo), `async run_worker(address)`, `main(argv)` (argparse), `__main__`-Guard. |
+| `backend/app/plugins/sandbox/channel.py` (modify) | Additive `async wait_closed()`-Methode. |
+| `backend/tests/plugins/sandbox/test_transport.py` (neu) | Adress-Schema + Accept-Roundtrip (Frame über den Transport). |
+| `backend/tests/plugins/sandbox/test_worker.py` (neu) | In-process: Health, Echo, argparse. |
+
+---
+
+## Task 1: Cross-platform Transport (`transport.py`)
+
+**Files:**
+- Create: `backend/app/plugins/sandbox/transport.py`
+- Test: `backend/tests/plugins/sandbox/test_transport.py`
+
+**Interfaces:**
+- Consumes: `Message`, `MsgType`, `read_frame`, `write_frame` aus `protocol.py` (nur in den Tests, zum Roundtrip-Beweis).
+- Produces:
+  - `_use_unix_socket() -> bool`
+  - `class WorkerListener`:
+    - `__init__(self, socket_dir: str | os.PathLike)` — `socket_dir` ist das Verzeichnis für die UDS-Datei (im Prod das Arbeitsverzeichnis des Workers); im TCP-Fall ungenutzt.
+    - `async start(self) -> str` — beginnt zu lauschen, gibt die `connect_address` zurück (`unix:<path>` oder `tcp:<host>:<port>`).
+    - `async accept(self, *, timeout: float) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]` — wartet auf die EINE Worker-Verbindung; `asyncio.TimeoutError` bei Ablauf.
+    - `async close(self) -> None` — schließt den Listener (nicht die akzeptierte Verbindung).
+    - Attribut `connect_address: str`.
+  - `async connect_to_host(address: str) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]` — Worker-Seite; parst `unix:`/`tcp:`.
+
+- [ ] **Step 1: Failing test schreiben**
+
+Create `backend/tests/plugins/sandbox/test_transport.py`:
+
+```python
+"""Tests for the cross-platform host<->worker transport."""
+import asyncio
+
+import pytest
+
+from app.plugins.sandbox.protocol import Message, MsgType, read_frame, write_frame
+from app.plugins.sandbox.transport import (
+    WorkerListener,
+    _use_unix_socket,
+    connect_to_host,
+)
+
+
+async def test_connect_address_scheme_matches_platform(tmp_path):
+    listener = WorkerListener(tmp_path)
+    address = await listener.start()
+    try:
+        expected = "unix:" if _use_unix_socket() else "tcp:"
+        assert address.startswith(expected)
+    finally:
+        await listener.close()
+
+
+async def test_accept_roundtrip_carries_a_frame(tmp_path):
+    listener = WorkerListener(tmp_path)
+    address = await listener.start()
+    try:
+        # Worker side connects back; host accepts the one connection.
+        w_reader, w_writer = await connect_to_host(address)
+        h_reader, h_writer = await listener.accept(timeout=5)
+
+        # Worker -> host
+        await write_frame(w_writer, Message(id=1, type=MsgType.LIFECYCLE, body={"ping": True}))
+        got = await read_frame(h_reader)
+        assert got == Message(id=1, type=MsgType.LIFECYCLE, body={"ping": True})
+
+        # Host -> worker
+        await write_frame(h_writer, Message(id=2, type=MsgType.HTTP_RESPONSE, body={"ok": 1}))
+        back = await read_frame(w_reader)
+        assert back == Message(id=2, type=MsgType.HTTP_RESPONSE, body={"ok": 1})
+
+        w_writer.close()
+        h_writer.close()
+    finally:
+        await listener.close()
+
+
+async def test_connect_to_host_rejects_unknown_scheme():
+    with pytest.raises(ValueError):
+        await connect_to_host("carrierpigeon:/nope")
+```
+
+- [ ] **Step 2: Test ausführen, Fehlschlag verifizieren**
+
+Run: `python -m pytest tests/plugins/sandbox/test_transport.py -v` (aus `backend/`)
+Expected: FAIL mit `ModuleNotFoundError: No module named 'app.plugins.sandbox.transport'`.
+
+- [ ] **Step 3: Implementierung schreiben**
+
+Create `backend/app/plugins/sandbox/transport.py`:
+
+```python
+"""Cross-platform host<->worker socket transport for the plugin sandbox.
+
+Prod (Linux): a Unix-domain socket whose path lives in the worker's working
+directory, so it works across a network-namespace boundary (the worker needs
+no host-loopback access — only the bind-mounted socket file). Dev (Windows, or
+any platform without AF_UNIX in asyncio): a loopback-TCP socket on 127.0.0.1.
+
+Either way the result is an (asyncio.StreamReader, asyncio.StreamWriter) pair
+that an RpcChannel wraps; the channel itself is transport-agnostic.
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+def _use_unix_socket() -> bool:
+    """True iff asyncio AF_UNIX servers are available (Linux/macOS, not Windows)."""
+    return hasattr(asyncio, "start_unix_server") and sys.platform != "win32"
+
+
+class WorkerListener:
+    """Host side: listen for the worker's callback connection and accept one.
+
+    The worker is spawned with the string returned by ``start()`` and connects
+    back exactly once. ``accept()`` resolves with that single connection.
+    """
+
+    def __init__(self, socket_dir: "str | os.PathLike[str]") -> None:
+        self._socket_dir = Path(socket_dir)
+        self._server: Optional[asyncio.AbstractServer] = None
+        self._accepted: Optional[asyncio.Future] = None
+        self.connect_address: str = ""
+
+    async def start(self) -> str:
+        loop = asyncio.get_running_loop()
+        self._accepted = loop.create_future()
+
+        def _on_conn(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            # Accept only the first connection; ignore any extras defensively.
+            if self._accepted is not None and not self._accepted.done():
+                self._accepted.set_result((reader, writer))
+            else:
+                writer.close()
+
+        if _use_unix_socket():
+            path = str(self._socket_dir / "plugin.sock")
+            # Stale socket file from a crashed prior worker would block bind.
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+            self._server = await asyncio.start_unix_server(_on_conn, path=path)
+            self.connect_address = f"unix:{path}"
+        else:
+            self._server = await asyncio.start_server(_on_conn, "127.0.0.1", 0)
+            host, port = self._server.sockets[0].getsockname()[:2]
+            self.connect_address = f"tcp:{host}:{port}"
+
+        return self.connect_address
+
+    async def accept(
+        self, *, timeout: float
+    ) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        if self._accepted is None:
+            raise RuntimeError("WorkerListener.accept() called before start()")
+        return await asyncio.wait_for(asyncio.shield(self._accepted), timeout)
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            try:
+                await self._server.wait_closed()
+            except Exception:
+                pass
+            self._server = None
+
+
+async def connect_to_host(
+    address: str,
+) -> Tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Worker side: connect back to the host using a ``start()`` address."""
+    scheme, _, rest = address.partition(":")
+    if scheme == "unix":
+        return await asyncio.open_unix_connection(path=rest)
+    if scheme == "tcp":
+        host, _, port = rest.rpartition(":")
+        return await asyncio.open_connection(host, int(port))
+    raise ValueError(f"unknown connect address scheme: {address!r}")
+```
+
+- [ ] **Step 4: Test ausführen, Erfolg verifizieren**
+
+Run: `python -m pytest tests/plugins/sandbox/test_transport.py -v` (aus `backend/`)
+Expected: PASS (3 passed).
+
+> Hinweis für den Implementierer: `asyncio.wait_for(asyncio.shield(...))` schützt das geteilte `_accepted`-Future davor, bei einem Accept-Timeout gecancelt zu werden (sonst wäre der Listener nach einem Timeout unbrauchbar). Das ist beabsichtigt.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/plugins/sandbox/transport.py backend/tests/plugins/sandbox/test_transport.py
+git commit -m "feat(plugin-sandbox): cross-platform host<->worker transport (UDS prod / TCP dev) (Track B Phase 2a)"
+```
+
+---
+
+## Task 2: Worker-Entry-Point + `RpcChannel.wait_closed()` (`worker.py`)
+
+**Files:**
+- Modify: `backend/app/plugins/sandbox/channel.py` (additive `wait_closed()`)
+- Create: `backend/app/plugins/sandbox/worker.py`
+- Test: `backend/tests/plugins/sandbox/test_worker.py`
+
+**Interfaces:**
+- Consumes: `RpcChannel` (+ neue `wait_closed`), `Message`, `MsgType` aus Phase 1; `WorkerListener`, `connect_to_host` aus Task 1.
+- Produces:
+  - `RpcChannel.wait_closed(self) -> None` (async) — blockt bis der Read-Loop endet.
+  - `build_worker_handler() -> RequestHandler` — der Phase-2 Health/Echo-Handler.
+  - `async run_worker(address: str) -> None` — verbindet, fährt den Channel, läuft bis Verbindungsschluss, räumt auf.
+  - `main(argv: list[str] | None = None) -> None` — argparse `--connect`, ruft `asyncio.run(run_worker(...))`.
+
+- [ ] **Step 1: `wait_closed()` an `RpcChannel` — Failing test schreiben**
+
+Create `backend/tests/plugins/sandbox/test_worker.py`:
+
+```python
+"""In-process tests for the sandbox worker entry point (no real subprocess)."""
+import asyncio
+
+import pytest
+
+from app.plugins.sandbox.channel import RpcChannel
+from app.plugins.sandbox.protocol import Message, MsgType
+from app.plugins.sandbox.transport import WorkerListener
+from app.plugins.sandbox.worker import build_worker_handler, main, run_worker
+
+
+async def _host_and_worker(tmp_path):
+    """Start a host listener + an in-process run_worker; return (host_channel,
+    worker_task, listener) wired and ready."""
+    listener = WorkerListener(tmp_path)
+    address = await listener.start()
+    worker_task = asyncio.create_task(run_worker(address))
+    reader, writer = await listener.accept(timeout=5)
+    host = RpcChannel(reader, writer)
+    host.start()
+    return host, worker_task, listener
+
+
+async def test_worker_answers_health(tmp_path):
+    host, worker_task, listener = await _host_and_worker(tmp_path)
+    try:
+        resp = await host.call(MsgType.LIFECYCLE, {"action": "health"}, timeout=5)
+        assert resp.type == MsgType.LIFECYCLE
+        assert resp.body == {"status": "ok"}
+    finally:
+        await host.close()
+        await asyncio.wait_for(worker_task, timeout=5)
+        await listener.close()
+
+
+async def test_worker_echoes_http_request(tmp_path):
+    host, worker_task, listener = await _host_and_worker(tmp_path)
+    try:
+        resp = await host.call(
+            MsgType.HTTP_REQUEST,
+            {"method": "GET", "path": "ping", "body": b"", "context": {"user_id": 7}},
+            timeout=5,
+        )
+        assert resp.type == MsgType.HTTP_RESPONSE
+        assert resp.body["status"] == 200
+        assert resp.body["echo"]["method"] == "GET"
+        assert resp.body["echo"]["path"] == "ping"
+        assert resp.body["echo"]["context"] == {"user_id": 7}
+    finally:
+        await host.close()
+        await asyncio.wait_for(worker_task, timeout=5)
+        await listener.close()
+
+
+async def test_worker_run_returns_when_host_closes(tmp_path):
+    host, worker_task, listener = await _host_and_worker(tmp_path)
+    await host.close()
+    # run_worker must observe the closed connection and return on its own.
+    await asyncio.wait_for(worker_task, timeout=5)
+    assert worker_task.done() and worker_task.exception() is None
+    await listener.close()
+
+
+def test_main_requires_connect_arg():
+    with pytest.raises(SystemExit):
+        main([])
+
+
+def test_build_worker_handler_is_async_callable():
+    handler = build_worker_handler()
+    assert asyncio.iscoroutinefunction(handler)
+```
+
+- [ ] **Step 2: Test ausführen, Fehlschlag verifizieren**
+
+Run: `python -m pytest tests/plugins/sandbox/test_worker.py -v` (aus `backend/`)
+Expected: FAIL mit `ModuleNotFoundError: No module named 'app.plugins.sandbox.worker'` (und/oder `ImportError` für `wait_closed` sobald worker.py existiert).
+
+- [ ] **Step 3: `wait_closed()` an `RpcChannel` ergänzen**
+
+In `backend/app/plugins/sandbox/channel.py`, direkt **vor** der `close`-Methode, diese Methode einfügen:
+
+```python
+    async def wait_closed(self) -> None:
+        """Block until the read loop ends (peer closed the connection or a
+        frame error tore it down). Returns immediately if never started."""
+        if self._read_task is not None:
+            try:
+                await self._read_task
+            except (asyncio.CancelledError, Exception):
+                pass
+```
+
+- [ ] **Step 4: `worker.py` schreiben**
+
+Create `backend/app/plugins/sandbox/worker.py`:
+
+```python
+"""Plugin sandbox worker entry point — runs inside the isolated child process.
+
+Phase 2 ships a minimal built-in request handler (health + echo) so the
+host<->worker round-trip can be exercised end-to-end. Real plugin loading and
+the capability SDK arrive in Phase 3, which replaces build_worker_handler().
+"""
+import argparse
+import asyncio
+from typing import List, Optional
+
+from app.plugins.sandbox.channel import RequestHandler, RpcChannel
+from app.plugins.sandbox.protocol import Message, MsgType
+from app.plugins.sandbox.transport import connect_to_host
+
+
+def build_worker_handler() -> RequestHandler:
+    """Return the Phase-2 placeholder handler: health pings + request echo."""
+
+    async def handler(msg: Message) -> Message:
+        if msg.type == MsgType.LIFECYCLE:
+            action = msg.body.get("action")
+            if action == "health":
+                return Message(id=msg.id, type=MsgType.LIFECYCLE, body={"status": "ok"})
+            if action == "shutdown":
+                return Message(
+                    id=msg.id, type=MsgType.LIFECYCLE, body={"status": "stopping"}
+                )
+            return Message(
+                id=msg.id, type=MsgType.LIFECYCLE, body={"status": "unknown_action"}
+            )
+        if msg.type == MsgType.HTTP_REQUEST:
+            # Phase-2 echo: prove the request contract round-trips intact.
+            return Message(
+                id=msg.id,
+                type=MsgType.HTTP_RESPONSE,
+                body={
+                    "status": 200,
+                    "headers": {},
+                    "echo": {
+                        "method": msg.body.get("method"),
+                        "path": msg.body.get("path"),
+                        "body": msg.body.get("body"),
+                        "context": msg.body.get("context"),
+                    },
+                },
+            )
+        return Message(id=msg.id, type=MsgType.ERROR, body={"error": "unsupported"})
+
+    return handler
+
+
+async def run_worker(address: str) -> None:
+    """Connect back to the host, serve requests until the connection closes."""
+    reader, writer = await connect_to_host(address)
+    channel = RpcChannel(reader, writer, request_handler=build_worker_handler())
+    channel.start()
+    try:
+        await channel.wait_closed()
+    finally:
+        await channel.close()
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(prog="plugin-sandbox-worker")
+    parser.add_argument(
+        "--connect",
+        required=True,
+        help="host callback address: 'unix:<path>' or 'tcp:<host>:<port>'",
+    )
+    args = parser.parse_args(argv)
+    asyncio.run(run_worker(args.connect))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 5: Tests ausführen, Erfolg verifizieren**
+
+Run: `python -m pytest tests/plugins/sandbox/test_worker.py -v` (aus `backend/`)
+Expected: PASS (5 passed).
+
+- [ ] **Step 6: Gesamte Sandbox-Suite + Lint**
+
+Run: `python -m pytest tests/plugins/sandbox/ -v` (aus `backend/`)
+Expected: PASS (alle Phase-1 + Phase-2a Tests; bestätige den Pass-Count und dass keine neuen `Task was destroyed`/`Task exception was never retrieved`-Warnings auftauchen).
+
+Run: `ruff check app/plugins/sandbox/ tests/plugins/sandbox/` (aus `backend/`)
+Expected: `All checks passed!`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/plugins/sandbox/channel.py backend/app/plugins/sandbox/worker.py backend/tests/plugins/sandbox/test_worker.py
+git commit -m "feat(plugin-sandbox): worker entry point with health/echo handler + RpcChannel.wait_closed (Track B Phase 2a)"
+```
+
+---
+
+## Definition of Done (Phase 2a)
+
+- `backend/app/plugins/sandbox/{transport,worker}.py` existieren, lint-clean.
+- `RpcChannel.wait_closed()` ergänzt (additiv, kein Verhalten der bestehenden Methoden geändert).
+- `python -m pytest tests/plugins/sandbox/ -v` grün (Phase 1 + 2a).
+- Transport wählt UDS auf Linux, Loopback-TCP auf Windows — beide Pfade durch denselben Roundtrip-Test abgedeckt (der jeweils plattformaktive Pfad läuft in CI/lokal).
+- Kein echter Subprozess in dieser Phase; Phase 2b (Supervisor) kann `WorkerListener` + `python -m app.plugins.sandbox.worker --connect <addr>` konsumieren.
+- Keine neue Dependency.
+
+---
+
+## Self-Review (gegen Spec)
+
+- **UDS prod / TCP dev, plattformgewählt, nicht plugin-konfigurierbar** → Task 1 (`_use_unix_socket`, `WorkerListener`) + Global Constraints. ✓ (Deckt Spec „Windows-Dev-Fallback" + „UDS ist der einzige Außen-Kanal" in prod.)
+- **Worker verbindet zurück, spannt RpcChannel auf, beantwortet Requests** → Task 2 (`run_worker` + `build_worker_handler`). ✓
+- **Worker-Entry per `python -m … --connect <addr>`** (für Phase-2b-Spawn) → Task 2 (`main`/argparse/`__main__`). ✓
+- **Request-Contract round-trip** (method/path/body/context) → Echo-Handler + `test_worker_echoes_http_request`. ✓ (Voller kuratierter Contract + Header-Allowlist = Phase 4.)
+- **Lifecycle health-ping** (vom Supervisor-Handshake in 2b gebraucht) → Health-Handler + Test. ✓
+- Bewusst NICHT in 2a (spätere Phasen): echter Subprozess-Spawn/Supervision/Restart (2b), echtes Plugin-Loading + Capability-Dispatch (3, ersetzt den Echo-Handler), Low-Priv-User/netns (5), Auth/Gating/Header-Allowlist/Scrubbing (4). Der Echo-Handler ist ein bewusster Platzhalter, kein Überbau.
+- **Keine Platzhalter** im Plan; vollständiger Code in jedem Code-Step; `wait_closed()` additiv und konsistent mit dem `_read_task`-Attribut aus Phase 1.

--- a/docs/superpowers/specs/2026-06-26-plugin-backend-isolation-design.md
+++ b/docs/superpowers/specs/2026-06-26-plugin-backend-isolation-design.md
@@ -1,0 +1,241 @@
+# Plugin-Backend-Isolation (Plugin-Sandboxing Track B) — Design
+
+- **Datum:** 2026-06-26
+- **Status:** Design / Spec (Brainstorm abgeschlossen, vor Implementierungsplan)
+- **Track:** Plugin-Sandboxing **Track B** aus dem Security-Audit 2026-06-14
+  (`SECURITY_AUDIT_2026-06-14.md`). Track A (Frontend-iframe-Isolation) ist
+  abgeschlossen (PR #278/#279); Track C (Supply-Chain-Signing) ist orthogonal
+  und nicht Teil dieser Spec.
+- **Verwandt:** `docs/superpowers/specs/2026-06-22-plugin-frontend-iframe-sandbox-design.md`,
+  `docs/superpowers/specs/2026-06-24-plugin-sandbox-phase3-5-design.md`
+
+---
+
+## Problem
+
+Externe (Marketplace-)Plugins laufen heute mit **vollem In-Process-RCE** im
+Backend-Prozess. Der Kern ist `app/plugins/manager.py` (`load_plugin`):
+
+```python
+module = importlib.util.module_from_spec(spec)
+sys.modules[module_name] = module
+spec.loader.exec_module(module)   # führt beliebigen Plugin-Code im Host-Prozess aus
+```
+
+Konkrete Konsequenzen:
+
+- **Laden = Code-Ausführung.** Schon `exec_module` führt Modul-Ebenen-Code aus —
+  ein bösartiges Plugin braucht keinen Route-Call (`import os; os.system(...)` reicht).
+- **Eigene Deps in-process.** Externe Plugins prependen ihr `site-packages/` auf
+  `sys.path` (`manager.py`), d.h. auch transitive Supply-Chain läuft im Host.
+- **Plugin-Router ist gleichberechtigter FastAPI-Code** (`manager.py` `get_router()`):
+  bekommt die echte `db`-Session, `Depends(get_current_user)`, importiert Host-Services
+  frei, ruft `subprocess`.
+- **Background-Tasks** sind `asyncio.create_task` im Host-Event-Loop.
+- **Permissions sind rein deklarativ.** `PermissionManager.validate_permissions`
+  prüft beim Enable nur `granted ⊇ required`. Zur Laufzeit gibt es **keinerlei**
+  Durchsetzung — ein Plugin ohne `system:execute` kann trotzdem `subprocess` aufrufen.
+
+Das ist exakt die im Audit als letzte große offene Schwachstelle geführte Backend-Lücke.
+
+## Ziel & Scope
+
+**Externe/Marketplace-Plugins** laufen isoliert in einem unprivilegierten
+Subprozess; der Host vermittelt jeden Zugriff über eine default-deny RPC-Grenze.
+
+**Bundled-Plugins bleiben unverändert in-process** (First-Party, trusted). Diese
+Spec ändert ihren Pfad nicht.
+
+Greenfield-Annahme: aktuell sind **null** externe Plugins deployed
+(Repo enthält nur `app/plugins/installed/` = bundled). Es gibt nichts zu
+migrieren — reines proaktives Härten „bevor das Ökosystem wächst".
+
+## Entscheidungen (aus dem Brainstorm)
+
+| Frage | Entscheidung |
+|---|---|
+| Welche Plugins isolieren? | **Nur external/Marketplace.** Bundled bleiben in-process trusted. |
+| Isolations-Mechanismus | **Subprozess als Low-Priv-OS-User** + UDS-RPC (spiegelt CI-Sandbox Layer A). Kein Container-Zwang; härtere Stufe später einsteckbar. |
+| Request-Pfad | **Ansatz A — Host-Proxy + RPC-Forward.** Host validiert Auth/Gating, schickt kuratierten, **token-freien** Request über RPC. |
+| Capabilities (default-deny) | **Per-User KV-Storage**, **eigene Plugin-Routen**, **kuratierte Core-API-Scopes**. **Kein** Outbound-Netz, **kein** Raw-DB/FS/Shell. |
+
+---
+
+## Architektur
+
+### Komponenten
+
+```
+Host-Prozess (Uvicorn-Worker, trusted)
+├── PluginManager                 # dual-path: bundled in-process | external → SandboxedPlugin
+├── SandboxSupervisor             # spawn/health/restart/kill der Worker (nur Primary-Worker)
+├── PluginProxyRouter             # FastAPI catch-all /api/plugins/{name}/{path}
+├── RpcChannel (Host-Seite)       # UDS, msgpack-Framing, voll-duplex, pending-map
+└── CapabilityRouter              # default-deny Dispatch von cap_call → schmale Host-Handler
+                                  #   storage.*  |  core.*  (fester Katalog)
+
+Sandbox-Worker (Subprozess, untrusted, Low-Priv-User, kein Netz)
+├── plugin_host_runner            # Entry-Point: UDS verbinden, RPC-Loop
+├── RpcChannel (Plugin-Seite)     # spiegelbildlich
+├── Plugin-SDK                    # host.storage.*, host.scopes.*, Routen-Registry
+└── <external plugin __init__.py> # exec NUR hier, nie im Host
+```
+
+### Prozess-Topologie & Lifecycle
+
+- **Dual-Path im `PluginManager`.** `load_plugin`/`enable_plugin` verzweigen anhand
+  `DiscoveredPlugin.source` (`manager.py`):
+  - `bundled` → unveränderter `exec_module`-Pfad.
+  - `external` → **nie** `exec_module` im Host; `SandboxSupervisor` spawnt einen Worker.
+- **Ein Prozess pro externem Plugin** (kein geteilter Pool): eigene `site-packages/`,
+  Blast-Radius-Isolation (kein Quer-Zugriff zwischen Plugins), Crash-Isolation.
+- **Worker-Eigenschaften** (gespiegelt von CI-Sandbox Layer A):
+  - dedizierter unprivilegierter OS-User (z.B. `baluhost-plugin`): kein sudo, keine
+    Gruppen, kein Lesezugriff auf `/opt/baluhost`, `.env.production`, Storage-Root.
+  - **Kein Netzwerk-Egress** (Netzwerk-Namespace / `unshare -n` bzw. Egress-Drop) —
+    UDS zum Host ist der einzige Kanal nach außen.
+  - Working-Dir = nur das Plugin-Verzeichnis.
+  - Optional als Härtung: `rlimit`/cgroup (CPU/Mem) beim Spawn.
+- **Multi-Worker (4 Uvicorn-Worker in prod):**
+  - Worker-Spawn + UDS-Ownership liegen **nur beim Primary-Worker** — exakt analog
+    zum bestehenden `start_background_tasks=False`-Muster auf Secondary-Workern
+    (`manager.py`).
+  - `PluginProxyRouter` läuft auf **jedem** Uvicorn-Worker und connectet zum geteilten UDS.
+  - `enable` → spawn + Health-Handshake; `disable` → graceful `shutdown`-RPC, dann
+    SIGTERM→SIGKILL mit Timeout; **Crash-Supervision** → bounded Restart
+    (max N Restarts/Fenster, sonst auto-disable + Audit-Log).
+
+### RPC-Protokoll
+
+- **Transport:** Längen-präfixierte Frames über UDS. Payload-Encoding **msgpack**
+  (native `bytes` → keine base64-Aufblähung für Bodies/Uploads). Frame =
+  `4-Byte-Length` + msgpack-Envelope.
+- **Voll-Duplex, reentrant, Correlation-IDs.** Während der Host auf die
+  `http_response` wartet, kann das Plugin `cap_call`s zurücksenden. Beide Seiten
+  halten eine `pending`-Map `{id → Future}`. Envelope: `{ id, type, ... }`.
+  - Host → Plugin: `http_request`, `lifecycle` (startup / health-ping / shutdown)
+  - Plugin → Host: `cap_call` → vom Host beantwortet mit `cap_result`
+  - Antworten: `http_response`, `cap_result`, `error`
+
+**Request-Contract (Ansatz A — kuratiert, Token bleibt im Host):**
+
+```
+http_request {
+  id, method, path,            # path = Subpfad NACH /plugins/{name}/
+  query: {str: str},
+  headers: {…},                # ALLOWLIST (content-type, accept, …)
+                               #   NIE Authorization / Cookie
+  body: bytes,
+  context: { user_id, username, role }   # vom Host aufgelöst, KEIN Token
+}
+http_response { id, status, headers (allowlist), body: bytes }
+```
+
+**Error-Handling & Limits** (schließt an Posten 2 / Error-Leakage an):
+
+- Plugin wirft/crasht im Request → Host liefert **gescrubbtes** 502/500; Detail nur
+  server-side geloggt, nie an den Client.
+- **Per-Request-Timeout** → 504, Request abgebrochen; wiederholte Timeouts zählen
+  auf das Crash-Budget.
+- **Body-Size-Cap** (Request & Response) + **max in-flight Requests/Plugin** → DoS-Schutz.
+- Malformed Frame → Connection-Drop + Supervisor-Restart.
+
+### Capability-Layer (default-deny)
+
+Jeder `cap_call {capability, request_id, args}` läuft host-seitig durch den
+`CapabilityRouter`:
+
+1. `capability ∈ granted_scopes`? Nein → `cap_result{error:"denied"}` + Audit-Log.
+   **Das ist die eigentliche Sandbox-Durchsetzung** (ersetzt die deklarative Prüfung).
+2. Ja → schmaler, validierter Host-Handler läuft mit Host-Rechten, gibt nur das
+   kuratierte Ergebnis zurück.
+
+**a) `storage.*` — Per-User KV** (reuse Track A `plugin_storage`, PR #279):
+`get/set/delete/list`, gebunden an `(plugin, user_id)`. Der `user_id` kommt **nicht**
+vom Plugin, sondern aus dem `context` des `request_id`, auf den sich der `cap_call`
+bezieht — der Host korreliert, welchen In-Flight-Request das Plugin gerade bedient.
+Ein Plugin kann so nie fremde User-Buckets adressieren. Quota: 64 KB / 100 keys
+(bestehender Service).
+
+**b) Eigene Routen** — kein Capability-Call, sondern der `http_request`-Pfad. Frei
+nutzbar (Plugin-Hauptzweck), immer hinter Host-Auth/Gating.
+
+**c) `core.*` — kuratierte Core-API-Scopes.** Fester, kleiner Katalog; jeder Scope =
+eine **enge** Host-Funktion (z.B. read-only Systemmetriken, Notification senden).
+**Kein** roher DB-/Shell-Zugriff. Katalog erweitern = Host-Code-Änderung + Review.
+Der Start-Katalog wird im Implementierungsplan festgelegt (minimal halten; YAGNI).
+
+**Single Source of Truth = `granted_api_scopes`** (DB `InstalledPlugin`,
+bereits vorhanden) — **dieselbe** Spalte, die Track A fürs Frontend-Gating nutzt.
+Backend-Cap-Gating und Frontend-Bridge-Gating teilen denselben Scope-Satz, vom Admin
+bei Install gewährt.
+
+**Plugin-SDK (im Sandbox-Prozess):** dünnes Python-SDK, das RPC-Calls zu einer
+sauberen API wrappt — `host.storage.get(key)`, `host.scopes.system_metrics()`, plus
+Routen-Registrierung — analog zu `window.BaluHost` im Frontend. Plugin-Autor schreibt
+nie rohes msgpack.
+
+**Permission-Modell-Aufräumung:** Die alte `PluginPermission`-Enum (`file:*`,
+`system:execute`, `db:*`) bleibt für **bundled** Plugins (dort informativ). Für
+**external** Plugins ist die gewährbare Menge ausschließlich der Scope-Katalog; die
+gefährlichen Raw-Permissions sind nicht installierbar.
+
+---
+
+## Trust-Boundary (Invarianten)
+
+- **Einziger Trust-Boundary = der Host.** Der Plugin-Prozess ist vollständig untrusted.
+- `exec_module` läuft für externe Plugins **nie** im Host-Prozess.
+- OS: Low-Priv-User, kein sudo, kein Lesezugriff auf Prod-Secrets/Storage-Root.
+- **Kein Netzwerk-Egress**; UDS zum Host ist der einzige Außen-Kanal.
+- **Token verlässt nie den Host** — Plugin sieht nur `context {user_id, role}`.
+- **Default-deny**, host-seitig am `cap_call`-Dispatch durchgesetzt.
+- **Alle Plugin-Fehler werden host-seitig gescrubbt** (kein Internals-Leak).
+
+**Dokumentierter Accepted Risk** (analog CI-Gap #2): Subprozess teilt den Host-Kernel;
+ein Kernel-/Namespace-Escape landet als Low-Priv-User — weiterhin ohne sudo/Prod-Zugriff.
+Härtere Stufe (Container/gVisor) bleibt einsteckbares Backend an derselben RPC-Grenze.
+
+## Explizit Out-of-Scope (v1)
+
+- **Bundled-Plugin-Isolation** — bleiben in-process trusted.
+- **Outbound-Netzwerk für Plugins** — gesperrt; spätere Lockerung nur via
+  Egress-Allowlist (wie CI-Gap #8).
+- **System-Event/Hook-Zustellung über die Grenze** (`on_file_uploaded` etc.) —
+  Host→Plugin-Event-Push ist Follow-up; v1-External-Plugins abonnieren keine
+  Core-Events. (Plugin-interne Periodik im eigenen Prozess geht trivial.)
+- **Direkter DB-Zugriff / eigene Plugin-Tabellen** für external — nur KV-Storage +
+  kuratierte Scopes. Reicht das nicht, ist das ein neuer kuratierter Scope (Review),
+  kein Raw-DB.
+- **Track C (Signing)** — orthogonaler eigener Track.
+- **Migration bestehender external Plugins** — Greenfield (0 deployed).
+
+---
+
+## Testing
+
+- **RPC-Unit-Tests:** Framing/Envelope-Roundtrip (msgpack), Correlation-ID-Matching,
+  reentrante `cap_call` während offenem `http_request`, malformed-Frame-Drop.
+- **CapabilityRouter:** default-deny (nicht-gewährter Scope → `denied` + Audit),
+  Storage-User-Bindung (Plugin kann fremden `user_id` nicht adressieren), Quota-Enforcement.
+- **Request-Proxy:** Host-Auth/Gating vor Forward; Token/Authorization-Header erscheinen
+  **nie** im an das Plugin gesendeten `http_request` (positiv-Assertion wie Track-A
+  `'BaluHost' in window === false`); Header-Allowlist greift.
+- **Error-Scrubbing:** Plugin-Exception → gescrubbte 5xx an den Client, kein Internals-Leak
+  (verknüpft mit Posten-2-Tests).
+- **Lifecycle/Supervisor:** spawn→health→ready, graceful + hard kill, bounded Restart →
+  auto-disable nach Budget, Primary-only-Spawn (Secondary-Worker spawnt nicht).
+- **Isolations-Smoke-Test:** ein Test-„böses" Plugin, das `subprocess`/`open('/etc/..')`/
+  Outbound-Socket versucht → scheitert (kein Zugriff), Host bleibt unbeeinträchtigt.
+- **End-to-End:** ein Beispiel-Sandbox-Plugin (eigene Route + Storage + ein Core-Scope)
+  durch den vollen Proxy→RPC→Capability-Pfad.
+
+## Offene Punkte für den Implementierungsplan
+
+- Konkreter Start-Katalog der `core.*`-Scopes (minimal).
+- Genauer OS-User-Provisioning-Schritt (deploy-Template / sudoers-frei), Netzwerk-Namespace-Mechanik
+  (`unshare -n` vs. spawn-Wrapper), Windows-Dev-Fallback (Subprozess ohne Low-Priv-User/Namespace
+  im Dev-Mode — Isolation nur in prod erzwungen, Dev simuliert).
+- Streaming-Bodies (große Up-/Downloads) über RPC: v1 buffered mit Body-Cap; Streaming als
+  Follow-up falls nötig.
+- Health-/Readiness-Protokolldetails und Restart-Budget-Parameter.

--- a/docs/superpowers/specs/2026-06-26-plugin-backend-isolation-design.md
+++ b/docs/superpowers/specs/2026-06-26-plugin-backend-isolation-design.md
@@ -182,6 +182,36 @@ gefährlichen Raw-Permissions sind nicht installierbar.
 
 ---
 
+### Frontend — Plugin-Dokumentations-Seite (muss mitziehen)
+
+Die Plugin-Page hat einen **Documentation-Tab** (`client/src/components/plugins/PluginDocumentation.tsx`,
+Strings im `plugins`-i18n-Namespace, de + en), der das **aktuelle In-Process-Modell**
+erklärt: rohe Permissions (`file:write`, `system:execute`, `db:write`, `user:write` als
+„dangerous"), Lifecycle (discovery → registration → permission check → activation),
+Plugin-Struktur (`__init__.py`/`routes.py`), Permissions-Katalog (file/system/network/
+database/user/device/events) und die Event-Hooks-Referenz (`on_file_uploaded` … via
+`event:subscribe`).
+
+Mit Track B wird das für **externe** Plugins größtenteils unzutreffend. Die Doku ist
+Teil des Track-B-Deliverables und muss das neue Modell abbilden:
+
+- **Zwei Trust-Stufen sichtbar machen:** *bundled* (First-Party, trusted, voller
+  In-Process-Zugriff — das bestehende Permissions/Hooks-Modell gilt hier weiter) vs.
+  *external/Marketplace* (sandboxed Subprozess, default-deny).
+- **Für external:** das rohe Permission-/Hooks-Modell ersetzen durch das
+  **Scope-Modell** (KV-Storage, eigene Routen, kuratierte `core.*`-Scopes); klarstellen,
+  dass `file:write`/`system:execute`/`db:*` und Event-Hooks für external **nicht
+  gewährbar** bzw. v1 nicht verfügbar sind, und welche Isolations-Garantien gelten
+  (kein Netz, kein Host-FS/DB, Token bleibt im Host).
+- **Konsistenz:** Die Doku darf erst auf das neue Modell umgeschrieben werden, *wenn*
+  die Isolation real existiert (sie beschreibt tatsächliches Verhalten) — daher als
+  späte Plan-Aufgabe, gemeinsam mit dem Backend, nicht vorab.
+
+Betroffen: `PluginDocumentation.tsx` + die `plugins`-Locale-Dateien
+(`client/src/i18n/locales/de/plugins.json`, `client/src/i18n/locales/en/plugins.json`)
+und ggf. der Enable-/Permission-Modal-Text in `PluginsPage.tsx`/`MarketplaceTab.tsx`,
+sofern er rohe Permissions zeigt.
+
 ## Trust-Boundary (Invarianten)
 
 - **Einziger Trust-Boundary = der Host.** Der Plugin-Prozess ist vollständig untrusted.


### PR DESCRIPTION
## Plugin-Sandboxing Track B — Backend-Python-Isolation (Phase 1 + Phase 2a)

Letzter großer offener Posten aus dem Security-Audit 2026-06-14. **Track A** (Frontend-iframe-Isolation) ist abgeschlossen (PR #278/#279); **Track B** isoliert den **Backend-Python-Code externer Plugins**, der heute mit vollem In-Process-RCE läuft (`exec_module` im Host-Prozess, deklarative Permissions ohne Laufzeit-Durchsetzung).

> **Hinweis:** Dieser PR enthält erst die unteren Schichten der Isolation. Bis Phase 4 den `PluginManager` verdrahtet, ist der neue Code **nicht aktiv** (kein Aufrufer außerhalb von `sandbox/`) — harmlos, aber vollständig getestet. Spec: `docs/superpowers/specs/2026-06-26-plugin-backend-isolation-design.md`.

### Entscheidungen (Brainstorm)
- Nur **external/Marketplace**-Plugins isolieren; **bundled bleiben in-process trusted** (First-Party).
- **Subprozess als Low-Priv-OS-User + UDS-RPC** (spiegelt die CI-Sandbox-Philosophie).
- Request-Pfad **Host-Proxy + RPC-Forward** — der JWT/Token verlässt nie den Host; das Plugin sieht nur `{user_id, role}`.
- **default-deny Capabilities**: Per-User-KV-Storage + eigene Routen + kuratierte `core.*`-Scopes. **Kein** Outbound-Netz, **kein** Raw-DB/FS/Shell.

### Enthalten

**Phase 1 — RPC-Fundament** (`backend/app/plugins/sandbox/`)
- `protocol.py` — längen-präfixierter msgpack-Frame-Codec + `Message`-Envelope + Frame-Size-Cap; jede Korruption (bad msgpack / falsche Felder) wird zu `FrameError` normalisiert → sauberer Connection-Drop gegen einen feindlichen Peer.
- `channel.py` — `RpcChannel`: voll-duplex, reentrant, per-Call Correlation-IDs, Pending-Future-Map, gehärtetes `close()`.

**Phase 2a — Transport + Worker-Runner**
- `transport.py` — cross-platform Host↔Worker-Transport: **UDS in prod** (funktioniert über eine Netzwerk-Namespace-Grenze via Socket-Datei im Worker-Workdir), **Loopback-TCP im Dev** (asyncio hat kein `open_unix_connection` auf Windows). Plattform-gewählt, nicht plugin-konfigurierbar.
- `worker.py` — Sandbox-Worker-Entry-Point mit einem Phase-2-**Echo/Health-Platzhalter-Handler** (echtes Plugin-Loading + Capability-SDK ersetzen ihn in Phase 3) + additive `RpcChannel.wait_closed()`.

### Tests
- 23 Tests in `backend/tests/plugins/sandbox/` grün, ruff clean (lokal Windows = TCP-Pfad; der UDS-Pfad läuft im Linux-CI).
- Volle Backend-Suite → CI.

### Roadmap (eigene Folge-PRs)
- **Phase 2b** — `SandboxSupervisor`: echter Subprozess-Spawn, Health-Handshake, Exit-Detection, bounded Restart→auto-disable, graceful+hard shutdown.
- **Phase 3** — Capability-Layer + Plugin-SDK (default-deny Dispatch, `storage.*`/`core.*`).
- **Phase 4** — Request-Proxy + `PluginManager`-Dual-Path (FastAPI-Wiring, Auth/Gating, Error-Scrubbing).
- **Phase 5** — Deploy-Härtung (Low-Priv-OS-User + netns) + Frontend-Doku-Update.

### Review-Hinweis
Subagent-driven umgesetzt mit Multi-Agent-Review je Task; das hat in beiden Phasen je einen reellen Defekt vor dem Festschreiben gefangen (decode-Korruptions-Pfad in Phase 1; `LIFECYCLE`-Korrelations-Bug → neuer `LIFECYCLE_RESULT`-Response-Typ in Phase 2a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
