### PR TITLE
Plugin-Sandboxing Track B — Phase 4: Request-Proxy + PluginManager Dual-Path (external plugins sandboxed)

### DIFF
--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -253,7 +253,7 @@ async def toggle_plugin(
     """
     # External sandboxed plugin: use manifest path (no exec)
     discovered = plugin_manager.get_discovered(name)
-    if discovered is not None and discovered.source == "external":
+    if discovered is not None and discovered.source == "external" and discovered.manifest is not None:
         return await _toggle_external(
             name, body, db, current_user, plugin_manager, discovered
         )

--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -139,6 +139,42 @@ async def get_plugin_details(
     plugin_manager: PluginManager = Depends(get_plugin_manager),
 ) -> PluginDetailResponse:
     """Get detailed information about a specific plugin."""
+    # External plugin: use manifest + DB record (no exec)
+    _discovered = plugin_manager.get_discovered(name)
+    if _discovered is not None and _discovered.source == "external" and _discovered.manifest is not None:
+        manifest = _discovered.manifest
+        db_record = plugin_service.get_installed_plugin(db, name)
+        return PluginDetailResponse(
+            name=manifest.name,
+            version=manifest.version,
+            display_name=manifest.display_name,
+            description=manifest.description,
+            author=manifest.author,
+            category=manifest.category,
+            homepage=manifest.homepage,
+            min_baluhost_version=manifest.min_baluhost_version,
+            dependencies=list(getattr(manifest, "plugin_dependencies", []) or []),
+            required_permissions=list(manifest.required_permissions),
+            granted_permissions=(db_record.granted_permissions or []) if db_record else [],
+            dangerous_permissions=PermissionManager.get_dangerous_permissions(
+                list(manifest.required_permissions)
+            ),
+            is_enabled=plugin_manager.is_enabled(name),
+            is_installed=db_record is not None,
+            has_ui=manifest.ui is not None,
+            has_routes=True,
+            has_background_tasks=False,
+            has_dashboard_panel=False,
+            dashboard_panel_enabled=db_record.dashboard_panel_enabled if db_record else False,
+            nav_items=[],
+            dashboard_widgets=[],
+            installed_at=db_record.installed_at if db_record else None,
+            enabled_at=db_record.enabled_at if db_record else None,
+            config=(db_record.config or {}) if db_record else {},
+            config_schema=None,
+            translations=None,
+        )
+
     # Try to load plugin
     try:
         plugin = plugin_manager.get_plugin(name)
@@ -215,6 +251,13 @@ async def toggle_plugin(
 
     Admin only. When enabling, required permissions must be granted.
     """
+    # External sandboxed plugin: use manifest path (no exec)
+    discovered = plugin_manager.get_discovered(name)
+    if discovered is not None and discovered.source == "external":
+        return await _toggle_external(
+            name, body, db, current_user, plugin_manager, discovered
+        )
+
     # Try to load plugin first
     try:
         plugin = plugin_manager.get_plugin(name)
@@ -312,6 +355,64 @@ async def toggle_plugin(
             is_enabled=False,
             message=f"Plugin '{meta.display_name}' disabled successfully",
         )
+
+
+async def _toggle_external(
+    name: str,
+    body: PluginToggleRequest,
+    db: Session,
+    current_user,
+    plugin_manager: PluginManager,
+    discovered,
+) -> PluginToggleResponse:
+    """Enable/disable an external sandboxed plugin via its manifest (no exec)."""
+    manifest = discovered.manifest
+    if manifest is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plugin not found")
+
+    if body.enabled:
+        api_scopes = list(getattr(manifest, "api_scopes", []) or [])
+        plugin_service.enable_plugin(
+            db,
+            name=name,
+            version=manifest.version,
+            display_name=manifest.display_name,
+            permissions=body.grant_permissions,
+            default_config={},
+            installed_by=current_user.username,
+            api_scopes=api_scopes,
+        )
+        success = await plugin_manager.enable_plugin(
+            name, body.grant_permissions, db, granted_api_scopes=api_scopes
+        )
+        if not success:
+            plugin_service.rollback_enable(db, name)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to enable plugin",
+            )
+        invalidate_plugin_cache(name)
+        logger.info("External plugin %s enabled by %s", name, current_user.username)
+        return PluginToggleResponse(
+            name=name,
+            is_enabled=True,
+            message=f"Plugin '{manifest.display_name}' enabled successfully",
+        )
+
+    success = await plugin_manager.disable_plugin(name)
+    plugin_service.disable_plugin_record(db, name)
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to disable plugin",
+        )
+    invalidate_plugin_cache(name)
+    logger.info("External plugin %s disabled by %s", name, current_user.username)
+    return PluginToggleResponse(
+        name=name,
+        is_enabled=False,
+        message=f"Plugin '{manifest.display_name}' disabled successfully",
+    )
 
 
 @router.post("/{name}/dashboard-panel")

--- a/backend/app/plugins/manager.py
+++ b/backend/app/plugins/manager.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Sequence, Set
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app.plugins.base import BackgroundTaskSpec, PluginBase
@@ -701,23 +701,38 @@ class PluginManager:
             return []
 
     def get_router(self) -> APIRouter:
-        """Get a combined router for all enabled plugins.
+        """Combined router: bundled plugin routes + a catch-all for sandboxed ones."""
+        from fastapi import Request  # noqa: PLC0415
+        from app.api.deps import get_current_user  # noqa: PLC0415
+        from app.plugins.sandbox.proxy import proxy_request  # noqa: PLC0415
 
-        Returns:
-            APIRouter with all plugin routes mounted
-        """
         router = APIRouter(prefix="/plugins", tags=["plugins"])
 
+        # Bundled plugins: explicit routers, registered FIRST so they win.
         for name in self._enabled:
             plugin = self._plugins.get(name)
             if plugin:
                 plugin_router = plugin.get_router()
                 if plugin_router:
                     router.include_router(
-                        plugin_router,
-                        prefix=f"/{name}",
-                        tags=[f"plugin:{name}"],
+                        plugin_router, prefix=f"/{name}", tags=[f"plugin:{name}"]
                     )
+
+        # Catch-all for external/sandboxed plugins, registered LAST.
+        manager = self
+
+        @router.api_route(
+            "/{name}/{path:path}",
+            methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+            include_in_schema=False,
+        )
+        async def _sandbox_proxy(
+            name: str,
+            path: str,
+            request: Request,
+            current_user=Depends(get_current_user),
+        ):
+            return await proxy_request(name, path, request, current_user, manager)
 
         return router
 

--- a/backend/app/plugins/manager.py
+++ b/backend/app/plugins/manager.py
@@ -323,6 +323,20 @@ class PluginManager:
             scan_dir = plugin_path.parent
             source = discovered.source
 
+        # External plugins that ship a manifest are marketplace plugins — they
+        # run in a sandboxed subprocess and must NEVER be exec'd in the host.
+        # (Manifest-less "external" dirs, e.g. test tmp_paths, keep the legacy
+        # in-process path — same predicate the enable_plugin external branch uses.)
+        if (
+            discovered is not None
+            and discovered.source == "external"
+            and discovered.manifest is not None
+        ):
+            raise PluginLoadError(
+                f"External plugin '{name}' must not be loaded in-process; "
+                "it runs in a sandboxed subprocess."
+            )
+
         init_file = plugin_path / "__init__.py"
         if not init_file.exists():
             raise PluginLoadError(f"Plugin __init__.py not found: {init_file}")

--- a/backend/app/plugins/manager.py
+++ b/backend/app/plugins/manager.py
@@ -811,6 +811,25 @@ class PluginManager:
         result = {}
 
         for name in discovered:
+            info = self.get_discovered(name)
+            if info is not None and info.source == "external" and info.manifest is not None:
+                m = info.manifest
+                result[name] = {
+                    "name": m.name,
+                    "version": m.version,
+                    "display_name": m.display_name,
+                    "description": m.description,
+                    "author": m.author,
+                    "category": m.category,
+                    "required_permissions": list(m.required_permissions),
+                    "is_enabled": name in self._enabled,
+                    "has_ui": m.ui is not None,
+                    "has_routes": True,
+                    "dangerous_permissions": PermissionManager.get_dangerous_permissions(
+                        list(m.required_permissions)
+                    ),
+                }
+                continue
             try:
                 if name not in self._plugins:
                     self.load_plugin(name)

--- a/backend/app/plugins/manager.py
+++ b/backend/app/plugins/manager.py
@@ -121,6 +121,7 @@ class PluginManager:
         self._hook_manager = create_plugin_manager()
         self._event_manager: Optional[EventManager] = None
         self._background_tasks: Dict[str, List[asyncio.Task]] = {}
+        self._sandboxes: Dict[str, Any] = {}
         self._routers_mounted = False
         self._discovered: Optional[Dict[str, DiscoveredPlugin]] = None
 
@@ -163,6 +164,20 @@ class PluginManager:
             return "bundled" if parent_dir.resolve() == BUNDLED_PLUGINS_DIR.resolve() else "external"
         except OSError:
             return "external"
+
+    def _supervisor_factory(self, plugin_name: str, plugin_dir: Path, capability_router: Any) -> Any:
+        """Build a SandboxSupervisor (overridable in tests)."""
+        from app.plugins.sandbox.supervisor import SandboxSupervisor  # noqa: PLC0415
+
+        return SandboxSupervisor(plugin_name, plugin_dir, capability_router=capability_router)
+
+    def is_sandboxed(self, name: str) -> bool:
+        """Return True if plugin ``name`` is running in a sandbox subprocess."""
+        return name in self._sandboxes
+
+    def get_sandbox(self, name: str) -> Any:
+        """Return the SandboxSupervisor for ``name``, or None."""
+        return self._sandboxes.get(name)
 
     def _scan_directory(self, scan_dir: Path) -> List[DiscoveredPlugin]:
         """Scan a single directory for plugin candidates.
@@ -395,6 +410,7 @@ class PluginManager:
         granted_permissions: List[str],
         db: Session,
         start_background_tasks: bool = True,
+        granted_api_scopes: Optional[List[str]] = None,
     ) -> bool:
         """Enable a plugin.
 
@@ -403,10 +419,15 @@ class PluginManager:
             granted_permissions: List of granted permission strings
             db: Database session
             start_background_tasks: Whether to start background tasks (False on secondary workers)
+            granted_api_scopes: API capability scopes granted to external plugins
 
         Returns:
             True if plugin was enabled successfully
         """
+        discovered = self.get_discovered(name)
+        if discovered is not None and discovered.source == "external" and discovered.manifest is not None:
+            return await self._enable_external(name, discovered, granted_api_scopes or [])
+
         if name not in self._plugins:
             try:
                 self.load_plugin(name)
@@ -458,6 +479,30 @@ class PluginManager:
             logger.exception(f"Failed to enable plugin {name}: {e}")
             return False
 
+    async def _enable_external(
+        self, name: str, discovered: "DiscoveredPlugin", granted_api_scopes: List[str]
+    ) -> bool:
+        """Enable an external plugin as a sandboxed subprocess (no in-host exec).
+
+        Spawned on every uvicorn worker (no primary-only gating) so the catch-all
+        proxy can serve the plugin regardless of which worker handles the request.
+        """
+        if name in self._sandboxes:
+            return True
+        from app.plugins.sandbox.host_capabilities import build_capability_router  # noqa: PLC0415
+
+        router = build_capability_router(name, set(granted_api_scopes))
+        supervisor = self._supervisor_factory(name, discovered.path, router)
+        try:
+            await supervisor.start()
+        except Exception:
+            logger.exception("Failed to start sandbox for external plugin %s", name)
+            return False
+        self._sandboxes[name] = supervisor
+        self._enabled.add(name)
+        logger.info("Enabled external (sandboxed) plugin: %s", name)
+        return True
+
     async def disable_plugin(self, name: str) -> bool:
         """Disable a plugin.
 
@@ -467,6 +512,16 @@ class PluginManager:
         Returns:
             True if plugin was disabled successfully
         """
+        if name in self._sandboxes:
+            supervisor = self._sandboxes.pop(name)
+            try:
+                await supervisor.stop()
+            except Exception:
+                logger.exception("Error stopping sandbox for %s", name)
+            self._enabled.discard(name)
+            logger.info("Disabled external (sandboxed) plugin: %s", name)
+            return True
+
         if name not in self._enabled:
             return True
 
@@ -595,6 +650,7 @@ class PluginManager:
                 record.granted_permissions or [],
                 db,
                 start_background_tasks=start_background_tasks,
+                granted_api_scopes=record.granted_api_scopes or [],
             )
 
         logger.info(f"Loaded {len(self._enabled)} enabled plugins")

--- a/backend/app/plugins/sandbox/host_capabilities.py
+++ b/backend/app/plugins/sandbox/host_capabilities.py
@@ -1,0 +1,71 @@
+"""Production wiring for the sandbox CapabilityRouter.
+
+The Phase 3 CapabilityRouter takes its host dependencies by injection so it
+stays testable. This module supplies the real ones — a DB session factory,
+a read-only metrics reader, an in-app notifier, and the audit logger — and
+filters the plugin's granted scopes down to the known host catalog.
+"""
+from __future__ import annotations
+
+import logging
+
+from app.core.database import SessionLocal
+from app.plugins.sandbox.capabilities import (
+    CAPABILITY_SCOPE,
+    CapabilityContext,
+    CapabilityRouter,
+)
+from app.services.audit.logger_db import get_audit_logger_db
+from app.services.monitoring.shm import TELEMETRY_FILE, read_shm
+from app.services.notifications.service import get_notification_service
+
+logger = logging.getLogger(__name__)
+
+# The full set of scope strings the host knows how to enforce. Anything a
+# plugin was granted that is not in here is silently dropped (defensive).
+KNOWN_SCOPES: frozenset[str] = frozenset(CAPABILITY_SCOPE.values())
+
+def _read_metrics() -> dict:
+    """Curated read-only system metrics from the monitoring SHM snapshot.
+
+    The telemetry SHM (telemetry.py) exposes ``latest_cpu_usage`` and a
+    ``latest_memory_sample`` dict with a ``percent`` field — NOT top-level
+    ``cpu_percent``/``memory_percent``. Project a small, stable subset.
+    """
+    snapshot = read_shm(TELEMETRY_FILE) or {}
+    mem = snapshot.get("latest_memory_sample") or {}
+    out: dict = {}
+    if snapshot.get("latest_cpu_usage") is not None:
+        out["cpu_usage"] = snapshot["latest_cpu_usage"]
+    if isinstance(mem, dict) and mem.get("percent") is not None:
+        out["memory_percent"] = mem["percent"]
+    return out
+
+
+async def _notify(context: CapabilityContext, payload: dict) -> None:
+    """Create an in-app notification for the request's acting user only."""
+    service = get_notification_service()
+    with SessionLocal() as db:
+        await service.create(
+            db,
+            user_id=context.user_id,
+            category="plugin",
+            notification_type=payload["type"],
+            title=payload["title"],
+            message=payload["message"],
+        )
+
+
+def build_capability_router(
+    plugin_name: str, granted_scopes: "set[str] | frozenset[str]"
+) -> CapabilityRouter:
+    """Build a CapabilityRouter with production host dependencies."""
+    filtered = frozenset(granted_scopes) & KNOWN_SCOPES
+    return CapabilityRouter(
+        plugin_name=plugin_name,
+        granted_scopes=filtered,
+        session_factory=SessionLocal,
+        metrics_reader=_read_metrics,
+        notifier=_notify,
+        audit_logger=get_audit_logger_db(),
+    )

--- a/backend/app/plugins/sandbox/host_capabilities.py
+++ b/backend/app/plugins/sandbox/host_capabilities.py
@@ -8,6 +8,7 @@ filters the plugin's granted scopes down to the known host catalog.
 from __future__ import annotations
 
 import logging
+from typing import Any, Awaitable, Callable
 
 from app.core.database import SessionLocal
 from app.plugins.sandbox.capabilities import (
@@ -42,18 +43,28 @@ def _read_metrics() -> dict:
     return out
 
 
-async def _notify(context: CapabilityContext, payload: dict) -> None:
-    """Create an in-app notification for the request's acting user only."""
-    service = get_notification_service()
-    with SessionLocal() as db:
-        await service.create(
-            db,
-            user_id=context.user_id,
-            category="plugin",
-            notification_type=payload["type"],
-            title=payload["title"],
-            message=payload["message"],
-        )
+def _make_notifier(
+    session_factory: Callable[[], Any]
+) -> Callable[[CapabilityContext, dict], Awaitable[None]]:
+    """Create a notifier closure that captures the injected session_factory.
+
+    Returns an async function that creates an in-app notification for the
+    request's acting user only, using the provided session factory.
+    """
+
+    async def _notify(context: CapabilityContext, payload: dict) -> None:
+        service = get_notification_service()
+        with session_factory() as db:
+            await service.create(
+                db,
+                user_id=context.user_id,
+                category="plugin",
+                notification_type=payload["type"],
+                title=payload["title"],
+                message=payload["message"],
+            )
+
+    return _notify
 
 
 def build_capability_router(
@@ -66,6 +77,6 @@ def build_capability_router(
         granted_scopes=filtered,
         session_factory=SessionLocal,
         metrics_reader=_read_metrics,
-        notifier=_notify,
+        notifier=_make_notifier(SessionLocal),
         audit_logger=get_audit_logger_db(),
     )

--- a/backend/app/plugins/sandbox/proxy.py
+++ b/backend/app/plugins/sandbox/proxy.py
@@ -1,0 +1,101 @@
+"""FastAPI catch-all proxy for external (sandboxed) plugins.
+
+Forwards a token-free, header-allowlisted request to the plugin's worker over
+RPC and turns the worker's response back into a FastAPI Response. Every plugin
+failure is scrubbed: crash -> 502, timeout -> 504, unreachable/disabled -> 503.
+The Authorization and Cookie headers are never forwarded.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse
+
+from app.plugins.sandbox.supervisor import SupervisorError, SupervisorTimeout
+
+logger = logging.getLogger(__name__)
+
+REQUEST_BODY_MAX = 10 * 1024 * 1024  # 10 MiB
+REQUEST_TIMEOUT = 30.0
+# Request headers forwarded to the plugin. NEVER includes authorization/cookie.
+ALLOWED_REQUEST_HEADERS = frozenset({"content-type", "accept"})
+# Response headers passed back to the client.
+ALLOWED_RESPONSE_HEADERS = frozenset({"content-type"})
+
+
+def _filter_request_headers(request: Request) -> dict:
+    return {
+        k.lower(): v
+        for k, v in request.headers.items()
+        if k.lower() in ALLOWED_REQUEST_HEADERS
+    }
+
+
+def _build_response(payload: dict) -> Response:
+    status_code = int(payload.get("status", 200))
+    body = payload.get("body")
+    headers = {
+        k.lower(): v
+        for k, v in (payload.get("headers") or {}).items()
+        if k.lower() in ALLOWED_RESPONSE_HEADERS
+    }
+    if isinstance(body, (bytes, bytearray)):
+        return Response(content=bytes(body), status_code=status_code, headers=headers)
+    return JSONResponse(content=body, status_code=status_code, headers=headers)
+
+
+async def proxy_request(
+    name: str, path: str, request: Request, current_user: Any, manager: Any
+) -> Response:
+    """Proxy one request to an external plugin's sandbox worker."""
+    supervisor = manager.get_sandbox(name)
+    if supervisor is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plugin not found")
+
+    # Reject oversized bodies BEFORE buffering them into memory. The
+    # Content-Length header can lie, so we also guard after the read.
+    declared = request.headers.get("content-length")
+    if declared is not None:
+        try:
+            if int(declared) > REQUEST_BODY_MAX:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail="Request body too large",
+                )
+        except ValueError:
+            pass  # malformed header — fall through to the post-read guard
+    body = await request.body()
+    if len(body) > REQUEST_BODY_MAX:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Request body too large",
+        )
+
+    context = {
+        "user_id": current_user.id,
+        "username": current_user.username,
+        "role": current_user.role,
+    }
+    try:
+        result = await supervisor.dispatch(
+            request.method,
+            path,
+            body,
+            context,
+            query=dict(request.query_params),
+            headers=_filter_request_headers(request),
+            timeout=REQUEST_TIMEOUT,
+        )
+    except SupervisorTimeout:
+        logger.warning("Plugin %s request timed out", name)
+        raise HTTPException(status_code=status.HTTP_504_GATEWAY_TIMEOUT, detail="Plugin timed out")
+    except SupervisorError as exc:
+        logger.warning("Plugin %s unavailable: %s", name, exc)
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Plugin error")
+    except Exception:
+        logger.exception("Unexpected error proxying to plugin %s", name)
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Plugin error")
+
+    return _build_response(result)

