### PR TITLE
fix(plugins): nsSeparator:false for colon-keyed i18n object lookups (#288)

### DIFF
--- a/client/src/__tests__/components/plugins/PluginDocumentation.test.tsx
+++ b/client/src/__tests__/components/plugins/PluginDocumentation.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * #288: i18next treats ':' as its namespace separator, so
+ * `t(\`permissionDescriptions.${perm.value}\`)` mis-parses keys like
+ * "file:read" and silently falls back to the English API description for
+ * German users. `returnObjects: true` alone does NOT fix this -- i18next
+ * re-parses each nested key against nsSeparator while building the returned
+ * object too, so `t('scopeDescriptions', { returnObjects: true })` with a
+ * key like "read:system-info" still collapses to just "system-info" (the
+ * whole {label, description} object replaced by a string). Both lookups
+ * need `nsSeparator: false` as well. This must be tested against a REAL
+ * i18next instance (unlike sibling component tests, which mock
+ * react-i18next's t() entirely) -- a mocked t() never reproduces either bug.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import i18next from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import PluginDocumentation from '../../../components/plugins/PluginDocumentation';
+import type { PermissionInfo, ScopeInfo } from '../../../api/plugins';
+
+vi.mock('../../../contexts/VersionContext', () => ({
+  useFormattedVersion: () => 'BaluHost v1.0.0',
+}));
+
+const PERMISSIONS: PermissionInfo[] = [
+  { name: 'Read files', value: 'file:read', dangerous: false, description: 'Read files from storage' },
+];
+
+const SCOPE_CATALOG: ScopeInfo[] = [
+  { key: 'read:system-info', tier: 'backend', dangerous: false },
+];
+
+async function makeI18n() {
+  const instance = i18next.createInstance();
+  await instance.use(initReactI18next).init({
+    lng: 'de',
+    fallbackLng: 'de',
+    ns: ['plugins'],
+    defaultNS: 'plugins',
+    resources: {
+      de: {
+        plugins: {
+          categories: { file: 'Datei' },
+          docs: { permissions: 'Berechtigungen', available: 'verfügbar', permissionsDescription: '' },
+          permissionDescriptions: { 'file:read': 'Dateien lesen (DE)' },
+          scopeDescriptions: {
+            'read:system-info': { label: 'System-Info lesen (DE)', description: 'Liest System-Informationen (DE)' },
+          },
+        },
+      },
+    },
+    interpolation: { escapeValue: false },
+  });
+  return instance;
+}
+
+describe('PluginDocumentation separator-safe i18n lookups (#288)', () => {
+  it('shows the localized description for a colon-containing permission key, not the English API fallback', async () => {
+    const i18n = await makeI18n();
+    render(
+      <I18nextProvider i18n={i18n}>
+        <PluginDocumentation permissions={PERMISSIONS} scopeCatalog={[]} />
+      </I18nextProvider>
+    );
+
+    expect(screen.getByText('Dateien lesen (DE)')).toBeTruthy();
+    expect(screen.queryByText('Read files from storage')).toBeNull();
+  });
+
+  it('shows the localized label and description for a colon-containing scope key, not the raw key', async () => {
+    const i18n = await makeI18n();
+    render(
+      <I18nextProvider i18n={i18n}>
+        <PluginDocumentation permissions={[]} scopeCatalog={SCOPE_CATALOG} />
+      </I18nextProvider>
+    );
+
+    expect(screen.getByText('System-Info lesen (DE)')).toBeTruthy();
+    expect(screen.getByText('Liest System-Informationen (DE)')).toBeTruthy();
+  });
+});

--- a/client/src/components/plugins/PluginDocumentation.tsx
+++ b/client/src/components/plugins/PluginDocumentation.tsx
@@ -50,10 +50,25 @@ export default function PluginDocumentation({ permissions, scopeCatalog }: Plugi
   const formattedVersion = useFormattedVersion('BaluHost');
 
   // Separator-safe scope-description lookup (scope keys contain ':' and '.').
-  const scopeDescs = t('scopeDescriptions', { returnObjects: true }) as Record<
+  // `nsSeparator: false` is required in addition to `returnObjects: true`:
+  // i18next re-parses each nested key against the namespace separator while
+  // building the returned object, so a key like "read:system-info" still
+  // collapses to just "system-info" (or the whole {label, description}
+  // object to a string) unless nsSeparator is disabled for this call (#288).
+  const scopeDescs = t('scopeDescriptions', { returnObjects: true, nsSeparator: false }) as Record<
     string,
     { label: string; description: string }
   >;
+
+  // Separator-safe permission-description lookup (#288): permission keys
+  // contain ':' (e.g. "file:read"), which i18next's nsSeparator otherwise
+  // mis-parses as namespace.key, silently falling back to the EN API copy.
+  // See the scopeDescs comment above for why nsSeparator: false is required
+  // here too, not just returnObjects: true.
+  const permissionDescs = t('permissionDescriptions', {
+    returnObjects: true,
+    nsSeparator: false,
+  }) as Record<string, string>;
 
   const permissionCategories = useMemo(() => {
     return PERMISSION_CATEGORY_KEYS.map((key) => ({
@@ -213,7 +228,7 @@ export default function PluginDocumentation({ permissions, scopeCatalog }: Plugi
                         {perm.dangerous && <AlertTriangle className="h-3 w-3 text-amber-400" />}
                       </div>
                       <p className="text-xs text-slate-500 mt-1">
-                        {t(`permissionDescriptions.${perm.value}`, { defaultValue: perm.description })}
+                        {permissionDescs?.[perm.value] ?? perm.description}
                       </p>
                     </li>
                   ))}


### PR DESCRIPTION
## Summary

Fixes #288 — `PluginDocumentation.tsx`'s permission-description lookup mis-parsed colon-containing keys (e.g. `file:read`) via i18next's `:` namespace separator, silently falling back to the English API description for German users.

The proposed fix in the issue (`returnObjects: true` alone) turned out to be insufficient — verified against a real i18next instance, not the project's usual mocked `t()`. i18next re-parses each nested key against `nsSeparator` while constructing the returned object too, so `t('permissionDescriptions', { returnObjects: true })` with key `file:read` still collapsed to `'read'`.

That also meant the **existing** `scopeDescriptions` lookup in the same component — cited by the issue as the safe pattern to copy — had the identical bug. Scope keys (`read:system-info`, `read:storage`, `read:power`, …) all contain `:`, so the whole `{label, description}` object was silently collapsing to a plain string; the "Capability Scopes" section's labels/descriptions have likely never rendered correctly in either locale. Fixed both in this PR since it's the same root cause/file/mechanism — see https://github.com/Xveyn/BaluHost/issues/288#issuecomment-4847973239 for the verification detail.

**Fix:** pass `nsSeparator: false` alongside `returnObjects: true` on both lookups.

## Test plan

Built test-first against a real i18next instance (a mocked `t()`, as used by sibling component tests, can't reproduce either bug):

- [x] `client/src/__tests__/components/plugins/PluginDocumentation.test.tsx` (new) — colon-keyed permission description renders correctly, not the EN fallback
- [x] Same file — colon-keyed scope label+description render correctly, not collapsed to a string
- [x] `npx tsc -b` — clean
- [x] `npx eslint` on touched files — clean
- [x] Full Vitest suite — 81 files / 476 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9wxiRpNou1qvvcA1oN7Cd
