### PR TITLE
feat(client): docs hooks (useDocsIndex/useDocsArticle) on TanStack Query (#299)

### DIFF
--- a/client/src/__tests__/hooks/useDocsArticle.test.tsx
+++ b/client/src/__tests__/hooks/useDocsArticle.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useDocsArticle } from '../../hooks/useDocsArticle';
+import * as docsApi from '../../api/docs';
+import type { DocsArticle } from '../../api/docs';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ i18n: { language: 'en-US' } }),
+}));
+
+vi.mock('../../api/docs');
+const api = vi.mocked(docsApi);
+
+const article: DocsArticle = {
+  content: '# Hello',
+  title: 'Hello',
+  slug: 'hello',
+  group: 'g1',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useDocsArticle', () => {
+  it('loads the article for a slug + language', async () => {
+    api.getDocsArticle.mockResolvedValue(article);
+
+    const { result } = renderHook(() => useDocsArticle('hello'), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(api.getDocsArticle).toHaveBeenCalledWith('hello', 'en');
+    expect(result.current.article?.title).toBe('Hello');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not fetch when slug is null', () => {
+    api.getDocsArticle.mockResolvedValue(article);
+
+    const { result } = renderHook(() => useDocsArticle(null), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(result.current.article).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(api.getDocsArticle).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error string when the fetch fails', async () => {
+    api.getDocsArticle.mockRejectedValue(new Error('article boom'));
+
+    const { result } = renderHook(() => useDocsArticle('hello'), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.error).toBe('article boom'));
+    expect(result.current.article).toBeNull();
+  });
+});