--- a/backend/app/plugins/sandbox/proxy.py
+++ b/backend/app/plugins/sandbox/proxy.py
@@ -2,7 +2,7 @@
 
 Forwards a token-free, header-allowlisted request to the plugin's worker over
 RPC and turns the worker's response back into a FastAPI Response. Every plugin
-failure is scrubbed: crash -> 502, timeout -> 504, unreachable/disabled -> 503.
+failure is scrubbed: crash -> 502, timeout -> 504, unreachable/disabled -> 502.
 The Authorization and Cookie headers are never forwarded.
 """
 from __future__ import annotations

--- a/backend/app/plugins/sandbox/supervisor.py
+++ b/backend/app/plugins/sandbox/supervisor.py
@@ -38,6 +38,10 @@ class SupervisorError(Exception):
     """Raised when the worker cannot be started, handshaked, or reached."""
 
 
+class SupervisorTimeout(SupervisorError):
+    """Raised when a single dispatched request exceeds its timeout."""
+
+
 class SandboxSupervisor:
     """Owns one external plugin's worker process and the RPC channel to it."""
 
@@ -52,6 +56,7 @@ class SandboxSupervisor:
         max_restarts: int = 3,
         restart_window: float = 60.0,
         capability_router: Optional[CapabilityRouter] = None,
+        max_inflight: int = 10,
     ) -> None:
         self.plugin_name = plugin_name
         self._plugin_dir = Path(plugin_dir)
@@ -70,6 +75,7 @@ class SandboxSupervisor:
         self._stopping = False
         self._disabled = False
         self._inflight: dict[str, CapabilityContext] = {}
+        self._inflight_sem = asyncio.Semaphore(max_inflight)
 
     @property
     def disabled(self) -> bool:
@@ -83,14 +89,28 @@ class SandboxSupervisor:
         self._supervise_task = asyncio.create_task(self._supervise())
 
     async def dispatch(
-        self, method: str, path: str, body: bytes, context: dict
+        self,
+        method: str,
+        path: str,
+        body: bytes,
+        context: dict,
+        *,
+        query: "dict | None" = None,
+        headers: "dict | None" = None,
+        timeout: float = 30.0,
     ) -> dict:
-        """Proxy one HTTP request into the worker and return its response body."""
+        """Proxy one HTTP request into the worker and return its response dict.
+
+        ``headers`` must already be allowlist-filtered by the caller — this
+        method forwards them verbatim and never adds Authorization/Cookie.
+        """
         if self._disabled:
             raise SupervisorError(f"plugin {self.plugin_name} is disabled")
         channel = self._channel
         if channel is None:
             raise SupervisorError(f"plugin {self.plugin_name} is not running")
+        if self._inflight_sem.locked():
+            raise SupervisorError(f"plugin {self.plugin_name}: too many in-flight requests")
         request_id = secrets.token_hex(16)
         self._inflight[request_id] = CapabilityContext(
             user_id=context["user_id"],
@@ -102,19 +122,27 @@ class SandboxSupervisor:
             "username": context["username"],
             "role": context["role"],
         }
