### PR TITLE
feat(client): memoizedApiRequest → TanStack Query (#299, closes #309)

### DIFF
--- a/client/src/__tests__/api/backup.test.ts
+++ b/client/src/__tests__/api/backup.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listBackups, createBackup, deleteBackup } from '../../api/backup';
+
+vi.mock('../../lib/api', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+  buildApiUrl: (p: string) => p,
+}));
+
+import { apiClient } from '../../lib/api';
+
+describe('backup API', () => {
+  beforeEach(() => {
+    vi.mocked(apiClient.get).mockReset();
+    vi.mocked(apiClient.post).mockReset();
+    vi.mocked(apiClient.delete).mockReset();
+  });
+
+  it('listBackups calls GET /api/backups/ directly (no memo cache)', async () => {
+    const payload = { backups: [], total_size_bytes: 0, total_size_mb: 0 };
+    vi.mocked(apiClient.get).mockResolvedValue({ data: payload });
+
+    const result = await listBackups();
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/backups/');
+    expect(result).toEqual(payload);
+  });
+
+  it('createBackup posts the request body', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { id: 1 } });
+
+    await createBackup({ includes_database: true });
+
+    expect(apiClient.post).toHaveBeenCalledWith('/api/backups/', { includes_database: true });
+  });
+
+  it('deleteBackup calls DELETE with the id', async () => {
+    vi.mocked(apiClient.delete).mockResolvedValue({});
+
+    await deleteBackup(7);
+
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/backups/7');
+  });
+});