--- a/client/src/__tests__/hooks/useDocsIndex.test.tsx
+++ b/client/src/__tests__/hooks/useDocsIndex.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useDocsIndex } from '../../hooks/useDocsIndex';
+import * as docsApi from '../../api/docs';
+import type { DocsGroupInfo } from '../../api/docs';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ i18n: { language: 'en-US' } }),
+}));
+
+vi.mock('../../api/docs');
+const api = vi.mocked(docsApi);
+
+const groups: DocsGroupInfo[] = [
+  { id: 'g1', label: 'Getting started', icon: 'book', articles: [{ slug: 'intro', title: 'Intro', icon: 'file' }] },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useDocsIndex', () => {
+  it('loads the index for the current language', async () => {
+    api.getDocsIndex.mockResolvedValue(groups);
+
+    const { result } = renderHook(() => useDocsIndex(), { wrapper: createQueryWrapper() });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(api.getDocsIndex).toHaveBeenCalledWith('en');
+    expect(result.current.groups).toHaveLength(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('surfaces an error string when the fetch fails', async () => {
+    api.getDocsIndex.mockRejectedValue(new Error('docs index boom'));
+
+    const { result } = renderHook(() => useDocsIndex(), { wrapper: createQueryWrapper() });
+
+    await waitFor(() => expect(result.current.error).toBe('docs index boom'));
+    expect(result.current.groups).toEqual([]);
+  });
+});

--- a/client/src/api/CLAUDE.md
+++ b/client/src/api/CLAUDE.md
@@ -52,6 +52,7 @@ All modules import from `lib/api.ts`:
 | `gpuPower.ts` | `/api/power` | GPU power monitoring and presence detection |
 | `nfs.ts` | `/api/nfs` | NFS share management |
 | `plugins-marketplace.ts` | `/api/plugins` | Plugin marketplace listing and install (external market) |
+| `docs.ts` | `/api/docs` | User-manual index + article content (language-scoped); consumed by useDocsIndex/useDocsArticle |
 
 ## Adding a New API Module
 

--- a/client/src/api/docs.ts
+++ b/client/src/api/docs.ts
@@ -1,0 +1,44 @@
+/**
+ * Docs (user manual) API client. The manual is language-scoped (lang param) and
+ * public to authenticated users; reads are cached via TanStack Query in the
+ * useDocsIndex / useDocsArticle hooks.
+ */
+import { apiClient } from '../lib/api';
+
+export interface DocsArticleInfo {
+  slug: string;
+  title: string;
+  icon: string;
+}
+
+export interface DocsGroupInfo {
+  id: string;
+  label: string;
+  icon: string;
+  articles: DocsArticleInfo[];
+}
+
+export interface DocsArticle {
+  content: string;
+  title: string;
+  slug: string;
+  group: string;
+}
+
+interface DocsIndexResponse {
+  groups: DocsGroupInfo[];
+}
+
+export async function getDocsIndex(lang: string): Promise<DocsGroupInfo[]> {
+  const { data } = await apiClient.get<DocsIndexResponse>('/api/docs/index', {
+    params: { lang },
+  });
+  return data.groups;
+}
+
+export async function getDocsArticle(slug: string, lang: string): Promise<DocsArticle> {
+  const { data } = await apiClient.get<DocsArticle>(`/api/docs/article/${slug}`, {
+    params: { lang },
+  });
+  return data;
+}

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -23,8 +23,8 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useRemoteServers.ts` | `api/remote-servers` | Remote server profiles |
 | `useActivityFeed.ts` | `api/activity` | Dashboard activity feed (own / admin all-users) via **TanStack Query** (`useQuery`, default 30s poll). Query holds raw API items (persister-safe); view mapping (i18n titles, relative "ago") is derived per render. User-scoped — cache cleared on identity change (AuthContext); `scope`+`limit` are part of the key |
 | `useLiveActivities.ts` | — | Real-time activity via polling. **Not yet on TanStack Query** — still polls fan/power status via `useAsyncData`; migrate together with the fans/power domains + the `useAsyncData` cleanup (#299) |
-| `useDocsIndex.ts` | `api/docs` | Documentation article index |
-| `useDocsArticle.ts` | `api/docs` | Single documentation article content |
+| `useDocsIndex.ts` | `api/docs` | Documentation article index via **TanStack Query** (`useQuery`; `lang` in the key → language switch refetches). Re-exports the `DocsGroupInfo`/`DocsArticleInfo` types |
+| `useDocsArticle.ts` | `api/docs` | Single documentation article content via **TanStack Query** (`useQuery`; `slug`+`lang` in the key, `enabled: !!slug`). Re-exports the `DocsArticle` type |
 | `usePluginsSummary.ts` | `api/plugins` | Plugin list summary for dashboard via **TanStack Query** (`useQuery`, default 60s poll). A 403 (non-admin) is treated as an empty list, silently — no error surfaced |
 | `useServicesSummary.ts` | `api/service-status` | Service health summary for dashboard via **TanStack Query** (`useQuery`, default 30s poll). Mounted at 3 sites (ServicesPanel, Dashboard, ServiceSummaryWidget) — the shared query key collapses them into one cache entry + one poll |
 | `useOpenApiSchema.ts` | — | OpenAPI schema for API docs page |

--- a/client/src/hooks/useDocsArticle.ts
+++ b/client/src/hooks/useDocsArticle.ts
@@ -1,53 +1,30 @@
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { apiClient } from '../lib/api';
+import { getDocsArticle } from '../api/docs';
+import { queryKeys } from '../lib/queryKeys';
+import { getApiErrorMessage } from '../lib/errorHandling';
 
-export interface DocsArticle {
-  content: string;
-  title: string;
-  slug: string;
-  group: string;
-}
+// Re-exported so existing consumers (UserManualPage, DocsGroupTab) can keep
+// importing the type from this hook.
+export type { DocsArticle } from '../api/docs';
 
+/**
+ * A single documentation article by slug, via TanStack Query. `slug`/`lang` are
+ * part of the query key; a null slug disables the query (no fetch, article null).
+ */
 export function useDocsArticle(slug: string | null) {
   const { i18n } = useTranslation();
   const lang = i18n.language?.split('-')[0] ?? 'de';
 
-  const [article, setArticle] = useState<DocsArticle | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const query = useQuery({
+    queryKey: queryKeys.docs.article(slug ?? '', lang),
+    queryFn: () => getDocsArticle(slug as string, lang),
+    enabled: !!slug,
+  });
 
-  useEffect(() => {
-    if (!slug) {
-      setArticle(null);
-      setIsLoading(false);
-      setError(null);
-      return;
-    }
-
-    let cancelled = false;
-    setIsLoading(true);
-    setError(null);
-
-    apiClient
-      .get<DocsArticle>(`/api/docs/article/${slug}`, { params: { lang } })
-      .then((res) => {
-        if (!cancelled) {
-          setArticle(res.data);
-          setIsLoading(false);
-        }
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setError(err?.response?.data?.detail ?? 'Failed to load article');
-          setIsLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [slug, lang]);
-
-  return { article, isLoading, error };
+  return {
+    article: query.data ?? null,
+    isLoading: query.isLoading,
+    error: query.isError ? getApiErrorMessage(query.error, 'Failed to load article') : null,
+  };
 }

--- a/client/src/hooks/useDocsIndex.ts
+++ b/client/src/hooks/useDocsIndex.ts
@@ -1,52 +1,31 @@
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { apiClient } from '../lib/api';
+import { getDocsIndex } from '../api/docs';
+import { queryKeys } from '../lib/queryKeys';
+import { getApiErrorMessage } from '../lib/errorHandling';
 
-export interface DocsArticleInfo {
-  slug: string;
-  title: string;
-  icon: string;
-}
+// Re-exported so existing consumers (DocsSidebar, DocsOverview, DocsGroupTab)
+// can keep importing the types from this hook.
+export type { DocsArticleInfo, DocsGroupInfo } from '../api/docs';
 
-export interface DocsGroupInfo {
-  id: string;
-  label: string;
-  icon: string;
-  articles: DocsArticleInfo[];
-}
-
+/**
+ * Documentation index (grouped articles) for the current UI language, via
+ * TanStack Query. `lang` is part of the query key — switching language refetches.
+ */
 export function useDocsIndex() {
   const { i18n } = useTranslation();
   const lang = i18n.language?.split('-')[0] ?? 'de';
 
-  const [groups, setGroups] = useState<DocsGroupInfo[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const query = useQuery({
+    queryKey: queryKeys.docs.index(lang),
+    queryFn: () => getDocsIndex(lang),
+  });
 
-  useEffect(() => {
-    let cancelled = false;
-    setIsLoading(true);
-    setError(null);
-
-    apiClient
-      .get<{ groups: DocsGroupInfo[] }>('/api/docs/index', { params: { lang } })
-      .then((res) => {
-        if (!cancelled) {
-          setGroups(res.data.groups);
-          setIsLoading(false);
-        }
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setError(err?.response?.data?.detail ?? 'Failed to load documentation index');
-          setIsLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [lang]);
-
-  return { groups, isLoading, error };
+  return {
+    groups: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.isError
+      ? getApiErrorMessage(query.error, 'Failed to load documentation index')
+      : null,
+  };
 }

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -52,6 +52,10 @@ export const queryKeys = {
     recent: (scope: 'mine' | 'all', limit: number) =>
       ['activity', 'recent', scope, limit] as const,
   },
+  docs: {
+    index: (lang: string) => ['docs', 'index', lang] as const,
+    article: (slug: string, lang: string) => ['docs', 'article', slug, lang] as const,
+  },
   services: {
     summary: () => ['services', 'summary'] as const,
   },


### PR DESCRIPTION
## Was

Migriert die User-Manual-Hooks **`useDocsIndex`** + **`useDocsArticle`** von hand-gerolltem `useState`/`useEffect` auf TanStack Query — nächster Happen von #299 (F1). Zusätzlich werden die direkten `apiClient`-Aufrufe in ein typisiertes **`api/docs`-Modul** ausgelagert (behebt den Konventionsbruch „Hooks nutzen `apiClient` direkt").

## Änderungen

- **Neu `api/docs.ts`:** `getDocsIndex(lang)` / `getDocsArticle(slug, lang)` + die Typen `DocsArticleInfo`/`DocsGroupInfo`/`DocsArticle`.
- **Query-Keys:** `queryKeys.docs.index(lang)` + `docs.article(slug, lang)` — `lang`/`slug` im Key → Sprachwechsel refetcht, Artikel cachen pro slug.
- **`useDocsIndex`/`useDocsArticle`** → `useQuery`. `useDocsArticle` mit `enabled: !!slug` (null-slug → kein Fetch, `article: null`, wie bisher). Fehler via `getApiErrorMessage` (extrahiert FastAPI-`detail` wie zuvor).
- **Typen** liegen jetzt in `api/docs` und werden aus den Hooks **re-exportiert** → Imports in `DocsSidebar`/`DocsOverview`/`DocsGroupTab`/`UserManualPage` unverändert.
- Return-Shapes (`{ groups|article, isLoading, error }`) **unverändert**.

## Tests

- Neu `useDocsIndex.test.tsx` + `useDocsArticle.test.tsx` (bisher gab es keine): Index-Mapping + Fehler; Artikel-Load, null-slug fetcht nicht, Fehler.
- ✅ `npx vitest run` — 97 Dateien / 532 Tests grün
- ✅ `eslint` — 0 Errors / 0 Warnings
- ✅ `npm run build` — tsc -b + vite grün

## Track

Teil von #299 (F1). Danach offen: schedulers, users, devices, mobile, remote-servers, smart, benchmark, admin-db + Aufräum-PR (`useAsyncData` inkl. `useLiveActivities`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