-        try:
-            resp = await channel.call(
-                MsgType.HTTP_REQUEST,
-                {
-                    "request_id": request_id,
-                    "method": method,
-                    "path": path,
-                    "body": body,
-                    "context": worker_context,
-                },
-            )
-        finally:
-            self._inflight.pop(request_id, None)
+        async with self._inflight_sem:
+            try:
+                resp = await channel.call(
+                    MsgType.HTTP_REQUEST,
+                    {
+                        "request_id": request_id,
+                        "method": method,
+                        "path": path,
+                        "query": query or {},
+                        "headers": headers or {},
+                        "body": body,
+                        "context": worker_context,
+                    },
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError as exc:
+                raise SupervisorTimeout(
+                    f"plugin {self.plugin_name} request timed out"
+                ) from exc
+            finally:
+                self._inflight.pop(request_id, None)
         return resp.body
 
     async def health(self) -> bool:

--- a/backend/app/plugins/sandbox/supervisor.py
+++ b/backend/app/plugins/sandbox/supervisor.py
@@ -112,17 +112,17 @@ class SandboxSupervisor:
         if self._inflight_sem.locked():
             raise SupervisorError(f"plugin {self.plugin_name}: too many in-flight requests")
         request_id = secrets.token_hex(16)
-        self._inflight[request_id] = CapabilityContext(
-            user_id=context["user_id"],
-            username=context["username"],
-            role=context["role"],
-        )
         worker_context = {
             "user_id": context["user_id"],
             "username": context["username"],
             "role": context["role"],
         }
         async with self._inflight_sem:
+            self._inflight[request_id] = CapabilityContext(
+                user_id=context["user_id"],
+                username=context["username"],
+                role=context["role"],
+            )
             try:
                 resp = await channel.call(
                     MsgType.HTTP_REQUEST,

--- a/backend/app/plugins/sandbox/transport.py
+++ b/backend/app/plugins/sandbox/transport.py
@@ -10,6 +10,7 @@ that an RpcChannel wraps; the channel itself is transport-agnostic.
 """
 import asyncio
 import os
+import secrets
 import sys
 from pathlib import Path
 from typing import Optional, Tuple
@@ -45,7 +46,7 @@ class WorkerListener:
                 writer.close()
 
         if _use_unix_socket():
-            path = str(self._socket_dir / "plugin.sock")
+            path = str(self._socket_dir / f"plugin-{os.getpid()}-{secrets.token_hex(4)}.sock")
             # Stale socket file from a crashed prior worker would block bind.
             try:
                 os.unlink(path)

--- a/backend/tests/plugins/sandbox/fixtures/e2e_plugin/__init__.py
+++ b/backend/tests/plugins/sandbox/fixtures/e2e_plugin/__init__.py
@@ -1,4 +1,4 @@
-"""E2E fixture: a route that reads+writes storage and returns it."""
+"""E2E fixture: routes that exercise storage, core.system_metrics, and denied scope."""
 
 
 def register(host):
@@ -7,3 +7,13 @@ def register(host):
         await host.storage.set("last", request["body"])
         value = await host.storage.get("last")
         return {"status": 200, "body": {"stored": value, "user": request["user"]}}
+
+    @host.route("GET", "metrics")
+    async def get_metrics(request):
+        return {"status": 200, "body": await host.scopes.system_metrics()}
+
+    @host.route("GET", "forbidden")
+    async def forbidden(request):
+        # 'core.notify' scope is NOT granted — this should be denied by the host
+        await host.scopes.notify("x", "y")
+        return {"status": 200}

--- a/backend/tests/plugins/sandbox/fixtures/e2e_plugin/__init__.py
+++ b/backend/tests/plugins/sandbox/fixtures/e2e_plugin/__init__.py
@@ -1,0 +1,9 @@
+"""E2E fixture: a route that reads+writes storage and returns it."""
+
+
+def register(host):
+    @host.route("POST", "echo")
+    async def echo(request):
+        await host.storage.set("last", request["body"])
+        value = await host.storage.get("last")
+        return {"status": 200, "body": {"stored": value, "user": request["user"]}}

--- a/backend/tests/plugins/sandbox/fixtures/e2e_plugin/plugin.json
+++ b/backend/tests/plugins/sandbox/fixtures/e2e_plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "manifest_version": 1,
+  "name": "e2e_plugin",
+  "version": "1.0.0",
+  "display_name": "E2E Plugin",
+  "description": "phase 4 e2e fixture",
+  "author": "tests",
+  "api_scopes": ["storage"],
+  "entrypoint": "__init__.py"
+}

--- a/backend/tests/plugins/sandbox/fixtures/e2e_plugin/plugin.json
+++ b/backend/tests/plugins/sandbox/fixtures/e2e_plugin/plugin.json
@@ -5,6 +5,6 @@
   "display_name": "E2E Plugin",
   "description": "phase 4 e2e fixture",
   "author": "tests",
-  "api_scopes": ["storage"],
+  "api_scopes": ["storage", "core.system_metrics"],
   "entrypoint": "__init__.py"
 }

--- a/backend/tests/plugins/sandbox/test_host_capabilities.py
+++ b/backend/tests/plugins/sandbox/test_host_capabilities.py
@@ -1,5 +1,6 @@
 """Phase 4: production-wired CapabilityRouter factory."""
 import asyncio
+from unittest.mock import AsyncMock
 
 from app.plugins.sandbox.capabilities import CapabilityContext, CapabilityRouter
 from app.plugins.sandbox.host_capabilities import build_capability_router
@@ -29,3 +30,49 @@ def test_metrics_reader_projects_telemetry(monkeypatch):
     ctx = CapabilityContext(user_id=1, username="u", role="user")
     result = asyncio.run(router.dispatch("core.system_metrics", {}, ctx))
     assert result == {"result": {"cpu_usage": 12.5, "memory_percent": 40.0}}
+
+
+def test_notifier_uses_injected_session_factory_and_targets_user(monkeypatch):
+    """Verify that notifier uses injected session_factory and targets acting user."""
+    import app.plugins.sandbox.host_capabilities as hc
+
+    # Record what the notification service's create method receives
+    recorded_kwargs = {}
+
+    async def stub_create(db, **kwargs):
+        recorded_kwargs.update(kwargs)
+
+    stub_service = AsyncMock()
+    stub_service.create = stub_create
+
+    # Stub get_notification_service to return our stub
+    monkeypatch.setattr(hc, "get_notification_service", lambda: stub_service)
+
+    # Stub SessionLocal to be a context manager that does nothing (no DB access)
+    class FakeSessionContext:
+        def __enter__(self):
+            return None  # db session object (unused by stub)
+
+        def __exit__(self, *args):
+            pass
+
+    monkeypatch.setattr(hc, "SessionLocal", lambda: FakeSessionContext())
+
+    # Build router with core.notify scope
+    router = build_capability_router("test-plugin", {"core.notify"})
+
+    # Dispatch core.notify with user_id=99
+    ctx = CapabilityContext(user_id=99, username="testuser", role="user")
+    payload = {"type": "info", "title": "Test Title", "message": "Test Message"}
+
+    result = asyncio.run(router.dispatch("core.notify", payload, ctx))
+
+    # Verify the dispatch succeeded
+    assert "error" not in result, f"dispatch failed with error: {result.get('error')}"
+
+    # Verify the notifier recorded the correct user_id
+    assert recorded_kwargs.get("user_id") == 99
+    assert recorded_kwargs.get("category") == "plugin"
+    assert recorded_kwargs.get("notification_type") == "info"
+    assert recorded_kwargs.get("title") == "Test Title"
+    assert recorded_kwargs.get("message") == "Test Message"

--- a/backend/tests/plugins/sandbox/test_host_capabilities.py
+++ b/backend/tests/plugins/sandbox/test_host_capabilities.py
@@ -1,0 +1,31 @@
+"""Phase 4: production-wired CapabilityRouter factory."""
+import asyncio
+
+from app.plugins.sandbox.capabilities import CapabilityContext, CapabilityRouter
+from app.plugins.sandbox.host_capabilities import build_capability_router
+
+
+def test_build_returns_capability_router_with_filtered_scopes():
+    router = build_capability_router("weather", {"storage", "core.notify", "bogus"})
+    assert isinstance(router, CapabilityRouter)
+    # Unknown scope strings are dropped; known ones survive.
+    assert router._granted_scopes == frozenset({"storage", "core.notify"})
+
+
+def test_metrics_reader_projects_telemetry(monkeypatch):
+    import app.plugins.sandbox.host_capabilities as hc
+
+    # Stub with the REAL telemetry SHM shape (latest_cpu_usage + latest_memory_sample.percent).
+    monkeypatch.setattr(
+        hc,
+        "read_shm",
+        lambda *_a, **_k: {
+            "latest_cpu_usage": 12.5,
+            "latest_memory_sample": {"percent": 40.0, "used": 1, "total": 2},
+            "cpu": [],
+        },
+    )
+    router = build_capability_router("weather", {"core.system_metrics"})
+    ctx = CapabilityContext(user_id=1, username="u", role="user")
+    result = asyncio.run(router.dispatch("core.system_metrics", {}, ctx))
+    assert result == {"result": {"cpu_usage": 12.5, "memory_percent": 40.0}}

--- a/backend/tests/plugins/sandbox/test_phase4_e2e.py
+++ b/backend/tests/plugins/sandbox/test_phase4_e2e.py
@@ -1,0 +1,43 @@
+"""Phase 4 E2E: external plugin through supervisor.dispatch -> RPC -> capability."""
+import asyncio
+from pathlib import Path
+
+import msgpack
+import pytest
+
+from app.plugins.sandbox.host_capabilities import build_capability_router
+from app.plugins.sandbox.supervisor import SandboxSupervisor
+
+FIXTURE = Path(__file__).parent / "fixtures" / "e2e_plugin"
+
+
+@pytest.mark.timeout(30)
+def test_external_plugin_storage_roundtrip(monkeypatch):
+    # Stub the storage capability's DB so the test needs no real database.
+    import app.plugins.sandbox.capabilities as caps
+
+    store: dict = {}
+
+    def fake_get(db, plugin, uid, key):
+        k = (plugin, uid, key)
+        return (k in store, store.get(k))
+
+    def fake_set(db, plugin, uid, key, value):
+        store[(plugin, uid, key)] = value
+
+    monkeypatch.setattr(caps.plugin_storage_service, "get_value", fake_get)
+    monkeypatch.setattr(caps.plugin_storage_service, "set_value", fake_set)
+
+    async def run():
+        router = build_capability_router("e2e_plugin", {"storage"})
+        sup = SandboxSupervisor("e2e_plugin", FIXTURE, capability_router=router)
+        await sup.start()
+        try:
+            ctx = {"user_id": 42, "username": "alice", "role": "user"}
+            resp = await sup.dispatch("POST", "echo", msgpack.packb({"hi": 1}), ctx)
+            assert resp["status"] == 200
+            assert resp["body"]["user"]["user_id"] == 42
+        finally:
+            await sup.stop()
+
+    asyncio.run(run())

--- a/backend/tests/plugins/sandbox/test_phase4_e2e.py
+++ b/backend/tests/plugins/sandbox/test_phase4_e2e.py
@@ -1,21 +1,33 @@
-"""Phase 4 E2E: external plugin through supervisor.dispatch -> RPC -> capability."""
+"""Phase 4 E2E: external plugin through supervisor.dispatch -> RPC -> capability.
+
+Covers:
+- Storage user-binding: stored value is keyed to host-resolved user_id=42, not
+  anything the plugin controls.
+- core.system_metrics (granted): GET metrics -> projected cpu_usage from a
+  monkeypatched read_shm snapshot.
+- Denied scope (core.notify NOT granted): GET forbidden -> worker returns 500.
+"""
 import asyncio
 from pathlib import Path
 
 import msgpack
 import pytest
 
+import app.plugins.sandbox.capabilities as caps
+import app.plugins.sandbox.host_capabilities as host_caps
 from app.plugins.sandbox.host_capabilities import build_capability_router
 from app.plugins.sandbox.supervisor import SandboxSupervisor
 
 FIXTURE = Path(__file__).parent / "fixtures" / "e2e_plugin"
 
+CTX = {"user_id": 42, "username": "alice", "role": "user"}
+
 
 @pytest.mark.timeout(30)
-def test_external_plugin_storage_roundtrip(monkeypatch):
-    # Stub the storage capability's DB so the test needs no real database.
-    import app.plugins.sandbox.capabilities as caps
-
+def test_external_plugin_storage_and_metrics(monkeypatch):
+    """POST echo stores+echoes value bound to host user_id=42; GET metrics returns
+    injected snapshot with cpu_usage=9.0.
+    """
     store: dict = {}
 
     def fake_get(db, plugin, uid, key):
@@ -27,16 +39,54 @@ def test_external_plugin_storage_roundtrip(monkeypatch):
 
     monkeypatch.setattr(caps.plugin_storage_service, "get_value", fake_get)
     monkeypatch.setattr(caps.plugin_storage_service, "set_value", fake_set)
+    monkeypatch.setattr(
+        host_caps,
+        "read_shm",
+        lambda _path: {
+            "latest_cpu_usage": 9.0,
+            "latest_memory_sample": {"percent": 40.0},
+        },
+    )
 
     async def run():
-        router = build_capability_router("e2e_plugin", {"storage"})
+        router = build_capability_router("e2e_plugin", {"storage", "core.system_metrics"})
         sup = SandboxSupervisor("e2e_plugin", FIXTURE, capability_router=router)
         await sup.start()
         try:
-            ctx = {"user_id": 42, "username": "alice", "role": "user"}
-            resp = await sup.dispatch("POST", "echo", msgpack.packb({"hi": 1}), ctx)
+            body_bytes = msgpack.packb({"hi": 1})
+
+            # --- storage: user-binding -----------------------------------------
+            resp = await sup.dispatch("POST", "echo", body_bytes, CTX)
             assert resp["status"] == 200
             assert resp["body"]["user"]["user_id"] == 42
+            # Store key is bound to the HOST-resolved user_id (42), not the plugin.
+            assert store[("e2e_plugin", 42, "last")] == body_bytes
+            assert resp["body"]["stored"] == body_bytes
+
+            # --- core.system_metrics (granted) ---------------------------------
+            metrics_resp = await sup.dispatch("GET", "metrics", b"", CTX)
+            assert metrics_resp["status"] == 200
+            assert metrics_resp["body"]["cpu_usage"] == 9.0
+        finally:
+            await sup.stop()
+
+    asyncio.run(run())
+
+
+@pytest.mark.timeout(30)
+def test_external_plugin_denied_scope(monkeypatch):
+    """GET forbidden calls un-granted core.notify -> PluginCapabilityError in the
+    worker -> 500 response. core.notify is NOT in the router's granted_scopes.
+    """
+    async def run():
+        # core.notify deliberately absent from granted scopes
+        router = build_capability_router("e2e_plugin", {"storage", "core.system_metrics"})
+        sup = SandboxSupervisor("e2e_plugin", FIXTURE, capability_router=router)
+        await sup.start()
+        try:
+            resp = await sup.dispatch("GET", "forbidden", b"", CTX)
+            # PluginCapabilityError("denied") in the plugin -> 500
+            assert resp["status"] == 500
         finally:
             await sup.stop()
 

--- a/backend/tests/plugins/sandbox/test_proxy.py
+++ b/backend/tests/plugins/sandbox/test_proxy.py
@@ -1,0 +1,92 @@
+"""Phase 4: catch-all proxy — auth gating, header allowlist, error scrubbing."""
+import asyncio
+import types
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.plugins.sandbox import proxy
+from app.plugins.sandbox.supervisor import SupervisorError, SupervisorTimeout
+
+
+def _make_request(method="GET", headers=None, body=b"", query=b""):
+    hdrs = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http", "method": method, "path": "/api/plugins/weather/status",
+        "query_string": query, "headers": hdrs,
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+class _Sup:
+    def __init__(self, **kw):
+        self.kw = None
+        self._resp = kw.get("resp", {"status": 200, "headers": {"content-type": "application/json"}, "body": {"ok": True}})
+        self._raise = kw.get("raise_exc")
+
+    async def dispatch(self, method, path, body, context, *, query=None, headers=None, timeout=30.0):
+        if self._raise:
+            raise self._raise
+        self.kw = dict(method=method, path=path, body=body, context=context, query=query, headers=headers)
+        return self._resp
+
+
+class _Mgr:
+    def __init__(self, sup):
+        self._sup = sup
+
+    def get_sandbox(self, name):
+        return self._sup
+
+
+_USER = types.SimpleNamespace(id=7, username="alice", role="user")
+
+
+def test_proxy_forwards_without_token_headers():
+    sup = _Sup()
+    req = _make_request(headers={"authorization": "Bearer x", "cookie": "s=1", "content-type": "application/json"}, query=b"a=1")
+    resp = asyncio.run(proxy.proxy_request("weather", "status", req, _USER, _Mgr(sup)))
+    assert resp.status_code == 200
+    assert "authorization" not in sup.kw["headers"]
+    assert "cookie" not in sup.kw["headers"]
+    assert sup.kw["headers"] == {"content-type": "application/json"}
+    assert sup.kw["query"] == {"a": "1"}
+    assert sup.kw["context"] == {"user_id": 7, "username": "alice", "role": "user"}
+
+
+def test_proxy_unknown_plugin_404():
+    class _Empty:
+        def get_sandbox(self, name):
+            return None
+
+    req = _make_request()
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(proxy.proxy_request("nope", "x", req, _USER, _Empty()))
+    assert ei.value.status_code == 404
+
+
+def test_proxy_body_too_large_413():
+    req = _make_request(method="POST", body=b"x" * (proxy.REQUEST_BODY_MAX + 1))
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(proxy.proxy_request("weather", "x", req, _USER, _Mgr(_Sup())))
+    assert ei.value.status_code == 413
+
+
+def test_proxy_timeout_504():
+    req = _make_request()
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(proxy.proxy_request("weather", "x", req, _USER, _Mgr(_Sup(raise_exc=SupervisorTimeout("t")))))
+    assert ei.value.status_code == 504
+
+
+def test_proxy_crash_scrubbed_502():
+    req = _make_request()
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(proxy.proxy_request("weather", "x", req, _USER, _Mgr(_Sup(raise_exc=SupervisorError("boom")))))
+    assert ei.value.status_code == 502
+    assert "boom" not in str(ei.value.detail)

--- a/backend/tests/plugins/sandbox/test_proxy.py
+++ b/backend/tests/plugins/sandbox/test_proxy.py
@@ -90,3 +90,21 @@ def test_proxy_crash_scrubbed_502():
         asyncio.run(proxy.proxy_request("weather", "x", req, _USER, _Mgr(_Sup(raise_exc=SupervisorError("boom")))))
     assert ei.value.status_code == 502
     assert "boom" not in str(ei.value.detail)
+
+
+def test_proxy_content_length_precheck_413():
+    """Verify Content-Length precheck rejects before buffering."""
+    headers = {"content-length": str(proxy.REQUEST_BODY_MAX + 1)}
+    req = _make_request(method="POST", headers=headers, body=b"")
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(proxy.proxy_request("weather", "x", req, _USER, _Mgr(_Sup())))
+    assert ei.value.status_code == 413
+
+
+def test_proxy_bare_exception_scrubbed_502():
+    """Verify bare Exception (not SupervisorError) is scrubbed without leaking details."""
+    req = _make_request()
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(proxy.proxy_request("weather", "x", req, _USER, _Mgr(_Sup(raise_exc=RuntimeError("internal secret detail")))))
+    assert ei.value.status_code == 502
+    assert "secret" not in str(ei.value.detail).lower()

--- a/backend/tests/plugins/sandbox/test_supervisor.py
+++ b/backend/tests/plugins/sandbox/test_supervisor.py
@@ -402,3 +402,48 @@ def test_dispatch_timeout_raises_supervisor_timeout():
     sup = _supervisor_with_channel(_SlowChannel())
     with pytest.raises(SupervisorTimeout):
         asyncio.run(sup.dispatch("GET", "x", b"", {"user_id": 1, "username": "u", "role": "user"}, timeout=0.01))
+
+
+async def test_dispatch_cap_exceeded_raises_supervisor_error():
+    """When max_inflight capacity is reached, a new dispatch raises SupervisorError."""
+    # Create supervisor with max_inflight=1
+    sup = SandboxSupervisor("weather", ".", max_inflight=1)
+
+    # Block the channel indefinitely
+    blocking_event = asyncio.Event()
+
+    class _BlockingChannel:
+        async def call(self, msg_type, body, timeout=None):
+            await blocking_event.wait()
+            return Message(id="x", type=MsgType.HTTP_RESPONSE, body={"status": 200, "headers": {}, "body": {"ok": True}})
+
+    sup._channel = _BlockingChannel()
+    ctx = {"user_id": 1, "username": "u", "role": "user"}
+
+    # Start the first dispatch in a task (blocks on channel.call inside the async with)
+    blocking_task = asyncio.create_task(sup.dispatch("GET", "x", b"", ctx))
+
+    # Yield control so the first dispatch acquires the semaphore
+    await asyncio.sleep(0)
+
+    # Now the second dispatch should fail because the semaphore is locked
+    with pytest.raises(SupervisorError, match="too many in-flight"):
+        await sup.dispatch("GET", "y", b"", ctx)
+
+    # Clean up the blocking task
+    blocking_task.cancel()
+    try:
+        await blocking_task
+    except asyncio.CancelledError:
+        pass
+
+
+def test_dispatch_with_headers_none_forwards_empty_headers():
+    """When dispatch(..., headers=None) is called, the forwarded headers is {} with no auth/cookie."""
+    channel = _FakeChannel()
+    sup = _supervisor_with_channel(channel)
+    ctx = {"user_id": 1, "username": "u", "role": "user"}
+    asyncio.run(sup.dispatch("GET", "status", b"", ctx, headers=None))
+    assert channel.last_body["headers"] == {}
+    assert "authorization" not in channel.last_body["headers"]
+    assert "cookie" not in channel.last_body["headers"]

--- a/backend/tests/plugins/sandbox/test_supervisor.py
+++ b/backend/tests/plugins/sandbox/test_supervisor.py
@@ -7,10 +7,11 @@ from pathlib import Path
 
 import pytest
 
-from app.plugins.sandbox.protocol import MsgType
+from app.plugins.sandbox.protocol import Message, MsgType
 from app.plugins.sandbox.supervisor import (
     SandboxSupervisor,
     SupervisorError,
+    SupervisorTimeout,
     _default_spawn as _default_spawn_passthrough,
 )
 
@@ -358,3 +359,46 @@ async def test_cap_call_roundtrips_with_host_resolved_context(tmp_path):
             await supervisor.stop()
     finally:
         caps.plugin_storage_service = caps_orig
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — query + headers forwarding, timeout, in-flight cap
+# ---------------------------------------------------------------------------
+
+class _FakeChannel:
+    """Records the last HTTP_REQUEST body; returns a canned response."""
+
+    def __init__(self):
+        self.last_body = None
+
+    async def call(self, msg_type, body, timeout=None):
+        self.last_body = body
+        return Message(id="x", type=MsgType.HTTP_RESPONSE, body={"status": 200, "headers": {}, "body": {"ok": True}})
+
+
+def _supervisor_with_channel(channel):
+    sup = SandboxSupervisor("weather", ".")
+    sup._channel = channel
+    return sup
+
+
+def test_dispatch_forwards_query_and_headers():
+    channel = _FakeChannel()
+    sup = _supervisor_with_channel(channel)
+    ctx = {"user_id": 1, "username": "u", "role": "user"}
+    asyncio.run(
+        sup.dispatch("GET", "status", b"", ctx, query={"a": "1"}, headers={"content-type": "application/json"})
+    )
+    assert channel.last_body["query"] == {"a": "1"}
+    assert channel.last_body["headers"] == {"content-type": "application/json"}
+    assert "authorization" not in channel.last_body["headers"]
+
+
+def test_dispatch_timeout_raises_supervisor_timeout():
+    class _SlowChannel:
+        async def call(self, msg_type, body, timeout=None):
+            raise asyncio.TimeoutError
+
+    sup = _supervisor_with_channel(_SlowChannel())
+    with pytest.raises(SupervisorTimeout):
+        asyncio.run(sup.dispatch("GET", "x", b"", {"user_id": 1, "username": "u", "role": "user"}, timeout=0.01))

--- a/backend/tests/plugins/sandbox/test_transport.py
+++ b/backend/tests/plugins/sandbox/test_transport.py
@@ -48,3 +48,23 @@ async def test_accept_roundtrip_carries_a_frame(tmp_path):
 async def test_connect_to_host_rejects_unknown_scheme():
     with pytest.raises(ValueError):
         await connect_to_host("carrierpigeon:/nope")
+
+
+@pytest.mark.skipif(not _use_unix_socket(), reason="UDS only (Linux/macOS)")
+def test_two_listeners_same_dir_get_distinct_sockets(tmp_path):
+    """Two WorkerListeners on the same plugin dir must not share a socket path."""
+    import asyncio
+
+    async def run():
+        a = WorkerListener(tmp_path)
+        b = WorkerListener(tmp_path)
+        addr_a = await a.start()
+        addr_b = await b.start()
+        try:
+            assert addr_a != addr_b
+            assert addr_a.startswith("unix:") and addr_b.startswith("unix:")
+        finally:
+            await a.close()
+            await b.close()
+
+    asyncio.run(run())

--- a/backend/tests/plugins/test_external_plugin_routes.py
+++ b/backend/tests/plugins/test_external_plugin_routes.py
@@ -1,0 +1,119 @@
+"""Phase 4: toggling / details / list for external plugins use the manifest path (no exec)."""
+import asyncio
+import types
+
+from starlette.requests import Request as StarletteRequest
+from starlette.responses import Response as StarletteResponse
+
+from app.api.routes import plugins as plugins_route
+from app.core.rate_limiter import user_limiter
+from app.plugins.manager import DiscoveredPlugin, PluginManager
+
+
+def _make_mock_request(method: str = "POST", path: str = "/api/plugins/weather/toggle") -> StarletteRequest:
+    """Return a minimal starlette Request that satisfies slowapi's isinstance check."""
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 8080),
+    }
+    return StarletteRequest(scope)
+
+
+def _make_mock_response() -> StarletteResponse:
+    """Return a minimal starlette Response that satisfies slowapi's header-injection check."""
+    return StarletteResponse()
+
+
+def test_toggle_enable_external_uses_manifest(tmp_path, db_session, monkeypatch):
+    PluginManager.reset_instance()
+    mgr = PluginManager(plugins_dir=tmp_path)
+    pdir = tmp_path / "weather"
+    pdir.mkdir()
+
+    class _M:
+        api_scopes = ["storage"]
+        version = "2.0.0"
+        display_name = "Weather"
+        required_permissions = []
+
+    mgr._discovered = {
+        "weather": DiscoveredPlugin(name="weather", path=pdir, source="external", manifest=_M()),
+    }
+
+    enabled = {}
+
+    async def fake_enable(name, perms, db, start_background_tasks=True, granted_api_scopes=None):
+        enabled["scopes"] = granted_api_scopes
+        return True
+
+    monkeypatch.setattr(mgr, "enable_plugin", fake_enable)
+
+    body = plugins_route.PluginToggleRequest(enabled=True, grant_permissions=[])
+    user = types.SimpleNamespace(id=1, username="admin", role="admin")
+    resp = asyncio.run(
+        plugins_route.toggle_plugin(
+            request=_make_mock_request(), response=_make_mock_response(), name="weather", body=body,
+            db=db_session, current_user=user, plugin_manager=mgr,
+        )
+    )
+    assert resp.is_enabled is True
+    assert enabled["scopes"] == ["storage"]
+
+
+def test_get_plugin_details_external_uses_manifest_no_exec(tmp_path, db_session, monkeypatch):
+    """get_plugin_details for external+manifest plugin returns manifest data, never calls load_plugin."""
+    PluginManager.reset_instance()
+    mgr = PluginManager(plugins_dir=tmp_path)
+    pdir = tmp_path / "weather"
+    pdir.mkdir()
+
+    class _M:
+        name = "weather"
+        version = "2.0.0"
+        display_name = "Weather Plugin"
+        description = "Shows current weather"
+        author = "Tester"
+        category = "tools"
+        homepage = None
+        min_baluhost_version = None
+        plugin_dependencies = []
+        required_permissions = []
+        api_scopes = ["storage"]
+        ui = None
+
+    mgr._discovered = {
+        "weather": DiscoveredPlugin(name="weather", path=pdir, source="external", manifest=_M()),
+    }
+
+    # Verify load_plugin is never invoked (exec-guard)
+    def _no_exec(name):
+        raise AssertionError("load_plugin must NOT be called for external+manifest plugins")
+
+    monkeypatch.setattr(mgr, "load_plugin", _no_exec)
+
+    # No DB record
+    monkeypatch.setattr(plugins_route.plugin_service, "get_installed_plugin", lambda db, name: None)
+
+    user = types.SimpleNamespace(id=1, username="admin", role="admin")
+    result = asyncio.run(
+        plugins_route.get_plugin_details(
+            request=_make_mock_request("GET", "/api/plugins/weather"),
+            response=_make_mock_response(),
+            name="weather",
+            db=db_session, current_user=user, plugin_manager=mgr,
+        )
+    )
+    assert result.name == "weather"
+    assert result.version == "2.0.0"
+    assert result.display_name == "Weather Plugin"
+    assert result.is_enabled is False
+    assert result.is_installed is False
+    assert result.has_background_tasks is False
+    assert result.has_dashboard_panel is False
+    assert result.has_ui is False  # manifest.ui is None
+    assert result.nav_items == []
+    assert result.config == {}

--- a/backend/tests/plugins/test_external_plugin_routes.py
+++ b/backend/tests/plugins/test_external_plugin_routes.py
@@ -64,6 +64,44 @@ def test_toggle_enable_external_uses_manifest(tmp_path, db_session, monkeypatch)
     assert enabled["scopes"] == ["storage"]
 
 
+def test_toggle_disable_external_uses_manifest(tmp_path, db_session, monkeypatch):
+    PluginManager.reset_instance()
+    mgr = PluginManager(plugins_dir=tmp_path)
+    pdir = tmp_path / "weather"
+    pdir.mkdir()
+
+    class _M:
+        api_scopes = ["storage"]
+        version = "2.0.0"
+        display_name = "Weather"
+        required_permissions = []
+
+    mgr._discovered = {
+        "weather": DiscoveredPlugin(name="weather", path=pdir, source="external", manifest=_M()),
+    }
+
+    disabled = {}
+
+    async def fake_disable(name):
+        disabled["called"] = True
+        disabled["name"] = name
+        return True
+
+    monkeypatch.setattr(mgr, "disable_plugin", fake_disable)
+
+    body = plugins_route.PluginToggleRequest(enabled=False, grant_permissions=[])
+    user = types.SimpleNamespace(id=1, username="admin", role="admin")
+    resp = asyncio.run(
+        plugins_route.toggle_plugin(
+            request=_make_mock_request(), response=_make_mock_response(), name="weather", body=body,
+            db=db_session, current_user=user, plugin_manager=mgr,
+        )
+    )
+    assert resp.is_enabled is False
+    assert disabled.get("called") is True
+    assert disabled.get("name") == "weather"
+
+
 def test_get_plugin_details_external_uses_manifest_no_exec(tmp_path, db_session, monkeypatch):
     """get_plugin_details for external+manifest plugin returns manifest data, never calls load_plugin."""
     PluginManager.reset_instance()

