### PR TITLE
feat(client): remote-servers hooks on TanStack Query (#299)

### DIFF
--- a/client/src/__tests__/hooks/useRemoteServers.test.tsx
+++ b/client/src/__tests__/hooks/useRemoteServers.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+import { useServerProfiles, useVPNProfiles } from '../../hooks/useRemoteServers';
+import * as remoteApi from '../../api/remote-servers';
+import type { ServerProfile, VPNProfile } from '../../api/remote-servers';
+
+vi.mock('../../api/remote-servers');
+const api = vi.mocked(remoteApi);
+
+const serverProfile: ServerProfile = {
+  id: 1,
+  user_id: 1,
+  name: 'NAS',
+  ssh_host: '10.0.0.1',
+  ssh_port: 22,
+  ssh_username: 'admin',
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+const vpnProfile: VPNProfile = {
+  id: 1,
+  user_id: 1,
+  name: 'Home VPN',
+  vpn_type: 'wireguard',
+  auto_connect: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.listServerProfiles.mockResolvedValue([serverProfile]);
+  api.listVPNProfiles.mockResolvedValue([vpnProfile]);
+});
+
+describe('useServerProfiles', () => {
+  it('loads the profile list', async () => {
+    const { result } = renderHook(() => useServerProfiles(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.profiles).toHaveLength(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('createProfile calls the API, returns the profile and refetches', async () => {
+    api.createServerProfile.mockResolvedValue({ ...serverProfile, id: 2, name: 'New' });
+    const { result } = renderHook(() => useServerProfiles(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const before = api.listServerProfiles.mock.calls.length;
+
+    let created: ServerProfile | undefined;
+    await act(async () => {
+      created = await result.current.createProfile({
+        name: 'New',
+        ssh_host: '10.0.0.2',
+        ssh_port: 22,
+        ssh_username: 'admin',
+        ssh_private_key: 'KEY',
+      });
+    });
+
+    expect(api.createServerProfile).toHaveBeenCalled();
+    expect(created?.id).toBe(2);
+    await waitFor(() => expect(api.listServerProfiles.mock.calls.length).toBeGreaterThan(before));
+  });
+
+  it('surfaces an error string when the list fetch fails', async () => {
+    api.listServerProfiles.mockReset();
+    api.listServerProfiles.mockRejectedValue(new Error('profiles boom'));
+    const { result } = renderHook(() => useServerProfiles(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.error).toBe('profiles boom'));
+  });
+});
+
+describe('useVPNProfiles', () => {
+  it('loads the VPN profile list', async () => {
+    const { result } = renderHook(() => useVPNProfiles(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.profiles).toHaveLength(1);
+  });
+
+  it('createProfile posts the FormData and refetches', async () => {
+    api.createVPNProfile.mockResolvedValue({ ...vpnProfile, id: 2 });
+    const { result } = renderHook(() => useVPNProfiles(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const before = api.listVPNProfiles.mock.calls.length;
+
+    const fd = new FormData();
+    await act(async () => {
+      await result.current.createProfile(fd);
+    });
+
+    expect(api.createVPNProfile).toHaveBeenCalledWith(fd);
+    await waitFor(() => expect(api.listVPNProfiles.mock.calls.length).toBeGreaterThan(before));
+  });
+});

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -20,7 +20,7 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useUserManagement.ts` | `api/users` | User list via **TanStack Query** (key includes the active search/role/status/sort → changing filters refetches; search debounced); CRUD (create/update/delete/bulkDelete/toggleActive) via **`useMutation`** with `onSettled: invalidateQueries(users.all())`. Filter/selection/sort/CSV/confirm state stays local. Public shape unchanged |
 | `useDeviceManagement.ts` | `api/devices` | Device list, pairing, removal |
 | `useMobile.ts` | `api/mobile` | Mobile device management |
-| `useRemoteServers.ts` | `api/remote-servers` | Remote server profiles |
+| `useRemoteServers.ts` | `api/remote-servers` | `useServerProfiles` + `useVPNProfiles` — lists via **TanStack Query**, CRUD (+ startServer) via **`useMutation`** with `onSettled: invalidateQueries(<domain>)`. testConnection is a passthrough (no cache effect). User-scoped — cache cleared on identity change |
 | `useActivityFeed.ts` | `api/activity` | Dashboard activity feed (own / admin all-users) via **TanStack Query** (`useQuery`, default 30s poll). Query holds raw API items (persister-safe); view mapping (i18n titles, relative "ago") is derived per render. User-scoped — cache cleared on identity change (AuthContext); `scope`+`limit` are part of the key |
 | `useLiveActivities.ts` | — | Real-time activity via polling. **Not yet on TanStack Query** — still polls fan/power status via `useAsyncData`; migrate together with the fans/power domains + the `useAsyncData` cleanup (#299) |
 | `useDocsIndex.ts` | `api/docs` | Documentation article index via **TanStack Query** (`useQuery`; `lang` in the key → language switch refetches). Re-exports the `DocsGroupInfo`/`DocsArticleInfo` types |

--- a/client/src/hooks/useRemoteServers.ts
+++ b/client/src/hooks/useRemoteServers.ts
@@ -1,66 +1,71 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import * as api from '../api/remote-servers';
+import { queryKeys } from '../lib/queryKeys';
+import { getApiErrorMessage } from '../lib/errorHandling';
 
+/**
+ * SSH server profiles — list via TanStack Query, CRUD + start via useMutation
+ * (each onSettled invalidates the server-profiles list). User-scoped: the cache
+ * is cleared on identity change (AuthContext). Public shape unchanged.
+ */
 export function useServerProfiles() {
-  const [profiles, setProfiles] = useState<api.ServerProfile[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
-  const fetchProfiles = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await api.listServerProfiles();
-      setProfiles(data);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to load profiles';
-      setError(message);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const query = useQuery({
+    queryKey: queryKeys.remoteServers.serverProfiles(),
+    queryFn: api.listServerProfiles,
+  });
 
-  const createProfile = useCallback(async (data: api.ServerProfileCreate) => {
-    const newProfile = await api.createServerProfile(data);
-    setProfiles([newProfile, ...profiles]);
-    return newProfile;
-  }, [profiles]);
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: queryKeys.remoteServers.serverProfiles() }),
+    [queryClient],
+  );
 
-  const updateProfile = useCallback(async (id: number, data: Partial<api.ServerProfileCreate>) => {
-    const updated = await api.updateServerProfile(id, data);
-    setProfiles(profiles.map(p => p.id === id ? updated : p));
-    return updated;
-  }, [profiles]);
+  const createMutation = useMutation({
+    mutationFn: (data: api.ServerProfileCreate) => api.createServerProfile(data),
+    onSettled: () => invalidate(),
+  });
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: Partial<api.ServerProfileCreate> }) =>
+      api.updateServerProfile(id, data),
+    onSettled: () => invalidate(),
+  });
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => api.deleteServerProfile(id),
+    onSettled: () => invalidate(),
+  });
+  const startMutation = useMutation({
+    mutationFn: (id: number) => api.startRemoteServer(id),
+    // Refresh so the server-provided last_used timestamp updates.
+    onSettled: () => invalidate(),
+  });
 
-  const deleteProfile = useCallback(async (id: number) => {
-    await api.deleteServerProfile(id);
-    setProfiles(profiles.filter(p => p.id !== id));
-  }, [profiles]);
-
-  const testConnection = useCallback(async (id: number) => {
-    return await api.testSSHConnection(id);
-  }, []);
-
-  const startServer = useCallback(async (id: number) => {
-    const result = await api.startRemoteServer(id);
-    // Update last_used timestamp
-    const profile = profiles.find(p => p.id === id);
-    if (profile) {
-      profile.last_used = new Date().toISOString();
-      setProfiles([...profiles]);
-    }
-    return result;
-  }, [profiles]);
-
-  useEffect(() => {
-    fetchProfiles();
-  }, [fetchProfiles]);
+  const createProfile = useCallback(
+    (data: api.ServerProfileCreate) => createMutation.mutateAsync(data),
+    [createMutation],
+  );
+  const updateProfile = useCallback(
+    (id: number, data: Partial<api.ServerProfileCreate>) => updateMutation.mutateAsync({ id, data }),
+    [updateMutation],
+  );
+  const deleteProfile = useCallback(
+    (id: number) => deleteMutation.mutateAsync(id),
+    [deleteMutation],
+  );
+  const startServer = useCallback(
+    (id: number) => startMutation.mutateAsync(id),
+    [startMutation],
+  );
+  const testConnection = useCallback((id: number) => api.testSSHConnection(id), []);
 
   return {
-    profiles,
-    loading,
-    error,
-    fetchProfiles,
+    profiles: query.data ?? [],
+    loading: query.isLoading,
+    error: query.isError ? getApiErrorMessage(query.error, 'Failed to load profiles') : null,
+    fetchProfiles: async () => {
+      await query.refetch();
+    },
     createProfile,
     updateProfile,
     deleteProfile,
@@ -69,55 +74,58 @@ export function useServerProfiles() {
   };
 }
 
+/**
+ * VPN profiles — same pattern as useServerProfiles (create/update via FormData,
+ * testConnection is a passthrough with no cache effect).
+ */
 export function useVPNProfiles() {
-  const [profiles, setProfiles] = useState<api.VPNProfile[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
-  const fetchProfiles = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await api.listVPNProfiles();
-      setProfiles(data);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to load VPN profiles';
-      setError(message);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const query = useQuery({
+    queryKey: queryKeys.remoteServers.vpnProfiles(),
+    queryFn: api.listVPNProfiles,
+  });
 
-  const createProfile = useCallback(async (formData: FormData) => {
-    const newProfile = await api.createVPNProfile(formData);
-    setProfiles([newProfile, ...profiles]);
-    return newProfile;
-  }, [profiles]);
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: queryKeys.remoteServers.vpnProfiles() }),
+    [queryClient],
+  );
 
-  const updateProfile = useCallback(async (id: number, formData: FormData) => {
-    const updated = await api.updateVPNProfile(id, formData);
-    setProfiles(profiles.map(p => p.id === id ? updated : p));
-    return updated;
-  }, [profiles]);
+  const createMutation = useMutation({
+    mutationFn: (formData: FormData) => api.createVPNProfile(formData),
+    onSettled: () => invalidate(),
+  });
+  const updateMutation = useMutation({
+    mutationFn: ({ id, formData }: { id: number; formData: FormData }) =>
+      api.updateVPNProfile(id, formData),
+    onSettled: () => invalidate(),
+  });
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => api.deleteVPNProfile(id),
+    onSettled: () => invalidate(),
+  });
 
-  const deleteProfile = useCallback(async (id: number) => {
-    await api.deleteVPNProfile(id);
-    setProfiles(profiles.filter(p => p.id !== id));
-  }, [profiles]);
-
-  const testConnection = useCallback(async (id: number) => {
-    return await api.testVPNConnection(id);
-  }, []);
-
-  useEffect(() => {
-    fetchProfiles();
-  }, [fetchProfiles]);
+  const createProfile = useCallback(
+    (formData: FormData) => createMutation.mutateAsync(formData),
+    [createMutation],
+  );
+  const updateProfile = useCallback(
+    (id: number, formData: FormData) => updateMutation.mutateAsync({ id, formData }),
+    [updateMutation],
+  );
+  const deleteProfile = useCallback(
+    (id: number) => deleteMutation.mutateAsync(id),
+    [deleteMutation],
+  );
+  const testConnection = useCallback((id: number) => api.testVPNConnection(id), []);
 
   return {
-    profiles,
-    loading,
-    error,
-    fetchProfiles,
+    profiles: query.data ?? [],
+    loading: query.isLoading,
+    error: query.isError ? getApiErrorMessage(query.error, 'Failed to load VPN profiles') : null,
+    fetchProfiles: async () => {
+      await query.refetch();
+    },
     createProfile,
     updateProfile,
     deleteProfile,

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -64,6 +64,10 @@ export const queryKeys = {
     all: () => ['users'] as const,
     list: (params: Record<string, string | undefined>) => ['users', 'list', params] as const,
   },
+  remoteServers: {
+    serverProfiles: () => ['remote-servers', 'server-profiles'] as const,
+    vpnProfiles: () => ['remote-servers', 'vpn-profiles'] as const,
+  },
   schedulers: {
     /** Domain-Prefix — invalidiert list + history (Mutations betreffen beide). */
     all: () => ['schedulers'] as const,


### PR DESCRIPTION
## Was

Migriert die remote-servers-Hooks (`useServerProfiles` + `useVPNProfiles`) auf TanStack Query — nächster CRUD-Happen von #299, mit dem #373-Template.

## Änderungen

- **Listen** via `useQuery` (`queryKeys.remoteServers.{serverProfiles,vpnProfiles}`).
- **`create`/`update`/`delete`** (+ `startServer` bei SSH-Profilen) via **`useMutation`**, je `onSettled: invalidateQueries(<Liste>)`. Rückgabewerte bleiben erhalten (`createProfile` liefert weiterhin das neue Profil etc.). `mutationFn`s in Arrows gewrappt (v5-`context`-Arg nicht durchreichen).
- **`testConnection`** bleibt Passthrough (kein Cache-Effekt).
- `fetchProfiles` → `query.refetch`. Öffentliche Shapes **unverändert** → RemoteServersPage unberührt. User-scoped → Cache-Clear bei Identitätswechsel (#368).

## Tests

- Neu `useRemoteServers.test.tsx` (bisher keiner): List-Load, `createProfile` (Call + Rückgabe + Refetch), Fehler — für beide Hooks.
- ✅ `npx vitest run` — 101 Dateien / 552 Tests grün
- ✅ `eslint` — 0 Errors / 0 Warnings
- ✅ `npm run build` — tsc -b + vite grün

## Bewusste Mini-Änderung

Nach einer Mutation refetcht die Liste (Invalidierung) statt des bisherigen manuellen lokalen Array-Splice — Standard-TanStack-Query, hält die Liste serverkonsistent (z. B. `last_used` nach `startServer`).

## Track

Teil von #299 (F1). Danach offen: devices, mobile, smart, benchmark, admin-db + Aufräum-PR (`useAsyncData` inkl. `useLiveActivities`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
