### PR TITLE
feat(client): RaidManagement page on TanStack Query (#299)

### DIFF
--- a/client/src/__tests__/hooks/useAvailableDisks.test.tsx
+++ b/client/src/__tests__/hooks/useAvailableDisks.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useAvailableDisks } from '../../hooks/useAvailableDisks';
+import * as raidApi from '../../api/raid';
+
+vi.mock('../../api/raid');
+const api = vi.mocked(raidApi);
+
+const sample = {
+  disks: [
+    { name: 'sdb', size_bytes: 100, is_partitioned: false, partitions: [], in_raid: false },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useAvailableDisks', () => {
+  it('maps the disk list into the result shape', async () => {
+    api.getAvailableDisks.mockResolvedValue(sample);
+    const { result } = renderHook(() => useAvailableDisks(), {
+      wrapper: createQueryWrapper(),
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.disks).toHaveLength(1);
+    expect(result.current.disks[0].name).toBe('sdb');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('defaults to an empty list before data arrives', () => {
+    api.getAvailableDisks.mockResolvedValue(sample);
+    const { result } = renderHook(() => useAvailableDisks(), {
+      wrapper: createQueryWrapper(),
+    });
+    expect(result.current.disks).toEqual([]);
+  });
+
+  it('surfaces the raw error when the fetch rejects', async () => {
+    const boom = new Error('disks boom');
+    api.getAvailableDisks.mockRejectedValue(boom);
+    const { result } = renderHook(() => useAvailableDisks(), {
+      wrapper: createQueryWrapper(),
+    });
+    await waitFor(() => expect(result.current.error).toBe(boom));
+    expect(result.current.disks).toEqual([]);
+  });
+});

--- a/client/src/__tests__/hooks/useRaidStatus.test.tsx
+++ b/client/src/__tests__/hooks/useRaidStatus.test.tsx
@@ -42,4 +42,14 @@ describe('useRaidStatus', () => {
     expect(result.current.raidLoading).toBe(false);
     expect(api.getRaidStatus).not.toHaveBeenCalled();
   });
+
+  it('exposes lastUpdated after a successful fetch', async () => {
+    api.getRaidStatus.mockResolvedValue(sample);
+    const { result } = renderHook(() => useRaidStatus({ pollInterval: 999999 }), {
+      wrapper: createQueryWrapper(),
+    });
+    expect(result.current.lastUpdated).toBeNull();
+    await waitFor(() => expect(result.current.raidLoading).toBe(false));
+    expect(result.current.lastUpdated).toBeInstanceOf(Date);
+  });
 });

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -8,7 +8,8 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 |---|---|---|
 | `useMonitoring.ts` | `api/monitoring` | Unified CPU/memory/network/disk/process data via **TanStack Query** (`useQuery`), configurable `pollInterval` (mapped to `refetchInterval`) + history; public return shape unchanged |
 | `useSystemTelemetry.ts` | `api/system` | System info + aggregated storage + telemetry history for the dashboard via **TanStack Query** (`useQuery`, one combined snapshot, `pollInterval`→`refetchInterval`); hand-rolled sessionStorage cache removed, F5 persistence now comes from the app-wide persister (#299); public shape unchanged |
-| `useRaidStatus.ts` | `api/raid` | RAID array status via **TanStack Query** (`useQuery`, 60s poll); F5-persisted via the app-wide persister |
+| `useRaidStatus.ts` | `api/raid` | RAID array status via **TanStack Query** (`useQuery`; default 60s poll, 8s on the RAID page — shared cache key); F5-persisted via the app-wide persister. Exposes `lastUpdated` + a `refetch` resolving to a success boolean |
+| `useAvailableDisks.ts` | `api/raid` | Unassigned disks for the RAID management page via **TanStack Query** (no polling; format/create/delete mutations invalidate `queryKeys.raid.availableDisks()`). Returns raw `error` |
 | `useBackups.ts` | `api/backup` | Backup list via **TanStack Query** (no polling; create/delete mutations invalidate). Returns raw `error` for i18n formatting by the caller |
 | `useFileShares.ts` | `api/shares` | The three shares-domain reads (user shares, shared-with-me, statistics) via **TanStack Query**; user-scoped — cache is cleared on every identity change (AuthContext) |
 | `useFanControl.ts` | `api/fan-control` | Fan config, curves, schedules — full fan management state |

--- a/client/src/hooks/useAvailableDisks.ts
+++ b/client/src/hooks/useAvailableDisks.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../lib/queryKeys';
+import { getAvailableDisks, type AvailableDisk } from '../api/raid';
+
+export interface UseAvailableDisksResult {
+  disks: AvailableDisk[];
+  loading: boolean;
+  /** Raw query error (null when none) — caller formats via getApiErrorMessage. */
+  error: unknown;
+}
+
+/**
+ * Available (unassigned) disks for the RAID management page. Query-backed, no
+ * polling — format/create/delete mutations invalidate queryKeys.raid.availableDisks()
+ * (or the whole raid domain via queryKeys.raid.all()).
+ */
+export function useAvailableDisks(): UseAvailableDisksResult {
+  const query = useQuery({
+    queryKey: queryKeys.raid.availableDisks(),
+    queryFn: getAvailableDisks,
+  });
+
+  return {
+    disks: query.data?.disks ?? [],
+    loading: query.isLoading,
+    error: query.isError ? query.error : null,
+  };
+}

--- a/client/src/hooks/useRaidStatus.ts
+++ b/client/src/hooks/useRaidStatus.ts
@@ -7,7 +7,10 @@ export interface UseRaidStatusResult {
   raidData: RaidStatusResponse | null;
   raidLoading: boolean;
   error: string | null;
-  refetch: () => Promise<void>;
+  /** Timestamp of the last successful fetch (from `dataUpdatedAt`), null before the first. */
+  lastUpdated: Date | null;
+  /** Manual refetch; resolves to `true` on success, `false` if the refetch errored. */
+  refetch: () => Promise<boolean>;
 }
 
 /**
@@ -32,8 +35,10 @@ export function useRaidStatus(
     error: query.isError
       ? getApiErrorMessage(query.error, 'Failed to fetch RAID status')
       : null,
+    lastUpdated: query.dataUpdatedAt ? new Date(query.dataUpdatedAt) : null,
     refetch: async () => {
-      await query.refetch();
+      const res = await query.refetch();
+      return !res.isError;
     },
   };
 }

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -26,9 +26,13 @@ export const queryKeys = {
   },
   system: {
     telemetry: () => ['system', 'telemetry'] as const,
+    info: () => ['system', 'info'] as const,
   },
   raid: {
+    /** Domain-Prefix — invalidiert Status + Disks auf einmal. */
+    all: () => ['raid'] as const,
     status: () => ['raid', 'status'] as const,
+    availableDisks: () => ['raid', 'available-disks'] as const,
   },
   backups: {
     list: () => ['backups', 'list'] as const,

--- a/client/src/pages/RaidManagement.tsx
+++ b/client/src/pages/RaidManagement.tsx
@@ -1,14 +1,13 @@
-import { type FormEvent, useEffect, useMemo, useState } from 'react';
+import { type FormEvent, useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { handleApiError, getApiErrorMessage } from '../lib/errorHandling';
+import { handleApiError } from '../lib/errorHandling';
 import {
   deleteArray,
   finalizeRaidRebuild,
   formatDisk,
-  getAvailableDisks,
-  getRaidStatus,
   markDeviceFailed,
   startRaidRebuild,
   type AvailableDisk,
@@ -16,10 +15,12 @@ import {
   type RaidArray,
   type RaidDevice,
   type RaidOptionsPayload,
-  type RaidSpeedLimits,
   updateRaidOptions,
 } from '../api/raid';
 import { getSystemInfo } from '../api/system';
+import { queryKeys } from '../lib/queryKeys';
+import { useRaidStatus } from '../hooks/useRaidStatus';
+import { useAvailableDisks } from '../hooks/useAvailableDisks';
 import RaidSetupWizard from '../components/RaidSetupWizard';
 import MockDiskWizard from '../components/MockDiskWizard';
 import { useConfirmDialog } from '../hooks/useConfirmDialog';
@@ -31,64 +32,49 @@ export default function RaidManagement() {
   const { t } = useTranslation(['system', 'common']);
   const navigate = useNavigate();
   const { confirm, dialog } = useConfirmDialog();
-  const [arrays, setArrays] = useState<RaidArray[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-  const [busy, setBusy] = useState<boolean>(false);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-  const [speedLimits, setSpeedLimits] = useState<RaidSpeedLimits | null>(null);
+  const queryClient = useQueryClient();
 
-  // Disk Management States
-  const [availableDisks, setAvailableDisks] = useState<AvailableDisk[]>([]);
+  // Reads — TanStack Query. Status polls every REFRESH_INTERVAL_MS (shared cache
+  // with the dashboard's useRaidStatus); disks + dev-mode fetch once (no poll).
+  const {
+    raidData,
+    raidLoading: loading,
+    error,
+    lastUpdated,
+    refetch: refetchStatus,
+  } = useRaidStatus({ pollInterval: REFRESH_INTERVAL_MS });
+  const { disks: availableDisks } = useAvailableDisks();
+  const { data: systemInfo } = useQuery({
+    queryKey: queryKeys.system.info(),
+    queryFn: getSystemInfo,
+  });
+
+  const arrays = raidData?.arrays ?? [];
+  const speedLimits = raidData?.speed_limits ?? null;
+  const isDevMode = systemInfo?.dev_mode === true;
+
+  const [busy, setBusy] = useState<boolean>(false);
+
+  // Disk Management dialog states
   const [showFormatDialog, setShowFormatDialog] = useState<boolean>(false);
   const [showCreateArrayDialog, setShowCreateArrayDialog] = useState<boolean>(false);
   const [showMockDiskWizard, setShowMockDiskWizard] = useState<boolean>(false);
   const [selectedDisk, setSelectedDisk] = useState<AvailableDisk | null>(null);
-  const [isDevMode, setIsDevMode] = useState<boolean>(false);
 
-  const loadStatus = async (notifySuccess = false) => {
-    try {
-      const status = await getRaidStatus();
-      setArrays(status.arrays ?? []);
-      setSpeedLimits(status.speed_limits ?? null);
-      setError(null);
-      setLastUpdated(new Date());
-      if (notifySuccess) {
-        toast.success(t('system:raid.messages.statusUpdated'));
-      }
-    } catch (err) {
-      const message = getApiErrorMessage(err, t('system:raid.messages.loadError'));
-      setError(message);
-      handleApiError(err, t('system:raid.messages.loadError'));
-    } finally {
-      setLoading(false);
+  // Mutations stay imperative (own the `busy` flag + per-action toast) but route
+  // their reload through the query layer — awaited so buttons stay disabled until
+  // fresh data lands, preserving the previous busy-until-refresh UX.
+  const refreshStatus = () =>
+    queryClient.invalidateQueries({ queryKey: queryKeys.raid.status() });
+  const refreshDisks = () =>
+    queryClient.invalidateQueries({ queryKey: queryKeys.raid.availableDisks() });
+
+  const handleManualRefresh = async () => {
+    const ok = await refetchStatus();
+    if (ok) {
+      toast.success(t('system:raid.messages.statusUpdated'));
     }
   };
-
-  const loadAvailableDisks = async () => {
-    try {
-      const response = await getAvailableDisks();
-      setAvailableDisks(response.disks ?? []);
-    } catch (err) {
-      handleApiError(err, t('system:raid.messages.loadDisksError'));
-    }
-  };
-
-  useEffect(() => {
-    void loadStatus();
-    void loadAvailableDisks();
-
-    // Check if Dev-Mode is active
-    getSystemInfo()
-      .then(data => setIsDevMode(data.dev_mode === true))
-      .catch(() => setIsDevMode(false));
-
-    const intervalId = window.setInterval(() => {
-      void loadStatus();
-    }, REFRESH_INTERVAL_MS);
-
-    return () => window.clearInterval(intervalId);
-  }, []);
 
   const refreshDisabled = useMemo(() => busy || loading, [busy, loading]);
 
@@ -97,7 +83,7 @@ export default function RaidManagement() {
     try {
       const response = await markDeviceFailed(array.name, device?.name);
       toast.success(response.message);
-      await loadStatus();
+      await refreshStatus();
     } catch (err) {
       handleApiError(err, t('system:raid.messages.simulationFailed'));
     } finally {
@@ -110,7 +96,7 @@ export default function RaidManagement() {
     try {
       const response = await startRaidRebuild(array.name, device.name);
       toast.success(response.message);
-      await loadStatus();
+      await refreshStatus();
     } catch (err) {
       handleApiError(err, t('system:raid.messages.rebuildFailed'));
     } finally {
@@ -123,7 +109,7 @@ export default function RaidManagement() {
     try {
       const response = await finalizeRaidRebuild(array.name);
       toast.success(response.message);
-      await loadStatus();
+      await refreshStatus();
     } catch (err) {
       handleApiError(err, t('system:raid.messages.finalizeFailed'));
     } finally {
@@ -139,7 +125,7 @@ export default function RaidManagement() {
         enable_bitmap: !array.bitmap,
       });
       toast.success(response.message);
-      await loadStatus();
+      await refreshStatus();
     } catch (err) {
       handleApiError(err, t('system:raid.messages.bitmapUpdateFailed'));
     } finally {
@@ -155,7 +141,7 @@ export default function RaidManagement() {
         trigger_scrub: true,
       });
       toast.success(response.message);
-      await loadStatus();
+      await refreshStatus();
     } catch (err) {
       handleApiError(err, t('system:raid.messages.scrubFailed'));
     } finally {
@@ -172,7 +158,7 @@ export default function RaidManagement() {
         write_mostly: device.state !== 'write-mostly',
       });
       toast.success(response.message);
-      await loadStatus();
+      await refreshStatus();
     } catch (err) {
       handleApiError(err, t('system:raid.messages.writeMostlyFailed'));
     } finally {
@@ -188,7 +174,7 @@ export default function RaidManagement() {
         remove_device: device.name,
       });
       toast.success(response.message);
-      await loadStatus();
+      await refreshStatus();
     } catch (err) {
       handleApiError(err, t('system:raid.messages.removeDeviceFailed'));
     } finally {
@@ -211,7 +197,7 @@ export default function RaidManagement() {
     try {
       const response = await updateRaidOptions({ array: array.name, add_spare: rawDevice });
       toast.success(response.message);
-      await loadStatus();
+      await refreshStatus();
     } catch (err) {
       handleApiError(err, t('system:raid.messages.addSpareFailed'));
     } finally {
@@ -242,7 +228,7 @@ export default function RaidManagement() {
     try {
       const response = await updateRaidOptions(payload);
       toast.success(response.message);
-      await loadStatus();
+      await refreshStatus();
     } catch (err) {
       handleApiError(err, t('system:raid.messages.speedLimitFailed'));
     } finally {
@@ -272,7 +258,7 @@ export default function RaidManagement() {
       toast.success(response.message);
       setShowFormatDialog(false);
       setSelectedDisk(null);
-      await loadAvailableDisks();
+      await refreshDisks();
     } catch (err) {
       handleApiError(err, t('system:raid.messages.formatFailed'));
     } finally {
@@ -292,8 +278,8 @@ export default function RaidManagement() {
     try {
       const response = await deleteArray({ array: arrayName, force: true });
       toast.success(response.message);
-      await loadStatus();
-      await loadAvailableDisks();
+      await refreshStatus();
+      await refreshDisks();
     } catch (err) {
       handleApiError(err, t('system:raid.messages.deleteFailed'));
     } finally {
@@ -317,7 +303,7 @@ export default function RaidManagement() {
             </span>
           )}
           <button
-            onClick={() => loadStatus(true)}
+            onClick={handleManualRefresh}
             disabled={refreshDisabled}
             className={`rounded-xl border px-3 sm:px-4 py-2 text-xs sm:text-sm font-medium transition touch-manipulation active:scale-95 ${
               refreshDisabled
@@ -390,7 +376,7 @@ export default function RaidManagement() {
         arrays={arrays}
         busy={busy}
         isDevMode={isDevMode}
-        onRefreshDisks={() => void loadAvailableDisks()}
+        onRefreshDisks={() => void refreshDisks()}
         onShowMockWizard={() => setShowMockDiskWizard(true)}
         onShowCreateArray={() => setShowCreateArrayDialog(true)}
         onFormatDisk={(disk) => {
@@ -418,8 +404,8 @@ export default function RaidManagement() {
           availableDisks={availableDisks}
           onClose={() => setShowCreateArrayDialog(false)}
           onSuccess={async () => {
-            await loadStatus();
-            await loadAvailableDisks();
+            await refreshStatus();
+            await refreshDisks();
           }}
         />
       )}
@@ -429,8 +415,8 @@ export default function RaidManagement() {
         <MockDiskWizard
           onClose={() => setShowMockDiskWizard(false)}
           onSuccess={async () => {
-            await loadStatus();
-            await loadAvailableDisks();
+            await refreshStatus();
+            await refreshDisks();
             setShowMockDiskWizard(false);
           }}
         />


### PR DESCRIPTION
## Was

Migriert die **RaidManagement-Seite** (`/raid`) auf TanStack Query — der nächste bereichsweise Happen der Data-Fetching-Migration (#299, Zeile „restliche Daten-Hooks"). Entfernt den letzten hand-gerollten `setInterval`-Poller + Read-State dieser Seite.

## Änderungen

**Reads → TanStack Query:**
- `useRaidStatus({ pollInterval: 8000 })` liefert Status (teilt sich den Cache-Key `['raid','status']` mit dem Dashboard — dort weiterhin 60 s).
- Neuer Hook `useAvailableDisks()` für die freien Disks (kein Poll; wird nach format/create/delete invalidiert).
- Kleine `system.info`-Query ersetzt den einmaligen `getSystemInfo()`-Effekt für den Dev-Mode-Check.
- Weg: `arrays`/`loading`/`error`/`speedLimits`/`availableDisks`/`isDevMode`/`lastUpdated` als `useState`, die beiden Loader-Funktionen und der 8s-`setInterval`.

**Query-Keys:** `queryKeys.raid.all()`/`availableDisks()` + `queryKeys.system.info()`.

**`useRaidStatus` additiv erweitert** (Dashboard unberührt): `lastUpdated: Date | null` (aus `dataUpdatedAt`) und `refetch()` liefert jetzt einen Erfolgs-`boolean` (für den „Aktualisiert"-Toast des manuellen Refresh-Buttons).

**Mutations:** Die 11 Action-Handler bleiben bewusst imperativ (eigener `busy`-Flag + per-Action-Toast), routen ihr Reload aber über `queryClient.invalidateQueries` durch den Query-Layer — `await`ed, sodass Buttons bis zum Eintreffen frischer Daten deaktiviert bleiben (unveränderte UX). Die volle `useMutation`-Umstellung ist ein bewusster Folge-PR (minimal-blast-radius pro PR, wie im Track vereinbart).

## Scope-Hinweis

Kleine, akzeptierte Verhaltensänderung: Fehler beim Disk-Laden zeigen keinen Toast mehr (Fehler werden vom Hook gehalten); Status-Ladefehler erscheinen nur noch im Fehler-Banner statt zusätzlich als Toast — beides sauberer, kein doppeltes Error-Surface.

## Tests

- Neuer `useAvailableDisks.test.tsx` (3 Fälle: Mapping, Leer-Default, Fehler-Durchreichung).
- `useRaidStatus.test.tsx` um `lastUpdated` ergänzt.
- ✅ `npx vitest run` — 93 Dateien / 520 Tests grün
- ✅ `eslint` — 0 Errors (CI-Gate)
- ✅ `npm run build` — tsc -b + vite grün

## Track

Teil von #299 (F1). Danach noch offen: schedulers, users, devices, mobile, remote-servers, smart, benchmark, admin-db, plugins, services, activity, docs + Aufräum-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