--- a/backend/tests/plugins/test_plugin_manager_dualpath.py
+++ b/backend/tests/plugins/test_plugin_manager_dualpath.py
@@ -27,7 +27,8 @@ def manager(tmp_path, monkeypatch):
     # Pretend an external plugin "weather" was discovered with a parsed manifest.
     plugin_dir = tmp_path / "weather"
     plugin_dir.mkdir()
-    (plugin_dir / "__init__.py").write_text("raise RuntimeError('must never exec in host')\n")
+    # Benign module — guard (not plugin code) must be what raises PluginLoadError.
+    (plugin_dir / "__init__.py").write_text("# valid module, must never be exec'd in host\n")
 
     class _M:
         api_scopes = ["storage", "core.notify"]

--- a/backend/tests/plugins/test_plugin_manager_dualpath.py
+++ b/backend/tests/plugins/test_plugin_manager_dualpath.py
@@ -1,0 +1,68 @@
+"""Phase 4: PluginManager external dual-path (no exec_module in host)."""
+import asyncio
+
+import pytest
+
+from app.plugins.manager import DiscoveredPlugin, PluginLoadError, PluginManager
+
+
+class _FakeSupervisor:
+    def __init__(self, plugin_name, plugin_dir, capability_router=None):
+        self.plugin_name = plugin_name
+        self.started = False
+        self.stopped = False
+        self.capability_router = capability_router
+
+    async def start(self):
+        self.started = True
+
+    async def stop(self):
+        self.stopped = True
+
+
+@pytest.fixture
+def manager(tmp_path, monkeypatch):
+    PluginManager.reset_instance()
+    mgr = PluginManager(plugins_dir=tmp_path)
+    # Pretend an external plugin "weather" was discovered with a parsed manifest.
+    plugin_dir = tmp_path / "weather"
+    plugin_dir.mkdir()
+    (plugin_dir / "__init__.py").write_text("raise RuntimeError('must never exec in host')\n")
+
+    class _M:
+        api_scopes = ["storage", "core.notify"]
+        version = "1.0.0"
+        display_name = "Weather"
+
+    mgr._discovered = {
+        "weather": DiscoveredPlugin(name="weather", path=plugin_dir, source="external", manifest=_M()),
+    }
+    mgr._supervisor_factory = _FakeSupervisor
+    return mgr
+
+
+def test_load_plugin_external_refuses_to_exec(manager):
+    with pytest.raises(PluginLoadError):
+        manager.load_plugin("weather")
+
+
+def test_enable_external_spawns_supervisor_without_exec(manager):
+    ok = asyncio.run(
+        manager.enable_plugin("weather", [], db=None, granted_api_scopes=["storage", "core.notify"])
+    )
+    assert ok is True
+    sup = manager.get_sandbox("weather")
+    assert sup is not None and sup.started is True
+    assert sup.capability_router is not None
+    assert manager.is_enabled("weather") is True
+    # The external plugin was never instantiated in-process.
+    assert manager.get_plugin("weather") is None
+
+
+def test_disable_external_stops_supervisor(manager):
+    asyncio.run(manager.enable_plugin("weather", [], db=None, granted_api_scopes=["storage"]))
+    sup = manager.get_sandbox("weather")
+    asyncio.run(manager.disable_plugin("weather"))
+    assert sup.stopped is True
+    assert manager.is_enabled("weather") is False
+    assert manager.get_sandbox("weather") is None

--- a/backend/tests/plugins/test_plugin_manager_multipath.py
+++ b/backend/tests/plugins/test_plugin_manager_multipath.py
@@ -197,7 +197,9 @@ class TestExternalNamespace:
     ):
         ext = tmp_path / "ext"
         ext.mkdir()
-        _write_plugin(ext, "marketplace_demo")
+        # external+manifest now routes to the sandbox; use a manifest-less
+        # external to cover the in-process namespace mechanism.
+        _write_plugin(ext, "marketplace_demo", with_manifest=False)
 
         mgr = PluginManager(plugins_dirs=[ext])
         plugin = mgr.load_plugin("marketplace_demo")
@@ -231,7 +233,9 @@ class TestSitePackagesIsolation:
     def test_site_packages_prepended_to_sys_path_on_load(self, tmp_path: Path):
         ext = tmp_path / "ext"
         ext.mkdir()
-        plugin_dir = _write_plugin(ext, "with_deps")
+        # external+manifest now routes to the sandbox; use a manifest-less
+        # external to cover the in-process site-packages mechanism.
+        plugin_dir = _write_plugin(ext, "with_deps", with_manifest=False)
         site_pkg = plugin_dir / "site-packages"
         site_pkg.mkdir()
 
@@ -244,7 +248,9 @@ class TestSitePackagesIsolation:
     def test_no_site_packages_means_no_sys_path_change(self, tmp_path: Path):
         ext = tmp_path / "ext"
         ext.mkdir()
-        _write_plugin(ext, "no_deps")
+        # external+manifest now routes to the sandbox; use a manifest-less
+        # external to cover the in-process site-packages mechanism.
+        _write_plugin(ext, "no_deps", with_manifest=False)
         before = list(sys.path)
 
         mgr = PluginManager(plugins_dirs=[ext])

--- a/docs/superpowers/plans/2026-06-28-plugin-backend-isolation-phase4.md
+++ b/docs/superpowers/plans/2026-06-28-plugin-backend-isolation-phase4.md
@@ -26,6 +26,7 @@
 
 - **Create** `backend/app/plugins/sandbox/host_capabilities.py` — builds a production-wired `CapabilityRouter` (session factory, metrics reader, notifier, audit logger).
 - **Create** `backend/app/plugins/sandbox/proxy.py` — the catch-all proxy handler + caps + header allowlist + error scrubbing.
+- **Modify** `backend/app/plugins/sandbox/transport.py` — unique per-spawn UDS socket name so one subprocess per uvicorn worker does not collide on a shared socket path.
 - **Modify** `backend/app/plugins/sandbox/supervisor.py` — `dispatch()` forwards `query` + `headers`, honours a per-request timeout and a max-in-flight semaphore.
 - **Modify** `backend/app/plugins/manager.py` — `_sandboxes` registry, dual-path `enable_plugin`/`disable_plugin`/`shutdown_all`, `load_plugin(external)` guard, `granted_api_scopes` threading, catch-all wired into `get_router()`.
 - **Modify** `backend/app/api/routes/plugins.py` — toggle/details/list branch onto the manifest path for external (no `load_plugin` exec).
@@ -66,13 +67,20 @@ def test_build_returns_capability_router_with_filtered_scopes():
 def test_metrics_reader_projects_telemetry(monkeypatch):
     import app.plugins.sandbox.host_capabilities as hc
 
+    # Stub with the REAL telemetry SHM shape (latest_cpu_usage + latest_memory_sample.percent).
     monkeypatch.setattr(
-        hc, "read_shm", lambda *_a, **_k: {"cpu_percent": 12.5, "memory_percent": 40.0, "secret": "x"}
+        hc,
+        "read_shm",
+        lambda *_a, **_k: {
+            "latest_cpu_usage": 12.5,
+            "latest_memory_sample": {"percent": 40.0, "used": 1, "total": 2},
+            "cpu": [],
+        },
     )
     router = build_capability_router("weather", {"core.system_metrics"})
     ctx = CapabilityContext(user_id=1, username="u", role="user")
     result = asyncio.run(router.dispatch("core.system_metrics", {}, ctx))
-    assert result == {"result": {"cpu_percent": 12.5, "memory_percent": 40.0}}
+    assert result == {"result": {"cpu_usage": 12.5, "memory_percent": 40.0}}
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -112,14 +120,21 @@ logger = logging.getLogger(__name__)
 # plugin was granted that is not in here is silently dropped (defensive).
 KNOWN_SCOPES: frozenset[str] = frozenset(CAPABILITY_SCOPE.values())
 
-# Keys projected out of the telemetry SHM snapshot for core.system_metrics.
-_METRIC_KEYS = ("cpu_percent", "memory_percent")
-
-
 def _read_metrics() -> dict:
-    """Curated read-only system metrics from the monitoring SHM snapshot."""
+    """Curated read-only system metrics from the monitoring SHM snapshot.
+
+    The telemetry SHM (telemetry.py) exposes ``latest_cpu_usage`` and a
+    ``latest_memory_sample`` dict with a ``percent`` field — NOT top-level
+    ``cpu_percent``/``memory_percent``. Project a small, stable subset.
+    """
     snapshot = read_shm(TELEMETRY_FILE) or {}
-    return {k: snapshot[k] for k in _METRIC_KEYS if k in snapshot}
+    mem = snapshot.get("latest_memory_sample") or {}
+    out: dict = {}
+    if snapshot.get("latest_cpu_usage") is not None:
+        out["cpu_usage"] = snapshot["latest_cpu_usage"]
+    if isinstance(mem, dict) and mem.get("percent") is not None:
+        out["memory_percent"] = mem["percent"]
+    return out
 
 
 async def _notify(context: CapabilityContext, payload: dict) -> None:
