### PR TITLE
feat(client): migrate simple setInterval pollers to TanStack Query (#299)

### DIFF
--- a/client/src/__tests__/components/dashboard/ConnectedDevicesWidget.test.tsx
+++ b/client/src/__tests__/components/dashboard/ConnectedDevicesWidget.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '../../helpers/queryClient';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string, o?: { count?: number }) => (o?.count != null ? `${k}:${o.count}` : k) }),
+}));
+vi.mock('../../../api/devices', () => ({ getAllDevices: vi.fn() }));
+
+import { getAllDevices } from '../../../api/devices';
+import { ConnectedDevicesWidget } from '../../../components/dashboard/ConnectedDevicesWidget';
+
+beforeEach(() => vi.clearAllMocks());
+
+function renderWidget() {
+  return render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <MemoryRouter><ConnectedDevicesWidget /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('ConnectedDevicesWidget (query migration #299)', () => {
+  it('treats a 403 as "no devices" instead of surfacing an error', async () => {
+    (getAllDevices as any).mockRejectedValue(new Error('Request failed with status code 403'));
+    renderWidget();
+    // Empty state (clickable), NOT the "unable to load" error state.
+    await waitFor(() =>
+      expect(screen.getByText('dashboard:devices.noDevicesRegistered')).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('dashboard:devices.unableToLoad')).not.toBeInTheDocument();
+  });
+
+  it('renders mobile/desktop counts on success', async () => {
+    (getAllDevices as any).mockResolvedValue([
+      { id: 1, name: 'Phone', type: 'mobile', is_active: true, last_seen: null },
+      { id: 2, name: 'Laptop', type: 'desktop', is_active: true, last_seen: null },
+      { id: 3, name: 'Tablet', type: 'mobile', is_active: true, last_seen: null },
+    ]);
+    renderWidget();
+    await waitFor(() => expect(screen.getByText('dashboard:devices.mobile')).toBeInTheDocument());
+    // 2 mobile, 1 desktop
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('shows the error state for a non-403 failure', async () => {
+    (getAllDevices as any).mockRejectedValue(new Error('Request failed with status code 500'));
+    renderWidget();
+    await waitFor(() =>
+      expect(screen.getByText('dashboard:devices.unableToLoad')).toBeInTheDocument(),
+    );
+  });
+});

--- a/client/src/__tests__/components/device-management/QrCodeDialog.test.tsx
+++ b/client/src/__tests__/components/device-management/QrCodeDialog.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '../../helpers/queryClient';
+
+vi.mock('react-i18next', () => ({
+  // Return the default string when one is given, else the key — never an options object.
+  useTranslation: () => ({ t: (k: string, d?: unknown) => (typeof d === 'string' ? d : k) }),
+}));
+const toastSuccess = vi.fn();
+vi.mock('react-hot-toast', () => ({ default: { success: (...a: unknown[]) => toastSuccess(...a), error: vi.fn() } }));
+// Render the Modal body inline so we don't wrestle with portals/focus-traps.
+vi.mock('../../../components/ui/Modal', () => ({
+  Modal: ({ isOpen, children }: { isOpen: boolean; children: ReactNode }) =>
+    isOpen ? <div>{children}</div> : null,
+}));
+vi.mock('../../../api/mobile', () => ({ getTokenStatus: vi.fn() }));
+
+import { getTokenStatus } from '../../../api/mobile';
+import { QrCodeDialog } from '../../../components/device-management/QrCodeDialog';
+
+const tokenData = {
+  token: 'abc123',
+  qr_code: 'PHN2Zz48L3N2Zz4=',
+  expires_at: new Date(0).toISOString(),
+  device_token_validity_days: 30,
+  vpn_config: null,
+} as any;
+
+beforeEach(() => vi.clearAllMocks());
+
+function renderDialog(onClose = vi.fn()) {
+  render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <QrCodeDialog data={tokenData} onClose={onClose} />
+    </QueryClientProvider>,
+  );
+  return onClose;
+}
+
+describe('QrCodeDialog poll-until-used (query migration #299)', () => {
+  it('closes the dialog and notifies once the token is used', async () => {
+    (getTokenStatus as any).mockResolvedValue({ used: true });
+    const onClose = renderDialog();
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(getTokenStatus).toHaveBeenCalledWith('abc123');
+  });
+
+  it('stays open while the token is unused', async () => {
+    (getTokenStatus as any).mockResolvedValue({ used: false });
+    const onClose = renderDialog();
+    await waitFor(() => expect(getTokenStatus).toHaveBeenCalled());
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/PowerStatusWidget.tsx
+++ b/client/src/components/PowerStatusWidget.tsx
@@ -5,15 +5,15 @@
  * Shows current profile, frequency, and active demand count.
  */
 
-import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
 import {
   getPowerStatus,
   PROFILE_INFO,
-  type PowerStatusResponse,
   type PowerProfile,
 } from '../api/power-management';
+import { queryKeys } from '../lib/queryKeys';
 import { formatNumber } from '../lib/formatters';
 
 const REFRESH_INTERVAL_MS = 10000;
@@ -52,27 +52,19 @@ interface PowerStatusWidgetProps {
 
 export default function PowerStatusWidget({ className = '' }: PowerStatusWidgetProps) {
   const { t } = useTranslation('system');
-  const [status, setStatus] = useState<PowerStatusResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  // Query-backed (#299): shares the `power.status()` cache/poll with the
+  // dashboard live-activity feed. `refetchInterval` replaces the setInterval.
+  const {
+    data: status = null,
+    isLoading: loading,
+    isError,
+  } = useQuery({
+    queryKey: queryKeys.power.status(),
+    queryFn: getPowerStatus,
+    refetchInterval: REFRESH_INTERVAL_MS,
+  });
 
-  useEffect(() => {
-    const loadStatus = async () => {
-      try {
-        const data = await getPowerStatus();
-        setStatus(data);
-        setError(null);
-      } catch {
-        setError(t('powerStatus.loadFailed'));
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    void loadStatus();
-    const interval = setInterval(() => void loadStatus(), REFRESH_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, []);
+  const error = isError ? t('powerStatus.loadFailed') : null;
 
   if (loading) {
     return (

--- a/client/src/components/admin/DatabaseStatsCards.tsx
+++ b/client/src/components/admin/DatabaseStatsCards.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useQuery } from '@tanstack/react-query'
 import { getDatabaseStats } from '../../api/monitoring'
-import type { DatabaseStatsResponse, MetricDatabaseStats } from '../../api/monitoring'
+import type { MetricDatabaseStats } from '../../api/monitoring'
 import { Database, HardDrive, Activity, RefreshCw } from 'lucide-react'
 import { METRIC_CONFIG, DEFAULT_METRIC_CONFIG } from './metricConfig'
+import { queryKeys } from '../../lib/queryKeys'
+import { getApiErrorMessage } from '../../lib/errorHandling'
 import { formatBytes } from '../../lib/formatters'
 import { StatCard } from '../ui/StatCard'
 import { ProgressBar } from '../ui/ProgressBar'
@@ -145,43 +147,36 @@ interface DatabaseStatsCardsProps {
 
 export default function DatabaseStatsCards({ autoRefresh = true, refreshInterval = 30000 }: DatabaseStatsCardsProps) {
   const { t, i18n } = useTranslation(['admin', 'common'])
-  const [stats, setStats] = useState<DatabaseStatsResponse | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
+  // Query-backed (#299): `refetchInterval` replaces the hand-rolled setInterval,
+  // the manual refresh button uses `refetch`, and F5 instant-paint comes from
+  // the app-wide persister. `dataUpdatedAt` supplies the "last updated" stamp.
+  const {
+    data: stats = null,
+    isLoading,
+    isError,
+    error,
+    isFetching,
+    dataUpdatedAt,
+    refetch,
+  } = useQuery({
+    queryKey: queryKeys.adminDb.stats(),
+    queryFn: getDatabaseStats,
+    refetchInterval: autoRefresh && refreshInterval > 0 ? refreshInterval : false,
+  })
 
-  const fetchStats = useCallback(async () => {
-    try {
-      setError(null)
-      const data = await getDatabaseStats()
-      setStats(data)
-      setLastUpdate(new Date())
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Failed to load database stats')
-    } finally {
-      setLoading(false)
-    }
-  }, [])
+  const errorMessage = isError ? getApiErrorMessage(error, 'Failed to load database stats') : null
+  const lastUpdate = stats && dataUpdatedAt ? new Date(dataUpdatedAt) : null
 
-  useEffect(() => {
-    fetchStats()
-
-    if (autoRefresh) {
-      const interval = setInterval(fetchStats, refreshInterval)
-      return () => clearInterval(interval)
-    }
-  }, [fetchStats, autoRefresh, refreshInterval])
-
-  if (loading && !stats) {
+  if (isLoading && !stats) {
     return <StatsCardsSkeleton />
   }
 
-  if (error && !stats) {
+  if (errorMessage && !stats) {
     return (
       <div className="bg-gradient-to-r from-red-500/10 to-red-600/5 border border-red-500/30 rounded-xl px-5 py-4 backdrop-blur-sm">
-        <p className="text-red-400 text-sm font-medium">{error}</p>
+        <p className="text-red-400 text-sm font-medium">{errorMessage}</p>
         <button
-          onClick={fetchStats}
+          onClick={() => refetch()}
           className="mt-3 inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-red-500/20 text-red-300 hover:bg-red-500/30 transition-colors text-sm"
         >
           <RefreshCw className="w-4 h-4" />
@@ -214,11 +209,11 @@ export default function DatabaseStatsCards({ autoRefresh = true, refreshInterval
           )}
         </div>
         <button
-          onClick={fetchStats}
-          disabled={loading}
+          onClick={() => refetch()}
+          disabled={isFetching}
           className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-700/40 text-slate-300 hover:bg-slate-700/60 hover:text-white transition-colors text-sm border border-slate-600/50"
         >
-          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+          <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} />
           {t('common:refresh')}
         </button>
       </div>

--- a/client/src/components/dashboard/ConnectedDevicesWidget.tsx
+++ b/client/src/components/dashboard/ConnectedDevicesWidget.tsx
@@ -2,10 +2,13 @@
  * Connected Devices Widget for Dashboard
  * Shows mobile and desktop device counts
  */
-import React, { useState, useEffect, useCallback } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
 import { getAllDevices, type Device } from '../../api/devices';
+import { queryKeys } from '../../lib/queryKeys';
+import { getApiErrorMessage } from '../../lib/errorHandling';
 import { Smartphone, Monitor, Wifi, WifiOff } from 'lucide-react';
 
 interface DeviceSummary {
@@ -22,35 +25,27 @@ interface ConnectedDevicesWidgetProps {
 export const ConnectedDevicesWidget: React.FC<ConnectedDevicesWidgetProps> = ({ className = '' }) => {
   const { t } = useTranslation(['dashboard', 'common']);
   const navigate = useNavigate();
-  const [devices, setDevices] = useState<Device[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  // Query-backed (#299): shares the `devices.list()` cache/poll with the
+  // device-management page. A 403 (user lacks the permission) is treated as
+  // "no devices" rather than an error, matching the old hand-rolled catch.
+  const {
+    data: devicesData,
+    isLoading: loading,
+    isError,
+    error: queryError,
+  } = useQuery({
+    queryKey: queryKeys.devices.list(),
+    queryFn: getAllDevices,
+    refetchInterval: 60000,
+  });
 
-  const loadData = useCallback(async () => {
-    try {
-      const response = await getAllDevices();
-      setDevices(response);
-      setError(null);
-    } catch (err: unknown) {
-      // Don't show error for 403 (user may not have permission)
-      const msg = err instanceof Error ? err.message : '';
-      if (msg.includes('403') || msg.includes('Forbidden')) {
-        setDevices([]);
-        setError(null);
-        return;
-      }
-      setError(msg || 'Failed to load devices');
-    }
-  }, []);
-
-  useEffect(() => {
-    setLoading(true);
-    loadData().finally(() => setLoading(false));
-
-    // Refresh every 60 seconds
-    const interval = setInterval(loadData, 60000);
-    return () => clearInterval(interval);
-  }, [loadData]);
+  const errorMessage = getApiErrorMessage(queryError, '');
+  const isForbidden = errorMessage.includes('403') || errorMessage.includes('Forbidden');
+  const error = isError && !isForbidden ? errorMessage || 'Failed to load devices' : null;
+  const devices: Device[] = React.useMemo(
+    () => (error ? [] : devicesData ?? []),
+    [error, devicesData],
+  );
 
   const handleViewDevices = () => {
     navigate('/sync-prototype');

--- a/client/src/components/device-management/QrCodeDialog.tsx
+++ b/client/src/components/device-management/QrCodeDialog.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
 import { Eye, EyeOff, Copy } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { Modal } from '../ui/Modal';
 import { getTokenStatus } from '../../api/mobile';
 import type { MobileRegistrationToken } from '../../api/mobile';
+import { queryKeys } from '../../lib/queryKeys';
 
 const POLL_INTERVAL_MS = 3000;
 
@@ -16,35 +18,28 @@ interface QrCodeDialogProps {
 export function QrCodeDialog({ data, onClose }: QrCodeDialogProps) {
   const { t } = useTranslation(['devices']);
   const [showToken, setShowToken] = useState(false);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
 
-  // Poll token status while dialog is open
+  // Poll token status while the dialog is open — query-backed (#299): the
+  // `refetchInterval` polls every 3s and stops once the token is used. Polling
+  // errors (expired token / network) are swallowed (query stays pending → keeps
+  // polling), matching the old silent catch.
+  const { data: tokenStatus } = useQuery({
+    queryKey: queryKeys.mobile.tokenStatus(data?.token ?? ''),
+    queryFn: () => getTokenStatus(data!.token),
+    enabled: !!data,
+    refetchInterval: (query) => (query.state.data?.used ? false : POLL_INTERVAL_MS),
+  });
+
+  // Device registered — close dialog and notify (fires once on the used flip).
+  const used = tokenStatus?.used ?? false;
   useEffect(() => {
-    if (!data) return;
-
-    const poll = async () => {
-      try {
-        const { used } = await getTokenStatus(data.token);
-        if (used) {
-          // Device registered — close dialog and notify
-          if (intervalRef.current) clearInterval(intervalRef.current);
-          toast.success(t('qrDialog.deviceRegistered', 'Gerät erfolgreich verbunden!'));
-          setShowToken(false);
-          onCloseRef.current();
-        }
-      } catch {
-        // Silently ignore polling errors (e.g. token expired, network issues)
-      }
-    };
-
-    intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
-
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [data, t]);
+    if (!used) return;
+    toast.success(t('qrDialog.deviceRegistered', 'Gerät erfolgreich verbunden!'));
+    setShowToken(false);
+    onCloseRef.current();
+  }, [used, t]);
 
   const handleClose = () => {
     setShowToken(false);

--- a/client/src/components/system-monitor/GpuTab.tsx
+++ b/client/src/components/system-monitor/GpuTab.tsx
@@ -1,19 +1,17 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  getGpuCurrent,
   getGpuHistory,
   type GpuSample,
   type TimeRange,
 } from '../../api/monitoring';
 import { useGpuPresence } from '../../hooks/useGpuPresence';
+import { useGpuCurrent } from '../../hooks/useGpuCurrent';
 import { MetricChart } from '../monitoring';
 
 interface Props {
   timeRange: TimeRange;
 }
-
-const POLL_MS = 3000;
 
 function formatBytes(n: number | null): string {
   if (n == null) return '—';
@@ -43,7 +41,9 @@ export function GpuTab({ timeRange }: Props) {
   const { t } = useTranslation('system');
   const { info } = useGpuPresence();
 
-  const [current, setCurrent] = useState<GpuSample | null>(null);
+  // Current sample: shared `gpu.current` query (#299) — same cache/poll as the
+  // dashboard GPU widget. History stays a per-timeRange one-shot fetch.
+  const current = useGpuCurrent();
   const [history, setHistory] = useState<GpuSample[]>([]);
   const [historyLoading, setHistoryLoading] = useState(true);
   const [engineView, setEngineView] = useState<'overview' | 'per-engine'>('overview');
@@ -56,19 +56,6 @@ export function GpuTab({ timeRange }: Props) {
         usage: s.usage_percent ?? 0,
       }));
   }, [history]);
-
-  useEffect(() => {
-    let cancelled = false;
-    const tick = async () => {
-      try {
-        const c = await getGpuCurrent();
-        if (!cancelled) setCurrent(c);
-      } catch { /* ignore transient errors */ }
-    };
-    tick();
-    const id = setInterval(tick, POLL_MS);
-    return () => { cancelled = true; clearInterval(id); };
-  }, []);
 
   useEffect(() => {
     let cancelled = false;

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -28,6 +28,7 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useDocsArticle.ts` | `api/docs` | Single documentation article content via **TanStack Query** (`useQuery`; `slug`+`lang` in the key, `enabled: !!slug`). Re-exports the `DocsArticle` type |
 | `usePluginsSummary.ts` | `api/plugins` | Plugin list summary for dashboard via **TanStack Query** (`useQuery`, default 60s poll). A 403 (non-admin) is treated as an empty list, silently — no error surfaced |
 | `useServicesSummary.ts` | `api/service-status` | Service health summary for dashboard via **TanStack Query** (`useQuery`, default 30s poll). Mounted at 3 sites (ServicesPanel, Dashboard, ServiceSummaryWidget) — the shared query key collapses them into one cache entry + one poll |
+| `useGpuCurrent.ts` | `api/monitoring` | Current GPU sample via **TanStack Query** (`useQuery`, 3s poll, `gpu.current()` key). Mounted by `GpuTab` + `Dashboard` — the shared key collapses the two former `setInterval` pollers into one cache entry + one poll (#299). Returns `GpuSample \| null`; `enabled` arg gates polling on GPU presence. Keeps the last value on transient errors (TanStack default) |
 | `useOpenApiSchema.ts` | — | OpenAPI schema for API docs page |
 
 ## Utility Hooks

--- a/client/src/hooks/useGpuCurrent.ts
+++ b/client/src/hooks/useGpuCurrent.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../lib/queryKeys';
+import { getGpuCurrent, type GpuSample } from '../api/monitoring';
+
+const POLL_MS = 3000;
+
+/**
+ * Current GPU sample via TanStack Query (#299). Replaces the two hand-rolled
+ * `setInterval` pollers in `GpuTab` and `Dashboard` — both mount this hook so
+ * the `gpu.current` key collapses them into one cache entry + one 3s poll.
+ *
+ * On a transient fetch error TanStack keeps the last successful `data`, so the
+ * UI retains its previous reading (matching the old "keep last value" catch).
+ * Pass `enabled: false` to suspend polling (Dashboard gates on GPU presence).
+ */
+export function useGpuCurrent(enabled = true): GpuSample | null {
+  const { data } = useQuery({
+    queryKey: queryKeys.gpu.current(),
+    queryFn: getGpuCurrent,
+    enabled,
+    refetchInterval: POLL_MS,
+  });
+  return data ?? null;
+}

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -77,10 +77,19 @@ export const queryKeys = {
     devices: () => ['mobile', 'devices'] as const,
     vpnTypes: () => ['mobile', 'vpn-types'] as const,
     deviceNotifications: (deviceId: string) => ['mobile', 'device-notifications', deviceId] as const,
+    /** Registration-token status (poll-until-used); token is part of the key. */
+    tokenStatus: (token: string) => ['mobile', 'token-status', token] as const,
   },
   smart: {
     status: () => ['smart', 'status'] as const,
     mode: () => ['smart', 'mode'] as const,
+  },
+  /** Smart plugs / Tapo devices (`api/smart-devices`), distinct from `smart` (disk health). */
+  smartDevices: {
+    list: () => ['smart-devices', 'list'] as const,
+  },
+  gpu: {
+    current: () => ['gpu', 'current'] as const,
   },
   fans: {
     status: () => ['fans', 'status'] as const,
@@ -96,6 +105,7 @@ export const queryKeys = {
   adminDb: {
     /** Domain-Prefix. */
     all: () => ['admin-db'] as const,
+    stats: () => ['admin-db', 'stats'] as const,
     tables: () => ['admin-db', 'tables'] as const,
     tableData: (table: string | null, params: Record<string, unknown>) =>
       ['admin-db', 'table-data', table, params] as const,

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -5,9 +5,9 @@ import { useAuth } from '../contexts/AuthContext';
 import { useSystemTelemetry } from '../hooks/useSystemTelemetry';
 import { useSmartData } from '../hooks/useSmartData';
 import { useGpuPresence } from '../hooks/useGpuPresence';
+import { useGpuCurrent } from '../hooks/useGpuCurrent';
 import { useRaidStatus } from '../hooks/useRaidStatus';
 import { getSystemMode } from '../api/system';
-import { getGpuCurrent, type GpuSample } from '../api/monitoring';
 import { useNextMaintenance } from '../hooks/useNextMaintenance';
 import { useServicesSummary } from '../hooks/useServicesSummary';
 import { useLiveActivities } from '../hooks/useLiveActivities';
@@ -58,24 +58,9 @@ export default function Dashboard() {
   const [smartMode, setSmartMode] = useState<string | null>(null);
   const [smartModeLoading, setSmartModeLoading] = useState(false);
 
-  // GPU presence + polling
+  // GPU presence + polling — shared `gpu.current` query (#299), gated on presence
   const { present: hasGpu, info: gpuInfo } = useGpuPresence();
-  const [gpuSample, setGpuSample] = useState<GpuSample | null>(null);
-  useEffect(() => {
-    if (!hasGpu) return;
-    let cancelled = false;
-    const tick = async () => {
-      try {
-        const s = await getGpuCurrent();
-        if (!cancelled) setGpuSample(s);
-      } catch {
-        /* keep last value on transient failure */
-      }
-    };
-    tick();
-    const id = setInterval(tick, 3000);
-    return () => { cancelled = true; clearInterval(id); };
-  }, [hasGpu]);
+  const gpuSample = useGpuCurrent(hasGpu);
 
   // Hooks for alert generation
   const { allSchedulers } = useNextMaintenance();

--- a/client/src/pages/SystemMonitor.tsx
+++ b/client/src/pages/SystemMonitor.tsx
@@ -6,7 +6,7 @@
  * - Sub-tabs within each category
  */
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Cpu, ArrowLeftRight, Settings, FileText, Terminal, Clock } from 'lucide-react';
@@ -25,9 +25,11 @@ import { NetworkTab } from '../components/system-monitor/NetworkTab';
 import { DiskIoTab } from '../components/system-monitor/DiskIoTab';
 import { PowerTab } from '../components/system-monitor/PowerTab';
 import { UptimeTab } from '../components/system-monitor/UptimeTab';
+import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '../contexts/AuthContext';
 import { useGpuPresence } from '../hooks/useGpuPresence';
 import { smartDevicesApi } from '../api/smart-devices';
+import { queryKeys } from '../lib/queryKeys';
 
 type TabType = 'cpu' | 'gpu' | 'memory' | 'network' | 'disk-io' | 'power' | 'uptime' | 'services' | 'health' | 'backend-logs' | 'logs' | 'activity';
 type CategoryType = 'hardware' | 'io' | 'system' | 'logs';
@@ -199,23 +201,19 @@ export default function SystemMonitor() {
   const { user, isAdmin } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
   const [timeRange, setTimeRange] = useState<TimeRange>('1h');
-  const [hasPowerMonitoring, setHasPowerMonitoring] = useState(false);
   const { present: hasGpu } = useGpuPresence();
 
-  // Check if any active smart device has power_monitor capability
-  useEffect(() => {
-    const check = () => {
-      smartDevicesApi.list().then(res => {
-        const has = (res.data.devices ?? []).some(
-          (d: any) => d.is_active && d.capabilities?.includes('power_monitor')
-        );
-        setHasPowerMonitoring(has);
-      }).catch(() => setHasPowerMonitoring(false));
-    };
-    check();
-    const interval = setInterval(check, 30000);
-    return () => clearInterval(interval);
-  }, []);
+  // Check if any active smart device has power_monitor capability — query-backed
+  // (#299): `refetchInterval` replaces the setInterval; an error resolves to
+  // "no power monitoring" (the old `.catch(() => false)`).
+  const { data: smartDevices } = useQuery({
+    queryKey: queryKeys.smartDevices.list(),
+    queryFn: () => smartDevicesApi.list().then(res => res.data),
+    refetchInterval: 30000,
+  });
+  const hasPowerMonitoring = (smartDevices?.devices ?? []).some(
+    (d) => d.is_active && d.capabilities?.includes('power_monitor'),
+  );
 
   // Dynamic categories: hide 'power' tab when no power-monitoring plugin is active
   const categories = useMemo(() => {


### PR DESCRIPTION
## Was & Warum

**F1-Resttail (#299), PR 1 von 8** aus der [`setInterval`-Triage](https://github.com/Xveyn/BaluHost/issues/299#issuecomment-4887349943): der Daten-Hook-Layer ist durch (bis #382); dieser PR nimmt den **S-Poller-Batch** im Component/Page-Layer — die trivialen 1:1-Read-Poller, die je ein hand-gerolltes `useState`+`useEffect`+`setInterval` gegen `useQuery` + `refetchInterval` tauschen.

## Migrierte Sites (7)

| Site | Key | Notiz |
|---|---|---|
| `admin/DatabaseStatsCards` | neu `adminDb.stats()` | `autoRefresh`/`refreshInterval`-Props → `refetchInterval`; Refresh-Button → `refetch`; „last updated" aus `dataUpdatedAt` |
| `dashboard/ConnectedDevicesWidget` | ✅ `devices.list()` | teilt Cache/Poll mit der Device-Management-Page — **identische** `getAllDevices`-queryFn (keine queryFn-Divergenz); 403→„keine Geräte" wandert auf Consumer-Ebene |
| `PowerStatusWidget` | ✅ `power.status()` | teilt Cache/Poll mit dem Dashboard-Live-Activity-Feed |
| `pages/SystemMonitor` (Power-Capability-Check) | neu `smartDevices.list()` | entfernt einen `any`-Cast (`SmartDevice` ist typisiert) |
| `system-monitor/GpuTab` + `pages/Dashboard` | neu `gpu.current()` | beide mounten den neuen geteilten Hook **`useGpuCurrent`** — die zwei identischen 3s-GPU-Poller kollabieren zu **einem** Cache-Eintrag + einem Poll |
| `device-management/QrCodeDialog` | neu `mobile.tokenStatus(token)` | poll-until-used via bedingtem `refetchInterval` (stoppt bei `used`); Fehler bleiben still |

Neue Query-Keys: `adminDb.stats`, `smartDevices.list`, `gpu.current`, `mobile.tokenStatus`. Neuer Hook `useGpuCurrent` (in `hooks/CLAUDE.md` dokumentiert).

## Semantik-Hinweise

- **Poll pausiert bei verstecktem Tab** (TanStack-Default `refetchIntervalInBackground:false`) — bewusst für ein LAN-Dashboard, anders als das alte always-on `setInterval`.
- **Letzter Wert bleibt bei transientem Fehler** erhalten (TanStack behält `data`) — deckt die alten „keep last value"-Catches ab.
- **QrCodeDialog** fetcht den Token-Status jetzt **sofort** beim Öffnen statt erst nach 3s (schnellere Erkennung, harmlos).
- **F5 Instant-Paint** kommt für alle neuen Queries gratis aus dem app-weiten Persister.

## Tests & Verifikation

- Neu: `ConnectedDevicesWidget` (403→leer, Counts, Non-403-Error) + `QrCodeDialog` (closes-on-used, stays-open-while-unused).
- Volle Vitest-Suite **566/566, 107/107** grün · ESLint **0 Errors** · `npm run build` grün.

## Scope

Nur `client/`. Reine interne Migration — öffentliche Komponenten-Props/Verhalten unverändert. Nächste PRs des Tracks: Services · Pihole · Power/Energy · UptimeTab · Progress-Polls (MIXED) · PiDashboard · `useNetworkStatus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qhypmw5Lqi9hhsLUpa4mP
