### PR TITLE
feat(client): schedulers hooks on TanStack Query — useMutation template (#299)

### DIFF
--- a/client/src/__tests__/hooks/useSchedulerHistory.test.tsx
+++ b/client/src/__tests__/hooks/useSchedulerHistory.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useSchedulerHistory } from '../../hooks/useSchedulers';
+import * as schedulersApi from '../../api/schedulers';
+import type { SchedulerHistoryResponse } from '../../api/schedulers';
+
+vi.mock('../../api/schedulers');
+const api = vi.mocked(schedulersApi);
+
+const historyResponse: SchedulerHistoryResponse = {
+  executions: [],
+  total: 0,
+  page: 1,
+  page_size: 50,
+  total_pages: 1,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getAllSchedulerHistory.mockResolvedValue(historyResponse);
+  api.getSchedulerHistory.mockResolvedValue(historyResponse);
+});
+
+describe('useSchedulerHistory', () => {
+  it('fetches all-scheduler history when no name is given', async () => {
+    const { result } = renderHook(() => useSchedulerHistory({ page: 1, pageSize: 50 }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(api.getAllSchedulerHistory).toHaveBeenCalledWith(1, 50, undefined, undefined);
+    expect(api.getSchedulerHistory).not.toHaveBeenCalled();
+  });
+
+  it('fetches a specific scheduler + status filter when given', async () => {
+    const { result } = renderHook(
+      () => useSchedulerHistory({ schedulerName: 'backup', page: 2, pageSize: 20, statusFilter: 'failed' }),
+      { wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(api.getSchedulerHistory).toHaveBeenCalledWith('backup', 2, 20, 'failed');
+  });
+
+  // Regression guard for the fixed pagination bug: an option change must refetch.
+  it('refetches when the page option changes', async () => {
+    const { result, rerender } = renderHook(
+      ({ page }: { page: number }) => useSchedulerHistory({ page, pageSize: 50 }),
+      { initialProps: { page: 1 }, wrapper: createQueryWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(api.getAllSchedulerHistory).toHaveBeenCalledWith(1, 50, undefined, undefined);
+
+    rerender({ page: 2 });
+    await waitFor(() =>
+      expect(api.getAllSchedulerHistory).toHaveBeenCalledWith(2, 50, undefined, undefined),
+    );
+  });
+
+  it('does not fetch when disabled', () => {
+    const { result } = renderHook(() => useSchedulerHistory({ enabled: false }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(api.getAllSchedulerHistory).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/hooks/useSchedulers.test.tsx
+++ b/client/src/__tests__/hooks/useSchedulers.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useSchedulers } from '../../hooks/useSchedulers';
+import * as schedulersApi from '../../api/schedulers';
+import type {
+  SchedulerListResponse,
+  RunNowResponse,
+  SchedulerToggleResponse,
+} from '../../api/schedulers';
+
+vi.mock('../../api/schedulers');
+const api = vi.mocked(schedulersApi);
+
+const listResponse: SchedulerListResponse = {
+  schedulers: [
+    {
+      name: 'backup',
+      display_name: 'Backup',
+      description: '',
+      is_running: false,
+      is_enabled: true,
+      interval_seconds: 3600,
+      interval_display: 'Every hour',
+      last_run_at: null,
+      next_run_at: null,
+      last_status: null,
+      last_error: null,
+      last_duration_ms: null,
+      config_key: null,
+      can_run_manually: true,
+      extra_config: null,
+      worker_healthy: true,
+    },
+  ],
+  total_running: 0,
+  total_enabled: 1,
+  worker_healthy: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getSchedulers.mockResolvedValue(listResponse);
+});
+
+describe('useSchedulers', () => {
+  it('maps the list response into the result shape', async () => {
+    const { result } = renderHook(() => useSchedulers({ refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.schedulers).toHaveLength(1);
+    expect(result.current.totalEnabled).toBe(1);
+    expect(result.current.workerHealthy).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('runNow calls the API, returns the response and refetches the list', async () => {
+    const runResp: RunNowResponse = {
+      success: true,
+      message: 'ok',
+      execution_id: 1,
+      scheduler_name: 'backup',
+      status: 'requested',
+    };
+    api.runSchedulerNow.mockResolvedValue(runResp);
+
+    const { result } = renderHook(() => useSchedulers({ refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(api.getSchedulers).toHaveBeenCalledTimes(1);
+
+    let resp: RunNowResponse | undefined;
+    await act(async () => {
+      resp = await result.current.runNow('backup');
+    });
+
+    expect(api.runSchedulerNow).toHaveBeenCalledWith('backup', false);
+    expect(resp).toEqual(runResp);
+    // onSettled invalidates schedulers.all() → list refetches
+    await waitFor(() => expect(api.getSchedulers.mock.calls.length).toBeGreaterThanOrEqual(2));
+  });
+
+  it('toggle calls the API and returns the response', async () => {
+    const toggleResp: SchedulerToggleResponse = {
+      success: true,
+      scheduler_name: 'backup',
+      is_enabled: false,
+      message: 'disabled',
+    };
+    api.toggleScheduler.mockResolvedValue(toggleResp);
+
+    const { result } = renderHook(() => useSchedulers({ refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let resp: SchedulerToggleResponse | undefined;
+    await act(async () => {
+      resp = await result.current.toggle('backup', false);
+    });
+
+    expect(api.toggleScheduler).toHaveBeenCalledWith('backup', false);
+    expect(resp).toEqual(toggleResp);
+  });
+
+  it('updateConfig returns true on success and false on failure', async () => {
+    api.updateSchedulerConfig.mockResolvedValueOnce({ success: true, message: 'ok' });
+
+    const { result } = renderHook(() => useSchedulers({ refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.updateConfig('backup', { is_enabled: true });
+    });
+    expect(ok).toBe(true);
+
+    api.updateSchedulerConfig.mockRejectedValueOnce(new Error('nope'));
+    let ok2: boolean | undefined;
+    await act(async () => {
+      ok2 = await result.current.updateConfig('backup', { is_enabled: false });
+    });
+    expect(ok2).toBe(false);
+  });
+
+  it('surfaces an error string when the list fetch fails', async () => {
+    api.getSchedulers.mockReset();
+    api.getSchedulers.mockRejectedValue(new Error('sched boom'));
+
+    const { result } = renderHook(() => useSchedulers({ refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.error).toBe('sched boom'));
+  });
+});

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -13,7 +13,7 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useBackups.ts` | `api/backup` | Backup list via **TanStack Query** (no polling; create/delete mutations invalidate). Returns raw `error` for i18n formatting by the caller |
 | `useFileShares.ts` | `api/shares` | The three shares-domain reads (user shares, shared-with-me, statistics) via **TanStack Query**; user-scoped — cache is cleared on every identity change (AuthContext) |
 | `useFanControl.ts` | `api/fan-control` | Fan config, curves, schedules — full fan management state |
-| `useSchedulers.ts` | `api/schedulers` | Scheduler list, status, history, run-now |
+| `useSchedulers.ts` | `api/schedulers` | Scheduler list + history via **TanStack Query**; the three actions (runNow/toggle/updateConfig) via **`useMutation`** with `onSettled: invalidateQueries(schedulers.all())` — the reference for the mutation pattern. runNow keeps the 3s/30s fast-poll (via a function `refetchInterval`). `useSchedulerHistory` is fully options-driven (page/filter in the key → changing them refetches; fixed a latent no-refetch bug) |
 | `useBenchmark.ts` | `api/benchmark` | Disk benchmark state, progress, results |
 | `useSmartData.ts` | `api/smart` | SMART disk health data |
 | `useAdminDb.ts` | `api/admin-db` | Admin database inspection |

--- a/client/src/hooks/useSchedulers.ts
+++ b/client/src/hooks/useSchedulers.ts
@@ -1,4 +1,6 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useCallback, useRef } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '../lib/queryKeys';
 import { getApiErrorMessage } from '../lib/errorHandling';
 import {
   getSchedulers,
@@ -9,7 +11,6 @@ import {
   updateSchedulerConfig,
 } from '../api/schedulers';
 import type {
-  SchedulerListResponse,
   SchedulerStatus,
   SchedulerHistoryResponse,
   SchedulerExecStatus,
@@ -43,97 +44,89 @@ const FAST_POLL_DURATION = 30_000;
 const FAST_POLL_INTERVAL = 3_000;
 
 /**
- * Hook for managing all schedulers
+ * Hook for managing all schedulers. Reads are TanStack Query backed; the three
+ * mutations (runNow/toggle/updateConfig) go through useMutation and invalidate
+ * the schedulers domain (list + history) on settle. Public shape unchanged.
  */
 export function useSchedulers(options: UseSchedulersOptions = {}): UseSchedulersReturn {
   const { refreshInterval = 30000, enabled = true, pauseRefresh = false } = options;
-  const [data, setData] = useState<SchedulerListResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
+  const queryClient = useQueryClient();
+
+  // After a Run Now we poll fast (3s) for 30s so the user sees the execution go
+  // requested → running → completed, then fall back to the normal interval.
   const fastPollUntilRef = useRef<number>(0);
 
-  const loadData = useCallback(async () => {
-    try {
-      const response = await getSchedulers();
-      setData(response);
-      setError(null);
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, 'Failed to load schedulers'));
-    }
-  }, []);
+  const query = useQuery({
+    queryKey: queryKeys.schedulers.list(),
+    queryFn: getSchedulers,
+    enabled,
+    refetchInterval: pauseRefresh
+      ? false
+      : () => (Date.now() < fastPollUntilRef.current ? FAST_POLL_INTERVAL : refreshInterval),
+  });
 
-  // Initial load
-  useEffect(() => {
-    if (!enabled || hasLoadedOnce) return;
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: queryKeys.schedulers.all() }),
+    [queryClient],
+  );
 
-    setLoading(true);
-    loadData().finally(() => {
-      setLoading(false);
-      setHasLoadedOnce(true);
-    });
-  }, [enabled, hasLoadedOnce, loadData]);
+  const runNowMutation = useMutation({
+    mutationFn: ({ name, force }: { name: string; force: boolean }) => runSchedulerNow(name, force),
+    onSuccess: (response) => {
+      if (response.success) {
+        fastPollUntilRef.current = Date.now() + FAST_POLL_DURATION;
+      }
+    },
+    // Refresh immediately (and await, so callers see fresh data on resolve).
+    onSettled: () => invalidate(),
+  });
 
-  // Auto-refresh (respects fast-poll mode after Run Now)
-  useEffect(() => {
-    if (!enabled || !hasLoadedOnce) return;
-    if (pauseRefresh) return;
+  const toggleMutation = useMutation({
+    mutationFn: ({ name, enabled: toggleEnabled }: { name: string; enabled: boolean }) =>
+      toggleScheduler(name, toggleEnabled),
+    onSettled: () => invalidate(),
+  });
 
-    const tick = () => {
-      const now = Date.now();
-      const isFastPolling = now < fastPollUntilRef.current;
-      const interval = isFastPolling ? FAST_POLL_INTERVAL : refreshInterval;
+  const updateConfigMutation = useMutation({
+    mutationFn: ({ name, config }: { name: string; config: SchedulerConfigUpdate }) =>
+      updateSchedulerConfig(name, config),
+    onSettled: () => invalidate(),
+  });
 
-      if (interval <= 0) return;
+  const runNow = useCallback(
+    (name: string, force = false): Promise<RunNowResponse> =>
+      runNowMutation.mutateAsync({ name, force }),
+    [runNowMutation],
+  );
 
-      loadData();
-      timerId = window.setTimeout(tick, interval);
-    };
+  const toggle = useCallback(
+    (name: string, toggleEnabled: boolean): Promise<SchedulerToggleResponse> =>
+      toggleMutation.mutateAsync({ name, enabled: toggleEnabled }),
+    [toggleMutation],
+  );
 
-    const initialInterval =
-      Date.now() < fastPollUntilRef.current ? FAST_POLL_INTERVAL : refreshInterval;
-    let timerId = window.setTimeout(tick, initialInterval);
-
-    return () => window.clearTimeout(timerId);
-  }, [enabled, hasLoadedOnce, refreshInterval, pauseRefresh, loadData]);
-
-  const runNow = useCallback(async (name: string, force: boolean = false): Promise<RunNowResponse> => {
-    const response = await runSchedulerNow(name, force);
-    // Enable fast polling for 30s so the user sees requested → running → completed
-    if (response.success) {
-      fastPollUntilRef.current = Date.now() + FAST_POLL_DURATION;
-    }
-    // Refresh data immediately
-    await loadData();
-    return response;
-  }, [loadData]);
-
-  const toggle = useCallback(async (name: string, toggleEnabled: boolean): Promise<SchedulerToggleResponse> => {
-    const response = await toggleScheduler(name, toggleEnabled);
-    // Refresh data after toggle
-    await loadData();
-    return response;
-  }, [loadData]);
-
-  const updateConfig = useCallback(async (name: string, config: SchedulerConfigUpdate): Promise<boolean> => {
-    try {
-      await updateSchedulerConfig(name, config);
-      // Refresh data after config update
-      await loadData();
-      return true;
-    } catch {
-      return false;
-    }
-  }, [loadData]);
+  const updateConfig = useCallback(
+    async (name: string, config: SchedulerConfigUpdate): Promise<boolean> => {
+      try {
+        await updateConfigMutation.mutateAsync({ name, config });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [updateConfigMutation],
+  );
 
   return {
-    schedulers: data?.schedulers || [],
-    totalRunning: data?.total_running || 0,
-    totalEnabled: data?.total_enabled || 0,
-    workerHealthy: data?.worker_healthy ?? null,
-    loading,
-    error,
-    refetch: loadData,
+    schedulers: query.data?.schedulers ?? [],
+    totalRunning: query.data?.total_running ?? 0,
+    totalEnabled: query.data?.total_enabled ?? 0,
+    workerHealthy: query.data?.worker_healthy ?? null,
+    loading: query.isLoading,
+    error: query.isError ? getApiErrorMessage(query.error, 'Failed to load schedulers') : null,
+    refetch: async () => {
+      await query.refetch();
+    },
     runNow,
     toggle,
     updateConfig,
@@ -155,70 +148,45 @@ interface UseSchedulerHistoryReturn {
   loading: boolean;
   error: string | null;
   refetch: () => Promise<void>;
-  setPage: (page: number) => void;
-  setStatusFilter: (filter: SchedulerExecStatus | undefined) => void;
 }
 
 /**
- * Hook for scheduler execution history
+ * Hook for scheduler execution history. Fully options-driven — page, pageSize,
+ * statusFilter and schedulerName are part of the query key, so changing any of
+ * them refetches. (Previously these seeded internal state once and later option
+ * changes were ignored, so consumer-driven pagination/filtering never refetched.)
  */
 export function useSchedulerHistory(options: UseSchedulerHistoryOptions = {}): UseSchedulerHistoryReturn {
   const {
     schedulerName,
-    page: initialPage = 1,
+    page = 1,
     pageSize = 20,
-    statusFilter: initialStatusFilter,
+    statusFilter,
     refreshInterval = 0,
     enabled = true,
   } = options;
 
-  const [page, setPage] = useState(initialPage);
-  const [statusFilter, setStatusFilter] = useState<SchedulerExecStatus | undefined>(initialStatusFilter);
-  const [history, setHistory] = useState<SchedulerHistoryResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const loadData = useCallback(async () => {
-    try {
-      let response: SchedulerHistoryResponse;
-
-      if (schedulerName) {
-        response = await getSchedulerHistory(schedulerName, page, pageSize, statusFilter);
-      } else {
-        response = await getAllSchedulerHistory(page, pageSize, statusFilter, undefined);
-      }
-
-      setHistory(response);
-      setError(null);
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, 'Failed to load history'));
-    }
-  }, [schedulerName, page, pageSize, statusFilter]);
-
-  // Load on mount and when params change
-  useEffect(() => {
-    if (!enabled) return;
-
-    setLoading(true);
-    loadData().finally(() => {
-      setLoading(false);
-    });
-  }, [enabled, loadData]);
-
-  // Auto-refresh if interval set
-  useEffect(() => {
-    if (!enabled || refreshInterval <= 0) return;
-
-    const interval = setInterval(loadData, refreshInterval);
-    return () => clearInterval(interval);
-  }, [enabled, refreshInterval, loadData]);
+  const query = useQuery({
+    queryKey: queryKeys.schedulers.history(
+      schedulerName ?? null,
+      page,
+      pageSize,
+      statusFilter ?? null,
+    ),
+    queryFn: () =>
+      schedulerName
+        ? getSchedulerHistory(schedulerName, page, pageSize, statusFilter)
+        : getAllSchedulerHistory(page, pageSize, statusFilter, undefined),
+    enabled,
+    refetchInterval: refreshInterval > 0 ? refreshInterval : false,
+  });
 
   return {
-    history,
-    loading,
-    error,
-    refetch: loadData,
-    setPage,
-    setStatusFilter,
+    history: query.data ?? null,
+    loading: query.isLoading,
+    error: query.isError ? getApiErrorMessage(query.error, 'Failed to load history') : null,
+    refetch: async () => {
+      await query.refetch();
+    },
   };
 }

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -59,4 +59,15 @@ export const queryKeys = {
   services: {
     summary: () => ['services', 'summary'] as const,
   },
+  schedulers: {
+    /** Domain-Prefix — invalidiert list + history (Mutations betreffen beide). */
+    all: () => ['schedulers'] as const,
+    list: () => ['schedulers', 'list'] as const,
+    history: (
+      name: string | null,
+      page: number,
+      pageSize: number,
+      statusFilter: string | null,
+    ) => ['schedulers', 'history', name, page, pageSize, statusFilter] as const,
+  },
 } as const;


### PR DESCRIPTION
## Was

Migriert `useSchedulers` + `useSchedulerHistory` auf TanStack Query — der erste **Mutation-Happen** von #299 und damit die **Referenz für das `useMutation`-Muster**, das die übrigen CRUD-Domains übernehmen.

## `useSchedulers`

- **List-Read** via `useQuery`. Die **Fast-Poll-Mechanik** (nach „Run Now" 30 s lang alle 3 s, danach normales Intervall) bleibt erhalten — über ein Funktions-`refetchInterval`, das eine Ref liest; `pauseRefresh` → `refetchInterval: false`.
- **`runNow` / `toggle` / `updateConfig`** via **`useMutation`**, jeweils `onSettled: invalidateQueries(schedulers.all())` (das Promise wird zurückgegeben → `mutateAsync` resolved erst nach dem Refetch, wie zuvor „await loadData, dann return"). Öffentliche Signaturen **unverändert** (`runNow→RunNowResponse`, `toggle→ToggleResponse`, `updateConfig→boolean`) → SchedulerDashboard unberührt.

## `useSchedulerHistory` — inkl. Bugfix

Jetzt **vollständig options-getrieben**: `schedulerName`/`page`/`pageSize`/`statusFilter` sind Teil des Query-Keys → eine Options-Änderung refetcht.

**Behebt einen latenten Bug:** der alte Hook seedete internen State nur einmal (`useState(initialPage)`) und ignorierte spätere Options-Änderungen — die im SchedulerDashboard über `onPageChange→setHistoryPage→page`-Option gesteuerte **Pagination/Statusfilter refetchten also nie** (fiel nur bei ≤ 50 Executions nicht auf). Die ungenutzten `setPage`/`setStatusFilter` entfallen aus dem Return (der Konsument steuert page/filter über eigenen State + Optionen). *(Fix vorab abgestimmt.)*

## Query-Keys

`queryKeys.schedulers.{all,list,history}`. `all()` invalidiert list **und** history — ein Run-Now erzeugt eine History-Execution, also müssen beide frisch werden.

## Tests

- Neu `useSchedulers.test.tsx` (list, runNow+Invalidierung, toggle, updateConfig true/false, error) + `useSchedulerHistory.test.tsx` inkl. **Regression-Guard**, dass ein `page`-Options-Wechsel refetcht.
- ✅ `npx vitest run` — 99 Dateien / 541 Tests grün
- ✅ `eslint` — 0 Errors / 0 Warnings
- ✅ `npm run build` — tsc -b + vite grün (bestätigt SchedulerDashboard trotz entfernter setPage/setStatusFilter)

## Track

Teil von #299 (F1); setzt das `useMutation`-Template. Danach offen: users, devices, mobile, remote-servers, smart, benchmark, admin-db + Aufräum-PR (`useAsyncData` inkl. `useLiveActivities`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
