### PR TITLE
fix(mobile): naive DateTime columns cause TypeError on aware comparison (#241)

### DIFF
--- a/backend/alembic/versions/08e59058edac_mobile_timestamp_columns_timezone_aware.py
+++ b/backend/alembic/versions/08e59058edac_mobile_timestamp_columns_timezone_aware.py
@@ -1,0 +1,85 @@
+"""mobile timestamp columns timezone aware
+
+Brings backend/app/models/mobile.py in line with the models/CLAUDE.md
+convention ("Timestamps: DateTime(timezone=True)") and fixes the root cause
+of #241: naive TIMESTAMP WITHOUT TIME ZONE columns compared against an aware
+datetime.now(timezone.utc) raise "can't compare offset-naive and
+offset-aware datetimes".
+
+PostgreSQL only -- ALTER COLUMN ... TYPE TIMESTAMPTZ is a no-op on SQLite
+(dev mode), which has no real timezone-aware storage and always returns
+naive datetimes on read regardless of declared column type; the defensive
+naive->UTC guards added alongside #241 stay in application code for that
+reason and are not removed by this migration.
+
+Revision ID: 08e59058edac
+Revises: 7fd13b0509a2
+Create Date: 2026-06-30 22:43:59.988379
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '08e59058edac'
+down_revision: Union[str, Sequence[str], None] = '7fd13b0509a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# (table, column, existing_nullable)
+COLUMNS = [
+    ("mobile_devices", "last_seen", True),
+    ("mobile_devices", "last_sync", True),
+    ("mobile_devices", "expires_at", True),
+    ("mobile_devices", "created_at", False),
+    ("mobile_devices", "updated_at", False),
+    ("mobile_registration_tokens", "expires_at", False),
+    ("mobile_registration_tokens", "created_at", False),
+    ("camera_backups", "last_backup", True),
+    ("camera_backups", "created_at", False),
+    ("camera_backups", "updated_at", True),
+    ("sync_folders", "last_sync", True),
+    ("sync_folders", "created_at", False),
+    ("sync_folders", "updated_at", True),
+    ("upload_queue", "created_at", False),
+    ("upload_queue", "started_at", True),
+    ("upload_queue", "completed_at", True),
+    ("expiration_notifications", "sent_at", False),
+    ("expiration_notifications", "device_expires_at", False),
+]
+
+
+def upgrade() -> None:
+    """Convert mobile.py timestamp columns from TIMESTAMP to TIMESTAMPTZ."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    for table, column, existing_nullable in COLUMNS:
+        op.alter_column(
+            table, column,
+            type_=sa.DateTime(timezone=True),
+            existing_type=sa.DateTime(),
+            existing_nullable=existing_nullable,
+            postgresql_using=f'"{column}" AT TIME ZONE \'UTC\'',
+        )
+
+
+def downgrade() -> None:
+    """Convert back to naive TIMESTAMP (no precision/data loss -- the
+    session is always pinned to UTC via core/database.py's _set_pg_timezone
+    connect event, so AT TIME ZONE 'UTC' round-trips losslessly)."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    for table, column, existing_nullable in COLUMNS:
+        op.alter_column(
+            table, column,
+            type_=sa.DateTime(),
+            existing_type=sa.DateTime(timezone=True),
+            existing_nullable=existing_nullable,
+            postgresql_using=f'"{column}" AT TIME ZONE \'UTC\'',
+        )

--- a/backend/app/models/mobile.py
+++ b/backend/app/models/mobile.py
@@ -29,15 +29,15 @@ class MobileDevice(Base):
 
     # Status
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
-    last_seen: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)  # Last API request from this device
-    last_sync: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)  # Last sync operation (camera/files)
+    last_seen: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)  # Last API request from this device
+    last_sync: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)  # Last sync operation (camera/files)
 
     # Device token expiration (30 days minimum, 6 months maximum)
-    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Timestamps
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
 
     # Relationships
     user = relationship("User", back_populates="mobile_devices")
@@ -52,9 +52,9 @@ class MobileRegistrationToken(Base):
     token: Mapped[str] = mapped_column(String, primary_key=True)
     user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     device_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
-    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     used: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
 
     # Relationships
     user = relationship("User")
@@ -76,7 +76,7 @@ class CameraBackup(Base):
     max_video_size_mb: Mapped[int] = mapped_column(Integer, default=500, nullable=False)
 
     # Status
-    last_backup: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    last_backup: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     total_photos: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     total_videos: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     pending_uploads: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
@@ -84,8 +84,8 @@ class CameraBackup(Base):
     storage_used_bytes: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
 
     # Timestamps
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
-    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime, onupdate=datetime.utcnow, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), onupdate=datetime.utcnow, nullable=True)
 
     # Relationships
     device = relationship("MobileDevice", back_populates="camera_backups")
@@ -107,13 +107,13 @@ class SyncFolder(Base):
     auto_sync: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
 
     # Status
-    last_sync: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    last_sync: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     status: Mapped[str] = mapped_column(String, default="idle", nullable=False)  # idle, syncing, error
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     # Timestamps
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
-    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime, onupdate=datetime.utcnow, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), onupdate=datetime.utcnow, nullable=True)
 
     # Relationships
     device = relationship("MobileDevice", back_populates="sync_folders")
@@ -142,9 +142,9 @@ class UploadQueue(Base):
     max_retries: Mapped[int] = mapped_column(Integer, default=3, nullable=False)
 
     # Timestamps
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
-    started_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
-    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+    started_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
 class ExpirationNotification(Base):
@@ -156,7 +156,7 @@ class ExpirationNotification(Base):
 
     # Notification details
     notification_type: Mapped[str] = mapped_column(String, nullable=False)  # "7_days", "3_days", "1_hour"
-    sent_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    sent_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
 
     # FCM response
     success: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
@@ -164,7 +164,7 @@ class ExpirationNotification(Base):
     error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     # Device expiration context (for audit trail)
-    device_expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    device_expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
     # Relationships
     device = relationship("MobileDevice")

--- a/backend/app/services/sync/file_sync.py
+++ b/backend/app/services/sync/file_sync.py
@@ -234,7 +234,10 @@ class FileSyncService:
             raise ValueError("Invalid registration token")
         if record.used:
             raise ValueError("Registration token already used")
-        if record.expires_at < datetime.now(timezone.utc):
+        expires_at = record.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at < datetime.now(timezone.utc):
             raise ValueError("Registration token expired")
         if str(record.user_id) != str(user_id):
             raise ValueError("Registration token does not belong to the current user")

--- a/backend/tests/models/test_mobile_timezone_columns.py
+++ b/backend/tests/models/test_mobile_timezone_columns.py
@@ -1,0 +1,33 @@
+"""Mobile model timestamp columns must be timezone-aware (#241).
+
+models/CLAUDE.md convention: "Timestamps: DateTime(timezone=True)". mobile.py
+predates this convention; columns were plain DateTime (naive), which was the
+root cause of #241's TypeError-on-comparison bugs against aware datetime.now().
+"""
+from app.models.mobile import (
+    CameraBackup,
+    ExpirationNotification,
+    MobileDevice,
+    MobileRegistrationToken,
+    SyncFolder,
+    UploadQueue,
+)
+
+EXPECTED_AWARE_COLUMNS = {
+    MobileDevice: ["last_seen", "last_sync", "expires_at", "created_at", "updated_at"],
+    MobileRegistrationToken: ["expires_at", "created_at"],
+    CameraBackup: ["last_backup", "created_at", "updated_at"],
+    SyncFolder: ["last_sync", "created_at", "updated_at"],
+    UploadQueue: ["created_at", "started_at", "completed_at"],
+    ExpirationNotification: ["sent_at", "device_expires_at"],
+}
+
+
+def test_mobile_timestamp_columns_are_timezone_aware():
+    for model, columns in EXPECTED_AWARE_COLUMNS.items():
+        for col_name in columns:
+            column = model.__table__.columns[col_name]
+            assert column.type.timezone is True, (
+                f"{model.__name__}.{col_name} must use DateTime(timezone=True) "
+                f"per models/CLAUDE.md convention"
+            )

--- a/backend/tests/services/test_file_sync_registration_token.py
+++ b/backend/tests/services/test_file_sync_registration_token.py
@@ -1,0 +1,47 @@
+"""Regression tests for FileSyncService.validate_registration_token (#241).
+
+MobileRegistrationToken.expires_at is a naive DateTime column; comparing it
+directly against an aware datetime.now(timezone.utc) raises TypeError. This
+path is reachable via POST /api/sync/register (desktop/BaluDesk token-based
+registration) and previously had no guard.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models.mobile import MobileRegistrationToken
+from app.services.sync.file_sync import FileSyncService
+
+
+def _make_token(db_session, user, expires_at, used=False):
+    token = MobileRegistrationToken(
+        token="reg_test_token",
+        user_id=user.id,
+        device_name="Test Desktop",
+        expires_at=expires_at,
+        used=used,
+    )
+    db_session.add(token)
+    db_session.commit()
+    return token
+
+
+def test_validate_registration_token_accepts_naive_unexpired_token(db_session, regular_user):
+    """A naive (no tzinfo) expires_at in the future must not raise TypeError."""
+    naive_future = (datetime.now(timezone.utc) + timedelta(minutes=5)).replace(tzinfo=None)
+    _make_token(db_session, regular_user, naive_future)
+
+    service = FileSyncService(db_session)
+    record = service.validate_registration_token("reg_test_token", regular_user.id)
+
+    assert record.token == "reg_test_token"
+
+
+def test_validate_registration_token_rejects_naive_expired_token(db_session, regular_user):
+    """A naive (no tzinfo) expires_at in the past must raise ValueError, not TypeError."""
+    naive_past = (datetime.now(timezone.utc) - timedelta(minutes=5)).replace(tzinfo=None)
+    _make_token(db_session, regular_user, naive_past)
+
+    service = FileSyncService(db_session)
+    with pytest.raises(ValueError, match="expired"):
+        service.validate_registration_token("reg_test_token", regular_user.id)


### PR DESCRIPTION
## Summary

Fixes #241 — naive `DateTime` columns in `backend/app/models/mobile.py` (no `timezone=True`, contrary to the `models/CLAUDE.md` convention) caused `TypeError: can't compare offset-naive and offset-aware datetimes` whenever compared against an aware `datetime.now(timezone.utc)`.

- **Live bug fixed:** `FileSyncService.validate_registration_token` (`backend/app/services/sync/file_sync.py`) compared `MobileRegistrationToken.expires_at` (naive) against aware `now()` with **no guard**. Reachable via `POST /api/sync/register` (desktop/BaluDesk token-based registration); the route only caught `ValueError`, so a `TypeError` here surfaced as an unhandled 500 instead of a clean 401. Added the same naive→UTC guard already used at the other (already-mitigated) call sites.
- **Root cause fixed:** all timestamp columns in `mobile.py` (`MobileDevice`, `MobileRegistrationToken`, `CameraBackup`, `SyncFolder`, `UploadQueue`, `ExpirationNotification`) now use `DateTime(timezone=True)`, matching the model convention.
- **Migration:** PostgreSQL-only `ALTER COLUMN ... TYPE TIMESTAMPTZ USING ... AT TIME ZONE 'UTC'` for every affected column (mirrors the existing dialect-guard pattern from migration `017_fix_monitoring_bigint_columns.py`). No-op on dev SQLite — verified upgrade/downgrade/upgrade round-trips cleanly there.
- Existing defensive naive→UTC guards at other call sites (`deps.py`, the notification scheduler's expiration warner) are **kept**, not removed — SQLite always returns naive datetimes on read regardless of declared column type, so they remain necessary for dev-mode correctness even after this migration.

Also posted a status update + this finding as a comment on #241 before starting: https://github.com/Xveyn/BaluHost/issues/241#issuecomment-4847701588

## Test plan

All done test-first (RED confirmed before each fix):

- [x] `backend/tests/services/test_file_sync_registration_token.py` (new) — naive expired/unexpired token comparison no longer raises `TypeError`
- [x] `backend/tests/models/test_mobile_timezone_columns.py` (new) — asserts every listed column is `DateTime(timezone=True)`
- [x] Alembic migration applied/downgraded/re-applied cleanly against the dev SQLite DB (no-op, single head confirmed via `alembic heads`)
- [x] Full targeted regression sweep (models, file-sync, notification scheduler, mobile expiry/registration, sync integration, desktop pairing, expiry catch-up-on-resume): **57/57 passing**

Closes #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9wxiRpNou1qvvcA1oN7Cd
