### PR TITLE
feat(auth): self-service password recovery codes (LAN-only, no email)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ The same machine doubles as a KDE Plasma desktop and — thanks to the Radeon GP
 
 ### Security
 - JWT authentication with role-based access (admin/user)
+- Two-factor authentication (TOTP) with single-use backup codes
+- Self-service password recovery codes (single-use, LAN-only reset, step-up protected, no email required)
 - Rate limiting on all endpoints (slowapi)
 - Security headers (CSP, HSTS, X-Frame-Options)
 - Path jailing for user file isolation

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,6 +7,7 @@ FastAPI-basierter Backend für NAS-Management mit vollständiger Database-Integr
 ### Core Features
 - **JWT Authentication** - Sichere Token-basierte Auth mit Refresh Tokens
 - **Two-Factor Authentication (TOTP)** - Optionale 2FA mit Authenticator Apps
+- **Password Recovery Codes** - Self-Service "Passwort vergessen" über einmalige Codes (LAN-only Reset, Step-up-geschützt, kein E-Mail-Versand)
 - **SQLite/PostgreSQL Database** - Persistente Datenspeicherung mit Alembic Migrations
 - **User Management** - CRUD Operations mit Rollen (Admin/User)
 - **File Metadata** - Database-backed Ownership & Permissions

