### PR TITLE
fix(settings): align RecoveryCodesCard with sibling card styling

### DIFF
--- a/client/src/components/settings/RecoveryCodesCard.tsx
+++ b/client/src/components/settings/RecoveryCodesCard.tsx
@@ -80,20 +80,32 @@ export const RecoveryCodesCard: React.FC = () => {
         </div>
       )}
 
-      <label className="mt-4 block space-y-1">
-        <span className="text-xs text-slate-300">{twoFA ? t('recovery.stepUpCode') : t('recovery.stepUpPassword')}</span>
+      <div className="mt-4 space-y-3">
         <input
           type={twoFA ? 'text' : 'password'}
+          inputMode={twoFA ? 'text' : undefined}
           autoComplete={twoFA ? 'one-time-code' : 'current-password'}
-          value={stepUp} onChange={(e) => setStepUp(e.target.value)}
-          className="w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+          placeholder={twoFA ? t('recovery.stepUpCode') : t('recovery.stepUpPassword')}
+          aria-label={twoFA ? t('recovery.stepUpCode') : t('recovery.stepUpPassword')}
+          className="input"
+          value={stepUp}
+          onChange={(e) => setStepUp(e.target.value)}
         />
-      </label>
-      <button onClick={handleGenerate} disabled={loading || !stepUp}
-        className="mt-3 rounded-lg bg-sky-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-50">
-        {loading ? t('recovery.generating') : status?.configured ? t('recovery.regenerate') : t('recovery.generate')}
-      </button>
-      {status?.configured && <p className="mt-1 text-xs text-slate-400">{t('recovery.regenWarning')}</p>}
+        <p className="text-xs text-slate-400">
+          {twoFA ? t('recovery.stepUpHintCode') : t('recovery.stepUpHintPassword')}
+        </p>
+
+        <div className="flex gap-2">
+          <button
+            onClick={handleGenerate}
+            disabled={loading || !stepUp}
+            className="btn btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? t('recovery.generating') : status?.configured ? t('recovery.regenerate') : t('recovery.generate')}
+          </button>
+        </div>
+        {status?.configured && <p className="text-xs text-slate-400">{t('recovery.regenWarning')}</p>}
+      </div>
     </div>
   );
 };

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -397,6 +397,8 @@
     "generateFailed": "Fehler beim Generieren der Wiederherstellungs-Codes",
     "stepUpCode": "2FA-Code",
     "stepUpPassword": "Aktuelles Passwort",
+    "stepUpHintCode": "Gib zur Bestätigung deinen aktuellen 2FA-Code (oder einen Backup-Code) ein.",
+    "stepUpHintPassword": "Gib zur Bestätigung dein aktuelles Passwort ein.",
     "generate": "Codes generieren",
     "regenerate": "Codes neu generieren",
     "generating": "Wird generiert…",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -397,6 +397,8 @@
     "generateFailed": "Failed to generate recovery codes",
     "stepUpCode": "2FA code",
     "stepUpPassword": "Current password",
+    "stepUpHintCode": "Enter your current 2FA code (or a backup code) to confirm.",
+    "stepUpHintPassword": "Enter your current password to confirm.",
     "generate": "Generate codes",
     "regenerate": "Regenerate codes",
     "generating": "Generating…",


### PR DESCRIPTION
## Was & Warum

Polish-Fix nach Deploy von #292: Die **Recovery-Codes-Card** in den Sicherheitseinstellungen sah neben der **Desktop-App-PIN-Card** inkonsistent aus. Sie hatte Eingabefeld und Button handgerollt (Label-über-Feld + flacher `bg-sky-600`-Button), während die Geschwister-Card (`DesktopPinSettings`) die geteilten `.input`- und `.btn btn-primary`-Klassen nutzt.

## Änderung

Übernimmt das Muster von `DesktopPinSettings` (gleiche Shell war schon identisch):

- Step-up-Feld nutzt jetzt `.input` mit **Placeholder + `aria-label`** statt Label-Span darüber
- **Helper-Zeile** unter dem Feld erklärt die Eingabe — 2FA-Code (**oder Backup-Code**, da der Generieren-Step-up via `_verify_fresh_totp` einen Backup-Code akzeptiert, wenn 2FA aktiv ist — gleiche Formulierung wie der PIN-Flow) bzw. aktuelles Passwort
- Generieren-Button nutzt den geteilten Gradient-Primary-Button (`btn btn-primary`)

Neue i18n-Keys `recovery.stepUpHintCode` / `recovery.stepUpHintPassword` (de + en).

Reines Frontend-/Styling-Change — keine API-, Logik- oder Sicherheitsänderung.

## Tests

- `eslint .` → 0 Errors (Warnings sind pre-existing)
- `npm run build` (tsc -b + vite) → grün
- Beide `settings.json` (de/en) parsen, neue Keys vorhanden

🤖 Generated with [Claude Code](https://claude.com/claude-code)
