### PR TITLE
feat(client): dashboard summary hooks (plugins/services) on TanStack Query (#299)

### DIFF
--- a/client/src/__tests__/hooks/usePluginsSummary.test.tsx
+++ b/client/src/__tests__/hooks/usePluginsSummary.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { usePluginsSummary } from '../../hooks/usePluginsSummary';
+import * as pluginsApi from '../../api/plugins';
+import type { PluginInfo } from '../../api/plugins';
+
+vi.mock('../../api/plugins');
+const api = vi.mocked(pluginsApi);
+
+function plugin(overrides: Partial<PluginInfo>): PluginInfo {
+  return {
+    name: 'p',
+    version: '1.0.0',
+    display_name: 'P',
+    description: '',
+    author: '',
+    category: '',
+    required_permissions: [],
+    dangerous_permissions: [],
+    is_enabled: true,
+    has_ui: false,
+    has_routes: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('usePluginsSummary', () => {
+  it('derives the summary from the plugin list', async () => {
+    const plugins = [
+      plugin({ name: 'a', is_enabled: true }),
+      plugin({ name: 'b', is_enabled: false }),
+      plugin({ name: 'c', is_enabled: true, error: 'boom' }),
+    ];
+    api.listPlugins.mockResolvedValue({ plugins, total: plugins.length });
+
+    const { result } = renderHook(() => usePluginsSummary({ refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.summary).toEqual({ total: 3, enabled: 2, disabled: 1, withErrors: 1 });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('treats a 403 as an empty (silent) result — no error surfaced', async () => {
+    api.listPlugins.mockRejectedValue({ response: { status: 403 } });
+
+    const { result } = renderHook(() => usePluginsSummary({ refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.plugins).toEqual([]);
+    expect(result.current.summary.total).toBe(0);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('surfaces a non-403 error as a string', async () => {
+    api.listPlugins.mockRejectedValue(new Error('plugins boom'));
+
+    const { result } = renderHook(() => usePluginsSummary({ refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.error).toBe('plugins boom'));
+  });
+
+  it('does not fetch when disabled', () => {
+    api.listPlugins.mockResolvedValue({ plugins: [], total: 0 });
+
+    const { result } = renderHook(() => usePluginsSummary({ enabled: false }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(api.listPlugins).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/hooks/useServicesSummary.test.tsx
+++ b/client/src/__tests__/hooks/useServicesSummary.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useServicesSummary } from '../../hooks/useServicesSummary';
+import * as serviceApi from '../../api/service-status';
+import { ServiceState, type ServiceStatus, type AdminDebugSnapshot } from '../../api/service-status';
+
+vi.mock('../../api/service-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/service-status')>();
+  return { ...actual, getDebugSnapshot: vi.fn() };
+});
+const api = vi.mocked(serviceApi);
+
+function service(state: ServiceState): ServiceStatus {
+  return {
+    name: 's',
+    display_name: 'S',
+    state,
+    started_at: null,
+    uptime_seconds: null,
+    sample_count: null,
+    error_count: 0,
+    last_error: null,
+    last_error_at: null,
+    config_enabled: true,
+    interval_seconds: null,
+    restartable: false,
+  };
+}
+
+function snapshot(services: ServiceStatus[]): AdminDebugSnapshot {
+  return { services } as unknown as AdminDebugSnapshot;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useServicesSummary', () => {
+  it('derives the summary from the service list', async () => {
+    api.getDebugSnapshot.mockResolvedValue(
+      snapshot([
+        service(ServiceState.RUNNING),
+        service(ServiceState.RUNNING),
+        service(ServiceState.STOPPED),
+        service(ServiceState.ERROR),
+        service(ServiceState.DISABLED),
+      ]),
+    );
+
+    const { result } = renderHook(() => useServicesSummary({ refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.summary).toEqual({
+      running: 2,
+      stopped: 1,
+      error: 1,
+      disabled: 1,
+      total: 5,
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not fetch when disabled', () => {
+    api.getDebugSnapshot.mockResolvedValue(snapshot([]));
+
+    const { result } = renderHook(() => useServicesSummary({ enabled: false }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(api.getDebugSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error as a string', async () => {
+    api.getDebugSnapshot.mockRejectedValue(new Error('services boom'));
+
+    const { result } = renderHook(() => useServicesSummary({ refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.error).toBe('services boom'));
+  });
+});

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -25,8 +25,8 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useLiveActivities.ts` | — | Real-time activity via polling |
 | `useDocsIndex.ts` | `api/docs` | Documentation article index |
 | `useDocsArticle.ts` | `api/docs` | Single documentation article content |
-| `usePluginsSummary.ts` | `api/plugins` | Plugin list summary for dashboard |
-| `useServicesSummary.ts` | `api/service-status` | Service health summary for dashboard |
+| `usePluginsSummary.ts` | `api/plugins` | Plugin list summary for dashboard via **TanStack Query** (`useQuery`, default 60s poll). A 403 (non-admin) is treated as an empty list, silently — no error surfaced |
+| `useServicesSummary.ts` | `api/service-status` | Service health summary for dashboard via **TanStack Query** (`useQuery`, default 30s poll). Mounted at 3 sites (ServicesPanel, Dashboard, ServiceSummaryWidget) — the shared query key collapses them into one cache entry + one poll |
 | `useOpenApiSchema.ts` | — | OpenAPI schema for API docs page |
 
 ## Utility Hooks

--- a/client/src/hooks/usePluginsSummary.ts
+++ b/client/src/hooks/usePluginsSummary.ts
@@ -1,7 +1,9 @@
 /**
- * Hook for getting plugin status summary (admin only)
+ * Hook for getting plugin status summary (admin only) — TanStack Query backed.
  */
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../lib/queryKeys';
 import { getApiErrorMessage } from '../lib/errorHandling';
 import { listPlugins, type PluginInfo } from '../api/plugins';
 
@@ -25,47 +27,35 @@ interface UsePluginsSummaryReturn {
   refetch: () => Promise<void>;
 }
 
+/**
+ * Non-admins get a 403 from /api/plugins — treat that as "no plugins" silently
+ * (unchanged from the pre-Query behavior) rather than surfacing an error.
+ */
+async function fetchPluginsSafe(): Promise<PluginInfo[]> {
+  try {
+    const response = await listPlugins();
+    return response.plugins;
+  } catch (err: unknown) {
+    const status =
+      err != null && typeof err === 'object' && 'response' in err
+        ? (err as { response?: { status?: number } }).response?.status
+        : undefined;
+    if (status === 403) return [];
+    throw err;
+  }
+}
+
 export function usePluginsSummary(options: UsePluginsSummaryOptions = {}): UsePluginsSummaryReturn {
   const { refreshInterval = 60000, enabled = true } = options;
 
-  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const query = useQuery({
+    queryKey: queryKeys.plugins.summary(),
+    queryFn: fetchPluginsSafe,
+    refetchInterval: refreshInterval > 0 ? refreshInterval : false,
+    enabled,
+  });
 
-  const loadData = useCallback(async () => {
-    try {
-      const response = await listPlugins();
-      setPlugins(response.plugins);
-      setError(null);
-    } catch (err: unknown) {
-      // Don't show error if user is not admin (403)
-      const status = err != null && typeof err === 'object' && 'response' in err
-        ? (err as { response?: { status?: number } }).response?.status
-        : undefined;
-      if (status === 403) {
-        setPlugins([]);
-        setError(null);
-        return;
-      }
-      setError(getApiErrorMessage(err, 'Failed to load plugins'));
-    }
-  }, []);
-
-  // Initial load
-  useEffect(() => {
-    if (!enabled) return;
-
-    setLoading(true);
-    loadData().finally(() => setLoading(false));
-  }, [enabled, loadData]);
-
-  // Auto-refresh
-  useEffect(() => {
-    if (!enabled || refreshInterval <= 0) return;
-
-    const interval = setInterval(loadData, refreshInterval);
-    return () => clearInterval(interval);
-  }, [enabled, refreshInterval, loadData]);
+  const plugins = useMemo(() => query.data ?? [], [query.data]);
 
   const summary = useMemo<PluginsSummary>(() => {
     return {
@@ -79,8 +69,10 @@ export function usePluginsSummary(options: UsePluginsSummaryOptions = {}): UsePl
   return {
     summary,
     plugins,
-    loading,
-    error,
-    refetch: loadData,
+    loading: query.isLoading,
+    error: query.isError ? getApiErrorMessage(query.error, 'Failed to load plugins') : null,
+    refetch: async () => {
+      await query.refetch();
+    },
   };
 }

--- a/client/src/hooks/useServicesSummary.ts
+++ b/client/src/hooks/useServicesSummary.ts
@@ -1,7 +1,13 @@
 /**
- * Hook for getting service status summary (all authenticated users)
+ * Hook for getting service status summary — TanStack Query backed.
+ *
+ * Mounted at three sites (ServicesPanel, Dashboard, ServiceSummaryWidget); the
+ * shared query key collapses them into one cache entry + one poll instead of
+ * three independent setInterval loops.
  */
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../lib/queryKeys';
 import { getApiErrorMessage } from '../lib/errorHandling';
 import { getDebugSnapshot, type ServiceStatus, ServiceState } from '../api/service-status';
 
@@ -29,35 +35,14 @@ interface UseServicesSummaryReturn {
 export function useServicesSummary(options: UseServicesSummaryOptions = {}): UseServicesSummaryReturn {
   const { refreshInterval = 30000, enabled = true } = options;
 
-  const [services, setServices] = useState<ServiceStatus[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const query = useQuery({
+    queryKey: queryKeys.services.summary(),
+    queryFn: async () => (await getDebugSnapshot()).services,
+    refetchInterval: refreshInterval > 0 ? refreshInterval : false,
+    enabled,
+  });
 
-  const loadData = useCallback(async () => {
-    try {
-      const response = await getDebugSnapshot();
-      setServices(response.services);
-      setError(null);
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, 'Failed to load services'));
-    }
-  }, []);
-
-  // Initial load
-  useEffect(() => {
-    if (!enabled) return;
-
-    setLoading(true);
-    loadData().finally(() => setLoading(false));
-  }, [enabled, loadData]);
-
-  // Auto-refresh
-  useEffect(() => {
-    if (!enabled || refreshInterval <= 0) return;
-
-    const interval = setInterval(loadData, refreshInterval);
-    return () => clearInterval(interval);
-  }, [enabled, refreshInterval, loadData]);
+  const services = useMemo(() => query.data ?? [], [query.data]);
 
   const summary = useMemo<ServicesSummary>(() => {
     return {
@@ -72,8 +57,10 @@ export function useServicesSummary(options: UseServicesSummaryOptions = {}): Use
   return {
     summary,
     services,
-    loading,
-    error,
-    refetch: loadData,
+    loading: query.isLoading,
+    error: query.isError ? getApiErrorMessage(query.error, 'Failed to load services') : null,
+    refetch: async () => {
+      await query.refetch();
+    },
   };
 }

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -44,4 +44,10 @@ export const queryKeys = {
     sharedWithMe: () => ['shares', 'shared-with-me'] as const,
     statistics: () => ['shares', 'statistics'] as const,
   },
+  plugins: {
+    summary: () => ['plugins', 'summary'] as const,
+  },
+  services: {
+    summary: () => ['services', 'summary'] as const,
+  },
 } as const;


### PR DESCRIPTION
## Was

Migriert die zwei Dashboard-Summary-Hooks **`usePluginsSummary`** + **`useServicesSummary`** von hand-gerolltem `useState`/`useEffect`/`setInterval` auf TanStack Query — nächster bereichsweiser Happen von #299 (F1). Reine Read-Poller, keine Mutations.

## Änderungen

- **Query-Keys:** `queryKeys.plugins.summary()` + `queryKeys.services.summary()`.
- **`usePluginsSummary`** → `useQuery` (default 60s Poll). Das **403-Verhalten bleibt erhalten**: queryFn schluckt 403 (Nicht-Admin) → leere Liste, still, kein Error; andere Fehler landen in `query.error`.
- **`useServicesSummary`** → `useQuery` (default 30s Poll). Die **drei Mount-Punkte** (`ServicesPanel`, `Dashboard`, `ServiceSummaryWidget`) teilen sich jetzt **eine** Cache-Entry + **einen** Poll statt drei unabhängiger `setInterval`-Loops.

Öffentliche Return-Shapes (`{ summary, plugins|services, loading, error, refetch }`) und Optionen (`{ refreshInterval, enabled }`) sind **unverändert** → alle Konsumenten unberührt.

## Bewusste Mini-Verhaltensänderung

Wie bei der RAID-Migration: bei `enabled: false` ist `loading` künftig `false` (useQuery-`isLoading`-Semantik) statt permanent `true`. Konsumenten mit `enabled: isAdmin` sind ohnehin admin-gated.

## Tests

- Neu `usePluginsSummary.test.tsx` (Summary-Ableitung, 403→leer/still, Nicht-403-Fehler, disabled).
- Neu `useServicesSummary.test.tsx` (Summary-Ableitung, disabled fetcht nicht, Fehler).
- ✅ `npx vitest run` — 95 Dateien / 527 Tests grün
- ✅ `eslint` — 0 Errors / 0 Warnings
- ✅ `npm run build` — tsc -b + vite grün

## Track

Teil von #299 (F1). Danach noch offen: schedulers, users, devices, mobile, remote-servers, smart, benchmark, admin-db, activity, docs + Aufräum-PR (`useAsyncData`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
