### PR TITLE
feat(client): migrate useNetworkStatus to TanStack Query (#299)

### DIFF
--- a/client/src/__tests__/hooks/useNetworkStatus.test.ts
+++ b/client/src/__tests__/hooks/useNetworkStatus.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
-import { useNetworkStatus } from '../../hooks/useNetworkStatus';
+import { createQueryWrapper } from '../helpers/queryClient';
 
 const mockResponse = {
   timestamp: '2026-02-07T12:00:00Z',
@@ -14,6 +14,8 @@ vi.mock('../../api/monitoring', () => ({
 }));
 
 import { getNetworkCurrent } from '../../api/monitoring';
+import { useNetworkStatus } from '../../hooks/useNetworkStatus';
+import { useNetworkMonitoring } from '../../hooks/useMonitoring';
 
 describe('useNetworkStatus', () => {
   beforeEach(() => {
@@ -26,9 +28,9 @@ describe('useNetworkStatus', () => {
   });
 
   it('fetches and returns network status', async () => {
-    const { result } = renderHook(() =>
-      useNetworkStatus({ refreshInterval: 0 })
-    );
+    const { result } = renderHook(() => useNetworkStatus({ refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
 
     expect(result.current.loading).toBe(true);
 
@@ -46,9 +48,9 @@ describe('useNetworkStatus', () => {
   it('handles errors', async () => {
     vi.mocked(getNetworkCurrent).mockRejectedValue(new Error('API down'));
 
-    const { result } = renderHook(() =>
-      useNetworkStatus({ refreshInterval: 0 })
-    );
+    const { result } = renderHook(() => useNetworkStatus({ refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -59,9 +61,9 @@ describe('useNetworkStatus', () => {
   });
 
   it('does not fetch when enabled=false', async () => {
-    const { result } = renderHook(() =>
-      useNetworkStatus({ enabled: false, refreshInterval: 0 })
-    );
+    const { result } = renderHook(() => useNetworkStatus({ enabled: false, refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
 
     // Give time for effects
     await new Promise((r) => setTimeout(r, 50));
@@ -73,9 +75,9 @@ describe('useNetworkStatus', () => {
   it('auto-refreshes with interval', async () => {
     vi.useFakeTimers();
 
-    renderHook(() =>
-      useNetworkStatus({ refreshInterval: 3000 })
-    );
+    renderHook(() => useNetworkStatus({ refreshInterval: 3000 }), {
+      wrapper: createQueryWrapper(),
+    });
 
     // Initial call
     await act(async () => {
@@ -93,9 +95,9 @@ describe('useNetworkStatus', () => {
   });
 
   it('refetch() works', async () => {
-    const { result } = renderHook(() =>
-      useNetworkStatus({ refreshInterval: 0 })
-    );
+    const { result } = renderHook(() => useNetworkStatus({ refreshInterval: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -108,5 +110,25 @@ describe('useNetworkStatus', () => {
     });
 
     expect(getNetworkCurrent).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares the monitoring networkCurrent query — one fetch feeds both hooks', async () => {
+    // useNetworkStatus and useNetworkMonitoring hit the same endpoint. After the
+    // TanStack migration they share queryKeys.monitoring.networkCurrent(), so
+    // mounting both under one client must trigger only a single network fetch.
+    const { result } = renderHook(
+      () => ({
+        widget: useNetworkStatus({ refreshInterval: 0 }),
+        monitoring: useNetworkMonitoring({ pollInterval: 0, enabled: true }),
+      }),
+      { wrapper: createQueryWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.widget.status).not.toBeNull();
+      expect(result.current.monitoring.current).not.toBeNull();
+    });
+
+    expect(getNetworkCurrent).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -32,6 +32,7 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useSleepStatus.ts` | `api/sleep`, `api/fritzbox` | Sleep-mode status via **TanStack Query** (`useQuery`) with an **adaptive** `refetchInterval` — the pure `sleepPollInterval(state)` returns 30s in `soft_sleep` (so the poll can't auto-wake the box) / 5s otherwise (#299). Fritz!Box config is a separate once-only query (`staleTime: Infinity`, `retry: false` → unconfigured = `null`, no spam). Consumer: `SleepModePanel` (mutations stay imperative, call `refetch`) |
 | `useGpuPower.ts` | `api/gpuPower` | GPU-power status + config + capabilities via **TanStack Query** (`useQuery`, 5s poll, combined `gpuPower.overview()` key). `draft` is the editable config copy, **seeded once** (`prev ?? config`) so a background poll never wipes an in-progress edit (draft-guard); `config` still tracks the server so `dirty` is accurate. Save = **`useMutation`** (`putConfig`) that re-seeds the draft. Consumer: `GpuPowerCard` |
 | `useGpuCurrent.ts` | `api/monitoring` | Current GPU sample via **TanStack Query** (`useQuery`, 3s poll, `gpu.current()` key). Mounted by `GpuTab` + `Dashboard` — the shared key collapses the two former `setInterval` pollers into one cache entry + one poll (#299). Returns `GpuSample \| null`; `enabled` arg gates polling on GPU presence. Keeps the last value on transient errors (TanStack default) |
+| `useNetworkStatus.ts` | `api/monitoring` | Current network I/O for `NetworkWidget` via **TanStack Query** (`useQuery`, default 3s poll via `refreshInterval`→`refetchInterval`, `queryKeys.monitoring.networkCurrent()` key). Shares that key with `useNetworkMonitoring` → the two former pollers of the same endpoint collapse to one cache entry + one poll (#299). Public shape unchanged (`{ status, loading, error, refetch }`); `formatNetworkSpeed` helper co-located |
 | `useOpenApiSchema.ts` | — | OpenAPI schema for API docs page |
 
 ## Utility Hooks
@@ -42,7 +43,6 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useSortableTable.ts` | Table sorting state (column, direction) |
 | `useByteUnitMode.ts` | Binary (GiB) vs decimal (GB) byte unit preference |
 | `useIdleTimeout.ts` | Auto-logout after inactivity period |
-| `useNetworkStatus.ts` | Online/offline detection |
 | `useNotificationSocket.ts` | WebSocket connection for real-time notifications |
 | `useNextMaintenance.ts` | Next scheduled maintenance window |
 | `usePresenceHeartbeat.ts` | Presence heartbeat to `/api/system/sleep/presence` while tab visible (blocks auto true-suspend, #214); fire-and-forget, mounted once in `AppRoutes` (auth-gated via `enabled`); paused while the idle-logout warning is visible (#222) |

--- a/client/src/hooks/useNetworkStatus.ts
+++ b/client/src/hooks/useNetworkStatus.ts
@@ -1,9 +1,11 @@
 /**
  * Hook for getting current network I/O status
  */
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../lib/queryKeys';
 import { getApiErrorMessage } from '../lib/errorHandling';
-import { getNetworkCurrent, type CurrentNetworkResponse, type InterfaceType } from '../api/monitoring';
+import { getNetworkCurrent, type InterfaceType } from '../api/monitoring';
 import { formatNumber } from '../lib/formatters';
 
 export interface NetworkStatus {
@@ -28,36 +30,17 @@ interface UseNetworkStatusReturn {
 export function useNetworkStatus(options: UseNetworkStatusOptions = {}): UseNetworkStatusReturn {
   const { refreshInterval = 3000, enabled = true } = options;
 
-  const [data, setData] = useState<CurrentNetworkResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  // Shares queryKeys.monitoring.networkCurrent() with useNetworkMonitoring, so
+  // mounting both (dashboard widget + system-monitor tab) collapses to a single
+  // poll of the same endpoint.
+  const query = useQuery({
+    queryKey: queryKeys.monitoring.networkCurrent(),
+    queryFn: getNetworkCurrent,
+    refetchInterval: refreshInterval > 0 ? refreshInterval : false,
+    enabled,
+  });
 
-  const loadData = useCallback(async () => {
-    try {
-      const response = await getNetworkCurrent();
-      setData(response);
-      setError(null);
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, 'Failed to load network status'));
-    }
-  }, []);
-
-  // Initial load
-  useEffect(() => {
-    if (!enabled) return;
-
-    setLoading(true);
-    loadData().finally(() => setLoading(false));
-  }, [enabled, loadData]);
-
-  // Auto-refresh
-  useEffect(() => {
-    if (!enabled || refreshInterval <= 0) return;
-
-    const interval = setInterval(loadData, refreshInterval);
-    return () => clearInterval(interval);
-  }, [enabled, refreshInterval, loadData]);
-
+  const data = query.data;
   const status = useMemo<NetworkStatus | null>(() => {
     if (!data) return null;
 
@@ -71,9 +54,11 @@ export function useNetworkStatus(options: UseNetworkStatusOptions = {}): UseNetw
 
   return {
     status,
-    loading,
-    error,
-    refetch: loadData,
+    loading: query.isLoading,
+    error: query.error ? getApiErrorMessage(query.error, 'Failed to load network status') : null,
+    refetch: async () => {
+      await query.refetch();
+    },
   };
 }
 


### PR DESCRIPTION
## Was

Migriert `useNetworkStatus` von hand-gerolltem `useState`/`useEffect`/`setInterval` auf **TanStack Query** (`useQuery`) — Teil des Component/Page-Layer-Tracks von #299 (F1-Resttail).

## Warum

Der Hook pollte denselben Endpoint (`getNetworkCurrent`) wie das bereits migrierte `useNetworkMonitoring`, aber mit eigenem 3s-`setInterval`. Durch den geteilten Query-Key `queryKeys.monitoring.networkCurrent()` teilen sich beide Hooks jetzt **eine Cache-Entry und einen Poll** — sind Dashboard-`NetworkWidget` und der System-Monitor-Network-Tab gleichzeitig gemountet, entfällt ein redundanter Request.

## Details

- Public-Shape (`{ status, loading, error, refetch }`) und die `refreshInterval`/`enabled`-Optionen **unverändert** → `NetworkWidget` bleibt untouched (Approach A, minimaler Blast-Radius).
- `refreshInterval` → `refetchInterval` (`<= 0` deaktiviert, alte Semantik erhalten).
- Poll pausiert jetzt bei verstecktem Tab (TanStack-Default) — bewusst, wie bei den anderen migrierten Dashboard-Pollern.
- `hooks/CLAUDE.md` korrigiert: Eintrag war fälschlich unter *Utility Hooks* mit „Online/offline detection" (falsche Beschreibung) — jetzt bei den Data-Fetching-Hooks.

## Tests (TDD)

- Test-Suite auf den geteilten `createQueryWrapper` umgestellt; neuer **Dedup-Test** (schlug RED korrekt fehl: 2 Fetches → jetzt 1).
- `useNetworkStatus.test.ts` + `formatNetworkSpeed.test.ts`: **12/12 grün**
- `eslint` (geänderte Dateien): 0 Errors · `npm run build` (`tsc -b` + vite): grün

Teil von #299.
