### PR TITLE
feat(client): migrate Pi-hole pollers to TanStack Query (#299)

### DIFF
--- a/client/src/__tests__/components/pihole/QueryCollectorStatus.test.tsx
+++ b/client/src/__tests__/components/pihole/QueryCollectorStatus.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '../../helpers/queryClient';
+import { queryKeys } from '../../../lib/queryKeys';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('../../../api/pihole', () => ({
+  getCollectorStatus: vi.fn(),
+  updateCollectorConfig: vi.fn(),
+}));
+
+import { getCollectorStatus, updateCollectorConfig } from '../../../api/pihole';
+import type { QueryCollectorStatus as CollectorStatus } from '../../../api/pihole';
+import QueryCollectorStatus from '../../../components/pihole/QueryCollectorStatus';
+
+function collector(over: Partial<CollectorStatus> = {}): CollectorStatus {
+  return {
+    running: true,
+    is_enabled: true,
+    last_poll_at: null,
+    total_queries_stored: 100,
+    last_error: null,
+    last_error_at: null,
+    poll_interval_seconds: 30,
+    retention_days: 30,
+    ...over,
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+function renderCollector() {
+  const client = createTestQueryClient();
+  render(
+    <QueryClientProvider client={client}>
+      <QueryCollectorStatus />
+    </QueryClientProvider>,
+  );
+  return client;
+}
+
+describe('QueryCollectorStatus (query migration #299)', () => {
+  it('seeds the form once and a later poll does NOT clobber it (dirty-guard)', async () => {
+    (getCollectorStatus as any).mockResolvedValue(collector({ poll_interval_seconds: 30 }));
+    const client = renderCollector();
+
+    await waitFor(() => expect(screen.getByText('100')).toBeInTheDocument());
+    const pollInput = screen.getAllByRole('spinbutton')[0] as HTMLInputElement;
+    expect(pollInput.value).toBe('30');
+
+    // Next poll returns a DIFFERENT server config + new total.
+    (getCollectorStatus as any).mockResolvedValue(
+      collector({ poll_interval_seconds: 99, total_queries_stored: 200 }),
+    );
+    await act(async () => {
+      await client.invalidateQueries({ queryKey: queryKeys.pihole.collectorStatus() });
+    });
+
+    // The status display refreshed (200), but the form field stays at the seeded 30.
+    await waitFor(() => expect(screen.getByText('200')).toBeInTheDocument());
+    expect((screen.getAllByRole('spinbutton')[0] as HTMLInputElement).value).toBe('30');
+  });
+
+  it('save sends the edited config values', async () => {
+    (getCollectorStatus as any).mockResolvedValue(collector());
+    (updateCollectorConfig as any).mockResolvedValue(collector({ poll_interval_seconds: 45 }));
+    renderCollector();
+
+    await waitFor(() => expect(screen.getByText('100')).toBeInTheDocument());
+    const pollInput = screen.getAllByRole('spinbutton')[0] as HTMLInputElement;
+    fireEvent.change(pollInput, { target: { value: '45' } });
+
+    fireEvent.click(screen.getByText('collector.save'));
+
+    await waitFor(() =>
+      expect(updateCollectorConfig).toHaveBeenCalledWith({
+        poll_interval_seconds: 45,
+        retention_days: 30,
+      }),
+    );
+  });
+});

--- a/client/src/components/pihole/PiholeStatusBar.tsx
+++ b/client/src/components/pihole/PiholeStatusBar.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from 'react';
 import { Shield, ShieldOff, Clock, Server, ArrowRightLeft } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
 import { formatUptime } from '../../lib/formatters';
-import type { PiholeStatus, FailoverStatus } from '../../api/pihole';
+import type { PiholeStatus } from '../../api/pihole';
 import { getFailoverStatus } from '../../api/pihole';
+import { queryKeys } from '../../lib/queryKeys';
 
 interface PiholeStatusBarProps {
   status: PiholeStatus;
@@ -13,15 +14,12 @@ interface PiholeStatusBarProps {
 
 export default function PiholeStatusBar({ status, onBlockingToggle, loading }: PiholeStatusBarProps) {
   const { t } = useTranslation('pihole');
-  const [failover, setFailover] = useState<FailoverStatus | null>(null);
-
-  useEffect(() => {
-    getFailoverStatus().then(setFailover).catch(() => {});
-    const interval = setInterval(() => {
-      getFailoverStatus().then(setFailover).catch(() => {});
-    }, 30000);
-    return () => clearInterval(interval);
-  }, []);
+  // Query-backed (#299): 30s failover poll; errors keep the last value (null).
+  const { data: failover = null } = useQuery({
+    queryKey: queryKeys.pihole.failoverStatus(),
+    queryFn: getFailoverStatus,
+    refetchInterval: 30000,
+  });
 
   const statusColor =
     status.container_status === 'running'

--- a/client/src/components/pihole/QueryCollectorStatus.tsx
+++ b/client/src/components/pihole/QueryCollectorStatus.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Database, RefreshCw, Power, PowerOff } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -7,62 +8,68 @@ import {
   updateCollectorConfig,
   type QueryCollectorStatus as CollectorStatus,
 } from '../../api/pihole';
+import { queryKeys } from '../../lib/queryKeys';
+import { getApiErrorMessage } from '../../lib/errorHandling';
 
 export default function QueryCollectorStatus() {
   const { t } = useTranslation('pihole');
-  const [status, setStatus] = useState<CollectorStatus | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
+  const queryClient = useQueryClient();
+
+  // Query-backed (#299): 15s status poll. Errors are swallowed (collector may
+  // not be initialized yet) → status stays null and the component renders null.
+  const { data: status = null, isLoading: loading } = useQuery({
+    queryKey: queryKeys.pihole.collectorStatus(),
+    queryFn: getCollectorStatus,
+    refetchInterval: 15000,
+  });
+
   const [pollInterval, setPollInterval] = useState(30);
   const [retentionDays, setRetentionDays] = useState(30);
 
-  const fetchStatus = async () => {
-    try {
-      const data = await getCollectorStatus();
-      setStatus(data);
+  // Seed the editable form from the config ONCE on first load (dirty-guard): the
+  // old code re-synced these fields on every 15s poll, clobbering in-progress
+  // edits. A save re-seeds via the mutation below.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (status && !seededRef.current) {
+      seededRef.current = true;
+      setPollInterval(status.poll_interval_seconds);
+      setRetentionDays(status.retention_days);
+    }
+  }, [status]);
+
+  const applyConfig = (data: CollectorStatus) => {
+    queryClient.setQueryData(queryKeys.pihole.collectorStatus(), data);
+  };
+
+  const toggleMutation = useMutation({
+    mutationFn: () => updateCollectorConfig({ is_enabled: !status!.is_enabled }),
+    onSuccess: (data) => {
+      applyConfig(data);
+      toast.success(data.is_enabled ? t('collector.enabledToast') : t('collector.disabledToast'));
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err, t('collector.updateFailed'))),
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      updateCollectorConfig({ poll_interval_seconds: pollInterval, retention_days: retentionDays }),
+    onSuccess: (data) => {
+      applyConfig(data);
       setPollInterval(data.poll_interval_seconds);
       setRetentionDays(data.retention_days);
-    } catch {
-      // Silently fail — collector might not be initialized yet
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchStatus();
-    const interval = setInterval(fetchStatus, 15000);
-    return () => clearInterval(interval);
-  }, []);
-
-  const handleToggle = async () => {
-    if (!status) return;
-    setSaving(true);
-    try {
-      const data = await updateCollectorConfig({ is_enabled: !status.is_enabled });
-      setStatus(data);
-      toast.success(data.is_enabled ? t('collector.enabledToast') : t('collector.disabledToast'));
-    } catch (err: any) {
-      toast.error(err?.response?.data?.detail || t('collector.updateFailed'));
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleSave = async () => {
-    setSaving(true);
-    try {
-      const data = await updateCollectorConfig({
-        poll_interval_seconds: pollInterval,
-        retention_days: retentionDays,
-      });
-      setStatus(data);
       toast.success(t('collector.savedToast'));
-    } catch (err: any) {
-      toast.error(err?.response?.data?.detail || t('collector.saveFailed'));
-    } finally {
-      setSaving(false);
-    }
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err, t('collector.saveFailed'))),
+  });
+
+  const saving = toggleMutation.isPending || saveMutation.isPending;
+  const handleToggle = () => {
+    if (!status) return;
+    toggleMutation.mutate();
+  };
+  const handleSave = () => {
+    saveMutation.mutate();
   };
 
   if (loading) {

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -95,6 +95,14 @@ export const queryKeys = {
   gpu: {
     current: () => ['gpu', 'current'] as const,
   },
+  pihole: {
+    /** Domain-Prefix. */
+    all: () => ['pihole'] as const,
+    /** Aggregate overview (status + summary + top domains/clients + history). */
+    overview: () => ['pihole', 'overview'] as const,
+    failoverStatus: () => ['pihole', 'failover-status'] as const,
+    collectorStatus: () => ['pihole', 'collector-status'] as const,
+  },
   fans: {
     status: () => ['fans', 'status'] as const,
     /** Combined fan status + permission for the fan-control page. */

--- a/client/src/pages/PiholePage.tsx
+++ b/client/src/pages/PiholePage.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import {
@@ -29,6 +30,8 @@ import {
   type ClientEntry,
   type HistoryEntry,
 } from '../api/pihole';
+import { queryKeys } from '../lib/queryKeys';
+import { getApiErrorMessage } from '../lib/errorHandling';
 import PiholeStatusBar from '../components/pihole/PiholeStatusBar';
 import PiholeSummaryCards from '../components/pihole/PiholeSummaryCards';
 import PiholeQueryTimeline from '../components/pihole/PiholeQueryTimeline';
@@ -76,66 +79,104 @@ const TABS: TabConfig[] = [
   { key: 'container', labelKey: 'tabs.container', icon: <Terminal className="h-4 w-4" /> },
 ];
 
+interface PiholeOverview {
+  status: PiholeStatus;
+  summary: PiholeSummary | null;
+  topPermitted: DomainEntry[];
+  topBlocked: DomainEntry[];
+  topClients: ClientEntry[];
+  history: HistoryEntry[];
+  /** True when status loaded but the statistics fan-out failed. */
+  statsError: boolean;
+  statsErrorMsg: string;
+}
+
+/**
+ * Aggregate overview fetch (#299) — one query replaces the old 30s setInterval.
+ * A statistics-fan-out failure does NOT reject (status still renders); it is
+ * surfaced via `statsError`. A status failure rejects → the query goes to error.
+ */
+async function fetchPiholeOverview(): Promise<PiholeOverview> {
+  const status = await getPiholeStatus();
+  const empty = { summary: null, topPermitted: [], topBlocked: [], topClients: [], history: [] };
+  if (!status.connected) {
+    return { status, ...empty, statsError: false, statsErrorMsg: '' };
+  }
+  try {
+    const [summaryData, domainsData, blockedData, clientsData, historyData] = await Promise.all([
+      getPiholeSummary(),
+      getTopDomains(10),
+      getTopBlocked(10),
+      getTopClients(10),
+      getHistory(),
+    ]);
+    return {
+      status,
+      summary: summaryData,
+      topPermitted: domainsData.top_permitted,
+      topBlocked: blockedData.top_blocked,
+      topClients: clientsData.top_clients,
+      history: historyData.history,
+      statsError: false,
+      statsErrorMsg: '',
+    };
+  } catch (err) {
+    return { status, ...empty, statsError: true, statsErrorMsg: getApiErrorMessage(err, '') };
+  }
+}
+
 export default function PiholePage() {
   const { t } = useTranslation('pihole');
+  const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState<Tab>('overview');
-  const [status, setStatus] = useState<PiholeStatus | null>(null);
-  const [summary, setSummary] = useState<PiholeSummary | null>(null);
-  const [topPermitted, setTopPermitted] = useState<DomainEntry[]>([]);
-  const [topBlocked, setTopBlocked] = useState<DomainEntry[]>([]);
-  const [topClients, setTopClients] = useState<ClientEntry[]>([]);
-  const [history, setHistory] = useState<HistoryEntry[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [fetchError, setFetchError] = useState(false);
 
-  const fetchOverview = useCallback(async () => {
-    setLoading(true);
-    try {
-      const statusData = await getPiholeStatus();
-      setStatus(statusData);
-      setFetchError(false);
+  // Query-backed (#299): the single 30s aggregate poll. `isLoading` gates the
+  // first-load skeletons only (the old code flashed them on every poll).
+  const { data, isLoading: loading, isError, error } = useQuery({
+    queryKey: queryKeys.pihole.overview(),
+    queryFn: fetchPiholeOverview,
+    refetchInterval: 30000,
+  });
 
-      if (statusData.connected) {
-        try {
-          const [summaryData, domainsData, blockedData, clientsData, historyData] = await Promise.all([
-            getPiholeSummary(),
-            getTopDomains(10),
-            getTopBlocked(10),
-            getTopClients(10),
-            getHistory(),
-          ]);
-          setSummary(summaryData);
-          setTopPermitted(domainsData.top_permitted);
-          setTopBlocked(blockedData.top_blocked);
-          setTopClients(clientsData.top_clients);
-          setHistory(historyData.history);
-        } catch (err: any) {
-          toast.error(err?.response?.data?.detail || t('states.loadFailedStatistics'));
-        }
-      }
-    } catch (err: any) {
-      setFetchError(true);
-      toast.error(err?.response?.data?.detail || t('states.loadFailedData'));
-    } finally {
-      setLoading(false);
-    }
-  }, [t]);
+  const status = data?.status ?? null;
+  const summary = data?.summary ?? null;
+  const topPermitted = data?.topPermitted ?? [];
+  const topBlocked = data?.topBlocked ?? [];
+  const topClients = data?.topClients ?? [];
+  const history = data?.history ?? [];
+  const fetchError = isError;
 
+  // Toast once per error-onset (not on every poll like the old code). Preserves
+  // the FastAPI detail via getApiErrorMessage.
+  const prevFetchError = useRef(false);
   useEffect(() => {
-    fetchOverview();
-    const interval = setInterval(fetchOverview, 30000);
-    return () => clearInterval(interval);
-  }, [fetchOverview]);
-
-  const handleBlockingToggle = async (enabled: boolean) => {
-    try {
-      await setBlocking(enabled);
-      setStatus((prev) => (prev ? { ...prev, blocking_enabled: enabled } : prev));
-      toast.success(enabled ? t('status.blockingOn') : t('status.blockingOff'));
-    } catch (err: any) {
-      toast.error(err?.response?.data?.detail || t('status.blockingToggleFailed'));
+    if (isError && !prevFetchError.current) {
+      toast.error(getApiErrorMessage(error, t('states.loadFailedData')));
     }
-  };
+    prevFetchError.current = isError;
+  }, [isError, error, t]);
+
+  const statsError = data?.statsError ?? false;
+  const prevStatsError = useRef(false);
+  useEffect(() => {
+    if (statsError && !prevStatsError.current) {
+      toast.error(data?.statsErrorMsg || t('states.loadFailedStatistics'));
+    }
+    prevStatsError.current = statsError;
+  }, [statsError, data?.statsErrorMsg, t]);
+
+  const blockingMutation = useMutation({
+    mutationFn: (enabled: boolean) => setBlocking(enabled),
+    onSuccess: (_res, enabled) => {
+      // Optimistically patch the cached status so the toggle reflects immediately.
+      queryClient.setQueryData<PiholeOverview>(queryKeys.pihole.overview(), (prev) =>
+        prev ? { ...prev, status: { ...prev.status, blocking_enabled: enabled } } : prev,
+      );
+      toast.success(enabled ? t('status.blockingOn') : t('status.blockingOff'));
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err, t('status.blockingToggleFailed'))),
+  });
+  const handleBlockingToggle = (enabled: boolean) => blockingMutation.mutate(enabled);
 
   const unreachableMessage =
     status?.mode === 'docker'


### PR DESCRIPTION
## Was & Warum

**F1-Resttail (#299), PR 3 von 8** aus der [`setInterval`-Triage](https://github.com/Xveyn/BaluHost/issues/299#issuecomment-4887349943) — der Pi-hole-Bereich (3 Poller).

## Änderungen

- **`PiholeStatusBar`** — 30s Failover-Poll → `useQuery` (`pihole.failoverStatus()`). Trivial.
- **`QueryCollectorStatus`** — 15s Status-Poll → `useQuery` (`pihole.collectorStatus()`); Toggle/Save → `useMutation`. **Behebt einen latenten UX-Bug:** der alte Poll re-synchronisierte die editierbaren Felder (Poll-Intervall / Retention) bei **jedem** 15s-Tick und überschrieb damit laufende Eingaben. Jetzt wird die Form **einmalig** beim ersten Load geseedet (Dirty-Guard) und nur nach einem Save neu geseedet. Entfernt zwei `any`-Error-Casts.
- **`PiholePage`** — der 30s-Aggregat-Poll → **eine** `useQuery` (`pihole.overview()`), deren queryFn exakt das alte `status` + bedingte 5-Endpoint-Fan-out kapselt. Ein Fehlschlag der Statistik-Fan-out **rejected nicht mehr** (Status rendert weiter) → via `statsError`-Flag signalisiert. Blocking-Toggle → `useMutation` mit optimistischem Cache-Patch.

## Semantik-Hinweise (bewusste kleine Verbesserungen)

- **Kein 30s-Skeleton-Flash mehr:** der alte Code setzte `loading=true` bei jedem Poll → die Overview-Karten flashten alle 30s in den Skeleton. Jetzt gaten nur `isLoading` (First-Load) die Skeletons.
- **Fehler-Toasts nur bei Error-*Onset*** statt bei jedem Poll (via `useRef`-Transition-Guard). FastAPI-`detail` bleibt via `getApiErrorMessage` erhalten.
- **Weiterer Split** von `pihole.overview()` in Einzel-Endpoint-Queries ist bewusst **aufgeschoben** (kleiner Blast-Radius); der F1-Poller ist damit trotzdem weg.

Neue Query-Keys: `pihole.all` / `overview` / `failoverStatus` / `collectorStatus`.

## Tests & Verifikation

- Neu: `QueryCollectorStatus` — Dirty-Guard (ein Poll clobbert die Form **nicht**) + Save-sendet-editierte-Werte.
- Volle Vitest-Suite **573/573, 109/109** grün · ESLint **0 Errors** · `npm run build` grün.

## Scope

Nur `client/`. Nächste PRs: Power/Energy (7 Sites, dickster) · UptimeTab · Progress-Polls (MIXED) · PiDashboard · `useNetworkStatus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qhypmw5Lqi9hhsLUpa4mP