--- a/backend/alembic/versions/7fd13b0509a2_add_password_recovery_codes_encrypted_.py
+++ b/backend/alembic/versions/7fd13b0509a2_add_password_recovery_codes_encrypted_.py
@@ -1,0 +1,26 @@
+"""add password_recovery_codes_encrypted to users
+
+Revision ID: 7fd13b0509a2
+Revises: b616a346ef70
+Create Date: 2026-06-29 16:29:43.451101
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7fd13b0509a2'
+down_revision: Union[str, Sequence[str], None] = 'b616a346ef70'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("password_recovery_codes_encrypted", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "password_recovery_codes_encrypted")

--- a/backend/app/api/CLAUDE.md
+++ b/backend/app/api/CLAUDE.md
@@ -7,6 +7,7 @@ REST API endpoints for BaluHost. All routes are registered in `routes/__init__.p
 - `deps.py` — FastAPI dependency injection for auth (`get_current_user`, `get_current_admin`, `get_current_user_optional`, `verify_mobile_device_token`)
 - `docs.py` — Custom Swagger UI + ReDoc with BaluHost dark theme styling
 - `routes/` — One file per feature domain (~65 route modules)
+  - `auth.py` — Auth endpoints. Recovery-code routes: `POST /recovery-codes` (step-up: TOTP if 2FA on, else current-password), `GET /recovery-codes/status`, `POST /recovery-reset` (LAN-only, no session issued; consumes a single-use code to reset password).
   - `setup.py` — Setup wizard endpoints (status, admin creation, user creation, file access, completion)
   - `plugins_marketplace.py` — Marketplace listing + install routes. **Must be registered before `plugins.router`** in `routes/__init__.py`; otherwise `GET /plugins/marketplace` is swallowed as a plugin-name lookup.
 - `versioned/` — API versioning support (reserved)

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -24,8 +24,12 @@ from app.models.user import User as UserModel
 from app.core.config import settings
 from app.services.audit.logger_db import get_audit_logger_db
 from app.plugins.emit import emit_hook
+from app.core.network_utils import is_private_or_local_ip
 
+import logging
 import time as _time
+
+logger = logging.getLogger(__name__)
 
 from cachetools import TTLCache
 
@@ -575,6 +579,65 @@ async def recovery_codes_status(
     from app.services import recovery_code_service
     remaining = recovery_code_service.get_recovery_codes_remaining(db, current_user.id)
     return RecoveryCodesStatusResponse(configured=remaining > 0, remaining=remaining)
+
+
+@router.post("/recovery-reset")
+@limiter.limit(get_limit("auth_recovery_reset"))
+async def recovery_reset(
+    payload: RecoveryResetRequest,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    """Reset a password via a single-use recovery code — LAN-only. Issues NO session.
+
+    The user logs in normally afterward (2FA stays enforced). On success the user's
+    refresh tokens are revoked. Generic failures avoid username enumeration.
+    """
+    from app.services import recovery_code_service
+    from app.services.token_service import token_service
+    audit_logger = get_audit_logger_db()
+    ip_address = request.client.host if request.client else None
+
+    # LAN gate (real client IP via --proxy-headers --forwarded-allow-ips=127.0.0.1).
+    if not is_private_or_local_ip(ip_address):
+        audit_logger.log_security_event(
+            action="password_reset_via_recovery_failed", user=payload.username,
+            details={"ip_address": ip_address, "reason": "non_local"}, success=False, db=db,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"error": "local_network_required",
+                    "message": "Password recovery is only available from the local network."},
+        )
+
+    user_record = recovery_code_service.verify_and_consume_for_username(
+        db, payload.username, payload.recovery_code
+    )
+    if not user_record:
+        audit_logger.log_security_event(
+            action="password_reset_via_recovery_failed", user=payload.username,
+            details={"ip_address": ip_address}, success=False, db=db,
+        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
+                            detail="Invalid username or recovery code")
+
+    user_service.update_user_password(user_record.id, payload.new_password, db=db)
+    token_service.revoke_all_user_tokens(db, user_record.id, reason="password_reset_via_recovery")
+
+    # Best-effort Samba sync — never fail the reset on an SMB hiccup.
+    if user_record.smb_enabled:
+        try:
+            from app.services import samba_service
+            await samba_service.sync_smb_password(user_record.username, payload.new_password)
+        except Exception:
+            logger.warning("Samba password sync failed after recovery reset for %s", user_record.username)
+
+    audit_logger.log_security_event(
+        action="password_reset_via_recovery", user=user_record.username,
+        details={"ip_address": ip_address}, success=True, db=db,
+    )
+    return {"message": "Password reset successfully"}
 
 
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -13,6 +13,8 @@ from app.schemas.auth import (
     TwoFactorDisableRequest, TwoFactorBackupCodesResponse,
     TwoFactorStatusResponse,
     PinLoginRequest, PinSetRequest, PinRemoveRequest, PinStatusResponse,
+    RecoveryCodesGenerateRequest, RecoveryCodesResponse, RecoveryCodesStatusResponse,
+    RecoveryResetRequest,
 )
 from app.schemas.user import UserPublic, UserCreate
 from app.services import auth as auth_service
@@ -519,6 +521,60 @@ async def regenerate_backup_codes(
     )
 
     return TwoFactorBackupCodesResponse(backup_codes=backup_codes)
+
+
+@router.post("/recovery-codes", response_model=RecoveryCodesResponse)
+@limiter.limit(get_limit("auth_2fa_setup"))
+async def generate_recovery_codes_endpoint(
+    payload: RecoveryCodesGenerateRequest,
+    request: Request,
+    response: Response,
+    current_user=Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Generate/regenerate the caller's own recovery codes (shown once). Step-up required."""
+    from app.services import recovery_code_service
+    audit_logger = get_audit_logger_db()
+    ip_address = request.client.host if request.client else None
+    user_record = db.query(UserModel).filter(UserModel.id == current_user.id).first()
+    if not user_record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    # Step-up: fresh TOTP when 2FA is on, else current-password re-entry.
+    ok = False
+    if user_record.totp_enabled:
+        ok = bool(payload.code) and _verify_fresh_totp(db, current_user.id, payload.code)
+    else:
+        ok = bool(payload.current_password) and bool(
+            auth_service.authenticate_user(current_user.username, payload.current_password, db=db)
+        )
+    if not ok:
+        audit_logger.log_security_event(
+            action="recovery_codes_generate_denied", user=current_user.username,
+            details={"ip_address": ip_address}, success=False, db=db,
+        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Step-up authentication failed")
+
+    codes = recovery_code_service.generate_recovery_codes(db, current_user.id)
+    audit_logger.log_security_event(
+        action="recovery_codes_generated", user=current_user.username,
+        details={"ip_address": ip_address}, success=True, db=db,
+    )
+    return RecoveryCodesResponse(recovery_codes=codes)
+
+
+@router.get("/recovery-codes/status", response_model=RecoveryCodesStatusResponse)
+@limiter.limit(get_limit("auth_2fa_setup"))
+async def recovery_codes_status(
+    request: Request,
+    response: Response,
+    current_user=Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Whether the caller has recovery codes configured (drives the setup banner)."""
+    from app.services import recovery_code_service
+    remaining = recovery_code_service.get_recovery_codes_remaining(db, current_user.id)
+    return RecoveryCodesStatusResponse(configured=remaining > 0, remaining=remaining)
 
 
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/app/core/CLAUDE.md
+++ b/backend/app/core/CLAUDE.md
@@ -9,6 +9,7 @@ Application foundation: configuration, database, security, and cross-cutting inf
 | `config.py` | `Settings` (pydantic-settings) — all config via env vars. Access via `settings` singleton or `get_settings()`. Production validators reject weak secrets |
 | `database.py` | SQLAlchemy engine + `SessionLocal` factory. SQLite (dev, WAL mode) or PostgreSQL (prod, QueuePool). `get_db()` is the FastAPI dependency. `init_db()` creates tables (SQLite only; Postgres uses Alembic) |
 | `security.py` | JWT token creation/verification (HS256). Token types: `access` (15min), `refresh` (7d, has JTI), `sse` (60s), `ws` (60s), `2fa_pending` (5min). Always validates `type` claim |
+| `crypto.py` | Shared at-rest encryption (MultiFernet, TOTP→VPN key); totp_service delegates here |
 | `rate_limiter.py` | slowapi-based rate limiting. `limiter` instance + `get_limit(endpoint_type)` lookup. DB-backed config with in-memory cache. Dev/test mode relaxes non-auth limits. `user_limiter` for per-user limits |
 | `lifespan.py` | FastAPI lifespan: startup/shutdown orchestration. Primary-worker election via file lock. Starts hardware services, plugins, mDNS, heartbeat writer. `IS_PRIMARY_WORKER` flag controls which process runs hardware tasks |
 | `service_registry.py` | Registers all background services with the admin status dashboard. Provides DB-based status readers for secondary workers. Defines `PRIMARY_ONLY_SERVICES` and `MONITORING_WORKER_SERVICES` |

--- a/backend/app/core/crypto.py
+++ b/backend/app/core/crypto.py
@@ -1,0 +1,28 @@
+"""Shared at-rest encryption (Fernet/MultiFernet).
+
+Single seam for encrypting secrets at rest. Encrypts with TOTP_ENCRYPTION_KEY
+when set (else VPN_ENCRYPTION_KEY); decrypts by trying the dedicated key first,
+then the VPN key (dual-key fallback). A future RECOVERY_CODES_ENCRYPTION_KEY can
+be added here without touching consumers.
+"""
+from cryptography.fernet import Fernet, MultiFernet
+
+
+def get_at_rest_fernet() -> MultiFernet:
+    from app.core.config import settings
+    keys: list[Fernet] = []
+    if settings.totp_encryption_key:
+        keys.append(Fernet(settings.totp_encryption_key.encode()))
+    if settings.vpn_encryption_key:
+        keys.append(Fernet(settings.vpn_encryption_key.encode()))
+    if not keys:
+        raise ValueError("No encryption key configured (set TOTP_ENCRYPTION_KEY or VPN_ENCRYPTION_KEY)")
+    return MultiFernet(keys)
+
+
+def encrypt_at_rest(plaintext: str) -> str:
+    return get_at_rest_fernet().encrypt(plaintext.encode()).decode()
+
+
+def decrypt_at_rest(ciphertext: str) -> str:
+    return get_at_rest_fernet().decrypt(ciphertext.encode()).decode()

--- a/backend/app/core/rate_limiter.py
+++ b/backend/app/core/rate_limiter.py
@@ -119,6 +119,7 @@ RATE_LIMITS = {
     "auth_2fa_verify": "5/minute",
     "auth_2fa_setup": "5/minute",
     "auth_pin_login": "5/minute",
+    "auth_recovery_reset": "5/minute",
 
     # API key management
     "api_key_operations": "30/minute",

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -51,6 +51,10 @@ class User(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    # Password recovery codes (self-service forgot-password, LAN-only reset).
+    # Fernet-encrypted JSON array of SHA-256 hashes; None = not configured.
+    password_recovery_codes_encrypted: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
     # PIN login (Tauri local channel) — anchored on 2FA
     pin_hash: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     pin_grace_until: Mapped[Optional[datetime]] = mapped_column(

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import re
 
-from pydantic import BaseModel, EmailStr, field_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from app.schemas.user import UserPublic
 from app.schemas.validators import validate_username
@@ -93,6 +93,31 @@ class ChangePasswordRequest(BaseModel):
     @classmethod
     def validate_new_password_strength(cls, v: str) -> str:
         """Enforce password policy on new password."""
+        return _validate_password_strength(v)
+
+
+class RecoveryCodesGenerateRequest(BaseModel):
+    code: str | None = None              # fresh TOTP/backup code (when 2FA enabled)
+    current_password: str | None = None  # password re-entry (when 2FA disabled)
+
+
+class RecoveryCodesResponse(BaseModel):
+    recovery_codes: list[str]
+
+
+class RecoveryCodesStatusResponse(BaseModel):
+    configured: bool
+    remaining: int
+
+
+class RecoveryResetRequest(BaseModel):
+    username: str = Field(max_length=64)
+    recovery_code: str = Field(max_length=32)
+    new_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def validate_new_password_strength(cls, v: str) -> str:
         return _validate_password_strength(v)
 
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -111,8 +111,8 @@ class RecoveryCodesStatusResponse(BaseModel):
 
 
 class RecoveryResetRequest(BaseModel):
-    username: str = Field(max_length=64)
-    recovery_code: str = Field(max_length=32)
+    username: str = Field(min_length=1, max_length=64)
+    recovery_code: str = Field(min_length=1, max_length=32)
     new_password: str
 
     @field_validator("new_password")

--- a/backend/app/services/CLAUDE.md
+++ b/backend/app/services/CLAUDE.md
@@ -22,6 +22,7 @@ Business logic layer. Routes delegate to services — services contain the actua
 | `upload_progress.py` | SSE-based upload progress tracking |
 | `api_key_service.py` | API key CRUD, validation, usage tracking |
 | `totp_service.py` | TOTP 2FA setup, verification, backup codes |
+| `recovery_code_service.py` | Password recovery codes — generate/verify/consume single-use codes (hash+encrypt at rest), timing-equalized username verify |
 | `token_service.py` | Refresh token management, rotation |
 | `plugin_service.py` | Plugin install/uninstall/toggle operations |
 | `power_permissions.py` | Per-user power action permissions (get, update, check), incl. `can_toggle_desktop`. UI name: "System Permissions / Systemberechtigungen"; backend identifiers stay `power_permissions` (deliberate — no rename/migration). |

--- a/backend/app/services/recovery_code_service.py
+++ b/backend/app/services/recovery_code_service.py
@@ -1,0 +1,103 @@
+"""Password recovery codes.
+
+Single-use codes that let a user reset their own password without an admin or
+shell access. Stored like 2FA backup codes: a Fernet-encrypted JSON array of
+SHA-256 hashes (hash + encrypt; never plaintext). LAN-only reset is enforced at
+the route layer.
+"""
+import hashlib
+import json
+import logging
+import secrets
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.crypto import encrypt_at_rest, decrypt_at_rest
+from app.models.user import User
+
+logger = logging.getLogger(__name__)
+
+RECOVERY_CODE_COUNT = 10
+RECOVERY_CODE_HEX_BYTES = 5  # → 10 hex chars / 40 bits per code
+
+_DUMMY_BLOB: Optional[str] = None
+
+
+def _generate_codes() -> list[str]:
+    return [secrets.token_hex(RECOVERY_CODE_HEX_BYTES).upper() for _ in range(RECOVERY_CODE_COUNT)]
+
+
+def _store_codes(user: User, plain_codes: list[str]) -> None:
+    hashed = [hashlib.sha256(c.encode()).hexdigest() for c in plain_codes]
+    user.password_recovery_codes_encrypted = encrypt_at_rest(json.dumps(hashed))
+
+
+def _load_hashes(user: User) -> list[str]:
+    if not user.password_recovery_codes_encrypted:
+        return []
+    try:
+        return json.loads(decrypt_at_rest(user.password_recovery_codes_encrypted))
+    except Exception:
+        return []
+
+
+def _equalize_timing(code: str) -> None:
+    """Run an equivalent decrypt+hash for unknown/disabled users (anti-enumeration)."""
+    global _DUMMY_BLOB
+    try:
+        if _DUMMY_BLOB is None:
+            _DUMMY_BLOB = encrypt_at_rest(json.dumps([hashlib.sha256(b"dummy").hexdigest()]))
+        hashes = json.loads(decrypt_at_rest(_DUMMY_BLOB))
+    except Exception:
+        hashes = []
+    _ = hashlib.sha256(code.strip().upper().encode()).hexdigest() in hashes
+
+
+def generate_recovery_codes(db: Session, user_id: int) -> list[str]:
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise ValueError("User not found")
+    codes = _generate_codes()
+    _store_codes(user, codes)
+    db.commit()
+    return codes
+
+
+def verify_and_consume_recovery_code(db: Session, user_id: int, code: str) -> bool:
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        return False
+    hashes = _load_hashes(user)
+    if not hashes:
+        return False
+    code_hash = hashlib.sha256(code.strip().upper().encode()).hexdigest()
+    if code_hash not in hashes:
+        return False
+    hashes.remove(code_hash)
+    user.password_recovery_codes_encrypted = encrypt_at_rest(json.dumps(hashes))
+    db.commit()
+    logger.info("Recovery code consumed for user %d, %d remaining", user_id, len(hashes))
+    return True
+
+
+def verify_and_consume_for_username(db: Session, username: str, code: str) -> Optional[User]:
+    """Resolve username, verify+consume a code. Returns the User on success, else None.
+    Unknown or disabled users run a dummy verify to equalize timing (anti-enumeration)."""
+    from app.services import users as user_service
+    user = user_service.get_user_by_username(username, db=db)
+    if not user or not user.is_active:
+        _equalize_timing(code)
+        return None
+    if verify_and_consume_recovery_code(db, user.id, code):
+        return user
+    return None
+
+
+def get_recovery_codes_remaining(db: Session, user_id: int) -> int:
+    user = db.query(User).filter(User.id == user_id).first()
+    return len(_load_hashes(user)) if user else 0
+
+
+def has_recovery_codes(db: Session, user_id: int) -> bool:
+    return get_recovery_codes_remaining(db, user_id) > 0

--- a/backend/app/services/totp_service.py
+++ b/backend/app/services/totp_service.py
@@ -13,7 +13,6 @@ from datetime import datetime, timezone
 
 import pyotp
 import qrcode
-from cryptography.fernet import Fernet, MultiFernet
 from sqlalchemy.orm import Session
 
 from app.models.user import User
@@ -26,32 +25,19 @@ BACKUP_CODE_LENGTH = 8
 ISSUER_NAME = "BaluHost"
 
 
-def _get_totp_fernet() -> MultiFernet:
-    """Encrypt with TOTP_ENCRYPTION_KEY when set (else the VPN key); decrypt by trying the
-    dedicated key first, then the VPN key (dual-key fallback for secrets written under the
-    VPN-key fallback). The "not set in prod" warning lives in the config validator."""
-    from app.core.config import settings
-    keys: list[Fernet] = []
-    if settings.totp_encryption_key:
-        keys.append(Fernet(settings.totp_encryption_key.encode()))
-    if settings.vpn_encryption_key:
-        keys.append(Fernet(settings.vpn_encryption_key.encode()))
-    if not keys:
-        raise ValueError(
-            "No encryption key configured for TOTP "
-            "(set TOTP_ENCRYPTION_KEY or VPN_ENCRYPTION_KEY)"
-        )
-    return MultiFernet(keys)
+def _get_totp_fernet():
+    from app.core.crypto import get_at_rest_fernet
+    return get_at_rest_fernet()
 
 
 def _totp_encrypt(plaintext: str) -> str:
-    """Encrypt a plain-text string for TOTP storage."""
-    return _get_totp_fernet().encrypt(plaintext.encode()).decode()
+    from app.core.crypto import encrypt_at_rest
+    return encrypt_at_rest(plaintext)
 
 
 def _totp_decrypt(ciphertext: str) -> str:
-    """Decrypt a TOTP-stored ciphertext."""
-    return _get_totp_fernet().decrypt(ciphertext.encode()).decode()
+    from app.core.crypto import decrypt_at_rest
+    return decrypt_at_rest(ciphertext)
 
 
 def generate_setup(user: User) -> dict:

--- a/backend/tests/api/test_recovery_codes.py
+++ b/backend/tests/api/test_recovery_codes.py
@@ -1,4 +1,6 @@
 """Recovery-code management endpoints (generate with step-up, status)."""
+import pyotp
+
 from app.core.config import settings
 
 PREFIX = settings.api_prefix
@@ -29,8 +31,49 @@ class TestRecoveryCodeManagement:
     def test_generate_requires_auth(self, client):
         assert client.post(f"{PREFIX}/auth/recovery-codes", json={}).status_code == 401
 
+    def test_totp_stepup_required_and_succeeds(self, client, user_headers):
+        """TOTP-enabled user must provide a valid TOTP code, not a password, to generate codes."""
+        # Enable 2FA for testuser via the API (mirrors test_2fa_endpoints.py patterns).
+        setup_resp = client.post(f"{PREFIX}/auth/2fa/setup", headers=user_headers)
+        assert setup_resp.status_code == 200
+        secret = setup_resp.json()["secret"]
+        totp = pyotp.TOTP(secret)
+        verify_resp = client.post(
+            f"{PREFIX}/auth/2fa/verify-setup",
+            json={"secret": secret, "code": totp.now()},
+            headers=user_headers,
+        )
+        assert verify_resp.status_code == 200
+
+        # (a) Wrong TOTP code → step-up fails → 401.
+        bad = client.post(f"{PREFIX}/auth/recovery-codes",
+                          json={"code": "000000"}, headers=user_headers)
+        assert bad.status_code == 401
+
+        # (b) Fresh valid TOTP code → 200 + exactly 10 codes.
+        good = client.post(f"{PREFIX}/auth/recovery-codes",
+                           json={"code": totp.now()}, headers=user_headers)
+        assert good.status_code == 200
+        assert len(good.json()["recovery_codes"]) == 10
+
 
 import pytest
+
+
+@pytest.fixture
+def disabled_reset_user(db_session):
+    """A user with recovery codes generated but whose account is disabled (is_active=False)."""
+    from app.services import users as user_service
+    from app.schemas.user import UserCreate
+    from app.services import recovery_code_service
+    u = user_service.create_user(
+        UserCreate(username="disableduser", email="disabled@example.com", password="OldPass123x", role="user"),
+        db=db_session,
+    )
+    codes = recovery_code_service.generate_recovery_codes(db_session, u.id)
+    u.is_active = False
+    db_session.commit()
+    return u, codes
 
 
 @pytest.fixture
@@ -122,3 +165,13 @@ class TestRecoveryReset:
         from app.models import AuditLog
         row = db_session.query(AuditLog).filter(AuditLog.action == "password_reset_via_recovery").first()
         assert row is not None
+
+    def test_disabled_user_reset_generic_401(self, client, disabled_reset_user):
+        """A disabled (is_active=False) user with valid recovery codes must receive the same
+        generic 401 as an unknown/wrong-code attempt (anti-enumeration invariant)."""
+        u, codes = disabled_reset_user
+        r = client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": "disableduser", "recovery_code": codes[0], "new_password": "BrandNew9xPass",
+        })
+        assert r.status_code == 401
+        assert r.json()["detail"] == "Invalid username or recovery code"

--- a/backend/tests/api/test_recovery_codes.py
+++ b/backend/tests/api/test_recovery_codes.py
@@ -31,33 +31,66 @@ class TestRecoveryCodeManagement:
     def test_generate_requires_auth(self, client):
         assert client.post(f"{PREFIX}/auth/recovery-codes", json={}).status_code == 401
 
-    def test_totp_stepup_required_and_succeeds(self, client, user_headers):
-        """TOTP-enabled user must provide a valid TOTP code, not a password, to generate codes."""
-        # Enable 2FA for testuser via the API (mirrors test_2fa_endpoints.py patterns).
-        setup_resp = client.post(f"{PREFIX}/auth/2fa/setup", headers=user_headers)
+    def test_totp_stepup_required_and_succeeds(self, client, totp_stepup_user_and_headers):
+        """TOTP-enabled user must provide a valid TOTP code, not a password, to generate codes.
+
+        Uses a dedicated throwaway user so the shared testuser (user_headers) is never
+        mutated — this prevents order-dependent failures in test_status_unconfigured_then_*
+        which asserts testuser has no 2FA configured.
+        """
+        step_headers = totp_stepup_user_and_headers
+        # Enable 2FA for the dedicated user via the API (mirrors test_2fa_endpoints.py patterns).
+        setup_resp = client.post(f"{PREFIX}/auth/2fa/setup", headers=step_headers)
         assert setup_resp.status_code == 200
         secret = setup_resp.json()["secret"]
         totp = pyotp.TOTP(secret)
         verify_resp = client.post(
             f"{PREFIX}/auth/2fa/verify-setup",
             json={"secret": secret, "code": totp.now()},
-            headers=user_headers,
+            headers=step_headers,
         )
         assert verify_resp.status_code == 200
 
         # (a) Wrong TOTP code → step-up fails → 401.
         bad = client.post(f"{PREFIX}/auth/recovery-codes",
-                          json={"code": "000000"}, headers=user_headers)
+                          json={"code": "000000"}, headers=step_headers)
         assert bad.status_code == 401
 
         # (b) Fresh valid TOTP code → 200 + exactly 10 codes.
         good = client.post(f"{PREFIX}/auth/recovery-codes",
-                           json={"code": totp.now()}, headers=user_headers)
+                           json={"code": totp.now()}, headers=step_headers)
         assert good.status_code == 200
         assert len(good.json()["recovery_codes"]) == 10
 
 
 import pytest
+
+
+@pytest.fixture
+def totp_stepup_user_and_headers(client, db_session):
+    """Dedicated throwaway user for test_totp_stepup_required_and_succeeds.
+
+    Creates a fresh user (username=totpstepup) that is independent of the
+    shared testuser, so enabling 2FA here never leaks into other tests that
+    rely on testuser having no 2FA configured.
+    """
+    from app.services import users as user_service
+    from app.schemas.user import UserCreate
+    user_service.create_user(
+        UserCreate(
+            username="totpstepup",
+            email="totpstepup@example.com",
+            password="StrongPass9x",
+            role="user",
+        ),
+        db=db_session,
+    )
+    login = client.post(
+        f"{PREFIX}/auth/login",
+        json={"username": "totpstepup", "password": "StrongPass9x"},
+    )
+    assert login.status_code == 200, f"Dedicated-user login failed: {login.json()}"
+    return {"Authorization": f"Bearer {login.json()['access_token']}"}
 
 
 @pytest.fixture

--- a/backend/tests/api/test_recovery_codes.py
+++ b/backend/tests/api/test_recovery_codes.py
@@ -1,0 +1,30 @@
+"""Recovery-code management endpoints (generate with step-up, status)."""
+from app.core.config import settings
+
+PREFIX = settings.api_prefix
+# user_headers logs in as testuser / Testpass123! (conftest)
+USER_PW = "Testpass123!"
+
+
+class TestRecoveryCodeManagement:
+    def test_status_unconfigured_then_generate_with_password_stepup(self, client, user_headers):
+        s = client.get(f"{PREFIX}/auth/recovery-codes/status", headers=user_headers)
+        assert s.status_code == 200
+        assert s.json() == {"configured": False, "remaining": 0}
+
+        # testuser has no 2FA → step-up is current_password
+        g = client.post(f"{PREFIX}/auth/recovery-codes",
+                        json={"current_password": USER_PW}, headers=user_headers)
+        assert g.status_code == 200
+        assert len(g.json()["recovery_codes"]) == 10
+
+        s2 = client.get(f"{PREFIX}/auth/recovery-codes/status", headers=user_headers)
+        assert s2.json() == {"configured": True, "remaining": 10}
+
+    def test_generate_wrong_password_denied(self, client, user_headers):
+        g = client.post(f"{PREFIX}/auth/recovery-codes",
+                        json={"current_password": "WrongPass9x"}, headers=user_headers)
+        assert g.status_code == 401
+
+    def test_generate_requires_auth(self, client):
+        assert client.post(f"{PREFIX}/auth/recovery-codes", json={}).status_code == 401

--- a/backend/tests/api/test_recovery_codes.py
+++ b/backend/tests/api/test_recovery_codes.py
@@ -28,3 +28,97 @@ class TestRecoveryCodeManagement:
 
     def test_generate_requires_auth(self, client):
         assert client.post(f"{PREFIX}/auth/recovery-codes", json={}).status_code == 401
+
+
+import pytest
+
+
+@pytest.fixture
+def reset_user(db_session):
+    from app.services import users as user_service
+    from app.schemas.user import UserCreate
+    from app.services import recovery_code_service
+    u = user_service.create_user(
+        UserCreate(username="resetme", email="reset@example.com", password="OldPass123x", role="user"),
+        db=db_session,
+    )
+    codes = recovery_code_service.generate_recovery_codes(db_session, u.id)
+    return u, codes
+
+
+class TestRecoveryReset:
+    # The test client sends host='testclient', which is not a recognised private IP.
+    # Patch the bound name in the auth module to True for all tests in this class;
+    # test_non_local_forbidden overrides it to False via its own monkeypatch call.
+    @pytest.fixture(autouse=True)
+    def _patch_local_ip(self, monkeypatch):
+        import app.api.routes.auth as auth_routes
+        monkeypatch.setattr(auth_routes, "is_private_or_local_ip", lambda ip: True)
+
+    def test_happy_path_no_token_and_login_works(self, client, reset_user, db_session):
+        u, codes = reset_user
+        r = client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": "resetme", "recovery_code": codes[0], "new_password": "BrandNew9xPass",
+        })
+        assert r.status_code == 200, r.text
+        assert "access_token" not in r.json()
+        login = client.post(f"{PREFIX}/auth/login", json={"username": "resetme", "password": "BrandNew9xPass"})
+        assert login.status_code == 200
+
+    def test_revokes_existing_refresh_tokens(self, client, reset_user, db_session):
+        u, codes = reset_user
+        from app.services.token_service import token_service
+        # seed an active refresh token
+        from datetime import datetime, timezone, timedelta
+        token_service.store_refresh_token(
+            db_session, jti="jti-test", user_id=u.id, token="rawtok",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+        client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": "resetme", "recovery_code": codes[0], "new_password": "BrandNew9xPass",
+        })
+        assert token_service.is_token_revoked(db_session, "jti-test") is True
+
+    def test_wrong_code_generic(self, client, reset_user):
+        r = client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": "resetme", "recovery_code": "WRONGCODE0", "new_password": "BrandNew9xPass",
+        })
+        assert r.status_code == 401
+        assert r.json()["detail"] == "Invalid username or recovery code"
+
+    def test_unknown_user_same_generic(self, client):
+        r = client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": "ghost", "recovery_code": "ABCD123456", "new_password": "BrandNew9xPass",
+        })
+        assert r.status_code == 401
+        assert r.json()["detail"] == "Invalid username or recovery code"
+
+    def test_weak_password_422_does_not_consume(self, client, reset_user):
+        u, codes = reset_user
+        bad = client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": "resetme", "recovery_code": codes[0], "new_password": "weak",
+        })
+        assert bad.status_code == 422
+        good = client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": "resetme", "recovery_code": codes[0], "new_password": "BrandNew9xPass",
+        })
+        assert good.status_code == 200
+
+    def test_non_local_forbidden(self, client, reset_user, monkeypatch):
+        u, codes = reset_user
+        import app.api.routes.auth as auth_routes
+        monkeypatch.setattr(auth_routes, "is_private_or_local_ip", lambda ip: False)
+        r = client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": "resetme", "recovery_code": codes[0], "new_password": "BrandNew9xPass",
+        })
+        assert r.status_code == 403
+        assert r.json()["detail"]["error"] == "local_network_required"
+
+    def test_audit_rows_written(self, client, reset_user, db_session):
+        u, codes = reset_user
+        client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": "resetme", "recovery_code": codes[0], "new_password": "BrandNew9xPass",
+        })
+        from app.models import AuditLog
+        row = db_session.query(AuditLog).filter(AuditLog.action == "password_reset_via_recovery").first()
+        assert row is not None

--- a/backend/tests/core/test_crypto_at_rest.py
+++ b/backend/tests/core/test_crypto_at_rest.py
@@ -1,0 +1,16 @@
+from app.core import crypto
+
+
+def test_round_trip():
+    ct = crypto.encrypt_at_rest("hello")
+    assert ct != "hello"
+    assert crypto.decrypt_at_rest(ct) == "hello"
+
+
+def test_totp_helpers_delegate_and_interop():
+    # Data written via totp helpers must decrypt via the shared helper and vice versa.
+    from app.services import totp_service
+    ct = totp_service._totp_encrypt("x")
+    assert crypto.decrypt_at_rest(ct) == "x"
+    ct2 = crypto.encrypt_at_rest("y")
+    assert totp_service._totp_decrypt(ct2) == "y"

--- a/backend/tests/services/test_recovery_code_service.py
+++ b/backend/tests/services/test_recovery_code_service.py
@@ -1,0 +1,8 @@
+"""Tests for password recovery codes (column + service)."""
+from app.models.user import User
+
+
+def test_user_has_recovery_codes_column():
+    u = User(username="x", hashed_password="h", role="user")
+    assert hasattr(u, "password_recovery_codes_encrypted")
+    assert u.password_recovery_codes_encrypted is None

--- a/backend/tests/services/test_recovery_code_service.py
+++ b/backend/tests/services/test_recovery_code_service.py
@@ -1,4 +1,5 @@
 """Tests for password recovery codes (column + service)."""
+import pytest
 from app.models.user import User
 
 
@@ -6,3 +7,54 @@ def test_user_has_recovery_codes_column():
     u = User(username="x", hashed_password="h", role="user")
     assert hasattr(u, "password_recovery_codes_encrypted")
     assert u.password_recovery_codes_encrypted is None
+
+
+from app.services import recovery_code_service as rcs
+
+
+@pytest.fixture
+def a_user(db_session):
+    from app.services import users as user_service
+    from app.schemas.user import UserCreate
+    return user_service.create_user(
+        UserCreate(username="recov", email="r@example.com", password="StrongPass9x", role="user"),
+        db=db_session,
+    )
+
+
+def test_generate_returns_ten_codes(db_session, a_user):
+    codes = rcs.generate_recovery_codes(db_session, a_user.id)
+    assert len(codes) == rcs.RECOVERY_CODE_COUNT
+    assert rcs.has_recovery_codes(db_session, a_user.id) is True
+    assert rcs.get_recovery_codes_remaining(db_session, a_user.id) == 10
+
+
+def test_code_is_single_use(db_session, a_user):
+    codes = rcs.generate_recovery_codes(db_session, a_user.id)
+    assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, codes[0]) is True
+    assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, codes[0]) is False
+    assert rcs.get_recovery_codes_remaining(db_session, a_user.id) == 9
+
+
+def test_regenerate_invalidates_old(db_session, a_user):
+    old = rcs.generate_recovery_codes(db_session, a_user.id)
+    new = rcs.generate_recovery_codes(db_session, a_user.id)
+    assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, old[0]) is False
+    assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, new[0]) is True
+
+
+def test_verify_for_username_success_and_misses(db_session, a_user):
+    codes = rcs.generate_recovery_codes(db_session, a_user.id)
+    assert rcs.verify_and_consume_for_username(db_session, "recov", codes[0]) is not None
+    # consumed
+    assert rcs.verify_and_consume_for_username(db_session, "recov", codes[0]) is None
+    # unknown user → None (no raise)
+    assert rcs.verify_and_consume_for_username(db_session, "ghost", "AAAA111122") is None
+
+
+def test_verify_for_username_disabled_user(db_session, a_user):
+    rcs.generate_recovery_codes(db_session, a_user.id)
+    a_user.is_active = False
+    db_session.commit()
+    codes = rcs.generate_recovery_codes(db_session, a_user.id)  # still generatable directly
+    assert rcs.verify_and_consume_for_username(db_session, "recov", codes[0]) is None

--- a/client/README.md
+++ b/client/README.md
@@ -17,7 +17,7 @@ Modern React TypeScript frontend for the BaluHost home server platform.
 
 ```
 src/
-├── api/                    # API client modules (38 modules)
+├── api/                    # API client modules (39 modules)
 │   ├── admin-db.ts        # Admin database API
 │   ├── api-keys.ts        # API key management
 │   ├── backend-logs.ts    # Backend logs API
@@ -41,6 +41,7 @@ src/
 │   ├── power-management.ts # Power management API
 │   ├── power.ts           # Power API
 │   ├── raid.ts            # RAID management API
+│   ├── recovery-codes.ts  # Password recovery codes API
 │   ├── remote-servers.ts  # Remote servers API
 │   ├── samba.ts           # Samba shares API
 │   ├── schedulers.ts      # Scheduler API

--- a/client/src/__tests__/api/recovery-codes.test.ts
+++ b/client/src/__tests__/api/recovery-codes.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateRecoveryCodes, getRecoveryCodesStatus } from '../../api/recovery-codes';
+import { apiClient } from '../../lib/api';
+
+vi.mock('../../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/api')>();
+  return { ...actual, apiClient: { get: vi.fn(), post: vi.fn() }, buildApiUrl: (p: string) => p };
+});
+
+describe('recovery-codes api', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('generateRecoveryCodes posts step-up body and unwraps data', async () => {
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({ data: { recovery_codes: ['A', 'B'] } });
+    const res = await generateRecoveryCodes({ current_password: 'pw' });
+    expect(apiClient.post).toHaveBeenCalledWith('/api/auth/recovery-codes', { current_password: 'pw' });
+    expect(res.recovery_codes).toEqual(['A', 'B']);
+  });
+
+  it('getRecoveryCodesStatus unwraps data', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({ data: { configured: true, remaining: 9 } });
+    expect(await getRecoveryCodesStatus()).toEqual({ configured: true, remaining: 9 });
+  });
+});

--- a/client/src/api/recovery-codes.ts
+++ b/client/src/api/recovery-codes.ts
@@ -1,0 +1,34 @@
+/** Password recovery codes: self-service management + LAN-only reset. */
+import { apiClient, buildApiUrl } from '../lib/api';
+
+export interface RecoveryCodes { recovery_codes: string[]; }
+export interface RecoveryCodesStatus { configured: boolean; remaining: number; }
+export interface RecoveryCodesStepUp { code?: string; current_password?: string; }
+
+export async function generateRecoveryCodes(stepUp: RecoveryCodesStepUp): Promise<RecoveryCodes> {
+  const res = await apiClient.post<RecoveryCodes>('/api/auth/recovery-codes', stepUp);
+  return res.data;
+}
+
+export async function getRecoveryCodesStatus(): Promise<RecoveryCodesStatus> {
+  const res = await apiClient.get<RecoveryCodesStatus>('/api/auth/recovery-codes/status');
+  return res.data;
+}
+
+/** Pre-auth, LAN-only. Raw fetch (no bearer). Throws with the server's message. */
+export async function recoveryReset(username: string, recoveryCode: string, newPassword: string): Promise<{ message: string }> {
+  const res = await fetch(buildApiUrl('/api/auth/recovery-reset'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, recovery_code: recoveryCode, new_password: newPassword }),
+  });
+  const data = (await res.json().catch(() => ({}))) as { message?: string; detail?: unknown };
+  if (!res.ok) {
+    const d = data.detail;
+    const msg = typeof d === 'string' ? d
+      : d && typeof d === 'object' && 'message' in d ? String((d as { message: unknown }).message)
+      : `Reset failed (${res.status})`;
+    throw new Error(msg);
+  }
+  return { message: String(data.message ?? 'Password reset successfully') };
+}

--- a/client/src/components/auth/ForgotPasswordForm.tsx
+++ b/client/src/components/auth/ForgotPasswordForm.tsx
@@ -1,0 +1,62 @@
+import { useState, type FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { recoveryReset } from '../../api/recovery-codes';
+
+interface Props { onDone: () => void; }
+
+export const ForgotPasswordForm = ({ onDone }: Props) => {
+  const { t } = useTranslation('login');
+  const [username, setUsername] = useState('');
+  const [code, setCode] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+    if (newPassword !== confirm) { setError(t('forgot.mismatch')); return; }
+    setLoading(true);
+    try {
+      await recoveryReset(username.trim(), code.trim(), newPassword);
+      toast.success(t('forgot.success'));
+      onDone();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('forgot.failed'));
+    } finally { setLoading(false); }
+  };
+
+  const field = 'w-full rounded-lg border border-slate-800 bg-slate-950-secondary px-3 py-2 text-sm';
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <p className="text-xs text-slate-100-tertiary">{t('forgot.hint')}</p>
+      {error && <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">{error}</div>}
+      <label className="block space-y-1">
+        <span className="text-xs text-slate-100-secondary">{t('forgot.username')}</span>
+        <input className={field} autoComplete="username" value={username} onChange={(e) => setUsername(e.target.value)} required />
+      </label>
+      <label className="block space-y-1">
+        <span className="text-xs text-slate-100-secondary">{t('forgot.code')}</span>
+        <input className={field} value={code} onChange={(e) => setCode(e.target.value)} required />
+      </label>
+      <label className="block space-y-1">
+        <span className="text-xs text-slate-100-secondary">{t('forgot.newPassword')}</span>
+        <input type="password" className={field} autoComplete="new-password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} required />
+      </label>
+      <label className="block space-y-1">
+        <span className="text-xs text-slate-100-secondary">{t('forgot.confirm')}</span>
+        <input type="password" className={field} autoComplete="new-password" value={confirm} onChange={(e) => setConfirm(e.target.value)} required />
+      </label>
+      <div className="flex gap-2">
+        <button type="submit" disabled={loading} className="flex-1 rounded-lg bg-sky-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-50">
+          {loading ? t('forgot.resetting') : t('forgot.reset')}
+        </button>
+        <button type="button" onClick={onDone} className="rounded-lg border border-slate-800 px-3 py-2 text-sm text-slate-100-secondary">
+          {t('forgot.back')}
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/client/src/components/settings/RecoveryCodesCard.tsx
+++ b/client/src/components/settings/RecoveryCodesCard.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { generateRecoveryCodes, getRecoveryCodesStatus, type RecoveryCodesStatus } from '../../api/recovery-codes';
+import { get2FAStatus } from '../../api/two-factor';
+
+export const RecoveryCodesCard: React.FC = () => {
+  const { t } = useTranslation('settings');
+  const [status, setStatus] = useState<RecoveryCodesStatus | null>(null);
+  const [twoFA, setTwoFA] = useState(false);
+  const [stepUp, setStepUp] = useState('');
+  const [codes, setCodes] = useState<string[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = async () => {
+    try { setStatus(await getRecoveryCodesStatus()); } catch { /* best-effort */ }
+    try { setTwoFA((await get2FAStatus()).enabled); } catch { /* best-effort */ }
+  };
+  useEffect(() => { void refresh(); }, []);
+
+  const handleGenerate = async () => {
+    setLoading(true);
+    try {
+      const body = twoFA ? { code: stepUp } : { current_password: stepUp };
+      const res = await generateRecoveryCodes(body);
+      setCodes(res.recovery_codes);
+      setStepUp('');
+      await refresh();
+      toast.success(t('recovery.generated'));
+    } catch {
+      toast.error(t('recovery.generateFailed'));
+    } finally { setLoading(false); }
+  };
+
+  const handleCopy = async () => {
+    if (!codes) return;
+    try {
+      if (!navigator.clipboard?.writeText) throw new Error('no clipboard');
+      await navigator.clipboard.writeText(codes.join('\n'));
+      toast.success(t('recovery.copied'));
+    } catch {
+      toast.error(t('recovery.copyUnavailable'));
+    }
+  };
+
+  const handleDownload = () => {
+    if (!codes) return;
+    const blob = new Blob([codes.join('\n') + '\n'], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'baluhost-recovery-codes.txt';
+    a.click(); URL.revokeObjectURL(url);
+  };
+
+  const notConfigured = status !== null && !status.configured;
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+      <h3 className="text-lg font-semibold text-slate-100">{t('recovery.title')}</h3>
+      <p className="mt-1 text-sm text-slate-400">{t('recovery.desc')}</p>
+
+      {notConfigured && (
+        <div className="mt-3 rounded-lg border border-amber-700/50 bg-amber-950/30 px-3 py-2 text-xs text-amber-300">
+          {t('recovery.banner')}
+        </div>
+      )}
+      {status?.configured && !codes && (
+        <p className="mt-3 text-xs text-slate-400">{t('recovery.remaining', { count: status.remaining })}</p>
+      )}
+
+      {codes && (
+        <div className="mt-3">
+          <div className="grid grid-cols-2 gap-2 rounded-lg bg-slate-950 p-3 font-mono text-xs text-slate-100">
+            {codes.map((c) => (<span key={c}>{c}</span>))}
+          </div>
+          <div className="mt-2 flex gap-3">
+            <button onClick={handleCopy} className="text-xs text-sky-400 hover:text-sky-300">{t('recovery.copy')}</button>
+            <button onClick={handleDownload} className="text-xs text-sky-400 hover:text-sky-300">{t('recovery.download')}</button>
+          </div>
+          <p className="mt-1 text-xs text-amber-300">{t('recovery.shownOnce')}</p>
+        </div>
+      )}
+
+      <label className="mt-4 block space-y-1">
+        <span className="text-xs text-slate-300">{twoFA ? t('recovery.stepUpCode') : t('recovery.stepUpPassword')}</span>
+        <input
+          type={twoFA ? 'text' : 'password'}
+          autoComplete={twoFA ? 'one-time-code' : 'current-password'}
+          value={stepUp} onChange={(e) => setStepUp(e.target.value)}
+          className="w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+        />
+      </label>
+      <button onClick={handleGenerate} disabled={loading || !stepUp}
+        className="mt-3 rounded-lg bg-sky-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-50">
+        {loading ? t('recovery.generating') : status?.configured ? t('recovery.regenerate') : t('recovery.generate')}
+      </button>
+      {status?.configured && <p className="mt-1 text-xs text-slate-400">{t('recovery.regenWarning')}</p>}
+    </div>
+  );
+};

--- a/client/src/i18n/locales/de/login.json
+++ b/client/src/i18n/locales/de/login.json
@@ -35,7 +35,7 @@
   },
   "forgot": {
     "forgotLink": "Passwort vergessen?",
-    "hint": "Benutzername und einen Recovery-Code eingeben, um ein neues Passwort zu setzen.",
+    "hint": "Benutzernamen und einen Recovery-Code eingeben, um ein neues Passwort zu setzen.",
     "username": "Benutzername",
     "code": "Recovery-Code",
     "newPassword": "Neues Passwort",

--- a/client/src/i18n/locales/de/login.json
+++ b/client/src/i18n/locales/de/login.json
@@ -33,6 +33,20 @@
     "usePin": "Stattdessen PIN verwenden",
     "usePassword": "Passwort verwenden"
   },
+  "forgot": {
+    "forgotLink": "Passwort vergessen?",
+    "hint": "Benutzername und einen Recovery-Code eingeben, um ein neues Passwort zu setzen.",
+    "username": "Benutzername",
+    "code": "Recovery-Code",
+    "newPassword": "Neues Passwort",
+    "confirm": "Neues Passwort bestätigen",
+    "reset": "Passwort zurücksetzen",
+    "resetting": "Zurücksetzen...",
+    "back": "Abbrechen",
+    "mismatch": "Die Passwörter stimmen nicht überein.",
+    "success": "Passwort erfolgreich zurückgesetzt. Bitte einloggen.",
+    "failed": "Passwort zurücksetzen fehlgeschlagen."
+  },
   "defaultCredentials": "Standard-Anmeldedaten",
   "systemStatus": "System-Status",
   "optimal": "Optimal",

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -382,5 +382,24 @@
     "removed": "PIN entfernt",
     "saveError": "PIN konnte nicht gespeichert werden",
     "removeError": "PIN konnte nicht entfernt werden"
+  },
+  "recovery": {
+    "title": "Wiederherstellungs-Codes",
+    "desc": "Mit Wiederherstellungs-Codes kannst du Zugang zu deinem Konto wiederherstellen, wenn du dein Passwort vergisst.",
+    "banner": "Keine Wiederherstellungs-Codes gesetzt — generiere welche, um den Kontozugang zu sichern.",
+    "remaining": "{{count}} Wiederherstellungs-Code(s) verbleibend",
+    "copy": "In Zwischenablage kopieren",
+    "download": ".txt herunterladen",
+    "shownOnce": "Diese Codes sichern — sie werden nicht erneut angezeigt.",
+    "copied": "Wiederherstellungs-Codes kopiert",
+    "copyUnavailable": "Zwischenablage nicht verfügbar — Download verwenden",
+    "generated": "Wiederherstellungs-Codes generiert",
+    "generateFailed": "Fehler beim Generieren der Wiederherstellungs-Codes",
+    "stepUpCode": "2FA-Code",
+    "stepUpPassword": "Aktuelles Passwort",
+    "generate": "Codes generieren",
+    "regenerate": "Codes neu generieren",
+    "generating": "Wird generiert…",
+    "regenWarning": "Neu generieren macht alle bestehenden Wiederherstellungs-Codes ungültig."
   }
 }

--- a/client/src/i18n/locales/en/login.json
+++ b/client/src/i18n/locales/en/login.json
@@ -33,6 +33,20 @@
     "usePin": "Use a PIN instead",
     "usePassword": "Use password"
   },
+  "forgot": {
+    "forgotLink": "Forgot password?",
+    "hint": "Enter your username and a recovery code to set a new password.",
+    "username": "Username",
+    "code": "Recovery Code",
+    "newPassword": "New Password",
+    "confirm": "Confirm New Password",
+    "reset": "Reset Password",
+    "resetting": "Resetting...",
+    "back": "Cancel",
+    "mismatch": "Passwords do not match.",
+    "success": "Password reset successfully. Please log in.",
+    "failed": "Password reset failed."
+  },
   "defaultCredentials": "Default credentials",
   "systemStatus": "System Status",
   "optimal": "Optimal",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -382,5 +382,24 @@
     "removed": "PIN removed",
     "saveError": "Could not save PIN",
     "removeError": "Could not remove PIN"
+  },
+  "recovery": {
+    "title": "Recovery Codes",
+    "desc": "Recovery codes can be used to regain access to your account if you lose your password.",
+    "banner": "No recovery codes set — generate some to protect account access.",
+    "remaining": "{{count}} recovery code(s) remaining",
+    "copy": "Copy to clipboard",
+    "download": "Download .txt",
+    "shownOnce": "Save these codes — they won't be shown again.",
+    "copied": "Recovery codes copied",
+    "copyUnavailable": "Clipboard not available — use Download instead",
+    "generated": "Recovery codes generated",
+    "generateFailed": "Failed to generate recovery codes",
+    "stepUpCode": "2FA code",
+    "stepUpPassword": "Current password",
+    "generate": "Generate codes",
+    "regenerate": "Regenerate codes",
+    "generating": "Generating…",
+    "regenWarning": "Regenerating will invalidate all existing recovery codes."
   }
 }

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -7,6 +7,7 @@ import { localApi } from '../lib/localApi';
 import { buildApiUrl, isTauri } from '../lib/api';
 import { sanitizeTwoFactorCode, isTwoFactorCodeComplete } from '../lib/twoFactorCode';
 import { loginWithPin } from '../api/pin';
+import { ForgotPasswordForm } from '../components/auth/ForgotPasswordForm';
 import { useVersion } from '../contexts/VersionContext';
 import { DeveloperBadge } from '../components/ui/DeveloperBadge';
 import { useAuth } from '../contexts/AuthContext';
@@ -34,6 +35,7 @@ export default function Login() {
   const [showPassword, setShowPassword] = useState(false);
   const [pinMode, setPinMode] = useState(false);
   const [pin, setPin] = useState('');
+  const [forgotMode, setForgotMode] = useState(false);
 
   // Check if local backend is available on component mount
   useEffect(() => {
@@ -343,6 +345,10 @@ export default function Login() {
                     {t('pin.usePassword')}
                   </button>
                 </form>
+              ) : forgotMode ? (
+                <div className="mt-8 sm:mt-10">
+                  <ForgotPasswordForm onDone={() => setForgotMode(false)} />
+                </div>
               ) : (
               <form onSubmit={handleSubmit} className="mt-8 sm:mt-10 space-y-4 sm:space-y-5">
                 {error && (
@@ -398,6 +404,13 @@ export default function Login() {
                   disabled={loading}
                 >
                   {loading ? t('form.loading') : t('form.submit')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setForgotMode(true)}
+                  className="w-full text-center text-xs text-sky-400 hover:text-sky-300 transition-colors"
+                >
+                  {t('forgot.forgotLink')}
                 </button>
               </form>
               )}

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { User, Lock, Clock, Download, Globe, GitBranch, Bell, HardDrive, Plug } from 'lucide-react';
 import TwoFactorCard from '../components/settings/TwoFactorCard';
+import { RecoveryCodesCard } from '../components/settings/RecoveryCodesCard';
 import { DesktopPinSettings } from '../components/settings/DesktopPinSettings';
 import { useTwoFactorStatus } from '../components/quickSettings/twoFactorStatusStore';
 import VCLTrackingPanel from '../components/vcl/VCLTrackingPanel';
@@ -290,6 +291,9 @@ export default function SettingsPage() {
 
             {/* Two-Factor Authentication */}
             <TwoFactorCard />
+
+            {/* Recovery Codes */}
+            <RecoveryCodesCard />
 
             {/* Desktop-app PIN (2FA-gated) */}
             <DesktopPinSettings twoFactorEnabled={twoFactorEnabled} />

--- a/docs/superpowers/plans/2026-06-29-password-recovery-codes.md
+++ b/docs/superpowers/plans/2026-06-29-password-recovery-codes.md
@@ -1,0 +1,1060 @@
+# Password Recovery Codes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a LAN-only, self-service "forgot password" flow using single-use recovery codes, mirroring the existing 2FA backup-code mechanism.
+
+**Architecture:** A new encrypted column on `User` stores Fernet-encrypted SHA-256 hashes of recovery codes (identical at-rest protection to 2FA backup codes). A dedicated `recovery_code_service` generates/verifies/consumes codes. Three new `auth` endpoints: two session-gated (generate, status) bound to the caller's own account, and one **pre-auth, local-channel-only** reset that sets a new password and issues **no token** (so 2FA stays enforced at the subsequent login). Frontend adds a "Passwort vergessen?" form on the login page and a recovery-codes management card (with a setup-nudge banner) in security settings.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0, Alembic, Pydantic v2, slowapi, `cryptography` Fernet (via `totp_service`), pytest; React 18 + TypeScript, axios (`apiClient`), Vitest.
+
+## Global Constraints
+
+- **Reset is LOCAL CHANNEL ONLY.** Gate with `getattr(request.state, "channel", "remote") != "local"` → `403 {"error": "local_channel_required", ...}`. Mirror `login_pin` (`backend/app/api/routes/auth.py`).
+- **Reset issues NO session/token.** It only sets a new password. 2FA is preserved because the user logs in normally afterward.
+- **Codes are hashed THEN encrypted at rest.** SHA-256 hex of each code, JSON array, Fernet-encrypted via `totp_service._totp_encrypt` / `_totp_decrypt` (`TOTP_ENCRYPTION_KEY` → `VPN_ENCRYPTION_KEY` fallback). Never store or log plaintext codes.
+- **RBAC:** management endpoints use `Depends(deps.get_current_user)` and operate only on `current_user.id` — never another user's codes. No admin endpoint reveals codes.
+- **Password strength:** `new_password` validated by `_validate_password_strength` (`backend/app/schemas/auth.py`) — via a Pydantic `field_validator`, NOT a raw `dict`, so a weak password is `422` **before** the handler runs (no code consumed).
+- **Anti-enumeration:** unknown user, wrong code, no-codes-configured all return the **same** `401 "Invalid username or recovery code"`.
+- **Scope:** all roles (admin + user).
+- **Codes:** `RECOVERY_CODE_COUNT = 10`, format = uppercased `secrets.token_hex(4)` (8 hex chars), identical to 2FA backup codes.
+- **Alembic head pitfall:** set the migration `down_revision` to the real `alembic heads` output, NOT a stale dev-DB head.
+- **Windows CRLF repo:** repo uses `core.autocrlf=true`; the `LF will be replaced by CRLF` warning on commit is expected.
+- **Spec:** `docs/superpowers/specs/2026-06-29-password-recovery-codes-design.md`.
+
+---
+
+## File Structure
+
+**Backend**
+- `backend/app/models/user.py` — new `password_recovery_codes_encrypted` column.
+- `backend/alembic/versions/<rev>_add_password_recovery_codes.py` — migration.
+- `backend/app/services/recovery_code_service.py` — new service (generate/verify/consume/status).
+- `backend/app/schemas/auth.py` — `RecoveryResetRequest`, `RecoveryCodesResponse`, `RecoveryCodesStatusResponse`.
+- `backend/app/core/rate_limiter.py` — `auth_recovery_reset` limit key.
+- `backend/app/api/routes/auth.py` — 3 endpoints.
+- `backend/tests/services/test_recovery_code_service.py`, `backend/tests/api/test_recovery_codes.py`.
+
+**Frontend**
+- `client/src/api/recovery-codes.ts` — typed client (management + reset).
+- `client/src/api/__tests__/recovery-codes.test.ts` — vitest.
+- `client/src/components/auth/ForgotPasswordForm.tsx` — self-contained reset form.
+- `client/src/pages/Login.tsx` — render the form behind a "Passwort vergessen?" link.
+- `client/src/components/settings/RecoveryCodesCard.tsx` — management card + nudge banner.
+- Settings security section — render `<RecoveryCodesCard />` next to `<TwoFactorCard />`.
+
+**Docs**
+- `backend/app/services/CLAUDE.md`, `backend/app/api/CLAUDE.md`, `backend/app/models/CLAUDE.md`.
+
+---
+
+### Task 1: User model column + migration
+
+**Files:**
+- Modify: `backend/app/models/user.py:49` (after `totp_backup_codes_encrypted`)
+- Create: `backend/alembic/versions/<rev>_add_password_recovery_codes.py`
+- Test: `backend/tests/services/test_recovery_code_service.py`
+
+**Interfaces:**
+- Produces: `User.password_recovery_codes_encrypted: Mapped[str | None]` (Text, nullable, default `None`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/services/test_recovery_code_service.py`:
+
+```python
+"""Tests for password recovery codes (column + service)."""
+from app.models.user import User
+
+
+def test_user_has_recovery_codes_column():
+    # Column exists and defaults to None on a fresh instance.
+    u = User(username="x", hashed_password="h", role="user")
+    assert hasattr(u, "password_recovery_codes_encrypted")
+    assert u.password_recovery_codes_encrypted is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/services/test_recovery_code_service.py::test_user_has_recovery_codes_column -v --no-cov`
+Expected: FAIL — `AttributeError: ... has no attribute 'password_recovery_codes_encrypted'`.
+
+- [ ] **Step 3: Add the column**
+
+In `backend/app/models/user.py`, immediately after line 52 (the `totp_enabled_at` column, end of the "TOTP 2FA fields" block) add:
+
+```python
+
+    # Password recovery codes (self-service forgot-password, LAN-only reset).
+    # Fernet-encrypted JSON array of SHA-256 hashes; None = not configured.
+    password_recovery_codes_encrypted: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+```
+
+(`Text` and `Optional` are already imported in this file.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/services/test_recovery_code_service.py::test_user_has_recovery_codes_column -v --no-cov`
+Expected: PASS.
+
+- [ ] **Step 5: Generate the migration against the REAL head**
+
+Run: `cd backend && alembic heads`
+Note the revision id printed (call it `<HEAD>`).
+
+Run: `cd backend && alembic revision -m "add password_recovery_codes_encrypted to users"`
+
+Open the new file in `backend/alembic/versions/`. Set `down_revision = "<HEAD>"` (the value from `alembic heads`) and make the body exactly:
+
+```python
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("password_recovery_codes_encrypted", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "password_recovery_codes_encrypted")
+```
+
+- [ ] **Step 6: Verify the migration is reversible**
+
+Run: `cd backend && alembic upgrade head && alembic downgrade -1 && alembic upgrade head`
+Expected: upgrade adds the column, downgrade drops it, re-upgrade re-adds — no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/models/user.py backend/alembic/versions/ backend/tests/services/test_recovery_code_service.py
+git commit -m "feat(auth): add password_recovery_codes_encrypted column + migration"
+```
+
+---
+
+### Task 2: `recovery_code_service`
+
+**Files:**
+- Create: `backend/app/services/recovery_code_service.py`
+- Test: `backend/tests/services/test_recovery_code_service.py` (append)
+
+**Interfaces:**
+- Consumes: `User.password_recovery_codes_encrypted`; `totp_service._totp_encrypt/_totp_decrypt`.
+- Produces:
+  - `generate_recovery_codes(db: Session, user_id: int) -> list[str]`
+  - `verify_and_consume_recovery_code(db: Session, user_id: int, code: str) -> bool`
+  - `get_recovery_codes_remaining(db: Session, user_id: int) -> int`
+  - `has_recovery_codes(db: Session, user_id: int) -> bool`
+  - `RECOVERY_CODE_COUNT = 10`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/services/test_recovery_code_service.py`:
+
+```python
+import pytest
+from app.services import recovery_code_service as rcs
+
+
+@pytest.fixture
+def a_user(db_session):
+    from app.services import users as user_service
+    from app.schemas.user import UserCreate
+    return user_service.create_user(
+        UserCreate(username="recov", email="r@example.com", password="StrongPass9x", role="user"),
+        db=db_session,
+    )
+
+
+def test_generate_returns_ten_codes(db_session, a_user):
+    codes = rcs.generate_recovery_codes(db_session, a_user.id)
+    assert len(codes) == rcs.RECOVERY_CODE_COUNT
+    assert all(isinstance(c, str) and c for c in codes)
+    assert rcs.has_recovery_codes(db_session, a_user.id) is True
+    assert rcs.get_recovery_codes_remaining(db_session, a_user.id) == 10
+
+
+def test_code_is_single_use(db_session, a_user):
+    codes = rcs.generate_recovery_codes(db_session, a_user.id)
+    assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, codes[0]) is True
+    # second use of the same code fails
+    assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, codes[0]) is False
+    assert rcs.get_recovery_codes_remaining(db_session, a_user.id) == 9
+
+
+def test_regenerate_invalidates_old_codes(db_session, a_user):
+    old = rcs.generate_recovery_codes(db_session, a_user.id)
+    new = rcs.generate_recovery_codes(db_session, a_user.id)
+    assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, old[0]) is False
+    assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, new[0]) is True
+
+
+def test_wrong_code_and_unconfigured(db_session, a_user):
+    assert rcs.has_recovery_codes(db_session, a_user.id) is False
+    assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, "DEADBEEF") is False
+    rcs.generate_recovery_codes(db_session, a_user.id)
+    assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, "NOTACODE") is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/services/test_recovery_code_service.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError: app.services.recovery_code_service`.
+
+- [ ] **Step 3: Implement the service**
+
+Create `backend/app/services/recovery_code_service.py`:
+
+```python
+"""Password recovery codes.
+
+Single-use codes that let a user reset their own password without an admin or
+shell access. Stored exactly like 2FA backup codes: a Fernet-encrypted JSON
+array of SHA-256 hashes (hash + encrypt; never plaintext at rest). LAN-only
+reset is enforced at the route layer, not here.
+"""
+import hashlib
+import json
+import logging
+import secrets
+
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from app.services.totp_service import _totp_encrypt, _totp_decrypt
+
+logger = logging.getLogger(__name__)
+
+RECOVERY_CODE_COUNT = 10
+RECOVERY_CODE_HEX_BYTES = 4  # → 8 hex chars per code (matches 2FA backup codes)
+
+
+def _generate_codes() -> list[str]:
+    return [secrets.token_hex(RECOVERY_CODE_HEX_BYTES).upper() for _ in range(RECOVERY_CODE_COUNT)]
+
+
+def _store_codes(user: User, plain_codes: list[str]) -> None:
+    hashed = [hashlib.sha256(c.encode()).hexdigest() for c in plain_codes]
+    user.password_recovery_codes_encrypted = _totp_encrypt(json.dumps(hashed))
+
+
+def _load_hashes(user: User) -> list[str]:
+    if not user.password_recovery_codes_encrypted:
+        return []
+    try:
+        return json.loads(_totp_decrypt(user.password_recovery_codes_encrypted))
+    except Exception:
+        return []
+
+
+def generate_recovery_codes(db: Session, user_id: int) -> list[str]:
+    """Generate fresh codes, store hashed+encrypted, return plaintext ONCE.
+    Regenerating overwrites the column → all previous codes are invalidated."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise ValueError("User not found")
+    codes = _generate_codes()
+    _store_codes(user, codes)
+    db.commit()
+    return codes
+
+
+def verify_and_consume_recovery_code(db: Session, user_id: int, code: str) -> bool:
+    """Verify a code and consume it (single-use). False on any miss; never raises."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        return False
+    hashes = _load_hashes(user)
+    if not hashes:
+        return False
+    code_hash = hashlib.sha256(code.strip().upper().encode()).hexdigest()
+    if code_hash not in hashes:
+        return False
+    hashes.remove(code_hash)
+    user.password_recovery_codes_encrypted = _totp_encrypt(json.dumps(hashes))
+    db.commit()
+    logger.info("Recovery code consumed for user %d, %d remaining", user_id, len(hashes))
+    return True
+
+
+def get_recovery_codes_remaining(db: Session, user_id: int) -> int:
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        return 0
+    return len(_load_hashes(user))
+
+
+def has_recovery_codes(db: Session, user_id: int) -> bool:
+    return get_recovery_codes_remaining(db, user_id) > 0
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/services/test_recovery_code_service.py -v --no-cov`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/recovery_code_service.py backend/tests/services/test_recovery_code_service.py
+git commit -m "feat(auth): recovery_code_service (generate/verify/consume, hash+encrypt at rest)"
+```
+
+---
+
+### Task 3: Schemas, rate-limit key, management endpoints
+
+**Files:**
+- Modify: `backend/app/schemas/auth.py` (after `ChangePasswordRequest`)
+- Modify: `backend/app/core/rate_limiter.py:151` (inside `RATE_LIMITS`)
+- Modify: `backend/app/api/routes/auth.py` (after the `2fa/backup-codes` endpoint)
+- Test: `backend/tests/api/test_recovery_codes.py`
+
+**Interfaces:**
+- Consumes: `recovery_code_service`, `deps.get_current_user`, `get_limit`, `get_audit_logger_db`.
+- Produces (schemas):
+  - `RecoveryCodesResponse{ recovery_codes: list[str] }`
+  - `RecoveryCodesStatusResponse{ configured: bool, remaining: int }`
+  - `RecoveryResetRequest{ username: str, recovery_code: str, new_password: str }` (strength-validated)
+- Produces (routes): `POST /api/auth/recovery-codes`, `GET /api/auth/recovery-codes/status`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/api/test_recovery_codes.py`:
+
+```python
+"""Recovery-code management endpoints + LAN-only reset."""
+from app.core.config import settings
+
+PREFIX = settings.api_prefix
+
+
+class TestRecoveryCodeManagement:
+    def test_status_unconfigured_then_generate(self, client, user_headers):
+        s = client.get(f"{PREFIX}/auth/recovery-codes/status", headers=user_headers)
+        assert s.status_code == 200
+        assert s.json() == {"configured": False, "remaining": 0}
+
+        g = client.post(f"{PREFIX}/auth/recovery-codes", headers=user_headers)
+        assert g.status_code == 200
+        codes = g.json()["recovery_codes"]
+        assert len(codes) == 10
+
+        s2 = client.get(f"{PREFIX}/auth/recovery-codes/status", headers=user_headers)
+        assert s2.json() == {"configured": True, "remaining": 10}
+
+    def test_generate_requires_auth(self, client):
+        r = client.post(f"{PREFIX}/auth/recovery-codes")
+        assert r.status_code == 401
+```
+
+> Fixtures `client`, `user_headers` come from `backend/tests/conftest.py` (same ones the 2FA endpoint tests use). The default `client` runs `channel=local`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/api/test_recovery_codes.py -v --no-cov`
+Expected: FAIL — 404 (routes not defined).
+
+- [ ] **Step 3: Add the schemas**
+
+In `backend/app/schemas/auth.py`, immediately after `ChangePasswordRequest` (line 96) add:
+
+```python
+class RecoveryCodesResponse(BaseModel):
+    recovery_codes: list[str]
+
+
+class RecoveryCodesStatusResponse(BaseModel):
+    configured: bool
+    remaining: int
+
+
+class RecoveryResetRequest(BaseModel):
+    username: str
+    recovery_code: str
+    new_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def validate_new_password_strength(cls, v: str) -> str:
+        """Enforce password policy; a weak password fails BEFORE the handler runs."""
+        return _validate_password_strength(v)
+```
+
+- [ ] **Step 4: Add the rate-limit key**
+
+In `backend/app/core/rate_limiter.py`, inside the `RATE_LIMITS` dict, after the `"auth_pin_login": "5/minute",` line (line 121) add:
+
+```python
+    "auth_recovery_reset": "5/minute",
+```
+
+- [ ] **Step 5: Add the management endpoints**
+
+In `backend/app/api/routes/auth.py`, find the `regenerate_backup_codes` endpoint (the `@router.post("/2fa/backup-codes" ...)` block) and add immediately after it. First ensure the new schemas are imported — locate the existing `from app.schemas.auth import (...)` block and add `RecoveryCodesResponse`, `RecoveryCodesStatusResponse`, `RecoveryResetRequest` to it.
+
+```python
+@router.post("/recovery-codes", response_model=RecoveryCodesResponse)
+@limiter.limit(get_limit("auth_2fa_setup"))
+async def generate_recovery_codes_endpoint(
+    request: Request,
+    response: Response,
+    current_user=Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Generate/regenerate the caller's own password-recovery codes (shown once)."""
+    from app.services import recovery_code_service
+    audit_logger = get_audit_logger_db()
+    ip_address = request.client.host if request.client else None
+
+    codes = recovery_code_service.generate_recovery_codes(db, current_user.id)
+    audit_logger.log_security_event(
+        action="recovery_codes_generated",
+        user=current_user.username,
+        details={"ip_address": ip_address},
+        success=True,
+        db=db,
+    )
+    return RecoveryCodesResponse(recovery_codes=codes)
+
+
+@router.get("/recovery-codes/status", response_model=RecoveryCodesStatusResponse)
+@limiter.limit(get_limit("auth_2fa_setup"))
+async def recovery_codes_status(
+    request: Request,
+    response: Response,
+    current_user=Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Whether the caller has recovery codes configured (drives the setup banner)."""
+    from app.services import recovery_code_service
+    remaining = recovery_code_service.get_recovery_codes_remaining(db, current_user.id)
+    return RecoveryCodesStatusResponse(configured=remaining > 0, remaining=remaining)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/api/test_recovery_codes.py -v --no-cov`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/schemas/auth.py backend/app/core/rate_limiter.py backend/app/api/routes/auth.py backend/tests/api/test_recovery_codes.py
+git commit -m "feat(auth): recovery-code management endpoints (generate + status)"
+```
+
+---
+
+### Task 4: LAN-only `recovery-reset` endpoint
+
+**Files:**
+- Modify: `backend/app/api/routes/auth.py` (after `recovery_codes_status`)
+- Test: `backend/tests/api/test_recovery_codes.py` (append)
+
+**Interfaces:**
+- Consumes: `RecoveryResetRequest`, `recovery_code_service`, `user_service.get_user_by_username/update_user_password`, `samba_service.sync_smb_password`, channel gate.
+- Produces: `POST /api/auth/recovery-reset` → `{ "message": str }`, no token.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/api/test_recovery_codes.py`:
+
+```python
+class TestRecoveryReset:
+    def test_reset_happy_path_no_token(self, client, user_headers, db_session):
+        # Arrange: the seeded test user generates codes via the API.
+        g = client.post(f"{PREFIX}/auth/recovery-codes", headers=user_headers)
+        code = g.json()["recovery_codes"][0]
+        # Resolve the username behind user_headers.
+        me = client.get(f"{PREFIX}/auth/me", headers=user_headers).json()
+        username = me["username"]
+
+        # Act: reset (default client = local channel).
+        r = client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": username, "recovery_code": code, "new_password": "BrandNew9xPass",
+        })
+        assert r.status_code == 200, r.text
+        assert "access_token" not in r.json()
+
+        # New password works at the normal login.
+        login = client.post(f"{PREFIX}/auth/login", json={
+            "username": username, "password": "BrandNew9xPass",
+        })
+        assert login.status_code == 200
+
+    def test_reset_rejects_wrong_code_generic(self, client, user_headers):
+        client.post(f"{PREFIX}/auth/recovery-codes", headers=user_headers)
+        me = client.get(f"{PREFIX}/auth/me", headers=user_headers).json()
+        r = client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": me["username"], "recovery_code": "WRONGCOD", "new_password": "BrandNew9xPass",
+        })
+        assert r.status_code == 401
+        assert r.json()["detail"] == "Invalid username or recovery code"
+
+    def test_reset_unknown_user_same_generic(self, client):
+        r = client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": "ghost", "recovery_code": "ABCD1234", "new_password": "BrandNew9xPass",
+        })
+        assert r.status_code == 401
+        assert r.json()["detail"] == "Invalid username or recovery code"
+
+    def test_reset_weak_password_422_does_not_consume(self, client, user_headers, db_session):
+        g = client.post(f"{PREFIX}/auth/recovery-codes", headers=user_headers)
+        code = g.json()["recovery_codes"][0]
+        me = client.get(f"{PREFIX}/auth/me", headers=user_headers).json()
+        # weak password → 422 before handler; code must remain usable.
+        bad = client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": me["username"], "recovery_code": code, "new_password": "weak",
+        })
+        assert bad.status_code == 422
+        good = client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": me["username"], "recovery_code": code, "new_password": "BrandNew9xPass",
+        })
+        assert good.status_code == 200
+
+    def test_reset_remote_channel_forbidden(self, remote_client, user_headers):
+        # Generate codes over the local client first.
+        from app.core.config import settings as _s
+        gen = remote_client.post(f"{PREFIX}/auth/recovery-codes", headers=user_headers)
+        # management endpoints are not channel-gated, so this still works (200);
+        code = gen.json()["recovery_codes"][0]
+        me = remote_client.get(f"{PREFIX}/auth/me", headers=user_headers).json()
+        r = remote_client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": me["username"], "recovery_code": code, "new_password": "BrandNew9xPass",
+        })
+        assert r.status_code == 403
+        assert r.json()["detail"]["error"] == "local_channel_required"
+```
+
+> Notes: `remote_client` monkeypatches `settings.channel="remote"` (canonical example: `backend/tests/api/test_power_authority_routes.py::test_put_authority_requires_local_channel`). Remove the stray `user_service_module` placeholder import — it was only to flag that you resolve usernames via `users.get_user_by_username`; the actual tests use `/auth/me`. If `/auth/me` is not the correct path in this repo, resolve the username via the `user_headers` fixture's known username instead.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/api/test_recovery_codes.py::TestRecoveryReset -v --no-cov`
+Expected: FAIL — 404 (route not defined). Fix the `_seed_codes` helper / `/auth/me` path per the note before continuing if a test errors for an unrelated reason.
+
+- [ ] **Step 3: Add the reset endpoint**
+
+In `backend/app/api/routes/auth.py`, immediately after `recovery_codes_status`, add:
+
+```python
+@router.post("/recovery-reset")
+@limiter.limit(get_limit("auth_recovery_reset"))
+async def recovery_reset(
+    payload: RecoveryResetRequest,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    """Reset a password via a single-use recovery code — LOCAL CHANNEL ONLY.
+
+    Issues NO session: the user logs in normally afterward, so 2FA stays
+    enforced. Returns a generic failure to avoid username enumeration.
+    """
+    from app.services import recovery_code_service
+    audit_logger = get_audit_logger_db()
+    ip_address = request.client.host if request.client else None
+
+    # Hard invariant: recovery reset is only valid over the local channel.
+    if getattr(request.state, "channel", "remote") != "local":
+        audit_logger.log_security_event(
+            action="password_reset_via_recovery_failed",
+            user=payload.username,
+            details={"ip_address": ip_address, "reason": "remote_channel"},
+            success=False,
+            db=db,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "local_channel_required",
+                "message": "Password recovery is only available from the local network.",
+            },
+        )
+
+    user_record = user_service.get_user_by_username(payload.username, db=db)
+    code_ok = False
+    if user_record:
+        code_ok = recovery_code_service.verify_and_consume_recovery_code(
+            db, user_record.id, payload.recovery_code
+        )
+    if not user_record or not code_ok:
+        audit_logger.log_security_event(
+            action="password_reset_via_recovery_failed",
+            user=payload.username,
+            details={"ip_address": ip_address},
+            success=False,
+            db=db,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid username or recovery code",
+        )
+
+    user_service.update_user_password(user_record.id, payload.new_password, db=db)
+
+    # Keep the Samba password in sync when SMB is enabled (mirror change_password).
+    user_record = db.query(UserModel).filter(UserModel.id == user_record.id).first()
+    if user_record and user_record.smb_enabled:
+        from app.services import samba_service
+        await samba_service.sync_smb_password(user_record.username, payload.new_password)
+
+    audit_logger.log_security_event(
+        action="password_reset_via_recovery",
+        user=user_record.username,
+        details={"ip_address": ip_address},
+        success=True,
+        db=db,
+    )
+    return {"message": "Password reset successfully"}
+```
+
+> `UserModel`, `user_service`, `status`, `HTTPException`, `Request`, `Response`, `get_db`, `get_audit_logger_db` are all already imported in this file (used by `change_password`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/api/test_recovery_codes.py -v --no-cov`
+Expected: PASS (all).
+
+- [ ] **Step 5: Run the auth/2FA suites for regressions**
+
+Run: `cd backend && python -m pytest tests/api/test_2fa_endpoints.py tests/security/test_change_password_validation.py tests/api/test_pin_login.py -q --no-cov`
+Expected: PASS (no regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/api/routes/auth.py backend/tests/api/test_recovery_codes.py
+git commit -m "feat(auth): LAN-only recovery-reset endpoint (no session, anti-enumeration)"
+```
+
+---
+
+### Task 5: Frontend API client
+
+**Files:**
+- Create: `client/src/api/recovery-codes.ts`
+- Test: `client/src/api/__tests__/recovery-codes.test.ts`
+
+**Interfaces:**
+- Produces: `generateRecoveryCodes()`, `getRecoveryCodesStatus()`, `recoveryReset(username, recoveryCode, newPassword)` and types `RecoveryCodes`, `RecoveryCodesStatus`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/api/__tests__/recovery-codes.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateRecoveryCodes, getRecoveryCodesStatus } from '../recovery-codes';
+import { apiClient } from '../../lib/api';
+
+vi.mock('../../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/api')>();
+  return {
+    ...actual,
+    apiClient: { get: vi.fn(), post: vi.fn() },
+    buildApiUrl: (p: string) => p,
+  };
+});
+
+describe('recovery-codes api', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('generateRecoveryCodes posts and unwraps data', async () => {
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({ data: { recovery_codes: ['A', 'B'] } });
+    const res = await generateRecoveryCodes();
+    expect(apiClient.post).toHaveBeenCalledWith('/api/auth/recovery-codes');
+    expect(res.recovery_codes).toEqual(['A', 'B']);
+  });
+
+  it('getRecoveryCodesStatus gets and unwraps data', async () => {
+    (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({ data: { configured: true, remaining: 9 } });
+    const res = await getRecoveryCodesStatus();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/auth/recovery-codes/status');
+    expect(res).toEqual({ configured: true, remaining: 9 });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd client && npx vitest run src/api/__tests__/recovery-codes.test.ts`
+Expected: FAIL — cannot resolve `../recovery-codes`.
+
+- [ ] **Step 3: Implement the client**
+
+Create `client/src/api/recovery-codes.ts`:
+
+```typescript
+/** Password recovery codes: self-service management + LAN-only reset. */
+import { apiClient, buildApiUrl } from '../lib/api';
+
+export interface RecoveryCodes {
+  recovery_codes: string[];
+}
+
+export interface RecoveryCodesStatus {
+  configured: boolean;
+  remaining: number;
+}
+
+export async function generateRecoveryCodes(): Promise<RecoveryCodes> {
+  const res = await apiClient.post<RecoveryCodes>('/api/auth/recovery-codes');
+  return res.data;
+}
+
+export async function getRecoveryCodesStatus(): Promise<RecoveryCodesStatus> {
+  const res = await apiClient.get<RecoveryCodesStatus>('/api/auth/recovery-codes/status');
+  return res.data;
+}
+
+/**
+ * Pre-auth, local-channel-only reset. Mirrors Login.tsx's raw-fetch path
+ * (no bearer token). Throws with the server's message on failure.
+ */
+export async function recoveryReset(
+  username: string,
+  recoveryCode: string,
+  newPassword: string,
+): Promise<{ message: string }> {
+  const res = await fetch(buildApiUrl('/api/auth/recovery-reset'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, recovery_code: recoveryCode, new_password: newPassword }),
+  });
+  const data = (await res.json().catch(() => ({}))) as { message?: string; detail?: unknown };
+  if (!res.ok) {
+    const d = data.detail;
+    const msg =
+      typeof d === 'string'
+        ? d
+        : d && typeof d === 'object' && 'message' in d
+          ? String((d as { message: unknown }).message)
+          : `Reset failed (${res.status})`;
+    throw new Error(msg);
+  }
+  return { message: String(data.message ?? 'Password reset successfully') };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd client && npx vitest run src/api/__tests__/recovery-codes.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/api/recovery-codes.ts client/src/api/__tests__/recovery-codes.test.ts
+git commit -m "feat(client): recovery-codes API client (management + LAN-only reset)"
+```
+
+---
+
+### Task 6: "Passwort vergessen?" form on the login page
+
+**Files:**
+- Create: `client/src/components/auth/ForgotPasswordForm.tsx`
+- Modify: `client/src/pages/Login.tsx`
+
+**Interfaces:**
+- Consumes: `recoveryReset` from `../api/recovery-codes`.
+- Produces: `<ForgotPasswordForm onDone={() => void} />` (self-contained).
+
+- [ ] **Step 1: Create the self-contained form**
+
+Create `client/src/components/auth/ForgotPasswordForm.tsx`:
+
+```tsx
+import React, { FormEvent, useState } from 'react';
+import toast from 'react-hot-toast';
+import { recoveryReset } from '../../api/recovery-codes';
+
+interface Props {
+  /** Called after a successful reset (e.g. to return to the login form). */
+  onDone: () => void;
+}
+
+export const ForgotPasswordForm: React.FC<Props> = ({ onDone }) => {
+  const [username, setUsername] = useState('');
+  const [code, setCode] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+    if (newPassword !== confirm) {
+      setError('Passwords do not match');
+      return;
+    }
+    setLoading(true);
+    try {
+      await recoveryReset(username.trim(), code.trim(), newPassword);
+      toast.success('Password reset. Please sign in with your new password.');
+      onDone();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Reset failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <p className="text-xs text-slate-100-tertiary">
+        Reset your password with a recovery code. Only available on the local network.
+      </p>
+      {error && <div className="rounded-lg bg-red-950/40 px-3 py-2 text-xs text-red-300">{error}</div>}
+      <input
+        className="w-full rounded-lg border border-slate-800 bg-slate-950-secondary px-3 py-2 text-sm"
+        placeholder="Username" autoComplete="username" value={username}
+        onChange={(e) => setUsername(e.target.value)} required
+      />
+      <input
+        className="w-full rounded-lg border border-slate-800 bg-slate-950-secondary px-3 py-2 text-sm"
+        placeholder="Recovery code" value={code}
+        onChange={(e) => setCode(e.target.value)} required
+      />
+      <input
+        type="password"
+        className="w-full rounded-lg border border-slate-800 bg-slate-950-secondary px-3 py-2 text-sm"
+        placeholder="New password" autoComplete="new-password" value={newPassword}
+        onChange={(e) => setNewPassword(e.target.value)} required
+      />
+      <input
+        type="password"
+        className="w-full rounded-lg border border-slate-800 bg-slate-950-secondary px-3 py-2 text-sm"
+        placeholder="Confirm new password" autoComplete="new-password" value={confirm}
+        onChange={(e) => setConfirm(e.target.value)} required
+      />
+      <div className="flex gap-2">
+        <button
+          type="submit" disabled={loading}
+          className="flex-1 rounded-lg bg-sky-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-50"
+        >
+          {loading ? 'Resetting…' : 'Reset password'}
+        </button>
+        <button
+          type="button" onClick={onDone}
+          className="rounded-lg border border-slate-800 px-3 py-2 text-sm text-slate-100-secondary"
+        >
+          Back
+        </button>
+      </div>
+    </form>
+  );
+};
+```
+
+> Tailwind tokens (`slate-950-secondary`, `slate-100-tertiary`) are taken from `Login.tsx`'s existing classes — if a class name differs in this repo, copy the equivalent token actually used in `Login.tsx`.
+
+- [ ] **Step 2: Wire it into `Login.tsx`**
+
+In `client/src/pages/Login.tsx`:
+- Add the import near the other imports: `import { ForgotPasswordForm } from '../components/auth/ForgotPasswordForm';`
+- Add state next to the other `useState` hooks (e.g. after `const [showPassword, setShowPassword] = useState(false);`): `const [forgotMode, setForgotMode] = useState(false);`
+- In the JSX, wrap the existing login `<form>` so that when `forgotMode` is true the form is replaced by `<ForgotPasswordForm onDone={() => setForgotMode(false)} />`. Concretely, find the element that renders the main login form (the `<form onSubmit={handleSubmit}>`) and render conditionally:
+
+```tsx
+{forgotMode ? (
+  <ForgotPasswordForm onDone={() => setForgotMode(false)} />
+) : (
+  /* existing login form JSX (the <form onSubmit={handleSubmit}> … </form>) */
+)}
+```
+
+- Add the link that enters forgot mode. Below the login form's submit button (inside the `else` branch, near the existing dev-credentials hint block), add:
+
+```tsx
+{!twoFactorRequired && (
+  <button
+    type="button"
+    onClick={() => setForgotMode(true)}
+    className="mt-4 w-full text-center text-xs text-sky-400 hover:text-sky-300"
+  >
+    Passwort vergessen?
+  </button>
+)}
+```
+
+- [ ] **Step 3: Typecheck / build**
+
+Run: `cd client && npx eslint src/components/auth/ForgotPasswordForm.tsx src/pages/Login.tsx && npm run build`
+Expected: PASS (0 eslint errors, build succeeds).
+
+- [ ] **Step 4: Manual smoke test**
+
+Run (repo root): `python start_dev.py`. Open `http://localhost:5173/login`:
+- Click "Passwort vergessen?" → the reset form appears.
+- With a seeded user, generate codes in settings first (Task 7), then reset here; confirm login with the new password works.
+- "Back" returns to the login form.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/auth/ForgotPasswordForm.tsx client/src/pages/Login.tsx
+git commit -m "feat(client): forgot-password form on the login page (LAN-only reset)"
+```
+
+---
+
+### Task 7: Recovery-codes management card + nudge banner
+
+**Files:**
+- Create: `client/src/components/settings/RecoveryCodesCard.tsx`
+- Modify: the settings security section that renders `<TwoFactorCard />`
+
+**Interfaces:**
+- Consumes: `generateRecoveryCodes`, `getRecoveryCodesStatus` from `../../api/recovery-codes`.
+- Produces: `<RecoveryCodesCard />` (self-contained, fetches its own status).
+
+- [ ] **Step 1: Create the card**
+
+Create `client/src/components/settings/RecoveryCodesCard.tsx`:
+
+```tsx
+import React, { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { generateRecoveryCodes, getRecoveryCodesStatus, RecoveryCodesStatus } from '../../api/recovery-codes';
+
+export const RecoveryCodesCard: React.FC = () => {
+  const [status, setStatus] = useState<RecoveryCodesStatus | null>(null);
+  const [codes, setCodes] = useState<string[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = async () => {
+    try {
+      setStatus(await getRecoveryCodesStatus());
+    } catch {
+      /* status is best-effort; leave null */
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  const handleGenerate = async () => {
+    setLoading(true);
+    try {
+      const res = await generateRecoveryCodes();
+      setCodes(res.recovery_codes);
+      await refresh();
+      toast.success('Recovery codes generated. Store them somewhere safe.');
+    } catch {
+      toast.error('Could not generate recovery codes');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCopy = () => {
+    if (codes) void navigator.clipboard.writeText(codes.join('\n'));
+    toast.success('Copied');
+  };
+
+  const notConfigured = status !== null && !status.configured;
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-950-secondary p-4">
+      <h3 className="text-sm font-semibold text-slate-100">Recovery codes</h3>
+      <p className="mt-1 text-xs text-slate-100-tertiary">
+        Single-use codes to reset your password if you forget it. The reset works only on the local network.
+      </p>
+
+      {notConfigured && (
+        <div className="mt-3 rounded-lg border border-amber-700/50 bg-amber-950/30 px-3 py-2 text-xs text-amber-300">
+          You have no recovery codes yet. We strongly recommend generating a set and storing them safely.
+        </div>
+      )}
+
+      {status?.configured && !codes && (
+        <p className="mt-3 text-xs text-slate-100-secondary">{status.remaining} unused codes remaining.</p>
+      )}
+
+      {codes && (
+        <div className="mt-3">
+          <div className="grid grid-cols-2 gap-2 rounded-lg bg-slate-950 p-3 font-mono text-xs text-slate-100">
+            {codes.map((c) => (
+              <span key={c}>{c}</span>
+            ))}
+          </div>
+          <button onClick={handleCopy} className="mt-2 text-xs text-sky-400 hover:text-sky-300">
+            Copy all
+          </button>
+          <p className="mt-1 text-xs text-amber-300">Shown once — save them now.</p>
+        </div>
+      )}
+
+      <button
+        onClick={handleGenerate}
+        disabled={loading}
+        className="mt-4 rounded-lg bg-sky-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-50"
+      >
+        {loading ? 'Generating…' : status?.configured ? 'Regenerate codes' : 'Generate codes'}
+      </button>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Render it next to the 2FA card**
+
+Find where `TwoFactorCard` is rendered in the settings security section (search the codebase for `<TwoFactorCard`). In that file:
+- Add the import: `import { RecoveryCodesCard } from '<correct relative path>/RecoveryCodesCard';`
+- Render `<RecoveryCodesCard />` immediately after `<TwoFactorCard ... />`.
+
+- [ ] **Step 3: Typecheck / build**
+
+Run: `cd client && npx eslint src/components/settings/RecoveryCodesCard.tsx && npm run build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/components/settings/RecoveryCodesCard.tsx client/src/<settings file edited>
+git commit -m "feat(client): recovery-codes settings card + setup-nudge banner"
+```
+
+---
+
+### Task 8: Docs sync + final verification
+
+**Files:**
+- Modify: `backend/app/services/CLAUDE.md`, `backend/app/api/CLAUDE.md`, `backend/app/models/CLAUDE.md`
+
+- [ ] **Step 1: Update the backend CLAUDE.md indexes**
+
+- In `backend/app/services/CLAUDE.md`, add to the top-level services table:
+  `| recovery_code_service.py | Password recovery codes — generate/verify/consume single-use codes (hash+encrypt at rest), LAN-only reset |`
+- In `backend/app/api/CLAUDE.md`, note the three new `auth` routes (`/recovery-codes`, `/recovery-codes/status`, `/recovery-reset` — LAN-only, no session).
+- In `backend/app/models/CLAUDE.md` (or wherever the `User` columns are summarized), note the `password_recovery_codes_encrypted` column under Auth & Users if columns are listed there.
+
+- [ ] **Step 2: Run the full new test set + targeted regressions**
+
+Run: `cd backend && python -m pytest tests/services/test_recovery_code_service.py tests/api/test_recovery_codes.py tests/api/test_2fa_endpoints.py tests/security/test_change_password_validation.py -q --no-cov`
+Expected: PASS (all). The full backend suite on Windows may be run in CI (per repo convention) — the relevant subset above is the local gate.
+
+Run: `cd client && npx vitest run src/api/__tests__/recovery-codes.test.ts && npx eslint . && npm run build`
+Expected: PASS (vitest, 0 eslint errors, build succeeds).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/services/CLAUDE.md backend/app/api/CLAUDE.md backend/app/models/CLAUDE.md
+git commit -m "docs(claude): index recovery-code service + auth routes"
+```
+
+---
+
+## Self-Review notes for the implementer
+
+- **Username resolution in tests:** the reset tests resolve the test user's username via `GET /api/auth/me`. If that route differs in this repo, use the username the `user_headers` fixture logs in as (check `backend/tests/conftest.py`).
+- **`remote_client` fixture:** confirm it exists in `conftest.py` (it backs the PIN-login remote test). If named differently, mirror that fixture's `settings.channel="remote"` monkeypatch.
+- **Encryption helpers:** importing `_totp_encrypt`/`_totp_decrypt` from `totp_service` is deliberate — identical key + at-rest posture as 2FA backup codes (per spec). Do not duplicate key logic.
+- **No token from reset:** the happy-path test asserts `"access_token" not in r.json()` — keep it.
+- **Frontend i18n:** strings are inline English/German for self-containment. If the security settings + login page are fully i18n'd in this repo, lift these strings into the existing `settings`/`auth` locale namespaces as a follow-up (out of scope for the core feature).

--- a/docs/superpowers/plans/2026-06-29-password-recovery-codes.md
+++ b/docs/superpowers/plans/2026-06-29-password-recovery-codes.md
@@ -2,65 +2,46 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add a LAN-only, self-service "forgot password" flow using single-use recovery codes, mirroring the existing 2FA backup-code mechanism.
+**Goal:** A LAN-only, self-service "forgot password" flow using single-use recovery codes, mirroring the 2FA backup-code mechanism, hardened per a three-agent critical review.
 
-**Architecture:** A new encrypted column on `User` stores Fernet-encrypted SHA-256 hashes of recovery codes (identical at-rest protection to 2FA backup codes). A dedicated `recovery_code_service` generates/verifies/consumes codes. Three new `auth` endpoints: two session-gated (generate, status) bound to the caller's own account, and one **pre-auth, local-channel-only** reset that sets a new password and issues **no token** (so 2FA stays enforced at the subsequent login). Frontend adds a "Passwort vergessen?" form on the login page and a recovery-codes management card (with a setup-nudge banner) in security settings.
+**Architecture:** A new encrypted column on `User` stores Fernet-encrypted SHA-256 hashes of recovery codes. A shared `app/core/crypto.py` provides public at-rest encrypt/decrypt (TOTP delegates to it). A `recovery_code_service` generates/verifies/consumes codes with timing equalization. Three new `auth` endpoints: generate (session + **step-up auth**) and status (session), both bound to the caller's own account; and a **pre-auth, LAN-gated** reset (`is_private_or_local_ip`) that sets a new password, **revokes the user's refresh tokens**, and issues **no token**. Frontend adds a "Passwort vergessen?" form and a recovery-codes settings card.
 
-**Tech Stack:** FastAPI, SQLAlchemy 2.0, Alembic, Pydantic v2, slowapi, `cryptography` Fernet (via `totp_service`), pytest; React 18 + TypeScript, axios (`apiClient`), Vitest.
+**Tech Stack:** FastAPI, SQLAlchemy 2.0, Alembic, Pydantic v2, slowapi, `cryptography` Fernet, pytest; React 18 + TypeScript, axios, Vitest, react-hot-toast, i18next.
 
 ## Global Constraints
 
-- **Reset is LOCAL CHANNEL ONLY.** Gate with `getattr(request.state, "channel", "remote") != "local"` → `403 {"error": "local_channel_required", ...}`. Mirror `login_pin` (`backend/app/api/routes/auth.py`).
-- **Reset issues NO session/token.** It only sets a new password. 2FA is preserved because the user logs in normally afterward.
-- **Codes are hashed THEN encrypted at rest.** SHA-256 hex of each code, JSON array, Fernet-encrypted via `totp_service._totp_encrypt` / `_totp_decrypt` (`TOTP_ENCRYPTION_KEY` → `VPN_ENCRYPTION_KEY` fallback). Never store or log plaintext codes.
-- **RBAC:** management endpoints use `Depends(deps.get_current_user)` and operate only on `current_user.id` — never another user's codes. No admin endpoint reveals codes.
-- **Password strength:** `new_password` validated by `_validate_password_strength` (`backend/app/schemas/auth.py`) — via a Pydantic `field_validator`, NOT a raw `dict`, so a weak password is `422` **before** the handler runs (no code consumed).
-- **Anti-enumeration:** unknown user, wrong code, no-codes-configured all return the **same** `401 "Invalid username or recovery code"`.
-- **Scope:** all roles (admin + user).
-- **Codes:** `RECOVERY_CODE_COUNT = 10`, format = uppercased `secrets.token_hex(4)` (8 hex chars), identical to 2FA backup codes.
-- **Alembic head pitfall:** set the migration `down_revision` to the real `alembic heads` output, NOT a stale dev-DB head.
-- **Windows CRLF repo:** repo uses `core.autocrlf=true`; the `LF will be replaced by CRLF` warning on commit is expected.
+- **Reset LAN gate:** `is_private_or_local_ip(request.client.host)` from `app.core.network_utils` (NOT `request.state.channel` — that's a same-host-UDS signal, hardwired `remote` in prod). Valid because uvicorn runs `--proxy-headers --forwarded-allow-ips=127.0.0.1` (`backend/tests/test_deploy_proxy_headers.py`), so `request.client.host` is the real, unspoofable client IP. Failure → `403 {"error":"local_network_required","message":...}`, audit-logged.
+- **Reset issues NO token.** It only resets the password (2FA preserved at next login) and revokes the user's refresh tokens (`TokenService.revoke_all_user_tokens`).
+- **Generation requires step-up:** if `user.totp_enabled` → fresh TOTP/backup code via `_verify_fresh_totp(db, user_id, code)`; else → `current_password` re-verified via `auth_service.authenticate_user(username, password, db=db)`. Failure → 401.
+- **Codes hashed THEN encrypted at rest** via `app/core/crypto.encrypt_at_rest`/`decrypt_at_rest`. Never store/log plaintext. `RECOVERY_CODE_COUNT=10`, `secrets.token_hex(5).upper()` (40 bits).
+- **RBAC:** management endpoints use `Depends(deps.get_current_user)`, act only on `current_user.id`.
+- **Password strength:** `new_password` via `_validate_password_strength` field_validator (422 before handler → no code consumed). Bound attacker fields: `username` ≤ 64, `recovery_code` ≤ 32.
+- **Anti-enumeration + timing:** unknown user, `is_active=false` user, and wrong code all return identical `401 "Invalid username or recovery code"`; unknown/disabled paths run a dummy decrypt+hash to equalize timing.
+- **Alembic head pitfall:** `down_revision` = real `alembic heads` output.
+- **Windows CRLF repo:** the `LF will be replaced by CRLF` commit warning is expected.
+- **Vitest collects only `client/src/__tests__/**`** (`vite.config.ts` include glob).
 - **Spec:** `docs/superpowers/specs/2026-06-29-password-recovery-codes-design.md`.
 
----
+## Verified anchors (from review)
 
-## File Structure
-
-**Backend**
-- `backend/app/models/user.py` — new `password_recovery_codes_encrypted` column.
-- `backend/alembic/versions/<rev>_add_password_recovery_codes.py` — migration.
-- `backend/app/services/recovery_code_service.py` — new service (generate/verify/consume/status).
-- `backend/app/schemas/auth.py` — `RecoveryResetRequest`, `RecoveryCodesResponse`, `RecoveryCodesStatusResponse`.
-- `backend/app/core/rate_limiter.py` — `auth_recovery_reset` limit key.
-- `backend/app/api/routes/auth.py` — 3 endpoints.
-- `backend/tests/services/test_recovery_code_service.py`, `backend/tests/api/test_recovery_codes.py`.
-
-**Frontend**
-- `client/src/api/recovery-codes.ts` — typed client (management + reset).
-- `client/src/api/__tests__/recovery-codes.test.ts` — vitest.
-- `client/src/components/auth/ForgotPasswordForm.tsx` — self-contained reset form.
-- `client/src/pages/Login.tsx` — render the form behind a "Passwort vergessen?" link.
-- `client/src/components/settings/RecoveryCodesCard.tsx` — management card + nudge banner.
-- Settings security section — render `<RecoveryCodesCard />` next to `<TwoFactorCard />`.
-
-**Docs**
-- `backend/app/services/CLAUDE.md`, `backend/app/api/CLAUDE.md`, `backend/app/models/CLAUDE.md`.
+- `users.get_user_by_username(username, db=)`:164, `update_user_password(user_id, new_password, db=)`:265, `create_user(UserCreate(...), db=)`:170. `UserCreate(username, email, password, role)`.
+- `auth_service.authenticate_user(username, password, db=)` (used by `change_password`).
+- `auth.py` already imports: `Depends, HTTPException, Request, Response, status, get_db, limiter, get_limit, auth_service, user_service, UserModel, get_audit_logger_db, deps, totp_service`. `_verify_fresh_totp(db, user_id, code)` defined at `auth.py:441`. `from app.schemas.auth import (...)` block at `auth.py:8-16`.
+- `TokenService.revoke_all_user_tokens(db, user_id, reason=)`:132 (`from app.services.token_service import token_service`).
+- `samba_service.sync_smb_password(username, plaintext_password)` async:99.
+- `network_utils.is_private_or_local_ip(ip)`:6.
+- conftest: `client` (channel=local), `user_headers` → `testuser`/`Testpass123!`, `admin_headers`, `db_session`. `_validate_password_strength` in `schemas/auth.py:15`.
+- Frontend: `apiClient`/`buildApiUrl` in `lib/api.ts`; `<TwoFactorCard>` rendered in `client/src/pages/SettingsPage.tsx`; `Login.tsx` form nests `twoFactorRequired ? … : (pinMode ? … : <form onSubmit={handleSubmit}>)`; `toast` from `react-hot-toast`.
 
 ---
 
 ### Task 1: User model column + migration
 
-**Files:**
-- Modify: `backend/app/models/user.py:49` (after `totp_backup_codes_encrypted`)
-- Create: `backend/alembic/versions/<rev>_add_password_recovery_codes.py`
-- Test: `backend/tests/services/test_recovery_code_service.py`
+**Files:** Modify `backend/app/models/user.py` (after line 52); Create `backend/alembic/versions/<rev>_add_password_recovery_codes.py`; Test `backend/tests/services/test_recovery_code_service.py`.
 
-**Interfaces:**
-- Produces: `User.password_recovery_codes_encrypted: Mapped[str | None]` (Text, nullable, default `None`).
+**Produces:** `User.password_recovery_codes_encrypted: Mapped[Optional[str]]` (Text, nullable).
 
-- [ ] **Step 1: Write the failing test**
-
-Create `backend/tests/services/test_recovery_code_service.py`:
+- [ ] **Step 1: Failing test** — create `backend/tests/services/test_recovery_code_service.py`:
 
 ```python
 """Tests for password recovery codes (column + service)."""
@@ -68,20 +49,14 @@ from app.models.user import User
 
 
 def test_user_has_recovery_codes_column():
-    # Column exists and defaults to None on a fresh instance.
     u = User(username="x", hashed_password="h", role="user")
     assert hasattr(u, "password_recovery_codes_encrypted")
     assert u.password_recovery_codes_encrypted is None
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Run → fail.** `cd backend && python -m pytest tests/services/test_recovery_code_service.py::test_user_has_recovery_codes_column -v --no-cov` → `AttributeError`.
 
-Run: `cd backend && python -m pytest tests/services/test_recovery_code_service.py::test_user_has_recovery_codes_column -v --no-cov`
-Expected: FAIL — `AttributeError: ... has no attribute 'password_recovery_codes_encrypted'`.
-
-- [ ] **Step 3: Add the column**
-
-In `backend/app/models/user.py`, immediately after line 52 (the `totp_enabled_at` column, end of the "TOTP 2FA fields" block) add:
+- [ ] **Step 3: Add the column.** In `backend/app/models/user.py`, after the `totp_enabled_at` column (line 52):
 
 ```python
 
@@ -90,66 +65,120 @@ In `backend/app/models/user.py`, immediately after line 52 (the `totp_enabled_at
     password_recovery_codes_encrypted: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 ```
 
-(`Text` and `Optional` are already imported in this file.)
+(`Text` and `Optional` are already imported.)
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 4: Run → pass.**
 
-Run: `cd backend && python -m pytest tests/services/test_recovery_code_service.py::test_user_has_recovery_codes_column -v --no-cov`
-Expected: PASS.
-
-- [ ] **Step 5: Generate the migration against the REAL head**
-
-Run: `cd backend && alembic heads`
-Note the revision id printed (call it `<HEAD>`).
-
-Run: `cd backend && alembic revision -m "add password_recovery_codes_encrypted to users"`
-
-Open the new file in `backend/alembic/versions/`. Set `down_revision = "<HEAD>"` (the value from `alembic heads`) and make the body exactly:
+- [ ] **Step 5: Migration.** `cd backend && alembic heads` (note `<HEAD>`). `cd backend && alembic revision -m "add password_recovery_codes_encrypted to users"`. Edit the new file: `down_revision = "<HEAD>"`, body:
 
 ```python
 def upgrade() -> None:
-    op.add_column(
-        "users",
-        sa.Column("password_recovery_codes_encrypted", sa.Text(), nullable=True),
-    )
+    op.add_column("users", sa.Column("password_recovery_codes_encrypted", sa.Text(), nullable=True))
 
 
 def downgrade() -> None:
     op.drop_column("users", "password_recovery_codes_encrypted")
 ```
 
-- [ ] **Step 6: Verify the migration is reversible**
+- [ ] **Step 6: Reversible.** `cd backend && alembic upgrade head && alembic downgrade -1 && alembic upgrade head` → no errors.
 
-Run: `cd backend && alembic upgrade head && alembic downgrade -1 && alembic upgrade head`
-Expected: upgrade adds the column, downgrade drops it, re-upgrade re-adds — no errors.
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add backend/app/models/user.py backend/alembic/versions/ backend/tests/services/test_recovery_code_service.py
-git commit -m "feat(auth): add password_recovery_codes_encrypted column + migration"
-```
+- [ ] **Step 7: Commit.** `git add backend/app/models/user.py backend/alembic/versions/ backend/tests/services/test_recovery_code_service.py && git commit -m "feat(auth): add password_recovery_codes_encrypted column + migration"`
 
 ---
 
-### Task 2: `recovery_code_service`
+### Task 2: Shared at-rest crypto helper
 
-**Files:**
-- Create: `backend/app/services/recovery_code_service.py`
-- Test: `backend/tests/services/test_recovery_code_service.py` (append)
+**Files:** Create `backend/app/core/crypto.py`; Modify `backend/app/services/totp_service.py:29-54`; Test `backend/tests/core/test_crypto_at_rest.py`.
 
-**Interfaces:**
-- Consumes: `User.password_recovery_codes_encrypted`; `totp_service._totp_encrypt/_totp_decrypt`.
-- Produces:
-  - `generate_recovery_codes(db: Session, user_id: int) -> list[str]`
-  - `verify_and_consume_recovery_code(db: Session, user_id: int, code: str) -> bool`
-  - `get_recovery_codes_remaining(db: Session, user_id: int) -> int`
-  - `has_recovery_codes(db: Session, user_id: int) -> bool`
-  - `RECOVERY_CODE_COUNT = 10`
+**Interfaces — Produces:** `get_at_rest_fernet() -> MultiFernet`, `encrypt_at_rest(str) -> str`, `decrypt_at_rest(str) -> str`.
 
-- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 1: Failing test** — create `backend/tests/core/test_crypto_at_rest.py`:
 
-Append to `backend/tests/services/test_recovery_code_service.py`:
+```python
+from app.core import crypto
+
+
+def test_round_trip():
+    ct = crypto.encrypt_at_rest("hello")
+    assert ct != "hello"
+    assert crypto.decrypt_at_rest(ct) == "hello"
+
+
+def test_totp_helpers_delegate_and_interop():
+    # Data written via totp helpers must decrypt via the shared helper and vice versa.
+    from app.services import totp_service
+    ct = totp_service._totp_encrypt("x")
+    assert crypto.decrypt_at_rest(ct) == "x"
+    ct2 = crypto.encrypt_at_rest("y")
+    assert totp_service._totp_decrypt(ct2) == "y"
+```
+
+- [ ] **Step 2: Run → fail.** `cd backend && python -m pytest tests/core/test_crypto_at_rest.py -v --no-cov` → `ModuleNotFoundError: app.core.crypto`.
+
+- [ ] **Step 3: Create `backend/app/core/crypto.py`** (logic lifted verbatim from `totp_service._get_totp_fernet`):
+
+```python
+"""Shared at-rest encryption (Fernet/MultiFernet).
+
+Single seam for encrypting secrets at rest. Encrypts with TOTP_ENCRYPTION_KEY
+when set (else VPN_ENCRYPTION_KEY); decrypts by trying the dedicated key first,
+then the VPN key (dual-key fallback). A future RECOVERY_CODES_ENCRYPTION_KEY can
+be added here without touching consumers.
+"""
+from cryptography.fernet import Fernet, MultiFernet
+
+
+def get_at_rest_fernet() -> MultiFernet:
+    from app.core.config import settings
+    keys: list[Fernet] = []
+    if settings.totp_encryption_key:
+        keys.append(Fernet(settings.totp_encryption_key.encode()))
+    if settings.vpn_encryption_key:
+        keys.append(Fernet(settings.vpn_encryption_key.encode()))
+    if not keys:
+        raise ValueError("No encryption key configured (set TOTP_ENCRYPTION_KEY or VPN_ENCRYPTION_KEY)")
+    return MultiFernet(keys)
+
+
+def encrypt_at_rest(plaintext: str) -> str:
+    return get_at_rest_fernet().encrypt(plaintext.encode()).decode()
+
+
+def decrypt_at_rest(ciphertext: str) -> str:
+    return get_at_rest_fernet().decrypt(ciphertext.encode()).decode()
+```
+
+- [ ] **Step 4: Delegate the TOTP helpers.** In `backend/app/services/totp_service.py`, replace the bodies of `_get_totp_fernet`/`_totp_encrypt`/`_totp_decrypt` (lines 29-54) with delegations (keep the names — existing imports/tests unchanged):
+
+```python
+def _get_totp_fernet():
+    from app.core.crypto import get_at_rest_fernet
+    return get_at_rest_fernet()
+
+
+def _totp_encrypt(plaintext: str) -> str:
+    from app.core.crypto import encrypt_at_rest
+    return encrypt_at_rest(plaintext)
+
+
+def _totp_decrypt(ciphertext: str) -> str:
+    from app.core.crypto import decrypt_at_rest
+    return decrypt_at_rest(ciphertext)
+```
+
+- [ ] **Step 5: Run → pass + no 2FA regression.** `cd backend && python -m pytest tests/core/test_crypto_at_rest.py tests/security/test_totp_2fa.py -q --no-cov` → PASS (all).
+
+- [ ] **Step 6: Commit.** `git add backend/app/core/crypto.py backend/app/services/totp_service.py backend/tests/core/test_crypto_at_rest.py && git commit -m "refactor(core): shared at-rest crypto helper; totp delegates to it"`
+
+---
+
+### Task 3: `recovery_code_service`
+
+**Files:** Create `backend/app/services/recovery_code_service.py`; Test append to `backend/tests/services/test_recovery_code_service.py`.
+
+**Interfaces — Consumes:** `User.password_recovery_codes_encrypted`, `core.crypto`, `users.get_user_by_username`. **Produces:** `RECOVERY_CODE_COUNT=10`, `generate_recovery_codes(db,user_id)->list[str]`, `verify_and_consume_recovery_code(db,user_id,code)->bool`, `verify_and_consume_for_username(db,username,code)->User|None`, `get_recovery_codes_remaining(db,user_id)->int`, `has_recovery_codes(db,user_id)->bool`.
+
+- [ ] **Step 1: Failing tests** — append:
 
 ```python
 import pytest
@@ -169,7 +198,6 @@ def a_user(db_session):
 def test_generate_returns_ten_codes(db_session, a_user):
     codes = rcs.generate_recovery_codes(db_session, a_user.id)
     assert len(codes) == rcs.RECOVERY_CODE_COUNT
-    assert all(isinstance(c, str) and c for c in codes)
     assert rcs.has_recovery_codes(db_session, a_user.id) is True
     assert rcs.get_recovery_codes_remaining(db_session, a_user.id) == 10
 
@@ -177,56 +205,63 @@ def test_generate_returns_ten_codes(db_session, a_user):
 def test_code_is_single_use(db_session, a_user):
     codes = rcs.generate_recovery_codes(db_session, a_user.id)
     assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, codes[0]) is True
-    # second use of the same code fails
     assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, codes[0]) is False
     assert rcs.get_recovery_codes_remaining(db_session, a_user.id) == 9
 
 
-def test_regenerate_invalidates_old_codes(db_session, a_user):
+def test_regenerate_invalidates_old(db_session, a_user):
     old = rcs.generate_recovery_codes(db_session, a_user.id)
     new = rcs.generate_recovery_codes(db_session, a_user.id)
     assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, old[0]) is False
     assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, new[0]) is True
 
 
-def test_wrong_code_and_unconfigured(db_session, a_user):
-    assert rcs.has_recovery_codes(db_session, a_user.id) is False
-    assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, "DEADBEEF") is False
+def test_verify_for_username_success_and_misses(db_session, a_user):
+    codes = rcs.generate_recovery_codes(db_session, a_user.id)
+    assert rcs.verify_and_consume_for_username(db_session, "recov", codes[0]) is not None
+    # consumed
+    assert rcs.verify_and_consume_for_username(db_session, "recov", codes[0]) is None
+    # unknown user → None (no raise)
+    assert rcs.verify_and_consume_for_username(db_session, "ghost", "AAAA111122") is None
+
+
+def test_verify_for_username_disabled_user(db_session, a_user):
     rcs.generate_recovery_codes(db_session, a_user.id)
-    assert rcs.verify_and_consume_recovery_code(db_session, a_user.id, "NOTACODE") is False
+    a_user.is_active = False
+    db_session.commit()
+    codes = rcs.generate_recovery_codes(db_session, a_user.id)  # still generatable directly
+    assert rcs.verify_and_consume_for_username(db_session, "recov", codes[0]) is None
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [ ] **Step 2: Run → fail.** `ModuleNotFoundError`.
 
-Run: `cd backend && python -m pytest tests/services/test_recovery_code_service.py -v --no-cov`
-Expected: FAIL — `ModuleNotFoundError: app.services.recovery_code_service`.
-
-- [ ] **Step 3: Implement the service**
-
-Create `backend/app/services/recovery_code_service.py`:
+- [ ] **Step 3: Implement** `backend/app/services/recovery_code_service.py`:
 
 ```python
 """Password recovery codes.
 
 Single-use codes that let a user reset their own password without an admin or
-shell access. Stored exactly like 2FA backup codes: a Fernet-encrypted JSON
-array of SHA-256 hashes (hash + encrypt; never plaintext at rest). LAN-only
-reset is enforced at the route layer, not here.
+shell access. Stored like 2FA backup codes: a Fernet-encrypted JSON array of
+SHA-256 hashes (hash + encrypt; never plaintext). LAN-only reset is enforced at
+the route layer.
 """
 import hashlib
 import json
 import logging
 import secrets
+from typing import Optional
 
 from sqlalchemy.orm import Session
 
+from app.core.crypto import encrypt_at_rest, decrypt_at_rest
 from app.models.user import User
-from app.services.totp_service import _totp_encrypt, _totp_decrypt
 
 logger = logging.getLogger(__name__)
 
 RECOVERY_CODE_COUNT = 10
-RECOVERY_CODE_HEX_BYTES = 4  # → 8 hex chars per code (matches 2FA backup codes)
+RECOVERY_CODE_HEX_BYTES = 5  # → 10 hex chars / 40 bits per code
+
+_DUMMY_BLOB: Optional[str] = None
 
 
 def _generate_codes() -> list[str]:
@@ -235,21 +270,31 @@ def _generate_codes() -> list[str]:
 
 def _store_codes(user: User, plain_codes: list[str]) -> None:
     hashed = [hashlib.sha256(c.encode()).hexdigest() for c in plain_codes]
-    user.password_recovery_codes_encrypted = _totp_encrypt(json.dumps(hashed))
+    user.password_recovery_codes_encrypted = encrypt_at_rest(json.dumps(hashed))
 
 
 def _load_hashes(user: User) -> list[str]:
     if not user.password_recovery_codes_encrypted:
         return []
     try:
-        return json.loads(_totp_decrypt(user.password_recovery_codes_encrypted))
+        return json.loads(decrypt_at_rest(user.password_recovery_codes_encrypted))
     except Exception:
         return []
 
 
+def _equalize_timing(code: str) -> None:
+    """Run an equivalent decrypt+hash for unknown/disabled users (anti-enumeration)."""
+    global _DUMMY_BLOB
+    try:
+        if _DUMMY_BLOB is None:
+            _DUMMY_BLOB = encrypt_at_rest(json.dumps([hashlib.sha256(b"dummy").hexdigest()]))
+        hashes = json.loads(decrypt_at_rest(_DUMMY_BLOB))
+    except Exception:
+        hashes = []
+    _ = hashlib.sha256(code.strip().upper().encode()).hexdigest() in hashes
+
+
 def generate_recovery_codes(db: Session, user_id: int) -> list[str]:
-    """Generate fresh codes, store hashed+encrypted, return plaintext ONCE.
-    Regenerating overwrites the column → all previous codes are invalidated."""
     user = db.query(User).filter(User.id == user_id).first()
     if not user:
         raise ValueError("User not found")
@@ -260,7 +305,6 @@ def generate_recovery_codes(db: Session, user_id: int) -> list[str]:
 
 
 def verify_and_consume_recovery_code(db: Session, user_id: int, code: str) -> bool:
-    """Verify a code and consume it (single-use). False on any miss; never raises."""
     user = db.query(User).filter(User.id == user_id).first()
     if not user:
         return False
@@ -271,95 +315,91 @@ def verify_and_consume_recovery_code(db: Session, user_id: int, code: str) -> bo
     if code_hash not in hashes:
         return False
     hashes.remove(code_hash)
-    user.password_recovery_codes_encrypted = _totp_encrypt(json.dumps(hashes))
+    user.password_recovery_codes_encrypted = encrypt_at_rest(json.dumps(hashes))
     db.commit()
     logger.info("Recovery code consumed for user %d, %d remaining", user_id, len(hashes))
     return True
 
 
+def verify_and_consume_for_username(db: Session, username: str, code: str) -> Optional[User]:
+    """Resolve username, verify+consume a code. Returns the User on success, else None.
+    Unknown or disabled users run a dummy verify to equalize timing (anti-enumeration)."""
+    from app.services import users as user_service
+    user = user_service.get_user_by_username(username, db=db)
+    if not user or not user.is_active:
+        _equalize_timing(code)
+        return None
+    if verify_and_consume_recovery_code(db, user.id, code):
+        return user
+    return None
+
+
 def get_recovery_codes_remaining(db: Session, user_id: int) -> int:
     user = db.query(User).filter(User.id == user_id).first()
-    if not user:
-        return 0
-    return len(_load_hashes(user))
+    return len(_load_hashes(user)) if user else 0
 
 
 def has_recovery_codes(db: Session, user_id: int) -> bool:
     return get_recovery_codes_remaining(db, user_id) > 0
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [ ] **Step 4: Run → pass.** `cd backend && python -m pytest tests/services/test_recovery_code_service.py -v --no-cov`.
 
-Run: `cd backend && python -m pytest tests/services/test_recovery_code_service.py -v --no-cov`
-Expected: PASS (all).
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add backend/app/services/recovery_code_service.py backend/tests/services/test_recovery_code_service.py
-git commit -m "feat(auth): recovery_code_service (generate/verify/consume, hash+encrypt at rest)"
-```
+- [ ] **Step 5: Commit.** `git add backend/app/services/recovery_code_service.py backend/tests/services/test_recovery_code_service.py && git commit -m "feat(auth): recovery_code_service with timing-equalized username verify"`
 
 ---
 
-### Task 3: Schemas, rate-limit key, management endpoints
+### Task 4: Schemas, rate-limit key, management endpoints (generate + step-up, status)
 
-**Files:**
-- Modify: `backend/app/schemas/auth.py` (after `ChangePasswordRequest`)
-- Modify: `backend/app/core/rate_limiter.py:151` (inside `RATE_LIMITS`)
-- Modify: `backend/app/api/routes/auth.py` (after the `2fa/backup-codes` endpoint)
-- Test: `backend/tests/api/test_recovery_codes.py`
+**Files:** Modify `backend/app/schemas/auth.py` (after `ChangePasswordRequest`:96); `backend/app/core/rate_limiter.py:121`; `backend/app/api/routes/auth.py` (after `2fa/backup-codes`); Test `backend/tests/api/test_recovery_codes.py`.
 
-**Interfaces:**
-- Consumes: `recovery_code_service`, `deps.get_current_user`, `get_limit`, `get_audit_logger_db`.
-- Produces (schemas):
-  - `RecoveryCodesResponse{ recovery_codes: list[str] }`
-  - `RecoveryCodesStatusResponse{ configured: bool, remaining: int }`
-  - `RecoveryResetRequest{ username: str, recovery_code: str, new_password: str }` (strength-validated)
-- Produces (routes): `POST /api/auth/recovery-codes`, `GET /api/auth/recovery-codes/status`.
+**Produces:** `RecoveryCodesGenerateRequest{ code?, current_password? }`, `RecoveryCodesResponse{ recovery_codes }`, `RecoveryCodesStatusResponse{ configured, remaining }`; routes `POST /api/auth/recovery-codes`, `GET /api/auth/recovery-codes/status`.
 
-- [ ] **Step 1: Write the failing tests**
-
-Create `backend/tests/api/test_recovery_codes.py`:
+- [ ] **Step 1: Failing tests** — create `backend/tests/api/test_recovery_codes.py`:
 
 ```python
-"""Recovery-code management endpoints + LAN-only reset."""
+"""Recovery-code management endpoints (generate with step-up, status)."""
 from app.core.config import settings
 
 PREFIX = settings.api_prefix
+# user_headers logs in as testuser / Testpass123! (conftest)
+USER_PW = "Testpass123!"
 
 
 class TestRecoveryCodeManagement:
-    def test_status_unconfigured_then_generate(self, client, user_headers):
+    def test_status_unconfigured_then_generate_with_password_stepup(self, client, user_headers):
         s = client.get(f"{PREFIX}/auth/recovery-codes/status", headers=user_headers)
         assert s.status_code == 200
         assert s.json() == {"configured": False, "remaining": 0}
 
-        g = client.post(f"{PREFIX}/auth/recovery-codes", headers=user_headers)
+        # testuser has no 2FA → step-up is current_password
+        g = client.post(f"{PREFIX}/auth/recovery-codes",
+                        json={"current_password": USER_PW}, headers=user_headers)
         assert g.status_code == 200
-        codes = g.json()["recovery_codes"]
-        assert len(codes) == 10
+        assert len(g.json()["recovery_codes"]) == 10
 
         s2 = client.get(f"{PREFIX}/auth/recovery-codes/status", headers=user_headers)
         assert s2.json() == {"configured": True, "remaining": 10}
 
+    def test_generate_wrong_password_denied(self, client, user_headers):
+        g = client.post(f"{PREFIX}/auth/recovery-codes",
+                        json={"current_password": "WrongPass9x"}, headers=user_headers)
+        assert g.status_code == 401
+
     def test_generate_requires_auth(self, client):
-        r = client.post(f"{PREFIX}/auth/recovery-codes")
-        assert r.status_code == 401
+        assert client.post(f"{PREFIX}/auth/recovery-codes", json={}).status_code == 401
 ```
 
-> Fixtures `client`, `user_headers` come from `backend/tests/conftest.py` (same ones the 2FA endpoint tests use). The default `client` runs `channel=local`.
+- [ ] **Step 2: Run → fail** (404).
 
-- [ ] **Step 2: Run tests to verify they fail**
-
-Run: `cd backend && python -m pytest tests/api/test_recovery_codes.py -v --no-cov`
-Expected: FAIL — 404 (routes not defined).
-
-- [ ] **Step 3: Add the schemas**
-
-In `backend/app/schemas/auth.py`, immediately after `ChangePasswordRequest` (line 96) add:
+- [ ] **Step 3: Schemas.** In `backend/app/schemas/auth.py`, after `ChangePasswordRequest` (line 96):
 
 ```python
+class RecoveryCodesGenerateRequest(BaseModel):
+    code: str | None = None              # fresh TOTP/backup code (when 2FA enabled)
+    current_password: str | None = None  # password re-entry (when 2FA disabled)
+
+
 class RecoveryCodesResponse(BaseModel):
     recovery_codes: list[str]
 
@@ -370,50 +410,59 @@ class RecoveryCodesStatusResponse(BaseModel):
 
 
 class RecoveryResetRequest(BaseModel):
-    username: str
-    recovery_code: str
+    username: str = Field(max_length=64)
+    recovery_code: str = Field(max_length=32)
     new_password: str
 
     @field_validator("new_password")
     @classmethod
     def validate_new_password_strength(cls, v: str) -> str:
-        """Enforce password policy; a weak password fails BEFORE the handler runs."""
         return _validate_password_strength(v)
 ```
 
-- [ ] **Step 4: Add the rate-limit key**
+Add `Field` to the pydantic import at the top of the file: `from pydantic import BaseModel, EmailStr, Field, field_validator`.
 
-In `backend/app/core/rate_limiter.py`, inside the `RATE_LIMITS` dict, after the `"auth_pin_login": "5/minute",` line (line 121) add:
+- [ ] **Step 4: Rate-limit key.** In `backend/app/core/rate_limiter.py`, after `"auth_pin_login": "5/minute",` (line 121): `    "auth_recovery_reset": "5/minute",`
 
-```python
-    "auth_recovery_reset": "5/minute",
-```
-
-- [ ] **Step 5: Add the management endpoints**
-
-In `backend/app/api/routes/auth.py`, find the `regenerate_backup_codes` endpoint (the `@router.post("/2fa/backup-codes" ...)` block) and add immediately after it. First ensure the new schemas are imported — locate the existing `from app.schemas.auth import (...)` block and add `RecoveryCodesResponse`, `RecoveryCodesStatusResponse`, `RecoveryResetRequest` to it.
+- [ ] **Step 5: Endpoints.** In `backend/app/api/routes/auth.py`, add `RecoveryCodesGenerateRequest, RecoveryCodesResponse, RecoveryCodesStatusResponse, RecoveryResetRequest` to the `from app.schemas.auth import (...)` block, then add after the `regenerate_backup_codes` endpoint:
 
 ```python
 @router.post("/recovery-codes", response_model=RecoveryCodesResponse)
 @limiter.limit(get_limit("auth_2fa_setup"))
 async def generate_recovery_codes_endpoint(
+    payload: RecoveryCodesGenerateRequest,
     request: Request,
     response: Response,
     current_user=Depends(deps.get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Generate/regenerate the caller's own password-recovery codes (shown once)."""
+    """Generate/regenerate the caller's own recovery codes (shown once). Step-up required."""
     from app.services import recovery_code_service
     audit_logger = get_audit_logger_db()
     ip_address = request.client.host if request.client else None
+    user_record = db.query(UserModel).filter(UserModel.id == current_user.id).first()
+    if not user_record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    # Step-up: fresh TOTP when 2FA is on, else current-password re-entry.
+    ok = False
+    if user_record.totp_enabled:
+        ok = bool(payload.code) and _verify_fresh_totp(db, current_user.id, payload.code)
+    else:
+        ok = bool(payload.current_password) and bool(
+            auth_service.authenticate_user(current_user.username, payload.current_password, db=db)
+        )
+    if not ok:
+        audit_logger.log_security_event(
+            action="recovery_codes_generate_denied", user=current_user.username,
+            details={"ip_address": ip_address}, success=False, db=db,
+        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Step-up authentication failed")
 
     codes = recovery_code_service.generate_recovery_codes(db, current_user.id)
     audit_logger.log_security_event(
-        action="recovery_codes_generated",
-        user=current_user.username,
-        details={"ip_address": ip_address},
-        success=True,
-        db=db,
+        action="recovery_codes_generated", user=current_user.username,
+        details={"ip_address": ip_address}, success=True, db=db,
     )
     return RecoveryCodesResponse(recovery_codes=codes)
 
@@ -432,111 +481,112 @@ async def recovery_codes_status(
     return RecoveryCodesStatusResponse(configured=remaining > 0, remaining=remaining)
 ```
 
-- [ ] **Step 6: Run tests to verify they pass**
+- [ ] **Step 6: Run → pass.** `cd backend && python -m pytest tests/api/test_recovery_codes.py -v --no-cov`.
 
-Run: `cd backend && python -m pytest tests/api/test_recovery_codes.py -v --no-cov`
-Expected: PASS (2 tests).
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add backend/app/schemas/auth.py backend/app/core/rate_limiter.py backend/app/api/routes/auth.py backend/tests/api/test_recovery_codes.py
-git commit -m "feat(auth): recovery-code management endpoints (generate + status)"
-```
+- [ ] **Step 7: Commit.** `git add backend/app/schemas/auth.py backend/app/core/rate_limiter.py backend/app/api/routes/auth.py backend/tests/api/test_recovery_codes.py && git commit -m "feat(auth): recovery-code management endpoints (generate w/ step-up, status)"`
 
 ---
 
-### Task 4: LAN-only `recovery-reset` endpoint
+### Task 5: LAN-only `recovery-reset` endpoint
 
-**Files:**
-- Modify: `backend/app/api/routes/auth.py` (after `recovery_codes_status`)
-- Test: `backend/tests/api/test_recovery_codes.py` (append)
+**Files:** Modify `backend/app/api/routes/auth.py` (after `recovery_codes_status`); Test append `backend/tests/api/test_recovery_codes.py`.
 
-**Interfaces:**
-- Consumes: `RecoveryResetRequest`, `recovery_code_service`, `user_service.get_user_by_username/update_user_password`, `samba_service.sync_smb_password`, channel gate.
-- Produces: `POST /api/auth/recovery-reset` → `{ "message": str }`, no token.
+**Produces:** `POST /api/auth/recovery-reset` → `{ "message": str }`, no token.
 
-- [ ] **Step 1: Write the failing tests**
-
-Append to `backend/tests/api/test_recovery_codes.py`:
+- [ ] **Step 1: Failing tests** — append. A dedicated throwaway user avoids polluting the shared fixture; the non-local case overrides `is_private_or_local_ip`.
 
 ```python
-class TestRecoveryReset:
-    def test_reset_happy_path_no_token(self, client, user_headers, db_session):
-        # Arrange: the seeded test user generates codes via the API.
-        g = client.post(f"{PREFIX}/auth/recovery-codes", headers=user_headers)
-        code = g.json()["recovery_codes"][0]
-        # Resolve the username behind user_headers.
-        me = client.get(f"{PREFIX}/auth/me", headers=user_headers).json()
-        username = me["username"]
+import pytest
 
-        # Act: reset (default client = local channel).
+
+@pytest.fixture
+def reset_user(db_session):
+    from app.services import users as user_service
+    from app.schemas.user import UserCreate
+    from app.services import recovery_code_service
+    u = user_service.create_user(
+        UserCreate(username="resetme", email="reset@example.com", password="OldPass123x", role="user"),
+        db=db_session,
+    )
+    codes = recovery_code_service.generate_recovery_codes(db_session, u.id)
+    return u, codes
+
+
+class TestRecoveryReset:
+    def test_happy_path_no_token_and_login_works(self, client, reset_user, db_session):
+        u, codes = reset_user
         r = client.post(f"{PREFIX}/auth/recovery-reset", json={
-            "username": username, "recovery_code": code, "new_password": "BrandNew9xPass",
+            "username": "resetme", "recovery_code": codes[0], "new_password": "BrandNew9xPass",
         })
         assert r.status_code == 200, r.text
         assert "access_token" not in r.json()
-
-        # New password works at the normal login.
-        login = client.post(f"{PREFIX}/auth/login", json={
-            "username": username, "password": "BrandNew9xPass",
-        })
+        login = client.post(f"{PREFIX}/auth/login", json={"username": "resetme", "password": "BrandNew9xPass"})
         assert login.status_code == 200
 
-    def test_reset_rejects_wrong_code_generic(self, client, user_headers):
-        client.post(f"{PREFIX}/auth/recovery-codes", headers=user_headers)
-        me = client.get(f"{PREFIX}/auth/me", headers=user_headers).json()
+    def test_revokes_existing_refresh_tokens(self, client, reset_user, db_session):
+        u, codes = reset_user
+        from app.services.token_service import token_service
+        # seed an active refresh token
+        from datetime import datetime, timezone, timedelta
+        token_service.store_refresh_token(
+            db_session, jti="jti-test", user_id=u.id, token="rawtok",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+        client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": "resetme", "recovery_code": codes[0], "new_password": "BrandNew9xPass",
+        })
+        assert token_service.is_token_revoked(db_session, "jti-test") is True
+
+    def test_wrong_code_generic(self, client, reset_user):
         r = client.post(f"{PREFIX}/auth/recovery-reset", json={
-            "username": me["username"], "recovery_code": "WRONGCOD", "new_password": "BrandNew9xPass",
+            "username": "resetme", "recovery_code": "WRONGCODE0", "new_password": "BrandNew9xPass",
         })
         assert r.status_code == 401
         assert r.json()["detail"] == "Invalid username or recovery code"
 
-    def test_reset_unknown_user_same_generic(self, client):
+    def test_unknown_user_same_generic(self, client):
         r = client.post(f"{PREFIX}/auth/recovery-reset", json={
-            "username": "ghost", "recovery_code": "ABCD1234", "new_password": "BrandNew9xPass",
+            "username": "ghost", "recovery_code": "ABCD123456", "new_password": "BrandNew9xPass",
         })
         assert r.status_code == 401
         assert r.json()["detail"] == "Invalid username or recovery code"
 
-    def test_reset_weak_password_422_does_not_consume(self, client, user_headers, db_session):
-        g = client.post(f"{PREFIX}/auth/recovery-codes", headers=user_headers)
-        code = g.json()["recovery_codes"][0]
-        me = client.get(f"{PREFIX}/auth/me", headers=user_headers).json()
-        # weak password → 422 before handler; code must remain usable.
+    def test_weak_password_422_does_not_consume(self, client, reset_user):
+        u, codes = reset_user
         bad = client.post(f"{PREFIX}/auth/recovery-reset", json={
-            "username": me["username"], "recovery_code": code, "new_password": "weak",
+            "username": "resetme", "recovery_code": codes[0], "new_password": "weak",
         })
         assert bad.status_code == 422
         good = client.post(f"{PREFIX}/auth/recovery-reset", json={
-            "username": me["username"], "recovery_code": code, "new_password": "BrandNew9xPass",
+            "username": "resetme", "recovery_code": codes[0], "new_password": "BrandNew9xPass",
         })
         assert good.status_code == 200
 
-    def test_reset_remote_channel_forbidden(self, remote_client, user_headers):
-        # Generate codes over the local client first.
-        from app.core.config import settings as _s
-        gen = remote_client.post(f"{PREFIX}/auth/recovery-codes", headers=user_headers)
-        # management endpoints are not channel-gated, so this still works (200);
-        code = gen.json()["recovery_codes"][0]
-        me = remote_client.get(f"{PREFIX}/auth/me", headers=user_headers).json()
-        r = remote_client.post(f"{PREFIX}/auth/recovery-reset", json={
-            "username": me["username"], "recovery_code": code, "new_password": "BrandNew9xPass",
+    def test_non_local_forbidden(self, client, reset_user, monkeypatch):
+        u, codes = reset_user
+        import app.api.routes.auth as auth_routes
+        monkeypatch.setattr(auth_routes, "is_private_or_local_ip", lambda ip: False)
+        r = client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": "resetme", "recovery_code": codes[0], "new_password": "BrandNew9xPass",
         })
         assert r.status_code == 403
-        assert r.json()["detail"]["error"] == "local_channel_required"
+        assert r.json()["detail"]["error"] == "local_network_required"
+
+    def test_audit_rows_written(self, client, reset_user, db_session):
+        u, codes = reset_user
+        client.post(f"{PREFIX}/auth/recovery-reset", json={
+            "username": "resetme", "recovery_code": codes[0], "new_password": "BrandNew9xPass",
+        })
+        from app.models import AuditLog
+        row = db_session.query(AuditLog).filter(AuditLog.action == "password_reset_via_recovery").first()
+        assert row is not None
 ```
 
-> Notes: `remote_client` monkeypatches `settings.channel="remote"` (canonical example: `backend/tests/api/test_power_authority_routes.py::test_put_authority_requires_local_channel`). Remove the stray `user_service_module` placeholder import — it was only to flag that you resolve usernames via `users.get_user_by_username`; the actual tests use `/auth/me`. If `/auth/me` is not the correct path in this repo, resolve the username via the `user_headers` fixture's known username instead.
+> The non-local test monkeypatches the name `is_private_or_local_ip` **as imported into the auth module** (`import app.api.routes.auth as auth_routes`), so import it by name in the endpoint (Step 3) rather than calling it through the package.
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [ ] **Step 2: Run → fail** (404 / NameError until Step 3).
 
-Run: `cd backend && python -m pytest tests/api/test_recovery_codes.py::TestRecoveryReset -v --no-cov`
-Expected: FAIL — 404 (route not defined). Fix the `_seed_codes` helper / `/auth/me` path per the note before continuing if a test errors for an unrelated reason.
-
-- [ ] **Step 3: Add the reset endpoint**
-
-In `backend/app/api/routes/auth.py`, immediately after `recovery_codes_status`, add:
+- [ ] **Step 3: Add the endpoint.** In `backend/app/api/routes/auth.py`, add the import near the top: `from app.core.network_utils import is_private_or_local_ip`. Then after `recovery_codes_status`:
 
 ```python
 @router.post("/recovery-reset")
@@ -547,160 +597,116 @@ async def recovery_reset(
     response: Response,
     db: Session = Depends(get_db),
 ):
-    """Reset a password via a single-use recovery code — LOCAL CHANNEL ONLY.
+    """Reset a password via a single-use recovery code — LAN-only. Issues NO session.
 
-    Issues NO session: the user logs in normally afterward, so 2FA stays
-    enforced. Returns a generic failure to avoid username enumeration.
+    The user logs in normally afterward (2FA stays enforced). On success the user's
+    refresh tokens are revoked. Generic failures avoid username enumeration.
     """
     from app.services import recovery_code_service
+    from app.services.token_service import token_service
     audit_logger = get_audit_logger_db()
     ip_address = request.client.host if request.client else None
 
-    # Hard invariant: recovery reset is only valid over the local channel.
-    if getattr(request.state, "channel", "remote") != "local":
+    # LAN gate (real client IP via --proxy-headers --forwarded-allow-ips=127.0.0.1).
+    if not is_private_or_local_ip(ip_address):
         audit_logger.log_security_event(
-            action="password_reset_via_recovery_failed",
-            user=payload.username,
-            details={"ip_address": ip_address, "reason": "remote_channel"},
-            success=False,
-            db=db,
+            action="password_reset_via_recovery_failed", user=payload.username,
+            details={"ip_address": ip_address, "reason": "non_local"}, success=False, db=db,
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail={
-                "error": "local_channel_required",
-                "message": "Password recovery is only available from the local network.",
-            },
+            detail={"error": "local_network_required",
+                    "message": "Password recovery is only available from the local network."},
         )
 
-    user_record = user_service.get_user_by_username(payload.username, db=db)
-    code_ok = False
-    if user_record:
-        code_ok = recovery_code_service.verify_and_consume_recovery_code(
-            db, user_record.id, payload.recovery_code
-        )
-    if not user_record or not code_ok:
+    user_record = recovery_code_service.verify_and_consume_for_username(
+        db, payload.username, payload.recovery_code
+    )
+    if not user_record:
         audit_logger.log_security_event(
-            action="password_reset_via_recovery_failed",
-            user=payload.username,
-            details={"ip_address": ip_address},
-            success=False,
-            db=db,
+            action="password_reset_via_recovery_failed", user=payload.username,
+            details={"ip_address": ip_address}, success=False, db=db,
         )
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid username or recovery code",
-        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
+                            detail="Invalid username or recovery code")
 
     user_service.update_user_password(user_record.id, payload.new_password, db=db)
+    token_service.revoke_all_user_tokens(db, user_record.id, reason="password_reset_via_recovery")
 
-    # Keep the Samba password in sync when SMB is enabled (mirror change_password).
-    user_record = db.query(UserModel).filter(UserModel.id == user_record.id).first()
-    if user_record and user_record.smb_enabled:
-        from app.services import samba_service
-        await samba_service.sync_smb_password(user_record.username, payload.new_password)
+    # Best-effort Samba sync — never fail the reset on an SMB hiccup.
+    if user_record.smb_enabled:
+        try:
+            from app.services import samba_service
+            await samba_service.sync_smb_password(user_record.username, payload.new_password)
+        except Exception:
+            logger.warning("Samba password sync failed after recovery reset for %s", user_record.username)
 
     audit_logger.log_security_event(
-        action="password_reset_via_recovery",
-        user=user_record.username,
-        details={"ip_address": ip_address},
-        success=True,
-        db=db,
+        action="password_reset_via_recovery", user=user_record.username,
+        details={"ip_address": ip_address}, success=True, db=db,
     )
     return {"message": "Password reset successfully"}
 ```
 
-> `UserModel`, `user_service`, `status`, `HTTPException`, `Request`, `Response`, `get_db`, `get_audit_logger_db` are all already imported in this file (used by `change_password`).
+> `logger` is already module-level in `auth.py`. If not, add `import logging; logger = logging.getLogger(__name__)`.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [ ] **Step 4: Run → pass.** `cd backend && python -m pytest tests/api/test_recovery_codes.py -v --no-cov`.
 
-Run: `cd backend && python -m pytest tests/api/test_recovery_codes.py -v --no-cov`
-Expected: PASS (all).
+- [ ] **Step 5: Regression.** `cd backend && python -m pytest tests/api/test_2fa_endpoints.py tests/security/test_change_password_validation.py tests/api/test_pin_login.py tests/security/test_totp_2fa.py -q --no-cov` → PASS.
 
-- [ ] **Step 5: Run the auth/2FA suites for regressions**
-
-Run: `cd backend && python -m pytest tests/api/test_2fa_endpoints.py tests/security/test_change_password_validation.py tests/api/test_pin_login.py -q --no-cov`
-Expected: PASS (no regressions).
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add backend/app/api/routes/auth.py backend/tests/api/test_recovery_codes.py
-git commit -m "feat(auth): LAN-only recovery-reset endpoint (no session, anti-enumeration)"
-```
+- [ ] **Step 6: Commit.** `git add backend/app/api/routes/auth.py backend/tests/api/test_recovery_codes.py && git commit -m "feat(auth): LAN-only recovery-reset (no session, revoke tokens, anti-enumeration)"`
 
 ---
 
-### Task 5: Frontend API client
+### Task 6: Frontend API client
 
-**Files:**
-- Create: `client/src/api/recovery-codes.ts`
-- Test: `client/src/api/__tests__/recovery-codes.test.ts`
+**Files:** Create `client/src/api/recovery-codes.ts`; Test `client/src/__tests__/api/recovery-codes.test.ts` (note: `src/__tests__/api/`, the only dir vitest collects).
 
-**Interfaces:**
-- Produces: `generateRecoveryCodes()`, `getRecoveryCodesStatus()`, `recoveryReset(username, recoveryCode, newPassword)` and types `RecoveryCodes`, `RecoveryCodesStatus`.
+**Produces:** `generateRecoveryCodes(body)`, `getRecoveryCodesStatus()`, `recoveryReset(username, code, newPassword)`; types `RecoveryCodes`, `RecoveryCodesStatus`.
 
-- [ ] **Step 1: Write the failing test**
-
-Create `client/src/api/__tests__/recovery-codes.test.ts`:
+- [ ] **Step 1: Failing test** — create `client/src/__tests__/api/recovery-codes.test.ts`:
 
 ```typescript
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { generateRecoveryCodes, getRecoveryCodesStatus } from '../recovery-codes';
+import { generateRecoveryCodes, getRecoveryCodesStatus } from '../../api/recovery-codes';
 import { apiClient } from '../../lib/api';
 
 vi.mock('../../lib/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../lib/api')>();
-  return {
-    ...actual,
-    apiClient: { get: vi.fn(), post: vi.fn() },
-    buildApiUrl: (p: string) => p,
-  };
+  return { ...actual, apiClient: { get: vi.fn(), post: vi.fn() }, buildApiUrl: (p: string) => p };
 });
 
 describe('recovery-codes api', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('generateRecoveryCodes posts and unwraps data', async () => {
+  it('generateRecoveryCodes posts step-up body and unwraps data', async () => {
     (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({ data: { recovery_codes: ['A', 'B'] } });
-    const res = await generateRecoveryCodes();
-    expect(apiClient.post).toHaveBeenCalledWith('/api/auth/recovery-codes');
+    const res = await generateRecoveryCodes({ current_password: 'pw' });
+    expect(apiClient.post).toHaveBeenCalledWith('/api/auth/recovery-codes', { current_password: 'pw' });
     expect(res.recovery_codes).toEqual(['A', 'B']);
   });
 
-  it('getRecoveryCodesStatus gets and unwraps data', async () => {
+  it('getRecoveryCodesStatus unwraps data', async () => {
     (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({ data: { configured: true, remaining: 9 } });
-    const res = await getRecoveryCodesStatus();
-    expect(apiClient.get).toHaveBeenCalledWith('/api/auth/recovery-codes/status');
-    expect(res).toEqual({ configured: true, remaining: 9 });
+    expect(await getRecoveryCodesStatus()).toEqual({ configured: true, remaining: 9 });
   });
 });
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] **Step 2: Run → fail.** `cd client && npx vitest run src/__tests__/api/recovery-codes.test.ts` → cannot resolve.
 
-Run: `cd client && npx vitest run src/api/__tests__/recovery-codes.test.ts`
-Expected: FAIL — cannot resolve `../recovery-codes`.
-
-- [ ] **Step 3: Implement the client**
-
-Create `client/src/api/recovery-codes.ts`:
+- [ ] **Step 3: Implement** `client/src/api/recovery-codes.ts`:
 
 ```typescript
 /** Password recovery codes: self-service management + LAN-only reset. */
 import { apiClient, buildApiUrl } from '../lib/api';
 
-export interface RecoveryCodes {
-  recovery_codes: string[];
-}
+export interface RecoveryCodes { recovery_codes: string[]; }
+export interface RecoveryCodesStatus { configured: boolean; remaining: number; }
+export interface RecoveryCodesStepUp { code?: string; current_password?: string; }
 
-export interface RecoveryCodesStatus {
-  configured: boolean;
-  remaining: number;
-}
-
-export async function generateRecoveryCodes(): Promise<RecoveryCodes> {
-  const res = await apiClient.post<RecoveryCodes>('/api/auth/recovery-codes');
+export async function generateRecoveryCodes(stepUp: RecoveryCodesStepUp): Promise<RecoveryCodes> {
+  const res = await apiClient.post<RecoveryCodes>('/api/auth/recovery-codes', stepUp);
   return res.data;
 }
 
@@ -709,15 +715,8 @@ export async function getRecoveryCodesStatus(): Promise<RecoveryCodesStatus> {
   return res.data;
 }
 
-/**
- * Pre-auth, local-channel-only reset. Mirrors Login.tsx's raw-fetch path
- * (no bearer token). Throws with the server's message on failure.
- */
-export async function recoveryReset(
-  username: string,
-  recoveryCode: string,
-  newPassword: string,
-): Promise<{ message: string }> {
+/** Pre-auth, LAN-only. Raw fetch (no bearer). Throws with the server's message. */
+export async function recoveryReset(username: string, recoveryCode: string, newPassword: string): Promise<{ message: string }> {
   const res = await fetch(buildApiUrl('/api/auth/recovery-reset'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -726,57 +725,37 @@ export async function recoveryReset(
   const data = (await res.json().catch(() => ({}))) as { message?: string; detail?: unknown };
   if (!res.ok) {
     const d = data.detail;
-    const msg =
-      typeof d === 'string'
-        ? d
-        : d && typeof d === 'object' && 'message' in d
-          ? String((d as { message: unknown }).message)
-          : `Reset failed (${res.status})`;
+    const msg = typeof d === 'string' ? d
+      : d && typeof d === 'object' && 'message' in d ? String((d as { message: unknown }).message)
+      : `Reset failed (${res.status})`;
     throw new Error(msg);
   }
   return { message: String(data.message ?? 'Password reset successfully') };
 }
 ```
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [ ] **Step 4: Run → pass.**
 
-Run: `cd client && npx vitest run src/api/__tests__/recovery-codes.test.ts`
-Expected: PASS (2 tests).
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add client/src/api/recovery-codes.ts client/src/api/__tests__/recovery-codes.test.ts
-git commit -m "feat(client): recovery-codes API client (management + LAN-only reset)"
-```
+- [ ] **Step 5: Commit.** `git add client/src/api/recovery-codes.ts client/src/__tests__/api/recovery-codes.test.ts && git commit -m "feat(client): recovery-codes API client (step-up + LAN-only reset)"`
 
 ---
 
-### Task 6: "Passwort vergessen?" form on the login page
+### Task 7: "Passwort vergessen?" form on the login page
 
-**Files:**
-- Create: `client/src/components/auth/ForgotPasswordForm.tsx`
-- Modify: `client/src/pages/Login.tsx`
+**Files:** Create `client/src/components/auth/ForgotPasswordForm.tsx`; Modify `client/src/pages/Login.tsx`; i18n: add keys to the `auth` namespace locales.
 
-**Interfaces:**
-- Consumes: `recoveryReset` from `../api/recovery-codes`.
-- Produces: `<ForgotPasswordForm onDone={() => void} />` (self-contained).
-
-- [ ] **Step 1: Create the self-contained form**
-
-Create `client/src/components/auth/ForgotPasswordForm.tsx`:
+- [ ] **Step 1: Create the form** (labels for a11y; i18n via `useTranslation('auth')`). Create `client/src/components/auth/ForgotPasswordForm.tsx`:
 
 ```tsx
 import React, { FormEvent, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import { recoveryReset } from '../../api/recovery-codes';
 
-interface Props {
-  /** Called after a successful reset (e.g. to return to the login form). */
-  onDone: () => void;
-}
+interface Props { onDone: () => void; }
 
 export const ForgotPasswordForm: React.FC<Props> = ({ onDone }) => {
+  const { t } = useTranslation('auth');
   const [username, setUsername] = useState('');
   const [code, setCode] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -787,62 +766,44 @@ export const ForgotPasswordForm: React.FC<Props> = ({ onDone }) => {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError('');
-    if (newPassword !== confirm) {
-      setError('Passwords do not match');
-      return;
-    }
+    if (newPassword !== confirm) { setError(t('forgot.mismatch')); return; }
     setLoading(true);
     try {
       await recoveryReset(username.trim(), code.trim(), newPassword);
-      toast.success('Password reset. Please sign in with your new password.');
+      toast.success(t('forgot.success'));
       onDone();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Reset failed');
-    } finally {
-      setLoading(false);
-    }
+      setError(err instanceof Error ? err.message : t('forgot.failed'));
+    } finally { setLoading(false); }
   };
 
+  const field = 'w-full rounded-lg border border-slate-800 bg-slate-950-secondary px-3 py-2 text-sm';
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <p className="text-xs text-slate-100-tertiary">
-        Reset your password with a recovery code. Only available on the local network.
-      </p>
-      {error && <div className="rounded-lg bg-red-950/40 px-3 py-2 text-xs text-red-300">{error}</div>}
-      <input
-        className="w-full rounded-lg border border-slate-800 bg-slate-950-secondary px-3 py-2 text-sm"
-        placeholder="Username" autoComplete="username" value={username}
-        onChange={(e) => setUsername(e.target.value)} required
-      />
-      <input
-        className="w-full rounded-lg border border-slate-800 bg-slate-950-secondary px-3 py-2 text-sm"
-        placeholder="Recovery code" value={code}
-        onChange={(e) => setCode(e.target.value)} required
-      />
-      <input
-        type="password"
-        className="w-full rounded-lg border border-slate-800 bg-slate-950-secondary px-3 py-2 text-sm"
-        placeholder="New password" autoComplete="new-password" value={newPassword}
-        onChange={(e) => setNewPassword(e.target.value)} required
-      />
-      <input
-        type="password"
-        className="w-full rounded-lg border border-slate-800 bg-slate-950-secondary px-3 py-2 text-sm"
-        placeholder="Confirm new password" autoComplete="new-password" value={confirm}
-        onChange={(e) => setConfirm(e.target.value)} required
-      />
+      <p className="text-xs text-slate-100-tertiary">{t('forgot.hint')}</p>
+      {error && <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">{error}</div>}
+      <label className="block space-y-1">
+        <span className="text-xs text-slate-100-secondary">{t('forgot.username')}</span>
+        <input className={field} autoComplete="username" value={username} onChange={(e) => setUsername(e.target.value)} required />
+      </label>
+      <label className="block space-y-1">
+        <span className="text-xs text-slate-100-secondary">{t('forgot.code')}</span>
+        <input className={field} value={code} onChange={(e) => setCode(e.target.value)} required />
+      </label>
+      <label className="block space-y-1">
+        <span className="text-xs text-slate-100-secondary">{t('forgot.newPassword')}</span>
+        <input type="password" className={field} autoComplete="new-password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} required />
+      </label>
+      <label className="block space-y-1">
+        <span className="text-xs text-slate-100-secondary">{t('forgot.confirm')}</span>
+        <input type="password" className={field} autoComplete="new-password" value={confirm} onChange={(e) => setConfirm(e.target.value)} required />
+      </label>
       <div className="flex gap-2">
-        <button
-          type="submit" disabled={loading}
-          className="flex-1 rounded-lg bg-sky-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-50"
-        >
-          {loading ? 'Resetting…' : 'Reset password'}
+        <button type="submit" disabled={loading} className="flex-1 rounded-lg bg-sky-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-50">
+          {loading ? t('forgot.resetting') : t('forgot.reset')}
         </button>
-        <button
-          type="button" onClick={onDone}
-          className="rounded-lg border border-slate-800 px-3 py-2 text-sm text-slate-100-secondary"
-        >
-          Back
+        <button type="button" onClick={onDone} className="rounded-lg border border-slate-800 px-3 py-2 text-sm text-slate-100-secondary">
+          {t('forgot.back')}
         </button>
       </div>
     </form>
@@ -850,211 +811,176 @@ export const ForgotPasswordForm: React.FC<Props> = ({ onDone }) => {
 };
 ```
 
-> Tailwind tokens (`slate-950-secondary`, `slate-100-tertiary`) are taken from `Login.tsx`'s existing classes — if a class name differs in this repo, copy the equivalent token actually used in `Login.tsx`.
+- [ ] **Step 2: i18n keys.** Add a `forgot` block to the `auth` namespace files (`client/src/i18n/locales/{en,de}/auth.json` — match the repo's locale layout): `hint`, `username`, `code`, `newPassword`, `confirm`, `reset`, `resetting`, `back`, `mismatch`, `success`, `failed`, and a `forgotLink` ("Passwort vergessen?" / "Forgot password?"). If the `auth` namespace file name differs, use the existing one that holds Login strings.
 
-- [ ] **Step 2: Wire it into `Login.tsx`**
-
-In `client/src/pages/Login.tsx`:
-- Add the import near the other imports: `import { ForgotPasswordForm } from '../components/auth/ForgotPasswordForm';`
-- Add state next to the other `useState` hooks (e.g. after `const [showPassword, setShowPassword] = useState(false);`): `const [forgotMode, setForgotMode] = useState(false);`
-- In the JSX, wrap the existing login `<form>` so that when `forgotMode` is true the form is replaced by `<ForgotPasswordForm onDone={() => setForgotMode(false)} />`. Concretely, find the element that renders the main login form (the `<form onSubmit={handleSubmit}>`) and render conditionally:
+- [ ] **Step 3: Wire into `Login.tsx`.** Add `import { ForgotPasswordForm } from '../components/auth/ForgotPasswordForm';` and `const [forgotMode, setForgotMode] = useState(false);`. **Inside the existing `pinMode` else-branch** (around `Login.tsx:346`, where `<form onSubmit={handleSubmit}>` lives), render conditionally:
 
 ```tsx
 {forgotMode ? (
   <ForgotPasswordForm onDone={() => setForgotMode(false)} />
 ) : (
-  /* existing login form JSX (the <form onSubmit={handleSubmit}> … </form>) */
+  /* existing <form onSubmit={handleSubmit}> … </form> */
 )}
 ```
 
-- Add the link that enters forgot mode. Below the login form's submit button (inside the `else` branch, near the existing dev-credentials hint block), add:
+And add the trigger link in the `else` (non-forgot) branch, near the dev-credentials hint (`:415`):
 
 ```tsx
 {!twoFactorRequired && (
-  <button
-    type="button"
-    onClick={() => setForgotMode(true)}
-    className="mt-4 w-full text-center text-xs text-sky-400 hover:text-sky-300"
-  >
-    Passwort vergessen?
+  <button type="button" onClick={() => setForgotMode(true)}
+    className="mt-4 w-full text-center text-xs text-sky-400 hover:text-sky-300">
+    {t('forgot.forgotLink')}
   </button>
 )}
 ```
 
-- [ ] **Step 3: Typecheck / build**
+(Use whatever `t`/`useTranslation` hook `Login.tsx` already has; if it uses a different namespace, key it accordingly.)
 
-Run: `cd client && npx eslint src/components/auth/ForgotPasswordForm.tsx src/pages/Login.tsx && npm run build`
-Expected: PASS (0 eslint errors, build succeeds).
+- [ ] **Step 4: Lint + build.** `cd client && npx eslint src/components/auth/ForgotPasswordForm.tsx src/pages/Login.tsx && npm run build` → PASS.
 
-- [ ] **Step 4: Manual smoke test**
-
-Run (repo root): `python start_dev.py`. Open `http://localhost:5173/login`:
-- Click "Passwort vergessen?" → the reset form appears.
-- With a seeded user, generate codes in settings first (Task 7), then reset here; confirm login with the new password works.
-- "Back" returns to the login form.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add client/src/components/auth/ForgotPasswordForm.tsx client/src/pages/Login.tsx
-git commit -m "feat(client): forgot-password form on the login page (LAN-only reset)"
-```
+- [ ] **Step 5: Commit.** `git add client/src/components/auth/ForgotPasswordForm.tsx client/src/pages/Login.tsx client/src/i18n/locales && git commit -m "feat(client): forgot-password form on login (a11y + i18n)"`
 
 ---
 
-### Task 7: Recovery-codes management card + nudge banner
+### Task 8: Recovery-codes settings card + step-up prompt + banner
 
-**Files:**
-- Create: `client/src/components/settings/RecoveryCodesCard.tsx`
-- Modify: the settings security section that renders `<TwoFactorCard />`
+**Files:** Create `client/src/components/settings/RecoveryCodesCard.tsx`; Modify `client/src/pages/SettingsPage.tsx`; i18n: `settings` namespace.
 
-**Interfaces:**
-- Consumes: `generateRecoveryCodes`, `getRecoveryCodesStatus` from `../../api/recovery-codes`.
-- Produces: `<RecoveryCodesCard />` (self-contained, fetches its own status).
-
-- [ ] **Step 1: Create the card**
-
-Create `client/src/components/settings/RecoveryCodesCard.tsx`:
+- [ ] **Step 1: Create the card.** Production is HTTP-over-LAN, so `navigator.clipboard` may be undefined — guard it and provide a Download .txt fallback. The card needs a step-up input (password, or a code if 2FA). It reads 2FA status via the existing `get2FAStatus` client. Create `client/src/components/settings/RecoveryCodesCard.tsx`:
 
 ```tsx
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import { generateRecoveryCodes, getRecoveryCodesStatus, RecoveryCodesStatus } from '../../api/recovery-codes';
+import { get2FAStatus } from '../../api/two-factor';
 
 export const RecoveryCodesCard: React.FC = () => {
+  const { t } = useTranslation('settings');
   const [status, setStatus] = useState<RecoveryCodesStatus | null>(null);
+  const [twoFA, setTwoFA] = useState(false);
+  const [stepUp, setStepUp] = useState('');
   const [codes, setCodes] = useState<string[] | null>(null);
   const [loading, setLoading] = useState(false);
 
   const refresh = async () => {
-    try {
-      setStatus(await getRecoveryCodesStatus());
-    } catch {
-      /* status is best-effort; leave null */
-    }
+    try { setStatus(await getRecoveryCodesStatus()); } catch { /* best-effort */ }
+    try { setTwoFA((await get2FAStatus()).enabled); } catch { /* best-effort */ }
   };
-
-  useEffect(() => {
-    void refresh();
-  }, []);
+  useEffect(() => { void refresh(); }, []);
 
   const handleGenerate = async () => {
     setLoading(true);
     try {
-      const res = await generateRecoveryCodes();
+      const body = twoFA ? { code: stepUp } : { current_password: stepUp };
+      const res = await generateRecoveryCodes(body);
       setCodes(res.recovery_codes);
+      setStepUp('');
       await refresh();
-      toast.success('Recovery codes generated. Store them somewhere safe.');
+      toast.success(t('recovery.generated'));
     } catch {
-      toast.error('Could not generate recovery codes');
-    } finally {
-      setLoading(false);
+      toast.error(t('recovery.generateFailed'));
+    } finally { setLoading(false); }
+  };
+
+  const handleCopy = async () => {
+    if (!codes) return;
+    try {
+      if (!navigator.clipboard?.writeText) throw new Error('no clipboard');
+      await navigator.clipboard.writeText(codes.join('\n'));
+      toast.success(t('recovery.copied'));
+    } catch {
+      toast.error(t('recovery.copyUnavailable'));
     }
   };
 
-  const handleCopy = () => {
-    if (codes) void navigator.clipboard.writeText(codes.join('\n'));
-    toast.success('Copied');
+  const handleDownload = () => {
+    if (!codes) return;
+    const blob = new Blob([codes.join('\n') + '\n'], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'baluhost-recovery-codes.txt';
+    a.click(); URL.revokeObjectURL(url);
   };
 
   const notConfigured = status !== null && !status.configured;
-
   return (
     <div className="rounded-xl border border-slate-800 bg-slate-950-secondary p-4">
-      <h3 className="text-sm font-semibold text-slate-100">Recovery codes</h3>
-      <p className="mt-1 text-xs text-slate-100-tertiary">
-        Single-use codes to reset your password if you forget it. The reset works only on the local network.
-      </p>
+      <h3 className="text-sm font-semibold text-slate-100">{t('recovery.title')}</h3>
+      <p className="mt-1 text-xs text-slate-100-tertiary">{t('recovery.desc')}</p>
 
       {notConfigured && (
         <div className="mt-3 rounded-lg border border-amber-700/50 bg-amber-950/30 px-3 py-2 text-xs text-amber-300">
-          You have no recovery codes yet. We strongly recommend generating a set and storing them safely.
+          {t('recovery.banner')}
         </div>
       )}
-
       {status?.configured && !codes && (
-        <p className="mt-3 text-xs text-slate-100-secondary">{status.remaining} unused codes remaining.</p>
+        <p className="mt-3 text-xs text-slate-100-secondary">{t('recovery.remaining', { count: status.remaining })}</p>
       )}
 
       {codes && (
         <div className="mt-3">
           <div className="grid grid-cols-2 gap-2 rounded-lg bg-slate-950 p-3 font-mono text-xs text-slate-100">
-            {codes.map((c) => (
-              <span key={c}>{c}</span>
-            ))}
+            {codes.map((c) => (<span key={c}>{c}</span>))}
           </div>
-          <button onClick={handleCopy} className="mt-2 text-xs text-sky-400 hover:text-sky-300">
-            Copy all
-          </button>
-          <p className="mt-1 text-xs text-amber-300">Shown once — save them now.</p>
+          <div className="mt-2 flex gap-3">
+            <button onClick={handleCopy} className="text-xs text-sky-400 hover:text-sky-300">{t('recovery.copy')}</button>
+            <button onClick={handleDownload} className="text-xs text-sky-400 hover:text-sky-300">{t('recovery.download')}</button>
+          </div>
+          <p className="mt-1 text-xs text-amber-300">{t('recovery.shownOnce')}</p>
         </div>
       )}
 
-      <button
-        onClick={handleGenerate}
-        disabled={loading}
-        className="mt-4 rounded-lg bg-sky-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-50"
-      >
-        {loading ? 'Generating…' : status?.configured ? 'Regenerate codes' : 'Generate codes'}
+      <label className="mt-4 block space-y-1">
+        <span className="text-xs text-slate-100-secondary">{twoFA ? t('recovery.stepUpCode') : t('recovery.stepUpPassword')}</span>
+        <input
+          type={twoFA ? 'text' : 'password'}
+          autoComplete={twoFA ? 'one-time-code' : 'current-password'}
+          value={stepUp} onChange={(e) => setStepUp(e.target.value)}
+          className="w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+        />
+      </label>
+      <button onClick={handleGenerate} disabled={loading || !stepUp}
+        className="mt-3 rounded-lg bg-sky-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-50">
+        {loading ? t('recovery.generating') : status?.configured ? t('recovery.regenerate') : t('recovery.generate')}
       </button>
+      {status?.configured && <p className="mt-1 text-xs text-slate-100-tertiary">{t('recovery.regenWarning')}</p>}
     </div>
   );
 };
 ```
 
-- [ ] **Step 2: Render it next to the 2FA card**
+- [ ] **Step 2: i18n keys.** Add a `recovery` block to the `settings` namespace (`title`, `desc`, `banner`, `remaining` (with `{{count}}`), `copy`, `download`, `shownOnce`, `copied`, `copyUnavailable`, `generated`, `generateFailed`, `stepUpCode`, `stepUpPassword`, `generate`, `regenerate`, `generating`, `regenWarning`) in `client/src/i18n/locales/{en,de}/settings.json`.
 
-Find where `TwoFactorCard` is rendered in the settings security section (search the codebase for `<TwoFactorCard`). In that file:
-- Add the import: `import { RecoveryCodesCard } from '<correct relative path>/RecoveryCodesCard';`
-- Render `<RecoveryCodesCard />` immediately after `<TwoFactorCard ... />`.
+- [ ] **Step 3: Render in `SettingsPage.tsx`.** Add `import { RecoveryCodesCard } from '../components/settings/RecoveryCodesCard';` and render `<RecoveryCodesCard />` immediately after `<TwoFactorCard ... />` in the security section.
 
-- [ ] **Step 3: Typecheck / build**
+- [ ] **Step 4: Lint + build.** `cd client && npx eslint src/components/settings/RecoveryCodesCard.tsx src/pages/SettingsPage.tsx && npm run build` → PASS.
 
-Run: `cd client && npx eslint src/components/settings/RecoveryCodesCard.tsx && npm run build`
-Expected: PASS.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add client/src/components/settings/RecoveryCodesCard.tsx client/src/<settings file edited>
-git commit -m "feat(client): recovery-codes settings card + setup-nudge banner"
-```
+- [ ] **Step 5: Commit.** `git add client/src/components/settings/RecoveryCodesCard.tsx client/src/pages/SettingsPage.tsx client/src/i18n/locales && git commit -m "feat(client): recovery-codes settings card (step-up, clipboard guard, download, banner)"`
 
 ---
 
-### Task 8: Docs sync + final verification
+### Task 9: Docs sync + final verification
 
-**Files:**
-- Modify: `backend/app/services/CLAUDE.md`, `backend/app/api/CLAUDE.md`, `backend/app/models/CLAUDE.md`
+**Files:** Modify `backend/app/services/CLAUDE.md`, `backend/app/api/CLAUDE.md`, `backend/app/core/CLAUDE.md`.
 
-- [ ] **Step 1: Update the backend CLAUDE.md indexes**
+- [ ] **Step 1: CLAUDE.md indexes.**
+  - `services/CLAUDE.md` top-level table: `| recovery_code_service.py | Password recovery codes — generate/verify/consume single-use codes (hash+encrypt at rest), timing-equalized username verify |`.
+  - `core/CLAUDE.md` files table: `| crypto.py | Shared at-rest encryption (MultiFernet, TOTP→VPN key); totp_service delegates here |`.
+  - `api/CLAUDE.md`: note the three new `auth` routes (`/recovery-codes` [step-up], `/recovery-codes/status`, `/recovery-reset` [LAN-only, no session]).
 
-- In `backend/app/services/CLAUDE.md`, add to the top-level services table:
-  `| recovery_code_service.py | Password recovery codes — generate/verify/consume single-use codes (hash+encrypt at rest), LAN-only reset |`
-- In `backend/app/api/CLAUDE.md`, note the three new `auth` routes (`/recovery-codes`, `/recovery-codes/status`, `/recovery-reset` — LAN-only, no session).
-- In `backend/app/models/CLAUDE.md` (or wherever the `User` columns are summarized), note the `password_recovery_codes_encrypted` column under Auth & Users if columns are listed there.
+- [ ] **Step 2: Backend verification.** `cd backend && python -m pytest tests/core/test_crypto_at_rest.py tests/services/test_recovery_code_service.py tests/api/test_recovery_codes.py tests/security/test_totp_2fa.py tests/api/test_2fa_endpoints.py tests/security/test_change_password_validation.py -q --no-cov` → PASS. (Full Windows suite may go to CI.)
 
-- [ ] **Step 2: Run the full new test set + targeted regressions**
+- [ ] **Step 3: Frontend verification.** `cd client && npx vitest run src/__tests__/api/recovery-codes.test.ts && npx eslint . && npm run build` → PASS (vitest, 0 eslint errors, build OK).
 
-Run: `cd backend && python -m pytest tests/services/test_recovery_code_service.py tests/api/test_recovery_codes.py tests/api/test_2fa_endpoints.py tests/security/test_change_password_validation.py -q --no-cov`
-Expected: PASS (all). The full backend suite on Windows may be run in CI (per repo convention) — the relevant subset above is the local gate.
-
-Run: `cd client && npx vitest run src/api/__tests__/recovery-codes.test.ts && npx eslint . && npm run build`
-Expected: PASS (vitest, 0 eslint errors, build succeeds).
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add backend/app/services/CLAUDE.md backend/app/api/CLAUDE.md backend/app/models/CLAUDE.md
-git commit -m "docs(claude): index recovery-code service + auth routes"
-```
+- [ ] **Step 4: Commit.** `git add backend/app/services/CLAUDE.md backend/app/api/CLAUDE.md backend/app/core/CLAUDE.md && git commit -m "docs(claude): index recovery-code service, core/crypto, auth routes"`
 
 ---
 
-## Self-Review notes for the implementer
+## Notes for the implementer
 
-- **Username resolution in tests:** the reset tests resolve the test user's username via `GET /api/auth/me`. If that route differs in this repo, use the username the `user_headers` fixture logs in as (check `backend/tests/conftest.py`).
-- **`remote_client` fixture:** confirm it exists in `conftest.py` (it backs the PIN-login remote test). If named differently, mirror that fixture's `settings.channel="remote"` monkeypatch.
-- **Encryption helpers:** importing `_totp_encrypt`/`_totp_decrypt` from `totp_service` is deliberate — identical key + at-rest posture as 2FA backup codes (per spec). Do not duplicate key logic.
-- **No token from reset:** the happy-path test asserts `"access_token" not in r.json()` — keep it.
-- **Frontend i18n:** strings are inline English/German for self-containment. If the security settings + login page are fully i18n'd in this repo, lift these strings into the existing `settings`/`auth` locale namespaces as a follow-up (out of scope for the core feature).
+- **Step-up in tests:** `testuser` has no 2FA, so generate uses `current_password: "Testpass123!"`. For a 2FA path test, enable 2FA first (see `test_2fa_endpoints.py` setup) and pass a fresh TOTP as `code`.
+- **Non-local simulation:** monkeypatch `is_private_or_local_ip` *as bound in the auth module* (import it by name in the endpoint, Step 3 of Task 5). The default test `client` would otherwise present a loopback IP that passes the gate.
+- **No `/api/auth/me` round-trip** — tests use the known fixture usernames and a dedicated `resetme`/`resetuser` throwaway user.
+- **Crypto helper** is the single seam; do not re-introduce `_totp_encrypt` imports into `recovery_code_service`.
+- **Frontend i18n namespaces** — match the repo's existing `auth`/`settings` namespace files; if Login.tsx uses a different namespace for its strings, key `forgotLink` there.

--- a/docs/superpowers/specs/2026-06-29-password-recovery-codes-design.md
+++ b/docs/superpowers/specs/2026-06-29-password-recovery-codes-design.md
@@ -1,88 +1,80 @@
 # Password Recovery Codes — Self-Service Reset (LAN-only)
 
 **Date:** 2026-06-29
-**Status:** Approved (design)
+**Status:** Approved (design) — revised after critical review
 **Branch:** `feat/password-recovery-codes`
+
+> **Revision note (2026-06-29, post-review):** Three parallel review agents
+> (security, correctness, design) found one critical design flaw and several
+> hardening gaps. This spec is the corrected version. Key changes vs. the first
+> draft: the LAN gate uses **`is_private_or_local_ip(request.client.host)`**
+> (the Setup-wizard precedent) — **not** the `request.state.channel` mechanism,
+> which is a same-host-UDS signal that is hardwired to `remote` in production and
+> would 403 every web client. Generation now requires **step-up auth**, reset
+> **revokes the user's sessions**, plus timing/field hardening. See "Review
+> findings folded in" at the end.
 
 ## Problem
 
 A user who forgets their password and is **not** an admin and has **no shell
-access** to the box cannot recover on their own. Today the only ways to reset a
-password are:
+access** cannot recover on their own. Today: `change-password` needs the old
+password; admin reset needs an admin; `backend/scripts/reset_password.py` needs
+shell access. There is no self-service path. We want one that adds **no email
+infrastructure** (email was deliberately removed — migration
+`042_remove_email_notifications.py`) and keeps the attack surface minimal.
 
-- `POST /api/auth/change-password` — requires being logged in **and** knowing
-  the current password (`backend/app/api/routes/auth.py:588`).
-- Admin reset via `PUT /api/users/{id}` with `{password}` — requires an admin.
-- `backend/scripts/reset_password.py` — direct DB write, requires shell access
-  to the server.
+## Goals / Non-Goals
 
-There is no self-service recovery path for a locked-out user. We want one that
-adds **no new email infrastructure** (email was deliberately removed —
-migration `042_remove_email_notifications.py`) and keeps the attack surface
-minimal.
+**Goals:** a locked-out user on the local network resets their own password using
+a pre-provisioned single-use recovery code; security-first; mirror the proven 2FA
+backup-code mechanism.
 
-## Goals
+**Non-Goals:** no email reset links; no off-LAN reset (a VPN/WAN-only user keeps
+the admin / `reset_password.py` fallback); no change to `change-password` or
+admin-reset.
 
-- A locked-out user on the local network can reset their own password using a
-  pre-provisioned, single-use **recovery code**.
-- Security-first: minimal attack surface, no weakening of existing controls
-  (2FA, rate limiting, audit logging, encryption-at-rest).
-- Mirror the proven 2FA backup-code mechanism (`totp_service.py`) rather than
-  invent a new primitive.
-
-## Non-Goals
-
-- **No email** reset links.
-- **No remote (off-LAN) reset.** A user reachable only via VPN/WAN keeps the
-  admin / `reset_password.py` fallback. (Explicitly accepted.)
-- No change to the existing `change-password` or admin-reset paths.
-
-## Key Decisions (from brainstorming)
+## Key Decisions
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| Channel | **LAN-only** | Smallest attack surface; mirrors Setup + PIN-login. A code leaked off-box is useless without local-network presence. |
-| Effect of a valid code | **Reset password only — no session/token** | The recovery code replaces *only* the password. The user then logs in normally, so **2FA stays fully enforced**; the code can never become a 2FA bypass. |
-| Provisioning | **On-demand in Security settings**, with a recommendation **banner** in user settings when not yet configured | Mirrors 2FA backup-code UX; opt-in but nudged. |
-| Scope | **All roles (admin + user)** | Admin lockout is the most dangerous case (no super-admin above). Uniform UX. |
-| Mechanism | **Dedicated recovery codes mirroring 2FA backup codes** | Clean boundary between two distinct secrets; single-column migration; reuses a tested pattern. |
+| Channel/exposure | **LAN-only via `is_private_or_local_ip(request.client.host)`** | Realizes the user's "local network only" choice. Works in production because uvicorn runs `--proxy-headers --forwarded-allow-ips=127.0.0.1` (tested in `backend/tests/test_deploy_proxy_headers.py`), so `request.client.host` is the **real** client IP and X-Forwarded-For is only trusted from the local nginx (not spoofable). WireGuard-VPN clients fall in the private range and count as local — consistent with the system's trust model (VPN is the encrypted remote-access path). |
+| Effect of a valid code | **Reset password only — no session/token** | The code replaces only the password. The user logs in normally afterward, so **2FA stays enforced**; the code can never become a 2FA bypass. |
+| Session handling on reset | **Revoke all of the user's refresh tokens** | A recovery reset is an "I lost control" event. `TokenService.revoke_all_user_tokens` evicts an attacker holding a still-valid refresh token. |
+| Code generation | **Requires step-up auth** | A recovery code is a password-equivalent, pre-auth-usable secret. Mirrors `set_pin` (fresh TOTP) so a hijacked session can't silently mint codes. Step-up = fresh TOTP/backup code when 2FA is enabled, else current-password re-entry. |
+| Provisioning | **On-demand in Security settings** + a recommendation **banner** when not configured | Opt-in, nudged; mirrors 2FA backup-code UX. |
+| Scope | **All roles (admin + user)** | Admin lockout is the worst case (no super-admin above). |
+| Mechanism | **Dedicated recovery codes mirroring 2FA backup codes** | Clean boundary between two distinct secrets; single-column migration. |
 
 ### Approaches considered
 
-1. **(Chosen) Dedicated recovery codes mirroring the 2FA backup-code pattern.**
-   New encrypted column on `User`, dedicated service, dedicated endpoints.
-2. **Reuse 2FA backup codes for both purposes.** Rejected — conflates two
-   distinct secrets, a 2FA backup code would also reset the password, and codes
-   would only exist when 2FA is enabled.
-3. **Generic single-use token table for future reuse.** Rejected — YAGNI /
-   over-engineering for a single use case.
+1. **(Chosen)** Dedicated recovery codes mirroring the 2FA backup-code pattern.
+2. Reuse 2FA backup codes for both purposes — rejected (conflates secrets; only
+   exists when 2FA is enabled; a 2FA code would also reset the password).
+3. Generic single-use token table — rejected (YAGNI).
 
 ## Security: Encryption-at-rest + RBAC (hard requirement)
 
-Recovery codes are a **password-equivalent secret**. They are protected exactly
-like 2FA backup codes, on two layers:
+Recovery codes are a **password-equivalent secret**, protected like 2FA backup
+codes:
 
-- **Hashed, then encrypted at rest.** Stored as a Fernet-encrypted JSON array of
-  **SHA-256 hashes** of the codes — never plaintext, never a reversible form.
-  Reuses the existing `MultiFernet` mechanism from `totp_service._get_totp_fernet()`
-  (`TOTP_ENCRYPTION_KEY`, falling back to `VPN_ENCRYPTION_KEY`; dual-key decrypt).
-  A DB dump alone yields neither the codes nor their bare hashes.
-- **Plaintext shown exactly once.** Generation/regeneration returns the codes a
-  single time in the HTTP response; they are never persisted in plaintext, never
-  logged, and cannot be retrieved again.
-- **RBAC-gated.** Code *management* (generate/regenerate/status) is bound to the
-  **authenticated session** and operates **only on the caller's own account** —
-  there is no cross-user code access and no admin endpoint that reveals another
-  user's codes. The pre-auth *reset* endpoint is additionally **LAN-gated** and
-  consumes a code without ever returning code material or a session.
-- **Fail-closed.** If no encryption key is configured, code operations raise
-  (same as TOTP/VPN) rather than degrade to plaintext.
+- **Hashed, then encrypted at rest.** A Fernet-encrypted JSON array of SHA-256
+  hashes — never plaintext, never a bare hash on disk. Uses a shared public
+  helper `app/core/crypto.py` (`encrypt_at_rest`/`decrypt_at_rest`, same
+  `MultiFernet` key resolution as TOTP: `TOTP_ENCRYPTION_KEY` → `VPN_ENCRYPTION_KEY`).
+  `totp_service._totp_encrypt/_totp_decrypt` are refactored to delegate to this
+  helper (no behavior change, no private cross-module imports). A DB dump alone
+  yields neither codes nor bare hashes.
+- **Plaintext shown once.** Generation returns codes a single time; never
+  persisted in plaintext, never logged, not retrievable again.
+- **RBAC-gated + step-up.** Management (generate/status) is bound to the
+  authenticated session and the caller's **own** account only — no cross-user
+  access, no admin endpoint that reveals codes. Generation additionally requires
+  step-up auth. The pre-auth reset is LAN-gated and returns no session.
+- **Fail-closed.** No encryption key → operations raise (same as TOTP/VPN).
 
-Alignment note: the in-flight `2026-06-21-crypto-key-isolation.md` plan aims to
-isolate per-domain crypto keys. This feature deliberately reuses the *current*
-TOTP/VPN key mechanism (no weakening vs. today). If/when key isolation lands, a
-dedicated `RECOVERY_CODES_ENCRYPTION_KEY` slots in via the same
-`_get_*_fernet()` shape — called out as follow-up, out of scope here.
+Alignment note: the in-flight `2026-06-21-crypto-key-isolation.md` plan can later
+slot a dedicated `RECOVERY_CODES_ENCRYPTION_KEY` into `app/core/crypto.py` — this
+spec creates that seam (the shared helper) without weakening today's posture.
 
 ## Design
 
@@ -92,146 +84,181 @@ One new **nullable** column on `User` (mirrors `totp_backup_codes_encrypted`):
 
 ```python
 # backend/app/models/user.py
-password_recovery_codes_encrypted: Mapped[str | None] = mapped_column(
-    Text, nullable=True, default=None
-)
+password_recovery_codes_encrypted: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 ```
 
-- `None` ⇒ recovery codes not configured (drives the banner + `configured=false`).
-- Value ⇒ Fernet ciphertext of `json.dumps([sha256_hex, ...])`.
-- One Alembic migration, chained onto the **real** `alembic heads` (per
-  `project_alembic_migration_head_pitfall`). No new table.
+`None` ⇒ not configured (drives the banner + `configured=false`); value ⇒ Fernet
+ciphertext of `json.dumps([sha256_hex, ...])`. One Alembic migration chained onto
+the **real** `alembic heads` (per `project_alembic_migration_head_pitfall`). No
+new table.
 
-### 2. Service — `backend/app/services/recovery_code_service.py`
+### 2. Shared crypto helper — `backend/app/core/crypto.py`
 
-Mirrors the TOTP backup-code functions; same hash+encrypt helpers (reuse
-`totp_service._totp_encrypt`/`_totp_decrypt`, or a shared crypto util factored
-out — implementation detail for the plan).
+Public API extracted so a second consumer doesn't import TOTP's underscore-private
+functions:
+
+```python
+def get_at_rest_fernet() -> MultiFernet   # TOTP_ENCRYPTION_KEY then VPN_ENCRYPTION_KEY; raises if none
+def encrypt_at_rest(plaintext: str) -> str
+def decrypt_at_rest(ciphertext: str) -> str
+```
+
+`totp_service._totp_encrypt/_totp_decrypt` become thin delegates (names kept so
+existing imports/tests are untouched).
+
+### 3. Service — `backend/app/services/recovery_code_service.py`
 
 ```python
 RECOVERY_CODE_COUNT = 10
-RECOVERY_CODE_LENGTH = 8  # bytes of entropy per code (token_hex(LENGTH//2)... mirror TOTP format)
+RECOVERY_CODE_HEX_BYTES = 5  # → 10 hex chars / 40 bits per code
 
-def generate_recovery_codes(db: Session, user_id: int) -> list[str]:
-    """Generate N high-entropy codes, store hashed+encrypted, return plaintext ONCE.
-    Regenerating overwrites the column → all previous codes are invalidated."""
-
-def verify_and_consume_recovery_code(db: Session, user_id: int, code: str) -> bool:
-    """Verify a code and consume it (single-use: remove its hash). Returns False on miss."""
-
-def get_recovery_codes_remaining(db: Session, user_id: int) -> int: ...
-
-def has_recovery_codes(db: Session, user_id: int) -> bool:
-    """True iff the column is non-null and contains at least one unused code."""
+def generate_recovery_codes(db, user_id) -> list[str]   # store hashed+encrypted, return plaintext once; regenerate overwrites
+def verify_and_consume_recovery_code(db, user_id, code) -> bool   # single-use; never raises
+def get_recovery_codes_remaining(db, user_id) -> int
+def has_recovery_codes(db, user_id) -> bool
 ```
 
-Codes are generated with `secrets.token_hex(...)` (CSPRNG), uppercased, format
-identical to 2FA backup codes for UI consistency.
+Codes: `secrets.token_hex(5).upper()` (CSPRNG, 40 bits). Verify uppercases input.
 
-### 3. Endpoints (`backend/app/api/routes/auth.py`)
+### 4. Endpoints (`backend/app/api/routes/auth.py`)
 
-**Authenticated management (RBAC: own account only)** — mirrors the 2FA backup
-endpoints:
+**Authenticated management (RBAC: own account; step-up on generate):**
 
-| Method/Path | Auth | Returns | Notes |
+| Method/Path | Auth | Body | Returns |
 |---|---|---|---|
-| `POST /api/auth/recovery-codes` | `get_current_user` | `{ recovery_codes: string[] }` (once) | Generate/regenerate. `@limiter.limit(...)`. Audit-logged. |
-| `GET /api/auth/recovery-codes/status` | `get_current_user` | `{ configured: bool, remaining: int }` | Drives the banner. No code material. |
+| `POST /api/auth/recovery-codes` | `get_current_user` **+ step-up** | `RecoveryCodesGenerateRequest{ code?, current_password? }` | `{ recovery_codes: string[] }` once |
+| `GET /api/auth/recovery-codes/status` | `get_current_user` | — | `{ configured: bool, remaining: int }` |
 
-**Pre-auth reset (the "forgot password" flow)** — LAN-gated:
+Step-up rule (mirror `set_pin` + `change_password`): if `user.totp_enabled`,
+require a fresh TOTP/backup code via `_verify_fresh_totp`; else require
+`current_password` re-verified via `auth_service.authenticate_user`. On failure →
+`401`.
+
+**Pre-auth reset (LAN-only):**
 
 | Method/Path | Gate | Body | Returns |
 |---|---|---|---|
-| `POST /api/auth/recovery-reset` | **Local channel only** + hard rate limit | `RecoveryResetRequest{ username, recovery_code, new_password }` | `{ message }` — **no token** |
+| `POST /api/auth/recovery-reset` | `is_private_or_local_ip(client.host)` + `auth_recovery_reset` limit | `RecoveryResetRequest{ username, recovery_code, new_password }` | `{ message }` — no token |
 
-Reset handler order (so a weak password never burns a code):
+Reset handler order:
 
-1. **Pydantic validation** of `RecoveryResetRequest` — `new_password` runs the
-   full strength validator (reuse the `RegisterRequest` password rules;
-   deliberately **not** a raw `dict` like the `change-password` Known-Gap #8).
-   Weak password ⇒ `422` **before** the handler body runs ⇒ code not consumed.
-2. **LAN gate** — reuse the local-channel mechanism used by `login-pin`
-   (`request.state.channel == "local"` / `is_private_or_local_ip`). Non-local ⇒
-   `403`.
-3. **Resolve user** by username; **verify + consume** the recovery code.
-4. On success: `user_service.update_user_password(...)`; **Samba sync** if
-   `user.smb_enabled` (mirror `change_password`'s `samba_service.sync_smb_password`).
-5. Audit-log; return generic success. **No access token issued.**
+1. **Pydantic validation:** `new_password` runs `_validate_password_strength`
+   (field_validator, not a raw `dict`); `username` ≤ 64 and `recovery_code` ≤ 32
+   length bounds (the endpoint is pre-auth and writes `username` to the audit log
+   — bound the attacker-controlled fields). A weak password ⇒ `422` before the
+   handler ⇒ no code consumed.
+2. **LAN gate:** `is_private_or_local_ip(request.client.host)` — else `403`
+   `{"error": "local_network_required", "message": ...}` (audit-logged).
+3. **Resolve + verify:** look up by username; treat `is_active=false` users as
+   not-found. **Timing equalization:** on unknown/disabled user, run a dummy
+   decrypt+hash so the response time matches the real path (no enumeration oracle).
+   Verify + consume the code.
+4. **On success:** `update_user_password`; **revoke all the user's refresh tokens**
+   (`TokenService.revoke_all_user_tokens(db, user.id, reason="password_reset_via_recovery")`);
+   **Samba sync in try/except** if `smb_enabled` (best-effort: log failure, still
+   succeed); audit-log; return generic success. **No token issued.**
 
-**Anti-enumeration:** unknown username, wrong code, and "no codes configured"
-all return the **same** generic failure (`"Invalid username or recovery code"`,
-same status) with best-effort uniform timing. Hard rate limit
-(`auth_recovery_reset`, on par with login) caps brute force; combined with
-LAN-only + 10 single-use high-entropy codes, online guessing is impractical.
+**Anti-enumeration:** unknown user, disabled user, and wrong code all return the
+same `401 "Invalid username or recovery code"` with timing equalized.
 
-### 4. Frontend
+### 5. Frontend
 
-- **`client/src/api/recovery-codes.ts`** — new API client mirroring
-  `two-factor.ts` (`generateRecoveryCodes`, `getRecoveryCodesStatus`,
-  `recoveryReset`).
-- **Login page (`Login.tsx`)** — a **"Passwort vergessen?"** link opening a
-  reset form (username, recovery code, new password + confirm). Uses the same
-  pre-auth `fetch(buildApiUrl(...))` path as PIN-login. A `403` (non-local)
-  shows a clear "only available on the local network" message.
-- **Security settings** — a "Recovery-Codes" section analogous to the 2FA
-  backup-codes UI: generate/regenerate, **show once**, copy/download, remaining
-  count.
-- **Banner** — in user settings, shown when `status.configured === false`, with
-  an explicit recommendation to set up recovery codes.
+- **`client/src/api/recovery-codes.ts`** — typed client (generate w/ step-up,
+  status, reset). Reset uses the raw-`fetch` pre-auth path (no bearer).
+- **Login page (`Login.tsx`)** — a "Passwort vergessen?" link (placed inside the
+  existing `pinMode` else-branch) opening `ForgotPasswordForm` (username, code,
+  new password + confirm). A `403` shows "only available on the local network".
+- **Security settings (`SettingsPage.tsx`)** — a `RecoveryCodesCard` next to
+  `TwoFactorCard`: generate/regenerate (with the step-up prompt), **show once**,
+  remaining count, and a **Download .txt** (Blob) plus copy. **Copy guards
+  `navigator.clipboard?.writeText`** and toasts only on success (production is
+  HTTP-over-LAN where `clipboard` is undefined) — the visible codes + download are
+  the reliable path.
+- **Banner** — shown when `status.configured === false`, recommending setup. A
+  regenerate prompt warns it invalidates existing codes.
+- **a11y:** real `<label>`/`aria-label` on every input (no placeholder-only labels).
+- **i18n:** strings go into the existing `auth`/`settings` locale namespaces (the
+  app is fully i18n'd; the entry point is a German string on the most-seen page).
 
-### 5. Error handling & audit
+### 6. Error handling & audit
 
-- Audit via `get_audit_logger_db()`:
-  - `recovery_codes_generated` (success)
-  - `password_reset_via_recovery` (success)
-  - `password_reset_via_recovery_failed` (bad code / unknown user / non-local)
-- **Codes are never logged** at any level. Failures log username + reason only.
-- Fail-closed on missing encryption key (raise, like TOTP/VPN).
-- 2FA remains structurally intact: reset issues no session, so the subsequent
-  normal login still enforces TOTP.
+- Audit via `get_audit_logger_db()`: `recovery_codes_generated`,
+  `recovery_codes_generate_denied` (failed step-up), `password_reset_via_recovery`
+  (success), `password_reset_via_recovery_failed` (bad code / unknown / disabled /
+  non-local). **Codes never logged.**
+- Fail-closed on missing encryption key.
+- Reset issues no session → 2FA enforced at the next login.
 
-### 6. Testing (mirror `backend/tests/security/test_totp_2fa.py`)
+### 7. Testing
 
-**Service:**
-- `generate_recovery_codes` returns `RECOVERY_CODE_COUNT` codes.
-- A code verifies once, then is consumed (second use fails); remaining count
-  decrements.
-- Regenerate invalidates all previous codes.
-- `has_recovery_codes` reflects configured/empty state.
+**Service:** generate → 10 codes; single-use consume; regenerate invalidates old;
+remaining count; `has_recovery_codes`.
+
+**Crypto helper:** round-trips; `totp_service` delegates still decrypt
+existing-format data (no 2FA regression).
 
 **Endpoints:**
-- Management requires auth; `POST` returns codes once; status endpoint shape.
-- Reset (happy path): valid code + strong password ⇒ password changed, code
-  consumed, **no token in response**, subsequent login with the new password
-  succeeds.
-- Reset rejects: wrong code, unknown user (generic identical response), **weak
-  password ⇒ 422 and code NOT consumed**, reused code, **non-local channel ⇒ 403**.
-- 2FA still required at login after a recovery reset (when enabled).
-- Samba sync invoked when `smb_enabled`.
+- generate requires auth **and** step-up (wrong/missing TOTP or password → 401;
+  correct → codes).
+- status shape.
+- reset happy path: valid code + strong password ⇒ password changed, code
+  consumed, **no token**, login with new password works, **pre-existing refresh
+  token rejected** after reset.
+- reset rejects: wrong code, unknown user (generic identical), **disabled user
+  (generic)**, **weak password ⇒ 422 and code NOT consumed**, reused code,
+  **non-local IP ⇒ 403**.
+- **2FA still required at login after reset** (when enabled).
+- **audit rows** asserted for success + non-local-denied.
+- Samba sync invoked when `smb_enabled`; a sync failure still returns success.
+
+Tests use a **dedicated throwaway user** (not the shared seeded fixture) and learn
+its username from the fixture constant (no `/auth/me` round-trip). The non-local
+case is simulated by overriding the client IP / `is_private_or_local_ip`.
 
 ## Files to add / modify
 
-**Backend**
-- `backend/app/models/user.py` — new column.
-- `backend/alembic/versions/<rev>_add_password_recovery_codes.py` — migration.
-- `backend/app/services/recovery_code_service.py` — new service.
-- `backend/app/schemas/auth.py` — `RecoveryResetRequest` (+ response schema).
-- `backend/app/api/routes/auth.py` — 3 endpoints.
-- `backend/app/core/rate_limiter.py` — `auth_recovery_reset` limit key.
-- `backend/tests/security/test_recovery_codes.py` (+ endpoint tests).
+**Backend:** `models/user.py` (+column, +migration); `core/crypto.py` (new);
+`services/totp_service.py` (delegate); `services/recovery_code_service.py` (new);
+`schemas/auth.py` (`RecoveryCodesGenerateRequest`, `RecoveryResetRequest`,
+`RecoveryCodesResponse`, `RecoveryCodesStatusResponse`); `core/rate_limiter.py`
+(`auth_recovery_reset`); `api/routes/auth.py` (3 endpoints); tests under
+`tests/services/`, `tests/core/`, `tests/api/`.
 
-**Frontend**
-- `client/src/api/recovery-codes.ts` — new client.
-- `client/src/pages/Login.tsx` — "Passwort vergessen?" link + reset form.
-- Security settings component — recovery-codes section + banner.
-- i18n strings.
+**Frontend:** `api/recovery-codes.ts` (+test under `src/__tests__/api/`);
+`components/auth/ForgotPasswordForm.tsx`; `pages/Login.tsx`;
+`components/settings/RecoveryCodesCard.tsx`; `pages/SettingsPage.tsx`; i18n locales.
 
-**Docs**
-- `backend/app/models/CLAUDE.md`, `backend/app/services/CLAUDE.md`,
-  `backend/app/api/CLAUDE.md` — keep indexes in sync.
+**Docs:** `backend/app/services/CLAUDE.md`, `backend/app/api/CLAUDE.md`,
+`backend/app/core/CLAUDE.md`.
+
+## Review findings folded in
+
+- **CRITICAL — wrong gate.** `request.state.channel == "local"` is a same-host-UDS
+  signal (Tauri local-admin), hardwired to `remote` in the deployed backend (no
+  UDS unit installed) → would 403 every LAN web client. **Fixed:** use
+  `is_private_or_local_ip(request.client.host)`, valid because of the deployed
+  `--proxy-headers --forwarded-allow-ips=127.0.0.1` anti-spoof pin. Removed the
+  false "channel == local / is_private_or_local_ip" equivalence from the design.
+- **HIGH — no session revocation.** Fixed: `revoke_all_user_tokens` on reset.
+- **MUST — no step-up on generation.** Fixed: fresh TOTP (2FA) or current password.
+- **MUST — clipboard silently fails on HTTP.** Fixed: guard + Download .txt fallback.
+- **Hardening:** timing equalization on unknown/disabled user; length-bounded
+  `username`/`recovery_code`; `is_active=false` treated as not-found; Samba sync
+  best-effort; shared `core/crypto.py` instead of private `_totp` imports.
+- **Test/infra fixes:** dedicated throwaway user; audit-row + 2FA-after-reset
+  assertions; **vitest test under `src/__tests__/api/`** (the only path vitest
+  collects); Login.tsx insertion inside the `pinMode` else-branch.
+- **Accepted as-is:** JSON-blob column (mirrors 2FA, proportionate for a NAS);
+  in-memory per-IP rate limiter resets on restart and is per-worker (existing
+  Known Gap; brute-forcing one of 10×40-bit single-use codes is already
+  negligible); no dedicated per-account lockout (LAN-gate + step-up + entropy make
+  it unnecessary).
 
 ## Open follow-ups (out of scope)
 
-- Dedicated `RECOVERY_CODES_ENCRYPTION_KEY` once key isolation
-  (`2026-06-21-crypto-key-isolation.md`) lands.
-- Optional: surface recovery-code management in the TUI users screen.
+- Dedicated `RECOVERY_CODES_ENCRYPTION_KEY` once key isolation lands (the
+  `core/crypto.py` seam is ready).
+- Same session-revocation hardening for `change_password` (separate issue per the
+  repo's Nebenbefund rule).
+- Optional `password_recovery_codes_generated_at` timestamp for a "generated on X"
+  UI hint.

--- a/docs/superpowers/specs/2026-06-29-password-recovery-codes-design.md
+++ b/docs/superpowers/specs/2026-06-29-password-recovery-codes-design.md
@@ -1,0 +1,237 @@
+# Password Recovery Codes — Self-Service Reset (LAN-only)
+
+**Date:** 2026-06-29
+**Status:** Approved (design)
+**Branch:** `feat/password-recovery-codes`
+
+## Problem
+
+A user who forgets their password and is **not** an admin and has **no shell
+access** to the box cannot recover on their own. Today the only ways to reset a
+password are:
+
+- `POST /api/auth/change-password` — requires being logged in **and** knowing
+  the current password (`backend/app/api/routes/auth.py:588`).
+- Admin reset via `PUT /api/users/{id}` with `{password}` — requires an admin.
+- `backend/scripts/reset_password.py` — direct DB write, requires shell access
+  to the server.
+
+There is no self-service recovery path for a locked-out user. We want one that
+adds **no new email infrastructure** (email was deliberately removed —
+migration `042_remove_email_notifications.py`) and keeps the attack surface
+minimal.
+
+## Goals
+
+- A locked-out user on the local network can reset their own password using a
+  pre-provisioned, single-use **recovery code**.
+- Security-first: minimal attack surface, no weakening of existing controls
+  (2FA, rate limiting, audit logging, encryption-at-rest).
+- Mirror the proven 2FA backup-code mechanism (`totp_service.py`) rather than
+  invent a new primitive.
+
+## Non-Goals
+
+- **No email** reset links.
+- **No remote (off-LAN) reset.** A user reachable only via VPN/WAN keeps the
+  admin / `reset_password.py` fallback. (Explicitly accepted.)
+- No change to the existing `change-password` or admin-reset paths.
+
+## Key Decisions (from brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Channel | **LAN-only** | Smallest attack surface; mirrors Setup + PIN-login. A code leaked off-box is useless without local-network presence. |
+| Effect of a valid code | **Reset password only — no session/token** | The recovery code replaces *only* the password. The user then logs in normally, so **2FA stays fully enforced**; the code can never become a 2FA bypass. |
+| Provisioning | **On-demand in Security settings**, with a recommendation **banner** in user settings when not yet configured | Mirrors 2FA backup-code UX; opt-in but nudged. |
+| Scope | **All roles (admin + user)** | Admin lockout is the most dangerous case (no super-admin above). Uniform UX. |
+| Mechanism | **Dedicated recovery codes mirroring 2FA backup codes** | Clean boundary between two distinct secrets; single-column migration; reuses a tested pattern. |
+
+### Approaches considered
+
+1. **(Chosen) Dedicated recovery codes mirroring the 2FA backup-code pattern.**
+   New encrypted column on `User`, dedicated service, dedicated endpoints.
+2. **Reuse 2FA backup codes for both purposes.** Rejected — conflates two
+   distinct secrets, a 2FA backup code would also reset the password, and codes
+   would only exist when 2FA is enabled.
+3. **Generic single-use token table for future reuse.** Rejected — YAGNI /
+   over-engineering for a single use case.
+
+## Security: Encryption-at-rest + RBAC (hard requirement)
+
+Recovery codes are a **password-equivalent secret**. They are protected exactly
+like 2FA backup codes, on two layers:
+
+- **Hashed, then encrypted at rest.** Stored as a Fernet-encrypted JSON array of
+  **SHA-256 hashes** of the codes — never plaintext, never a reversible form.
+  Reuses the existing `MultiFernet` mechanism from `totp_service._get_totp_fernet()`
+  (`TOTP_ENCRYPTION_KEY`, falling back to `VPN_ENCRYPTION_KEY`; dual-key decrypt).
+  A DB dump alone yields neither the codes nor their bare hashes.
+- **Plaintext shown exactly once.** Generation/regeneration returns the codes a
+  single time in the HTTP response; they are never persisted in plaintext, never
+  logged, and cannot be retrieved again.
+- **RBAC-gated.** Code *management* (generate/regenerate/status) is bound to the
+  **authenticated session** and operates **only on the caller's own account** —
+  there is no cross-user code access and no admin endpoint that reveals another
+  user's codes. The pre-auth *reset* endpoint is additionally **LAN-gated** and
+  consumes a code without ever returning code material or a session.
+- **Fail-closed.** If no encryption key is configured, code operations raise
+  (same as TOTP/VPN) rather than degrade to plaintext.
+
+Alignment note: the in-flight `2026-06-21-crypto-key-isolation.md` plan aims to
+isolate per-domain crypto keys. This feature deliberately reuses the *current*
+TOTP/VPN key mechanism (no weakening vs. today). If/when key isolation lands, a
+dedicated `RECOVERY_CODES_ENCRYPTION_KEY` slots in via the same
+`_get_*_fernet()` shape — called out as follow-up, out of scope here.
+
+## Design
+
+### 1. Data model
+
+One new **nullable** column on `User` (mirrors `totp_backup_codes_encrypted`):
+
+```python
+# backend/app/models/user.py
+password_recovery_codes_encrypted: Mapped[str | None] = mapped_column(
+    Text, nullable=True, default=None
+)
+```
+
+- `None` ⇒ recovery codes not configured (drives the banner + `configured=false`).
+- Value ⇒ Fernet ciphertext of `json.dumps([sha256_hex, ...])`.
+- One Alembic migration, chained onto the **real** `alembic heads` (per
+  `project_alembic_migration_head_pitfall`). No new table.
+
+### 2. Service — `backend/app/services/recovery_code_service.py`
+
+Mirrors the TOTP backup-code functions; same hash+encrypt helpers (reuse
+`totp_service._totp_encrypt`/`_totp_decrypt`, or a shared crypto util factored
+out — implementation detail for the plan).
+
+```python
+RECOVERY_CODE_COUNT = 10
+RECOVERY_CODE_LENGTH = 8  # bytes of entropy per code (token_hex(LENGTH//2)... mirror TOTP format)
+
+def generate_recovery_codes(db: Session, user_id: int) -> list[str]:
+    """Generate N high-entropy codes, store hashed+encrypted, return plaintext ONCE.
+    Regenerating overwrites the column → all previous codes are invalidated."""
+
+def verify_and_consume_recovery_code(db: Session, user_id: int, code: str) -> bool:
+    """Verify a code and consume it (single-use: remove its hash). Returns False on miss."""
+
+def get_recovery_codes_remaining(db: Session, user_id: int) -> int: ...
+
+def has_recovery_codes(db: Session, user_id: int) -> bool:
+    """True iff the column is non-null and contains at least one unused code."""
+```
+
+Codes are generated with `secrets.token_hex(...)` (CSPRNG), uppercased, format
+identical to 2FA backup codes for UI consistency.
+
+### 3. Endpoints (`backend/app/api/routes/auth.py`)
+
+**Authenticated management (RBAC: own account only)** — mirrors the 2FA backup
+endpoints:
+
+| Method/Path | Auth | Returns | Notes |
+|---|---|---|---|
+| `POST /api/auth/recovery-codes` | `get_current_user` | `{ recovery_codes: string[] }` (once) | Generate/regenerate. `@limiter.limit(...)`. Audit-logged. |
+| `GET /api/auth/recovery-codes/status` | `get_current_user` | `{ configured: bool, remaining: int }` | Drives the banner. No code material. |
+
+**Pre-auth reset (the "forgot password" flow)** — LAN-gated:
+
+| Method/Path | Gate | Body | Returns |
+|---|---|---|---|
+| `POST /api/auth/recovery-reset` | **Local channel only** + hard rate limit | `RecoveryResetRequest{ username, recovery_code, new_password }` | `{ message }` — **no token** |
+
+Reset handler order (so a weak password never burns a code):
+
+1. **Pydantic validation** of `RecoveryResetRequest` — `new_password` runs the
+   full strength validator (reuse the `RegisterRequest` password rules;
+   deliberately **not** a raw `dict` like the `change-password` Known-Gap #8).
+   Weak password ⇒ `422` **before** the handler body runs ⇒ code not consumed.
+2. **LAN gate** — reuse the local-channel mechanism used by `login-pin`
+   (`request.state.channel == "local"` / `is_private_or_local_ip`). Non-local ⇒
+   `403`.
+3. **Resolve user** by username; **verify + consume** the recovery code.
+4. On success: `user_service.update_user_password(...)`; **Samba sync** if
+   `user.smb_enabled` (mirror `change_password`'s `samba_service.sync_smb_password`).
+5. Audit-log; return generic success. **No access token issued.**
+
+**Anti-enumeration:** unknown username, wrong code, and "no codes configured"
+all return the **same** generic failure (`"Invalid username or recovery code"`,
+same status) with best-effort uniform timing. Hard rate limit
+(`auth_recovery_reset`, on par with login) caps brute force; combined with
+LAN-only + 10 single-use high-entropy codes, online guessing is impractical.
+
+### 4. Frontend
+
+- **`client/src/api/recovery-codes.ts`** — new API client mirroring
+  `two-factor.ts` (`generateRecoveryCodes`, `getRecoveryCodesStatus`,
+  `recoveryReset`).
+- **Login page (`Login.tsx`)** — a **"Passwort vergessen?"** link opening a
+  reset form (username, recovery code, new password + confirm). Uses the same
+  pre-auth `fetch(buildApiUrl(...))` path as PIN-login. A `403` (non-local)
+  shows a clear "only available on the local network" message.
+- **Security settings** — a "Recovery-Codes" section analogous to the 2FA
+  backup-codes UI: generate/regenerate, **show once**, copy/download, remaining
+  count.
+- **Banner** — in user settings, shown when `status.configured === false`, with
+  an explicit recommendation to set up recovery codes.
+
+### 5. Error handling & audit
+
+- Audit via `get_audit_logger_db()`:
+  - `recovery_codes_generated` (success)
+  - `password_reset_via_recovery` (success)
+  - `password_reset_via_recovery_failed` (bad code / unknown user / non-local)
+- **Codes are never logged** at any level. Failures log username + reason only.
+- Fail-closed on missing encryption key (raise, like TOTP/VPN).
+- 2FA remains structurally intact: reset issues no session, so the subsequent
+  normal login still enforces TOTP.
+
+### 6. Testing (mirror `backend/tests/security/test_totp_2fa.py`)
+
+**Service:**
+- `generate_recovery_codes` returns `RECOVERY_CODE_COUNT` codes.
+- A code verifies once, then is consumed (second use fails); remaining count
+  decrements.
+- Regenerate invalidates all previous codes.
+- `has_recovery_codes` reflects configured/empty state.
+
+**Endpoints:**
+- Management requires auth; `POST` returns codes once; status endpoint shape.
+- Reset (happy path): valid code + strong password ⇒ password changed, code
+  consumed, **no token in response**, subsequent login with the new password
+  succeeds.
+- Reset rejects: wrong code, unknown user (generic identical response), **weak
+  password ⇒ 422 and code NOT consumed**, reused code, **non-local channel ⇒ 403**.
+- 2FA still required at login after a recovery reset (when enabled).
+- Samba sync invoked when `smb_enabled`.
+
+## Files to add / modify
+
+**Backend**
+- `backend/app/models/user.py` — new column.
+- `backend/alembic/versions/<rev>_add_password_recovery_codes.py` — migration.
+- `backend/app/services/recovery_code_service.py` — new service.
+- `backend/app/schemas/auth.py` — `RecoveryResetRequest` (+ response schema).
+- `backend/app/api/routes/auth.py` — 3 endpoints.
+- `backend/app/core/rate_limiter.py` — `auth_recovery_reset` limit key.
+- `backend/tests/security/test_recovery_codes.py` (+ endpoint tests).
+
+**Frontend**
+- `client/src/api/recovery-codes.ts` — new client.
+- `client/src/pages/Login.tsx` — "Passwort vergessen?" link + reset form.
+- Security settings component — recovery-codes section + banner.
+- i18n strings.
+
+**Docs**
+- `backend/app/models/CLAUDE.md`, `backend/app/services/CLAUDE.md`,
+  `backend/app/api/CLAUDE.md` — keep indexes in sync.
+
+## Open follow-ups (out of scope)
+
+- Dedicated `RECOVERY_CODES_ENCRYPTION_KEY` once key isolation
+  (`2026-06-21-crypto-key-isolation.md`) lands.
+- Optional: surface recovery-code management in the TUI users screen.


### PR DESCRIPTION
## Was & Warum

Self-Service **„Passwort vergessen"** für ausgesperrte User (kein Admin, kein Shell-Zugriff) — **ohne** E-Mail-Infrastruktur (E-Mail wurde bewusst entfernt, Migration `042`). Spiegelt das bewährte 2FA-Backup-Code-Verfahren.

Lücke vorher: Reset ging nur via altes Passwort (`change-password`), Admin (`PUT /users/{id}`) oder Offline-`reset_password.py`. Ein ausgesperrter Nicht-Admin konnte sich nicht selbst erholen.

## Design (security-first)

- **Recovery-Codes** = 10× einmalige Codes (`token_hex(5)`, 40 bit), **SHA-256-gehasht dann Fernet-verschlüsselt** at rest in neuer Spalte `User.password_recovery_codes_encrypted`. Single-use. Neuer geteilter Helfer `app/core/crypto.py` (`encrypt_at_rest`/`decrypt_at_rest`); `totp_service` delegiert dorthin (kein Verhalten geändert).
- **Generieren erfordert Step-up** — frisches TOTP (wenn 2FA an) bzw. aktuelles Passwort (sonst). Eine gekaperte Session kann nicht still Codes prägen (wie `set_pin`).
- **Reset `POST /api/auth/recovery-reset`** ist **LAN-only** via `is_private_or_local_ip(client.host)` (nicht spoofbar dank deployed `--proxy-headers --forwarded-allow-ips=127.0.0.1`), gibt **kein Token** aus (2FA bleibt beim nächsten Login erzwungen), **widerruft die Refresh-Tokens** des Users und ist **anti-enumeration** (unbekannt/deaktiviert/falscher Code → identisches 401, Timing angeglichen). Schwaches Passwort → 422 **bevor** ein Code verbraucht wird.
- **Frontend:** „Passwort vergessen?"-Formular auf der Login-Seite (isoliert vom 2FA/PIN-Flow) + `RecoveryCodesCard` in den Sicherheitseinstellungen mit Setup-Banner, Step-up-Eingabe, **Clipboard-Guard** (kein falsches „Copied" auf HTTP-über-LAN) und **Download .txt**-Fallback. i18n de/en.

## Ablauf

Spec → Plan → **3 parallele kritische Reviews** (Security/Korrektheit/Design). Diese fanden einen **CRITICAL**: das ursprüngliche LAN-Gate (`request.state.channel`) ist ein Same-Host-UDS-Signal, in Prod hart auf `remote` → hätte jeden LAN-Browser ge-403et. Korrigiert auf `is_private_or_local_ip` (Setup-Wizard-Präzedenz). Weitere Härtungen (Step-up, Token-Revocation, Timing/Feld-Limits) eingearbeitet. Umsetzung dann subagent-driven (Implementer + Task-Review je Task), finaler Opus-Whole-Branch-Review = **READY TO MERGE**, 0 Critical/Important.

## Tests

- Backend: neuer Service + Endpoints + Krypto-Helfer; Sicherheits-Tests für no-token, Token-Revocation, generisches 401 (unbekannt/**deaktiviert**/falscher Code), schwaches-PW-verbrennt-keinen-Code, non-local-403, Audit-Rows, **TOTP-Step-up** (dedizierter User, isolationssicher). 2FA-Suite grün (Delegation behält Verhalten).
- Frontend: vitest für den API-Client, eslint 0 + `npm run build` grün.

## Akzeptierte Residuen / Follow-ups (im Spec dokumentiert)

- In-Memory-Rate-Limiter (Restart/Worker) — bestehende Known Gap.
- Winziges exists/active-Timing-Residual (Dummy gleicht Krypto an, nicht den Success-Pfad-DB-Write) — vertretbar bei LAN + 40-bit single-use.
- Kein dediziertes Per-Account-Lockout (LAN + Step-up + Entropie machen es unnötig).
- Follow-up: dedizierter `RECOVERY_CODES_ENCRYPTION_KEY` sobald Key-Isolation landet; gleiche Token-Revocation-Härtung für `change_password`; Deploy-Doku-Notiz zur `--forwarded-allow-ips`-Abhängigkeit.

Spec: `docs/superpowers/specs/2026-06-29-password-recovery-codes-design.md`
Plan: `docs/superpowers/plans/2026-06-29-password-recovery-codes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWbPAeDvtY47TSUBVv1zax