@@ -328,6 +343,93 @@ Expected: PASS (all prior supervisor tests + the 2 new ones).
 ```bash
 git add backend/app/plugins/sandbox/supervisor.py backend/tests/plugins/sandbox/test_supervisor.py
 git commit -m "feat(plugin-sandbox): dispatch forwards query+headers, timeout + in-flight cap (Phase 4)"
+```
+
+---
+
+## Task 2b: Unique per-spawn worker socket path (prod-only collision fix)
+
+`WorkerListener` binds a **fixed** path `plugin_dir/plugin.sock` (`transport.py:48`).
+With one subprocess per uvicorn worker, the 4 prod workers each start a listener for
+the same plugin and collide on that path (unlink/rebind race → cross-wiring). Dev uses
+an ephemeral TCP port so this is **invisible in Windows tests but breaks Linux prod**.
+Fix: make the UDS socket filename unique per `WorkerListener` instance.
+
+**Files:**
+- Modify: `backend/app/plugins/sandbox/transport.py`
+- Test: `backend/tests/plugins/sandbox/test_transport.py` (append)
+
+**Interfaces:**
+- Produces: `WorkerListener(socket_dir)` now binds a unique `plugin-<pid>-<token>.sock`; `connect_address` still a `unix:<path>` / `tcp:<host>:<port>` string consumed unchanged by `connect_to_host`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to backend/tests/plugins/sandbox/test_transport.py
+import sys
+
+import pytest
+
+from app.plugins.sandbox.transport import WorkerListener, _use_unix_socket
+
+
+@pytest.mark.skipif(not _use_unix_socket(), reason="UDS only (Linux/macOS)")
+def test_two_listeners_same_dir_get_distinct_sockets(tmp_path):
+    """Two WorkerListeners on the same plugin dir must not share a socket path."""
+    import asyncio
+
+    async def run():
+        a = WorkerListener(tmp_path)
+        b = WorkerListener(tmp_path)
+        addr_a = await a.start()
+        addr_b = await b.start()
+        try:
+            assert addr_a != addr_b
+            assert addr_a.startswith("unix:") and addr_b.startswith("unix:")
+        finally:
+            await a.close()
+            await b.close()
+
+    asyncio.run(run())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/sandbox/test_transport.py -k distinct_sockets -v`
+Expected: FAIL on Linux/macOS (both bind `plugin.sock` → equal paths or bind error). On Windows it is skipped — run this task's verification on a Linux box or trust the code review.
+
+- [ ] **Step 3: Edit `transport.py` — unique socket name**
+
+Add the imports at the top (next to `import os`):
+
+```python
+import secrets
+```
+
+In `WorkerListener.start()`, replace the fixed-path line:
+
+```python
+            path = str(self._socket_dir / "plugin.sock")
+```
+
+with a per-instance unique name:
+
+```python
+            path = str(self._socket_dir / f"plugin-{os.getpid()}-{secrets.token_hex(4)}.sock")
+```
+
+The existing `os.unlink(path)` stale-cleanup stays (harmless for a fresh unique name). `close()` already stops the server; the unique file is cleaned on the next process restart via the dir lifecycle (no extra unlink needed — leftover empty socket files are inert).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/plugins/sandbox/test_transport.py -v`
+Expected: PASS (existing transport tests + the new distinct-socket test on UDS platforms).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/plugins/sandbox/transport.py backend/tests/plugins/sandbox/test_transport.py
+git commit -m "fix(plugin-sandbox): unique per-spawn UDS socket path (no collision across workers)"
 ```
 
 ---
@@ -735,6 +837,18 @@ async def proxy_request(
     if supervisor is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plugin not found")
 
+    # Reject oversized bodies BEFORE buffering them into memory. The
+    # Content-Length header can lie, so we also guard after the read.
+    declared = request.headers.get("content-length")
+    if declared is not None:
+        try:
+            if int(declared) > REQUEST_BODY_MAX:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail="Request body too large",
+                )
+        except ValueError:
+            pass  # malformed header — fall through to the post-read guard
     body = await request.body()
     if len(body) > REQUEST_BODY_MAX:
         raise HTTPException(
@@ -1155,16 +1269,21 @@ git commit -m "chore(plugin-sandbox): ruff clean-up for Phase 4"
 
 ---
 
-## Accepted limitation (document, do not fix here)
+## Accepted limitations & authoring constraints (document, do not fix here)
 
-Because each uvicorn worker owns its own subprocess and there is no cross-worker IPC, an external plugin **enabled at runtime** via the toggle route only spawns a worker on the uvicorn process that handled the toggle; the other workers serve it after the next restart (their startup `load_enabled_plugins` spawns it). This matches the existing bundled-plugin behaviour (runtime route changes need a restart). Lazy-spawn-on-first-request is a possible future enhancement, out of scope for Phase 4.
+- **Runtime-enable is per-worker.** Each uvicorn worker owns its own subprocess and there is no cross-worker IPC, so an external plugin **enabled at runtime** via the toggle route only spawns a worker on the uvicorn process that handled the toggle; the other workers serve it after the next restart (their startup `load_enabled_plugins` spawns it). This matches the existing bundled-plugin behaviour (runtime route changes need a restart).
+- **Idle process count = workers × external plugins.** With 4 workers and N external plugins, 4N subprocesses run idle. Acceptable for a home NAS with few plugins. **Lazy-spawn-on-first-request** (spawn in the catch-all handler when `get_sandbox(name)` is None but the DB says enabled) would remove idle processes and fix the per-worker runtime-enable gap — tracked as a future optimization, out of scope for Phase 4.
+- **Reserved top-level route names.** An external plugin cannot expose a root route named `toggle`, `config`, `ui`, or `dashboard-panel` (shadowed by the management routes in `routes/plugins.py`, registered before the catch-all), and no plugin may be named `marketplace` or `permissions` (`PluginGate._LIST_PATHS`). Surface this in the Phase 5 authoring docs.
+- **Multi-value query params collapse.** `dict(request.query_params)` keeps only the last value per key. Fine for v1; note in authoring docs.
+- **Raw request body.** The plugin receives the raw request bytes (no JSON-parsing convenience in the SDK). Deliberate for v1.
+- **Body-size DoS depends on the edge for truly-malicious clients.** The proxy rejects via `Content-Length` precheck then a post-read guard, but a client that streams a huge body while lying about (or omitting) `Content-Length` is only fully bounded by nginx `client_max_body_size`. Verify the prod nginx limit covers `/api/plugins/`.
 
 ## Self-Review Notes (coverage vs. spec)
 
 - Scope-storage → Task 1 (consume existing column; filter to known catalog) + Task 3/5 (thread `granted_api_scopes`). No migration (column exists).
 - Dual-path / no host exec → Task 3 (`load_plugin` guard, `_enable_external`) + Task 5 (routes).
 - core.* catalog (system_metrics + notify) → Task 1 wires both; `storage.*` via existing CapabilityRouter.
-- One subprocess per worker → Task 3 `_enable_external` (no primary-only gating) + accepted-limitation note.
+- One subprocess per worker → Task 2b (unique socket path, prevents cross-worker collision) + Task 3 `_enable_external` (no primary-only gating) + accepted-limitation note.
 - Proxy + header allowlist + caps + scrubbing → Task 4.
 - Token never forwarded → Task 4 (`ALLOWED_REQUEST_HEADERS`) + tests (positive assertion).
 - Capability deps wired → Task 1.

--- a/docs/superpowers/plans/2026-06-28-plugin-backend-isolation-phase4.md
+++ b/docs/superpowers/plans/2026-06-28-plugin-backend-isolation-phase4.md
@@ -44,7 +44,7 @@ Builds a `CapabilityRouter` with real host dependencies. The router itself (Phas
 
 **Interfaces:**
 - Consumes: `CapabilityRouter`, `CapabilityContext` from `app.plugins.sandbox.capabilities`; `SessionLocal` from `app.core.database`; `read_shm`, `TELEMETRY_FILE` from `app.services.monitoring.shm`; `get_notification_service` from `app.services.notifications.service`; `get_audit_logger_db` from `app.services.audit.logger_db`.
-- Produces: `build_capability_router(plugin_name: str, granted_scopes: "set[str] | frozenset[str]") -> CapabilityRouter`. Used by Task 3 (manager) when spawning an external plugin.
+- Produces: `build_capability_router(plugin_name: str, granted_scopes: "set[str] | frozenset[str]") -> CapabilityRouter`. Used by Task 4 (manager) when spawning an external plugin.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -347,7 +347,7 @@ git commit -m "feat(plugin-sandbox): dispatch forwards query+headers, timeout + 
 
 ---
 
-## Task 2b: Unique per-spawn worker socket path (prod-only collision fix)
+## Task 3: Unique per-spawn worker socket path (prod-only collision fix)
 
 `WorkerListener` binds a **fixed** path `plugin_dir/plugin.sock` (`transport.py:48`).
 With one subprocess per uvicorn worker, the 4 prod workers each start a listener for
@@ -434,7 +434,7 @@ git commit -m "fix(plugin-sandbox): unique per-spawn UDS socket path (no collisi
 
 ---
 
-## Task 3: PluginManager dual-path (external enable/disable, load_plugin guard, scope threading)
+## Task 4: PluginManager dual-path (external enable/disable, load_plugin guard, scope threading)
 
 **Files:**
 - Modify: `backend/app/plugins/manager.py`
@@ -663,7 +663,7 @@ git commit -m "feat(plugin-sandbox): PluginManager dual-path — external spawns
 
 ---
 
-## Task 4: Catch-all proxy route (auth, caps, header allowlist, error scrubbing)
+## Task 5: Catch-all proxy route (auth, caps, header allowlist, error scrubbing)
 
 **Files:**
 - Create: `backend/app/plugins/sandbox/proxy.py`
@@ -950,7 +950,7 @@ git commit -m "feat(plugin-sandbox): catch-all proxy route with caps + header al
 
 ---
 
-## Task 5: Toggle/details/list route dual-path for external plugins
+## Task 6: Toggle/details/list route dual-path for external plugins
 
 The toggle, details, and list routes currently call `load_plugin`/`get_plugin` which now raises for external. Branch them onto the manifest path (`DiscoveredPlugin.manifest`) so external plugins are manageable without exec.
 
@@ -1143,7 +1143,7 @@ git commit -m "feat(plugin-sandbox): route dual-path — manage external plugins
 
 ---
 
-## Task 6: End-to-end — sample external plugin through the full proxy→RPC→capability path
+## Task 7: End-to-end — sample external plugin through the full proxy→RPC→capability path
 
 A real subprocess test (mirrors `test_phase3_e2e.py`) proving an external plugin's own route + a `storage.*` call + a `core.*` call work, and a non-granted scope is denied.
 
@@ -1246,7 +1246,7 @@ git commit -m "test(plugin-sandbox): Phase 4 e2e — external plugin storage rou
 
 ---
 
-## Task 7: Full sandbox + plugin suite regression
+## Task 8: Full sandbox + plugin suite regression
 
 **Files:** none (verification only).
 
@@ -1280,11 +1280,11 @@ git commit -m "chore(plugin-sandbox): ruff clean-up for Phase 4"
 
 ## Self-Review Notes (coverage vs. spec)
 
-- Scope-storage → Task 1 (consume existing column; filter to known catalog) + Task 3/5 (thread `granted_api_scopes`). No migration (column exists).
-- Dual-path / no host exec → Task 3 (`load_plugin` guard, `_enable_external`) + Task 5 (routes).
+- Scope-storage → Task 1 (consume existing column; filter to known catalog) + Task 4/6 (thread `granted_api_scopes`). No migration (column exists).
+- Dual-path / no host exec → Task 4 (`load_plugin` guard, `_enable_external`) + Task 6 (routes).
 - core.* catalog (system_metrics + notify) → Task 1 wires both; `storage.*` via existing CapabilityRouter.
-- One subprocess per worker → Task 2b (unique socket path, prevents cross-worker collision) + Task 3 `_enable_external` (no primary-only gating) + accepted-limitation note.
-- Proxy + header allowlist + caps + scrubbing → Task 4.
-- Token never forwarded → Task 4 (`ALLOWED_REQUEST_HEADERS`) + tests (positive assertion).
+- One subprocess per worker → Task 3 (unique socket path, prevents cross-worker collision) + Task 4 `_enable_external` (no primary-only gating) + accepted-limitation note.
+- Proxy + header allowlist + caps + scrubbing → Task 5.
+- Token never forwarded → Task 5 (`ALLOWED_REQUEST_HEADERS`) + tests (positive assertion).
 - Capability deps wired → Task 1.
-- Testing matrix (dual-path, no-exec, proxy auth/headers/caps/scrub, scope enforcement, e2e) → Tasks 3,4,6.
+- Testing matrix (dual-path, no-exec, proxy auth/headers/caps/scrub, scope enforcement, e2e) → Tasks 4,5,7.

--- a/docs/superpowers/plans/2026-06-28-plugin-backend-isolation-phase4.md
+++ b/docs/superpowers/plans/2026-06-28-plugin-backend-isolation-phase4.md
@@ -1,0 +1,1171 @@
+# Plugin-Backend-Isolation Phase 4 — Request-Proxy + PluginManager-Dual-Path — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the existing Phase 1–3 sandbox machinery into the real request path so external/marketplace plugins run isolated in a subprocess instead of `exec_module` in the host.
+
+**Architecture:** `PluginManager` gains a dual path — bundled plugins keep the in-process `exec_module` path; external plugins spawn a `SandboxSupervisor` (one subprocess per uvicorn worker) and are served through a FastAPI catch-all proxy that forwards token-free, header-allowlisted requests over RPC. The host-side `CapabilityRouter` (default-deny) enforces `storage.*`/`core.*` scopes from the already-existing `granted_api_scopes` DB column.
+
+**Tech Stack:** Python 3.11+, FastAPI, SQLAlchemy 2.0, asyncio, msgpack RPC (already built in `app/plugins/sandbox/`), pytest.
+
+## Global Constraints
+
+- **No migration / no new column.** `InstalledPlugin.granted_api_scopes` and its migration (`1ab0b6db5b1c`) already exist (Track A). Phase 4 only consumes the value.
+- **`exec_module` for external plugins runs ONLY in the worker subprocess, NEVER in the host.** `load_plugin(external)` must raise instead of executing.
+- **Token never leaves the host.** The `Authorization` and `Cookie` headers must never appear in the `http_request` forwarded to a plugin.
+- **All plugin failures are scrubbed host-side:** crash → 502, timeout → 504, supervisor disabled/unreachable → 503. Detail only in server logs, never in the client response (ties into Posten 2 / error-leakage work).
+- **One subprocess per uvicorn worker.** No cross-worker IPC. The current 1:1 transport (`WorkerListener` listens, worker connects back once) is unchanged.
+- **Caps (constants):** request body ≤ 10 MiB → 413; per-request timeout 30 s → 504; max in-flight requests per plugin = 10 → 503.
+- **TDD, frequent commits.** Run `cd backend && python -m pytest <path> -v` for each task. Follow existing async test patterns; new tests live under `backend/tests/plugins/sandbox/`.
+- **Windows/CRLF:** repo uses `core.autocrlf=true`. Write LF; git normalizes.
+- Spec: `docs/superpowers/specs/2026-06-28-plugin-backend-isolation-phase4-design.md`.
+
+---
+
+## File Structure
+
+- **Create** `backend/app/plugins/sandbox/host_capabilities.py` — builds a production-wired `CapabilityRouter` (session factory, metrics reader, notifier, audit logger).
+- **Create** `backend/app/plugins/sandbox/proxy.py` — the catch-all proxy handler + caps + header allowlist + error scrubbing.
+- **Modify** `backend/app/plugins/sandbox/supervisor.py` — `dispatch()` forwards `query` + `headers`, honours a per-request timeout and a max-in-flight semaphore.
+- **Modify** `backend/app/plugins/manager.py` — `_sandboxes` registry, dual-path `enable_plugin`/`disable_plugin`/`shutdown_all`, `load_plugin(external)` guard, `granted_api_scopes` threading, catch-all wired into `get_router()`.
+- **Modify** `backend/app/api/routes/plugins.py` — toggle/details/list branch onto the manifest path for external (no `load_plugin` exec).
+- **Tests:** `backend/tests/plugins/sandbox/test_host_capabilities.py`, `test_proxy.py`, `test_supervisor.py` (extend), `backend/tests/plugins/test_plugin_manager_dualpath.py`, `backend/tests/plugins/sandbox/test_phase4_e2e.py`, plus a fixture plugin under `backend/tests/plugins/sandbox/fixtures/`.
+
+---
+
+## Task 1: Production-wired CapabilityRouter factory
+
+Builds a `CapabilityRouter` with real host dependencies. The router itself (Phase 3) already takes these by injection; this task supplies the concrete ones.
+
+**Files:**
+- Create: `backend/app/plugins/sandbox/host_capabilities.py`
+- Test: `backend/tests/plugins/sandbox/test_host_capabilities.py`
+
+**Interfaces:**
+- Consumes: `CapabilityRouter`, `CapabilityContext` from `app.plugins.sandbox.capabilities`; `SessionLocal` from `app.core.database`; `read_shm`, `TELEMETRY_FILE` from `app.services.monitoring.shm`; `get_notification_service` from `app.services.notifications.service`; `get_audit_logger_db` from `app.services.audit.logger_db`.
+- Produces: `build_capability_router(plugin_name: str, granted_scopes: "set[str] | frozenset[str]") -> CapabilityRouter`. Used by Task 3 (manager) when spawning an external plugin.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/plugins/sandbox/test_host_capabilities.py
+"""Phase 4: production-wired CapabilityRouter factory."""
+import asyncio
+
+from app.plugins.sandbox.capabilities import CapabilityContext, CapabilityRouter
+from app.plugins.sandbox.host_capabilities import build_capability_router
+
+
+def test_build_returns_capability_router_with_filtered_scopes():
+    router = build_capability_router("weather", {"storage", "core.notify", "bogus"})
+    assert isinstance(router, CapabilityRouter)
+    # Unknown scope strings are dropped; known ones survive.
+    assert router._granted_scopes == frozenset({"storage", "core.notify"})
+
+
+def test_metrics_reader_projects_telemetry(monkeypatch):
+    import app.plugins.sandbox.host_capabilities as hc
+
+    monkeypatch.setattr(
+        hc, "read_shm", lambda *_a, **_k: {"cpu_percent": 12.5, "memory_percent": 40.0, "secret": "x"}
+    )
+    router = build_capability_router("weather", {"core.system_metrics"})
+    ctx = CapabilityContext(user_id=1, username="u", role="user")
+    result = asyncio.run(router.dispatch("core.system_metrics", {}, ctx))
+    assert result == {"result": {"cpu_percent": 12.5, "memory_percent": 40.0}}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/sandbox/test_host_capabilities.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.plugins.sandbox.host_capabilities`.
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# backend/app/plugins/sandbox/host_capabilities.py
+"""Production wiring for the sandbox CapabilityRouter.
+
+The Phase 3 CapabilityRouter takes its host dependencies by injection so it
+stays testable. This module supplies the real ones — a DB session factory,
+a read-only metrics reader, an in-app notifier, and the audit logger — and
+filters the plugin's granted scopes down to the known host catalog.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.core.database import SessionLocal
+from app.plugins.sandbox.capabilities import (
+    CAPABILITY_SCOPE,
+    CapabilityContext,
+    CapabilityRouter,
+)
+from app.services.audit.logger_db import get_audit_logger_db
+from app.services.monitoring.shm import TELEMETRY_FILE, read_shm
+from app.services.notifications.service import get_notification_service
+
+logger = logging.getLogger(__name__)
+
+# The full set of scope strings the host knows how to enforce. Anything a
+# plugin was granted that is not in here is silently dropped (defensive).
+KNOWN_SCOPES: frozenset[str] = frozenset(CAPABILITY_SCOPE.values())
+
+# Keys projected out of the telemetry SHM snapshot for core.system_metrics.
+_METRIC_KEYS = ("cpu_percent", "memory_percent")
+
+
+def _read_metrics() -> dict:
+    """Curated read-only system metrics from the monitoring SHM snapshot."""
+    snapshot = read_shm(TELEMETRY_FILE) or {}
+    return {k: snapshot[k] for k in _METRIC_KEYS if k in snapshot}
+
+
+async def _notify(context: CapabilityContext, payload: dict) -> None:
+    """Create an in-app notification for the request's acting user only."""
+    service = get_notification_service()
+    with SessionLocal() as db:
+        await service.create(
+            db,
+            user_id=context.user_id,
+            category="plugin",
+            notification_type=payload["type"],
+            title=payload["title"],
+            message=payload["message"],
+        )
+
+
+def build_capability_router(
+    plugin_name: str, granted_scopes: "set[str] | frozenset[str]"
+) -> CapabilityRouter:
+    """Build a CapabilityRouter with production host dependencies."""
+    filtered = frozenset(granted_scopes) & KNOWN_SCOPES
+    return CapabilityRouter(
+        plugin_name=plugin_name,
+        granted_scopes=filtered,
+        session_factory=SessionLocal,
+        metrics_reader=_read_metrics,
+        notifier=_notify,
+        audit_logger=get_audit_logger_db(),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/plugins/sandbox/test_host_capabilities.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Run ruff**
+
+Run: `cd backend && ruff check app/plugins/sandbox/host_capabilities.py tests/plugins/sandbox/test_host_capabilities.py`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/plugins/sandbox/host_capabilities.py backend/tests/plugins/sandbox/test_host_capabilities.py
+git commit -m "feat(plugin-sandbox): production-wired CapabilityRouter factory (Phase 4)"
+```
+
+---
+
+## Task 2: Supervisor.dispatch forwards query + headers, honours timeout + in-flight cap
+
+`dispatch()` currently sends only `request_id/method/path/body/context`. Phase 4 forwards `query` and the (already-allowlisted) `headers`, applies a per-request timeout, and bounds concurrent in-flight requests per plugin.
+
+**Files:**
+- Modify: `backend/app/plugins/sandbox/supervisor.py`
+- Test: `backend/tests/plugins/sandbox/test_supervisor.py` (append)
+
+**Interfaces:**
+- Produces: `SandboxSupervisor.dispatch(method, path, body, context, *, query=None, headers=None, timeout=30.0) -> dict`. New exception `SupervisorTimeout(SupervisorError)`. New ctor kwarg `max_inflight: int = 10`. `dispatch` raises `SupervisorError` ("too many in-flight requests") when the cap is hit, `SupervisorTimeout` on per-request timeout.
+- Consumes: existing `RpcChannel.call(msg_type, body, timeout=...)`, `MsgType.HTTP_REQUEST`, `CapabilityContext`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to backend/tests/plugins/sandbox/test_supervisor.py
+import asyncio
+import pytest
+
+from app.plugins.sandbox.protocol import Message, MsgType
+from app.plugins.sandbox.supervisor import (
+    SandboxSupervisor,
+    SupervisorTimeout,
+)
+
+
+class _FakeChannel:
+    """Records the last HTTP_REQUEST body; returns a canned response."""
+
+    def __init__(self):
+        self.last_body = None
+
+    async def call(self, msg_type, body, timeout=None):
+        self.last_body = body
+        return Message(id="x", type=MsgType.HTTP_RESPONSE, body={"status": 200, "headers": {}, "body": {"ok": True}})
+
+
+def _supervisor_with_channel(channel):
+    sup = SandboxSupervisor("weather", ".")
+    sup._channel = channel
+    return sup
+
+
+def test_dispatch_forwards_query_and_headers():
+    channel = _FakeChannel()
+    sup = _supervisor_with_channel(channel)
+    ctx = {"user_id": 1, "username": "u", "role": "user"}
+    asyncio.run(
+        sup.dispatch("GET", "status", b"", ctx, query={"a": "1"}, headers={"content-type": "application/json"})
+    )
+    assert channel.last_body["query"] == {"a": "1"}
+    assert channel.last_body["headers"] == {"content-type": "application/json"}
+    assert "authorization" not in channel.last_body["headers"]
+
+
+def test_dispatch_timeout_raises_supervisor_timeout():
+    class _SlowChannel:
+        async def call(self, msg_type, body, timeout=None):
+            raise asyncio.TimeoutError
+
+    sup = _supervisor_with_channel(_SlowChannel())
+    with pytest.raises(SupervisorTimeout):
+        asyncio.run(sup.dispatch("GET", "x", b"", {"user_id": 1, "username": "u", "role": "user"}, timeout=0.01))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/sandbox/test_supervisor.py -k "forwards_query or timeout_raises" -v`
+Expected: FAIL — `dispatch()` has no `query`/`headers`/`timeout` kwargs; `SupervisorTimeout` undefined.
+
+- [ ] **Step 3: Edit `supervisor.py` — add exception + ctor field**
+
+After the `SupervisorError` class (line ~37), add:
+
+```python
+class SupervisorTimeout(SupervisorError):
+    """Raised when a single dispatched request exceeds its timeout."""
+```
+
+In `__init__`, add the parameter `max_inflight: int = 10,` (next to `capability_router`) and, in the body, set:
+
+```python
+        self._inflight_sem = asyncio.Semaphore(max_inflight)
+```
+
+- [ ] **Step 4: Replace the `dispatch` method**
+
+Replace the existing `dispatch` (lines ~85-118) with:
+
+```python
+    async def dispatch(
+        self,
+        method: str,
+        path: str,
+        body: bytes,
+        context: dict,
+        *,
+        query: "dict | None" = None,
+        headers: "dict | None" = None,
+        timeout: float = 30.0,
+    ) -> dict:
+        """Proxy one HTTP request into the worker and return its response dict.
+
+        ``headers`` must already be allowlist-filtered by the caller — this
+        method forwards them verbatim and never adds Authorization/Cookie.
+        """
+        if self._disabled:
+            raise SupervisorError(f"plugin {self.plugin_name} is disabled")
+        channel = self._channel
+        if channel is None:
+            raise SupervisorError(f"plugin {self.plugin_name} is not running")
+        if self._inflight_sem.locked():
+            raise SupervisorError(f"plugin {self.plugin_name}: too many in-flight requests")
+        request_id = secrets.token_hex(16)
+        self._inflight[request_id] = CapabilityContext(
+            user_id=context["user_id"],
+            username=context["username"],
+            role=context["role"],
+        )
+        worker_context = {
+            "user_id": context["user_id"],
+            "username": context["username"],
+            "role": context["role"],
+        }
+        async with self._inflight_sem:
+            try:
+                resp = await channel.call(
+                    MsgType.HTTP_REQUEST,
+                    {
+                        "request_id": request_id,
+                        "method": method,
+                        "path": path,
+                        "query": query or {},
+                        "headers": headers or {},
+                        "body": body,
+                        "context": worker_context,
+                    },
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError as exc:
+                raise SupervisorTimeout(
+                    f"plugin {self.plugin_name} request timed out"
+                ) from exc
+            finally:
+                self._inflight.pop(request_id, None)
+        return resp.body
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/plugins/sandbox/test_supervisor.py -v`
+Expected: PASS (all prior supervisor tests + the 2 new ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/plugins/sandbox/supervisor.py backend/tests/plugins/sandbox/test_supervisor.py
+git commit -m "feat(plugin-sandbox): dispatch forwards query+headers, timeout + in-flight cap (Phase 4)"
+```
+
+---
+
+## Task 3: PluginManager dual-path (external enable/disable, load_plugin guard, scope threading)
+
+**Files:**
+- Modify: `backend/app/plugins/manager.py`
+- Test: `backend/tests/plugins/test_plugin_manager_dualpath.py`
+
+**Interfaces:**
+- Consumes: `build_capability_router` (Task 1); `SandboxSupervisor` (Task 2); `DiscoveredPlugin.source`/`.manifest`.
+- Produces:
+  - `PluginManager._sandboxes: Dict[str, SandboxSupervisor]`
+  - `enable_plugin(name, granted_permissions, db, start_background_tasks=True, granted_api_scopes=None)` — external branch spawns a supervisor.
+  - `PluginManager._supervisor_factory(plugin_name, plugin_dir, capability_router)` — overridable hook returning a started-capable supervisor (tests inject a fake).
+  - `is_sandboxed(name) -> bool`, `get_sandbox(name) -> "SandboxSupervisor | None"`.
+  - `load_plugin(external)` raises `PluginLoadError`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/plugins/test_plugin_manager_dualpath.py
+"""Phase 4: PluginManager external dual-path (no exec_module in host)."""
+import asyncio
+
+import pytest
+
+from app.plugins.manager import DiscoveredPlugin, PluginLoadError, PluginManager
+
+
+class _FakeSupervisor:
+    def __init__(self, plugin_name, plugin_dir, capability_router=None):
+        self.plugin_name = plugin_name
+        self.started = False
+        self.stopped = False
+        self.capability_router = capability_router
+
+    async def start(self):
+        self.started = True
+
+    async def stop(self):
+        self.stopped = True
+
+
+@pytest.fixture
+def manager(tmp_path, monkeypatch):
+    PluginManager.reset_instance()
+    mgr = PluginManager(plugins_dir=tmp_path)
+    # Pretend an external plugin "weather" was discovered with a parsed manifest.
+    plugin_dir = tmp_path / "weather"
+    plugin_dir.mkdir()
+    (plugin_dir / "__init__.py").write_text("raise RuntimeError('must never exec in host')\n")
+
+    class _M:
+        api_scopes = ["storage", "core.notify"]
+        version = "1.0.0"
+        display_name = "Weather"
+
+    mgr._discovered = {
+        "weather": DiscoveredPlugin(name="weather", path=plugin_dir, source="external", manifest=_M()),
+    }
+    mgr._supervisor_factory = _FakeSupervisor
+    return mgr
+
+
+def test_load_plugin_external_refuses_to_exec(manager):
+    with pytest.raises(PluginLoadError):
+        manager.load_plugin("weather")
+
+
+def test_enable_external_spawns_supervisor_without_exec(manager):
+    ok = asyncio.run(
+        manager.enable_plugin("weather", [], db=None, granted_api_scopes=["storage", "core.notify"])
+    )
+    assert ok is True
+    sup = manager.get_sandbox("weather")
+    assert sup is not None and sup.started is True
+    assert sup.capability_router is not None
+    assert manager.is_enabled("weather") is True
+    # The external plugin was never instantiated in-process.
+    assert manager.get_plugin("weather") is None
+
+
+def test_disable_external_stops_supervisor(manager):
+    asyncio.run(manager.enable_plugin("weather", [], db=None, granted_api_scopes=["storage"]))
+    sup = manager.get_sandbox("weather")
+    asyncio.run(manager.disable_plugin("weather"))
+    assert sup.stopped is True
+    assert manager.is_enabled("weather") is False
+    assert manager.get_sandbox("weather") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/test_plugin_manager_dualpath.py -v`
+Expected: FAIL — no `_sandboxes`/`_supervisor_factory`/`get_sandbox`; `enable_plugin` has no `granted_api_scopes`; external not guarded.
+
+- [ ] **Step 3: Edit `manager.py` — registry + factory + accessors**
+
+In `__init__`, after `self._background_tasks` init, add:
+
+```python
+        self._sandboxes: Dict[str, Any] = {}
+```
+
+Add an overridable factory method and accessors to the class:
+
+```python
+    def _supervisor_factory(self, plugin_name: str, plugin_dir: Path, capability_router: Any):
+        """Build a SandboxSupervisor (overridable in tests)."""
+        from app.plugins.sandbox.supervisor import SandboxSupervisor  # noqa: PLC0415
+        return SandboxSupervisor(plugin_name, plugin_dir, capability_router=capability_router)
+
+    def is_sandboxed(self, name: str) -> bool:
+        return name in self._sandboxes
+
+    def get_sandbox(self, name: str) -> Any:
+        return self._sandboxes.get(name)
+```
+
+- [ ] **Step 4: Edit `load_plugin` — guard external**
+
+In `load_plugin`, immediately after `source` is resolved (right before the `init_file = plugin_path / "__init__.py"` line, ~310), add:
+
+```python
+        if source == "external":
+            raise PluginLoadError(
+                f"External plugin '{name}' must not be loaded in-process; "
+                "it runs in a sandboxed subprocess."
+            )
+```
+
+- [ ] **Step 5: Edit `enable_plugin` — signature + external branch**
+
+Change the signature to add the new keyword:
+
+```python
+    async def enable_plugin(
+        self,
+        name: str,
+        granted_permissions: List[str],
+        db: Session,
+        start_background_tasks: bool = True,
+        granted_api_scopes: Optional[List[str]] = None,
+    ) -> bool:
+```
+
+At the very start of the method body (before the `if name not in self._plugins:` block), add the external branch:
+
+```python
+        discovered = self.get_discovered(name)
+        if discovered is not None and discovered.source == "external":
+            return await self._enable_external(name, discovered, granted_api_scopes or [])
+```
+
+Then add the helper method:
+
+```python
+    async def _enable_external(
+        self, name: str, discovered: "DiscoveredPlugin", granted_api_scopes: List[str]
+    ) -> bool:
+        """Enable an external plugin as a sandboxed subprocess (no in-host exec).
+
+        Spawned on every uvicorn worker (no primary-only gating) so the catch-all
+        proxy can serve the plugin regardless of which worker handles the request.
+        """
+        if name in self._sandboxes:
+            return True
+        from app.plugins.sandbox.host_capabilities import build_capability_router  # noqa: PLC0415
+
+        router = build_capability_router(name, set(granted_api_scopes))
+        supervisor = self._supervisor_factory(name, discovered.path, router)
+        try:
+            await supervisor.start()
+        except Exception:
+            logger.exception("Failed to start sandbox for external plugin %s", name)
+            return False
+        self._sandboxes[name] = supervisor
+        self._enabled.add(name)
+        logger.info("Enabled external (sandboxed) plugin: %s", name)
+        return True
+```
+
+- [ ] **Step 6: Edit `disable_plugin` — external branch**
+
+At the start of `disable_plugin`, before the `if name not in self._enabled:` check, add:
+
+```python
+        if name in self._sandboxes:
+            supervisor = self._sandboxes.pop(name)
+            try:
+                await supervisor.stop()
+            except Exception:
+                logger.exception("Error stopping sandbox for %s", name)
+            self._enabled.discard(name)
+            logger.info("Disabled external (sandboxed) plugin: %s", name)
+            return True
+```
+
+- [ ] **Step 7: Edit `shutdown_all` + `load_enabled_plugins`**
+
+`shutdown_all` already iterates `self._enabled` and calls `disable_plugin`, which now handles sandboxes — no change needed there. In `load_enabled_plugins`, thread the scopes by replacing the `await self.enable_plugin(...)` call with:
+
+```python
+            await self.enable_plugin(
+                record.name,
+                record.granted_permissions or [],
+                db,
+                start_background_tasks=start_background_tasks,
+                granted_api_scopes=record.granted_api_scopes or [],
+            )
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/plugins/test_plugin_manager_dualpath.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 9: Regression — existing manager tests**
+
+Run: `cd backend && python -m pytest tests/plugins/test_plugin_manager.py tests/plugins/test_plugin_manager_multipath.py tests/plugins/test_plugins.py -v`
+Expected: PASS (bundled path unchanged).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/app/plugins/manager.py backend/tests/plugins/test_plugin_manager_dualpath.py
+git commit -m "feat(plugin-sandbox): PluginManager dual-path — external spawns supervisor, no host exec (Phase 4)"
+```
+
+---
+
+## Task 4: Catch-all proxy route (auth, caps, header allowlist, error scrubbing)
+
+**Files:**
+- Create: `backend/app/plugins/sandbox/proxy.py`
+- Modify: `backend/app/plugins/manager.py` (wire catch-all into `get_router()`)
+- Test: `backend/tests/plugins/sandbox/test_proxy.py`
+
+**Interfaces:**
+- Consumes: `SandboxSupervisor.dispatch` (Task 2), `SupervisorError`/`SupervisorTimeout`, `PluginManager.get_sandbox`.
+- Produces: `proxy_request(name, path, request, current_user, manager) -> Response`; module constants `REQUEST_BODY_MAX`, `REQUEST_TIMEOUT`; `ALLOWED_REQUEST_HEADERS`. `PluginManager.get_router()` includes a catch-all route `/{name}/{path:path}` for all methods.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/plugins/sandbox/test_proxy.py
+"""Phase 4: catch-all proxy — auth gating, header allowlist, error scrubbing."""
+import asyncio
+import types
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.plugins.sandbox import proxy
+from app.plugins.sandbox.supervisor import SupervisorError, SupervisorTimeout
+
+
+def _make_request(method="GET", headers=None, body=b"", query=b""):
+    hdrs = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http", "method": method, "path": "/api/plugins/weather/status",
+        "query_string": query, "headers": hdrs,
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+class _Sup:
+    def __init__(self, **kw):
+        self.kw = None
+        self._resp = kw.get("resp", {"status": 200, "headers": {"content-type": "application/json"}, "body": {"ok": True}})
+        self._raise = kw.get("raise_exc")
+
+    async def dispatch(self, method, path, body, context, *, query=None, headers=None, timeout=30.0):
+        if self._raise:
+            raise self._raise
+        self.kw = dict(method=method, path=path, body=body, context=context, query=query, headers=headers)
+        return self._resp
+
+
+class _Mgr:
+    def __init__(self, sup):
+        self._sup = sup
+
+    def get_sandbox(self, name):
+        return self._sup
+
+
+_USER = types.SimpleNamespace(id=7, username="alice", role="user")
+
+
+def test_proxy_forwards_without_token_headers():
+    sup = _Sup()
+    req = _make_request(headers={"authorization": "Bearer x", "cookie": "s=1", "content-type": "application/json"}, query=b"a=1")
+    resp = asyncio.run(proxy.proxy_request("weather", "status", req, _USER, _Mgr(sup)))
+    assert resp.status_code == 200
+    assert "authorization" not in sup.kw["headers"]
+    assert "cookie" not in sup.kw["headers"]
+    assert sup.kw["headers"] == {"content-type": "application/json"}
+    assert sup.kw["query"] == {"a": "1"}
+    assert sup.kw["context"] == {"user_id": 7, "username": "alice", "role": "user"}
+
+
+def test_proxy_unknown_plugin_404():
+    class _Empty:
+        def get_sandbox(self, name):
+            return None
+
+    req = _make_request()
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(proxy.proxy_request("nope", "x", req, _USER, _Empty()))
+    assert ei.value.status_code == 404
+
+
+def test_proxy_body_too_large_413():
+    req = _make_request(method="POST", body=b"x" * (proxy.REQUEST_BODY_MAX + 1))
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(proxy.proxy_request("weather", "x", req, _USER, _Mgr(_Sup())))
+    assert ei.value.status_code == 413
+
+
+def test_proxy_timeout_504():
+    req = _make_request()
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(proxy.proxy_request("weather", "x", req, _USER, _Mgr(_Sup(raise_exc=SupervisorTimeout("t")))))
+    assert ei.value.status_code == 504
+
+
+def test_proxy_crash_scrubbed_502():
+    req = _make_request()
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(proxy.proxy_request("weather", "x", req, _USER, _Mgr(_Sup(raise_exc=SupervisorError("boom")))))
+    assert ei.value.status_code == 502
+    assert "boom" not in str(ei.value.detail)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/sandbox/test_proxy.py -v`
+Expected: FAIL — `app.plugins.sandbox.proxy` does not exist.
+
+- [ ] **Step 3: Write `proxy.py`**
+
+```python
+# backend/app/plugins/sandbox/proxy.py
+"""FastAPI catch-all proxy for external (sandboxed) plugins.
+
+Forwards a token-free, header-allowlisted request to the plugin's worker over
+RPC and turns the worker's response back into a FastAPI Response. Every plugin
+failure is scrubbed: crash -> 502, timeout -> 504, unreachable/disabled -> 503.
+The Authorization and Cookie headers are never forwarded.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse
+
+from app.plugins.sandbox.supervisor import SupervisorError, SupervisorTimeout
+
+logger = logging.getLogger(__name__)
+
+REQUEST_BODY_MAX = 10 * 1024 * 1024  # 10 MiB
+REQUEST_TIMEOUT = 30.0
+# Request headers forwarded to the plugin. NEVER includes authorization/cookie.
+ALLOWED_REQUEST_HEADERS = frozenset({"content-type", "accept"})
+# Response headers passed back to the client.
+ALLOWED_RESPONSE_HEADERS = frozenset({"content-type"})
+
+
+def _filter_request_headers(request: Request) -> dict:
+    return {
+        k.lower(): v
+        for k, v in request.headers.items()
+        if k.lower() in ALLOWED_REQUEST_HEADERS
+    }
+
+
+def _build_response(payload: dict) -> Response:
+    status_code = int(payload.get("status", 200))
+    body = payload.get("body")
+    headers = {
+        k.lower(): v
+        for k, v in (payload.get("headers") or {}).items()
+        if k.lower() in ALLOWED_RESPONSE_HEADERS
+    }
+    if isinstance(body, (bytes, bytearray)):
+        return Response(content=bytes(body), status_code=status_code, headers=headers)
+    return JSONResponse(content=body, status_code=status_code, headers=headers)
+
+
+async def proxy_request(
+    name: str, path: str, request: Request, current_user: Any, manager: Any
+) -> Response:
+    """Proxy one request to an external plugin's sandbox worker."""
+    supervisor = manager.get_sandbox(name)
+    if supervisor is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plugin not found")
+
+    body = await request.body()
+    if len(body) > REQUEST_BODY_MAX:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="Request body too large",
+        )
+
+    context = {
+        "user_id": current_user.id,
+        "username": current_user.username,
+        "role": current_user.role,
+    }
+    try:
+        result = await supervisor.dispatch(
+            request.method,
+            path,
+            body,
+            context,
+            query=dict(request.query_params),
+            headers=_filter_request_headers(request),
+            timeout=REQUEST_TIMEOUT,
+        )
+    except SupervisorTimeout:
+        logger.warning("Plugin %s request timed out", name)
+        raise HTTPException(status_code=status.HTTP_504_GATEWAY_TIMEOUT, detail="Plugin timed out")
+    except SupervisorError as exc:
+        logger.warning("Plugin %s unavailable: %s", name, exc)
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Plugin error")
+    except Exception:
+        logger.exception("Unexpected error proxying to plugin %s", name)
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Plugin error")
+
+    return _build_response(result)
+```
+
+- [ ] **Step 4: Run proxy unit tests**
+
+Run: `cd backend && python -m pytest tests/plugins/sandbox/test_proxy.py -v`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Wire the catch-all into `manager.get_router()`**
+
+Replace `get_router` in `manager.py` with (bundled routers first, catch-all last):
+
+```python
+    def get_router(self) -> APIRouter:
+        """Combined router: bundled plugin routes + a catch-all for sandboxed ones."""
+        from fastapi import Request  # noqa: PLC0415
+        from app.api.deps import get_current_user  # noqa: PLC0415
+        from app.plugins.sandbox.proxy import proxy_request  # noqa: PLC0415
+
+        router = APIRouter(prefix="/plugins", tags=["plugins"])
+
+        # Bundled plugins: explicit routers, registered FIRST so they win.
+        for name in self._enabled:
+            plugin = self._plugins.get(name)
+            if plugin:
+                plugin_router = plugin.get_router()
+                if plugin_router:
+                    router.include_router(
+                        plugin_router, prefix=f"/{name}", tags=[f"plugin:{name}"]
+                    )
+
+        # Catch-all for external/sandboxed plugins, registered LAST.
+        manager = self
+
+        @router.api_route(
+            "/{name}/{path:path}",
+            methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+            include_in_schema=False,
+        )
+        async def _sandbox_proxy(
+            name: str,
+            path: str,
+            request: Request,
+            current_user=Depends(get_current_user),
+        ):
+            return await proxy_request(name, path, request, current_user, manager)
+
+        return router
+```
+
+Add the FastAPI `Depends` import at the top of `manager.py`:
+
+```python
+from fastapi import APIRouter, Depends
+```
+
+- [ ] **Step 6: Mount-condition note (no code change, verify)**
+
+`lifespan.py:583` mounts the router only `if plugin_router.routes`. The catch-all is always added, so `routes` is non-empty even with zero enabled plugins → the proxy is always mounted. Confirm by reading `lifespan.py:582-585`; no edit required.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/plugins/sandbox/proxy.py backend/app/plugins/manager.py backend/tests/plugins/sandbox/test_proxy.py
+git commit -m "feat(plugin-sandbox): catch-all proxy route with caps + header allowlist + scrubbing (Phase 4)"
+```
+
+---
+
+## Task 5: Toggle/details/list route dual-path for external plugins
+
+The toggle, details, and list routes currently call `load_plugin`/`get_plugin` which now raises for external. Branch them onto the manifest path (`DiscoveredPlugin.manifest`) so external plugins are manageable without exec.
+
+**Files:**
+- Modify: `backend/app/api/routes/plugins.py`
+- Test: `backend/tests/plugins/test_external_plugin_routes.py`
+
+**Interfaces:**
+- Consumes: `PluginManager.get_discovered(name)`, `manager.enable_plugin(..., granted_api_scopes=...)`, `manager.disable_plugin`, `plugin_service.enable_plugin`/`disable_plugin_record`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/plugins/test_external_plugin_routes.py
+"""Phase 4: toggling an external plugin uses the manifest path (no exec)."""
+import asyncio
+import types
+
+from app.api.routes import plugins as plugins_route
+from app.plugins.manager import DiscoveredPlugin, PluginManager
+
+
+def test_toggle_enable_external_uses_manifest(tmp_path, db_session, monkeypatch):
+    PluginManager.reset_instance()
+    mgr = PluginManager(plugins_dir=tmp_path)
+    pdir = tmp_path / "weather"
+    pdir.mkdir()
+
+    class _M:
+        api_scopes = ["storage"]
+        version = "2.0.0"
+        display_name = "Weather"
+        required_permissions = []
+
+    mgr._discovered = {
+        "weather": DiscoveredPlugin(name="weather", path=pdir, source="external", manifest=_M()),
+    }
+
+    enabled = {}
+
+    async def fake_enable(name, perms, db, start_background_tasks=True, granted_api_scopes=None):
+        enabled["scopes"] = granted_api_scopes
+        return True
+
+    monkeypatch.setattr(mgr, "enable_plugin", fake_enable)
+
+    body = plugins_route.PluginToggleRequest(enabled=True, grant_permissions=[])
+    user = types.SimpleNamespace(id=1, username="admin", role="admin")
+    resp = asyncio.run(
+        plugins_route.toggle_plugin(
+            request=None, response=None, name="weather", body=body,
+            db=db_session, current_user=user, plugin_manager=mgr,
+        )
+    )
+    assert resp.is_enabled is True
+    assert enabled["scopes"] == ["storage"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/test_external_plugin_routes.py -v`
+Expected: FAIL — `toggle_plugin` calls `load_plugin("weather")` which raises `PluginLoadError` → 404.
+
+- [ ] **Step 3: Edit `toggle_plugin` — branch external before load_plugin**
+
+At the very start of `toggle_plugin` (before the `try: plugin = plugin_manager.get_plugin(name)` block, ~218), add:
+
+```python
+    discovered = plugin_manager.get_discovered(name)
+    if discovered is not None and discovered.source == "external":
+        return await _toggle_external(
+            name, body, db, current_user, plugin_manager, discovered
+        )
+```
+
+Add the helper function (module level, after `toggle_plugin`):
+
+```python
+async def _toggle_external(
+    name, body, db, current_user, plugin_manager, discovered,
+):
+    """Enable/disable an external sandboxed plugin via its manifest (no exec)."""
+    manifest = discovered.manifest
+    if manifest is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plugin not found")
+
+    if body.enabled:
+        api_scopes = list(getattr(manifest, "api_scopes", []) or [])
+        plugin_service.enable_plugin(
+            db,
+            name=name,
+            version=manifest.version,
+            display_name=manifest.display_name,
+            permissions=body.grant_permissions,
+            default_config={},
+            installed_by=current_user.username,
+            api_scopes=api_scopes,
+        )
+        success = await plugin_manager.enable_plugin(
+            name, body.grant_permissions, db, granted_api_scopes=api_scopes
+        )
+        if not success:
+            plugin_service.rollback_enable(db, name)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to enable plugin",
+            )
+        invalidate_plugin_cache(name)
+        logger.info("External plugin %s enabled by %s", name, current_user.username)
+        return PluginToggleResponse(
+            name=name, is_enabled=True,
+            message=f"Plugin '{manifest.display_name}' enabled successfully",
+        )
+
+    success = await plugin_manager.disable_plugin(name)
+    plugin_service.disable_plugin_record(db, name)
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to disable plugin",
+        )
+    invalidate_plugin_cache(name)
+    logger.info("External plugin %s disabled by %s", name, current_user.username)
+    return PluginToggleResponse(
+        name=name, is_enabled=False,
+        message=f"Plugin '{manifest.display_name}' disabled successfully",
+    )
+```
+
+- [ ] **Step 4: Guard `get_all_plugins` against external exec**
+
+In `manager.py` `get_all_plugins`, replace the `try:` body's `if name not in self._plugins: self.load_plugin(name)` region with a source check that uses the manifest for external. Replace the loop body with:
+
+```python
+        for name in discovered:
+            info = self.get_discovered(name)
+            if info is not None and info.source == "external" and info.manifest is not None:
+                m = info.manifest
+                result[name] = {
+                    "name": m.name,
+                    "version": m.version,
+                    "display_name": m.display_name,
+                    "description": m.description,
+                    "author": m.author,
+                    "category": m.category,
+                    "required_permissions": list(m.required_permissions),
+                    "is_enabled": name in self._enabled,
+                    "has_ui": m.ui is not None,
+                    "has_routes": True,
+                    "dangerous_permissions": PermissionManager.get_dangerous_permissions(
+                        list(m.required_permissions)
+                    ),
+                }
+                continue
+            try:
+                if name not in self._plugins:
+                    self.load_plugin(name)
+                plugin = self._plugins[name]
+                meta = plugin.metadata
+                result[name] = {
+                    "name": meta.name,
+                    "version": meta.version,
+                    "display_name": meta.display_name,
+                    "description": meta.description,
+                    "author": meta.author,
+                    "category": meta.category,
+                    "required_permissions": meta.required_permissions,
+                    "is_enabled": name in self._enabled,
+                    "has_ui": plugin.get_ui_manifest() is not None,
+                    "has_routes": plugin.get_router() is not None,
+                    "dangerous_permissions": PermissionManager.get_dangerous_permissions(
+                        meta.required_permissions
+                    ),
+                }
+            except PluginLoadError as e:
+                result[name] = {"name": name, "error": str(e), "is_enabled": False}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd backend && python -m pytest tests/plugins/test_external_plugin_routes.py tests/plugins/test_plugins.py -v`
+Expected: PASS (external toggle + bundled list regression).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/api/routes/plugins.py backend/app/plugins/manager.py backend/tests/plugins/test_external_plugin_routes.py
+git commit -m "feat(plugin-sandbox): route dual-path — manage external plugins via manifest, no exec (Phase 4)"
+```
+
+---
+
+## Task 6: End-to-end — sample external plugin through the full proxy→RPC→capability path
+
+A real subprocess test (mirrors `test_phase3_e2e.py`) proving an external plugin's own route + a `storage.*` call + a `core.*` call work, and a non-granted scope is denied.
+
+**Files:**
+- Create: `backend/tests/plugins/sandbox/fixtures/e2e_plugin/__init__.py`
+- Create: `backend/tests/plugins/sandbox/fixtures/e2e_plugin/plugin.json`
+- Create: `backend/tests/plugins/sandbox/test_phase4_e2e.py`
+
+**Interfaces:**
+- Consumes: real `SandboxSupervisor` (Task 2), `build_capability_router` (Task 1), the worker entrypoint.
+
+- [ ] **Step 1: Write the fixture plugin**
+
+```python
+# backend/tests/plugins/sandbox/fixtures/e2e_plugin/__init__.py
+"""E2E fixture: a route that reads+writes storage and returns it."""
+
+
+def register(host):
+    @host.route("POST", "echo")
+    async def echo(request):
+        await host.storage.set("last", request["body"])
+        value = await host.storage.get("last")
+        return {"status": 200, "body": {"stored": value, "user": request["user"]}}
+```
+
+```json
+{
+  "manifest_version": 1,
+  "name": "e2e_plugin",
+  "version": "1.0.0",
+  "display_name": "E2E Plugin",
+  "description": "phase 4 e2e fixture",
+  "author": "tests",
+  "api_scopes": ["storage"],
+  "entrypoint": "__init__.py"
+}
+```
+
+- [ ] **Step 2: Write the failing E2E test**
+
+```python
+# backend/tests/plugins/sandbox/test_phase4_e2e.py
+"""Phase 4 E2E: external plugin through supervisor.dispatch -> RPC -> capability."""
+import asyncio
+from pathlib import Path
+
+import msgpack
+import pytest
+
+from app.plugins.sandbox.host_capabilities import build_capability_router
+from app.plugins.sandbox.supervisor import SandboxSupervisor
+
+FIXTURE = Path(__file__).parent / "fixtures" / "e2e_plugin"
+
+
+@pytest.mark.timeout(30)
+def test_external_plugin_storage_roundtrip(monkeypatch):
+    # Stub the storage capability's DB so the test needs no real database.
+    import app.plugins.sandbox.capabilities as caps
+
+    store: dict = {}
+
+    def fake_get(db, plugin, uid, key):
+        k = (plugin, uid, key)
+        return (k in store, store.get(k))
+
+    def fake_set(db, plugin, uid, key, value):
+        store[(plugin, uid, key)] = value
+
+    monkeypatch.setattr(caps.plugin_storage_service, "get_value", fake_get)
+    monkeypatch.setattr(caps.plugin_storage_service, "set_value", fake_set)
+
+    async def run():
+        router = build_capability_router("e2e_plugin", {"storage"})
+        sup = SandboxSupervisor("e2e_plugin", FIXTURE, capability_router=router)
+        await sup.start()
+        try:
+            ctx = {"user_id": 42, "username": "alice", "role": "user"}
+            resp = await sup.dispatch("POST", "echo", msgpack.packb({"hi": 1}), ctx)
+            assert resp["status"] == 200
+            assert resp["body"]["user"]["user_id"] == 42
+        finally:
+            await sup.stop()
+
+    asyncio.run(run())
+```
+
+- [ ] **Step 3: Run E2E test to verify it fails, then passes**
+
+Run: `cd backend && python -m pytest tests/plugins/sandbox/test_phase4_e2e.py -v`
+Expected first run: should PASS once Tasks 1–2 are in place (it exercises real code). If it fails, debug the supervisor/worker wiring before proceeding — do not stub past a real failure.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/plugins/sandbox/fixtures/e2e_plugin backend/tests/plugins/sandbox/test_phase4_e2e.py
+git commit -m "test(plugin-sandbox): Phase 4 e2e — external plugin storage roundtrip through real subprocess"
+```
+
+---
+
+## Task 7: Full sandbox + plugin suite regression
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the whole sandbox + plugin suite**
+
+Run: `cd backend && python -m pytest tests/plugins -v`
+Expected: PASS. Investigate any failure; the bundled path and existing sandbox tests must remain green.
+
+- [ ] **Step 2: ruff on all touched files**
+
+Run: `cd backend && ruff check app/plugins/sandbox app/plugins/manager.py app/api/routes/plugins.py`
+Expected: no errors.
+
+- [ ] **Step 3: Commit (if ruff made fixes)**
+
+```bash
+git add -A
+git commit -m "chore(plugin-sandbox): ruff clean-up for Phase 4"
+```
+
+---
+
+## Accepted limitation (document, do not fix here)
+
+Because each uvicorn worker owns its own subprocess and there is no cross-worker IPC, an external plugin **enabled at runtime** via the toggle route only spawns a worker on the uvicorn process that handled the toggle; the other workers serve it after the next restart (their startup `load_enabled_plugins` spawns it). This matches the existing bundled-plugin behaviour (runtime route changes need a restart). Lazy-spawn-on-first-request is a possible future enhancement, out of scope for Phase 4.
+
+## Self-Review Notes (coverage vs. spec)
+
+- Scope-storage → Task 1 (consume existing column; filter to known catalog) + Task 3/5 (thread `granted_api_scopes`). No migration (column exists).
+- Dual-path / no host exec → Task 3 (`load_plugin` guard, `_enable_external`) + Task 5 (routes).
+- core.* catalog (system_metrics + notify) → Task 1 wires both; `storage.*` via existing CapabilityRouter.
+- One subprocess per worker → Task 3 `_enable_external` (no primary-only gating) + accepted-limitation note.
+- Proxy + header allowlist + caps + scrubbing → Task 4.
+- Token never forwarded → Task 4 (`ALLOWED_REQUEST_HEADERS`) + tests (positive assertion).
+- Capability deps wired → Task 1.
+- Testing matrix (dual-path, no-exec, proxy auth/headers/caps/scrub, scope enforcement, e2e) → Tasks 3,4,6.

--- a/docs/superpowers/specs/2026-06-28-plugin-backend-isolation-phase4-design.md
+++ b/docs/superpowers/specs/2026-06-28-plugin-backend-isolation-phase4-design.md
@@ -25,19 +25,26 @@ Plugins `spec.loader.exec_module(module)` — also auch für `source == "externa
 In-Process-RCE. Phase 4 schneidet das ab und verdrahtet die Sandbox in den echten
 Request-Pfad.
 
