### PR TITLE
feat(client): useUserManagement on TanStack Query (#299)

### DIFF
--- a/client/src/__tests__/hooks/useUserManagement.test.tsx
+++ b/client/src/__tests__/hooks/useUserManagement.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useUserManagement } from '../../hooks/useUserManagement';
+import * as usersApi from '../../api/users';
+import type { UserPublic, UsersResponse } from '../../api/users';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../lib/errorHandling', () => ({
+  handleApiError: vi.fn(),
+  getApiErrorMessage: (e: unknown, fallback: string) => (e instanceof Error ? e.message : fallback),
+}));
+
+vi.mock('../../hooks/useConfirmDialog', () => ({
+  useConfirmDialog: () => ({ confirm: vi.fn().mockResolvedValue(true), dialog: null }),
+}));
+
+vi.mock('../../api/users');
+const api = vi.mocked(usersApi);
+
+function user(overrides: Partial<UserPublic>): UserPublic {
+  return {
+    id: 1,
+    username: 'alice',
+    email: 'a@example.com',
+    role: 'admin',
+    is_active: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: null,
+    ...overrides,
+  };
+}
+
+const usersResponse: UsersResponse = {
+  users: [user({ id: 1, role: 'admin', is_active: true }), user({ id: 2, username: 'bob', role: 'user', is_active: false })],
+  total: 2,
+  active: 1,
+  inactive: 1,
+  admins: 1,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.listUsers.mockResolvedValue(usersResponse);
+});
+
+describe('useUserManagement', () => {
+  it('loads users and derives stats', async () => {
+    const { result } = renderHook(() => useUserManagement(), { wrapper: createQueryWrapper() });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.users).toHaveLength(2);
+    expect(result.current.stats).toEqual({ total: 2, active: 1, inactive: 1, admins: 1 });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('refetches with the new params when the role filter changes', async () => {
+    const { result } = renderHook(() => useUserManagement(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      result.current.setRoleFilter('admin');
+    });
+    await waitFor(() =>
+      expect(api.listUsers).toHaveBeenLastCalledWith(expect.objectContaining({ role: 'admin' })),
+    );
+  });
+
+  it('handleCreateUser creates, returns true and refetches', async () => {
+    api.createUser.mockResolvedValue(user({ id: 3, username: 'carol', role: 'user' }));
+    const { result } = renderHook(() => useUserManagement(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const before = api.listUsers.mock.calls.length;
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.handleCreateUser({
+        username: 'carol',
+        email: '',
+        password: 'Secret123',
+        role: 'user',
+        is_active: true,
+      });
+    });
+
+    expect(ok).toBe(true);
+    expect(api.createUser).toHaveBeenCalledWith({ username: 'carol', password: 'Secret123', role: 'user', email: undefined });
+    await waitFor(() => expect(api.listUsers.mock.calls.length).toBeGreaterThan(before));
+  });
+
+  it('handleCreateUser rejects an empty username without calling the API', async () => {
+    const { result } = renderHook(() => useUserManagement(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.handleCreateUser({
+        username: '',
+        email: '',
+        password: '',
+        role: 'user',
+        is_active: true,
+      });
+    });
+
+    expect(ok).toBe(false);
+    expect(api.createUser).not.toHaveBeenCalled();
+  });
+
+  it('handleToggleActive calls the API', async () => {
+    api.toggleUserActive.mockResolvedValue(user({ id: 1, is_active: false }));
+    const { result } = renderHook(() => useUserManagement(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.handleToggleActive(1);
+    });
+    expect(api.toggleUserActive).toHaveBeenCalledWith(1);
+  });
+
+  it('surfaces an error string when the list fetch fails', async () => {
+    api.listUsers.mockReset();
+    api.listUsers.mockRejectedValue(new Error('users boom'));
+    const { result } = renderHook(() => useUserManagement(), { wrapper: createQueryWrapper() });
+
+    await waitFor(() => expect(result.current.error).toBe('users boom'));
+  });
+});

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -17,7 +17,7 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useBenchmark.ts` | `api/benchmark` | Disk benchmark state, progress, results |
 | `useSmartData.ts` | `api/smart` | SMART disk health data |
 | `useAdminDb.ts` | `api/admin-db` | Admin database inspection |
-| `useUserManagement.ts` | `api/users` | User CRUD operations |
+| `useUserManagement.ts` | `api/users` | User list via **TanStack Query** (key includes the active search/role/status/sort → changing filters refetches; search debounced); CRUD (create/update/delete/bulkDelete/toggleActive) via **`useMutation`** with `onSettled: invalidateQueries(users.all())`. Filter/selection/sort/CSV/confirm state stays local. Public shape unchanged |
 | `useDeviceManagement.ts` | `api/devices` | Device list, pairing, removal |
 | `useMobile.ts` | `api/mobile` | Mobile device management |
 | `useRemoteServers.ts` | `api/remote-servers` | Remote server profiles |

--- a/client/src/hooks/useUserManagement.ts
+++ b/client/src/hooks/useUserManagement.ts
@@ -1,7 +1,9 @@
-import { useState, useEffect, useRef, useCallback, type ReactNode } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
-import { handleApiError } from '../lib/errorHandling';
+import { handleApiError, getApiErrorMessage } from '../lib/errorHandling';
+import { queryKeys } from '../lib/queryKeys';
 import { useConfirmDialog } from './useConfirmDialog';
 import {
   listUsers,
@@ -11,7 +13,8 @@ import {
   bulkDeleteUsers,
   toggleUserActive,
   type UserPublic,
-  type UsersResponse,
+  type CreateUserPayload,
+  type UpdateUserPayload,
 } from '../api/users';
 
 export interface UserFormData {
@@ -32,11 +35,7 @@ interface UserStats {
 export function useUserManagement() {
   const { t } = useTranslation(['admin', 'common']);
 
-  // Data
-  const [users, setUsers] = useState<UserPublic[]>([]);
-  const [stats, setStats] = useState<UserStats>({ total: 0, active: 0, inactive: 0, admins: 0 });
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
   // Filters
   const [searchTerm, setSearchTerm] = useState('');
@@ -59,39 +58,61 @@ export function useUserManagement() {
     return () => clearTimeout(debounceRef.current);
   }, [searchTerm]);
 
-  // Load users when filters change
-  const loadUsers = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+  // Load users — TanStack Query keyed on the active filters/sort, so changing any
+  // of them refetches. Search is debounced above. No polling.
+  const listParams = useMemo(
+    () => ({
+      search: debouncedSearch || undefined,
+      role: roleFilter || undefined,
+      is_active: statusFilter || undefined,
+      sort_by: sortBy || undefined,
+      sort_order: sortBy && sortOrder ? sortOrder : undefined,
+    }),
+    [debouncedSearch, roleFilter, statusFilter, sortBy, sortOrder],
+  );
 
-    try {
-      const data: UsersResponse = await listUsers({
-        search: debouncedSearch || undefined,
-        role: roleFilter || undefined,
-        is_active: statusFilter || undefined,
-        sort_by: sortBy || undefined,
-        sort_order: sortBy && sortOrder ? sortOrder : undefined,
-      });
+  const query = useQuery({
+    queryKey: queryKeys.users.list(listParams),
+    queryFn: () => listUsers(listParams),
+  });
 
-      setUsers(data.users);
-      setStats({
-        total: data.total,
-        active: data.active,
-        inactive: data.inactive,
-        admins: data.admins,
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to load users';
-      setError(message);
-      handleApiError(err, 'Failed to load users');
-    } finally {
-      setLoading(false);
-    }
-  }, [debouncedSearch, roleFilter, statusFilter, sortBy, sortOrder]);
+  const users = useMemo(() => query.data?.users ?? [], [query.data]);
+  const stats: UserStats = {
+    total: query.data?.total ?? 0,
+    active: query.data?.active ?? 0,
+    inactive: query.data?.inactive ?? 0,
+    admins: query.data?.admins ?? 0,
+  };
+  const loading = query.isLoading;
+  const error = query.isError ? getApiErrorMessage(query.error, 'Failed to load users') : null;
 
-  useEffect(() => {
-    loadUsers();
-  }, [loadUsers]);
+  // Mutations invalidate the whole users domain on settle (#373 pattern).
+  const invalidateUsers = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: queryKeys.users.all() }),
+    [queryClient],
+  );
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateUserPayload) => createUser(payload),
+    onSettled: () => invalidateUsers(),
+  });
+  const updateMutation = useMutation({
+    mutationFn: ({ userId, payload }: { userId: number; payload: UpdateUserPayload }) =>
+      updateUser(userId, payload),
+    onSettled: () => invalidateUsers(),
+  });
+  const deleteMutation = useMutation({
+    mutationFn: (userId: number) => deleteUser(userId),
+    onSettled: () => invalidateUsers(),
+  });
+  const bulkDeleteMutation = useMutation({
+    mutationFn: (userIds: number[]) => bulkDeleteUsers(userIds),
+    onSettled: () => invalidateUsers(),
+  });
+  const toggleActiveMutation = useMutation({
+    mutationFn: (userId: number) => toggleUserActive(userId),
+    onSettled: () => invalidateUsers(),
+  });
 
   // Sort handler
   const handleSort = useCallback((field: string) => {
@@ -135,43 +156,41 @@ export function useUserManagement() {
       }
 
       try {
-        await createUser({
+        await createMutation.mutateAsync({
           username: form.username,
           password: form.password,
           role: form.role || 'user',
           email: form.email || undefined,
         });
         toast.success(t('users.messages.created'));
-        loadUsers();
         return true;
       } catch (err) {
         handleApiError(err, t('users.messages.createFailed'));
         return false;
       }
     },
-    [t, loadUsers],
+    [t, createMutation],
   );
 
   const handleUpdateUser = useCallback(
     async (userId: number, form: UserFormData, original: UserPublic): Promise<boolean> => {
       try {
-        const updateData: Record<string, unknown> = {};
+        const updateData: UpdateUserPayload = {};
         if (form.username !== original.username) updateData.username = form.username;
         if (form.email !== (original.email ?? '')) updateData.email = form.email || null;
         if (form.role !== original.role) updateData.role = form.role;
         if (form.is_active !== original.is_active) updateData.is_active = form.is_active;
         if (form.password) updateData.password = form.password;
 
-        await updateUser(userId, updateData);
+        await updateMutation.mutateAsync({ userId, payload: updateData });
         toast.success(t('users.messages.updated'));
-        loadUsers();
         return true;
       } catch (err) {
         handleApiError(err, t('users.messages.updateFailed'));
         return false;
       }
     },
-    [t, loadUsers],
+    [t, updateMutation],
   );
 
   const handleDeleteUser = useCallback(
@@ -184,40 +203,37 @@ export function useUserManagement() {
       if (!confirmed) return;
 
       try {
-        await deleteUser(userId);
+        await deleteMutation.mutateAsync(userId);
         toast.success(t('users.messages.deleted'));
-        loadUsers();
       } catch (err) {
         handleApiError(err, t('users.messages.deleteFailed'));
       }
     },
-    [t, confirm, loadUsers],
+    [t, confirm, deleteMutation],
   );
 
   const handleBulkDelete = useCallback(async () => {
     if (selectedUsers.size === 0) return;
 
     try {
-      const result = await bulkDeleteUsers(Array.from(selectedUsers));
+      const result = await bulkDeleteMutation.mutateAsync(Array.from(selectedUsers));
       toast.success(t('users.bulk.deleted', { count: result.deleted }));
       setSelectedUsers(new Set());
-      loadUsers();
     } catch (err) {
       handleApiError(err, t('users.messages.bulkDeleteFailed'));
     }
-  }, [selectedUsers, t, loadUsers]);
+  }, [selectedUsers, t, bulkDeleteMutation]);
 
   const handleToggleActive = useCallback(
     async (userId: number) => {
       try {
-        await toggleUserActive(userId);
+        await toggleActiveMutation.mutateAsync(userId);
         toast.success(t('users.messages.statusUpdated'));
-        loadUsers();
       } catch (err) {
         handleApiError(err, t('users.messages.toggleFailed'));
       }
     },
-    [t, loadUsers],
+    [t, toggleActiveMutation],
   );
 
   const handleExportCSV = useCallback(() => {

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -59,6 +59,11 @@ export const queryKeys = {
   services: {
     summary: () => ['services', 'summary'] as const,
   },
+  users: {
+    /** Domain-Prefix — invalidiert alle users-Reads (CRUD-Mutations). */
+    all: () => ['users'] as const,
+    list: (params: Record<string, string | undefined>) => ['users', 'list', params] as const,
+  },
   schedulers: {
     /** Domain-Prefix — invalidiert list + history (Mutations betreffen beide). */
     all: () => ['schedulers'] as const,


### PR DESCRIPTION
## Was

Migriert `useUserManagement` auf TanStack Query — der größte CRUD-Happen von #299, angewandt auf das in #373 etablierte `useMutation`-Template.

## Änderungen

- **List-Read** via `useQuery`, Key enthält die aktiven Filter (`search`/`role`/`status`/`sort`) → Filterwechsel refetcht automatisch; die Suche bleibt debounced. `users`/`stats` aus `query.data` abgeleitet. Kein Polling.
- **CRUD** (`create`/`update`/`delete`/`bulkDelete`/`toggleActive`) via **`useMutation`**, je `onSettled: invalidateQueries(users.all())`. Die Handler behalten **Signatur, Validierung, Toasts und Confirm-Dialog** exakt — nur der API-Call wird `mutateAsync`, die manuellen `loadUsers()`-Reloads entfallen.
- `mutationFn`s in Arrows gewrappt, damit das **zweite `MutationFunctionContext`-Argument von TanStack Query v5** nicht an die API-Funktionen durchgereicht wird.
- Filter-/Sort-/Selection-/CSV-/Confirm-State bleibt lokal (UI-Concern).
- Öffentliche Hook-Shape **unverändert** → UserManagement-Page unberührt.

## Query-Keys

`queryKeys.users.{all,list}`. `list(params)` — RQ hasht den Params-Key wertbasiert.

## Tests

- Neu `useUserManagement.test.tsx` (bisher keiner): List+Stats, Filterwechsel refetcht, `handleCreateUser` (success→true+Invalidierung / leerer Username→false ohne Call), `handleToggleActive`, error.
- ✅ `npx vitest run` — 100 Dateien / 547 Tests grün
- ✅ `eslint` — 0 Errors / 0 Warnings
- ✅ `npm run build` — tsc -b + vite grün

## Bewusste Mini-Änderung

Wie bei den anderen Read-Migrationen: ein List-Ladefehler erscheint nur noch im Error-Banner, nicht zusätzlich als Toast (`useQuery` v5 hat kein `onError`). CRUD-Fehler-Toasts unverändert.

## Track

Teil von #299 (F1). Danach offen: devices, mobile, remote-servers, smart, benchmark, admin-db + Aufräum-PR (`useAsyncData` inkl. `useLiveActivities`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
