### PR TITLE
feat(client): useActivityFeed on TanStack Query (#299)

### DIFF
--- a/client/src/__tests__/hooks/useActivityFeed.test.ts
+++ b/client/src/__tests__/hooks/useActivityFeed.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
 import { useActivityFeed } from '../../hooks/useActivityFeed';
 import type { ActivityListResponse } from '../../api/activity';
 
@@ -48,7 +49,9 @@ describe('useActivityFeed', () => {
   afterEach(() => vi.restoreAllMocks());
 
   it('requests scope=all when allUsers is true and maps action types', async () => {
-    const { result } = renderHook(() => useActivityFeed({ limit: 5, allUsers: true }));
+    const { result } = renderHook(() => useActivityFeed({ limit: 5, allUsers: true }), {
+      wrapper: createQueryWrapper(),
+    });
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(getRecentActivities).toHaveBeenCalledWith({ limit: 5, scope: 'all' });
@@ -71,7 +74,9 @@ describe('useActivityFeed', () => {
       }],
     });
 
-    const { result } = renderHook(() => useActivityFeed({ limit: 5 }));
+    const { result } = renderHook(() => useActivityFeed({ limit: 5 }), {
+      wrapper: createQueryWrapper(),
+    });
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(getRecentActivities).toHaveBeenCalledWith({ limit: 5, scope: 'mine' });
@@ -81,7 +86,9 @@ describe('useActivityFeed', () => {
 
   it('sets error and leaves activities empty when the request fails', async () => {
     vi.mocked(getRecentActivities).mockRejectedValueOnce(new Error('boom'));
-    const { result } = renderHook(() => useActivityFeed({ limit: 5 }));
+    const { result } = renderHook(() => useActivityFeed({ limit: 5 }), {
+      wrapper: createQueryWrapper(),
+    });
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toBe('Failed to load activity feed');
     expect(result.current.activities).toEqual([]);

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -21,8 +21,8 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useDeviceManagement.ts` | `api/devices` | Device list, pairing, removal |
 | `useMobile.ts` | `api/mobile` | Mobile device management |
 | `useRemoteServers.ts` | `api/remote-servers` | Remote server profiles |
-| `useActivityFeed.ts` | `api/activity` | Dashboard activity feed (own / admin all-users) |
-| `useLiveActivities.ts` | — | Real-time activity via polling |
+| `useActivityFeed.ts` | `api/activity` | Dashboard activity feed (own / admin all-users) via **TanStack Query** (`useQuery`, default 30s poll). Query holds raw API items (persister-safe); view mapping (i18n titles, relative "ago") is derived per render. User-scoped — cache cleared on identity change (AuthContext); `scope`+`limit` are part of the key |
+| `useLiveActivities.ts` | — | Real-time activity via polling. **Not yet on TanStack Query** — still polls fan/power status via `useAsyncData`; migrate together with the fans/power domains + the `useAsyncData` cleanup (#299) |
 | `useDocsIndex.ts` | `api/docs` | Documentation article index |
 | `useDocsArticle.ts` | `api/docs` | Single documentation article content |
 | `usePluginsSummary.ts` | `api/plugins` | Plugin list summary for dashboard via **TanStack Query** (`useQuery`, default 60s poll). A 403 (non-admin) is treated as an empty list, silently — no error surfaced |

--- a/client/src/hooks/useActivityFeed.ts
+++ b/client/src/hooks/useActivityFeed.ts
@@ -2,9 +2,11 @@
  * Hook for fetching the dashboard activity feed from the user-scoped
  * /api/activity API. Admins may request all users' activity (scope=all).
  */
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { getRecentActivities, type ActivityItem as ApiActivityItem } from '../api/activity';
+import { queryKeys } from '../lib/queryKeys';
 import { formatBytes } from '../lib/formatters';
 import { getApiErrorMessage } from '../lib/errorHandling';
 
@@ -71,9 +73,17 @@ export function useActivityFeed(options: UseActivityFeedOptions = {}): UseActivi
   const { limit = 5, allUsers = false, refreshInterval = 30000 } = options;
   const { t } = useTranslation('dashboard');
 
-  const [activities, setActivities] = useState<ActivityItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const scope: 'mine' | 'all' = allUsers ? 'all' : 'mine';
+
+  // Query holds the raw API items (JSON-serializable → persister-friendly); the
+  // view mapping (i18n titles, relative "ago") is derived per render below. The
+  // feed is user-scoped — AuthContext clears the query cache on every identity
+  // change, so entries can't leak between users.
+  const query = useQuery({
+    queryKey: queryKeys.activity.recent(scope, limit),
+    queryFn: async () => (await getRecentActivities({ limit, scope })).activities,
+    refetchInterval: refreshInterval > 0 ? refreshInterval : false,
+  });
 
   const toViewItem = useCallback(
     (item: ApiActivityItem): ActivityItem => {
@@ -99,26 +109,17 @@ export function useActivityFeed(options: UseActivityFeedOptions = {}): UseActivi
     [t],
   );
 
-  const loadData = useCallback(async () => {
-    try {
-      const response = await getRecentActivities({ limit, scope: allUsers ? 'all' : 'mine' });
-      setActivities(response.activities.map(toViewItem));
-      setError(null);
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, 'Failed to load activity feed'));
-    }
-  }, [limit, allUsers, toViewItem]);
+  const activities = useMemo(
+    () => (query.data ?? []).map(toViewItem),
+    [query.data, toViewItem],
+  );
 
-  useEffect(() => {
-    setLoading(true);
-    loadData().finally(() => setLoading(false));
-  }, [loadData]);
-
-  useEffect(() => {
-    if (refreshInterval <= 0) return;
-    const interval = setInterval(loadData, refreshInterval);
-    return () => clearInterval(interval);
-  }, [refreshInterval, loadData]);
-
-  return { activities, loading, error, refetch: loadData };
+  return {
+    activities,
+    loading: query.isLoading,
+    error: query.isError ? getApiErrorMessage(query.error, 'Failed to load activity feed') : null,
+    refetch: async () => {
+      await query.refetch();
+    },
+  };
 }

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -47,6 +47,11 @@ export const queryKeys = {
   plugins: {
     summary: () => ['plugins', 'summary'] as const,
   },
+  activity: {
+    /** User-scoped feed; scope ('mine'|'all') + limit are part of the key. */
+    recent: (scope: 'mine' | 'all', limit: number) =>
+      ['activity', 'recent', scope, limit] as const,
+  },
   services: {
     summary: () => ['services', 'summary'] as const,
   },


### PR DESCRIPTION
## Was

Migriert den Dashboard-**Activity-Feed** (`useActivityFeed`, `/api/activity/recent`) von hand-gerolltem `useState`/`useEffect`/`setInterval` auf TanStack Query — nächster Happen von #299 (F1).

## Änderungen

- **Query-Key:** `queryKeys.activity.recent(scope, limit)` — `scope` (`mine`|`all`) + `limit` sind Teil des Keys, own- und all-users-Feed cachen also getrennt.
- **`useActivityFeed`** → `useQuery` (default 30s Poll). Der Query hält die **rohen JSON-API-Items** (persister-safe); das View-Mapping (i18n-Titel + relative „ago") wird per Render via `useMemo` abgeleitet.
- **User-scoped:** `AuthContext` leert den Query-Cache bereits bei jedem Identitätswechsel (#368) → keine Cross-User-Leaks.
- Bestehender Hook-Test läuft jetzt über `createQueryWrapper` (`useQuery` braucht einen `QueryClientProvider`).

Öffentliche Shape (`{ activities, loading, error, refetch }`) + Optionen (`{ limit, allUsers, refreshInterval }`) **unverändert** → `ActivityFeed` unberührt.

## Bewusst nicht in diesem PR

**`useLiveActivities`** bleibt vorerst auf `useAsyncData` — es pollt Fan-/Power-Status und gehört zur **fans/power-Migration + `useAsyncData`-Aufräumung**. Es hier mitzunehmen würde ungewollt zwei fremde Domains anziehen (minimal-blast-radius pro PR).

## Tests

- `useActivityFeed.test.ts` auf QueryClient-Wrapper umgestellt (3 Fälle: scope=all/mine-Mapping, Fehler).
- ✅ `npx vitest run` — 95 Dateien / 527 Tests grün
- ✅ `eslint` — 0 Errors / 0 Warnings
- ✅ `npm run build` — tsc -b + vite grün

## Track

Teil von #299 (F1). Danach offen: schedulers, users, devices, mobile, remote-servers, smart, benchmark, admin-db, docs + Aufräum-PR (`useAsyncData` inkl. `useLiveActivities`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
