### PR TITLE
feat(client): migrate useSystemTelemetry to TanStack Query (#299)

### DIFF
--- a/client/src/__tests__/api/system.telemetry.test.ts
+++ b/client/src/__tests__/api/system.telemetry.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { apiClient } from '../../lib/api';
+import { getAggregatedStorage, getTelemetryHistory } from '../../api/system';
+
+vi.mock('../../lib/api', () => ({
+  apiClient: { get: vi.fn() },
+}));
+const mockedGet = vi.mocked(apiClient.get);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('telemetry api', () => {
+  it('getAggregatedStorage calls the aggregated endpoint and unwraps data', async () => {
+    mockedGet.mockResolvedValue({ data: { total: 100, used: 10, available: 90 } });
+    const res = await getAggregatedStorage();
+    expect(mockedGet).toHaveBeenCalledWith('/api/system/storage/aggregated');
+    expect(res.total).toBe(100);
+  });
+
+  it('getTelemetryHistory calls the history endpoint and unwraps data', async () => {
+    mockedGet.mockResolvedValue({ data: { cpu: [], memory: [], network: [] } });
+    const res = await getTelemetryHistory();
+    expect(mockedGet).toHaveBeenCalledWith('/api/system/telemetry/history');
+    expect(res.cpu).toEqual([]);
+  });
+});

--- a/client/src/__tests__/hooks/useSystemTelemetry.test.tsx
+++ b/client/src/__tests__/hooks/useSystemTelemetry.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useSystemTelemetry } from '../../hooks/useSystemTelemetry';
+import * as systemApi from '../../api/system';
+
+vi.mock('../../api/system');
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+const api = vi.mocked(systemApi);
+
+const sampleSystem = {
+  cpu: { usage: 5, cores: 4 },
+  memory: { total: 100, used: 40, free: 60 },
+  disk: { total: 200, used: 50, free: 150 },
+  uptime: 10,
+  dev_mode: true,
+};
+const sampleStorage = {
+  filesystem: '/dev/md0',
+  total: 200,
+  used: 50,
+  available: 150,
+  use_percent: '25%',
+  mount_point: '/',
+};
+const sampleHistory = { cpu: [{ timestamp: 1, usage: 5 }], memory: [], network: [] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionStorage.clear();
+});
+
+describe('useSystemTelemetry', () => {
+  it('maps system/storage/history into the legacy shape', async () => {
+    api.getSystemInfo.mockResolvedValue(sampleSystem);
+    api.getAggregatedStorage.mockResolvedValue(sampleStorage);
+    api.getTelemetryHistory.mockResolvedValue(sampleHistory);
+
+    const { result } = renderHook(() => useSystemTelemetry(999999), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.system?.cpu.usage).toBe(5);
+    expect(result.current.storage?.percent).toBe(25); // 50 / 200
+    expect(result.current.history.cpu).toHaveLength(1);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastUpdated).toBeInstanceOf(Date);
+  });
+
+  it('is loading on first render with an empty cache', async () => {
+    api.getSystemInfo.mockResolvedValue(sampleSystem);
+    api.getAggregatedStorage.mockResolvedValue(sampleStorage);
+    api.getTelemetryHistory.mockResolvedValue(sampleHistory);
+
+    const { result } = renderHook(() => useSystemTelemetry(999999), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  it('paints instantly (loading false) when a fresh sessionStorage cache exists', async () => {
+    sessionStorage.setItem(
+      'system_telemetry_cache',
+      JSON.stringify({
+        system: sampleSystem,
+        storage: sampleStorage,
+        history: sampleHistory,
+        timestamp: Date.now(),
+      })
+    );
+    api.getSystemInfo.mockResolvedValue(sampleSystem);
+    api.getAggregatedStorage.mockResolvedValue(sampleStorage);
+    api.getTelemetryHistory.mockResolvedValue(sampleHistory);
+
+    const { result } = renderHook(() => useSystemTelemetry(999999), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.system?.cpu.usage).toBe(5);
+  });
+
+  it('surfaces an error string when a fetch rejects', async () => {
+    api.getSystemInfo.mockRejectedValue(new Error('telemetry boom'));
+    api.getAggregatedStorage.mockResolvedValue(sampleStorage);
+    api.getTelemetryHistory.mockResolvedValue(sampleHistory);
+
+    const { result } = renderHook(() => useSystemTelemetry(999999), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.error).toBe('telemetry boom'));
+  });
+});

--- a/client/src/__tests__/lib/query-foundation.test.ts
+++ b/client/src/__tests__/lib/query-foundation.test.ts
@@ -31,3 +31,9 @@ describe('queryKeys.monitoring', () => {
     ]);
   });
 });
+
+describe('queryKeys.system', () => {
+  it('builds the telemetry key', () => {
+    expect(queryKeys.system.telemetry()).toEqual(['system', 'telemetry']);
+  });
+});

--- a/client/src/api/system.ts
+++ b/client/src/api/system.ts
@@ -31,6 +31,7 @@ export interface SystemInfoResponse {
   memory: MemoryInfo;
   disk: DiskInfo;
   uptime: number;
+  system_uptime?: number;
   dev_mode: boolean;
 }
 