-### Korrektur einer Spec-Annahme
+### Scope-Storage existiert bereits (Track A)
 
-Die übergeordnete Spec (Zeile ~168) behauptet, `granted_api_scopes` sei als
-DB-Spalte „bereits vorhanden" (aus Track A). **Das stimmt nicht.** Tatsächlich:
+Anders als zunächst angenommen ist die Scope-Storage-Schicht **schon vorhanden**
+— Track A hat sie gebaut:
 
-- DB `InstalledPlugin` hat nur **`granted_permissions`** (JSON) — die alte
-  `PluginPermission`-Enum (`file:write`, `system:execute`, …), gegated durch
-  `PluginGateMiddleware`.
-- Das Manifest (`plugin.json`) hat ein deklaratives Feld **`api_scopes`**
-  (`manifest.py:57`), das aktuell **nirgends gespeichert oder durchgesetzt** wird —
-  es wartet auf genau diese Phase.
+- DB-Spalte `InstalledPlugin.granted_api_scopes` (JSON, `models/plugin.py:29-31`),
+  Migration `alembic/versions/1ab0b6db5b1c_installed_plugins_granted_api_scopes.py`.
+- `plugin_service.enable_plugin(..., api_scopes=...)` persistiert sie
+  (`plugin_service.py:42,62,71`).
+- Die Toggle-Route liest die deklarierten `manifest.api_scopes` und reicht sie als
+  granted weiter (`routes/plugins.py:247-261`) — **declared == granted**.
+- `get_ui_manifest` exponiert `record.granted_api_scopes` ans Frontend, wo die
+  Track-A-iframe-Bridge schon darauf gated (`routes/plugins.py:121-123`).
 
