### PR TITLE
feat(client): migrate PowerTab pollers to TanStack Query (#299)

### DIFF
--- a/client/src/__tests__/lib/resolveCumulativeArgs.test.ts
+++ b/client/src/__tests__/lib/resolveCumulativeArgs.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCumulativeArgs } from '../../lib/energyPolling';
+
+describe('resolveCumulativeArgs', () => {
+  it('passes a preset period through with no custom range', () => {
+    expect(resolveCumulativeArgs('today', null, null)).toEqual({
+      period: 'today',
+      start: undefined,
+      end: undefined,
+    });
+    expect(resolveCumulativeArgs('week', null, null)).toEqual({
+      period: 'week',
+      start: undefined,
+      end: undefined,
+    });
+  });
+
+  it('maps a custom range to period=today + the start/end bounds', () => {
+    expect(
+      resolveCumulativeArgs('custom', '2026-01-01T00:00:00Z', '2026-01-31T23:59:59Z'),
+    ).toEqual({
+      period: 'today',
+      start: '2026-01-01T00:00:00Z',
+      end: '2026-01-31T23:59:59Z',
+    });
+  });
+
+  it('yields undefined bounds for a custom period with nothing applied yet', () => {
+    expect(resolveCumulativeArgs('custom', null, null)).toEqual({
+      period: 'today',
+      start: undefined,
+      end: undefined,
+    });
+  });
+});

