### PR TITLE
feat(client): useDeviceManagement reads on TanStack Query, drop useAsyncData (#299)

### DIFF
--- a/client/src/__tests__/hooks/useDeviceManagement.test.ts
+++ b/client/src/__tests__/hooks/useDeviceManagement.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
 import { useDeviceManagement } from '../../hooks/useDeviceManagement';
 import type { Device } from '../../api/devices';
 
@@ -50,13 +51,16 @@ vi.mock('../../api/mobile', () => ({
 }));
 
 import { getAllDevices, updateMobileDeviceName, updateDesktopDeviceName } from '../../api/devices';
-import { listSyncSchedules } from '../../api/sync';
+import { listSyncSchedules, getBandwidthLimits, getSyncPreflight } from '../../api/sync';
 import { generateMobileToken } from '../../api/mobile';
 
 describe('useDeviceManagement', () => {
   beforeEach(() => {
     vi.mocked(getAllDevices).mockResolvedValue(mockDevices);
     vi.mocked(listSyncSchedules).mockResolvedValue([]);
+    // useQuery rejects an undefined queryFn result — give the other reads data.
+    vi.mocked(getBandwidthLimits).mockResolvedValue({ upload_kbps: null, download_kbps: null } as never);
+    vi.mocked(getSyncPreflight).mockResolvedValue({ sleep_schedule: null } as never);
   });
 
   afterEach(() => {
@@ -64,7 +68,7 @@ describe('useDeviceManagement', () => {
   });
 
   it('loads devices and computes stats', async () => {
-    const { result } = renderHook(() => useDeviceManagement());
+    const { result } = renderHook(() => useDeviceManagement(), { wrapper: createQueryWrapper() });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -81,7 +85,7 @@ describe('useDeviceManagement', () => {
 
   it('handleSaveDeviceName calls correct API for mobile', async () => {
     vi.mocked(updateMobileDeviceName).mockResolvedValue(undefined as any);
-    const { result } = renderHook(() => useDeviceManagement());
+    const { result } = renderHook(() => useDeviceManagement(), { wrapper: createQueryWrapper() });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -96,7 +100,7 @@ describe('useDeviceManagement', () => {
 
   it('handleSaveDeviceName calls correct API for desktop', async () => {
     vi.mocked(updateDesktopDeviceName).mockResolvedValue(undefined as any);
-    const { result } = renderHook(() => useDeviceManagement());
+    const { result } = renderHook(() => useDeviceManagement(), { wrapper: createQueryWrapper() });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -109,7 +113,7 @@ describe('useDeviceManagement', () => {
 
   it('handleSaveDeviceName rejects empty name', async () => {
     const toast = await import('react-hot-toast');
-    const { result } = renderHook(() => useDeviceManagement());
+    const { result } = renderHook(() => useDeviceManagement(), { wrapper: createQueryWrapper() });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -126,7 +130,7 @@ describe('useDeviceManagement', () => {
     const mockToken = { token: 'abc', qr_code: 'data:image/png;base64,...' };
     vi.mocked(generateMobileToken).mockResolvedValue(mockToken as any);
 
-    const { result } = renderHook(() => useDeviceManagement());
+    const { result } = renderHook(() => useDeviceManagement(), { wrapper: createQueryWrapper() });
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     let token: any;
@@ -140,7 +144,7 @@ describe('useDeviceManagement', () => {
 
   it('handleGenerateToken rejects empty name', async () => {
     const toast = await import('react-hot-toast');
-    const { result } = renderHook(() => useDeviceManagement());
+    const { result } = renderHook(() => useDeviceManagement(), { wrapper: createQueryWrapper() });
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     let token: any;

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -18,7 +18,7 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useSmartData.ts` | `api/smart` | SMART disk health data |
 | `useAdminDb.ts` | `api/admin-db` | Admin database inspection |
 | `useUserManagement.ts` | `api/users` | User list via **TanStack Query** (key includes the active search/role/status/sort → changing filters refetches; search debounced); CRUD (create/update/delete/bulkDelete/toggleActive) via **`useMutation`** with `onSettled: invalidateQueries(users.all())`. Filter/selection/sort/CSV/confirm state stays local. Public shape unchanged |
-| `useDeviceManagement.ts` | `api/devices` | Device list, pairing, removal |
+| `useDeviceManagement.ts` | `api/devices` (+ `api/sync`, `api/mobile`) | Devices/schedules/bandwidth/preflight reads via **TanStack Query** (was the last `useAsyncData` list consumer); the mutation handlers stay imperative and call the `refetch*` wrappers (stable `() => void` around `query.refetch`). Public shape unchanged |
 | `useMobile.ts` | `api/mobile` | Mobile device management |
 | `useRemoteServers.ts` | `api/remote-servers` | `useServerProfiles` + `useVPNProfiles` — lists via **TanStack Query**, CRUD (+ startServer) via **`useMutation`** with `onSettled: invalidateQueries(<domain>)`. testConnection is a passthrough (no cache effect). User-scoped — cache cleared on identity change |
 | `useActivityFeed.ts` | `api/activity` | Dashboard activity feed (own / admin all-users) via **TanStack Query** (`useQuery`, default 30s poll). Query holds raw API items (persister-safe); view mapping (i18n titles, relative "ago") is derived per render. User-scoped — cache cleared on identity change (AuthContext); `scope`+`limit` are part of the key |

--- a/client/src/hooks/useDeviceManagement.ts
+++ b/client/src/hooks/useDeviceManagement.ts
@@ -1,8 +1,9 @@
 import { useCallback, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
-import { handleApiError } from '../lib/errorHandling';
-import { useAsyncData } from './useAsyncData';
+import { handleApiError, getApiErrorMessage } from '../lib/errorHandling';
+import { queryKeys } from '../lib/queryKeys';
 import { useConfirmDialog } from './useConfirmDialog';
 import {
   getAllDevices,
@@ -28,25 +29,41 @@ import { generateMobileToken, type MobileRegistrationToken } from '../api/mobile
 export function useDeviceManagement() {
   const { t } = useTranslation(['devices', 'common']);
 
-  const {
-    data: devices,
-    loading,
-    error,
-    refetch: refetchDevices,
-  } = useAsyncData(getAllDevices);
+  // Reads — TanStack Query (no polling). refetch* wrappers keep the () => void
+  // shape the handlers already call after mutations; refetch is stable in v5.
+  const devicesQuery = useQuery({ queryKey: queryKeys.devices.list(), queryFn: getAllDevices });
+  const schedulesQuery = useQuery({ queryKey: queryKeys.sync.schedules(), queryFn: listSyncSchedules });
+  const bandwidthQuery = useQuery({ queryKey: queryKeys.sync.bandwidth(), queryFn: getBandwidthLimits });
+  const preflightQuery = useQuery({ queryKey: queryKeys.sync.preflight(), queryFn: getSyncPreflight });
 
-  const {
-    data: schedules,
-    loading: schedulesLoading,
-    refetch: refetchSchedules,
-  } = useAsyncData(listSyncSchedules);
+  const devices = devicesQuery.data ?? null;
+  const loading = devicesQuery.isLoading;
+  const error = devicesQuery.isError
+    ? getApiErrorMessage(devicesQuery.error, 'An error occurred')
+    : null;
+  const schedules = schedulesQuery.data ?? null;
+  const schedulesLoading = schedulesQuery.isLoading;
+  const bandwidth = bandwidthQuery.data;
+  const preflight = preflightQuery.data;
 
-  const { data: bandwidth, refetch: refetchBandwidth } = useAsyncData(getBandwidthLimits);
-  const { data: preflight } = useAsyncData(getSyncPreflight);
+  // v5 refetch is referentially stable; destructure so the wrappers stay stable
+  // (handlers depend on these) without pulling in the whole query object.
+  const { refetch: refetchDevicesRaw } = devicesQuery;
+  const { refetch: refetchSchedulesRaw } = schedulesQuery;
+  const { refetch: refetchBandwidthRaw } = bandwidthQuery;
+  const refetchDevices = useCallback(() => {
+    void refetchDevicesRaw();
+  }, [refetchDevicesRaw]);
+  const refetchSchedules = useCallback(() => {
+    void refetchSchedulesRaw();
+  }, [refetchSchedulesRaw]);
+  const refetchBandwidth = useCallback(() => {
+    void refetchBandwidthRaw();
+  }, [refetchBandwidthRaw]);
 
   const { confirm, dialog: confirmDialog } = useConfirmDialog();
 
-  const deviceList = devices ?? [];
+  const deviceList = useMemo(() => devices ?? [], [devices]);
   const scheduleList = schedules ?? [];
 
   const mobileDevices = useMemo(() => deviceList.filter((d) => d.type === 'mobile'), [deviceList]);

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -68,6 +68,15 @@ export const queryKeys = {
     serverProfiles: () => ['remote-servers', 'server-profiles'] as const,
     vpnProfiles: () => ['remote-servers', 'vpn-profiles'] as const,
   },
+  devices: {
+    all: () => ['devices'] as const,
+    list: () => ['devices', 'list'] as const,
+  },
+  sync: {
+    schedules: () => ['sync', 'schedules'] as const,
+    bandwidth: () => ['sync', 'bandwidth'] as const,
+    preflight: () => ['sync', 'preflight'] as const,
+  },
   schedulers: {
     /** Domain-Prefix — invalidiert list + history (Mutations betreffen beide). */
     all: () => ['schedulers'] as const,


### PR DESCRIPTION
## Was

Migriert die Reads von `useDeviceManagement` auf TanStack Query — nächster Happen von #299. Damit hängt der Hook **nicht mehr an `useAsyncData`** (nur noch `useLiveActivities` nutzt es).

## Änderungen

- Die **vier `useAsyncData`-Reads** (devices, sync-schedules, bandwidth, preflight) → `useQuery`. Kein Polling (wie zuvor).
- **Query-Keys:** `queryKeys.devices.{all,list}` + `queryKeys.sync.{schedules,bandwidth,preflight}`.
- **Minimaler Blast-Radius:** `refetchDevices`/`refetchSchedules`/`refetchBandwidth` bleiben als stabile `() => void`-Wrapper um das (referenz­stabile) `query.refetch` — dadurch sind **alle Mutation-Handler unverändert** (sie riefen ohnehin `refetch*` nach jeder Operation).
- `devices/loading/error/schedules/bandwidth/preflight` aus den Queries abgeleitet; öffentliche Return-Shape **unverändert** → DeviceManagement-Page unberührt.
- User-scoped Reads → Cache-Clear bei Identitätswechsel (#368).

## Tests

- Bestehender `useDeviceManagement.test.ts` (6 Fälle) auf `createQueryWrapper` umgestellt + bandwidth/preflight-Reads geseedet (`useQuery` lehnt ein `undefined`-queryFn-Ergebnis ab).
- ✅ `npx vitest run` — 101 Dateien / 552 Tests grün
- ✅ `eslint` — 0 Errors (nur vorbestehende `as any`-Warnings im Alt-Test)
- ✅ `npm run build` — tsc -b + vite grün

## Track

Teil von #299 (F1). Danach offen: mobile, smart, benchmark, admin-db + Aufräum-PR (`useAsyncData` restlos entfernen inkl. `useLiveActivities`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