--- a/client/src/__tests__/api/files.test.ts
+++ b/client/src/__tests__/api/files.test.ts
@@ -9,19 +9,19 @@ import {
 
 vi.mock('../../lib/api', () => ({
   apiClient: {
+    get: vi.fn(),
     post: vi.fn(),
     put: vi.fn(),
   },
-  memoizedApiRequest: vi.fn(),
 }));
 
-import { apiClient, memoizedApiRequest } from '../../lib/api';
+import { apiClient } from '../../lib/api';
 
 describe('files API', () => {
   beforeEach(() => {
+    vi.mocked(apiClient.get).mockReset();
     vi.mocked(apiClient.post).mockReset();
     vi.mocked(apiClient.put).mockReset();
-    vi.mocked(memoizedApiRequest).mockReset();
   });
 
   it('checkFilesExist posts filenames and target path', async () => {
@@ -37,12 +37,13 @@ describe('files API', () => {
     expect(result.duplicates).toHaveLength(1);
   });
 
-  it('getFilePermissions uses memoizedApiRequest', async () => {
-    vi.mocked(memoizedApiRequest).mockResolvedValue({ owner_id: 1, rules: [] });
+  it('getFilePermissions calls GET with the path param (always fresh, no memo cache)', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { owner_id: 1, rules: [] } });
 
-    await getFilePermissions('/my/file.txt');
+    const result = await getFilePermissions('/my/file.txt');
 
-    expect(memoizedApiRequest).toHaveBeenCalledWith('/api/files/permissions', { path: '/my/file.txt' });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/files/permissions', { params: { path: '/my/file.txt' } });
+    expect(result).toEqual({ owner_id: 1, rules: [] });
   });
 
   it('setFilePermissions calls PUT /api/files/permissions', async () => {

--- a/client/src/__tests__/api/plugins.scopeCatalog.test.ts
+++ b/client/src/__tests__/api/plugins.scopeCatalog.test.ts
@@ -4,7 +4,6 @@ import { getScopeCatalog } from '../../api/plugins';
 
 vi.mock('../../lib/api', () => ({
   apiClient: { get: vi.fn() },
-  memoizedApiRequest: vi.fn(),
 }));
 
 describe('getScopeCatalog', () => {

--- a/client/src/__tests__/api/shares.test.ts
+++ b/client/src/__tests__/api/shares.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   getShareableUsers,
   createFileShare,
+  listFileShares,
   listFileSharesForFile,
   listFilesSharedWithMe,
   updateFileShare,
@@ -16,11 +17,9 @@ vi.mock('../../lib/api', () => ({
     patch: vi.fn(),
     delete: vi.fn(),
   },
-  apiCache: { delete: vi.fn() },
-  memoizedApiRequest: vi.fn(),
 }));
 
-import { apiClient, apiCache } from '../../lib/api';
+import { apiClient } from '../../lib/api';
 
 describe('shares API', () => {
   beforeEach(() => {
@@ -28,7 +27,6 @@ describe('shares API', () => {
     vi.mocked(apiClient.post).mockReset();
     vi.mocked(apiClient.patch).mockReset();
     vi.mocked(apiClient.delete).mockReset();
-    vi.mocked(apiCache.delete).mockReset();
   });
 
   it('getShareableUsers calls GET /api/shares/users', async () => {
@@ -41,14 +39,13 @@ describe('shares API', () => {
     expect(result).toEqual(users);
   });
 
-  it('createFileShare calls POST and clears cache', async () => {
+  it('createFileShare calls POST', async () => {
     const shareData = { file_id: 10, shared_with_user_id: 2, can_read: true };
     vi.mocked(apiClient.post).mockResolvedValue({ data: { id: 1, ...shareData } });
 
     const result = await createFileShare(shareData);
 
     expect(apiClient.post).toHaveBeenCalledWith('/api/shares/user-shares', shareData);
-    expect(apiCache.delete).toHaveBeenCalled();
     expect(result.file_id).toBe(10);
   });
 
@@ -68,23 +65,21 @@ describe('shares API', () => {
     expect(apiClient.get).toHaveBeenCalledWith('/api/shares/shared-with-me');
   });
 
-  it('updateFileShare calls PATCH and clears cache', async () => {
+  it('updateFileShare calls PATCH', async () => {
     const update = { can_write: true };
     vi.mocked(apiClient.patch).mockResolvedValue({ data: { id: 5, ...update } });
 
     await updateFileShare(5, update);
 
     expect(apiClient.patch).toHaveBeenCalledWith('/api/shares/user-shares/5', update);
-    expect(apiCache.delete).toHaveBeenCalled();
   });
 
-  it('deleteFileShare calls DELETE and clears cache', async () => {
+  it('deleteFileShare calls DELETE', async () => {
     vi.mocked(apiClient.delete).mockResolvedValue({});
 
     await deleteFileShare(3);
 
     expect(apiClient.delete).toHaveBeenCalledWith('/api/shares/user-shares/3');
-    expect(apiCache.delete).toHaveBeenCalled();
   });
 
   it('getShareStatistics calls GET /api/shares/statistics', async () => {
@@ -95,5 +90,15 @@ describe('shares API', () => {
 
     expect(apiClient.get).toHaveBeenCalledWith('/api/shares/statistics');
     expect(result).toEqual(stats);
+  });
+
+  it('listFileShares calls GET /api/shares/user-shares directly (no memo cache)', async () => {
+    const shares = [{ id: 1, file_id: 10 }];
+    vi.mocked(apiClient.get).mockResolvedValue({ data: shares });
+
+    const result = await listFileShares();
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/shares/user-shares');
+    expect(result).toEqual(shares);
   });
 });

--- a/client/src/__tests__/contexts/AuthContext.impersonation.test.tsx
+++ b/client/src/__tests__/contexts/AuthContext.impersonation.test.tsx
@@ -11,6 +11,12 @@ vi.mock('../../lib/api', async (orig) => ({
   buildApiUrl: (p: string) => p,
 }));
 
+import { queryClient } from '../../lib/queryClient';
+import { queryPersister } from '../../lib/queryPersister';
+
+vi.spyOn(queryClient, 'clear').mockImplementation(() => {});
+vi.spyOn(queryPersister, 'removeClient').mockResolvedValue(undefined);
+
 import { impersonateUser } from '../../api/authDev';
 
 const adminUser = { id: 1, username: 'admin', role: 'admin' as const };
@@ -60,6 +66,10 @@ describe('AuthContext impersonation', () => {
     expect(ctx.isImpersonating).toBe(true);
     expect(ctx.impersonationOrigin).toBe('admin');
     expect(ctx.user?.username).toBe('alice');
+
+    // Identity change → cached queries of the admin must not leak to alice
+    expect(queryClient.clear).toHaveBeenCalled();
+    expect(queryPersister.removeClient).toHaveBeenCalled();
   });
 
   it('endImpersonation restores the admin token', async () => {
@@ -94,5 +104,8 @@ describe('AuthContext impersonation', () => {
     expect(localStorage.getItem('token')).toBe('admin-token');
     expect(sessionStorage.getItem('impersonation_origin_token')).toBeNull();
     expect(ctx.user?.username).toBe('admin');
+
+    // Both swaps (impersonate + end) clear the cache
+    expect(vi.mocked(queryClient.clear).mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/client/src/__tests__/contexts/AuthContext.logout.test.tsx
+++ b/client/src/__tests__/contexts/AuthContext.logout.test.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { AuthProvider, useAuth } from '../../contexts/AuthContext';
 import { queryClient } from '../../lib/queryClient';
 import { queryPersister } from '../../lib/queryPersister';
+import type { User } from '../../types/auth';
 
 vi.spyOn(queryClient, 'clear').mockImplementation(() => {});
 vi.spyOn(queryPersister, 'removeClient').mockResolvedValue(undefined);
@@ -25,5 +26,24 @@ describe('AuthContext logout', () => {
     expect(queryClient.clear).toHaveBeenCalledTimes(1);
     expect(queryPersister.removeClient).toHaveBeenCalledTimes(1);
     expect(localStorage.getItem('token')).toBeNull();
+  });
+
+  it('login clears any cached data from a previous session', () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    act(() => {
+      result.current.login({ id: 1, username: 'bob', role: 'user' } as unknown as User, 'new-token');
+    });
+    expect(queryClient.clear).toHaveBeenCalledTimes(1);
+    expect(queryPersister.removeClient).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('token')).toBe('new-token');
+  });
+
+  it('auth:expired (plain, no impersonation) clears the query cache', () => {
+    renderHook(() => useAuth(), { wrapper });
+    act(() => {
+      window.dispatchEvent(new CustomEvent('auth:expired'));
+    });
+    expect(queryClient.clear).toHaveBeenCalledTimes(1);
+    expect(queryPersister.removeClient).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/__tests__/contexts/AuthContext.logout.test.tsx
+++ b/client/src/__tests__/contexts/AuthContext.logout.test.tsx
@@ -39,11 +39,13 @@ describe('AuthContext logout', () => {
   });
 
   it('auth:expired (plain, no impersonation) clears the query cache', () => {
+    localStorage.setItem('token', 'expired-token');
     renderHook(() => useAuth(), { wrapper });
     act(() => {
       window.dispatchEvent(new CustomEvent('auth:expired'));
     });
     expect(queryClient.clear).toHaveBeenCalledTimes(1);
     expect(queryPersister.removeClient).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('token')).toBeNull();
   });
 });

--- a/client/src/__tests__/hooks/useBackups.test.tsx
+++ b/client/src/__tests__/hooks/useBackups.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useBackups } from '../../hooks/useBackups';
+import * as backupApi from '../../api/backup';
+
+vi.mock('../../api/backup');
+const api = vi.mocked(backupApi);
+
+const sample = {
+  backups: [
+    {
+      id: 1, filename: 'b1.tar.gz', filepath: '/tmp/b1.tar.gz', size_bytes: 1000,
+      size_mb: 0, backup_type: 'full' as const, status: 'completed' as const,
+      created_at: '2026-07-01T00:00:00Z', completed_at: null, creator_id: 1,
+      error_message: null, includes_database: true, includes_files: true, includes_config: false,
+    },
+  ],
+  total_size_bytes: 1000,
+  total_size_mb: 0,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useBackups', () => {
+  it('unwraps the backup list from the response', async () => {
+    api.listBackups.mockResolvedValue(sample);
+    const { result } = renderHook(() => useBackups(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.backups).toHaveLength(1);
+    expect(result.current.backups[0].filename).toBe('b1.tar.gz');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('exposes the raw error when the fetch rejects', async () => {
+    api.listBackups.mockRejectedValue(new Error('backup boom'));
+    const { result } = renderHook(() => useBackups(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect((result.current.error as Error).message).toBe('backup boom');
+    expect(result.current.backups).toEqual([]);
+  });
+});

--- a/client/src/__tests__/hooks/useFileShares.test.tsx
+++ b/client/src/__tests__/hooks/useFileShares.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useFileShares } from '../../hooks/useFileShares';
+import * as sharesApi from '../../api/shares';
+import type { FileShare, SharedWithMe } from '../../api/shares';
+
+vi.mock('../../api/shares');
+const api = vi.mocked(sharesApi);
+
+const stats = { total_file_shares: 2, active_file_shares: 1, files_shared_with_me: 3 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.listFileShares.mockResolvedValue([{ id: 1 } as unknown as FileShare]);
+  api.listFilesSharedWithMe.mockResolvedValue([{ share_id: 9 } as unknown as SharedWithMe]);
+  api.getShareStatistics.mockResolvedValue(stats);
+});
+
+describe('useFileShares', () => {
+  it('exposes all three reads under the SharesPage state names', async () => {
+    const { result } = renderHook(() => useFileShares(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.fileShares).toHaveLength(1);
+    expect(result.current.sharedWithMe).toHaveLength(1);
+    expect(result.current.statistics).toEqual(stats);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('stays loading until every query settled', async () => {
+    let resolveStats!: (v: typeof stats) => void;
+    api.getShareStatistics.mockReturnValue(new Promise((r) => { resolveStats = r; }));
+    const { result } = renderHook(() => useFileShares(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.fileShares).toHaveLength(1));
+    expect(result.current.loading).toBe(true);
+    resolveStats(stats);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  it('surfaces the first failing query as raw error', async () => {
+    api.listFileShares.mockRejectedValue(new Error('shares boom'));
+    const { result } = renderHook(() => useFileShares(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect((result.current.error as Error).message).toBe('shares boom');
+    expect(result.current.fileShares).toEqual([]);
+  });
+});

--- a/client/src/__tests__/lib/query-foundation.test.ts
+++ b/client/src/__tests__/lib/query-foundation.test.ts
@@ -43,3 +43,18 @@ describe('queryKeys.raid', () => {
     expect(queryKeys.raid.status()).toEqual(['raid', 'status']);
   });
 });
+
+describe('queryKeys.backups', () => {
+  it('builds the list key', () => {
+    expect(queryKeys.backups.list()).toEqual(['backups', 'list']);
+  });
+});
+
+describe('queryKeys.shares', () => {
+  it('builds the domain prefix and entity keys', () => {
+    expect(queryKeys.shares.all()).toEqual(['shares']);
+    expect(queryKeys.shares.userShares()).toEqual(['shares', 'user-shares']);
+    expect(queryKeys.shares.sharedWithMe()).toEqual(['shares', 'shared-with-me']);
+    expect(queryKeys.shares.statistics()).toEqual(['shares', 'statistics']);
+  });
+});

--- a/client/src/api/CLAUDE.md
+++ b/client/src/api/CLAUDE.md
@@ -6,7 +6,6 @@ Typed axios wrappers for backend API communication. One file per feature domain,
 
 All modules import from `lib/api.ts`:
 - `apiClient` — axios instance with auth interceptor (auto-attaches `Bearer` token from localStorage)
-- `memoizedApiRequest<T>(url, params?, ttl?)` — GET with in-memory cache (60s default TTL)
 - `buildApiUrl(path)` — resolves path for dev (Vite proxy) vs production
 - `extractErrorMessage(detail, fallback)` — extracts user-facing message from FastAPI error responses
 
@@ -15,7 +14,7 @@ All modules import from `lib/api.ts`:
 - Export typed interfaces for request/response shapes (mirrors backend Pydantic schemas)
 - Export async functions, not classes — each function maps to one API endpoint
 - Use `apiClient.get/post/put/delete()` for standard calls
-- Use `memoizedApiRequest()` for frequently polled read-only data (e.g., permissions, system info)
+- No client-side memo caching in api/* — read-caching/dedup lives in TanStack Query hooks (`useQuery` + `lib/queryKeys.ts`); mutations invalidate their domain (`invalidateQueries`)
 - Return `res.data` directly (unwrap axios response)
 - No error handling here — callers handle errors via `handleApiError()` from `lib/errorHandling.ts`
 

--- a/client/src/api/backup.ts
+++ b/client/src/api/backup.ts
@@ -2,7 +2,7 @@
  * API client for backup functionality
  */
 
-import { apiClient, memoizedApiRequest, buildApiUrl } from '../lib/api';
+import { apiClient, buildApiUrl } from '../lib/api';
 
 export interface Backup {
   id: number;
@@ -62,16 +62,8 @@ export async function createBackup(request: CreateBackupRequest = {}): Promise<B
  * List all backups
  */
 export async function listBackups(): Promise<BackupListResponse> {
-  // Memoized: Backups werden für 60s gecached
-  return memoizedApiRequest<BackupListResponse>('/api/backups/');
-}
-
-/**
- * Get backup details by ID
- */
-export async function getBackup(backupId: number): Promise<Backup> {
-  // Memoized: Backup-Details werden für 60s gecached
-  return memoizedApiRequest<Backup>(`/api/backups/${backupId}/`);
+  const response = await apiClient.get<BackupListResponse>('/api/backups/');
+  return response.data;
 }
 
 /**

--- a/client/src/api/files.ts
+++ b/client/src/api/files.ts
@@ -2,7 +2,7 @@
  * API client for file operations (permissions, duplicates, ownership transfer, residency)
  */
 
-import { apiClient, memoizedApiRequest } from '../lib/api';
+import { apiClient } from '../lib/api';
 
 // --- Duplicate Check API ---
 
@@ -27,8 +27,11 @@ export async function checkFilesExist(
 // --- File Permissions API ---
 
 export async function getFilePermissions(path: string) {
-  // Memoized GET: Permissions werden für 60s gecached
-  return memoizedApiRequest(`/api/files/permissions`, { path });
+  // Plain read on purpose: the permission dialog must always show fresh
+  // rules (the old 60s memo cache could serve stale ones) and this
+  // user-scoped data must not be mirrored into the persisted query cache.
+  const res = await apiClient.get(`/api/files/permissions`, { params: { path } });
+  return res.data;
 }
 
 export async function setFilePermissions(data: {

--- a/client/src/api/shares.ts
+++ b/client/src/api/shares.ts
@@ -2,7 +2,7 @@
  * API client for file sharing functionality
  */
 
-import { apiClient, apiCache, memoizedApiRequest } from '../lib/api';
+import { apiClient } from '../lib/api';
 
 export interface FileShare {
   id: number;
@@ -86,17 +86,14 @@ export const getShareableUsers = async (): Promise<ShareableUser[]> => {
 // File Shares API
 // ===========================
 
-const SHARES_CACHE_KEY = '/api/shares/user-shares' + JSON.stringify({});
-
 export const createFileShare = async (data: CreateFileShareRequest): Promise<FileShare> => {
   const response = await apiClient.post('/api/shares/user-shares', data);
-  apiCache.delete(SHARES_CACHE_KEY);
   return response.data;
 };
 
 export const listFileShares = async (): Promise<FileShare[]> => {
-  // Memoized: FileShares werden für 60s gecached
-  return memoizedApiRequest<FileShare[]>('/api/shares/user-shares');
+  const response = await apiClient.get('/api/shares/user-shares');
+  return response.data;
 };
 
 export const listFileSharesForFile = async (fileId: number): Promise<FileShare[]> => {
@@ -114,13 +111,11 @@ export const updateFileShare = async (
   data: UpdateFileShareRequest
 ): Promise<FileShare> => {
   const response = await apiClient.patch(`/api/shares/user-shares/${shareId}`, data);
-  apiCache.delete(SHARES_CACHE_KEY);
   return response.data;
 };
 
 export const deleteFileShare = async (shareId: number): Promise<void> => {
   await apiClient.delete(`/api/shares/user-shares/${shareId}`);
-  apiCache.delete(SHARES_CACHE_KEY);
 };
 
 export const getShareStatistics = async (): Promise<ShareStatistics> => {

--- a/client/src/components/BackupSettings.tsx
+++ b/client/src/components/BackupSettings.tsx
@@ -1,9 +1,11 @@
-import { useState, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { Download, Trash2, RotateCcw, AlertTriangle, Database, FolderOpen, Settings, CheckCircle, XCircle, Clock, HardDrive } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-	import { listBackups, createBackup, deleteBackup, restoreBackup, downloadBackup } from '../api/backup';
-	import type { Backup, BackupListResponse, CreateBackupRequest, RestoreBackupRequest } from '../api/backup';
-import { apiCache } from '../lib/api';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createBackup, deleteBackup, restoreBackup, downloadBackup } from '../api/backup';
+import type { Backup, CreateBackupRequest, RestoreBackupRequest } from '../api/backup';
+import { useBackups } from '../hooks/useBackups';
+import { queryKeys } from '../lib/queryKeys';
 import { getApiErrorMessage } from '../lib/errorHandling';
 import { formatBytes } from '../lib/formatters';
 
@@ -14,10 +16,6 @@ export default function BackupSettings() {
 	const [includesFiles, setIncludesFiles] = useState(true);
 	const [includesConfig, setIncludesConfig] = useState(false);
 	const [backupPath, setBackupPath] = useState('');
-	const [backups, setBackups] = useState<Backup[]>([]);
-	const [totalSizeBytes, setTotalSizeBytes] = useState(0);
-	const [loading, setLoading] = useState(true);
-	const [creating, setCreating] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [success, setSuccess] = useState<string | null>(null);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -25,69 +23,54 @@ export default function BackupSettings() {
 	const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
 	const [selectedBackup, setSelectedBackup] = useState<Backup | null>(null);
 	const [restoreConfirm, setRestoreConfirm] = useState('');
-	const [deleting, setDeleting] = useState(false);
 	const [restoring, setRestoring] = useState(false);
 
-	useEffect(() => {
-		loadBackups();
-	}, []);
+	const queryClient = useQueryClient();
+	const { backups, loading, error: loadError } = useBackups();
+	const totalSizeBytes = useMemo(
+		() => backups.reduce((acc, b) => acc + b.size_bytes, 0),
+		[backups]
+	);
 
-	async function loadBackups() {
-		setLoading(true);
-		setError(null);
-		try {
-			const response: BackupListResponse = await listBackups();
-			setBackups(response.backups);
-			const totalBytes = response.backups.reduce((acc, b) => acc + b.size_bytes, 0);
-			setTotalSizeBytes(totalBytes);
-		} catch (err: unknown) {
-			setError(getApiErrorMessage(err, t('backup.loadFailed')));
-			setBackups([]);
-		} finally {
-			setLoading(false);
-		}
-	}
-
-	async function handleCreateBackup() {
-		setCreating(true);
-		setError(null);
-		setSuccess(null);
-		try {
-			const request: CreateBackupRequest = {
-				includes_database: includesDatabase,
-				includes_files: includesFiles,
-				includes_config: includesConfig,
-				backup_path: backupPath
-			};
-			await createBackup(request);
+	const createMutation = useMutation({
+		mutationFn: (request: CreateBackupRequest) => createBackup(request),
+		onSuccess: () => {
 			setSuccess(t('backup.createSuccess'));
-			// Clear API cache to force fresh backup list
-			apiCache.clear();
-			await loadBackups();
-		} catch (err: unknown) {
+			void queryClient.invalidateQueries({ queryKey: queryKeys.backups.list() });
+		},
+		onError: (err: unknown) => {
 			setError(getApiErrorMessage(err, t('backup.createFailed')));
-		} finally {
-			setCreating(false);
-		}
-	}
+		},
+	});
 
-	async function handleDeleteBackup() {
-		if (!backupToDelete) return;
-		setDeleting(true);
-		setError(null);
-		try {
-			await deleteBackup(backupToDelete.id);
+	const deleteMutation = useMutation({
+		mutationFn: (backupId: number) => deleteBackup(backupId),
+		onSuccess: () => {
 			setSuccess(t('backup.deleteSuccess'));
-			// Clear API cache to force fresh backup list
-			apiCache.clear();
-			await loadBackups();
+			void queryClient.invalidateQueries({ queryKey: queryKeys.backups.list() });
 			setDeleteDialogOpen(false);
 			setBackupToDelete(null);
-		} catch (err: unknown) {
+		},
+		onError: (err: unknown) => {
 			setError(getApiErrorMessage(err, t('backup.deleteFailed')));
-		} finally {
-			setDeleting(false);
-		}
+		},
+	});
+
+	function handleCreateBackup() {
+		setError(null);
+		setSuccess(null);
+		createMutation.mutate({
+			includes_database: includesDatabase,
+			includes_files: includesFiles,
+			includes_config: includesConfig,
+			backup_path: backupPath,
+		});
+	}
+
+	function handleDeleteBackup() {
+		if (!backupToDelete) return;
+		setError(null);
+		deleteMutation.mutate(backupToDelete.id);
 	}
 
 	async function handleRestoreBackup() {
@@ -159,6 +142,8 @@ export default function BackupSettings() {
 		}
 	}
 
+	const displayError = error ?? (loadError ? getApiErrorMessage(loadError, t('backup.loadFailed')) : null);
+
 	return (
 		<div className="space-y-6 w-full px-0">
 			{/* Header & Formular */}
@@ -174,21 +159,21 @@ export default function BackupSettings() {
 								{/* Removed backup type selection, only checkboxes remain */}
 								<div className="flex items-center gap-6">
 									<label className="flex items-center gap-2 text-sm text-slate-400">
-										<input type="checkbox" checked={includesDatabase} onChange={e => setIncludesDatabase(e.target.checked)} disabled={creating} className="accent-sky-500" />
+										<input type="checkbox" checked={includesDatabase} onChange={e => setIncludesDatabase(e.target.checked)} disabled={createMutation.isPending} className="accent-sky-500" />
 										<Database className="w-4 h-4" /> DB
 									</label>
 									<label className="flex items-center gap-2 text-sm text-slate-400">
-										<input type="checkbox" checked={includesFiles} onChange={e => setIncludesFiles(e.target.checked)} disabled={creating} className="accent-sky-500" />
+										<input type="checkbox" checked={includesFiles} onChange={e => setIncludesFiles(e.target.checked)} disabled={createMutation.isPending} className="accent-sky-500" />
 										<FolderOpen className="w-4 h-4" /> Files
 									</label>
 									<label className="flex items-center gap-2 text-sm text-slate-400">
-										<input type="checkbox" checked={includesConfig} onChange={e => setIncludesConfig(e.target.checked)} disabled={creating} className="accent-sky-500" />
+										<input type="checkbox" checked={includesConfig} onChange={e => setIncludesConfig(e.target.checked)} disabled={createMutation.isPending} className="accent-sky-500" />
 										<Settings className="w-4 h-4" /> Config
 									</label>
 								</div>
 								<div className="flex items-center gap-2 mt-4">
 									<label htmlFor="backupPath" className="text-sm text-slate-400 min-w-[120px]">{t('backup.backupLocation')}:</label>
-									<input id="backupPath" type="text" value={backupPath} onChange={e => setBackupPath(e.target.value)} placeholder={t('backup.backupLocationPlaceholder')} className="px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-slate-100 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500 w-full" disabled={creating} />
+									<input id="backupPath" type="text" value={backupPath} onChange={e => setBackupPath(e.target.value)} placeholder={t('backup.backupLocationPlaceholder')} className="px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-slate-100 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500 w-full" disabled={createMutation.isPending} />
 								</div>
 							</div>
 							{backups && backups.length > 0 && (
@@ -207,17 +192,17 @@ export default function BackupSettings() {
 							)}
 						</div>
 					</div>
-					<button onClick={handleCreateBackup} disabled={creating} className="px-4 py-2 bg-sky-500 hover:bg-sky-600 disabled:bg-slate-700 disabled:text-slate-500 text-white rounded-lg flex items-center gap-2 transition-colors">
+					<button onClick={handleCreateBackup} disabled={createMutation.isPending} className="px-4 py-2 bg-sky-500 hover:bg-sky-600 disabled:bg-slate-700 disabled:text-slate-500 text-white rounded-lg flex items-center gap-2 transition-colors">
 						<Database className="w-4 h-4" />
-						{creating ? t('backup.creating') : t('backup.createBackup')}
+						{createMutation.isPending ? t('backup.creating') : t('backup.createBackup')}
 					</button>
 				</div>
 			</div>
-			{error && (
+			{displayError && (
 				<div className="rounded-lg bg-red-500/10 border border-red-500/20 p-4">
 					<div className="flex items-center gap-2 text-red-400">
 						<AlertTriangle className="w-5 h-5" />
-						<span>{error}</span>
+						<span>{displayError}</span>
 					</div>
 				</div>
 			)}
@@ -368,8 +353,8 @@ export default function BackupSettings() {
 							</div>
 						</div>
 						<div className="flex justify-end gap-3">
-							<button onClick={() => { setDeleteDialogOpen(false); setBackupToDelete(null); }} disabled={deleting} className="px-4 py-2 text-slate-300 hover:text-slate-100 hover:bg-slate-800 rounded-lg transition-colors">{t('backup.cancel')}</button>
-							<button onClick={handleDeleteBackup} disabled={deleting} className="px-4 py-2 bg-red-500 hover:bg-red-600 disabled:bg-slate-700 disabled:text-slate-500 text-white rounded-lg transition-colors">{deleting ? t('backup.deleting') : t('backup.delete')}</button>
+							<button onClick={() => { setDeleteDialogOpen(false); setBackupToDelete(null); }} disabled={deleteMutation.isPending} className="px-4 py-2 text-slate-300 hover:text-slate-100 hover:bg-slate-800 rounded-lg transition-colors">{t('backup.cancel')}</button>
+							<button onClick={handleDeleteBackup} disabled={deleteMutation.isPending} className="px-4 py-2 bg-red-500 hover:bg-red-600 disabled:bg-slate-700 disabled:text-slate-500 text-white rounded-lg transition-colors">{deleteMutation.isPending ? t('backup.deleting') : t('backup.delete')}</button>
 						</div>
 					</div>
 				</div>

--- a/client/src/components/CreateFileShareModal.tsx
+++ b/client/src/components/CreateFileShareModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   X,
   Folder,
@@ -12,6 +13,7 @@ import {
 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { createFileShare, type CreateFileShareRequest } from '../api/shares';
+import { queryKeys } from '../lib/queryKeys';
 import { apiClient } from '../lib/api';
 import { formatBytes } from '../lib/formatters';
 
@@ -32,6 +34,7 @@ interface CreateFileShareModalProps {
 
 const CreateFileShareModal = ({ fileId, users, onClose, onSuccess }: CreateFileShareModalProps) => {
   const { t } = useTranslation(['shares', 'common']);
+  const queryClient = useQueryClient();
   const [loading, setLoading] = useState(false);
   const [explorerPath, setExplorerPath] = useState('');
   const [explorerFiles, setExplorerFiles] = useState<ExplorerFile[]>([]);
@@ -97,6 +100,9 @@ const CreateFileShareModal = ({ fileId, users, onClose, onSuccess }: CreateFileS
         ...formData,
         expires_at: formData.expires_at || null,
       });
+      // Central invalidation (replaces the old apiCache.delete in the API fn):
+      // works from every mount point, incl. FileManager.
+      void queryClient.invalidateQueries({ queryKey: queryKeys.shares.all() });
       onSuccess();
     } catch (err: unknown) {
       const detail =

--- a/client/src/components/EditFileShareModal.tsx
+++ b/client/src/components/EditFileShareModal.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
 import { X } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { updateFileShare, type FileShare, type UpdateFileShareRequest } from '../api/shares';
+import { queryKeys } from '../lib/queryKeys';
 
 interface EditFileShareModalProps {
   fileShare: FileShare;
@@ -12,6 +14,7 @@ interface EditFileShareModalProps {
 
 export default function EditFileShareModal({ fileShare, onClose, onSuccess }: EditFileShareModalProps) {
   const { t } = useTranslation(['shares', 'common']);
+  const queryClient = useQueryClient();
   const [loading, setLoading] = useState(false);
   const [formData, setFormData] = useState<UpdateFileShareRequest>({
     can_read: fileShare.can_read,
@@ -30,6 +33,7 @@ export default function EditFileShareModal({ fileShare, onClose, onSuccess }: Ed
         ...formData,
         expires_at: formData.expires_at ? `${formData.expires_at}T23:59:59Z` : null
       });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.shares.all() });
       onSuccess();
     } catch {
       toast.error(t('shares:toast.updateFailed'));

--- a/client/src/components/ShareFileModal.tsx
+++ b/client/src/components/ShareFileModal.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
 import { X, Users, Cloud, Loader2, ExternalLink } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { createFileShare, type CreateFileShareRequest } from '../api/shares';
+import { queryKeys } from '../lib/queryKeys';
 import { startCloudExport, checkConnectionScope, getScopeUpgradeUrl } from '../api/cloud-export';
 import { getConnections, type CloudConnection } from '../api/cloud-import';
 
@@ -17,6 +19,7 @@ interface ShareFileModalProps {
 
 const ShareFileModal = ({ fileId, fileName, filePath, users, onClose, onSuccess }: ShareFileModalProps) => {
   const { t } = useTranslation(['shares', 'common']);
+  const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState<'internal' | 'cloud'>('internal');
   const [loading, setLoading] = useState(false);
 
@@ -73,6 +76,7 @@ const ShareFileModal = ({ fileId, fileName, filePath, users, onClose, onSuccess 
         ...formData,
         expires_at: formData.expires_at || null,
       });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.shares.all() });
       onSuccess();
     } catch (err: unknown) {
       const detail =

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -36,6 +36,17 @@ async function fetchMe(token: string): Promise<User | null> {
   }
 }
 
+/**
+ * Drop all cached queries and the persisted sessionStorage blob.
+ * MUST run on EVERY identity change (login, logout, impersonation swaps,
+ * auth expiry) — user-scoped queries (#299) would otherwise leak across
+ * users via the persister's F5 instant-paint.
+ */
+function clearQueryCache(): void {
+  queryClient.clear();
+  void queryPersister.removeClient();
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
@@ -94,6 +105,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const login = (userData: User, newToken: string) => {
+    // A previous session on this tab (e.g. ended via auth:expired) may have
+    // left user-scoped data in the cache/persister — never show it to the
+    // next account.
+    clearQueryCache();
     localStorage.setItem('token', newToken);
     setToken(newToken);
     setUser(userData);
@@ -107,10 +122,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setToken(null);
     setUser(null);
     // Drop any cached data for the ended session so a next login on the same
-    // tab can't briefly show it before refetch (the global persister mirrors
-    // the whole query cache to sessionStorage — see lib/queryPersister.ts).
-    queryClient.clear();
-    void queryPersister.removeClient();
+    // tab can't briefly show it before refetch (see clearQueryCache).
+    clearQueryCache();
   }, []);
 
   const impersonate = useCallback(async (userId: number) => {
@@ -128,6 +141,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setToken(result.access_token);
     setUser(result.user);
     setImpersonationOrigin(currentUsername);
+    clearQueryCache();
   }, [user]);
 
   const endImpersonation = useCallback(() => {
@@ -142,6 +156,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     localStorage.setItem('token', originToken);
     setToken(originToken);
     setImpersonationOrigin(null);
+    clearQueryCache();
 
     fetchMe(originToken).then((restoredUser) => {
       if (restoredUser) {
@@ -163,6 +178,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         localStorage.setItem('token', originToken);
         setToken(originToken);
         setImpersonationOrigin(null);
+        clearQueryCache();
         fetchMe(originToken).then((restoredUser) => {
           if (restoredUser) {
             setUser(restoredUser);
@@ -175,6 +191,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       } else {
         setToken(null);
         setUser(null);
+        clearQueryCache();
       }
     };
     window.addEventListener('auth:expired', handler);

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -189,6 +189,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           }
         });
       } else {
+        localStorage.removeItem('token');
         setToken(null);
         setUser(null);
         clearQueryCache();

--- a/client/src/contexts/CLAUDE.md
+++ b/client/src/contexts/CLAUDE.md
@@ -6,7 +6,7 @@ React Context providers for global state. Wrapped around the app in `App.tsx`.
 
 | File | Purpose | Key values |
 |---|---|---|
-| `AuthContext.tsx` | Authentication state. Validates stored JWT on mount via `/api/auth/me`. Listens for `auth:expired` events (fired by axios 401 interceptor) | `user`, `token`, `login()`, `logout()`, `isAdmin`, `loading` |
+| `AuthContext.tsx` | Authentication state. Validates stored JWT on mount via `/api/auth/me`. Listens for `auth:expired` events (fired by axios 401 interceptor). Clears the TanStack Query cache + persisted blob on EVERY identity change (login, logout, impersonate, endImpersonation, auth-expiry) so user-scoped queries never leak across users (#299) | `user`, `token`, `login()`, `logout()`, `isAdmin`, `loading` |
 | `ThemeContext.tsx` | Theme management. 6 themes: `light`, `dark`, `ocean`, `forest`, `sunset`, `midnight`. Applies CSS variables to `:root` | `theme`, `setTheme()` |
 | `UploadContext.tsx` | File upload state management (progress, queue, cancellation) | Upload queue, progress tracking |
 | `NotificationContext.tsx` | In-app notification state (WebSocket-driven) | Notification list, unread count |

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -9,6 +9,8 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useMonitoring.ts` | `api/monitoring` | Unified CPU/memory/network/disk/process data via **TanStack Query** (`useQuery`), configurable `pollInterval` (mapped to `refetchInterval`) + history; public return shape unchanged |
 | `useSystemTelemetry.ts` | `api/system` | System info + aggregated storage + telemetry history for the dashboard via **TanStack Query** (`useQuery`, one combined snapshot, `pollInterval`→`refetchInterval`); hand-rolled sessionStorage cache removed, F5 persistence now comes from the app-wide persister (#299); public shape unchanged |
 | `useRaidStatus.ts` | `api/raid` | RAID array status via **TanStack Query** (`useQuery`, 60s poll); F5-persisted via the app-wide persister |
+| `useBackups.ts` | `api/backup` | Backup list via **TanStack Query** (no polling; create/delete mutations invalidate). Returns raw `error` for i18n formatting by the caller |
+| `useFileShares.ts` | `api/shares` | The three shares-domain reads (user shares, shared-with-me, statistics) via **TanStack Query**; user-scoped — cache is cleared on every identity change (AuthContext) |
 | `useFanControl.ts` | `api/fan-control` | Fan config, curves, schedules — full fan management state |
 | `useSchedulers.ts` | `api/schedulers` | Scheduler list, status, history, run-now |
 | `useBenchmark.ts` | `api/benchmark` | Disk benchmark state, progress, results |
@@ -50,6 +52,7 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 - Return `{ data, loading, error, refetch }` pattern for data hooks
 - **Data hooks use TanStack Query** (`useQuery`) with keys from `lib/queryKeys.ts` and `refetchInterval` for polling — not hand-rolled `useState`+`setInterval`. `useMonitoring.ts` is the reference; remaining hooks migrate incrementally (#299). Keep the `{ data|current|..., loading, error, refetch }` public shape so consumers are unaffected.
 - Query-backed polling (`refetchInterval`) pauses while the browser tab is hidden and resumes on return (TanStack default; `refetchOnWindowFocus` is off) — intentional for a LAN dashboard, unlike the old always-on `setInterval`.
+- **Mutations use `useMutation`** with `onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.<domain>.all() })` — reference implementations: `BackupSettings.tsx`, the share modals (`CreateFileShareModal`/`EditFileShareModal`/`ShareFileModal` invalidate themselves so every mount point is covered), `SharesPage.tsx`
 - Accept `enabled?: boolean` option to conditionally disable fetching
 - Accept `pollInterval?: number` for configurable refresh rates
 - API calls go through typed functions in `api/` — hooks don't use `apiClient` directly

--- a/client/src/hooks/useBackups.ts
+++ b/client/src/hooks/useBackups.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../lib/queryKeys';
+import { listBackups, type Backup } from '../api/backup';
+
+export interface UseBackupsResult {
+  backups: Backup[];
+  loading: boolean;
+  /** Raw query error (null when none) — caller formats via getApiErrorMessage + i18n. */
+  error: unknown;
+}
+
+/**
+ * Backup list for BackupSettings. Query-backed — the two mount points
+ * (BackupPage + SystemControlPage backup tab) share one cache entry.
+ * No polling: create/delete mutations invalidate queryKeys.backups.list().
+ */
+export function useBackups(): UseBackupsResult {
+  const query = useQuery({
+    queryKey: queryKeys.backups.list(),
+    queryFn: listBackups,
+  });
+
+  return {
+    backups: query.data?.backups ?? [],
+    loading: query.isLoading,
+    error: query.isError ? query.error : null,
+  };
+}

--- a/client/src/hooks/useFileShares.ts
+++ b/client/src/hooks/useFileShares.ts
@@ -1,0 +1,48 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../lib/queryKeys';
+import {
+  listFileShares,
+  listFilesSharedWithMe,
+  getShareStatistics,
+  type FileShare,
+  type SharedWithMe,
+  type ShareStatistics,
+} from '../api/shares';
+
+export interface UseFileSharesResult {
+  fileShares: FileShare[];
+  sharedWithMe: SharedWithMe[];
+  statistics: ShareStatistics | null;
+  loading: boolean;
+  /** Raw error of the first failing query (null when all fine). */
+  error: unknown;
+}
+
+/**
+ * The three shares-domain reads for SharesPage (user-scoped!). Mutations
+ * anywhere in the app invalidate queryKeys.shares.all() — see the share
+ * modals. Cross-user leaking is prevented by AuthContext.clearQueryCache().
+ */
+export function useFileShares(): UseFileSharesResult {
+  const userShares = useQuery({
+    queryKey: queryKeys.shares.userShares(),
+    queryFn: listFileShares,
+  });
+  const sharedWithMe = useQuery({
+    queryKey: queryKeys.shares.sharedWithMe(),
+    queryFn: listFilesSharedWithMe,
+  });
+  const statistics = useQuery({
+    queryKey: queryKeys.shares.statistics(),
+    queryFn: getShareStatistics,
+  });
+
+  const queries = [userShares, sharedWithMe, statistics];
+  return {
+    fileShares: userShares.data ?? [],
+    sharedWithMe: sharedWithMe.data ?? [],
+    statistics: statistics.data ?? null,
+    loading: queries.some((q) => q.isLoading),
+    error: queries.find((q) => q.isError)?.error ?? null,
+  };
+}

--- a/client/src/lib/CLAUDE.md
+++ b/client/src/lib/CLAUDE.md
@@ -6,7 +6,7 @@ Shared utility functions and core infrastructure. No React components — pure T
 
 | File | Purpose |
 |---|---|
-| `api.ts` | **Core API client**: axios instance (`apiClient`), auth interceptor, 401 handling, `memoizedApiRequest()` with TTL cache, `buildApiUrl()` for dev/prod path resolution, API version check via `X-API-Min-Version` header |
+| `api.ts` | **Core API client**: axios instance (`apiClient`), auth interceptor, 401 handling, `buildApiUrl()` for dev/prod path resolution, API version check via `X-API-Min-Version` header |
 | `queryClient.ts` | Shared TanStack Query `QueryClient` + app-wide query defaults (`staleTime 0`, `retry 1`, `refetchOnWindowFocus false`). Mounted via `PersistQueryClientProvider` in `main.tsx` |
 | `queryPersister.ts` | TanStack Query **persister** — mirrors the whole query cache to `sessionStorage` (`baluhost-query-cache`, 24h `maxAge`, `API_VERSION` buster), rehydrated on boot via `PersistQueryClientProvider` in `main.tsx`. App-wide replacement for hand-rolled sessionStorage caches (F5 instant-paint) |
 | `queryKeys.ts` | Central query-key factory (`queryKeys.<domain>.<entity>()`) — the canonical key namespace for all `useQuery` calls |
@@ -36,7 +36,7 @@ Shared utility functions and core infrastructure. No React components — pure T
 - `apiClient` is the single axios instance — all API calls go through it
 - Auth token auto-attached via request interceptor from `localStorage.getItem('token')`
 - 401 responses fire `auth:expired` CustomEvent — `AuthContext` listens and logs out
-- `memoizedApiRequest()` uses an in-memory `Map` cache with configurable TTL (default 60s)
+- The old `memoizedApiRequest()` Map cache is gone (#299/#309) — caching/dedup is TanStack Query's job; api/* functions are plain typed calls
 - `FEATURES` object enables tree-shaking: `isDesktop ? import('./HeavyPage') : null` ensures Pi builds exclude desktop-only code
 - **Data fetching uses TanStack Query** (`@tanstack/react-query` v5). Hooks call typed `api/*` functions inside `useQuery`; keys come from `lib/queryKeys.ts`. Migration is incremental per domain (see #299) — new/edited data hooks should use `useQuery`, not hand-rolled `useState`+`setInterval`.
 - **Query cache persists across reloads** via `queryPersister.ts` + `PersistQueryClientProvider` (sessionStorage). New data hooks get F5 instant-paint for free — do not hand-roll sessionStorage caches. `queryClient` `gcTime` is 24h to satisfy the persister's `maxAge`.

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -79,23 +79,6 @@ apiClient.interceptors.response.use(
   }
 );
 
-// --- Memoized API Request Utility ---
-type CacheEntry = { data: any; expires: number };
-export const apiCache = new Map<string, CacheEntry>();
-const DEFAULT_TTL = 60 * 1000; // 60 Sekunden
-
-export async function memoizedApiRequest<T = any>(url: string, params?: any, ttl: number = DEFAULT_TTL): Promise<T> {
-  const key = url + JSON.stringify(params || {});
-  const now = Date.now();
-  const cached = apiCache.get(key);
-  if (cached && cached.expires > now) {
-    return cached.data;
-  }
-  const res = await apiClient.get(url, { params });
-  apiCache.set(key, { data: res.data, expires: now + ttl });
-  return res.data;
-}
-
 export function extractErrorMessage(detail: unknown, fallback: string): string {
   if (typeof detail === 'string') return detail;
   if (Array.isArray(detail) && detail.length > 0) {

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -30,4 +30,14 @@ export const queryKeys = {
   raid: {
     status: () => ['raid', 'status'] as const,
   },
+  backups: {
+    list: () => ['backups', 'list'] as const,
+  },
+  shares: {
+    /** Domain-Prefix — invalidiert alle drei shares-Reads auf einmal. */
+    all: () => ['shares'] as const,
+    userShares: () => ['shares', 'user-shares'] as const,
+    sharedWithMe: () => ['shares', 'shared-with-me'] as const,
+    statistics: () => ['shares', 'statistics'] as const,
+  },
 } as const;

--- a/client/src/pages/SharesPage.tsx
+++ b/client/src/pages/SharesPage.tsx
@@ -2,14 +2,9 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import {
-  listFileShares,
-  listFilesSharedWithMe,
-  getShareStatistics,
-  getShareableUsers,
   deleteFileShare,
+  getShareableUsers,
   type FileShare,
-  type SharedWithMe,
-  type ShareStatistics
 } from '../api/shares';
 import { Users, Share2, Trash2, Edit, Search, Filter, Calendar, Loader2, Folder, File as FileIcon, Cloud, Copy, RefreshCw } from 'lucide-react';
 import {
@@ -27,6 +22,9 @@ import EditFileShareModal from '../components/EditFileShareModal';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
 import { useSortableTable } from '../hooks/useSortableTable';
 import { SortableHeader } from '../components/ui/SortableHeader';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useFileShares } from '../hooks/useFileShares';
+import { queryKeys } from '../lib/queryKeys';
 
 export default function SharesPage() {
   const { t } = useTranslation(['shares', 'common']);
@@ -36,10 +34,11 @@ export default function SharesPage() {
   const [activeTab, setActiveTab] = useState<'shares' | 'shared-with-me' | 'cloud-exports'>('shares');
   const [cloudExports, setCloudExports] = useState<CloudExportJob[]>([]);
   const [cloudStats, setCloudStats] = useState<CloudExportStats | null>(null);
-  const [fileShares, setFileShares] = useState<FileShare[]>([]);
-  const [sharedWithMe, setSharedWithMe] = useState<SharedWithMe[]>([]);
-  const [statistics, setStatistics] = useState<ShareStatistics | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [cloudLoading, setCloudLoading] = useState(true);
+
+  const queryClient = useQueryClient();
+  const { fileShares, sharedWithMe, statistics, loading: sharesLoading } = useFileShares();
+  const loading = sharesLoading || cloudLoading;
   const [showCreateShareModal, setShowCreateShareModal] = useState(false);
 
   // Edit modals
@@ -51,7 +50,7 @@ export default function SharesPage() {
   const [showFilters, setShowFilters] = useState(false);
 
   useEffect(() => {
-    loadData();
+    loadCloudExports();
     fetchUsers();
   }, []);
 
@@ -64,38 +63,34 @@ export default function SharesPage() {
     }
   };
 
-  const loadData = async () => {
-    setLoading(true);
+  const loadCloudExports = async () => {
+    setCloudLoading(true);
     try {
-      const [stats, shares, shared, cExports, cStats] = await Promise.all([
-        getShareStatistics(),
-        listFileShares(),
-        listFilesSharedWithMe(),
+      const [cExports, cStats] = await Promise.all([
         listCloudExports().catch(() => []),
         getCloudExportStatistics().catch(() => null),
       ]);
-      setStatistics(stats);
-      setFileShares(shares);
-      setSharedWithMe(shared);
       setCloudExports(cExports);
       setCloudStats(cStats);
-    } catch {
-      // Load failure handled by empty state
     } finally {
-      setLoading(false);
+      setCloudLoading(false);
     }
   };
+
+  const deleteShareMutation = useMutation({
+    mutationFn: (shareId: number) => deleteFileShare(shareId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.shares.all() });
+    },
+    onError: () => {
+      toast.error(t('shares:toast.revokeFailed'));
+    },
+  });
 
   const handleDeleteFileShare = async (shareId: number) => {
     const ok = await confirm(t('confirm.revokeShare'), { title: t('confirm.revokeShare'), variant: 'danger', confirmLabel: t('common:actions.revoke', 'Revoke') });
     if (!ok) return;
-
-    try {
-      await deleteFileShare(shareId);
-      await loadData();
-    } catch {
-      toast.error(t('shares:toast.revokeFailed'));
-    }
+    deleteShareMutation.mutate(shareId);
   };
 
   const handleCopyLink = (link: string) => {
@@ -112,7 +107,7 @@ export default function SharesPage() {
     if (!ok) return;
     try {
       await revokeCloudExport(jobId);
-      await loadData();
+      await loadCloudExports();
       toast.success(t('shares:cloudExport.revoked', 'Cloud share revoked'));
     } catch {
       toast.error(t('shares:cloudExport.revokeFailed', 'Failed to revoke cloud share'));
@@ -122,7 +117,7 @@ export default function SharesPage() {
   const handleRetryExport = async (jobId: number) => {
     try {
       await retryCloudExport(jobId);
-      await loadData();
+      await loadCloudExports();
       toast.success(t('shares:cloudExport.retryStarted', 'Retry started'));
     } catch {
       toast.error(t('shares:cloudExport.retryFailed', 'Retry failed'));
@@ -887,20 +882,14 @@ export default function SharesPage() {
         <CreateFileShareModal
           users={users}
           onClose={() => setShowCreateShareModal(false)}
-          onSuccess={() => {
-            setShowCreateShareModal(false);
-            loadData();
-          }}
+          onSuccess={() => setShowCreateShareModal(false)}
         />
       )}
       {editingShare && (
         <EditFileShareModal
           fileShare={editingShare}
           onClose={() => setEditingShare(null)}
-          onSuccess={() => {
-            setEditingShare(null);
-            loadData();
-          }}
+          onSuccess={() => setEditingShare(null)}
         />
       )}
       {dialog}

--- a/docs/superpowers/plans/2026-07-03-memoized-api-request-tanstack-query.md
+++ b/docs/superpowers/plans/2026-07-03-memoized-api-request-tanstack-query.md
@@ -1,0 +1,1279 @@
+# memoizedApiRequest → TanStack Query Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Den In-Memory-Map-Cache (`apiCache`/`memoizedApiRequest`) in `client/src/lib/api.ts` ersatzlos entfernen und seine 3 Konsumenten (Backups, Shares, File-Permissions) auf TanStack Query bzw. Plain-Reads migrieren — schließt den #299-Bullet und #309/F6 vollständig.
+
+**Architecture:** Reads werden `useQuery`-Hooks (`useBackups`, `useFileShares`) mit Keys aus `lib/queryKeys.ts`; Mutationen werden `useMutation` + `invalidateQueries` (erstes Mutation-Muster im Frontend). Share-Invalidierung lebt **in den Modals** (zentrale Semantik wie der alte `apiCache.delete`). File-Permissions werden ein Plain-Read ohne Query-Beteiligung. `AuthContext` leert den Query-Cache bei **jedem** Identitätswechsel (5 Pfade), damit user-scoped Queries nie über den Persister leaken.
+
+**Tech Stack:** React 18, TypeScript strict, `@tanstack/react-query` v5 (installiert), Vitest + Testing Library, axios (`apiClient`).
+
+**Spec:** `docs/superpowers/specs/2026-07-03-memoized-api-request-tanstack-query-design.md`
+
+## Global Constraints
+
+- Branch: `feat/tanstack-query-memoized-cache-299` (existiert bereits, Spec liegt darauf).
+- Shell ist PowerShell 5.1: **niemals `&&`** — Befehle mit `;` verketten.
+- Repo läuft mit `core.autocrlf=true` — CRLF-Warnungen beim Commit sind normal.
+- Öffentliche Hook-/API-Signaturen stabil halten, wo Konsumenten existieren (Approach A aus #299). Ausnahme: `getBackup` wird gelöscht (toter Code, null Konsumenten).
+- Query-Keys IMMER aus `lib/queryKeys.ts` — nie inline-Arrays.
+- Kein neuer `refetchInterval` für Backups/Shares (Admin-/On-Demand-Daten; Mutationen invalidieren).
+- Vor dem PR müssen ALLE drei Gates grün sein: `npx vitest run`, `npx eslint .` (0 Errors), `npm run build` (tsc -b, prüft auch das Test-Projekt).
+- Alle Frontend-Kommandos laufen aus `client/`: `cd "D:\Programme (x86)\Baluhost\client"`.
+- Commits: konventionelle Prefixe (`feat(client):`, `refactor(client):`, `test(client):`, `docs(client):`), Referenz `(#299)`.
+
+---
+
+### Task 1: Query-Keys für backups + shares
+
+**Files:**
+- Modify: `client/src/lib/queryKeys.ts`
+- Test: `client/src/__tests__/lib/query-foundation.test.ts`
+
+**Interfaces:**
+- Produces: `queryKeys.backups.list(): readonly ['backups','list']`; `queryKeys.shares.all(): readonly ['shares']`; `queryKeys.shares.userShares(): readonly ['shares','user-shares']`; `queryKeys.shares.sharedWithMe(): readonly ['shares','shared-with-me']`; `queryKeys.shares.statistics(): readonly ['shares','statistics']`. Alle späteren Tasks nutzen exakt diese Namen.
+
+- [ ] **Step 1: Failing Tests schreiben**
+
+In `client/src/__tests__/lib/query-foundation.test.ts` ans Dateiende (nach dem `queryKeys.raid`-describe) anhängen:
+
+```ts
+describe('queryKeys.backups', () => {
+  it('builds the list key', () => {
+    expect(queryKeys.backups.list()).toEqual(['backups', 'list']);
+  });
+});
+
+describe('queryKeys.shares', () => {
+  it('builds the domain prefix and entity keys', () => {
+    expect(queryKeys.shares.all()).toEqual(['shares']);
+    expect(queryKeys.shares.userShares()).toEqual(['shares', 'user-shares']);
+    expect(queryKeys.shares.sharedWithMe()).toEqual(['shares', 'shared-with-me']);
+    expect(queryKeys.shares.statistics()).toEqual(['shares', 'statistics']);
+  });
+});
+```
+
+- [ ] **Step 2: Test laufen lassen — muss fehlschlagen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/lib/query-foundation.test.ts`
+Expected: FAIL — `queryKeys.backups is undefined` (Property existiert nicht).
+
+- [ ] **Step 3: Keys implementieren**
+
+In `client/src/lib/queryKeys.ts` nach dem `raid:`-Block (vor dem schließenden `} as const;`) einfügen:
+
+```ts
+  backups: {
+    list: () => ['backups', 'list'] as const,
+  },
+  shares: {
+    /** Domain-Prefix — invalidiert alle drei shares-Reads auf einmal. */
+    all: () => ['shares'] as const,
+    userShares: () => ['shares', 'user-shares'] as const,
+    sharedWithMe: () => ['shares', 'shared-with-me'] as const,
+    statistics: () => ['shares', 'statistics'] as const,
+  },
+```
+
+- [ ] **Step 4: Test laufen lassen — muss bestehen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/lib/query-foundation.test.ts`
+Expected: PASS (alle describe-Blöcke grün).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+cd "D:\Programme (x86)\Baluhost"; git add client/src/lib/queryKeys.ts client/src/__tests__/lib/query-foundation.test.ts; git commit -m "feat(client): query keys for backups + shares domains (#299)"
+```
+
+---
+
+### Task 2: AuthContext — Cache-Leerung bei jedem Identitätswechsel
+
+**Files:**
+- Modify: `client/src/contexts/AuthContext.tsx`
+- Test: `client/src/__tests__/contexts/AuthContext.impersonation.test.tsx`
+- Test: `client/src/__tests__/contexts/AuthContext.logout.test.tsx`
+
+**Interfaces:**
+- Consumes: `queryClient` aus `lib/queryClient`, `queryPersister` aus `lib/queryPersister` (beide bereits importiert).
+- Produces: keine neue öffentliche API — `login/logout/impersonate/endImpersonation` behalten ihre Signaturen; sie leeren jetzt zusätzlich den Query-Cache.
+
+**Kontext:** Sobald user-scoped Queries existieren (Task 7: `useFileShares`), darf der sessionStorage-Persister keine Daten des vorherigen Users an den nächsten leaken. Heute leert nur `logout()` (AuthContext.tsx:112-113). Fünf weitere Pfade müssen leeren — siehe Spec §3.6.
+
+- [ ] **Step 1: Failing Tests schreiben (Impersonation)**
+
+In `client/src/__tests__/contexts/AuthContext.impersonation.test.tsx`:
+
+Nach den bestehenden `vi.mock(...)`-Blöcken (nach Zeile 12) und vor `import { impersonateUser } ...` einfügen:
+
+```ts
+import { queryClient } from '../../lib/queryClient';
+import { queryPersister } from '../../lib/queryPersister';
+
+vi.spyOn(queryClient, 'clear').mockImplementation(() => {});
+vi.spyOn(queryPersister, 'removeClient').mockResolvedValue(undefined);
+```
+
+Im Test `'stores origin token and swaps to impersonation token'` ans Ende (nach `expect(ctx.user?.username).toBe('alice');`) anhängen:
+
+```ts
+    // Identity change → cached queries of the admin must not leak to alice
+    expect(queryClient.clear).toHaveBeenCalled();
+    expect(queryPersister.removeClient).toHaveBeenCalled();
+```
+
+Im Test `'endImpersonation restores the admin token'` ans Ende (nach `expect(ctx.user?.username).toBe('admin');`) anhängen:
+
+```ts
+    // Both swaps (impersonate + end) clear the cache
+    expect(vi.mocked(queryClient.clear).mock.calls.length).toBeGreaterThanOrEqual(2);
+```
+
+- [ ] **Step 2: Failing Tests schreiben (login + auth:expired)**
+
+In `client/src/__tests__/contexts/AuthContext.logout.test.tsx` innerhalb des `describe('AuthContext logout', ...)`-Blocks zwei Tests ergänzen (der Spy-Setup existiert dort bereits, Zeilen 8-9). Zusätzlich am Dateikopf den Typ-Import ergänzen:
+
+```ts
+import type { User } from '../../types/auth';
+```
+
+```ts
+  it('login clears any cached data from a previous session', () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    act(() => {
+      result.current.login({ id: 1, username: 'bob', role: 'user' } as unknown as User, 'new-token');
+    });
+    expect(queryClient.clear).toHaveBeenCalledTimes(1);
+    expect(queryPersister.removeClient).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('token')).toBe('new-token');
+  });
+
+  it('auth:expired (plain, no impersonation) clears the query cache', () => {
+    renderHook(() => useAuth(), { wrapper });
+    act(() => {
+      window.dispatchEvent(new CustomEvent('auth:expired'));
+    });
+    expect(queryClient.clear).toHaveBeenCalledTimes(1);
+    expect(queryPersister.removeClient).toHaveBeenCalledTimes(1);
+  });
+```
+
+- [ ] **Step 3: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/contexts/AuthContext.impersonation.test.tsx src/__tests__/contexts/AuthContext.logout.test.tsx`
+Expected: FAIL — `expected "clear" to be called at least once` (bzw. `toHaveBeenCalledTimes(1)` = 0 calls) in den 4 neuen/erweiterten Tests; die Bestandstests bleiben grün.
+
+- [ ] **Step 4: `clearQueryCache`-Helfer + 5 Aufrufe implementieren**
+
+In `client/src/contexts/AuthContext.tsx`:
+
+**(a)** Nach der `fetchMe`-Funktion (nach Zeile 37) modulweiten Helfer einfügen:
+
+```ts
+/**
+ * Drop all cached queries and the persisted sessionStorage blob.
+ * MUST run on EVERY identity change (login, logout, impersonation swaps,
+ * auth expiry) — user-scoped queries (#299) would otherwise leak across
+ * users via the persister's F5 instant-paint.
+ */
+function clearQueryCache(): void {
+  queryClient.clear();
+  void queryPersister.removeClient();
+}
+```
+
+**(b)** `login` (Zeile 96-100) — Leerung VOR dem Setzen der neuen Session:
+
+```ts
+  const login = (userData: User, newToken: string) => {
+    // A previous session on this tab (e.g. ended via auth:expired) may have
+    // left user-scoped data in the cache/persister — never show it to the
+    // next account.
+    clearQueryCache();
+    localStorage.setItem('token', newToken);
+    setToken(newToken);
+    setUser(userData);
+  };
+```
+
+**(c)** `logout` (Zeile 102-114) — die zwei Direktaufrufe durch den Helfer ersetzen:
+
+```ts
+  const logout = useCallback(() => {
+    localStorage.removeItem('token');
+    sessionStorage.removeItem(ORIGIN_TOKEN_KEY);
+    sessionStorage.removeItem(ORIGIN_USERNAME_KEY);
+    setImpersonationOrigin(null);
+    setToken(null);
+    setUser(null);
+    // Drop any cached data for the ended session so a next login on the same
+    // tab can't briefly show it before refetch (see clearQueryCache).
+    clearQueryCache();
+  }, []);
+```
+
+**(d)** `impersonate` (Zeile 116-131) — nach dem Token-Swap leeren (Reihenfolge: erst Token, dann leeren, damit die von `clear()` ausgelösten Refetches den neuen Token tragen):
+
+```ts
+    sessionStorage.setItem(ORIGIN_TOKEN_KEY, currentToken);
+    sessionStorage.setItem(ORIGIN_USERNAME_KEY, currentUsername);
+    localStorage.setItem('token', result.access_token);
+    setToken(result.access_token);
+    setUser(result.user);
+    setImpersonationOrigin(currentUsername);
+    clearQueryCache();
+```
+
+**(e)** `endImpersonation` (Zeile 133-153) — nach dem Restore leeren:
+
+```ts
+    sessionStorage.removeItem(ORIGIN_TOKEN_KEY);
+    sessionStorage.removeItem(ORIGIN_USERNAME_KEY);
+    localStorage.setItem('token', originToken);
+    setToken(originToken);
+    setImpersonationOrigin(null);
+    clearQueryCache();
+```
+(Der `if (!originToken) { logout(); return; }`-Frühausstieg leert bereits über `logout()`.)
+
+**(f)** `auth:expired`-Handler (Zeile 156-182) — BEIDE Zweige leeren. Im Impersonation-Zweig nach `setImpersonationOrigin(null);`:
+
+```ts
+        setImpersonationOrigin(null);
+        clearQueryCache();
+```
+
+Im Plain-Zweig:
+
+```ts
+      } else {
+        setToken(null);
+        setUser(null);
+        clearQueryCache();
+      }
+```
+
+- [ ] **Step 5: Tests laufen lassen — müssen bestehen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/contexts/`
+Expected: PASS — alle AuthContext-Tests (impersonation, logout inkl. der 2 neuen, der Bestand `AuthContext.test.tsx`).
+
+- [ ] **Step 6: Commit**
+
+```powershell
+cd "D:\Programme (x86)\Baluhost"; git add client/src/contexts/AuthContext.tsx client/src/__tests__/contexts/AuthContext.impersonation.test.tsx client/src/__tests__/contexts/AuthContext.logout.test.tsx; git commit -m "feat(client): clear query cache on every identity change, not just logout (#299)"
+```
+
+---
+
+### Task 3: api/backup.ts — plain listBackups, toten getBackup löschen
+
+**Files:**
+- Modify: `client/src/api/backup.ts`
+- Create: `client/src/__tests__/api/backup.test.ts`
+
+**Interfaces:**
+- Produces: `listBackups(): Promise<BackupListResponse>` (Signatur unverändert, intern plain GET). `getBackup` existiert danach NICHT mehr (war toter Code, kein Konsument — via Projektsuche verifiziert).
+
+- [ ] **Step 1: Failing Test schreiben**
+
+Create `client/src/__tests__/api/backup.test.ts` (Muster: `shares.test.ts`):
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listBackups, createBackup, deleteBackup } from '../../api/backup';
+
+vi.mock('../../lib/api', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+  buildApiUrl: (p: string) => p,
+}));
+
+import { apiClient } from '../../lib/api';
+
+describe('backup API', () => {
+  beforeEach(() => {
+    vi.mocked(apiClient.get).mockReset();
+    vi.mocked(apiClient.post).mockReset();
+    vi.mocked(apiClient.delete).mockReset();
+  });
+
+  it('listBackups calls GET /api/backups/ directly (no memo cache)', async () => {
+    const payload = { backups: [], total_size_bytes: 0, total_size_mb: 0 };
+    vi.mocked(apiClient.get).mockResolvedValue({ data: payload });
+
+    const result = await listBackups();
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/backups/');
+    expect(result).toEqual(payload);
+  });
+
+  it('createBackup posts the request body', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { id: 1 } });
+
+    await createBackup({ includes_database: true });
+
+    expect(apiClient.post).toHaveBeenCalledWith('/api/backups/', { includes_database: true });
+  });
+
+  it('deleteBackup calls DELETE with the id', async () => {
+    vi.mocked(apiClient.delete).mockResolvedValue({});
+
+    await deleteBackup(7);
+
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/backups/7');
+  });
+});
+```
+
+- [ ] **Step 2: Test laufen lassen — muss fehlschlagen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/api/backup.test.ts`
+Expected: FAIL — `listBackups` ruft `memoizedApiRequest` (nicht `apiClient.get`); der Mock liefert dafür `undefined` → `expect(apiClient.get).toHaveBeenCalledWith(...)` schlägt fehl. (Hinweis: die Mock-Factory exportiert bewusst KEIN `memoizedApiRequest` mehr — der Import in `backup.ts` wird dadurch `undefined` und der Test crasht kontrolliert. Beides zählt als erwarteter Fail.)
+
+- [ ] **Step 3: backup.ts umbauen**
+
+In `client/src/api/backup.ts`:
+
+Import (Zeile 5) ändern zu:
+
+```ts
+import { apiClient, buildApiUrl } from '../lib/api';
+```
+
+`listBackups` (Zeile 64-67) ersetzen durch:
+
+```ts
+export async function listBackups(): Promise<BackupListResponse> {
+  const response = await apiClient.get<BackupListResponse>('/api/backups/');
+  return response.data;
+}
+```
+
+`getBackup` (Zeile 69-75, inkl. des Doc-Kommentars „Get backup details by ID") **komplett löschen** — toter Code ohne Konsumenten.
+
+- [ ] **Step 4: Test laufen lassen — muss bestehen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/api/backup.test.ts`
+Expected: PASS (3 Tests).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+cd "D:\Programme (x86)\Baluhost"; git add client/src/api/backup.ts client/src/__tests__/api/backup.test.ts; git commit -m "refactor(client): listBackups without memo cache, drop dead getBackup (#299)"
+```
+
+---
+
+### Task 4: Hook useBackups
+
+**Files:**
+- Create: `client/src/hooks/useBackups.ts`
+- Test: `client/src/__tests__/hooks/useBackups.test.tsx`
+
+**Interfaces:**
+- Consumes: `queryKeys.backups.list()` (Task 1), `listBackups` (Task 3).
+- Produces: `useBackups(): { backups: Backup[]; loading: boolean; error: unknown; }` — `error` ist der ROHE Query-Error (oder `null`); der Konsument formatiert selbst via `getApiErrorMessage` + i18n (anders als `useRaidStatus`, das einen fertigen String liefert — hier braucht `BackupSettings` seine übersetzten Fallbacks).
+
+- [ ] **Step 1: Failing Test schreiben**
+
+Create `client/src/__tests__/hooks/useBackups.test.tsx` (Muster: `useRaidStatus.test.tsx`):
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useBackups } from '../../hooks/useBackups';
+import * as backupApi from '../../api/backup';
+
+vi.mock('../../api/backup');
+const api = vi.mocked(backupApi);
+
+const sample = {
+  backups: [
+    {
+      id: 1, filename: 'b1.tar.gz', filepath: '/tmp/b1.tar.gz', size_bytes: 1000,
+      size_mb: 0, backup_type: 'full' as const, status: 'completed' as const,
+      created_at: '2026-07-01T00:00:00Z', completed_at: null, creator_id: 1,
+      error_message: null, includes_database: true, includes_files: true, includes_config: false,
+    },
+  ],
+  total_size_bytes: 1000,
+  total_size_mb: 0,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useBackups', () => {
+  it('unwraps the backup list from the response', async () => {
+    api.listBackups.mockResolvedValue(sample);
+    const { result } = renderHook(() => useBackups(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.backups).toHaveLength(1);
+    expect(result.current.backups[0].filename).toBe('b1.tar.gz');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('exposes the raw error when the fetch rejects', async () => {
+    api.listBackups.mockRejectedValue(new Error('backup boom'));
+    const { result } = renderHook(() => useBackups(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect((result.current.error as Error).message).toBe('backup boom');
+    expect(result.current.backups).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Test laufen lassen — muss fehlschlagen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/hooks/useBackups.test.tsx`
+Expected: FAIL — `Cannot find module '../../hooks/useBackups'`.
+
+- [ ] **Step 3: Hook implementieren**
+
+Create `client/src/hooks/useBackups.ts`:
+
+```ts
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../lib/queryKeys';
+import { listBackups, type Backup } from '../api/backup';
+
+export interface UseBackupsResult {
+  backups: Backup[];
+  loading: boolean;
+  /** Raw query error (null when none) — caller formats via getApiErrorMessage + i18n. */
+  error: unknown;
+}
+
+/**
+ * Backup list for BackupSettings. Query-backed — the two mount points
+ * (BackupPage + SystemControlPage backup tab) share one cache entry.
+ * No polling: create/delete mutations invalidate queryKeys.backups.list().
+ */
+export function useBackups(): UseBackupsResult {
+  const query = useQuery({
+    queryKey: queryKeys.backups.list(),
+    queryFn: listBackups,
+  });
+
+  return {
+    backups: query.data?.backups ?? [],
+    loading: query.isLoading,
+    error: query.isError ? query.error : null,
+  };
+}
+```
+
+- [ ] **Step 4: Test laufen lassen — muss bestehen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/hooks/useBackups.test.tsx`
+Expected: PASS (2 Tests).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+cd "D:\Programme (x86)\Baluhost"; git add client/src/hooks/useBackups.ts client/src/__tests__/hooks/useBackups.test.tsx; git commit -m "feat(client): useBackups query hook (#299)"
+```
+
+---
+
+### Task 5: BackupSettings → useBackups + useMutation (erstes Mutation-Muster)
+
+**Files:**
+- Modify: `client/src/components/BackupSettings.tsx`
+
+**Interfaces:**
+- Consumes: `useBackups()` (Task 4), `queryKeys.backups.list()` (Task 1), `createBackup`/`deleteBackup`/`restoreBackup`/`downloadBackup` aus `api/backup` (unverändert), `getApiErrorMessage` aus `lib/errorHandling` (bereits importiert).
+- Produces: kein API-Export — aber dies ist die REFERENZ-Implementierung des `useMutation`+`invalidateQueries`-Musters für alle späteren Domain-PRs.
+
+Kein eigener Komponententest (BackupSettings hat keinen Bestand-Test; Absicherung: Hook-Test aus Task 4 + `npm run build` + volle Vitest-Suite am Ende). Verifikation hier: Build + bestehende Suite bleiben grün.
+
+- [ ] **Step 1: Imports umbauen**
+
+In `client/src/components/BackupSettings.tsx` Kopfzeilen (Zeilen 1-8) ersetzen durch:
+
+```tsx
+import { useState, useMemo } from 'react';
+import { Download, Trash2, RotateCcw, AlertTriangle, Database, FolderOpen, Settings, CheckCircle, XCircle, Clock, HardDrive } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createBackup, deleteBackup, restoreBackup, downloadBackup } from '../api/backup';
+import type { Backup, CreateBackupRequest, RestoreBackupRequest } from '../api/backup';
+import { useBackups } from '../hooks/useBackups';
+import { queryKeys } from '../lib/queryKeys';
+import { getApiErrorMessage } from '../lib/errorHandling';
+import { formatBytes } from '../lib/formatters';
+```
+
+(Entfällt: `useEffect`, `listBackups`, `BackupListResponse`-Typ, `import { apiCache } from '../lib/api';`.)
+
+- [ ] **Step 2: State + Laden ersetzen**
+
+Die States `backups`, `totalSizeBytes`, `loading`, `creating`, `deleting` (Zeilen 17-20, 28) sowie den `useEffect` + die `loadBackups`-Funktion (Zeilen 31-49) ersetzen durch:
+
+```tsx
+	const queryClient = useQueryClient();
+	const { backups, loading, error: loadError } = useBackups();
+	const totalSizeBytes = useMemo(
+		() => backups.reduce((acc, b) => acc + b.size_bytes, 0),
+		[backups]
+	);
+```
+
+Die übrigen States (`includesDatabase`, `includesFiles`, `includesConfig`, `backupPath`, `error`, `success`, Dialog-States, `restoring`) bleiben unverändert.
+
+- [ ] **Step 3: Mutationen implementieren**
+
+Die Funktionen `handleCreateBackup` (Zeilen 51-72) und `handleDeleteBackup` (Zeilen 74-91) ersetzen durch:
+
+```tsx
+	const createMutation = useMutation({
+		mutationFn: (request: CreateBackupRequest) => createBackup(request),
+		onSuccess: () => {
+			setSuccess(t('backup.createSuccess'));
+			void queryClient.invalidateQueries({ queryKey: queryKeys.backups.list() });
+		},
+		onError: (err: unknown) => {
+			setError(getApiErrorMessage(err, t('backup.createFailed')));
+		},
+	});
+
+	const deleteMutation = useMutation({
+		mutationFn: (backupId: number) => deleteBackup(backupId),
+		onSuccess: () => {
+			setSuccess(t('backup.deleteSuccess'));
+			void queryClient.invalidateQueries({ queryKey: queryKeys.backups.list() });
+			setDeleteDialogOpen(false);
+			setBackupToDelete(null);
+		},
+		onError: (err: unknown) => {
+			setError(getApiErrorMessage(err, t('backup.deleteFailed')));
+		},
+	});
+
+	function handleCreateBackup() {
+		setError(null);
+		setSuccess(null);
+		createMutation.mutate({
+			includes_database: includesDatabase,
+			includes_files: includesFiles,
+			includes_config: includesConfig,
+			backup_path: backupPath,
+		});
+	}
+
+	function handleDeleteBackup() {
+		if (!backupToDelete) return;
+		setError(null);
+		deleteMutation.mutate(backupToDelete.id);
+	}
+```
+
+- [ ] **Step 4: JSX auf isPending + Ladefehler umstellen**
+
+Alle JSX-Verwendungen anpassen (Suchen & Ersetzen im File):
+- Jedes `creating` → `createMutation.isPending` (Checkbox-`disabled`, Input-`disabled`, Create-Button `disabled` + Label).
+- Jedes `deleting` → `deleteMutation.isPending` (Dialog-Buttons).
+- Der Fehlerblock `{error && (...)}` zeigt zusätzlich Ladefehler. Direkt über dem `return` eine abgeleitete Variable einfügen und im JSX `error` durch `displayError` ersetzen (nur im Fehlerblock — die `setError`-Aufrufe bleiben):
+
+```tsx
+	const displayError = error ?? (loadError ? getApiErrorMessage(loadError, t('backup.loadFailed')) : null);
+```
+
+```tsx
+			{displayError && (
+				<div className="rounded-lg bg-red-500/10 border border-red-500/20 p-4">
+					<div className="flex items-center gap-2 text-red-400">
+						<AlertTriangle className="w-5 h-5" />
+						<span>{displayError}</span>
+					</div>
+				</div>
+			)}
+```
+
+`handleRestoreBackup`, `handleDownload` und der gesamte Rest des JSX bleiben unverändert.
+
+- [ ] **Step 5: Verifizieren (Build + Suite)**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npm run build; if ($?) { npx vitest run src/__tests__/hooks/useBackups.test.tsx src/__tests__/api/backup.test.ts }`
+Expected: Build erfolgreich (tsc findet keine `apiCache`/`listBackups`-Referenzen mehr in BackupSettings); Tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+cd "D:\Programme (x86)\Baluhost"; git add client/src/components/BackupSettings.tsx; git commit -m "feat(client): BackupSettings on useBackups + useMutation, drop apiCache.clear (#299)"
+```
+
+---
+
+### Task 6: api/shares.ts — plain listFileShares, apiCache-Invalidierung raus
+
+**Files:**
+- Modify: `client/src/api/shares.ts`
+- Test: `client/src/__tests__/api/shares.test.ts`
+
+**Interfaces:**
+- Produces: `listFileShares(): Promise<FileShare[]>` (Signatur unverändert, intern plain GET). `createFileShare`/`updateFileShare`/`deleteFileShare` rufen KEINE Cache-Invalidierung mehr auf — die übernimmt ab Task 8/9 die Query-Schicht (Modals + SharesPage).
+
+- [ ] **Step 1: Tests anpassen (failing)**
+
+In `client/src/__tests__/api/shares.test.ts`:
+
+Mock-Factory (Zeilen 12-21) ersetzen durch:
+
+```ts
+vi.mock('../../lib/api', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+```
+
+Import (Zeile 23) ändern zu:
+
+```ts
+import { apiClient } from '../../lib/api';
+```
+
+In `beforeEach` die Zeile `vi.mocked(apiCache.delete).mockReset();` entfernen.
+
+Die drei Tests mit Cache-Assertions umbenennen und die `apiCache.delete`-Erwartungen entfernen:
+- `'createFileShare calls POST and clears cache'` → `'createFileShare calls POST'`; Zeile `expect(apiCache.delete).toHaveBeenCalled();` löschen.
+- `'updateFileShare calls PATCH and clears cache'` → `'updateFileShare calls PATCH'`; Cache-Assertion löschen.
+- `'deleteFileShare calls DELETE and clears cache'` → `'deleteFileShare calls DELETE'`; Cache-Assertion löschen.
+
+Neuen Test ergänzen (nach `getShareableUsers`):
+
+```ts
+  it('listFileShares calls GET /api/shares/user-shares directly (no memo cache)', async () => {
+    const shares = [{ id: 1, file_id: 10 }];
+    vi.mocked(apiClient.get).mockResolvedValue({ data: shares });
+
+    const result = await listFileShares();
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/shares/user-shares');
+    expect(result).toEqual(shares);
+  });
+```
+
+Und `listFileShares` in den Import-Block am Dateikopf (Zeilen 2-10) aufnehmen.
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/api/shares.test.ts`
+Expected: FAIL — `shares.ts` importiert noch `apiCache`/`memoizedApiRequest`, die die Factory nicht mehr liefert (`apiCache.delete is not a function` bzw. `memoizedApiRequest is not a function` im neuen `listFileShares`-Test).
+
+- [ ] **Step 3: shares.ts umbauen**
+
+In `client/src/api/shares.ts`:
+
+Import (Zeile 5) ändern zu:
+
+```ts
+import { apiClient } from '../lib/api';
+```
+
+Die Konstante `SHARES_CACHE_KEY` (Zeile 89) löschen.
+
+`createFileShare` (Zeilen 91-95): die Zeile `apiCache.delete(SHARES_CACHE_KEY);` löschen.
+
+`listFileShares` (Zeilen 97-100) ersetzen durch:
+
+```ts
+export const listFileShares = async (): Promise<FileShare[]> => {
+  const response = await apiClient.get('/api/shares/user-shares');
+  return response.data;
+};
+```
+
+`updateFileShare` (Zeilen 112-119): die Zeile `apiCache.delete(SHARES_CACHE_KEY);` löschen.
+
+`deleteFileShare` (Zeilen 121-124): die Zeile `apiCache.delete(SHARES_CACHE_KEY);` löschen.
+
+- [ ] **Step 4: Tests laufen lassen — müssen bestehen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/api/shares.test.ts`
+Expected: PASS (8 Tests).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+cd "D:\Programme (x86)\Baluhost"; git add client/src/api/shares.ts client/src/__tests__/api/shares.test.ts; git commit -m "refactor(client): shares API without memo cache — invalidation moves to the query layer (#299)"
+```
+
+---
+
+### Task 7: Hook useFileShares
+
+**Files:**
+- Create: `client/src/hooks/useFileShares.ts`
+- Test: `client/src/__tests__/hooks/useFileShares.test.tsx`
+
+**Interfaces:**
+- Consumes: `queryKeys.shares.*` (Task 1); `listFileShares`, `listFilesSharedWithMe`, `getShareStatistics` + Typen `FileShare`, `SharedWithMe`, `ShareStatistics` aus `api/shares` (Task 6).
+- Produces: `useFileShares(): { fileShares: FileShare[]; sharedWithMe: SharedWithMe[]; statistics: ShareStatistics | null; loading: boolean; error: unknown; }` — Feldnamen matchen exakt die bisherigen `SharesPage`-State-Variablen, damit das JSX unberührt bleibt.
+
+- [ ] **Step 1: Failing Test schreiben**
+
+Create `client/src/__tests__/hooks/useFileShares.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useFileShares } from '../../hooks/useFileShares';
+import * as sharesApi from '../../api/shares';
+import type { FileShare, SharedWithMe } from '../../api/shares';
+
+vi.mock('../../api/shares');
+const api = vi.mocked(sharesApi);
+
+const stats = { total_file_shares: 2, active_file_shares: 1, files_shared_with_me: 3 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.listFileShares.mockResolvedValue([{ id: 1 } as unknown as FileShare]);
+  api.listFilesSharedWithMe.mockResolvedValue([{ share_id: 9 } as unknown as SharedWithMe]);
+  api.getShareStatistics.mockResolvedValue(stats);
+});
+
+describe('useFileShares', () => {
+  it('exposes all three reads under the SharesPage state names', async () => {
+    const { result } = renderHook(() => useFileShares(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.fileShares).toHaveLength(1);
+    expect(result.current.sharedWithMe).toHaveLength(1);
+    expect(result.current.statistics).toEqual(stats);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('stays loading until every query settled', async () => {
+    let resolveStats!: (v: typeof stats) => void;
+    api.getShareStatistics.mockReturnValue(new Promise((r) => { resolveStats = r; }));
+    const { result } = renderHook(() => useFileShares(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.fileShares).toHaveLength(1));
+    expect(result.current.loading).toBe(true);
+    resolveStats(stats);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  it('surfaces the first failing query as raw error', async () => {
+    api.listFileShares.mockRejectedValue(new Error('shares boom'));
+    const { result } = renderHook(() => useFileShares(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect((result.current.error as Error).message).toBe('shares boom');
+    expect(result.current.fileShares).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Test laufen lassen — muss fehlschlagen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/hooks/useFileShares.test.tsx`
+Expected: FAIL — `Cannot find module '../../hooks/useFileShares'`.
+
+- [ ] **Step 3: Hook implementieren**
+
+Create `client/src/hooks/useFileShares.ts`:
+
+```ts
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../lib/queryKeys';
+import {
+  listFileShares,
+  listFilesSharedWithMe,
+  getShareStatistics,
+  type FileShare,
+  type SharedWithMe,
+  type ShareStatistics,
+} from '../api/shares';
+
+export interface UseFileSharesResult {
+  fileShares: FileShare[];
+  sharedWithMe: SharedWithMe[];
+  statistics: ShareStatistics | null;
+  loading: boolean;
+  /** Raw error of the first failing query (null when all fine). */
+  error: unknown;
+}
+
+/**
+ * The three shares-domain reads for SharesPage (user-scoped!). Mutations
+ * anywhere in the app invalidate queryKeys.shares.all() — see the share
+ * modals. Cross-user leaking is prevented by AuthContext.clearQueryCache().
+ */
+export function useFileShares(): UseFileSharesResult {
+  const userShares = useQuery({
+    queryKey: queryKeys.shares.userShares(),
+    queryFn: listFileShares,
+  });
+  const sharedWithMe = useQuery({
+    queryKey: queryKeys.shares.sharedWithMe(),
+    queryFn: listFilesSharedWithMe,
+  });
+  const statistics = useQuery({
+    queryKey: queryKeys.shares.statistics(),
+    queryFn: getShareStatistics,
+  });
+
+  const queries = [userShares, sharedWithMe, statistics];
+  return {
+    fileShares: userShares.data ?? [],
+    sharedWithMe: sharedWithMe.data ?? [],
+    statistics: statistics.data ?? null,
+    loading: queries.some((q) => q.isLoading),
+    error: queries.find((q) => q.isError)?.error ?? null,
+  };
+}
+```
+
+- [ ] **Step 4: Test laufen lassen — muss bestehen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/hooks/useFileShares.test.tsx`
+Expected: PASS (3 Tests).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+cd "D:\Programme (x86)\Baluhost"; git add client/src/hooks/useFileShares.ts client/src/__tests__/hooks/useFileShares.test.tsx; git commit -m "feat(client): useFileShares query hook for the shares domain (#299)"
+```
+
+---
+
+### Task 8: Share-Modals invalidieren selbst (zentrale Semantik)
+
+**Files:**
+- Modify: `client/src/components/CreateFileShareModal.tsx`
+- Modify: `client/src/components/EditFileShareModal.tsx`
+- Modify: `client/src/components/ShareFileModal.tsx`
+
+**Interfaces:**
+- Consumes: `queryKeys.shares.all()` (Task 1), `useQueryClient` aus `@tanstack/react-query`.
+- Produces: Verhaltensgarantie für Task 9 — JEDE Share-Mutation invalidiert `['shares']` selbst, egal wo das Modal gemountet ist (SharesPage ODER FileManager). Die `onSuccess`-Props bleiben rein UI (Modal schließen).
+
+**Warum in den Modals:** Der alte `apiCache.delete` saß in den api-Funktionen → jede Mutation-Site invalidierte automatisch. `ShareFileModal` ist in `FileManager.tsx:900` gemountet — Invalidierung nur in SharesPage-Callbacks würde diese Site verfehlen (Spec §3.4).
+
+Kein eigener Komponententest (kein Bestand; Absicherung: Build + Suite; das Invalidierungs-Verhalten ist ein Ein-Zeilen-Call auf ein getestetes TanStack-Primitive).
+
+- [ ] **Step 1: CreateFileShareModal**
+
+In `client/src/components/CreateFileShareModal.tsx`:
+
+Bei den Imports ergänzen:
+
+```tsx
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '../lib/queryKeys';
+```
+
+In der Komponente (nach `const [loading, setLoading] = ...` bzw. bei den anderen Hook-Aufrufen am Komponentenanfang):
+
+```tsx
+  const queryClient = useQueryClient();
+```
+
+In `handleSubmit` (Zeile 91-110) nach dem `await createFileShare({...});` und vor `onSuccess();` einfügen:
+
+```tsx
+      // Central invalidation (replaces the old apiCache.delete in the API fn):
+      // works from every mount point, incl. FileManager.
+      void queryClient.invalidateQueries({ queryKey: queryKeys.shares.all() });
+```
+
+- [ ] **Step 2: EditFileShareModal**
+
+In `client/src/components/EditFileShareModal.tsx` identisch: die zwei Imports + `const queryClient = useQueryClient();` (nach Zeile 15), und in `handleSubmit` (Zeile 24-39) nach `await updateFileShare(...)` / vor `onSuccess();`:
+
+```tsx
+      void queryClient.invalidateQueries({ queryKey: queryKeys.shares.all() });
+```
+
+- [ ] **Step 3: ShareFileModal**
+
+In `client/src/components/ShareFileModal.tsx` identisch: Imports + `const queryClient = useQueryClient();` (nach Zeile 21), und in `handleInternalSubmit` (Zeile 67-86) nach `await createFileShare({...});` / vor `onSuccess();`:
+
+```tsx
+      void queryClient.invalidateQueries({ queryKey: queryKeys.shares.all() });
+```
+
+**Wichtig:** `handleCloudSubmit` (Zeile 89-106) NICHT anfassen — Cloud-Exports sind eine andere Domain (kein `['shares']`-Read betroffen).
+
+- [ ] **Step 4: Verifizieren**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npm run build`
+Expected: Build erfolgreich.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+cd "D:\Programme (x86)\Baluhost"; git add client/src/components/CreateFileShareModal.tsx client/src/components/EditFileShareModal.tsx client/src/components/ShareFileModal.tsx; git commit -m "feat(client): share modals invalidate the shares query domain after mutations (#299)"
+```
+
+---
+
+### Task 9: SharesPage → useFileShares + Delete-Mutation
+
+**Files:**
+- Modify: `client/src/pages/SharesPage.tsx`
+
+**Interfaces:**
+- Consumes: `useFileShares()` (Task 7) — Feldnamen `fileShares`/`sharedWithMe`/`statistics` matchen die bisherigen States, JSX bleibt unberührt; `queryKeys.shares.all()` (Task 1); Modals invalidieren selbst (Task 8).
+- Produces: kein Export.
+
+- [ ] **Step 1: Imports + State umbauen**
+
+In `client/src/pages/SharesPage.tsx`:
+
+Import-Block (Zeilen 4-13) ändern — `listFileShares`, `listFilesSharedWithMe`, `getShareStatistics` raus, Typen bleiben:
+
+```tsx
+import {
+  deleteFileShare,
+  getShareableUsers,
+  type FileShare,
+} from '../api/shares';
+```
+
+Neue Imports ergänzen:
+
+```tsx
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useFileShares } from '../hooks/useFileShares';
+import { queryKeys } from '../lib/queryKeys';
+```
+
+(`SharedWithMe`/`ShareStatistics`-Typimporte entfallen — die States dazu verschwinden.)
+
+Die States (Zeilen 37-42) umbauen — `fileShares`, `sharedWithMe`, `statistics`, `loading` entfallen; Cloud-States bleiben, bekommen eigenes Loading:
+
+```tsx
+  const [cloudExports, setCloudExports] = useState<CloudExportJob[]>([]);
+  const [cloudStats, setCloudStats] = useState<CloudExportStats | null>(null);
+  const [cloudLoading, setCloudLoading] = useState(true);
+```
+
+Direkt darunter Hook + kombiniertes Loading (Name `loading` bleibt → JSX unberührt):
+
+```tsx
+  const queryClient = useQueryClient();
+  const { fileShares, sharedWithMe, statistics, loading: sharesLoading } = useFileShares();
+  const loading = sharesLoading || cloudLoading;
+```
+
+- [ ] **Step 2: loadData durch loadCloudExports ersetzen**
+
+`loadData` (Zeilen 67-87) ersetzen durch:
+
+```tsx
+  const loadCloudExports = async () => {
+    setCloudLoading(true);
+    try {
+      const [cExports, cStats] = await Promise.all([
+        listCloudExports().catch(() => []),
+        getCloudExportStatistics().catch(() => null),
+      ]);
+      setCloudExports(cExports);
+      setCloudStats(cStats);
+    } finally {
+      setCloudLoading(false);
+    }
+  };
+```
+
+Den Mount-Effect (Zeilen 53-56) anpassen:
+
+```tsx
+  useEffect(() => {
+    loadCloudExports();
+    fetchUsers();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+```
+
+(Falls der bestehende Effect keinen eslint-disable-Kommentar hat und `eslint .` nicht meckert, den Kommentar weglassen — exakt dem Bestandsstil folgen.)
+
+- [ ] **Step 3: Delete als Mutation**
+
+`handleDeleteFileShare` (Zeilen 89-99) ersetzen durch:
+
+```tsx
+  const deleteShareMutation = useMutation({
+    mutationFn: (shareId: number) => deleteFileShare(shareId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.shares.all() });
+    },
+    onError: () => {
+      toast.error(t('shares:toast.revokeFailed'));
+    },
+  });
+
+  const handleDeleteFileShare = async (shareId: number) => {
+    const ok = await confirm(t('confirm.revokeShare'), { title: t('confirm.revokeShare'), variant: 'danger', confirmLabel: t('common:actions.revoke', 'Revoke') });
+    if (!ok) return;
+    deleteShareMutation.mutate(shareId);
+  };
+```
+
+- [ ] **Step 4: Cloud-Handler + Modal-Callbacks anpassen**
+
+In `handleRevokeExport` (Zeile ~115) und `handleRetryExport` (Zeile ~125): `await loadData();` → `await loadCloudExports();`.
+
+Modal-Callbacks (Zeilen 886-905): die `loadData();`-Aufrufe entfernen (Modals invalidieren seit Task 8 selbst):
+
+```tsx
+      {showCreateShareModal && (
+        <CreateFileShareModal
+          users={users}
+          onClose={() => setShowCreateShareModal(false)}
+          onSuccess={() => setShowCreateShareModal(false)}
+        />
+      )}
+      {editingShare && (
+        <EditFileShareModal
+          fileShare={editingShare}
+          onClose={() => setEditingShare(null)}
+          onSuccess={() => setEditingShare(null)}
+        />
+      )}
+```
+
+- [ ] **Step 5: Verifizieren**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npm run build; if ($?) { npx eslint src/pages/SharesPage.tsx }`
+Expected: Build erfolgreich (keine Referenzen mehr auf entfernte States/Imports); ESLint 0 Errors (insb. keine unused imports).
+
+- [ ] **Step 6: Commit**
+
+```powershell
+cd "D:\Programme (x86)\Baluhost"; git add client/src/pages/SharesPage.tsx; git commit -m "feat(client): SharesPage on useFileShares + delete mutation (#299)"
+```
+
+---
+
+### Task 10: api/files.ts — getFilePermissions als Plain-Read
+
+**Files:**
+- Modify: `client/src/api/files.ts`
+- Test: `client/src/__tests__/api/files.test.ts`
+- Modify: `client/src/__tests__/api/plugins.scopeCatalog.test.ts`
+
+**Interfaces:**
+- Produces: `getFilePermissions(path: string)` (Signatur unverändert, intern plain GET — KEINE Query-Beteiligung, siehe Spec §3.5: kein Persister-Bloat, immer frische Rechte). `FileManager.tsx` bleibt unberührt.
+
+- [ ] **Step 1: Tests anpassen (failing)**
+
+In `client/src/__tests__/api/files.test.ts`:
+
+Mock-Factory (Zeilen 10-16) ersetzen durch:
+
+```ts
+vi.mock('../../lib/api', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+```
+
+Import (Zeile 18) ändern zu:
+
+```ts
+import { apiClient } from '../../lib/api';
+```
+
+In `beforeEach`: `vi.mocked(memoizedApiRequest).mockReset();` ersetzen durch `vi.mocked(apiClient.get).mockReset();`.
+
+Den Test `'getFilePermissions uses memoizedApiRequest'` (Zeilen 40-46) ersetzen durch:
+
+```ts
+  it('getFilePermissions calls GET with the path param (always fresh, no memo cache)', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { owner_id: 1, rules: [] } });
+
+    const result = await getFilePermissions('/my/file.txt');
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/files/permissions', { params: { path: '/my/file.txt' } });
+    expect(result).toEqual({ owner_id: 1, rules: [] });
+  });
+```
+
+In `client/src/__tests__/api/plugins.scopeCatalog.test.ts`: die Zeile 7 `memoizedApiRequest: vi.fn(),` aus der `vi.mock('../../lib/api', ...)`-Factory entfernen (Rest der Factory unverändert).
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/api/files.test.ts src/__tests__/api/plugins.scopeCatalog.test.ts`
+Expected: `files.test.ts` FAIL (`getFilePermissions` ruft noch `memoizedApiRequest`, das die Factory nicht mehr liefert); `plugins.scopeCatalog.test.ts` PASS (der Eintrag war eine unbenutzte Leiche).
+
+- [ ] **Step 3: files.ts umbauen**
+
+In `client/src/api/files.ts`:
+
+Import (Zeile 5) ändern zu:
+
+```ts
+import { apiClient } from '../lib/api';
+```
+
+`getFilePermissions` (Zeilen 29-32) ersetzen durch:
+
+```ts
+export async function getFilePermissions(path: string) {
+  // Plain read on purpose: the permission dialog must always show fresh
+  // rules (the old 60s memo cache could serve stale ones) and this
+  // user-scoped data must not be mirrored into the persisted query cache.
+  const res = await apiClient.get(`/api/files/permissions`, { params: { path } });
+  return res.data;
+}
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen bestehen**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run src/__tests__/api/files.test.ts src/__tests__/api/plugins.scopeCatalog.test.ts`
+Expected: PASS (alle Tests beider Dateien).
+
+- [ ] **Step 5: Commit**
+
+```powershell
+cd "D:\Programme (x86)\Baluhost"; git add client/src/api/files.ts client/src/__tests__/api/files.test.ts client/src/__tests__/api/plugins.scopeCatalog.test.ts; git commit -m "refactor(client): getFilePermissions as plain read — always fresh, no memo cache (#299)"
+```
+
+---
+
+### Task 11: lib/api.ts — apiCache + memoizedApiRequest löschen
+
+**Files:**
+- Modify: `client/src/lib/api.ts:82-97`
+
+**Interfaces:**
+- Produces: `lib/api.ts` exportiert NUR noch `API_VERSION`, `isTauri`, `API_BASE_URL`, `buildApiUrl`, `apiClient`, `fireAuthExpired`, `extractErrorMessage`. `apiCache`, `memoizedApiRequest`, `CacheEntry`, `DEFAULT_TTL` existieren nicht mehr — der Compiler erzwingt, dass Tasks 3-10 alle Konsumenten erwischt haben.
+
+- [ ] **Step 1: Block löschen**
+
+In `client/src/lib/api.ts` die Zeilen 82-97 komplett entfernen:
+
+```ts
+// --- Memoized API Request Utility ---
+type CacheEntry = { data: any; expires: number };
+export const apiCache = new Map<string, CacheEntry>();
+const DEFAULT_TTL = 60 * 1000; // 60 Sekunden
+
+export async function memoizedApiRequest<T = any>(url: string, params?: any, ttl: number = DEFAULT_TTL): Promise<T> {
+  const key = url + JSON.stringify(params || {});
+  const now = Date.now();
+  const cached = apiCache.get(key);
+  if (cached && cached.expires > now) {
+    return cached.data;
+  }
+  const res = await apiClient.get(url, { params });
+  apiCache.set(key, { data: res.data, expires: now + ttl });
+  return res.data;
+}
+```
+
+(`extractErrorMessage` darunter bleibt.)
+
+- [ ] **Step 2: Compile-Gate — beweist, dass kein Konsument übrig ist**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npm run build`
+Expected: Build erfolgreich. Ein Fehler `Module '"../lib/api"' has no exported member 'memoizedApiRequest'` hieße: ein Konsument wurde in Tasks 3-10 übersehen — dann dort fixen, NICHT den Export wiederherstellen.
+
+- [ ] **Step 3: Volle Testsuite**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run`
+Expected: PASS — komplett grün (insb. keine `vi.mock`-Factory referenziert die entfernten Exporte mehr).
+
+- [ ] **Step 4: Commit**
+
+```powershell
+cd "D:\Programme (x86)\Baluhost"; git add client/src/lib/api.ts; git commit -m "refactor(client): remove apiCache + memoizedApiRequest — superseded by TanStack Query (#299, closes #309)"
+```
+
+---
+
+### Task 12: CLAUDE.md-Doku, Schlussgates, Index
+
+**Files:**
+- Modify: `client/src/lib/CLAUDE.md`
+- Modify: `client/src/api/CLAUDE.md`
+- Modify: `client/src/hooks/CLAUDE.md`
+- Modify: `client/src/contexts/CLAUDE.md`
+
+- [ ] **Step 1: lib/CLAUDE.md**
+
+In der Files-Tabelle die `api.ts`-Zeile ersetzen durch:
+
+```markdown
+| `api.ts` | **Core API client**: axios instance (`apiClient`), auth interceptor, 401 handling, `buildApiUrl()` for dev/prod path resolution, API version check via `X-API-Min-Version` header |
+```
+
+Im „Key Patterns"-Block die Zeile ``- `memoizedApiRequest()` uses an in-memory `Map` cache with configurable TTL (default 60s)`` ersetzen durch:
+
+```markdown
+- The old `memoizedApiRequest()` Map cache is gone (#299/#309) — caching/dedup is TanStack Query's job; api/* functions are plain typed calls
+```
+
+- [ ] **Step 2: api/CLAUDE.md**
+
+Im „Base Client"-Block die Zeile ``- `memoizedApiRequest<T>(url, params?, ttl?)` — GET with in-memory cache (60s default TTL)`` löschen.
+
+In „Conventions" die Zeile ``- Use `memoizedApiRequest()` for frequently polled read-only data (e.g., permissions, system info)`` ersetzen durch:
+
+```markdown
+- No client-side memo caching in api/* — read-caching/dedup lives in TanStack Query hooks (`useQuery` + `lib/queryKeys.ts`); mutations invalidate their domain (`invalidateQueries`)
+```
+
+- [ ] **Step 3: hooks/CLAUDE.md**
+
+In der Data-Fetching-Tabelle nach der `useRaidStatus.ts`-Zeile ergänzen:
+
+```markdown
+| `useBackups.ts` | `api/backup` | Backup list via **TanStack Query** (no polling; create/delete mutations invalidate). Returns raw `error` for i18n formatting by the caller |
+| `useFileShares.ts` | `api/shares` | The three shares-domain reads (user shares, shared-with-me, statistics) via **TanStack Query**; user-scoped — cache is cleared on every identity change (AuthContext) |
+```
+
+In „Conventions" nach der Query-Polling-Zeile ergänzen:
+
+```markdown
+- **Mutations use `useMutation`** with `onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.<domain>.all() })` — reference implementations: `BackupSettings.tsx`, the share modals (`CreateFileShareModal`/`EditFileShareModal`/`ShareFileModal` invalidate themselves so every mount point is covered), `SharesPage.tsx`
+```
+
+- [ ] **Step 4: contexts/CLAUDE.md**
+
+In der `AuthContext.tsx`-Tabellenzeile den Purpose-Text ergänzen um:
+
+```markdown
+Clears the TanStack Query cache + persisted blob on EVERY identity change (login, logout, impersonate, endImpersonation, auth-expiry) so user-scoped queries never leak across users (#299)
+```
+
+- [ ] **Step 5: Schlussgates (alle drei, aus Memory-Pflicht)**
+
+Run: `cd "D:\Programme (x86)\Baluhost\client"; npx vitest run; if ($?) { npx eslint . }; if ($?) { npm run build }`
+Expected: Suite komplett PASS; ESLint 0 Errors; Build erfolgreich.
+
+- [ ] **Step 6: vectordb-Index aktualisieren**
+
+`mcp__vectordb-search__index_update` mit projectPath `D:/Programme (x86)/Baluhost` aufrufen (neue Hooks/gelöschte Exporte indexieren).
+
+- [ ] **Step 7: Commit**
+
+```powershell
+cd "D:\Programme (x86)\Baluhost"; git add client/src/lib/CLAUDE.md client/src/api/CLAUDE.md client/src/hooks/CLAUDE.md client/src/contexts/CLAUDE.md; git commit -m "docs(client): CLAUDE.md updates for memoizedApiRequest removal + mutation pattern (#299)"
+```
+
+---
+
+## Nach Abschluss (nicht Teil der Tasks — Operator-Schritte)
+
+1. Push + PR gegen `main` (Release-Workflow: PR, kein lokaler Merge): `git push -u origin feat/tanstack-query-memoized-cache-299`, dann `gh pr create` (Body via `--body-file`, referenziert #299 + `Closes #309`).
+2. In #299 die Checkbox „PR — memoizedApiRequest ablösen" abhaken + Hinweis, dass die Impersonation-Cache-Leerung (Hinweis-Block im Issue) umgesetzt ist.
+3. Manueller Smoke (dev, `python start_dev.py`): Backup anlegen/löschen (Liste refresht ohne Reload), Share im FileManager anlegen → SharesPage zeigt ihn, Impersonation starten/beenden → keine fremden Shares sichtbar, F5 auf Dashboard → Instant-Paint intakt.

--- a/docs/superpowers/specs/2026-07-03-memoized-api-request-tanstack-query-design.md
+++ b/docs/superpowers/specs/2026-07-03-memoized-api-request-tanstack-query-design.md
@@ -1,0 +1,253 @@
+# Design: `memoizedApiRequest` ablösen → TanStack Query
+
+**Datum:** 2026-07-03
+**Issue:** #299 (F1, Bullet „memoizedApiRequest ablösen") — schließt #309 (F6)
+**Vorgänger:** #364 (Fundament), #365 (Telemetry), #366 (Dashboard-Caches/Persister)
+
+---
+
+## 1. Ziel & Scope
+
+Der In-Memory-`Map`-Cache (`apiCache` + `memoizedApiRequest`) in `client/src/lib/api.ts:82-97`
+ist einer der drei konkurrierenden Cache-Ansätze aus Finding F1. Er wird **ersatzlos
+entfernt**; seine drei echten Konsumenten werden auf TanStack Query migriert (idiomatisch:
+`useQuery` für Reads, `useMutation` + `invalidateQueries` für Writes).
+
+Damit ist F6/#309 **vollständig** erledigt:
+- Der Map-Cache-ohne-Invalidierung fällt weg (diese PR).
+- Das `Dashboard.tsx`-`sessionStorage`-Parsing-pro-Render wurde bereits durch **#366**
+  entfernt (Dashboard nutzt jetzt `useSystemTelemetry`/`useRaidStatus`, verifiziert).
+
+**Bewusst NICHT in Scope** (bleibt der späteren „restliche Daten-Hooks bereichsweise"-PR):
+- Cloud-Export-Reads in `SharesPage` (eigene Domain `cloud-export.ts`, nie memoized).
+- Sonstige nicht-memoized `useState`/`useEffect`-Fetches.
+
+---
+
+## 2. Ist-Zustand (vollständige Oberfläche)
+
+**Der Cache** (`lib/api.ts:82-97`): `apiCache = new Map<string, {data, expires}>()`,
+`memoizedApiRequest(url, params?, ttl=60s)`, **keine Invalidierung außer TTL**.
+
+**4 Producer-Funktionen:**
+
+| Funktion | Endpoint | Konsument | Status |
+|----------|----------|-----------|--------|
+| `listBackups()` `backup.ts:66` | `GET /api/backups/` | `BackupSettings.tsx:39` (useEffect, 1×/Mount) | invalidiert via `apiCache.clear()` |
+| `getBackup(id)` `backup.ts:74` | `GET /api/backups/{id}/` | **niemand** | **toter Code** |
+| `getFilePermissions(path)` `files.ts:31` | `GET /api/files/permissions` | `FileManager.tsx:570` (Click-Handler, on-demand) | TTL → potenziell veraltete Rechte |
+| `listFileShares()` `shares.ts:99` | `GET /api/shares/user-shares` | `SharesPage.tsx:72` (in `loadData` Promise.all) | invalidiert via `apiCache.delete()` |
+
+**2 Invalidierungs-Muster:**
+- `shares.ts:93/117/123` → `apiCache.delete(SHARES_CACHE_KEY)` nach create/update/delete.
+- `BackupSettings.tsx:65/82` → `apiCache.clear()` — **löscht den gesamten Cache** (globaler
+  Holzhammer, nicht nur Backups).
+
+**Etablierte Konventionen (aus #364/#365/#366):**
+- `lib/queryClient.ts`: App-weiter `QueryClient` (`staleTime 0`, `retry 1`,
+  `refetchOnWindowFocus false`, `gcTime 24h`).
+- `lib/queryPersister.ts`: spiegelt den **gesamten** Query-Cache nach `sessionStorage`
+  (`baluhost-query-cache`, 24h `maxAge`, `API_VERSION` buster).
+- `lib/queryKeys.ts`: zentrale Key-Factory `queryKeys.<domain>.<entity>()`.
+- Referenz-Read-Hook: `hooks/useRaidStatus.ts` (`useQuery`, Rückgabe
+  `{ data, loading, error, refetch }`).
+- **`useMutation` existiert im Frontend noch NICHT** — diese PR etabliert es erstmalig.
+
+---
+
+## 3. Architektur der Änderung
+
+### 3.1 `lib/queryKeys.ts` — neue Domains
+
+```ts
+backups: {
+  list: () => ['backups', 'list'] as const,
+},
+shares: {
+  userShares:   () => ['shares', 'user-shares'] as const,
+  sharedWithMe: () => ['shares', 'shared-with-me'] as const,
+  statistics:   () => ['shares', 'statistics'] as const,
+},
+files: {
+  permissions: (path: string) => ['files', 'permissions', path] as const,
+},
+```
+
+### 3.2 `lib/api.ts` — Cleanup
+
+`CacheEntry`, `apiCache`, `DEFAULT_TTL`, `memoizedApiRequest` **löschen**. Rest unverändert
+(`apiClient`, Interceptors, `buildApiUrl`, `extractErrorMessage`, `fireAuthExpired`).
+
+### 3.3 Backups-Domain
+
+**`api/backup.ts`:**
+- `listBackups()` → plain `apiClient.get('/api/backups/')`.
+- `getBackup(id)` → **löschen** (toter Code).
+
+**Neuer Hook `hooks/useBackups.ts`** (Muster: `useRaidStatus`):
+```ts
+export function useBackups() {
+  const query = useQuery({
+    queryKey: queryKeys.backups.list(),
+    queryFn: listBackups,   // kein refetchInterval — Admin-Daten, manueller Refresh
+  });
+  return { backups: query.data?.backups ?? [], loading: query.isLoading,
+           error: query.isError ? getApiErrorMessage(query.error, ...) : null,
+           refetch: query.refetch };
+}
+```
+
+**`BackupSettings.tsx`** (Mutations-Muster **1 — `useMutation`**):
+- `useState<Backup[]>` + `useEffect(loadBackups)` → `useBackups()`.
+- `totalSizeBytes` aus `backups` ableiten (`useMemo` oder inline reduce).
+- `createBackup`/`deleteBackup` → je ein `useMutation` mit
+  `onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.backups.list() })`
+  und `onError` → `setError(getApiErrorMessage(...))`.
+- Lokale Booleans `creating`/`deleting` → `mutation.isPending`.
+- `apiCache.clear()`-Zeilen + der `apiCache`-Import **entfernen**.
+- `restoreBackup` bleibt plain Call (lädt via `window.location.reload()` die Seite neu →
+  keine Query-Invalidierung nötig). `restoring`-Boolean darf bleiben oder ebenfalls
+  `useMutation.isPending` werden (Implementierungsdetail).
+
+### 3.4 Shares-Domain (SharesPage — **Breite A: 3 Reads**)
+
+**`api/shares.ts`:**
+- `listFileShares()` → plain `apiClient.get('/api/shares/user-shares')`.
+- `SHARES_CACHE_KEY` + alle `apiCache.delete(...)`-Zeilen (create/update/delete) + der
+  `apiCache`/`memoizedApiRequest`-Import **entfernen**.
+
+**Neuer Hook `hooks/useFileShares.ts`** (3× `useQuery`):
+```ts
+export function useFileShares() {
+  const userShares   = useQuery({ queryKey: queryKeys.shares.userShares(),   queryFn: listFileShares });
+  const sharedWithMe = useQuery({ queryKey: queryKeys.shares.sharedWithMe(), queryFn: listFilesSharedWithMe });
+  const statistics   = useQuery({ queryKey: queryKeys.shares.statistics(),   queryFn: getShareStatistics });
+  return { fileShares: userShares.data ?? [], sharedWithMe: sharedWithMe.data ?? [],
+           statistics: statistics.data ?? null,
+           loading: userShares.isLoading || sharedWithMe.isLoading || statistics.isLoading,
+           error: ..., refetch: ... };
+}
+```
+
+**`SharesPage.tsx`:**
+- Die 3 Shares-Reads aus `loadData()` entfernen → `useFileShares()`.
+- **Cloud-Exports bleiben** (`listCloudExports`/`getCloudExportStatistics`) — in eine kleine
+  `loadCloudExports()`-Funktion + eigenen `useEffect` extrahieren (eigener `'cloud-exports'`-Tab,
+  eigenes lokales Loading). Nicht Teil dieser PR.
+- `deleteFileShare` → `useMutation` mit `onSuccess: invalidateQueries(shares.*)`
+  (userShares **und** statistics; sharedWithMe unberührt vom eigenen Löschen, aber
+  Invalidierung der ganzen `['shares']`-Domain via Prefix ist zulässig und simpler).
+- Create/Edit-Modals (`CreateFileShareModal`, `EditFileShareModal`): deren `onSuccess`-Callback
+  ruft statt `loadData()` künftig `invalidateQueries(['shares'])`. Die Modals selbst rufen
+  `createFileShare`/`updateFileShare` (unverändert) — Invalidierung erfolgt im Parent-Callback.
+
+### 3.5 File-Permissions (FileManager — imperativ)
+
+`getFilePermissions` läuft **on-demand im Click-Handler** (`handleEditPermissionsClick`), ist
+also **keine** Render-Query → `useQuery` passt nicht.
+
+**`api/files.ts`:** `getFilePermissions(path)` → plain `apiClient.get('/api/files/permissions', { params: { path } })`.
+
+**`FileManager.tsx:570`:**
+```ts
+const perms = await queryClient.fetchQuery({
+  queryKey: queryKeys.files.permissions(file.path),
+  queryFn: () => getFilePermissions(file.path),
+  staleTime: 60_000,   // dedupt schnelle Re-Opens, aber invalidierbar
+});
+```
+Nach `setFilePermissions(...)` (PUT, im Speichern-Handler des Permission-Editors) →
+`queryClient.invalidateQueries({ queryKey: queryKeys.files.permissions(path) })`. **Bonus:**
+behebt die alte Staleness des TTL-Cache (Rechte waren bis zu 60s veraltet).
+
+### 3.6 ⚠️ Impersonation-Cache-Leerung (der #299-Hinweis wird hier real)
+
+`listFileShares` ist **user-scoped** (per `current_user`), und der globale Persister spiegelt
+es nach `sessionStorage`. Heute leert **nur `logout()`** den Query-Cache
+(`queryClient.clear(); void queryPersister.removeClient();`, `AuthContext.tsx:112-113`).
+`impersonate()`, `endImpersonation()` und der Impersonation-Zweig des `auth:expired`-Handlers
+tun das **nicht**.
+
+Ohne Fix: Beim Impersonation-Token-Swap bliebe die persistierte Shares-/Permissions-Query des
+*vorherigen* Users kurz sichtbar, bis der Refetch greift — ein Korrektheits-/Sicherheitsproblem
+(ein User sieht kurz die Shares eines anderen). Das ist exakt die Absicherung, die #299 für den
+ersten user-scoped Hook angekündigt hat.
+
+**Fix in `AuthContext.tsx`:** die vorhandene Cache-Leerung in einen kleinen internen Helfer
+ziehen …
+```ts
+const clearQueryCache = () => { queryClient.clear(); void queryPersister.removeClient(); };
+```
+… und in **allen drei** Token-Swap-Pfaden aufrufen:
+1. `impersonate()` — nach erfolgreichem `apiImpersonateUser` + Token-Swap.
+2. `endImpersonation()` — nach dem Restore auf den Origin-Token.
+3. Der Impersonation-Zweig des `auth:expired`-Handlers (Zeile ~158-174), der ebenfalls den
+   Token wechselt.
+
+`logout()` nutzt denselben Helfer (Refactor ohne Verhaltensänderung).
+
+---
+
+## 4. Tests
+
+- **`__tests__/api/files.test.ts`:** `getFilePermissions`-Test auf
+  `apiClient.get('/api/files/permissions', { params: { path } })` umstellen; `memoizedApiRequest`
+  aus der `vi.mock('../../lib/api', …)`-Factory entfernen; `apiClient.get` zur Mock-Factory
+  hinzufügen.
+- **`__tests__/api/shares.test.ts`:** `apiCache.delete`-Assertions entfernen; die create/update/
+  delete-Tests auf `apiClient.post/patch/delete` prüfen; `apiCache` aus der Mock-Factory raus.
+- **`__tests__/api/plugins.scopeCatalog.test.ts:7`:** `memoizedApiRequest`-Leiche aus der
+  Mock-Factory entfernen (harmlos, aber sauber).
+- **Neu `__tests__/hooks/useBackups.test.ts`** + **`useFileShares.test.ts`** (Vorlage:
+  `__tests__/hooks/useActivityFeed.test.ts`) — `QueryClientProvider`-Wrapper, gemockte
+  api-Funktion, `loading`/`data`/`error` prüfen.
+- **`__tests__/contexts/AuthContext.impersonation.test.tsx`** (existiert): eine Assertion
+  ergänzen, dass `impersonate`/`endImpersonation` den Query-Cache leeren (z. B. `queryClient.clear`
+  gespäht wird).
+
+**Pre-PR-Gates** (aus Memory): `cd client; npx vitest run` (echte Suite),
+`npx eslint .` (0-Error-Gate), `npm run build` (tsc -b über app/node/TEST).
+
+---
+
+## 5. Docs & Issue-Tracking
+
+- **`lib/CLAUDE.md`:** `memoizedApiRequest`-Zeile in der Files-Tabelle + im „Key Patterns"-Block
+  entfernen.
+- **`api/CLAUDE.md`:** `memoizedApiRequest` aus „Base Client" + „Conventions" entfernen.
+- **`hooks/CLAUDE.md`:** `useBackups`, `useFileShares` in die Data-Fetching-Tabelle aufnehmen;
+  ggf. Hinweis auf das neue `useMutation`+`invalidateQueries`-Muster in „Conventions".
+- **`contexts/CLAUDE.md`:** `logout()`/Impersonation-Zeile um „leert Query-Cache" ergänzen.
+- **#299:** Checkbox „memoizedApiRequest ablösen" abhaken; Hinweis, dass die Impersonation-
+  Absicherung nun umgesetzt ist.
+- **#309:** schließen (beide F6-Hälften erledigt).
+
+---
+
+## 6. Blast-Radius & Risiken
+
+**Berührte Dateien (Kern):** `lib/api.ts`, `lib/queryKeys.ts`, `api/backup.ts`, `api/shares.ts`,
+`api/files.ts`, `hooks/useBackups.ts` (neu), `hooks/useFileShares.ts` (neu),
+`components/BackupSettings.tsx`, `pages/SharesPage.tsx`, `pages/FileManager.tsx`,
+`components/CreateFileShareModal.tsx` + `EditFileShareModal.tsx` (nur onSuccess-Callback im
+Parent), `contexts/AuthContext.tsx` + 4 CLAUDE.md + 3–5 Tests.
+
+**Risiken:**
+- *Verlust des 60s-TTL-Dedup:* vernachlässigbar — alle Konsumenten laden 1×/Mount oder on-demand;
+  bei `getFilePermissions` ist Frische sogar korrekter.
+- *Erstes `useMutation`:* neues Muster, muss beim Review sitzen — dafür ersetzt `isPending`/`onError`
+  echten Boilerplate (nicht nur Zeremonie).
+- *Persister spiegelt jetzt Backups/Shares/Permissions:* gewollt (F5-Instant-Paint); Impersonation
+  wird explizit adressiert (§3.6); `logout()` leert bereits.
+- *`BackupPage.tsx` (`/backups`)* rendert vermutlich `BackupSettings` — beim Implementieren
+  verifizieren, dass es keinen zweiten `listBackups`-Konsumenten gibt (git-grep zeigt nur
+  `BackupSettings.tsx`).
+
+---
+
+## 7. Nordstern-Bezug
+
+Entfernt Cache-Ansatz #3 von 3 (nach memoized-Map ← diese PR; sessionStorage ← #366).
+Etabliert das `useMutation`-Muster für alle späteren mutation-lastigen Domain-PRs
+(„restliche Daten-Hooks bereichsweise": users, schedulers, devices, …).
+`useAsyncData.ts`-Aufräumen bleibt der finalen „Aufräumen"-PR vorbehalten.

--- a/docs/superpowers/specs/2026-07-03-memoized-api-request-tanstack-query-design.md
+++ b/docs/superpowers/specs/2026-07-03-memoized-api-request-tanstack-query-design.md
@@ -64,14 +64,15 @@ backups: {
   list: () => ['backups', 'list'] as const,
 },
 shares: {
+  all:          () => ['shares'] as const,   // Prefix für domain-weite Invalidierung
   userShares:   () => ['shares', 'user-shares'] as const,
   sharedWithMe: () => ['shares', 'shared-with-me'] as const,
   statistics:   () => ['shares', 'statistics'] as const,
 },
-files: {
-  permissions: (path: string) => ['files', 'permissions', path] as const,
-},
 ```
+
+Keine `files`-Domain: File-Permissions bleiben ein imperativer Plain-Read ohne
+Query-Beteiligung (siehe §3.5).
 
 ### 3.2 `lib/api.ts` — Cleanup
 
@@ -122,69 +123,98 @@ export function useFileShares() {
   const userShares   = useQuery({ queryKey: queryKeys.shares.userShares(),   queryFn: listFileShares });
   const sharedWithMe = useQuery({ queryKey: queryKeys.shares.sharedWithMe(), queryFn: listFilesSharedWithMe });
   const statistics   = useQuery({ queryKey: queryKeys.shares.statistics(),   queryFn: getShareStatistics });
-  return { fileShares: userShares.data ?? [], sharedWithMe: sharedWithMe.data ?? [],
-           statistics: statistics.data ?? null,
-           loading: userShares.isLoading || sharedWithMe.isLoading || statistics.isLoading,
-           error: ..., refetch: ... };
+  return {
+    fileShares:   userShares.data ?? [],
+    sharedWithMe: sharedWithMe.data ?? [],
+    statistics:   statistics.data ?? null,
+    loading: userShares.isLoading || sharedWithMe.isLoading || statistics.isLoading,
+    // SharesPage schluckt Ladefehler heute (Empty-State); erster fehlgeschlagener
+    // Query liefert die Message für optionale Anzeige:
+    error: [userShares, sharedWithMe, statistics].find(q => q.isError)?.error ?? null,
+    refetch: () => Promise.all([userShares.refetch(), sharedWithMe.refetch(), statistics.refetch()]),
+  };
 }
 ```
+
+**Invalidierung lebt in den Modals (zentrale Semantik erhalten):** Der alte
+`apiCache.delete(SHARES_CACHE_KEY)` saß *in* `createFileShare`/`updateFileShare`/
+`deleteFileShare` — damit invalidierte **jede** Mutation-Site automatisch, egal wo gemountet.
+Wichtig, denn es gibt eine Mutation-Site **außerhalb** der SharesPage: `ShareFileModal`
+(gemountet in `FileManager.tsx:900`) ruft ebenfalls `createFileShare`. Diese zentrale
+Semantik bleibt erhalten, indem die Invalidierung in die Modals wandert:
+- `CreateFileShareModal`, `EditFileShareModal`, `ShareFileModal` rufen nach erfolgreicher
+  Mutation selbst `queryClient.invalidateQueries({ queryKey: queryKeys.shares.all() })`
+  (Prefix `['shares']` → alle 3 Reads).
+- Die `onSuccess`-Parent-Callbacks bleiben rein UI (Modal schließen, Toast) — das bisherige
+  `loadData()` darin entfällt für die Shares-Hälfte.
 
 **`SharesPage.tsx`:**
 - Die 3 Shares-Reads aus `loadData()` entfernen → `useFileShares()`.
 - **Cloud-Exports bleiben** (`listCloudExports`/`getCloudExportStatistics`) — in eine kleine
   `loadCloudExports()`-Funktion + eigenen `useEffect` extrahieren (eigener `'cloud-exports'`-Tab,
   eigenes lokales Loading). Nicht Teil dieser PR.
-- `deleteFileShare` → `useMutation` mit `onSuccess: invalidateQueries(shares.*)`
-  (userShares **und** statistics; sharedWithMe unberührt vom eigenen Löschen, aber
-  Invalidierung der ganzen `['shares']`-Domain via Prefix ist zulässig und simpler).
-- Create/Edit-Modals (`CreateFileShareModal`, `EditFileShareModal`): deren `onSuccess`-Callback
-  ruft statt `loadData()` künftig `invalidateQueries(['shares'])`. Die Modals selbst rufen
-  `createFileShare`/`updateFileShare` (unverändert) — Invalidierung erfolgt im Parent-Callback.
+- `deleteFileShare` → `useMutation` mit `onSuccess: invalidateQueries(shares.all)`
+  (Löschen ändert userShares **und** statistics; Prefix-Invalidierung ist simpler und korrekt).
 
-### 3.5 File-Permissions (FileManager — imperativ)
+### 3.5 File-Permissions (FileManager — plain Call, KEINE Query-Beteiligung)
 
-`getFilePermissions` läuft **on-demand im Click-Handler** (`handleEditPermissionsClick`), ist
-also **keine** Render-Query → `useQuery` passt nicht.
+`getFilePermissions` läuft **on-demand im Click-Handler** (`handleEditPermissionsClick`,
+`FileManager.tsx:570`), ist also keine Render-Query — und auch `fetchQuery` wäre hier
+**überengineert**:
+- Der app-weite `gcTime` von 24h (Persister-Anforderung) würde user-scoped Rechte-Daten
+  **pro je geöffnetem Datei-Pfad** 24h in den sessionStorage-Persister spiegeln — Bloat
+  ohne Nutzen.
+- Der Dedup-Gewinn ist ~null (niemand öffnet denselben Permissions-Dialog mehrfach pro
+  Minute mit Performance-Not).
 
-**`api/files.ts`:** `getFilePermissions(path)` → plain `apiClient.get('/api/files/permissions', { params: { path } })`.
+**Entscheidung:** `api/files.ts` → `getFilePermissions(path)` wird plain
+`apiClient.get('/api/files/permissions', { params: { path } })`; der Call-Site in
+`FileManager.tsx` bleibt unverändert (`await getFilePermissions(file.path)`). Kein
+Query-Cache, keine Invalidierung, keine `queryKeys.files`-Domain.
 
-**`FileManager.tsx:570`:**
-```ts
-const perms = await queryClient.fetchQuery({
-  queryKey: queryKeys.files.permissions(file.path),
-  queryFn: () => getFilePermissions(file.path),
-  staleTime: 60_000,   // dedupt schnelle Re-Opens, aber invalidierbar
-});
-```
-Nach `setFilePermissions(...)` (PUT, im Speichern-Handler des Permission-Editors) →
-`queryClient.invalidateQueries({ queryKey: queryKeys.files.permissions(path) })`. **Bonus:**
-behebt die alte Staleness des TTL-Cache (Rechte waren bis zu 60s veraltet).
+**Verhaltensänderung (gewollt):** Der Dialog zeigt jetzt **immer frische** Rechte. Der alte
+TTL-Cache lieferte bis zu 60s veraltete Rechte — nach eigenem PUT *und* bei
+Fremd-Änderungen. Beides ist damit behoben (die `fetchQuery`-Alternative mit
+`staleTime 60s` hätte die Fremd-Änderungs-Staleness behalten).
 
-### 3.6 ⚠️ Impersonation-Cache-Leerung (der #299-Hinweis wird hier real)
+### 3.6 ⚠️ Cache-Leerung bei JEDEM Identitätswechsel (der #299-Hinweis wird hier real)
 
 `listFileShares` ist **user-scoped** (per `current_user`), und der globale Persister spiegelt
 es nach `sessionStorage`. Heute leert **nur `logout()`** den Query-Cache
 (`queryClient.clear(); void queryPersister.removeClient();`, `AuthContext.tsx:112-113`).
-`impersonate()`, `endImpersonation()` und der Impersonation-Zweig des `auth:expired`-Handlers
-tun das **nicht**.
+Sobald user-scoped Queries existieren, muss aber **jeder** Identitätswechsel leeren, sonst
+sieht der neue User kurz die Daten des alten (Instant-Paint aus dem Persister!), bis der
+Refetch greift — ein Korrektheits-/Sicherheitsproblem. Betroffen sind **fünf** Pfade, von
+denen heute keiner leert:
 
-Ohne Fix: Beim Impersonation-Token-Swap bliebe die persistierte Shares-/Permissions-Query des
-*vorherigen* Users kurz sichtbar, bis der Refetch greift — ein Korrektheits-/Sicherheitsproblem
-(ein User sieht kurz die Shares eines anderen). Das ist exakt die Absicherung, die #299 für den
-ersten user-scoped Hook angekündigt hat.
+1. `impersonate()` — nach erfolgreichem `apiImpersonateUser` + Token-Swap.
+2. `endImpersonation()` — nach dem Restore auf den Origin-Token.
+3. Impersonation-Zweig des `auth:expired`-Handlers (`AuthContext.tsx:158-174`) — swappt
+   ebenfalls den Token.
+4. **`login()`** (`AuthContext.tsx:96-100`) — deckt den Leak über den Ablauf-Pfad ab:
+   Token läuft ab → `auth:expired` (Plain-Zweig) setzt nur `token/user = null`, Cache +
+   Persister behalten die Daten → ein *anderer* User loggt sich auf demselben Tab ein →
+   sähe ohne Leerung kurz die Shares des Vorgängers. `login()` ist der Single Choke Point
+   für jede neue Session.
+5. Plain-Zweig des `auth:expired`-Handlers (`AuthContext.tsx:175-178`) — Defense in Depth:
+   räumt den Persister schon beim Sessionende auf, statt die Daten bis zum nächsten
+   `login()` im sessionStorage liegen zu lassen.
 
 **Fix in `AuthContext.tsx`:** die vorhandene Cache-Leerung in einen kleinen internen Helfer
 ziehen …
 ```ts
 const clearQueryCache = () => { queryClient.clear(); void queryPersister.removeClient(); };
 ```
-… und in **allen drei** Token-Swap-Pfaden aufrufen:
-1. `impersonate()` — nach erfolgreichem `apiImpersonateUser` + Token-Swap.
-2. `endImpersonation()` — nach dem Restore auf den Origin-Token.
-3. Der Impersonation-Zweig des `auth:expired`-Handlers (Zeile ~158-174), der ebenfalls den
-   Token wechselt.
+… und in allen fünf Pfaden + `logout()` aufrufen (`logout()` = Refactor ohne
+Verhaltensänderung). Reihenfolge bei den Swap-Pfaden: **erst Token swappen, dann leeren**,
+damit die von `clear()` ausgelösten Refetches bereits den neuen Token tragen.
 
-`logout()` nutzt denselben Helfer (Refactor ohne Verhaltensänderung).
+**Bekannter Trade-off (akzeptiert):** Bei `logout()` unmountet danach ohnehin alles Richtung
+Login-Screen. Bei `impersonate()`/`endImpersonation()` bleibt die App gemountet —
+`queryClient.clear()` reißt allen aktiven Queries (Monitoring-Polls etc.) die Daten weg →
+kurzer app-weiter Loading-Flash beim Identitätswechsel. Korrektheit > Kosmetik; eine
+selektive Invalidierung nur user-scoped Domains wäre fehleranfällig (jede neue user-scoped
+Domain müsste registriert werden) und lohnt bei der Seltenheit von Impersonation nicht.
 
 ---
 
@@ -201,9 +231,9 @@ const clearQueryCache = () => { queryClient.clear(); void queryPersister.removeC
 - **Neu `__tests__/hooks/useBackups.test.ts`** + **`useFileShares.test.ts`** (Vorlage:
   `__tests__/hooks/useActivityFeed.test.ts`) — `QueryClientProvider`-Wrapper, gemockte
   api-Funktion, `loading`/`data`/`error` prüfen.
-- **`__tests__/contexts/AuthContext.impersonation.test.tsx`** (existiert): eine Assertion
-  ergänzen, dass `impersonate`/`endImpersonation` den Query-Cache leeren (z. B. `queryClient.clear`
-  gespäht wird).
+- **`__tests__/contexts/AuthContext.impersonation.test.tsx`** (existiert): Assertions
+  ergänzen, dass `impersonate`/`endImpersonation` **und** `login()` den Query-Cache leeren
+  (z. B. `queryClient.clear` gespäht wird) — deckt alle fünf §3.6-Pfade soweit testbar ab.
 
 **Pre-PR-Gates** (aus Memory): `cd client; npx vitest run` (echte Suite),
 `npx eslint .` (0-Error-Gate), `npm run build` (tsc -b über app/node/TEST).
@@ -228,20 +258,24 @@ const clearQueryCache = () => { queryClient.clear(); void queryPersister.removeC
 
 **Berührte Dateien (Kern):** `lib/api.ts`, `lib/queryKeys.ts`, `api/backup.ts`, `api/shares.ts`,
 `api/files.ts`, `hooks/useBackups.ts` (neu), `hooks/useFileShares.ts` (neu),
-`components/BackupSettings.tsx`, `pages/SharesPage.tsx`, `pages/FileManager.tsx`,
-`components/CreateFileShareModal.tsx` + `EditFileShareModal.tsx` (nur onSuccess-Callback im
-Parent), `contexts/AuthContext.tsx` + 4 CLAUDE.md + 3–5 Tests.
+`components/BackupSettings.tsx`, `pages/SharesPage.tsx`,
+`components/CreateFileShareModal.tsx` + `EditFileShareModal.tsx` + `ShareFileModal.tsx`
+(Invalidierung nach Mutation, §3.4), `contexts/AuthContext.tsx` + 4 CLAUDE.md + 3–5 Tests.
+`pages/FileManager.tsx` bleibt unberührt (nur `api/files.ts` intern geändert, §3.5).
 
 **Risiken:**
 - *Verlust des 60s-TTL-Dedup:* vernachlässigbar — alle Konsumenten laden 1×/Mount oder on-demand;
-  bei `getFilePermissions` ist Frische sogar korrekter.
+  bei `getFilePermissions` ist Frische sogar korrekter (§3.5).
 - *Erstes `useMutation`:* neues Muster, muss beim Review sitzen — dafür ersetzt `isPending`/`onError`
   echten Boilerplate (nicht nur Zeremonie).
-- *Persister spiegelt jetzt Backups/Shares/Permissions:* gewollt (F5-Instant-Paint); Impersonation
-  wird explizit adressiert (§3.6); `logout()` leert bereits.
-- *`BackupPage.tsx` (`/backups`)* rendert vermutlich `BackupSettings` — beim Implementieren
-  verifizieren, dass es keinen zweiten `listBackups`-Konsumenten gibt (git-grep zeigt nur
-  `BackupSettings.tsx`).
+- *Persister spiegelt jetzt Backups/Shares:* gewollt (F5-Instant-Paint); dafür muss die
+  Cache-Leerung bei **jedem** Identitätswechsel sitzen — §3.6 zählt alle fünf Pfade auf.
+  Permissions landen bewusst NICHT im Persister (§3.5).
+- *Loading-Flash bei Impersonation durch `queryClient.clear()`:* akzeptiert, siehe §3.6.
+- *`BackupSettings` ist **zweimal** gemountet* — `BackupPage.tsx` (`/backups`) **und**
+  `SystemControlPage.tsx:197` (Backup-Tab). Mit `useQuery` unproblematisch, sogar ein
+  Vorteil: beide Mounts teilen den Query-Cache (Dedup statt Doppel-Fetch). Verifiziert:
+  `listBackups` wird nur von `BackupSettings.tsx` aufgerufen.
 
 ---
 


### PR DESCRIPTION
## Was & Warum

Entfernt den handgerollten In-Memory-`apiCache`-Map + `memoizedApiRequest` aus `client/src/lib/api.ts` — einen der drei konkurrierenden Cache-Ansätze aus **Finding F1 (#299)** — und migriert seine drei Konsumenten auf TanStack Query. Schließt **#309 (F6)** vollständig (die Dashboard-`sessionStorage`-Hälfte von F6 war bereits durch #366 erledigt).

Design-Spec: `docs/superpowers/specs/2026-07-03-memoized-api-request-tanstack-query-design.md`
Plan: `docs/superpowers/plans/2026-07-03-memoized-api-request-tanstack-query.md`

## Änderungen

- **Query-Keys**: neue Domains `queryKeys.backups` + `queryKeys.shares` in `lib/queryKeys.ts`.
- **Backups**: `api/backup.ts` `listBackups` → plain `apiClient.get` (toter `getBackup` gelöscht); neuer `useBackups()`-Hook; `BackupSettings.tsx` auf `useQuery` + **das erste `useMutation` im Frontend** (`isPending`/`onError`/`invalidateQueries` ersetzen manuelle Booleans + den globalen `apiCache.clear()`-Holzhammer).
- **Shares**: `api/shares.ts` `listFileShares` → plain `apiClient.get` (alle `apiCache.delete` raus); neuer `useFileShares()`-Hook (3 `useQuery`); `SharesPage.tsx` darauf umgestellt + Delete-`useMutation`. Invalidierung lebt **in den 3 Share-Modals** (`Create`/`Edit`/`ShareFileModal`) → deckt auch die Mutation-Site im FileManager ab, nicht nur die SharesPage.
- **File-Permissions**: `getFilePermissions` bewusst als **Plain-Read ohne Query-Beteiligung** (on-demand, immer frisch, kein Persister-Bloat — Design §3.5). Behebt nebenbei die alte 60s-Staleness.
- **⚠️ Cross-User-Cache-Leerung**: `listFileShares` ist die erste **user-scoped** persistierte Query. `AuthContext` leert Query-Cache + Persister jetzt bei **jedem** Identitätswechsel (login, logout, impersonate, endImpersonation, beide `auth:expired`-Zweige, swap-then-clear-Reihenfolge) — sonst würde der sessionStorage-Persister Daten eines Users an den nächsten leaken (Design §3.6). Das ist genau die Absicherung, die #299 für den ersten user-scoped Hook angekündigt hatte.
- **Cleanup**: `apiCache`/`memoizedApiRequest`/`CacheEntry`/`DEFAULT_TTL` aus `lib/api.ts` entfernt (Compile-Gate beweist, dass alle Konsumenten migriert sind); 4 CLAUDE.md aktualisiert.

## Tests & Gates

- Volle Vitest-Suite: **516/516 grün** (92 Dateien); u. a. neue Tests für `useBackups`, `useFileShares`, `backup`-API, erweiterte AuthContext-Impersonation/Logout-Tests.
- `eslint .` 0 Errors, `npm run build` (tsc -b) erfolgreich.
- Umgesetzt via TDD, 12 Tasks je mit eigenem Commit + Task-Review; abschließender Whole-Branch-Review (verdict: ready to merge) + ein eingefalteter Minor-Fix (Stale-Token-Entfernung im Plain-`auth:expired`-Zweig).

## Bewusste Trade-offs (dokumentiert in der Spec)

- Verlust des 60s-TTL-Dedup — vernachlässigbar (alle Konsumenten laden 1×/Mount oder on-demand).
- Kurzer app-weiter Loading-Flash bei Impersonation durch `queryClient.clear()` — Korrektheit > Kosmetik (§3.6).
- Backups/Shares werden nun (wie Telemetry/RAID) über den Persister nach sessionStorage gespiegelt — gewollt (F5-Instant-Paint), durch die Identitätswechsel-Leerung abgesichert.

## Nebenbefund

Beim Review aufgefallen und als separates Issue ausgelagert (nicht in diesem PR): **#367** — `restoreBackup` setzt den Authorization-Header manuell (redundant zum Interceptor).

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)