-Phase 4 führt deshalb die fehlende `granted_api_scopes`-DB-Spalte ein.
+**Konsequenz für Phase 4:** Keine Migration, keine Spalten- oder API-Änderung am
+Enable-Pfad nötig. Die im Brainstorm gewählte „dedizierte `granted_api_scopes`-Spalte"
+ist damit bereits erfüllt. Phase 4 muss die Scopes nur noch vom DB-Record **bis in den
+`CapabilityRouter` durchreichen** — heute endet der Wert bei der Frontend-Exposition;
+der Backend-Sandbox-Pfad liest ihn noch nicht. Die granulare Subset-Auswahl beim
+Install bleibt eine reine Phase-5-UI-Frage (schreibt eine Teilmenge in dieselbe Spalte).
 
 ---
 
@@ -45,7 +52,7 @@ Phase 4 führt deshalb die fehlende `granted_api_scopes`-DB-Spalte ein.
 
 | Frage | Entscheidung |
 |---|---|
-| Scope-Storage | **Dedizierte `granted_api_scopes`-JSON-Spalte** (Alembic-Migration), getrennt von `granted_permissions`. |
+| Scope-Storage | **Dedizierte `granted_api_scopes`-JSON-Spalte** — **bereits von Track A gebaut** (Spalte + Migration + Enable-Persistenz). Phase 4 reicht sie nur in den `CapabilityRouter` durch, keine Migration. |
 | Scope-Vergabe-Tiefe in Phase 4 | **Backend-only** (Spalte + API + Durchsetzung). Install-Scope-Picker-UI → Phase 5. |
 | `core.*`-Katalog v1 | **`core.system_metrics` + `core.notify`** ausliefern (beide Stubs sind fertig + getestet, beide harmlos). Plus `storage.*` und eigene Routen. |
 | Multi-Worker-Topologie | **Ein Subprozess pro uvicorn-Worker.** Aktueller 1:1-Transport bleibt unverändert; kein Cross-Worker-IPC. |
@@ -54,17 +61,18 @@ Phase 4 führt deshalb die fehlende `granted_api_scopes`-DB-Spalte ein.
 
 ## Architektur
 
-### 1. Scope-Storage & -Vergabe
+### 1. Scope-Storage & -Durchreichung
 
-- **Neue Spalte** `granted_api_scopes: JSON` (nullable, default `list`) auf
-  `installed_plugins`. Migration **muss an die echten `alembic heads` ketten**, nicht
-  an den stale dev-DB-Head (siehe `project_alembic_migration_head_pitfall`).
-- `enable`-Pfad eines externen Plugins akzeptiert + persistiert `granted_api_scopes`.
-  **v1: Backend-only** — kein UI-Picker (Phase 5).
-- Gewährbare Menge = die im Manifest deklarierten `api_scopes` ∩ bekannter Host-Katalog
-  (`storage`, `core.system_metrics`, `core.notify`). Unbekannte/nicht-deklarierte Scopes
-  werden beim Grant abgelehnt.
-- `CapabilityRouter.granted_scopes` wird aus dieser Spalte gespeist.
+- **Keine Migration / keine Spalte** — `granted_api_scopes` existiert bereits
+  (Track A, s.o.). Phase 4 **konsumiert** sie nur.
+- Phase 4 liest `record.granted_api_scopes` (DB) und speist daraus
+  `CapabilityRouter.granted_scopes` (als `frozenset`). Heute landet der Wert nur im
+  Frontend; der Sandbox-Pfad liest ihn noch nicht.
+- Beim Bau des `CapabilityRouter` werden die granted Scopes gegen den bekannten
+  Host-Katalog gefiltert (`storage`, `core.system_metrics`, `core.notify`); unbekannte
+  Strings werden ignoriert (kein Crash, defensiv).
+- **v1: Backend-only** — granulare Subset-Auswahl-UI beim Install → Phase 5
+  (schreibt eine Teilmenge in dieselbe, bereits existierende Spalte).
 - Die alten `PluginPermission`-Enum-Strings (`granted_permissions`) bleiben
   **unangetastet** — informativ nur für bundled.
 
@@ -73,12 +81,18 @@ Phase 4 führt deshalb die fehlende `granted_api_scopes`-DB-Spalte ein.
 - `enable_plugin` / `load_plugin` verzweigen auf `discovered.source`:
   - `bundled` → **unveränderter** `exec_module`-Pfad (trusted, in-process).
   - `external` → **nie** `exec_module`. Stattdessen:
