### PR TITLE
fix(login): restyle forgot-password form to match login glass style

### DIFF
--- a/client/src/components/auth/ForgotPasswordForm.tsx
+++ b/client/src/components/auth/ForgotPasswordForm.tsx
@@ -5,6 +5,8 @@ import { recoveryReset } from '../../api/recovery-codes';
 
 interface Props { onDone: () => void; }
 
+const labelClass = 'text-xs font-medium uppercase tracking-[0.2em] text-slate-100-tertiary';
+
 export const ForgotPasswordForm = ({ onDone }: Props) => {
   const { t } = useTranslation('login');
   const [username, setUsername] = useState('');
@@ -28,32 +30,81 @@ export const ForgotPasswordForm = ({ onDone }: Props) => {
     } finally { setLoading(false); }
   };
 
-  const field = 'w-full rounded-lg border border-slate-800 bg-slate-950-secondary px-3 py-2 text-sm';
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <p className="text-xs text-slate-100-tertiary">{t('forgot.hint')}</p>
-      {error && <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">{error}</div>}
-      <label className="block space-y-1">
-        <span className="text-xs text-slate-100-secondary">{t('forgot.username')}</span>
-        <input className={field} autoComplete="username" value={username} onChange={(e) => setUsername(e.target.value)} required />
-      </label>
-      <label className="block space-y-1">
-        <span className="text-xs text-slate-100-secondary">{t('forgot.code')}</span>
-        <input className={field} value={code} onChange={(e) => setCode(e.target.value)} required />
-      </label>
-      <label className="block space-y-1">
-        <span className="text-xs text-slate-100-secondary">{t('forgot.newPassword')}</span>
-        <input type="password" className={field} autoComplete="new-password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} required />
-      </label>
-      <label className="block space-y-1">
-        <span className="text-xs text-slate-100-secondary">{t('forgot.confirm')}</span>
-        <input type="password" className={field} autoComplete="new-password" value={confirm} onChange={(e) => setConfirm(e.target.value)} required />
-      </label>
-      <div className="flex gap-2">
-        <button type="submit" disabled={loading} className="flex-1 rounded-lg bg-sky-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-50">
+    <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-5">
+      <p className="text-sm text-slate-100-tertiary">{t('forgot.hint')}</p>
+
+      {error && (
+        <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 px-3 sm:px-4 py-2.5 sm:py-3 text-sm text-rose-200">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <label htmlFor="forgot-username" className={labelClass}>{t('forgot.username')}</label>
+        <input
+          type="text"
+          id="forgot-username"
+          className="input"
+          autoComplete="username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="forgot-code" className={labelClass}>{t('forgot.code')}</label>
+        <input
+          type="text"
+          id="forgot-code"
+          className="input font-mono tracking-wider"
+          autoComplete="one-time-code"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="forgot-new-password" className={labelClass}>{t('forgot.newPassword')}</label>
+        <input
+          type="password"
+          id="forgot-new-password"
+          className="input"
+          autoComplete="new-password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          required
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="forgot-confirm" className={labelClass}>{t('forgot.confirm')}</label>
+        <input
+          type="password"
+          id="forgot-confirm"
+          className="input"
+          autoComplete="new-password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          required
+        />
+      </div>
+
+      <div className="flex gap-2 pt-1">
+        <button
+          type="submit"
+          disabled={loading}
+          className="btn btn-primary flex-1 touch-manipulation active:scale-[0.98] disabled:opacity-50"
+        >
           {loading ? t('forgot.resetting') : t('forgot.reset')}
         </button>
-        <button type="button" onClick={onDone} className="rounded-lg border border-slate-800 px-3 py-2 text-sm text-slate-100-secondary">
+        <button
+          type="button"
+          onClick={onDone}
+          className="btn btn-secondary"
+        >
           {t('forgot.back')}
         </button>
       </div>


### PR DESCRIPTION
## Was & Warum

Das **„Passwort vergessen"**-Formular auf der Login-Seite rendert mit grellweißen, schlecht lesbaren Eingabefeldern, die nicht zum dunklen Glass-Stil der Login-Card passen (siehe Screenshot).

## Ursache

Das Formular hatte eine eigene `field`-Klasse mit **nicht existierenden** Tailwind-Color-Tokens (`bg-slate-950-secondary`, `text-slate-100-secondary`, `text-slate-100-tertiary`). `tailwind.config.js` definiert **keine** `-secondary`/`-tertiary`-Varianten (nur `primary`), also erzeugt `bg-slate-950-secondary` kein CSS → die Inputs fallen auf den Browser-Default (weiß) zurück.

> Das Login-Formular selbst nutzt dieselben ungültigen `text-*`-Tokens, fällt dort aber unsichtbar auf das geerbte `text-slate-100` der Root-Card zurück. Ein Hintergrund hat nichts zu erben — deshalb brach es hier sichtbar.

## Fix

Eigene `field`-Klasse raus, stattdessen die geteilten Bausteine, die auch das Login-Formular verwendet:

- jedes Feld nutzt `.input` (dunkler Glass-Hintergrund, Sky-Fokusring)
- Reset/Cancel nutzen `.btn btn-primary` / `.btn btn-secondary`
- Labels im selben Uppercase-Tracked-Stil wie das Login-Formular, mit `htmlFor`/`id`-Verdrahtung (a11y)

Reines Styling — keine Logik-, API- oder i18n-Änderung.

## Tests

- `eslint` auf der Datei → 0 Errors
- `npm run build` (tsc -b + vite) → grün

## Nebenbefund (out of scope)

Die ungültigen `-secondary`/`-tertiary`-Color-Tokens sind im Codebase verstreut (u. a. `Login.tsx`, `TwoFactorCard.tsx` mit `bg-sky-500-secondary`). Sie „funktionieren" nur dort, wo `text-*` auf eine geerbte Farbe zurückfällt — latent fragil. Auf Wunsch lege ich dafür ein separates GitHub-Issue an.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