--- a/client/src/components/system-monitor/PowerTab.tsx
+++ b/client/src/components/system-monitor/PowerTab.tsx
@@ -2,7 +2,8 @@
  * PowerTab -- Power/energy monitoring tab with smart device integration.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import {
@@ -21,18 +22,18 @@ import { getApiErrorMessage } from '../../lib/errorHandling';
 import { formatTimeForRange, parseUtcTimestamp, localRangeToUtcIso } from '../../lib/dateUtils';
 import type { ChartTimeRange } from '../../lib/dateUtils';
 import { smartDevicesApi } from '../../api/smart-devices';
-import type { SmartDevice, PowerSummary } from '../../api/smart-devices';
 import {
   getEnergyPriceConfig,
   updateEnergyPriceConfig,
   getCumulativeEnergy,
   getCumulativeEnergyTotal,
   type EnergyPriceConfig,
-  type CumulativeEnergyResponse,
 } from '../../api/energy';
 import { StatCard } from '../ui/StatCard';
 import { PluginBadge } from '../ui/PluginBadge';
 import { formatNumber } from '../../lib/formatters';
+import { queryKeys } from '../../lib/queryKeys';
+import { resolveCumulativeArgs } from '../../lib/energyPolling';
 import { usePlugins } from '../../contexts/PluginContext';
 
 type CumulativePeriod = 'today' | 'week' | 'month' | 'custom';
@@ -41,21 +42,16 @@ type ChartMode = 'cumulative' | 'instant';
 export function PowerTab() {
   const { t, i18n } = useTranslation(['system', 'common']);
   const { plugins } = usePlugins();
-  const [devices, setDevices] = useState<SmartDevice[]>([]);
-  const [powerSummary, setPowerSummary] = useState<PowerSummary | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
-  // Energy price config state
+  // Energy price config state (fetched once on mount; edited locally)
   const [priceConfig, setPriceConfig] = useState<EnergyPriceConfig | null>(null);
   const [editingPrice, setEditingPrice] = useState(false);
   const [priceInput, setPriceInput] = useState('');
   const [savingPrice, setSavingPrice] = useState(false);
 
-  // Cumulative energy state
+  // Chart selection state
   const [cumulativePeriod, setCumulativePeriod] = useState<CumulativePeriod>('today');
-  const [cumulativeData, setCumulativeData] = useState<CumulativeEnergyResponse | null>(null);
-  const [cumulativeLoading, setCumulativeLoading] = useState(false);
   const [selectedDeviceId, setSelectedDeviceId] = useState<number | null>(null);
   const [chartMode, setChartMode] = useState<ChartMode>('cumulative');
 
@@ -66,42 +62,54 @@ export function PowerTab() {
   const [draftStart, setDraftStart] = useState('');
   const [draftEnd, setDraftEnd] = useState('');
 
-  // Derive the API args (period vs. custom start/end) for the active selection.
-  // Shared by the polling effect and the price-edit refresh so they never drift.
-  const resolveRangeArgs = useCallback((): {
-    period: 'today' | 'week' | 'month';
-    start?: string;
-    end?: string;
-  } => {
-    const isCustom = cumulativePeriod === 'custom';
-    return {
-      period: (isCustom ? 'today' : cumulativePeriod) as 'today' | 'week' | 'month',
-      start: isCustom ? customStart ?? undefined : undefined,
-      end: isCustom ? customEnd ?? undefined : undefined,
-    };
-  }, [cumulativePeriod, customStart, customEnd]);
-
-  const fetchPower = useCallback(async () => {
-    try {
+  // Devices + power summary — query-backed (#299), 5s poll (per-device live watts
+  // come from the device list). A 404 (no power plugin) is swallowed like before;
+  // the last successful data is retained on any error.
+  const powerQuery = useQuery({
+    queryKey: queryKeys.powerTab.summary(),
+    queryFn: async () => {
       const [listRes, summaryRes] = await Promise.all([
         smartDevicesApi.list(),
         smartDevicesApi.getPowerSummary(),
       ]);
-      // Filter to devices with power_monitor capability
-      const powerDevices = listRes.data.devices.filter(d => d.capabilities?.includes('power_monitor'));
-      setDevices(powerDevices);
-      setPowerSummary(summaryRes.data);
-      setError(null);
-    } catch (err: unknown) {
-      const isAxiosLike = err != null && typeof err === 'object' && 'response' in err;
-      const status = isAxiosLike ? (err as { response?: { status?: number } }).response?.status : undefined;
-      if (status !== 404) {
-        setError(getApiErrorMessage(err, 'Failed to load power data'));
-      }
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+      const powerDevices = listRes.data.devices.filter((d) => d.capabilities?.includes('power_monitor'));
+      return { devices: powerDevices, powerSummary: summaryRes.data };
+    },
+    refetchInterval: 5000,
+  });
+  const devices = powerQuery.data?.devices ?? [];
+  const powerSummary = powerQuery.data?.powerSummary ?? null;
+  const loading = powerQuery.isLoading;
+  const errorStatus =
+    powerQuery.error && typeof powerQuery.error === 'object' && 'response' in powerQuery.error
+      ? (powerQuery.error as { response?: { status?: number } }).response?.status
+      : undefined;
+  const error =
+    powerQuery.isError && errorStatus !== 404
+      ? getApiErrorMessage(powerQuery.error, 'Failed to load power data')
+      : null;
+
+  // Cumulative energy — query-backed 60s poll. `resolveCumulativeArgs` (tested)
+  // maps the custom range; a custom period with nothing applied stays disabled.
+  const rangeArgs = resolveCumulativeArgs(cumulativePeriod, customStart, customEnd);
+  const cumulativeReady = !(cumulativePeriod === 'custom' && (!rangeArgs.start || !rangeArgs.end));
+  const cumulativeQuery = useQuery({
+    queryKey: queryKeys.powerTab.cumulative(
+      selectedDeviceId,
+      rangeArgs.period,
+      rangeArgs.start ?? null,
+      rangeArgs.end ?? null,
+    ),
+    queryFn: () =>
+      selectedDeviceId === null
+        ? getCumulativeEnergyTotal(rangeArgs.period, rangeArgs.start, rangeArgs.end)
+        : getCumulativeEnergy(selectedDeviceId, rangeArgs.period, rangeArgs.start, rangeArgs.end),
+    enabled: cumulativeReady,
+    refetchInterval: 60000,
+  });
+  const cumulativeData = cumulativeQuery.data ?? null;
+  // First-load spinner only — the old code re-showed it on every 60s poll.
+  const cumulativeLoading = cumulativeQuery.isLoading;
 
   // Fetch price config on mount
   useEffect(() => {
@@ -116,34 +124,6 @@ export function PowerTab() {
     };
     fetchPriceConfig();
   }, []);
-
-  // Fetch cumulative data with separate interval (60s - matches DB write interval)
-  useEffect(() => {
-    const { period, start, end } = resolveRangeArgs();
-    if (cumulativePeriod === 'custom' && (!start || !end)) {
-      return; // nothing applied yet
-    }
-    const fetchCumulative = async () => {
-      setCumulativeLoading(true);
-      try {
-        const data = selectedDeviceId === null
-          ? await getCumulativeEnergyTotal(period, start, end)
-          : await getCumulativeEnergy(selectedDeviceId, period, start, end);
-        setCumulativeData(data);
-      } catch {
-        // Non-critical: cumulative data will remain null
-      } finally {
-        setCumulativeLoading(false);
-      }
-    };
-
-    // Initial fetch
-    fetchCumulative();
-
-    // Separate interval: 60 seconds (matches DB write interval)
-    const interval = setInterval(fetchCumulative, 60000);
-    return () => clearInterval(interval);
-  }, [selectedDeviceId, cumulativePeriod, resolveRangeArgs]);
 
   const handleSavePrice = async () => {
     const newPrice = parseFloat(priceInput);
@@ -161,24 +141,21 @@ export function PowerTab() {
       setPriceConfig(updated);
       setEditingPrice(false);
       toast.success(t('monitor.power.priceUpdated'));
-      // Refresh cumulative data with new price (respect an active custom range)
-      const { period, start, end } = resolveRangeArgs();
-      const refreshData = selectedDeviceId === null
-        ? getCumulativeEnergyTotal(period, start, end)
-        : getCumulativeEnergy(selectedDeviceId, period, start, end);
-      setCumulativeData(await refreshData);
+      // Refresh cumulative data with the new price (active range key).
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.powerTab.cumulative(
+          selectedDeviceId,
+          rangeArgs.period,
+          rangeArgs.start ?? null,
+          rangeArgs.end ?? null,
+        ),
+      });
     } catch (err: unknown) {
       toast.error(getApiErrorMessage(err, t('monitor.power.saveError')));
     } finally {
       setSavingPrice(false);
     }
   };
-
-  useEffect(() => {
-    fetchPower();
-    const interval = setInterval(fetchPower, 5000);
-    return () => clearInterval(interval);
-  }, [fetchPower]);
 
   const totalCurrentPower = powerSummary?.total_watts ?? 0;
   const powerPluginName = devices.length > 0

--- a/client/src/lib/energyPolling.ts
+++ b/client/src/lib/energyPolling.ts
@@ -8,3 +8,30 @@ export type EnergyTimeWindow = '10min' | '1hour' | '24hours' | '7days';
 export function energyChartRefreshInterval(window: EnergyTimeWindow): number {
   return window === '10min' ? 5000 : 30000;
 }
+
+export type CumulativePeriod = 'today' | 'week' | 'month' | 'custom';
+
+interface CumulativeArgs {
+  period: 'today' | 'week' | 'month';
+  start?: string;
+  end?: string;
+}
+
+/**
+ * Resolve the cumulative-energy API args for the active PowerTab selection: a
+ * custom range maps to `period: 'today'` plus explicit start/end bounds, a preset
+ * passes through with no bounds. Pure — extracted from the old `resolveRangeArgs`
+ * callback so the query key + fetch never drift and the mapping is unit-tested.
+ */
+export function resolveCumulativeArgs(
+  period: CumulativePeriod,
+  customStart: string | null,
+  customEnd: string | null,
+): CumulativeArgs {
+  const isCustom = period === 'custom';
+  return {
+    period: isCustom ? 'today' : period,
+    start: isCustom ? customStart ?? undefined : undefined,
+    end: isCustom ? customEnd ?? undefined : undefined,
+  };
+}

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -111,6 +111,17 @@ export const queryKeys = {
     chart: (deviceId: number | null, window: string) =>
       ['energy', 'chart', deviceId, window] as const,
   },
+  powerTab: {
+    /** SystemMonitor PowerTab: smart-device list + power summary (5s poll). */
+    summary: () => ['power-tab', 'summary'] as const,
+    /** Cumulative energy for the chart; device + resolved period/range in the key. */
+    cumulative: (
+      deviceId: number | null,
+      period: string,
+      start: string | null,
+      end: string | null,
+    ) => ['power-tab', 'cumulative', deviceId, period, start, end] as const,
+  },
   pihole: {
     /** Domain-Prefix. */
     all: () => ['pihole'] as const,


### PR DESCRIPTION
## Was & Warum

**F1-Resttail (#299), PR 4c** aus der [`setInterval`-Triage](https://github.com/Xveyn/BaluHost/issues/299#issuecomment-4887349943). Power/Energy pro Komponente gesplittet — dieser PR: **PowerTab** (4d = `PowerManagement` folgt).

## Änderungen (beide Poller → `useQuery`)

- **Power-Summary** (Devices + `getPowerSummary`): 5s-Poll, eigener `powerTab.summary()`-Key (bewusst als kombinierter Fetch belassen, damit die per-Device-Live-Watts + das 404-Swallow **exakt** wie bisher funktionieren). Ein 404 gilt als „kein Fehler"; letzter Wert bleibt bei jedem Error erhalten.
- **Cumulative Energy**: 60s-Poll, `powerTab.cumulative(deviceId, period, start, end)`-Key. Der alte `resolveRangeArgs`-Callback ist in die pure, unit-getestete **`resolveCumulativeArgs`** extrahiert → Key und Fetch können nicht auseinanderlaufen; eine Custom-Periode ohne angewandten Bereich hält die Query `disabled`. Der Preis-Save invalidiert jetzt den aktiven Cumulative-Key statt manuell nachzuladen.

## Semantik-Hinweis (bewusste Verbesserung)

Der Cumulative-Chart-Spinner erscheint jetzt **nur beim First-Load** — der alte Code zeigte ihn bei **jedem** 60s-Poll (Chart-Blank jede Minute).

Neu: pure `resolveCumulativeArgs` in `lib/energyPolling.ts`, Keys `powerTab.summary` / `powerTab.cumulative`.

## Tests & Verifikation

- **Test-first** für `resolveCumulativeArgs` (Preset-Durchreichen · custom→today+bounds · custom-unapplied→undefined bounds).
- Volle Vitest-Suite **591/591, 114/114** grün (+3) · ESLint **0 Errors** · `npm run build` grün.

## Scope

Nur `client/`. Custom-Range-UI/JSX unverändert. Nächste PRs: **4d** (PowerManagement) · UptimeTab · Progress-Polls (MIXED) · PiDashboard · `useNetworkStatus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qhypmw5Lqi9hhsLUpa4mP