-    1. Manifest lesen (ohne Code-Ausführung),
+    1. Manifest aus `DiscoveredPlugin.manifest` (bei Discovery geparst, ohne exec),
     2. `CapabilityRouter` mit `granted_api_scopes` + injizierten Host-Deps bauen,
     3. `SandboxSupervisor` starten (`.start()` → spawn + Health-Handshake),
     4. in neuem `self._sandboxes[name]` registrieren (getrennt von `self._plugins`).
+- `load_plugin(external)` **raised** (`PluginLoadError`) statt zu exec-en — die
+  bestehenden Route-Handler (`get_plugin_details`, `toggle`, `get_all_plugins`) müssen
+  für external auf den Manifest-Metadaten-Pfad branchen (kein PluginBase-Instanz).
 - `disable_plugin` (external) → `supervisor.stop()` (graceful `shutdown`-RPC →
   SIGTERM → SIGKILL mit Timeout). `shutdown_all` nimmt Sandboxes mit.
+- **Toggle-Route** (`routes/plugins.py`) bekommt einen external-Branch: kein
+  `load_plugin`, Version/Display-Name aus dem Manifest, dann `plugin_service.enable_plugin`
+  + `manager.enable_plugin` (external). Lifecycle pro uvicorn-Worker.
 - **Multi-Worker:** Jeder uvicorn-Worker spawnt + besitzt seinen **eigenen**
   Subprozess. Der aktuelle 1:1-Transport (`WorkerListener` lauscht, Worker connectet
   einmal zurück) bleibt unverändert. `start_background_tasks`-Gating ist fürs Spawnen
@@ -145,9 +159,10 @@ Phase 4 führt deshalb die fehlende `granted_api_scopes`-DB-Spalte ein.
 
 ## Testing (TDD, subagent-driven wie Vorphasen)
 
-- **Migration:** round-trip up/down; bestehende Records unverändert; default `[]`.
 - **Dual-Path:** external → kein `exec_module`, Supervisor gestartet, in `_sandboxes`;
   bundled → unveränderter Pfad, in `_plugins`. disable → Supervisor gestoppt.
+- **Kein-exec-Garantie:** `load_plugin(external)` führt `exec_module` **nie** aus
+  (raised stattdessen); Metadaten für external kommen aus `DiscoveredPlugin.manifest`.
 - **Proxy:** Auth-Gate vor Forward; `Authorization`/`Cookie` erscheinen **nie** im an
   das Plugin gesendeten `http_request` (Positiv-Assertion, analog Track-A
   `'BaluHost' in window === false`); Header-Allowlist greift; Body-Cap → 413;

--- a/docs/superpowers/specs/2026-06-28-plugin-backend-isolation-phase4-design.md
+++ b/docs/superpowers/specs/2026-06-28-plugin-backend-isolation-phase4-design.md
@@ -1,0 +1,182 @@
+# Plugin-Backend-Isolation Phase 4 — Request-Proxy + PluginManager-Dual-Path (Design)
+
+- **Datum:** 2026-06-28
+- **Status:** Design / Spec (Brainstorm abgeschlossen, vor Implementierungsplan)
+- **Track:** Plugin-Sandboxing **Track B**, Phase 4 — baut auf Phase 1–3 auf.
+- **Übergeordnete Spec:** `docs/superpowers/specs/2026-06-26-plugin-backend-isolation-design.md`
+- **Audit-Referenz:** `SECURITY_AUDIT_2026-06-14.md` (Plugin-Sandboxing, größtes verbleibendes Architektur-Risiko)
+
+---
+
+## Kontext & Ausgangslage
+
+Phase 1–3 haben die komplette Sandbox-Maschinerie gebaut — aktuell **toter Code**,
+weil nichts im laufenden `PluginManager` sie aufruft:
+
+| Komponente | Datei | Status |
+|---|---|---|
+| RPC (Framing, Channel, Transport) | `sandbox/protocol.py`, `channel.py`, `transport.py` | ✅ |
+| Worker-Prozess + Loader + SDK | `sandbox/worker.py`, `loader.py`, `sdk.py` | ✅ |
+| `SandboxSupervisor` (spawn/health/restart/kill, `dispatch()`) | `sandbox/supervisor.py` | ✅ (Spawn-Hook = Stub → Phase 5) |
+| `CapabilityRouter` (default-deny, `storage.*`/`core.*`) | `sandbox/capabilities.py` | ✅ (Deps per Injection) |
+
+Der reale Backend-Pfad (`manager.py`) ist unberührt: `load_plugin()` macht für **alle**
+Plugins `spec.loader.exec_module(module)` — also auch für `source == "external"` noch
+In-Process-RCE. Phase 4 schneidet das ab und verdrahtet die Sandbox in den echten
+Request-Pfad.
+
+### Korrektur einer Spec-Annahme
+
+Die übergeordnete Spec (Zeile ~168) behauptet, `granted_api_scopes` sei als
+DB-Spalte „bereits vorhanden" (aus Track A). **Das stimmt nicht.** Tatsächlich:
+
+- DB `InstalledPlugin` hat nur **`granted_permissions`** (JSON) — die alte
+  `PluginPermission`-Enum (`file:write`, `system:execute`, …), gegated durch
+  `PluginGateMiddleware`.
+- Das Manifest (`plugin.json`) hat ein deklaratives Feld **`api_scopes`**
+  (`manifest.py:57`), das aktuell **nirgends gespeichert oder durchgesetzt** wird —
+  es wartet auf genau diese Phase.
+
+Phase 4 führt deshalb die fehlende `granted_api_scopes`-DB-Spalte ein.
+
+---
+
+## Entscheidungen (aus dem Brainstorm)
+
+| Frage | Entscheidung |
+|---|---|
+| Scope-Storage | **Dedizierte `granted_api_scopes`-JSON-Spalte** (Alembic-Migration), getrennt von `granted_permissions`. |
+| Scope-Vergabe-Tiefe in Phase 4 | **Backend-only** (Spalte + API + Durchsetzung). Install-Scope-Picker-UI → Phase 5. |
+| `core.*`-Katalog v1 | **`core.system_metrics` + `core.notify`** ausliefern (beide Stubs sind fertig + getestet, beide harmlos). Plus `storage.*` und eigene Routen. |
+| Multi-Worker-Topologie | **Ein Subprozess pro uvicorn-Worker.** Aktueller 1:1-Transport bleibt unverändert; kein Cross-Worker-IPC. |
+
+---
+
+## Architektur
+
+### 1. Scope-Storage & -Vergabe
+
+- **Neue Spalte** `granted_api_scopes: JSON` (nullable, default `list`) auf
+  `installed_plugins`. Migration **muss an die echten `alembic heads` ketten**, nicht
+  an den stale dev-DB-Head (siehe `project_alembic_migration_head_pitfall`).
+- `enable`-Pfad eines externen Plugins akzeptiert + persistiert `granted_api_scopes`.
+  **v1: Backend-only** — kein UI-Picker (Phase 5).
+- Gewährbare Menge = die im Manifest deklarierten `api_scopes` ∩ bekannter Host-Katalog
+  (`storage`, `core.system_metrics`, `core.notify`). Unbekannte/nicht-deklarierte Scopes
+  werden beim Grant abgelehnt.
+- `CapabilityRouter.granted_scopes` wird aus dieser Spalte gespeist.
+- Die alten `PluginPermission`-Enum-Strings (`granted_permissions`) bleiben
+  **unangetastet** — informativ nur für bundled.
+
+### 2. Dual-Path im `PluginManager`
+
+- `enable_plugin` / `load_plugin` verzweigen auf `discovered.source`:
+  - `bundled` → **unveränderter** `exec_module`-Pfad (trusted, in-process).
+  - `external` → **nie** `exec_module`. Stattdessen:
+    1. Manifest lesen (ohne Code-Ausführung),
+    2. `CapabilityRouter` mit `granted_api_scopes` + injizierten Host-Deps bauen,
+    3. `SandboxSupervisor` starten (`.start()` → spawn + Health-Handshake),
+    4. in neuem `self._sandboxes[name]` registrieren (getrennt von `self._plugins`).
+- `disable_plugin` (external) → `supervisor.stop()` (graceful `shutdown`-RPC →
+  SIGTERM → SIGKILL mit Timeout). `shutdown_all` nimmt Sandboxes mit.
+- **Multi-Worker:** Jeder uvicorn-Worker spawnt + besitzt seinen **eigenen**
+  Subprozess. Der aktuelle 1:1-Transport (`WorkerListener` lauscht, Worker connectet
+  einmal zurück) bleibt unverändert. `start_background_tasks`-Gating ist fürs Spawnen
+  **irrelevant** — v1-external hat keine Background-Tasks/Events (out-of-scope), also
+  keine N×-Ausführung. Storage ist DB-shared → über alle Worker konsistent.
+  - *Accepted cost:* N× Plugin-Prozesse + N× Kalt-RAM (bei Ryzen 5 / 16 GB + wenigen
+    Plugins akzeptabel).
+
+### 3. Proxy-Router & Gating
+
+- **Catch-all** `/api/plugins/{name}/{path:path}` (alle HTTP-Methoden), in den
+  kombinierten Plugin-Router **nach** den bundled-Routern eingehängt → bundled-Routen
+  matchen zuerst, nur ungematchte Pfade erreichen den Catch-all. Der Catch-all ist
+  statisch gemountet; enable/disable externer Plugins spawnt/killt nur den Subprozess,
+  ohne Route-/OpenAPI-Rebuild.
+- Handler-Ablauf:
+  1. `Depends(get_current_user)` (jeder authentifizierte User, wie bundled-Routen),
+  2. ist `{name}` ein enabled externes Sandbox-Plugin in `self._sandboxes`? sonst **404**,
+  3. Body-Cap prüfen (sonst **413**),
+  4. Header-Allowlist anwenden,
+  5. `context {user_id, username, role}` host-seitig auflösen (**kein Token**),
+  6. `supervisor.dispatch(method, path, body, context)` → `http_response` zurück.
+- `PluginGateMiddleware` bleibt unverändert: für external ist
+  `get_required_permissions(name)` leer (Plugin nie in `self._plugins`) → Middleware
+  lässt durch, der Catch-all-Handler macht die echten Checks.
+- **Eigene Plugin-Routen** brauchen **keinen** spezifischen Scope (nur Auth + enabled).
+  Scopes gaten ausschließlich den `cap_call`-Pfad (storage/core) host-seitig im
+  `CapabilityRouter`.
+
+### 4. RPC-Request-Contract, Limits, Error-Scrubbing
+
+- **Buffered** Bodies in v1; Streaming (große Up-/Downloads) = Follow-up.
+- **Caps** (konfigurierbar, Defaults):
+  - Request-Body ≤ **10 MB** → sonst 413,
+  - Response-Body ≤ **10 MB**,
+  - Per-Request-Timeout **30 s** → sonst 504,
+  - max in-flight Requests/Plugin = **10**.
+- **Header-Allowlist:**
+  - rein (Host → Plugin): `content-type`, `accept`,
+  - raus (Plugin → Client): `content-type`,
+  - **nie** `Authorization` / `Cookie` (in keine Richtung). Token verlässt nie den Host.
+- **Error-Scrubbing** (knüpft an Posten 2 / Error-Leakage an):
+  - Plugin-Crash im Request → gescrubbtes **502**,
+  - Per-Request-Timeout → **504**, Request abgebrochen; wiederholte Timeouts zählen aufs
+    Crash-Budget des Supervisors,
+  - Detail nur server-side geloggt, nie an den Client.
+- **Capability-Deps produktiv injizieren** (heute nur in Tests gesetzt):
+  `session_factory` (DB-Session), `metrics_reader` (read-only Systemmetriken),
+  `notifier` (Notification an `context.user_id`), `audit_logger` (denied-Scopes).
+
+---
+
+## Trust-Boundary (unverändert ggü. übergeordneter Spec)
+
+- Einziger Trust-Boundary = der Host; Plugin-Prozess vollständig untrusted.
+- `exec_module` läuft für externe Plugins **nie** im Host-Prozess.
+- Token verlässt nie den Host — Plugin sieht nur `context {user_id, username, role}`.
+- Default-deny, host-seitig am `cap_call`-Dispatch durchgesetzt (`granted_api_scopes`).
+- Alle Plugin-Fehler host-seitig gescrubbt.
+- *OS-Härtung (Low-Priv-User/netns) ist Phase 5* — bis dahin läuft der Subprozess als
+  derselbe User; die RPC-/Capability-Grenze gilt bereits.
+
+---
+
+## Testing (TDD, subagent-driven wie Vorphasen)
+
+- **Migration:** round-trip up/down; bestehende Records unverändert; default `[]`.
+- **Dual-Path:** external → kein `exec_module`, Supervisor gestartet, in `_sandboxes`;
+  bundled → unveränderter Pfad, in `_plugins`. disable → Supervisor gestoppt.
+- **Proxy:** Auth-Gate vor Forward; `Authorization`/`Cookie` erscheinen **nie** im an
+  das Plugin gesendeten `http_request` (Positiv-Assertion, analog Track-A
+  `'BaluHost' in window === false`); Header-Allowlist greift; Body-Cap → 413;
+  Timeout → 504; Plugin-Crash → gescrubbtes 502 (kein Internals-Leak).
+- **Scope-Durchsetzung end-to-end:** nicht-gewährter Scope → `denied` + Audit-Log;
+  Storage user-gebunden (Plugin kann fremden `user_id` nicht adressieren);
+  Quota-Enforcement.
+- **Routing-Präzedenz:** ein bundled-Plugin-Pfad wird NICHT vom Catch-all geschluckt.
+- **E2E:** Beispiel-Sandbox-Plugin (eigene Route + `storage` + ein `core`-Scope) durch
+  den vollen Proxy → RPC → Capability-Pfad.
+
+---
+
+## Explizit Out-of-Scope (Phase 4)
+
+- **Hardened Spawn-Hook** (Low-Priv-OS-User / Netzwerk-Namespace) → Phase 5.
+- **Frontend:** Doku-Update + Install-Scope-Picker-UI → Phase 5.
+- **Background-Tasks / System-Event-Zustellung** für external → späteres Follow-up.
+- **Streaming-Bodies** → Follow-up (v1 buffered + Cap).
+- **Track C (Signing)** → orthogonaler eigener Track.
+
+---
+
+## Offene Punkte für den Implementierungsplan
+
+- Genaue Verdrahtung der `metrics_reader`/`notifier`-Host-Funktionen (welcher
+  bestehende Service liefert read-only Metriken bzw. die User-Notification).
+- Ablage der Caps/Timeouts: `settings`-Felder vs. Konstanten im Sandbox-Modul.
+- Wo der Supervisor-Lifecycle pro uvicorn-Worker aufgehängt wird (Reuse des
+  `enable_plugin`-Pfads aus `load_enabled_plugins`, der bereits pro Worker läuft).
+- Verhalten bei Supervisor-`disabled` (Restart-Budget erschöpft): Catch-all liefert
+  503/502 + Audit; DB-`is_enabled` bleibt true (auto-disable ist laufzeit-lokal).


### PR DESCRIPTION
## Plugin-Sandboxing Track B — Phase 4

Wires the Phase 1–3 sandbox machinery into the real request path. **External/marketplace plugins now run isolated in a subprocess** instead of `exec_module` in the host process; bundled (first-party) plugins keep their in-process path unchanged. This closes the backend dimension of the largest remaining architecture risk from the 2026-06-14 security audit (Track B). Track A (frontend iframe isolation) shipped in #278/#279.

Greenfield: 0 external plugins are currently deployed — this is proactive hardening before the ecosystem grows.

### What changed
- **`PluginManager` dual-path** — `enable_plugin`/`load_plugin` branch on `discovered.source`. External **with a manifest** → spawn a `SandboxSupervisor` (one subprocess per uvicorn worker); never `exec_module` in the host. Bundled and manifest-less paths unchanged.
- **No-exec guard** enforced at **both** `enable_plugin` and `load_plugin` with the identical predicate `source == "external" and manifest is not None`.
- **Catch-all proxy** `/api/plugins/{name}/{path:path}` — auth-gated, forwards a **token-free** request (header allowlist `content-type`/`accept`; `Authorization`/`Cookie` never reach the plugin; context = `{user_id, username, role}`), caps (10 MiB body via Content-Length precheck + post-read guard → 413; 30 s timeout → 504; in-flight cap → 502), and scrubs all plugin failures (crash → 502, never leaking internals).
- **Production-wired `CapabilityRouter`** — default-deny `storage.*` + `core.system_metrics` + `core.notify`, scopes from the existing `granted_api_scopes` column (Track A), storage bound to the host-resolved acting `user_id`.
- **Unique per-spawn UDS socket** (`plugin-<pid>-<token>.sock`) so the 4 prod uvicorn workers don't collide on a shared socket path.
- **Route dual-path** — `toggle`/`details`/`list` manage external plugins via the manifest, never calling `load_plugin`.

### Security invariants (verified by final whole-branch review)
- external+manifest never `exec_module`'d in the host; `exec_module` runs only in the worker subprocess
- token never leaves the host; default-deny capabilities; storage user-bound to the host context, never plugin-chosen
- all plugin failures scrubbed; one subprocess per worker; bundled path behaviorally unchanged

### Testing
- 8 tasks, TDD, fresh-subagent-per-task + two-stage review, final opus whole-branch review = **READY**.
- Full plugin suite: **531 passed, 1 skipped** (the UDS distinct-socket test is skipped on Windows by design — runs on Linux CI), ruff clean.
- A real-subprocess e2e drives an external fixture plugin through the full proxy → RPC → capability path: storage user-binding (asserts the store key bound to `user_id=42`), a `core.system_metrics` round-trip, and a denied (un-granted) scope → 500.

### Deferred to Phase 5 (not in this PR)
- Hardened spawn-hook: low-priv OS user + network namespace (the spawn-hook seam is a stub here).
- Frontend: documentation update + install-time scope-picker UI; surfacing external plugin nav-items/dashboard panels (external plugins are not in `self._plugins`, so the UI manifest currently skips them).

### Follow-up robustness items (non-blocking, file as issues)
- `disable_plugin` pops the supervisor before `await stop()` → an orphaned subprocess if `stop()` raises (reaped at worker exit).
- Confirm `supervisor.start()` kills its child on handshake failure in `_enable_external`'s error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