@@ -100,6 +101,56 @@ export interface StorageBreakdownResponse {
 export async function getStorageBreakdown(): Promise<StorageBreakdownResponse> {
   const { data } = await apiClient.get<StorageBreakdownResponse>(
     '/api/system/storage/breakdown'
+  );
+  return data;
+}
+
+/** Storage shape returned by /api/system/storage/aggregated (telemetry). */
+export interface AggregatedStorageInfo {
+  filesystem?: string;
+  total: number;
+  used: number;
+  available: number;
+  usePercent?: string | number;
+  mountPoint?: string;
+}
+
+export interface CpuHistoryPoint {
+  timestamp: number;
+  usage: number;
+}
+
+export interface MemoryHistoryPoint {
+  timestamp: number;
+  used: number;
+  total: number;
+  percent: number;
+}
+
+export interface NetworkHistoryPoint {
+  timestamp: number;
+  downloadMbps: number;
+  uploadMbps: number;
+}
+
+export interface TelemetryHistory {
+  cpu: CpuHistoryPoint[];
+  memory: MemoryHistoryPoint[];
+  network: NetworkHistoryPoint[];
+}
+
+/** Get aggregated storage totals across all mountpoints (dashboard telemetry). */
+export async function getAggregatedStorage(): Promise<AggregatedStorageInfo> {
+  const { data } = await apiClient.get<AggregatedStorageInfo>(
+    '/api/system/storage/aggregated'
+  );
+  return data;
+}
+
+/** Get rolling CPU/memory/network telemetry history (dashboard charts). */
+export async function getTelemetryHistory(): Promise<TelemetryHistory> {
+  const { data } = await apiClient.get<TelemetryHistory>(
+    '/api/system/telemetry/history'
   );
   return data;
 }

--- a/client/src/api/system.ts
+++ b/client/src/api/system.ts
@@ -105,16 +105,6 @@ export async function getStorageBreakdown(): Promise<StorageBreakdownResponse> {
   return data;
 }
 
-/** Storage shape returned by /api/system/storage/aggregated (telemetry). */
-export interface AggregatedStorageInfo {
-  filesystem?: string;
-  total: number;
-  used: number;
-  available: number;
-  usePercent?: string | number;
-  mountPoint?: string;
-}
-
 export interface CpuHistoryPoint {
   timestamp: number;
   usage: number;
@@ -140,8 +130,8 @@ export interface TelemetryHistory {
 }
 
 /** Get aggregated storage totals across all mountpoints (dashboard telemetry). */
-export async function getAggregatedStorage(): Promise<AggregatedStorageInfo> {
-  const { data } = await apiClient.get<AggregatedStorageInfo>(
+export async function getAggregatedStorage(): Promise<StorageInfoResponse> {
+  const { data } = await apiClient.get<StorageInfoResponse>(
     '/api/system/storage/aggregated'
   );
   return data;

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -7,7 +7,7 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | Hook | API module | Purpose |
 |---|---|---|
 | `useMonitoring.ts` | `api/monitoring` | Unified CPU/memory/network/disk/process data via **TanStack Query** (`useQuery`), configurable `pollInterval` (mapped to `refetchInterval`) + history; public return shape unchanged |
-| `useSystemTelemetry.ts` | `api/system` | System telemetry (CPU, RAM, network) for dashboard widgets |
+| `useSystemTelemetry.ts` | `api/system` | System info + aggregated storage + telemetry history for the dashboard via **TanStack Query** (`useQuery`, one combined snapshot, `pollInterval`→`refetchInterval`); sessionStorage seeds `initialData` (removal deferred to #299 persister PR); public shape unchanged |
 | `useFanControl.ts` | `api/fan-control` | Fan config, curves, schedules — full fan management state |
 | `useSchedulers.ts` | `api/schedulers` | Scheduler list, status, history, run-now |
 | `useBenchmark.ts` | `api/benchmark` | Disk benchmark state, progress, results |

--- a/client/src/hooks/useSystemTelemetry.ts
+++ b/client/src/hooks/useSystemTelemetry.ts
@@ -1,72 +1,22 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { buildApiUrl, fireAuthExpired } from '../lib/api';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '../contexts/AuthContext';
-
-interface CpuInfo {
-  usage: number;
-  cores: number;
-  frequency_mhz?: number | null;
-  model?: string | null;
-  temperature_celsius?: number | null;
-}
-
-interface MemoryInfo {
-  total: number;
-  used: number;
-  free: number;
-  speed_mts?: number | null;
-  type?: string | null;
-}
-
-interface DiskInfo {
-  total: number;
-  used: number;
-  free: number;
-}
-
-interface SystemInfoResponse {
-  cpu: CpuInfo;
-  memory: MemoryInfo;
-  disk: DiskInfo;
-  uptime: number;
-  system_uptime?: number;
-}
-
-interface StorageInfoResponse {
-  filesystem?: string;
-  total: number;
-  used: number;
-  available: number;
-  usePercent?: string | number;
-  mountPoint?: string;
-}
+import { queryKeys } from '../lib/queryKeys';
+import { getApiErrorMessage } from '../lib/errorHandling';
+import {
+  getSystemInfo,
+  getAggregatedStorage,
+  getTelemetryHistory,
+  type SystemInfoResponse,
+  type StorageInfoResponse,
+  type TelemetryHistory,
+  type CpuHistoryPoint,
+  type MemoryHistoryPoint,
+  type NetworkHistoryPoint,
+} from '../api/system';
 
 interface NormalisedStorageInfo extends StorageInfoResponse {
   percent: number;
-}
-
-interface CpuHistoryPoint {
-  timestamp: number;
-  usage: number;
-}
-
-interface MemoryHistoryPoint {
-  timestamp: number;
-  used: number;
-  total: number;
-  percent: number;
-}
-
-interface NetworkHistoryPoint {
-  timestamp: number;
-  downloadMbps: number;
-  uploadMbps: number;
-}
-
-interface TelemetryHistory {
-  cpu: CpuHistoryPoint[];
-  memory: MemoryHistoryPoint[];
-  network: NetworkHistoryPoint[];
 }
 
 interface TelemetryState {
@@ -76,6 +26,12 @@ interface TelemetryState {
   refreshing: boolean;
   error: string | null;
   lastUpdated: Date | null;
+  history: TelemetryHistory;
+}
+
+interface TelemetrySnapshot {
+  system: SystemInfoResponse;
+  storage: StorageInfoResponse;
   history: TelemetryHistory;
 }
 
@@ -94,13 +50,13 @@ const parsePercent = (value: string | number | undefined): number => {
 const TELEMETRY_CACHE_KEY = 'system_telemetry_cache';
 const TELEMETRY_CACHE_DURATION = 120000; // 2 minutes
 
-function getCachedTelemetry(): { system: SystemInfoResponse | null; storage: StorageInfoResponse | null; history: TelemetryHistory } | null {
+function getCachedTelemetry(): TelemetrySnapshot | null {
   try {
     const cached = sessionStorage.getItem(TELEMETRY_CACHE_KEY);
     if (cached) {
       const data = JSON.parse(cached);
       const age = Date.now() - (data.timestamp || 0);
-      if (age < TELEMETRY_CACHE_DURATION) {
+      if (age < TELEMETRY_CACHE_DURATION && data.system && data.storage && data.history) {
         return { system: data.system, storage: data.storage, history: data.history };
       }
     }
@@ -110,14 +66,16 @@ function getCachedTelemetry(): { system: SystemInfoResponse | null; storage: Sto
   return null;
 }
 
-function setCachedTelemetry(system: SystemInfoResponse, storage: StorageInfoResponse, history: TelemetryHistory): void {
+function setCachedTelemetry(
+  system: SystemInfoResponse,
+  storage: StorageInfoResponse,
+  history: TelemetryHistory
+): void {
   try {
-    sessionStorage.setItem(TELEMETRY_CACHE_KEY, JSON.stringify({
-      system,
-      storage,
-      history,
-      timestamp: Date.now()
-    }));
+    sessionStorage.setItem(
+      TELEMETRY_CACHE_KEY,
+      JSON.stringify({ system, storage, history, timestamp: Date.now() })
+    );
   } catch {
     // Ignore cache write failures
   }
@@ -125,113 +83,26 @@ function setCachedTelemetry(system: SystemInfoResponse, storage: StorageInfoResp
 
 export const useSystemTelemetry = (pollInterval = 15000): TelemetryState => {
   const { token } = useAuth();
-  const cachedData = getCachedTelemetry();
-  const [system, setSystem] = useState<SystemInfoResponse | null>(cachedData?.system || null);
-  const [storage, setStorage] = useState<StorageInfoResponse | null>(cachedData?.storage || null);
-  const [loading, setLoading] = useState<boolean>(!cachedData);
-  const [refreshing, setRefreshing] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-  const [history, setHistory] = useState<TelemetryHistory>(cachedData?.history || { cpu: [], memory: [], network: [] });
-  const intervalRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    if (!token) {
-      setError('Missing authentication token.');
-      setLoading(false);
-      return () => undefined;
-    }
-
-    let isMounted = true;
-
-    const loadTelemetry = async (isInitial = false) => {
-      try {
-        // Set refreshing state for background updates
-        if (!isInitial && (system || cachedData)) {
-          setRefreshing(true);
-        } else {
-          setError(null);
-        }
-        
-        const [infoRes, storageRes, historyRes] = await Promise.all([
-          fetch(buildApiUrl('/api/system/info'), {
-            headers: { Authorization: `Bearer ${token}` }
-          }),
-          fetch(buildApiUrl('/api/system/storage/aggregated'), {
-            headers: { Authorization: `Bearer ${token}` }
-          }),
-          fetch(buildApiUrl('/api/system/telemetry/history'), {
-            headers: { Authorization: `Bearer ${token}` }
-          })
-        ]);
-
-        // Check for auth expiration on raw fetch responses
-        if (infoRes.status === 401 || storageRes.status === 401 || historyRes.status === 401) {
-          fireAuthExpired();
-          return;
-        }
-
-        if (!infoRes.ok) {
-          throw new Error('Failed to fetch system info');
-        }
-
-        if (!storageRes.ok) {
-          throw new Error('Failed to fetch storage info');
-        }
-
-        if (!historyRes.ok) {
-          throw new Error('Failed to fetch telemetry history');
-        }
-
-        const infoData: SystemInfoResponse = await infoRes.json();
-        const storageData: StorageInfoResponse = await storageRes.json();
-        const historyData: TelemetryHistory = await historyRes.json();
-
-        if (!isMounted) {
-          return;
-        }
-
-        setSystem(infoData);
-        setStorage(storageData);
-        setHistory(historyData);
-        setCachedTelemetry(infoData, storageData, historyData);
-        setLastUpdated(new Date());
-        setLoading(false);
-        setRefreshing(false);
-      } catch (err: unknown) {
-        if (!isMounted) {
-          return;
-        }
-
-        const message = err instanceof Error ? err.message : 'Unexpected telemetry error';
-        setError(message);
-        setLoading(false);
-        setRefreshing(false);
-      }
-    };
-
-    // Load immediately - either initial load or background refresh
-    if (!cachedData) {
-      void loadTelemetry(true);
-    } else {
-      // With cache, immediately start background refresh
-      setLoading(false);
-      void loadTelemetry(false);
-    }
-
-    intervalRef.current = window.setInterval(() => {
-      void loadTelemetry(false);
-    }, pollInterval);
-
-    return () => {
-      isMounted = false;
-      if (intervalRef.current) {
-        window.clearInterval(intervalRef.current);
-      }
-    };
-  }, [pollInterval, token]);
+  const query = useQuery({
+    queryKey: queryKeys.system.telemetry(),
+    queryFn: async (): Promise<TelemetrySnapshot> => {
+      const [system, storage, history] = await Promise.all([
+        getSystemInfo(),
+        getAggregatedStorage(),
+        getTelemetryHistory(),
+      ]);
+      setCachedTelemetry(system, storage, history); // keep the F5 instant-paint cache warm
+      return { system, storage, history };
+    },
+    refetchInterval: pollInterval,
+    enabled: !!token,
+    // Lazy: only read/parse sessionStorage when the cache actually seeds initial data.
+    initialData: () => getCachedTelemetry() ?? undefined,
+  });
 
   const normalisedStorage = useMemo<NormalisedStorageInfo | null>(() => {
+    const storage = query.data?.storage;
     if (!storage) {
       return null;
     }
@@ -239,25 +110,27 @@ export const useSystemTelemetry = (pollInterval = 15000): TelemetryState => {
     const total = Number(storage.total) || 0;
     const used = Number(storage.used) || 0;
     const available = Number(storage.available) || Math.max(total - used, 0);
-    const percent = total ? (used / total) * 100 : parsePercent(storage.usePercent);
+    const percent = total ? (used / total) * 100 : parsePercent(storage.use_percent);
 
     return {
       ...storage,
       total,
       used,
       available,
-      percent: Math.min(Math.max(percent, 0), 100)
+      percent: Math.min(Math.max(percent, 0), 100),
     };
-  }, [storage]);
+  }, [query.data?.storage]);
 
   return {
-    system,
+    system: query.data?.system ?? null,
     storage: normalisedStorage,
-    loading,
-    refreshing,
-    error,
-    lastUpdated,
-    history
+    loading: query.isLoading,
+    refreshing: query.isFetching && !query.isLoading,
+    error: query.isError
+      ? getApiErrorMessage(query.error, 'Unexpected telemetry error')
+      : null,
+    lastUpdated: query.dataUpdatedAt ? new Date(query.dataUpdatedAt) : null,
+    history: query.data?.history ?? { cpu: [], memory: [], network: [] },
   };
 };
 
@@ -268,5 +141,5 @@ export type {
   TelemetryHistory,
   CpuHistoryPoint,
   MemoryHistoryPoint,
-  NetworkHistoryPoint
+  NetworkHistoryPoint,
 };

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -24,4 +24,7 @@ export const queryKeys = {
     processesHistory: (duration: TimeRange, source: DataSource, processName?: string) =>
       ['monitoring', 'processes', 'history', duration, source, processName ?? null] as const,
   },
+  system: {
+    telemetry: () => ['system', 'telemetry'] as const,
+  },
 } as const;

--- a/docs/superpowers/plans/2026-07-02-telemetry-hook-tanstack-query-migration.md
+++ b/docs/superpowers/plans/2026-07-02-telemetry-hook-tanstack-query-migration.md
@@ -29,7 +29,7 @@
 ## File Structure
 
 - `client/src/lib/queryKeys.ts` — add a `system` domain (Task 1).
-- `client/src/api/system.ts` — add `system_uptime?` to `SystemInfoResponse`; add `AggregatedStorageInfo` + `getAggregatedStorage()`; add `TelemetryHistory` (+ point types) + `getTelemetryHistory()` (Task 1).
+- `client/src/api/system.ts` — add `system_uptime?` to `SystemInfoResponse`; add `getAggregatedStorage()` (returns the existing `StorageInfoResponse`, snake_case, matching the backend `StorageInfo` model); add `TelemetryHistory` (+ point types) + `getTelemetryHistory()` (Task 1).
 - `client/src/__tests__/lib/query-foundation.test.ts` — extend with the `system.telemetry()` key assertion (Task 1).
 - `client/src/__tests__/api/system.telemetry.test.ts` *(new)* — the two new API fns hit the right endpoints (Task 1).
 - `client/src/hooks/useSystemTelemetry.ts` — internal migration to `useQuery` (Task 2).
@@ -48,7 +48,7 @@
 
 **Interfaces:**
 - Produces: `queryKeys.system.telemetry(): readonly ['system','telemetry']`.
-- Produces: `getAggregatedStorage(): Promise<AggregatedStorageInfo>`, `getTelemetryHistory(): Promise<TelemetryHistory>`, and the exported types `AggregatedStorageInfo`, `TelemetryHistory`, `CpuHistoryPoint`, `MemoryHistoryPoint`, `NetworkHistoryPoint`. `SystemInfoResponse` gains optional `system_uptime?: number`.
+- Produces: `getAggregatedStorage(): Promise<StorageInfoResponse>` (reuses the existing `StorageInfoResponse` in `api/system.ts` — the aggregated endpoint returns the same backend `StorageInfo` model, snake_case `use_percent`/`mount_point`), `getTelemetryHistory(): Promise<TelemetryHistory>`, and the exported types `TelemetryHistory`, `CpuHistoryPoint`, `MemoryHistoryPoint`, `NetworkHistoryPoint`. `SystemInfoResponse` gains optional `system_uptime?: number`. No new `StorageInfoResponse` type is introduced (avoids duplicating `StorageInfoResponse`).
 - Consumes (test): `apiClient` from `lib/api` (mocked).
 
 - [ ] **Step 1: Add the `system` domain to the query-key factory**
@@ -85,18 +85,8 @@ In `client/src/api/system.ts`:
 
 (a) Add `system_uptime?: number;` to the existing `SystemInfoResponse` interface (after `uptime: number;`). This is additive — existing `getSystemInfo` consumers are unaffected.
 
-(b) Append these exports at the end of the file (after `getStorageBreakdown`):
+(b) Append these exports at the end of the file (after `getStorageBreakdown`). Note: `getAggregatedStorage` **reuses the existing `StorageInfoResponse`** already declared in this file (the aggregated endpoint returns the same backend `StorageInfo` model — snake_case `use_percent`/`mount_point`, all required). Do NOT introduce a new `StorageInfoResponse` type.
 ```ts
-/** Storage shape returned by /api/system/storage/aggregated (telemetry). */
-export interface AggregatedStorageInfo {
-  filesystem?: string;
-  total: number;
-  used: number;
-  available: number;
-  usePercent?: string | number;
-  mountPoint?: string;
-}
-
 export interface CpuHistoryPoint {
   timestamp: number;
   usage: number;
@@ -122,8 +112,8 @@ export interface TelemetryHistory {
 }
 
 /** Get aggregated storage totals across all mountpoints (dashboard telemetry). */
-export async function getAggregatedStorage(): Promise<AggregatedStorageInfo> {
-  const { data } = await apiClient.get<AggregatedStorageInfo>(
+export async function getAggregatedStorage(): Promise<StorageInfoResponse> {
+  const { data } = await apiClient.get<StorageInfoResponse>(
     '/api/system/storage/aggregated'
   );
   return data;
@@ -232,7 +222,14 @@ const sampleSystem = {
   uptime: 10,
   dev_mode: true,
 };
-const sampleStorage = { total: 200, used: 50, available: 150 };
+const sampleStorage = {
+  filesystem: '/dev/md0',
+  total: 200,
+  used: 50,
+  available: 150,
+  use_percent: '25%',
+  mount_point: '/',
+};
 const sampleHistory = { cpu: [{ timestamp: 1, usage: 5 }], memory: [], network: [] };
 
 beforeEach(() => {
@@ -329,14 +326,14 @@ import {
   getAggregatedStorage,
   getTelemetryHistory,
   type SystemInfoResponse,
-  type AggregatedStorageInfo,
+  type StorageInfoResponse,
   type TelemetryHistory,
   type CpuHistoryPoint,
   type MemoryHistoryPoint,
   type NetworkHistoryPoint,
 } from '../api/system';
 
-interface NormalisedStorageInfo extends AggregatedStorageInfo {
+interface NormalisedStorageInfo extends StorageInfoResponse {
   percent: number;
 }
 
@@ -352,7 +349,7 @@ interface TelemetryState {
 
 interface TelemetrySnapshot {
   system: SystemInfoResponse;
-  storage: AggregatedStorageInfo;
+  storage: StorageInfoResponse;
   history: TelemetryHistory;
 }
 
@@ -389,7 +386,7 @@ function getCachedTelemetry(): TelemetrySnapshot | null {
 
 function setCachedTelemetry(
   system: SystemInfoResponse,
-  storage: AggregatedStorageInfo,
+  storage: StorageInfoResponse,
   history: TelemetryHistory
 ): void {
   try {
@@ -431,7 +428,7 @@ export const useSystemTelemetry = (pollInterval = 15000): TelemetryState => {
     const total = Number(storage.total) || 0;
     const used = Number(storage.used) || 0;
     const available = Number(storage.available) || Math.max(total - used, 0);
-    const percent = total ? (used / total) * 100 : parsePercent(storage.usePercent);
+    const percent = total ? (used / total) * 100 : parsePercent(storage.use_percent);
 
     return {
       ...storage,
@@ -457,7 +454,7 @@ export const useSystemTelemetry = (pollInterval = 15000): TelemetryState => {
 
 export type {
   SystemInfoResponse,
-  AggregatedStorageInfo,
+  StorageInfoResponse,
   NormalisedStorageInfo,
   TelemetryHistory,
   CpuHistoryPoint,

--- a/docs/superpowers/plans/2026-07-02-telemetry-hook-tanstack-query-migration.md
+++ b/docs/superpowers/plans/2026-07-02-telemetry-hook-tanstack-query-migration.md
@@ -1,0 +1,538 @@
+# Telemetry Hook TanStack Query Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `useSystemTelemetry` internals to a single TanStack Query `useQuery` over the typed `apiClient`, keeping the public return shape bit-for-bit identical (Approach A) so `Dashboard.tsx` is untouched.
+
+**Architecture:** Move the three raw `fetch()` calls into typed `api/system.ts` functions that go through `apiClient` (central auth + 401 interceptor). The hook combines them in one `queryFn` (`Promise.all`) under a single `queryKey`, maps loading/refreshing/error/lastUpdated from the query, and keeps the existing sessionStorage cache wired as `initialData` (removal deferred to the later #299 persister PR).
+
+**Tech Stack:** React 18.2, TypeScript (strict, `verbatimModuleSyntax`), Vite 7, Vitest 4, `@testing-library/react`, `@tanstack/react-query` v5, axios via `apiClient`.
+
+**Spec:** `docs/superpowers/specs/2026-07-02-telemetry-hook-tanstack-query-migration-design.md`
+**Issue:** [#299](https://github.com/Xveyn/BaluHost/issues/299) — Track "PR — Telemetry"
+**Precedent:** #364 (monitoring pilot — the reference pattern)
+
+## Global Constraints
+
+- **Public hook signature unchanged.** `useSystemTelemetry(pollInterval = 15000)` keeps its exact return shape `{ system, storage, loading, refreshing, error, lastUpdated, history }`. Consumers (`pages/Dashboard.tsx:80`) must not be edited.
+- **TanStack Query v5** (already a dependency after #364). React 18.2 — do not bump.
+- **`verbatimModuleSyntax: true`** — all type-only imports MUST use the `type` modifier (`import { fn, type Foo }` or `import type`).
+- **Tests live under `client/src/__tests__/`** and match `**/*.test.{ts,tsx}`. Non-test helpers under `__tests__/` must NOT end in `.test.`.
+- **Query defaults (verbatim, from `lib/queryClient.ts`):** `staleTime: 0`, `retry: 1`, `refetchOnWindowFocus: false`. Test client (`__tests__/helpers/queryClient.tsx`) uses `retry: false`, `gcTime: Infinity`.
+- **CI gate:** `npm run build` (= `tsc -b && vite build`) AND `npm run lint` (= `eslint .`, 0-error) must be green; full Vitest suite stays green. Unused imports fail eslint.
+- **Repo is CRLF** (`core.autocrlf=true`) — editing tools normalize; not a content concern.
+- **Commit trailer:** every commit ends with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **All work on branch `feat/tanstack-telemetry-hook-299`** (already created off `main`; the design spec is already committed there).
+
+---
+
+## File Structure
+
+- `client/src/lib/queryKeys.ts` — add a `system` domain (Task 1).
+- `client/src/api/system.ts` — add `system_uptime?` to `SystemInfoResponse`; add `AggregatedStorageInfo` + `getAggregatedStorage()`; add `TelemetryHistory` (+ point types) + `getTelemetryHistory()` (Task 1).
+- `client/src/__tests__/lib/query-foundation.test.ts` — extend with the `system.telemetry()` key assertion (Task 1).
+- `client/src/__tests__/api/system.telemetry.test.ts` *(new)* — the two new API fns hit the right endpoints (Task 1).
+- `client/src/hooks/useSystemTelemetry.ts` — internal migration to `useQuery` (Task 2).
+- `client/src/__tests__/hooks/useSystemTelemetry.test.tsx` *(new)* — hook mapping + sessionStorage seed + error (Task 2).
+- `client/src/hooks/CLAUDE.md` — document the migration (Task 3).
+
+---
+
+### Task 1: API layer + query key
+
+**Files:**
+- Modify: `client/src/lib/queryKeys.ts`
+- Modify: `client/src/api/system.ts`
+- Test: `client/src/__tests__/lib/query-foundation.test.ts` (extend)
+- Test: `client/src/__tests__/api/system.telemetry.test.ts` (new)
+
+**Interfaces:**
+- Produces: `queryKeys.system.telemetry(): readonly ['system','telemetry']`.
+- Produces: `getAggregatedStorage(): Promise<AggregatedStorageInfo>`, `getTelemetryHistory(): Promise<TelemetryHistory>`, and the exported types `AggregatedStorageInfo`, `TelemetryHistory`, `CpuHistoryPoint`, `MemoryHistoryPoint`, `NetworkHistoryPoint`. `SystemInfoResponse` gains optional `system_uptime?: number`.
+- Consumes (test): `apiClient` from `lib/api` (mocked).
+
+- [ ] **Step 1: Add the `system` domain to the query-key factory**
+
+In `client/src/lib/queryKeys.ts`, add a `system` block after the closing `},` of the `monitoring` block (still inside the top-level `queryKeys` object):
+```ts
+  system: {
+    telemetry: () => ['system', 'telemetry'] as const,
+  },
+```
+
+- [ ] **Step 2: Extend the foundation test with the new key**
+
+In `client/src/__tests__/lib/query-foundation.test.ts`, add this `describe` block at the end of the file (after the existing `queryKeys.monitoring` block):
+```ts
+describe('queryKeys.system', () => {
+  it('builds the telemetry key', () => {
+    expect(queryKeys.system.telemetry()).toEqual(['system', 'telemetry']);
+  });
+});
+```
+
+- [ ] **Step 3: Run the key test to verify it passes**
+
+Run (from `client/`):
+```bash
+npx vitest run src/__tests__/lib/query-foundation.test.ts
+```
+Expected: PASS (existing tests + the new `queryKeys.system` test).
+
+- [ ] **Step 4: Add telemetry types + fetch functions to `api/system.ts`**
+
+In `client/src/api/system.ts`:
+
+(a) Add `system_uptime?: number;` to the existing `SystemInfoResponse` interface (after `uptime: number;`). This is additive — existing `getSystemInfo` consumers are unaffected.
+
+(b) Append these exports at the end of the file (after `getStorageBreakdown`):
+```ts
+/** Storage shape returned by /api/system/storage/aggregated (telemetry). */
+export interface AggregatedStorageInfo {
+  filesystem?: string;
+  total: number;
+  used: number;
+  available: number;
+  usePercent?: string | number;
+  mountPoint?: string;
+}
+
+export interface CpuHistoryPoint {
+  timestamp: number;
+  usage: number;
+}
+
+export interface MemoryHistoryPoint {
+  timestamp: number;
+  used: number;
+  total: number;
+  percent: number;
+}
+
+export interface NetworkHistoryPoint {
+  timestamp: number;
+  downloadMbps: number;
+  uploadMbps: number;
+}
+
+export interface TelemetryHistory {
+  cpu: CpuHistoryPoint[];
+  memory: MemoryHistoryPoint[];
+  network: NetworkHistoryPoint[];
+}
+
+/** Get aggregated storage totals across all mountpoints (dashboard telemetry). */
+export async function getAggregatedStorage(): Promise<AggregatedStorageInfo> {
+  const { data } = await apiClient.get<AggregatedStorageInfo>(
+    '/api/system/storage/aggregated'
+  );
+  return data;
+}
+
+/** Get rolling CPU/memory/network telemetry history (dashboard charts). */
+export async function getTelemetryHistory(): Promise<TelemetryHistory> {
+  const { data } = await apiClient.get<TelemetryHistory>(
+    '/api/system/telemetry/history'
+  );
+  return data;
+}
+```
+
+- [ ] **Step 5: Write the failing API test**
+
+Create `client/src/__tests__/api/system.telemetry.test.ts`:
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { apiClient } from '../../lib/api';
+import { getAggregatedStorage, getTelemetryHistory } from '../../api/system';
+
+vi.mock('../../lib/api', () => ({
+  apiClient: { get: vi.fn() },
+}));
+const mockedGet = vi.mocked(apiClient.get);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('telemetry api', () => {
+  it('getAggregatedStorage calls the aggregated endpoint and unwraps data', async () => {
+    mockedGet.mockResolvedValue({ data: { total: 100, used: 10, available: 90 } });
+    const res = await getAggregatedStorage();
+    expect(mockedGet).toHaveBeenCalledWith('/api/system/storage/aggregated');
+    expect(res.total).toBe(100);
+  });
+
+  it('getTelemetryHistory calls the history endpoint and unwraps data', async () => {
+    mockedGet.mockResolvedValue({ data: { cpu: [], memory: [], network: [] } });
+    const res = await getTelemetryHistory();
+    expect(mockedGet).toHaveBeenCalledWith('/api/system/telemetry/history');
+    expect(res.cpu).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 6: Run the API test to verify it passes**
+
+Run (from `client/`):
+```bash
+npx vitest run src/__tests__/api/system.telemetry.test.ts
+```
+Expected: PASS (2 tests). (If a resolution error appears, confirm the mock path `../../lib/api` matches how `api/system.ts` imports it as `../lib/api` — both resolve to the same module.)
+
+- [ ] **Step 7: Typecheck + lint the touched files**
+
+Run (from `client/`):
+```bash
+npx tsc -b
+npx eslint src/api/system.ts src/lib/queryKeys.ts
+```
+Expected: tsc clean, eslint clean.
+
+- [ ] **Step 8: Commit**
+
+Run (from repo root):
+```bash
+git add client/src/lib/queryKeys.ts client/src/api/system.ts client/src/__tests__/lib/query-foundation.test.ts client/src/__tests__/api/system.telemetry.test.ts
+git commit -m "feat(client): add system telemetry api fns + query key (#299)" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Migrate `useSystemTelemetry` to `useQuery`
+
+**Files:**
+- Modify: `client/src/hooks/useSystemTelemetry.ts` (full internal rewrite; public shape + module-level helpers preserved)
+- Test: `client/src/__tests__/hooks/useSystemTelemetry.test.tsx` (new)
+
+**Interfaces:**
+- Consumes: `queryKeys.system.telemetry` (Task 1), `getSystemInfo`/`getAggregatedStorage`/`getTelemetryHistory` + their types (Task 1), `useAuth` from `contexts/AuthContext`, `getApiErrorMessage` from `lib/errorHandling`, `useQuery`.
+- Produces: `useSystemTelemetry(pollInterval?: number): TelemetryState` — unchanged shape. Re-exports the telemetry types.
+
+- [ ] **Step 1: Write the failing hook test**
+
+Create `client/src/__tests__/hooks/useSystemTelemetry.test.tsx`:
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useSystemTelemetry } from '../../hooks/useSystemTelemetry';
+import * as systemApi from '../../api/system';
+
+vi.mock('../../api/system');
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+const api = vi.mocked(systemApi);
+
+const sampleSystem = {
+  cpu: { usage: 5, cores: 4 },
+  memory: { total: 100, used: 40, free: 60 },
+  disk: { total: 200, used: 50, free: 150 },
+  uptime: 10,
+  dev_mode: true,
+};
+const sampleStorage = { total: 200, used: 50, available: 150 };
+const sampleHistory = { cpu: [{ timestamp: 1, usage: 5 }], memory: [], network: [] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionStorage.clear();
+});
+
+describe('useSystemTelemetry', () => {
+  it('maps system/storage/history into the legacy shape', async () => {
+    api.getSystemInfo.mockResolvedValue(sampleSystem);
+    api.getAggregatedStorage.mockResolvedValue(sampleStorage);
+    api.getTelemetryHistory.mockResolvedValue(sampleHistory);
+
+    const { result } = renderHook(() => useSystemTelemetry(999999), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.system?.cpu.usage).toBe(5);
+    expect(result.current.storage?.percent).toBe(25); // 50 / 200
+    expect(result.current.history.cpu).toHaveLength(1);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastUpdated).toBeInstanceOf(Date);
+  });
+
+  it('is loading on first render with an empty cache', async () => {
+    api.getSystemInfo.mockResolvedValue(sampleSystem);
+    api.getAggregatedStorage.mockResolvedValue(sampleStorage);
+    api.getTelemetryHistory.mockResolvedValue(sampleHistory);
+
+    const { result } = renderHook(() => useSystemTelemetry(999999), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  it('paints instantly (loading false) when a fresh sessionStorage cache exists', async () => {
+    sessionStorage.setItem(
+      'system_telemetry_cache',
+      JSON.stringify({
+        system: sampleSystem,
+        storage: sampleStorage,
+        history: sampleHistory,
+        timestamp: Date.now(),
+      })
+    );
+    api.getSystemInfo.mockResolvedValue(sampleSystem);
+    api.getAggregatedStorage.mockResolvedValue(sampleStorage);
+    api.getTelemetryHistory.mockResolvedValue(sampleHistory);
+
+    const { result } = renderHook(() => useSystemTelemetry(999999), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.system?.cpu.usage).toBe(5);
+  });
+
+  it('surfaces an error string when a fetch rejects', async () => {
+    api.getSystemInfo.mockRejectedValue(new Error('telemetry boom'));
+    api.getAggregatedStorage.mockResolvedValue(sampleStorage);
+    api.getTelemetryHistory.mockResolvedValue(sampleHistory);
+
+    const { result } = renderHook(() => useSystemTelemetry(999999), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.error).toBe('telemetry boom'));
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it runs (fails against the old hook)**
+
+Run (from `client/`):
+```bash
+npx vitest run src/__tests__/hooks/useSystemTelemetry.test.tsx
+```
+Expected: the suite runs; assertions fail against the old `fetch`+`setInterval` hook (it uses raw `fetch`, not the mocked `api/system` fns, so the mocked resolves never arrive). Confirm it runs, then implement.
+
+- [ ] **Step 3: Rewrite the hook**
+
+Replace the **entire** contents of `client/src/hooks/useSystemTelemetry.ts` with:
+```ts
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '../contexts/AuthContext';
+import { queryKeys } from '../lib/queryKeys';
+import { getApiErrorMessage } from '../lib/errorHandling';
+import {
+  getSystemInfo,
+  getAggregatedStorage,
+  getTelemetryHistory,
+  type SystemInfoResponse,
+  type AggregatedStorageInfo,
+  type TelemetryHistory,
+  type CpuHistoryPoint,
+  type MemoryHistoryPoint,
+  type NetworkHistoryPoint,
+} from '../api/system';
+
+interface NormalisedStorageInfo extends AggregatedStorageInfo {
+  percent: number;
+}
+
+interface TelemetryState {
+  system: SystemInfoResponse | null;
+  storage: NormalisedStorageInfo | null;
+  loading: boolean;
+  refreshing: boolean;
+  error: string | null;
+  lastUpdated: Date | null;
+  history: TelemetryHistory;
+}
+
+interface TelemetrySnapshot {
+  system: SystemInfoResponse;
+  storage: AggregatedStorageInfo;
+  history: TelemetryHistory;
+}
+
+const parsePercent = (value: string | number | undefined): number => {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const cleaned = value.replace(/[^0-9.]/g, '');
+    const parsed = Number.parseFloat(cleaned);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+};
+
+const TELEMETRY_CACHE_KEY = 'system_telemetry_cache';
+const TELEMETRY_CACHE_DURATION = 120000; // 2 minutes
+
+function getCachedTelemetry(): TelemetrySnapshot | null {
+  try {
+    const cached = sessionStorage.getItem(TELEMETRY_CACHE_KEY);
+    if (cached) {
+      const data = JSON.parse(cached);
+      const age = Date.now() - (data.timestamp || 0);
+      if (age < TELEMETRY_CACHE_DURATION && data.system && data.storage && data.history) {
+        return { system: data.system, storage: data.storage, history: data.history };
+      }
+    }
+  } catch {
+    // Ignore cache read failures
+  }
+  return null;
+}
+
+function setCachedTelemetry(
+  system: SystemInfoResponse,
+  storage: AggregatedStorageInfo,
+  history: TelemetryHistory
+): void {
+  try {
+    sessionStorage.setItem(
+      TELEMETRY_CACHE_KEY,
+      JSON.stringify({ system, storage, history, timestamp: Date.now() })
+    );
+  } catch {
+    // Ignore cache write failures
+  }
+}
+
+export const useSystemTelemetry = (pollInterval = 15000): TelemetryState => {
+  const { token } = useAuth();
+
+  const query = useQuery({
+    queryKey: queryKeys.system.telemetry(),
+    queryFn: async (): Promise<TelemetrySnapshot> => {
+      const [system, storage, history] = await Promise.all([
+        getSystemInfo(),
+        getAggregatedStorage(),
+        getTelemetryHistory(),
+      ]);
+      setCachedTelemetry(system, storage, history); // keep the F5 instant-paint cache warm
+      return { system, storage, history };
+    },
+    refetchInterval: pollInterval,
+    enabled: !!token,
+    // Lazy: only read/parse sessionStorage when the cache actually seeds initial data.
+    initialData: () => getCachedTelemetry() ?? undefined,
+  });
+
+  const normalisedStorage = useMemo<NormalisedStorageInfo | null>(() => {
+    const storage = query.data?.storage;
+    if (!storage) {
+      return null;
+    }
+
+    const total = Number(storage.total) || 0;
+    const used = Number(storage.used) || 0;
+    const available = Number(storage.available) || Math.max(total - used, 0);
+    const percent = total ? (used / total) * 100 : parsePercent(storage.usePercent);
+
+    return {
+      ...storage,
+      total,
+      used,
+      available,
+      percent: Math.min(Math.max(percent, 0), 100),
+    };
+  }, [query.data?.storage]);
+
+  return {
+    system: query.data?.system ?? null,
+    storage: normalisedStorage,
+    loading: query.isLoading,
+    refreshing: query.isFetching && !query.isLoading,
+    error: query.isError
+      ? getApiErrorMessage(query.error, 'Unexpected telemetry error')
+      : null,
+    lastUpdated: query.dataUpdatedAt ? new Date(query.dataUpdatedAt) : null,
+    history: query.data?.history ?? { cpu: [], memory: [], network: [] },
+  };
+};
+
+export type {
+  SystemInfoResponse,
+  AggregatedStorageInfo,
+  NormalisedStorageInfo,
+  TelemetryHistory,
+  CpuHistoryPoint,
+  MemoryHistoryPoint,
+  NetworkHistoryPoint,
+};
+```
+
+- [ ] **Step 4: Run the hook test to verify it passes**
+
+Run (from `client/`):
+```bash
+npx vitest run src/__tests__/hooks/useSystemTelemetry.test.tsx
+```
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Typecheck + lint the hook**
+
+Run (from `client/`):
+```bash
+npx tsc -b
+npx eslint src/hooks/useSystemTelemetry.ts
+```
+Expected: tsc clean; eslint clean (no unused-import errors — `buildApiUrl`/`fireAuthExpired`/`useState`/`useEffect`/`useRef` are gone).
+
+- [ ] **Step 6: Commit**
+
+Run (from repo root):
+```bash
+git add client/src/hooks/useSystemTelemetry.ts client/src/__tests__/hooks/useSystemTelemetry.test.tsx
+git commit -m "feat(client): migrate useSystemTelemetry to useQuery (#299)" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Documentation + full verification gate
+
+**Files:**
+- Modify: `client/src/hooks/CLAUDE.md`
+
+- [ ] **Step 1: Update the hooks doc**
+
+In `client/src/hooks/CLAUDE.md`, replace the `useSystemTelemetry.ts` table row with:
+```markdown
+| `useSystemTelemetry.ts` | `api/system` | System info + aggregated storage + telemetry history for the dashboard via **TanStack Query** (`useQuery`, one combined snapshot, `pollInterval`→`refetchInterval`); sessionStorage seeds `initialData` (removal deferred to #299 persister PR); public shape unchanged |
+```
+
+- [ ] **Step 2: Full verification**
+
+Run (from `client/`):
+```bash
+npm run build
+npm run lint
+npx vitest run
+```
+Expected: build succeeds (`tsc -b` + `vite build`); eslint clean (0-error gate); **entire** Vitest suite green (foundation + api + hook + all pre-existing).
+
+- [ ] **Step 3: Commit**
+
+Run (from repo root):
+```bash
+git add client/src/hooks/CLAUDE.md
+git commit -m "docs(client): document useSystemTelemetry TanStack Query migration (#299)" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Post-Plan
+
+1. **Manual smoke (dev):** `python start_dev.py`; open the dashboard; confirm telemetry widgets populate, poll ~15 s, repaint instantly after F5 (sessionStorage seed), and that an expired/removed token triggers the central `auth:expired` logout (no manual 401 handler left in the hook).
+
+2. **Side finding — drifted duplicate `SystemInfoResponse`.** The `/api/system/info` shape is declared twice with different fields (hook history vs `api/system.ts`); this PR only reconciles additively. Per project CLAUDE.md, **ask the maintainer** whether to open a GitHub issue for the full unification before creating one.
+
+3. **Push + PR** (do not merge — Xveyn merges after CI):
+```bash
+git push -u origin feat/tanstack-telemetry-hook-299
+```
+Open a PR against `main` referencing #299 (checks the "PR — Telemetry" box in the #299 track).

--- a/docs/superpowers/specs/2026-07-02-telemetry-hook-tanstack-query-migration-design.md
+++ b/docs/superpowers/specs/2026-07-02-telemetry-hook-tanstack-query-migration-design.md
@@ -55,10 +55,15 @@ Replace the three raw `fetch()` calls with typed `apiClient` functions:
 - **Reuse** existing `getSystemInfo()` for `/api/system/info`. Additively extend its
   `SystemInfoResponse` with `system_uptime?: number` (non-breaking — existing consumers of
   `getSystemInfo`/`getStorageInfo` are unaffected).
-- **Add** `getAggregatedStorage(): Promise<AggregatedStorageInfo>` → `/api/system/storage/aggregated`.
-  `AggregatedStorageInfo` = `{ filesystem?, total, used, available, usePercent?, mountPoint? }`
-  (the telemetry storage shape; distinct from the existing `StorageInfoResponse` which serves
-  the different `/api/system/storage` endpoint — no name collision).
+- **Add** `getAggregatedStorage(): Promise<StorageInfoResponse>` → `/api/system/storage/aggregated`,
+  **reusing the existing `StorageInfoResponse`** already in `api/system.ts`. The aggregated
+  endpoint is declared `response_model=StorageInfo` on the backend, i.e. the same model
+  `getStorageInfo()` returns — snake_case `use_percent`/`mount_point` (all required). Reusing
+  the existing type keeps the client type accurate to the wire and avoids a duplicate.
+  (Correction to the initial draft, which specified a camelCase `AggregatedStorageInfo`
+  mirroring the old hook's inaccurate type — the old hook read `storage.usePercent`, which was
+  always `undefined` at runtime but harmless because that fallback branch only runs when
+  `total === 0`. The migration fixes this to `storage.use_percent`.)
 - **Add** `getTelemetryHistory(): Promise<TelemetryHistory>` → `/api/system/telemetry/history`,
   with `TelemetryHistory` + `CpuHistoryPoint` / `MemoryHistoryPoint` / `NetworkHistoryPoint`
   exported for reuse.

--- a/docs/superpowers/specs/2026-07-02-telemetry-hook-tanstack-query-migration-design.md
+++ b/docs/superpowers/specs/2026-07-02-telemetry-hook-tanstack-query-migration-design.md
@@ -1,0 +1,168 @@
+# Telemetry Hook → TanStack Query Migration Design
+
+**Date:** 2026-07-02
+**Issue:** [#299](https://github.com/Xveyn/BaluHost/issues/299) — Track "PR — Telemetry"
+**Overarching spec:** `docs/superpowers/specs/2026-07-01-frontend-data-fetching-tanstack-query-design.md`
+**Precedent PR:** #364 (monitoring pilot — the reference pattern)
+
+## Context
+
+Issue #299 (Finding F1) tracks the incremental migration of the frontend to TanStack
+Query v5, one domain per PR, keeping public hook signatures stable (Approach A). PR 1
+(monitoring pilot) is merged (#364). This spec covers the next track step: migrating
+`client/src/hooks/useSystemTelemetry.ts`.
+
+The telemetry hook is the dashboard's primary data source. Today it:
+
+- Fetches 3 endpoints with **raw `fetch()`** + manual `Authorization` header from
+  `useAuth()`: `/api/system/info`, `/api/system/storage/aggregated`,
+  `/api/system/telemetry/history` (`useSystemTelemetry.ts:156-166`).
+- Handles 401 manually via `fireAuthExpired()` (`:169-172`) — raw `fetch()` bypasses the
+  central `apiClient` interceptor. This is the #299/F5 overlap ("rohes `fetch()` →
+  `apiClient`").
+- Hand-rolls polling with `setInterval(pollInterval=15000)` (`:222-224`).
+- Uses a **sessionStorage cache** (`system_telemetry_cache`, 2-min TTL, `:94-124`) to paint
+  last values instantly after a full page reload (F5), then refreshes in the background.
+- Exposes `{ system, storage, loading, refreshing, error, lastUpdated, history }`.
+
+**Sole consumer:** `pages/Dashboard.tsx:80`, which destructures
+`{ system, storage, loading, error, lastUpdated, history }` — it does **not** use
+`refreshing` or `system_uptime`. Low blast radius.
+
+## Goal
+
+Migrate the hook's internals to a single `useQuery` over the typed `apiClient`, keeping the
+public return shape bit-for-bit identical, so `Dashboard.tsx` is untouched. Route all three
+requests through `apiClient` so the central auth/401 interceptor applies (closes the F5/#307
+raw-`fetch()` overlap for these endpoints).
+
+## Non-Goals (deferred by #299 sequencing)
+
+- **Removing / replacing the sessionStorage cache.** That is the separate "Dashboard-Caches"
+  PR (introduce a Query persister, delete all hand-rolled sessionStorage blobs at once).
+  TanStack's in-memory cache does **not** survive a full page reload, so dropping
+  sessionStorage now would regress the instant-paint-after-F5 behavior. This PR **keeps**
+  sessionStorage, wired as `initialData`.
+- Unifying the drifted `SystemInfoResponse` types (see Side Findings).
+- Migrating `Dashboard.tsx`'s own separate sessionStorage cache.
+
+## Architecture
+
+### 1. API layer — `client/src/api/system.ts`
+
+Replace the three raw `fetch()` calls with typed `apiClient` functions:
+
+- **Reuse** existing `getSystemInfo()` for `/api/system/info`. Additively extend its
+  `SystemInfoResponse` with `system_uptime?: number` (non-breaking — existing consumers of
+  `getSystemInfo`/`getStorageInfo` are unaffected).
+- **Add** `getAggregatedStorage(): Promise<AggregatedStorageInfo>` → `/api/system/storage/aggregated`.
+  `AggregatedStorageInfo` = `{ filesystem?, total, used, available, usePercent?, mountPoint? }`
+  (the telemetry storage shape; distinct from the existing `StorageInfoResponse` which serves
+  the different `/api/system/storage` endpoint — no name collision).
+- **Add** `getTelemetryHistory(): Promise<TelemetryHistory>` → `/api/system/telemetry/history`,
+  with `TelemetryHistory` + `CpuHistoryPoint` / `MemoryHistoryPoint` / `NetworkHistoryPoint`
+  exported for reuse.
+
+All go through `apiClient` → the request interceptor auto-attaches the bearer token from
+`localStorage` and the response interceptor fires `fireAuthExpired()` on 401 centrally
+(`lib/api.ts:48-80`).
+
+### 2. Query key — `client/src/lib/queryKeys.ts`
+
+Add a new `system` domain (the pilot's queryKeys already anticipates follow-up domains):
+
+```ts
+system: {
+  telemetry: () => ['system', 'telemetry'] as const,
+},
+```
+
+One combined key, because the hook's contract is one atomic snapshot (single `lastUpdated`,
+single loading/error), not three independently-cached slices.
+
+### 3. Hook — `client/src/hooks/useSystemTelemetry.ts`
+
+Single `useQuery`:
+
+```ts
+const { token } = useAuth();
+const query = useQuery({
+  queryKey: queryKeys.system.telemetry(),
+  queryFn: async () => {
+    const [system, storage, history] = await Promise.all([
+      getSystemInfo(),
+      getAggregatedStorage(),
+      getTelemetryHistory(),
+    ]);
+    setCachedTelemetry(system, storage, history); // keep sessionStorage warm
+    return { system, storage, history };
+  },
+  refetchInterval: pollInterval,           // default 15000
+  enabled: !!token,
+  initialData: getCachedTelemetry() ?? undefined, // instant-paint seed after F5
+});
+```
+
+Public mapping (shape unchanged):
+
+| Field | Source |
+|---|---|
+| `system` | `query.data?.system ?? null` |
+| `storage` | `normalisedStorage` (existing `useMemo` over `query.data?.storage`) |
+| `loading` | `query.isLoading` |
+| `refreshing` | `query.isFetching && !query.isLoading` |
+| `error` | `query.isError ? getApiErrorMessage(query.error, 'Unexpected telemetry error') : null` |
+| `lastUpdated` | `query.dataUpdatedAt ? new Date(query.dataUpdatedAt) : null` |
+| `history` | `query.data?.history ?? { cpu: [], memory: [], network: [] }` |
+
+The type re-exports at the bottom of the hook stay (now aliasing the `api/system.ts` types
+where applicable) so any type importer keeps working. `NormalisedStorageInfo` stays
+hook-owned (derived UI type). `useState`/`useEffect`/`useRef` and the manual polling/loader
+are removed; `getCachedTelemetry`/`setCachedTelemetry`/`parsePercent` stay.
+
+### Behavior parity notes
+
+- **initialData + `staleTime: 0`** (global default) ⇒ when a fresh sessionStorage cache
+  exists, `isLoading` is false immediately (instant paint) and a background refetch starts at
+  once — matching today's "with cache, start background refresh" path.
+- **Tab-hidden polling pause:** query-backed `refetchInterval` pauses while the tab is hidden
+  (TanStack default), unlike the old always-on `setInterval`. This is the intended,
+  already-documented behavior for the LAN dashboard (see `hooks/CLAUDE.md`).
+- **No-token:** `enabled: !!token` idles the query (no data, no error) instead of setting the
+  old `"Missing authentication token."` error. Acceptable — the dashboard is auth-gated; the
+  sole consumer does not surface that specific string.
+
+## Testing
+
+`client/src/__tests__/hooks/useSystemTelemetry.test.tsx` (new), mocking `../../api/system`
+and `sessionStorage`, using the existing `createQueryWrapper` helper:
+
+1. Maps `system` / `storage` (normalised `percent`) / `history` into the legacy shape;
+   `error` null; `lastUpdated` is a `Date`.
+2. `loading` is true on first render with an empty cache, false after data arrives.
+3. With a fresh sessionStorage seed, `loading` is false on first render (instant paint).
+4. Surfaces an error string when a fetch rejects.
+
+Full gate (per pilot): `npm run build` + `npm run lint` + `npx vitest run` all green.
+
+## Documentation
+
+Update the `useSystemTelemetry.ts` row in `client/src/hooks/CLAUDE.md` (now TanStack-backed,
+`api/system`). Add the two new functions to the `api/system.ts` description if warranted.
+
+## Side Findings (flag, do not fix here — per project CLAUDE.md "GitHub Issues für Nebenbefunde")
+
+1. **Drifted duplicate `SystemInfoResponse`.** The `/api/system/info` shape is declared twice
+   with different fields — hook (`system_uptime?`, no `dev_mode`) vs `api/system.ts`
+   (`dev_mode`, no `system_uptime`). This PR only additively reconciles (`system_uptime?`);
+   a full unification is a separate cleanup → propose a GitHub issue.
+2. **`Dashboard.tsx` has its own sessionStorage cache** (`:46-74`) — part of the "3 competing
+   cache approaches" in #299; addressed by the later Dashboard-Caches PR.
+
+## Verification
+
+1. `cd client && npm run build && npm run lint && npx vitest run` — all green.
+2. `python start_dev.py`; open the dashboard; confirm telemetry widgets populate, poll every
+   ~15 s, and repaint instantly after F5 (sessionStorage seed).
+3. Simulate a 401 (expire/remove token) → confirm central `auth:expired` logout fires (no
+   manual handler left in the hook).


### PR DESCRIPTION
## Summary

Migrates the dashboard's `useSystemTelemetry` hook to **TanStack Query** — the next step in the incremental #299 track (after the monitoring pilot #364). Internal migration only (Approach A): the hook's public return shape is unchanged, so the sole consumer `pages/Dashboard.tsx` is untouched.

Checks the **"PR — Telemetry"** box in the #299 track.

## What changed

- **`api/system.ts`**: the three raw `fetch()` calls become typed `apiClient` functions — `getSystemInfo()` (now with additive `system_uptime?`), `getAggregatedStorage()`, `getTelemetryHistory()`. Routing through `apiClient` means the **central 401 → `fireAuthExpired` interceptor** now applies (removes the hook's manual 401 handling; closes the raw-`fetch()` overlap noted in #299/F5).
- **`lib/queryKeys.ts`**: new `system` domain (`queryKeys.system.telemetry()`).
- **`hooks/useSystemTelemetry.ts`**: rewritten to one `useQuery` (combined `Promise.all` snapshot, `refetchInterval: pollInterval`, `enabled: !!token`). Loading/refreshing/error/lastUpdated map from the query; `refreshing = isFetching && !isLoading`.
- **sessionStorage cache kept** (seeds `initialData` for instant-paint after F5). Its removal is deliberately a **later** #299 PR (Query persister) — TanStack's in-memory cache does not survive a full reload.

## Behavior parity

- Public shape bit-for-bit identical; `Dashboard.tsx` reads only preserved fields (verified).
- Query-backed polling pauses on a hidden tab (TanStack default) — intended for a LAN dashboard.
- No-token now idles the query instead of the old `"Missing authentication token."` error string; Dashboard is auth-gated, so this is invisible to the consumer.
- Incidentally **fixes a latent bug** carried over from the old hook: it read `storage.usePercent` (camelCase), always `undefined` at runtime; the aggregated endpoint returns snake_case `use_percent`. Now reads the correct field via the existing `StorageInfoResponse`.

## Tests

Full gate green locally: `npm run build` ✓, `npm run lint` 0 errors, `npx vitest run` **86 files / 495 tests** pass. New tests: query-key + API-fn contract tests, and 4 hook tests (mapping, loading, sessionStorage instant-paint, error string) exercising the real `useQuery` stack.

## Type unification (resolved by this PR)

Before this PR, `SystemInfoResponse` was declared twice with drifted fields (hook-local vs `api/system.ts`) for the same `/api/system/info` endpoint. The hook rewrite drops its local copy and imports the `api/system.ts` type, which this PR extends additively with `system_uptime?`. The result is a single client type that now matches the backend `SystemInfo` schema (`backend/app/schemas/system.py`) field-for-field — no drift remains.

Refs #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
