### PR TITLE
refactor(power): decompose PowerManagement into subcomponents (#301)

### DIFF
--- a/client/src/__tests__/components/power/AutoScalingSection.test.tsx
+++ b/client/src/__tests__/components/power/AutoScalingSection.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('../../../api/power-management', async () => {
+  const actual = await vi.importActual<typeof import('../../../api/power-management')>('../../../api/power-management');
+  return { ...actual, updateAutoScalingConfig: vi.fn() };
+});
+
+import { updateAutoScalingConfig } from '../../../api/power-management';
+import { AutoScalingSection } from '../../../components/power/AutoScalingSection';
+
+const cfg = {
+  enabled: true,
+  cpu_surge_threshold: 90, cpu_medium_threshold: 60, cpu_low_threshold: 30,
+  cooldown_seconds: 15, use_cpu_monitoring: true,
+} as never;
+
+function renderSection() {
+  const onRefresh = vi.fn();
+  const onBusyChange = vi.fn();
+  const { container } = render(
+    <AutoScalingSection
+      autoScaling={cfg}
+      dimmed={false}
+      busy={false}
+      onBusyChange={onBusyChange}
+      onRefresh={onRefresh}
+    />,
+  );
+  return { onRefresh, onBusyChange, container };
+}
+
+describe('AutoScalingSection', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the config card in display mode', () => {
+    const { container } = renderSection();
+    expect(container.querySelector('[data-testid="auto-scaling-section"]')).not.toBeNull();
+  });
+
+  it('blocks save on an invalid threshold ordering (no API call)', async () => {
+    (updateAutoScalingConfig as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    renderSection();
+    fireEvent.click(screen.getByTestId('auto-scaling-edit'));
+    // surge (10) below medium (60) → invalid ordering
+    fireEvent.change(screen.getByTestId('auto-scaling-input-surge'), { target: { value: '10' } });
+    fireEvent.click(screen.getByTestId('auto-scaling-save'));
+    await waitFor(() => {});
+    expect(updateAutoScalingConfig).not.toHaveBeenCalled();
+  });
+
+  it('saves a valid edit: calls the API and onRefresh', async () => {
+    (updateAutoScalingConfig as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    const { onRefresh } = renderSection();
+    fireEvent.click(screen.getByTestId('auto-scaling-edit'));
+    fireEvent.click(screen.getByTestId('auto-scaling-save'));
+    await waitFor(() => expect(updateAutoScalingConfig).toHaveBeenCalledTimes(1));
+    expect(onRefresh).toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/components/power/PermissionStatusCard.test.tsx
+++ b/client/src/__tests__/components/power/PermissionStatusCard.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+import { PermissionStatusCard } from '../../../components/power/PermissionStatusCard';
+
+const linuxStatus = (writeAccess: boolean) => ({
+  is_using_linux_backend: true,
+  permission_status: {
+    has_write_access: writeAccess, user: 'baluhost',
+    in_cpufreq_group: true, sudo_available: false,
+  },
+}) as never;
+
+describe('PermissionStatusCard', () => {
+  it('renders nothing without a Linux backend', () => {
+    const { container } = render(<PermissionStatusCard status={{ is_using_linux_backend: false } as never} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the warning banner when write access is missing', () => {
+    const { container } = render(<PermissionStatusCard status={linuxStatus(false)} />);
+    expect(container.querySelector('[data-testid="power-permission-warning"]')).not.toBeNull();
+  });
+
+  it('hides the warning banner when write access is present', () => {
+    const { container } = render(<PermissionStatusCard status={linuxStatus(true)} />);
+    expect(container.querySelector('[data-testid="power-permission-warning"]')).toBeNull();
+  });
+});

--- a/client/src/__tests__/components/power/PowerStatusCards.test.tsx
+++ b/client/src/__tests__/components/power/PowerStatusCards.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+import { PowerStatusCards } from '../../../components/power/PowerStatusCards';
+import type { PowerDemandInfo } from '../../../api/power-management';
+
+const demands = [
+  { source: 'a', level: 'low' },
+  { source: 'b', level: 'medium' },
+] as unknown as PowerDemandInfo[];
+
+describe('PowerStatusCards', () => {
+  it('renders all four stat cards including the active-demands count', () => {
+    render(
+      <PowerStatusCards
+        status={{ current_frequency_mhz: 3400 } as never}
+        activePreset={{ id: 1, name: 'Balanced', description: 'desc' } as never}
+        currentProperty="low"
+        demands={demands}
+        lastUpdated={new Date(0)}
+      />,
+    );
+    expect(screen.getByText('system:power.statusCards.activePreset')).toBeTruthy();
+    expect(screen.getByText('system:power.statusCards.currentProperty')).toBeTruthy();
+    expect(screen.getByText('system:power.statusCards.cpuFrequency')).toBeTruthy();
+    expect(screen.getByText('system:power.statusCards.activeDemands')).toBeTruthy();
+    // active-demands StatCard value is `demands.length`
+    expect(screen.getByText('2')).toBeTruthy();
+  });
+});

--- a/client/src/__tests__/components/power/isValidAutoScaling.test.ts
+++ b/client/src/__tests__/components/power/isValidAutoScaling.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { isValidAutoScaling } from '../../../components/power/utils';
+
+const base = {
+  cpu_surge_threshold: 90,
+  cpu_medium_threshold: 60,
+  cpu_low_threshold: 30,
+  cooldown_seconds: 15,
+};
+
+describe('isValidAutoScaling', () => {
+  it('accepts a correctly ordered config', () => {
+    expect(isValidAutoScaling(base)).toBe(true);
+  });
+
+  it('rejects when surge is not strictly greater than medium', () => {
+    expect(isValidAutoScaling({ ...base, cpu_surge_threshold: 60 })).toBe(false);
+  });
+
+  it('rejects when medium is not strictly greater than low', () => {
+    expect(isValidAutoScaling({ ...base, cpu_medium_threshold: 30 })).toBe(false);
+  });
+
+  it('rejects an out-of-range threshold', () => {
+    expect(isValidAutoScaling({ ...base, cpu_surge_threshold: 120 })).toBe(false);
+    expect(isValidAutoScaling({ ...base, cpu_low_threshold: -1 })).toBe(false);
+  });
+
+  it('rejects a negative cooldown', () => {
+    expect(isValidAutoScaling({ ...base, cooldown_seconds: -5 })).toBe(false);
+  });
+
+  it('accepts boundary values 0 and 100 while preserving ordering', () => {
+    expect(isValidAutoScaling({
+      cpu_surge_threshold: 100, cpu_medium_threshold: 50, cpu_low_threshold: 0, cooldown_seconds: 0,
+    })).toBe(true);
+  });
+});

--- a/client/src/components/CLAUDE.md
+++ b/client/src/components/CLAUDE.md
@@ -51,7 +51,7 @@ Reusable, generic building blocks. No business logic, no API calls.
 | `monitoring/` | System monitoring charts and cards |
 | `pihole/` | Pi-hole DNS dashboard, `ad-discovery/` |
 | `plugins/` | Plugin management UI |
-| `power/` | Power profile management |
+| `power/` | Power profile management — `PowerManagement` page composes `PowerStatusCards`, `PermissionStatusCard`, `AutoScalingSection` (extracted F2/#301) |
 | `raid/` | RAID status, disk details |
 | `rate-limits/` | Rate limit configuration UI |
 | `RemoteServers/` | Remote server profile management |

--- a/client/src/components/power/AutoScalingSection.tsx
+++ b/client/src/components/power/AutoScalingSection.tsx
@@ -1,0 +1,189 @@
+/**
+ * Auto-Scaling config card for Power Management.
+ *
+ * Displays and edits the CPU-percentage thresholds that drive automatic
+ * profile scaling (surge/medium/low) plus the cooldown period.
+ */
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { AdminBadge } from '../ui/AdminBadge';
+import { handleApiError } from '../../lib/errorHandling';
+import { updateAutoScalingConfig, type AutoScalingConfig } from '../../api/power-management';
+import { isValidAutoScaling } from './utils';
+
+interface AutoScalingSectionProps {
+  autoScaling: AutoScalingConfig;
+  dimmed: boolean;
+  busy: boolean;
+  onBusyChange: (b: boolean) => void;
+  onRefresh: () => void;
+}
+
+export function AutoScalingSection({
+  autoScaling, dimmed, busy, onBusyChange, onRefresh,
+}: AutoScalingSectionProps) {
+  const { t } = useTranslation(['system', 'common']);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<AutoScalingConfig | null>(null);
+
+  const startEdit = () => {
+    setDraft({ ...autoScaling });
+    setEditing(true);
+  };
+  const cancelEdit = () => {
+    setEditing(false);
+    setDraft(null);
+  };
+  const save = async () => {
+    if (!draft || busy) return;
+    if (!isValidAutoScaling(draft)) {
+      toast.error(t('system:power.autoScaling.validationError'));
+      return;
+    }
+    onBusyChange(true);
+    try {
+      await updateAutoScalingConfig(draft);
+      onRefresh();
+      setEditing(false);
+      setDraft(null);
+      toast.success(t('system:power.autoScaling.thresholdsSaved'));
+    } catch (err) {
+      handleApiError(err, t('system:power.autoScaling.thresholdsSaveFailed'));
+    } finally {
+      onBusyChange(false);
+    }
+  };
+
+  return (
+    <div
+      data-testid="auto-scaling-section"
+      className={`card border-slate-700/50 p-4 sm:p-6 ${dimmed ? 'opacity-50 pointer-events-none' : ''}`}
+    >
+      <div className="mb-3 sm:mb-4 flex items-center justify-between">
+        <h2 className="text-base sm:text-lg font-medium text-white flex items-center gap-2">
+          {t('system:power.autoScaling.title')}
+          <AdminBadge />
+        </h2>
+        {!editing ? (
+          <button
+            data-testid="auto-scaling-edit"
+            onClick={startEdit}
+            disabled={busy}
+            className="text-xs text-slate-400 hover:text-white flex items-center gap-1"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+            {t('system:power.autoScaling.editButton')}
+          </button>
+        ) : (
+          <div className="flex gap-2">
+            <button
+              onClick={cancelEdit}
+              disabled={busy}
+              className="rounded px-3 py-1 text-xs bg-slate-700 text-slate-300 hover:bg-slate-600"
+            >
+              {t('system:power.autoScaling.cancelButton')}
+            </button>
+            <button
+              data-testid="auto-scaling-save"
+              onClick={save}
+              disabled={busy}
+              className="rounded px-3 py-1 text-xs bg-blue-500/20 text-blue-300 hover:bg-blue-500/30"
+            >
+              {t('system:power.autoScaling.saveButton')}
+            </button>
+          </div>
+        )}
+      </div>
+      {editing && draft ? (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-2 sm:gap-4">
+            <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
+              <label className="block text-[10px] sm:text-sm text-slate-400 mb-1">{t('system:power.autoScaling.surge')}</label>
+              <div className="flex items-center gap-1">
+                <span className="text-red-300 text-sm">&gt;</span>
+                <input
+                  data-testid="auto-scaling-input-surge"
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={draft.cpu_surge_threshold}
+                  onChange={(e) => setDraft({ ...draft!, cpu_surge_threshold: Number(e.target.value) })}
+                  className="w-full rounded bg-slate-900 border border-slate-600 px-2 py-1 text-sm sm:text-xl font-semibold text-red-300 focus:border-red-400 focus:outline-none"
+                />
+                <span className="text-red-300 text-sm">%</span>
+              </div>
+            </div>
+            <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
+              <label className="block text-[10px] sm:text-sm text-slate-400 mb-1">{t('system:power.autoScaling.medium')}</label>
+              <div className="flex items-center gap-1">
+                <span className="text-yellow-300 text-sm">&gt;</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={draft.cpu_medium_threshold}
+                  onChange={(e) => setDraft({ ...draft!, cpu_medium_threshold: Number(e.target.value) })}
+                  className="w-full rounded bg-slate-900 border border-slate-600 px-2 py-1 text-sm sm:text-xl font-semibold text-yellow-300 focus:border-yellow-400 focus:outline-none"
+                />
+                <span className="text-yellow-300 text-sm">%</span>
+              </div>
+            </div>
+            <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
+              <label className="block text-[10px] sm:text-sm text-slate-400 mb-1">{t('system:power.autoScaling.low')}</label>
+              <div className="flex items-center gap-1">
+                <span className="text-blue-300 text-sm">&gt;</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={draft.cpu_low_threshold}
+                  onChange={(e) => setDraft({ ...draft!, cpu_low_threshold: Number(e.target.value) })}
+                  className="w-full rounded bg-slate-900 border border-slate-600 px-2 py-1 text-sm sm:text-xl font-semibold text-blue-300 focus:border-blue-400 focus:outline-none"
+                />
+                <span className="text-blue-300 text-sm">%</span>
+              </div>
+            </div>
+          </div>
+          <div className="mt-2 sm:mt-3 flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <span className="text-xs sm:text-sm text-slate-500">{t('system:power.autoScaling.cooldown')}:</span>
+              <input
+                type="number"
+                min={0}
+                value={draft.cooldown_seconds}
+                onChange={(e) => setDraft({ ...draft!, cooldown_seconds: Number(e.target.value) })}
+                className="w-20 rounded bg-slate-900 border border-slate-600 px-2 py-1 text-xs sm:text-sm text-white focus:border-blue-400 focus:outline-none"
+              />
+              <span className="text-xs sm:text-sm text-slate-500">s</span>
+            </div>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-2 sm:gap-4">
+            <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
+              <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.autoScaling.surge')}</p>
+              <p className="text-sm sm:text-xl font-semibold text-red-300">&gt;{autoScaling.cpu_surge_threshold}%</p>
+            </div>
+            <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
+              <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.autoScaling.medium')}</p>
+              <p className="text-sm sm:text-xl font-semibold text-yellow-300">&gt;{autoScaling.cpu_medium_threshold}%</p>
+            </div>
+            <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
+              <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.autoScaling.low')}</p>
+              <p className="text-sm sm:text-xl font-semibold text-blue-300">&gt;{autoScaling.cpu_low_threshold}%</p>
+            </div>
+          </div>
+          <p className="mt-2 sm:mt-3 text-xs sm:text-sm text-slate-500">
+            {t('system:power.autoScaling.cooldown')}: {autoScaling.cooldown_seconds}s &bull; {t('system:power.autoScaling.cpuMonitor')}:{' '}
+            {autoScaling.use_cpu_monitoring ? t('system:power.autoScaling.active') : t('system:power.autoScaling.inactive')}
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/power/PermissionStatusCard.tsx
+++ b/client/src/components/power/PermissionStatusCard.tsx
@@ -1,0 +1,93 @@
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle } from 'lucide-react';
+import type { PowerStatusResponse } from '../../api/power-management';
+
+interface PermissionStatusCardProps {
+  status: PowerStatusResponse | null;
+}
+
+export function PermissionStatusCard({ status }: PermissionStatusCardProps) {
+  const { t } = useTranslation(['system', 'common']);
+  if (!status?.is_using_linux_backend || !status.permission_status) return null;
+  return (
+    <>
+      {/* Permission Warning Banner */}
+      {!status.permission_status.has_write_access && (
+        <div data-testid="power-permission-warning" className="mb-4 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="h-5 w-5 text-amber-400 flex-shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <h3 className="font-semibold text-amber-200">
+                {t('system:power.permissions.warningTitle')}
+              </h3>
+              <p className="text-sm text-amber-300 mt-1">
+                {t('system:power.permissions.warningMessage')}
+              </p>
+              <div className="mt-3 text-sm text-amber-300/80">
+                <p className="font-medium mb-1">{t('system:power.permissions.suggestions')}</p>
+                <ul className="list-disc list-inside space-y-1 font-mono text-xs">
+                  <li>sudo systemctl start baluhost-backend</li>
+                  <li>sudo usermod -aG cpufreq $USER</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Permission Status (Linux backend only) */}
+      <div className="card border-slate-700/50 p-4 sm:p-6">
+        <h2 className="mb-3 sm:mb-4 text-base sm:text-lg font-medium text-white">{t('system:power.permissions.title')}</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-4 lg:grid-cols-4">
+          {/* Write Access Status */}
+          <div className={`rounded-lg border p-2 sm:p-4 ${
+            status.permission_status.has_write_access
+              ? 'border-emerald-500/30 bg-emerald-500/10'
+              : 'border-red-500/30 bg-red-500/10'
+          }`}>
+            <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.permissions.writeAccess')}</p>
+            <p className={`text-sm sm:text-xl font-semibold ${
+              status.permission_status.has_write_access ? 'text-emerald-300' : 'text-red-300'
+            }`}>
+              {status.permission_status.has_write_access ? t('system:power.permissions.ok') : t('system:power.permissions.no')}
+            </p>
+          </div>
+
+          {/* User Info */}
+          <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
+            <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.permissions.user')}</p>
+            <p className="text-sm sm:text-xl font-semibold text-white truncate">{status.permission_status.user}</p>
+          </div>
+
+          {/* cpufreq Group Status */}
+          <div className={`rounded-lg border p-2 sm:p-4 ${
+            status.permission_status.in_cpufreq_group
+              ? 'border-emerald-500/30 bg-emerald-500/10'
+              : 'border-amber-500/30 bg-amber-500/10'
+          }`}>
+            <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.permissions.cpufreq')}</p>
+            <p className={`text-sm sm:text-xl font-semibold ${
+              status.permission_status.in_cpufreq_group ? 'text-emerald-300' : 'text-amber-300'
+            }`}>
+              {status.permission_status.in_cpufreq_group ? t('system:power.permissions.ok') : t('system:power.permissions.no')}
+            </p>
+          </div>
+
+          {/* Sudo Status */}
+          <div className={`rounded-lg border p-2 sm:p-4 ${
+            status.permission_status.sudo_available
+              ? 'border-emerald-500/30 bg-emerald-500/10'
+              : 'border-slate-700/50 bg-slate-800/30'
+          }`}>
+            <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.permissions.sudo')}</p>
+            <p className={`text-sm sm:text-xl font-semibold ${
+              status.permission_status.sudo_available ? 'text-emerald-300' : 'text-slate-400'
+            }`}>
+              {status.permission_status.sudo_available ? t('system:power.permissions.ok') : t('system:power.permissions.no')}
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/client/src/components/power/PowerStatusCards.tsx
+++ b/client/src/components/power/PowerStatusCards.tsx
@@ -1,0 +1,73 @@
+import { useTranslation } from 'react-i18next';
+import { StatCard } from '../ui/StatCard';
+import { getPresetIcon } from './utils';
+import {
+  PROFILE_INFO,
+  PROPERTY_INFO,
+  formatClockSpeed,
+  type PowerStatusResponse,
+  type PowerDemandInfo,
+  type ServicePowerProperty,
+  type PowerPreset,
+} from '../../api/power-management';
+
+interface PowerStatusCardsProps {
+  status: PowerStatusResponse | null;
+  activePreset?: PowerPreset;
+  currentProperty?: ServicePowerProperty;
+  demands: PowerDemandInfo[];
+  lastUpdated: Date | null;
+}
+
+export function PowerStatusCards({
+  status, activePreset, currentProperty, demands, lastUpdated,
+}: PowerStatusCardsProps) {
+  const { t } = useTranslation(['system', 'common']);
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <StatCard
+        label={t('system:power.statusCards.activePreset')}
+        value={status?.dynamic_mode_enabled ? t('system:power.dynamicMode.title') : (activePreset?.name || '-')}
+        subValue={status?.dynamic_mode_enabled ? status.target_frequency_range : activePreset?.description}
+        color={status?.dynamic_mode_enabled ? 'teal' : activePreset?.name.includes('Performance') ? 'red' : activePreset?.name.includes('Energy') ? 'emerald' : 'blue'}
+        icon={<span className="text-2xl">{status?.dynamic_mode_enabled ? '\u{26A1}' : activePreset ? getPresetIcon(activePreset.name) : '\u{26A1}'}</span>}
+      />
+      <StatCard
+        label={t('system:power.statusCards.currentProperty')}
+        value={currentProperty ? PROPERTY_INFO[currentProperty].name : '-'}
+        subValue={currentProperty ? t(`system:power.propertyDescription.${currentProperty}`) : undefined}
+        color={PROFILE_INFO[currentProperty || 'idle']?.color || 'slate'}
+        icon={<span className="text-2xl">{currentProperty ? PROPERTY_INFO[currentProperty].icon : '⚡'}</span>}
+      />
+      <StatCard
+        label={t('system:power.statusCards.cpuFrequency')}
+        value={status?.current_frequency_mhz ? formatClockSpeed(status.current_frequency_mhz) : '-'}
+        subValue={status?.target_frequency_range
+          ? `${t('system:power.statusCards.targetBand')}: ${status.target_frequency_range}`
+          : lastUpdated
+            ? `${t('system:power.statusCards.updated')}: ${lastUpdated.toLocaleTimeString()}`
+            : undefined}
+        color="blue"
+        icon={
+          <svg className="h-6 w-6 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+          </svg>
+        }
+      />
+      <StatCard
+        label={t('system:power.statusCards.activeDemands')}
+        value={demands.length}
+        subValue={demands.length > 0 ? `${t('system:power.statusCards.highest')}: ${PROPERTY_INFO[(demands.reduce((a, b) =>
+          ['surge', 'medium', 'low', 'idle'].indexOf((a.power_property || a.level) as string) <
+          ['surge', 'medium', 'low', 'idle'].indexOf((b.power_property || b.level) as string) ? a : b
+        ).power_property || demands[0].level) as ServicePowerProperty].name}` : t('system:power.statusCards.none')}
+        color="purple"
+        icon={
+          <svg className="h-6 w-6 text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+          </svg>
+        }
+      />
+    </div>
+  );
+}

--- a/client/src/components/power/utils.ts
+++ b/client/src/components/power/utils.ts
@@ -2,7 +2,7 @@
  * Shared helper functions for power management components.
  */
 
-import type { ServicePowerProperty } from '../../api/power-management';
+import type { AutoScalingConfig, ServicePowerProperty } from '../../api/power-management';
 
 // Format timestamp for display
 export const formatTimestamp = (ts: string): string => {
@@ -62,3 +62,21 @@ export const getPresetIcon = (presetName: string): string => {
   if (presetName.includes('Balanced')) return '⚖️';
   return '⚙️';
 };
+
+/**
+ * Validates auto-scaling CPU thresholds: surge > medium > low, each in [0,100],
+ * cooldown >= 0. Pure — extracted from PowerManagement's save handler.
+ */
+export function isValidAutoScaling(
+  cfg: Pick<AutoScalingConfig, 'cpu_surge_threshold' | 'cpu_medium_threshold' | 'cpu_low_threshold' | 'cooldown_seconds'>,
+): boolean {
+  const inRange = (n: number) => n >= 0 && n <= 100;
+  return (
+    cfg.cpu_surge_threshold > cfg.cpu_medium_threshold &&
+    cfg.cpu_medium_threshold > cfg.cpu_low_threshold &&
+    inRange(cfg.cpu_surge_threshold) &&
+    inRange(cfg.cpu_medium_threshold) &&
+    inRange(cfg.cpu_low_threshold) &&
+    cfg.cooldown_seconds >= 0
+  );
+}

--- a/client/src/pages/PowerManagement.tsx
+++ b/client/src/pages/PowerManagement.tsx
@@ -13,10 +13,8 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
-import { AlertTriangle } from 'lucide-react';
 import { handleApiError } from '../lib/errorHandling';
 import { Spinner } from '../components/ui/Spinner';
-import { StatCard } from '../components/ui/StatCard';
 import { AdminBadge } from '../components/ui/AdminBadge';
 import { PresetSelector } from '../components/power/PresetSelector';
 import { PresetEditor } from '../components/power/PresetEditor';
@@ -28,20 +26,18 @@ import { DynamicModeSection } from '../components/power/DynamicModeSection';
 import { GpuPowerCard } from '../components/power/GpuPowerCard';
 import { AuthorityPanel } from '../components/power/AuthorityPanel';
 import { BoostRulesEditor } from '../components/power/BoostRulesEditor';
-import { getPresetIcon } from '../components/power/utils';
+import { PowerStatusCards } from '../components/power/PowerStatusCards';
+import { PermissionStatusCard } from '../components/power/PermissionStatusCard';
+import { AutoScalingSection } from '../components/power/AutoScalingSection';
 import { usePowerManagementData } from '../hooks/usePowerManagementData';
 import {
   unregisterPowerDemand,
   updateAutoScalingConfig,
   switchPowerBackend,
-  PROFILE_INFO,
   activatePreset,
   createPreset,
   updatePreset,
   deletePreset,
-  formatClockSpeed,
-  PROPERTY_INFO,
-  type AutoScalingConfig,
   type ServicePowerProperty,
   type PowerPreset,
   type CreatePresetRequest,
@@ -71,8 +67,6 @@ export default function PowerManagement({ isAdmin }: PowerManagementProps) {
   } = usePowerManagementData();
   const [busy, setBusy] = useState(false);
   const [editorPreset, setEditorPreset] = useState<PowerPreset | null | 'new'>(null);
-  const [editingAutoScaling, setEditingAutoScaling] = useState(false);
-  const [editAutoScaling, setEditAutoScaling] = useState<AutoScalingConfig | null>(null);
 
   const handleRefresh = async () => {
     if (await refetch()) {
@@ -121,48 +115,6 @@ export default function PowerManagement({ isAdmin }: PowerManagementProps) {
       toast.success(newConfig.enabled ? t('system:power.toasts.autoScalingEnabled') : t('system:power.toasts.autoScalingDisabled'));
     } catch (err) {
       handleApiError(err, t('system:power.toasts.settingChangeFailed'));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const handleStartEditAutoScaling = () => {
-    if (autoScaling) {
-      setEditAutoScaling({ ...autoScaling });
-      setEditingAutoScaling(true);
-    }
-  };
-
-  const handleCancelEditAutoScaling = () => {
-    setEditingAutoScaling(false);
-    setEditAutoScaling(null);
-  };
-
-  const handleSaveAutoScaling = async () => {
-    if (!editAutoScaling || busy) return;
-
-    // Validate: surge > medium > low, all 0-100
-    if (
-      editAutoScaling.cpu_surge_threshold <= editAutoScaling.cpu_medium_threshold ||
-      editAutoScaling.cpu_medium_threshold <= editAutoScaling.cpu_low_threshold ||
-      editAutoScaling.cpu_surge_threshold < 0 || editAutoScaling.cpu_surge_threshold > 100 ||
-      editAutoScaling.cpu_medium_threshold < 0 || editAutoScaling.cpu_medium_threshold > 100 ||
-      editAutoScaling.cpu_low_threshold < 0 || editAutoScaling.cpu_low_threshold > 100 ||
-      editAutoScaling.cooldown_seconds < 0
-    ) {
-      toast.error(t('system:power.autoScaling.validationError'));
-      return;
-    }
-
-    setBusy(true);
-    try {
-      await updateAutoScalingConfig(editAutoScaling);
-      await refetch();
-      setEditingAutoScaling(false);
-      setEditAutoScaling(null);
-      toast.success(t('system:power.autoScaling.thresholdsSaved'));
-    } catch (err) {
-      handleApiError(err, t('system:power.autoScaling.thresholdsSaveFailed'));
     } finally {
       setBusy(false);
     }
@@ -297,51 +249,13 @@ export default function PowerManagement({ isAdmin }: PowerManagementProps) {
       </div>
 
       {/* Status Cards */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <StatCard
-          label={t('system:power.statusCards.activePreset')}
-          value={status?.dynamic_mode_enabled ? t('system:power.dynamicMode.title') : (activePreset?.name || '-')}
-          subValue={status?.dynamic_mode_enabled ? status.target_frequency_range : activePreset?.description}
-          color={status?.dynamic_mode_enabled ? 'teal' : activePreset?.name.includes('Performance') ? 'red' : activePreset?.name.includes('Energy') ? 'emerald' : 'blue'}
-          icon={<span className="text-2xl">{status?.dynamic_mode_enabled ? '\u{26A1}' : activePreset ? getPresetIcon(activePreset.name) : '\u{26A1}'}</span>}
-        />
-        <StatCard
-          label={t('system:power.statusCards.currentProperty')}
-          value={currentProperty ? PROPERTY_INFO[currentProperty].name : '-'}
-          subValue={currentProperty ? t(`system:power.propertyDescription.${currentProperty}`) : undefined}
-          color={PROFILE_INFO[currentProperty || 'idle']?.color || 'slate'}
-          icon={<span className="text-2xl">{currentProperty ? PROPERTY_INFO[currentProperty].icon : '⚡'}</span>}
-        />
-        <StatCard
-          label={t('system:power.statusCards.cpuFrequency')}
-          value={status?.current_frequency_mhz ? formatClockSpeed(status.current_frequency_mhz) : '-'}
-          subValue={status?.target_frequency_range
-            ? `${t('system:power.statusCards.targetBand')}: ${status.target_frequency_range}`
-            : lastUpdated
-              ? `${t('system:power.statusCards.updated')}: ${lastUpdated.toLocaleTimeString()}`
-              : undefined}
-          color="blue"
-          icon={
-            <svg className="h-6 w-6 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-            </svg>
-          }
-        />
-        <StatCard
-          label={t('system:power.statusCards.activeDemands')}
-          value={demands.length}
-          subValue={demands.length > 0 ? `${t('system:power.statusCards.highest')}: ${PROPERTY_INFO[(demands.reduce((a, b) =>
-            ['surge', 'medium', 'low', 'idle'].indexOf((a.power_property || a.level) as string) <
-            ['surge', 'medium', 'low', 'idle'].indexOf((b.power_property || b.level) as string) ? a : b
-          ).power_property || demands[0].level) as ServicePowerProperty].name}` : t('system:power.statusCards.none')}
-          color="purple"
-          icon={
-            <svg className="h-6 w-6 text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-            </svg>
-          }
-        />
-      </div>
+      <PowerStatusCards
+        status={status}
+        activePreset={activePreset}
+        currentProperty={currentProperty}
+        demands={demands}
+        lastUpdated={lastUpdated}
+      />
 
       {/* Dynamic Mode Section */}
       {dynamicConfig && (
@@ -455,209 +369,17 @@ export default function PowerManagement({ isAdmin }: PowerManagementProps) {
 
       {/* Auto-Scaling Config (Admin only) */}
       {isAdmin && autoScaling && (
-        <div className={`card border-slate-700/50 p-4 sm:p-6 ${status?.dynamic_mode_enabled ? 'opacity-50 pointer-events-none' : ''}`}>
-          <div className="mb-3 sm:mb-4 flex items-center justify-between">
-            <h2 className="text-base sm:text-lg font-medium text-white flex items-center gap-2">
-              {t('system:power.autoScaling.title')}
-              <AdminBadge />
-            </h2>
-            {!editingAutoScaling ? (
-              <button
-                onClick={handleStartEditAutoScaling}
-                disabled={busy}
-                className="text-xs text-slate-400 hover:text-white flex items-center gap-1"
-              >
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                </svg>
-                {t('system:power.autoScaling.editButton')}
-              </button>
-            ) : (
-              <div className="flex gap-2">
-                <button
-                  onClick={handleCancelEditAutoScaling}
-                  disabled={busy}
-                  className="rounded px-3 py-1 text-xs bg-slate-700 text-slate-300 hover:bg-slate-600"
-                >
-                  {t('system:power.autoScaling.cancelButton')}
-                </button>
-                <button
-                  onClick={handleSaveAutoScaling}
-                  disabled={busy}
-                  className="rounded px-3 py-1 text-xs bg-blue-500/20 text-blue-300 hover:bg-blue-500/30"
-                >
-                  {t('system:power.autoScaling.saveButton')}
-                </button>
-              </div>
-            )}
-          </div>
-          {editingAutoScaling && editAutoScaling ? (
-            <>
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-2 sm:gap-4">
-                <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
-                  <label className="block text-[10px] sm:text-sm text-slate-400 mb-1">{t('system:power.autoScaling.surge')}</label>
-                  <div className="flex items-center gap-1">
-                    <span className="text-red-300 text-sm">&gt;</span>
-                    <input
-                      type="number"
-                      min={0}
-                      max={100}
-                      value={editAutoScaling.cpu_surge_threshold}
-                      onChange={(e) => setEditAutoScaling({ ...editAutoScaling, cpu_surge_threshold: Number(e.target.value) })}
-                      className="w-full rounded bg-slate-900 border border-slate-600 px-2 py-1 text-sm sm:text-xl font-semibold text-red-300 focus:border-red-400 focus:outline-none"
-                    />
-                    <span className="text-red-300 text-sm">%</span>
-                  </div>
-                </div>
-                <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
-                  <label className="block text-[10px] sm:text-sm text-slate-400 mb-1">{t('system:power.autoScaling.medium')}</label>
-                  <div className="flex items-center gap-1">
-                    <span className="text-yellow-300 text-sm">&gt;</span>
-                    <input
-                      type="number"
-                      min={0}
-                      max={100}
-                      value={editAutoScaling.cpu_medium_threshold}
-                      onChange={(e) => setEditAutoScaling({ ...editAutoScaling, cpu_medium_threshold: Number(e.target.value) })}
-                      className="w-full rounded bg-slate-900 border border-slate-600 px-2 py-1 text-sm sm:text-xl font-semibold text-yellow-300 focus:border-yellow-400 focus:outline-none"
-                    />
-                    <span className="text-yellow-300 text-sm">%</span>
-                  </div>
-                </div>
-                <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
-                  <label className="block text-[10px] sm:text-sm text-slate-400 mb-1">{t('system:power.autoScaling.low')}</label>
-                  <div className="flex items-center gap-1">
-                    <span className="text-blue-300 text-sm">&gt;</span>
-                    <input
-                      type="number"
-                      min={0}
-                      max={100}
-                      value={editAutoScaling.cpu_low_threshold}
-                      onChange={(e) => setEditAutoScaling({ ...editAutoScaling, cpu_low_threshold: Number(e.target.value) })}
-                      className="w-full rounded bg-slate-900 border border-slate-600 px-2 py-1 text-sm sm:text-xl font-semibold text-blue-300 focus:border-blue-400 focus:outline-none"
-                    />
-                    <span className="text-blue-300 text-sm">%</span>
-                  </div>
-                </div>
-              </div>
-              <div className="mt-2 sm:mt-3 flex items-center gap-4">
-                <div className="flex items-center gap-2">
-                  <span className="text-xs sm:text-sm text-slate-500">{t('system:power.autoScaling.cooldown')}:</span>
-                  <input
-                    type="number"
-                    min={0}
-                    value={editAutoScaling.cooldown_seconds}
-                    onChange={(e) => setEditAutoScaling({ ...editAutoScaling, cooldown_seconds: Number(e.target.value) })}
-                    className="w-20 rounded bg-slate-900 border border-slate-600 px-2 py-1 text-xs sm:text-sm text-white focus:border-blue-400 focus:outline-none"
-                  />
-                  <span className="text-xs sm:text-sm text-slate-500">s</span>
-                </div>
-              </div>
-            </>
-          ) : (
-            <>
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-2 sm:gap-4">
-                <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
-                  <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.autoScaling.surge')}</p>
-                  <p className="text-sm sm:text-xl font-semibold text-red-300">&gt;{autoScaling.cpu_surge_threshold}%</p>
-                </div>
-                <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
-                  <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.autoScaling.medium')}</p>
-                  <p className="text-sm sm:text-xl font-semibold text-yellow-300">&gt;{autoScaling.cpu_medium_threshold}%</p>
-                </div>
-                <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
-                  <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.autoScaling.low')}</p>
-                  <p className="text-sm sm:text-xl font-semibold text-blue-300">&gt;{autoScaling.cpu_low_threshold}%</p>
-                </div>
-              </div>
-              <p className="mt-2 sm:mt-3 text-xs sm:text-sm text-slate-500">
-                {t('system:power.autoScaling.cooldown')}: {autoScaling.cooldown_seconds}s &bull; {t('system:power.autoScaling.cpuMonitor')}:{' '}
-                {autoScaling.use_cpu_monitoring ? t('system:power.autoScaling.active') : t('system:power.autoScaling.inactive')}
-              </p>
-            </>
-          )}
-        </div>
+        <AutoScalingSection
+          autoScaling={autoScaling}
+          dimmed={!!status?.dynamic_mode_enabled}
+          busy={busy}
+          onBusyChange={setBusy}
+          onRefresh={() => void refetch()}
+        />
       )}
 
-      {/* Permission Warning Banner */}
-      {status?.is_using_linux_backend && status.permission_status && !status.permission_status.has_write_access && (
-        <div className="mb-4 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-4">
-          <div className="flex items-start gap-3">
-            <AlertTriangle className="h-5 w-5 text-amber-400 flex-shrink-0 mt-0.5" />
-            <div className="flex-1">
-              <h3 className="font-semibold text-amber-200">
-                {t('system:power.permissions.warningTitle')}
-              </h3>
-              <p className="text-sm text-amber-300 mt-1">
-                {t('system:power.permissions.warningMessage')}
-              </p>
-              <div className="mt-3 text-sm text-amber-300/80">
-                <p className="font-medium mb-1">{t('system:power.permissions.suggestions')}</p>
-                <ul className="list-disc list-inside space-y-1 font-mono text-xs">
-                  <li>sudo systemctl start baluhost-backend</li>
-                  <li>sudo usermod -aG cpufreq $USER</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Permission Status (Linux backend only) */}
-      {status?.is_using_linux_backend && status.permission_status && (
-        <div className="card border-slate-700/50 p-4 sm:p-6">
-          <h2 className="mb-3 sm:mb-4 text-base sm:text-lg font-medium text-white">{t('system:power.permissions.title')}</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-4 lg:grid-cols-4">
-            {/* Write Access Status */}
-            <div className={`rounded-lg border p-2 sm:p-4 ${
-              status.permission_status.has_write_access
-                ? 'border-emerald-500/30 bg-emerald-500/10'
-                : 'border-red-500/30 bg-red-500/10'
-            }`}>
-              <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.permissions.writeAccess')}</p>
-              <p className={`text-sm sm:text-xl font-semibold ${
-                status.permission_status.has_write_access ? 'text-emerald-300' : 'text-red-300'
-              }`}>
-                {status.permission_status.has_write_access ? t('system:power.permissions.ok') : t('system:power.permissions.no')}
-              </p>
-            </div>
-
-            {/* User Info */}
-            <div className="rounded-lg border border-slate-700/50 bg-slate-800/30 p-2 sm:p-4">
-              <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.permissions.user')}</p>
-              <p className="text-sm sm:text-xl font-semibold text-white truncate">{status.permission_status.user}</p>
-            </div>
-
-            {/* cpufreq Group Status */}
-            <div className={`rounded-lg border p-2 sm:p-4 ${
-              status.permission_status.in_cpufreq_group
-                ? 'border-emerald-500/30 bg-emerald-500/10'
-                : 'border-amber-500/30 bg-amber-500/10'
-            }`}>
-              <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.permissions.cpufreq')}</p>
-              <p className={`text-sm sm:text-xl font-semibold ${
-                status.permission_status.in_cpufreq_group ? 'text-emerald-300' : 'text-amber-300'
-              }`}>
-                {status.permission_status.in_cpufreq_group ? t('system:power.permissions.ok') : t('system:power.permissions.no')}
-              </p>
-            </div>
-
-            {/* Sudo Status */}
-            <div className={`rounded-lg border p-2 sm:p-4 ${
-              status.permission_status.sudo_available
-                ? 'border-emerald-500/30 bg-emerald-500/10'
-                : 'border-slate-700/50 bg-slate-800/30'
-            }`}>
-              <p className="text-[10px] sm:text-sm text-slate-400">{t('system:power.permissions.sudo')}</p>
-              <p className={`text-sm sm:text-xl font-semibold ${
-                status.permission_status.sudo_available ? 'text-emerald-300' : 'text-slate-400'
-              }`}>
-                {status.permission_status.sudo_available ? t('system:power.permissions.ok') : t('system:power.permissions.no')}
-              </p>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* Permission panels (Linux backend only) */}
+      <PermissionStatusCard status={status} />
 
       {/* Preset Editor Modal */}
       {editorPreset && (

--- a/docs/superpowers/plans/2026-07-09-f2-powermanagement-decomposition.md
+++ b/docs/superpowers/plans/2026-07-09-f2-powermanagement-decomposition.md
@@ -10,11 +10,12 @@
 
 ## Global Constraints
 
-- **No behavior, UX, or layout change.** Rendered output must be identical. The auto-scaling **enable/disable toggle button** stays in the preset-selection card (do NOT move it).
+- **No behavior, UX, or layout change.** Rendered DOM must be identical. In particular: do NOT add wrapper `<div>`s to reach elements in tests (`StatCard` does not forward `data-testid` — its props are fixed `label, value, unit, subValue, color, icon`; wrapping a card would change the grid layout). Assert via text or via a component's *own* root `data-testid`.
+- The auto-scaling **enable/disable toggle button** lives in the preset-selection card and stays there (`handleToggleAutoScaling` stays in the page). Only the auto-scaling **config card** (`:456-580`) moves.
 - New components live in `client/src/components/power/` and use `useTranslation(['system','common'])` **internally** (no `t` prop) — matching `DynamicModeSection`/`OsAutoSuspendCard`.
-- Component tests go in `client/src/__tests__/components/power/`, following the `OsAutoSuspendCard.test.tsx` pattern: `vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k) => k }) }))`, `vi.mock` for api + `react-hot-toast`, assert via `data-testid`.
-- Verification gate (Task 5): full `npx vitest run` green (currently 603), `npx eslint .` 0 errors, `npm run build` green.
-- Windows shell: chain with `;`, never `&&` (see project CLAUDE.md).
+- Component tests go in `client/src/__tests__/components/power/`, following `OsAutoSuspendCard.test.tsx`: explicit `import { describe, expect, it, vi, beforeEach } from 'vitest'`; `vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }))`; `vi.mock` for api + `react-hot-toast`; query the component's own `data-testid` via `container.querySelector('[data-testid="…"]')`.
+- **Verification gate (Task 5):** `npx vitest run` all green (currently 603 + the new tests), `npx eslint .` 0 errors, `npm run build` (tsc -b + vite) green.
+- Windows shell: chain with `;`, never `&&`.
 
 ---
 
@@ -25,7 +26,7 @@
 - Test: `client/src/__tests__/components/power/isValidAutoScaling.test.ts`
 
 **Interfaces:**
-- Produces: `isValidAutoScaling(cfg: Pick<AutoScalingConfig, 'cpu_surge_threshold' | 'cpu_medium_threshold' | 'cpu_low_threshold' | 'cooldown_seconds'>): boolean` — `true` when `surge > medium > low`, each threshold in `[0,100]`, and `cooldown_seconds >= 0`. (Negation of the inline guard in `PowerManagement.tsx` `handleSaveAutoScaling`.)
+- Produces: `isValidAutoScaling(cfg: Pick<AutoScalingConfig, 'cpu_surge_threshold' | 'cpu_medium_threshold' | 'cpu_low_threshold' | 'cooldown_seconds'>): boolean` — `true` when `surge > medium > low`, each threshold in `[0,100]`, and `cooldown_seconds >= 0`. It is the exact negation of the inline guard in `PowerManagement.tsx:145-155`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -79,11 +80,9 @@ Expected: FAIL — `isValidAutoScaling` is not exported from `utils.ts`.
 
 - [ ] **Step 3: Append the implementation to `utils.ts`**
 
-Add at the end of `client/src/components/power/utils.ts` (add `AutoScalingConfig` to the existing `import type { ... } from '../../api/power-management'`):
+`client/src/components/power/utils.ts` already imports several types from `../../api/power-management`. Add `AutoScalingConfig` to that existing `import type { … }` line (do not add a second import statement), then append:
 
 ```ts
-import type { AutoScalingConfig } from '../../api/power-management';
-
 /**
  * Validates auto-scaling CPU thresholds: surge > medium > low, each in [0,100],
  * cooldown >= 0. Pure — extracted from PowerManagement's save handler.
@@ -103,6 +102,8 @@ export function isValidAutoScaling(
 }
 ```
 
+> If `utils.ts` has no existing `import type … from '../../api/power-management'` line, add `import type { AutoScalingConfig } from '../../api/power-management';` at the top.
+
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `cd client ; npx vitest run src/__tests__/components/power/isValidAutoScaling.test.ts`
@@ -119,14 +120,15 @@ git commit -m "refactor(power): extract pure isValidAutoScaling helper (#301)"
 
 ### Task 2: `PowerStatusCards` component
 
-Extracts the four top `StatCard`s (source: `PowerManagement.tsx:299-345`, the block after `{/* Status Cards */}` up to `{/* Dynamic Mode Section */}`).
+Extracts the four top `StatCard`s. **Source:** `PowerManagement.tsx:300-344` — the `<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">…</div>` block right after `{/* Status Cards */}`, up to (not including) `{/* Dynamic Mode Section */}`.
 
 **Files:**
 - Create: `client/src/components/power/PowerStatusCards.tsx`
 - Test: `client/src/__tests__/components/power/PowerStatusCards.test.tsx`
 
 **Interfaces:**
-- Produces: `PowerStatusCards` (default or named export — use **named**) with props
+- Consumes: nothing from other tasks.
+- Produces: named export `PowerStatusCards` with props
   `{ status: PowerStatusResponse | null; activePreset?: PowerPreset; currentProperty?: ServicePowerProperty; demands: PowerDemandInfo[]; lastUpdated: Date | null }`.
 
 - [ ] **Step 1: Write the failing test**
@@ -134,30 +136,39 @@ Extracts the four top `StatCard`s (source: `PowerManagement.tsx:299-345`, the bl
 Create `client/src/__tests__/components/power/PowerStatusCards.test.tsx`:
 
 ```tsx
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
 
 import { PowerStatusCards } from '../../../components/power/PowerStatusCards';
+import type { PowerDemandInfo } from '../../../api/power-management';
+
+const demands = [
+  { source: 'a', level: 'low' },
+  { source: 'b', level: 'medium' },
+] as unknown as PowerDemandInfo[];
 
 describe('PowerStatusCards', () => {
-  it('renders the active demands count', () => {
+  it('renders all four stat cards including the active-demands count', () => {
     render(
       <PowerStatusCards
         status={{ current_frequency_mhz: 3400 } as never}
-        activePreset={{ id: 1, name: 'Balanced', description: 'd' } as never}
+        activePreset={{ id: 1, name: 'Balanced', description: 'desc' } as never}
         currentProperty="low"
-        demands={[{ source: 'a', level: 'low' }, { source: 'b', level: 'medium' }] as never}
+        demands={demands}
         lastUpdated={new Date(0)}
       />,
     );
-    expect(screen.getByTestId('power-stat-active-demands').textContent).toContain('2');
+    expect(screen.getByText('system:power.statusCards.activePreset')).toBeTruthy();
+    expect(screen.getByText('system:power.statusCards.currentProperty')).toBeTruthy();
+    expect(screen.getByText('system:power.statusCards.cpuFrequency')).toBeTruthy();
+    expect(screen.getByText('system:power.statusCards.activeDemands')).toBeTruthy();
+    // active-demands StatCard value is `demands.length`
+    expect(screen.getByText('2')).toBeTruthy();
   });
 });
 ```
-
-> Note: add `import { vi } from 'vitest';` to the import line if the runner needs it explicitly (match the sibling `OsAutoSuspendCard.test.tsx`, which relies on global `vi`).
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -166,14 +177,22 @@ Expected: FAIL — cannot resolve `../../../components/power/PowerStatusCards`.
 
 - [ ] **Step 3: Create the component**
 
-Create `client/src/components/power/PowerStatusCards.tsx`:
-- Imports: `useTranslation` from `react-i18next`; `StatCard` from `../ui/StatCard`; `getPresetIcon` from `./utils`; `PROFILE_INFO, PROPERTY_INFO, formatClockSpeed, type PowerStatusResponse, type PowerDemandInfo, type ServicePowerProperty, type PowerPreset` from `../../api/power-management`.
-- Signature: `export function PowerStatusCards({ status, activePreset, currentProperty, demands, lastUpdated }: PowerStatusCardsProps) { const { t } = useTranslation(['system','common']); return (<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"> …four StatCards… </div>); }`
-- **Move the four `<StatCard …/>` elements verbatim from `PowerManagement.tsx:300-345`** (everything between the opening `<div className="grid …lg:grid-cols-4">` and its closing `</div>`). No expression changes — `status`, `activePreset`, `currentProperty`, `demands`, `lastUpdated`, `t`, `PROPERTY_INFO`, `PROFILE_INFO`, `formatClockSpeed`, `getPresetIcon` are all in scope via props/imports.
-- Add `data-testid="power-stat-active-demands"` to the **fourth** `StatCard` (active demands) by wrapping its `value={demands.length}` — pass `data-testid` if `StatCard` forwards it; otherwise wrap the card in a `<div data-testid="power-stat-active-demands">`. Verify by reading `components/ui/StatCard.tsx` whether it spreads extra props; if not, use the wrapping `<div>`.
-
-Define the props interface at the top:
-
+Create `client/src/components/power/PowerStatusCards.tsx`. Imports:
+```tsx
+import { useTranslation } from 'react-i18next';
+import { StatCard } from '../ui/StatCard';
+import { getPresetIcon } from './utils';
+import {
+  PROFILE_INFO,
+  PROPERTY_INFO,
+  formatClockSpeed,
+  type PowerStatusResponse,
+  type PowerDemandInfo,
+  type ServicePowerProperty,
+  type PowerPreset,
+} from '../../api/power-management';
+```
+Signature + props:
 ```tsx
 interface PowerStatusCardsProps {
   status: PowerStatusResponse | null;
@@ -182,12 +201,24 @@ interface PowerStatusCardsProps {
   demands: PowerDemandInfo[];
   lastUpdated: Date | null;
 }
+
+export function PowerStatusCards({
+  status, activePreset, currentProperty, demands, lastUpdated,
+}: PowerStatusCardsProps) {
+  const { t } = useTranslation(['system', 'common']);
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {/* the four <StatCard …/> elements, moved verbatim from PowerManagement.tsx:301-343 */}
+    </div>
+  );
+}
 ```
+**Move the four `<StatCard …/>` elements verbatim** from `PowerManagement.tsx:301-343` into the returned `<div>`. No expression edits — `status`, `activePreset`, `currentProperty`, `demands`, `lastUpdated`, `t`, `PROPERTY_INFO`, `PROFILE_INFO`, `formatClockSpeed`, `getPresetIcon` are all in scope via props/imports. Do NOT add any `data-testid` (the test asserts on text).
 
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `cd client ; npx vitest run src/__tests__/components/power/PowerStatusCards.test.tsx`
-Expected: PASS.
+Expected: PASS (1 test).
 
 - [ ] **Step 5: Commit**
 
@@ -200,22 +231,22 @@ git commit -m "refactor(power): extract PowerStatusCards (#301)"
 
 ### Task 3: `PermissionStatusCard` component
 
-Extracts the permission warning banner + status grid (source: `PowerManagement.tsx:582-661`, `{/* Permission Warning Banner */}` through the end of `{/* Permission Status (Linux backend only) */}`).
+Extracts the permission warning banner + the 4-tile status grid. **Source:** `PowerManagement.tsx:582-660` — the `{/* Permission Warning Banner */}` block (`:582-604`) and the `{/* Permission Status (Linux backend only) */}` block (`:606-660`).
 
 **Files:**
 - Create: `client/src/components/power/PermissionStatusCard.tsx`
 - Test: `client/src/__tests__/components/power/PermissionStatusCard.test.tsx`
 
 **Interfaces:**
-- Produces: `PermissionStatusCard` (named export) with props `{ status: PowerStatusResponse | null }`. Renders `null` unless `status?.is_using_linux_backend && status.permission_status`.
+- Produces: named export `PermissionStatusCard` with props `{ status: PowerStatusResponse | null }`. Returns `null` unless `status?.is_using_linux_backend && status.permission_status`.
 
 - [ ] **Step 1: Write the failing test**
 
 Create `client/src/__tests__/components/power/PermissionStatusCard.test.tsx`:
 
 ```tsx
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
 
@@ -236,13 +267,13 @@ describe('PermissionStatusCard', () => {
   });
 
   it('shows the warning banner when write access is missing', () => {
-    render(<PermissionStatusCard status={linuxStatus(false)} />);
-    expect(screen.getByTestId('power-permission-warning')).toBeTruthy();
+    const { container } = render(<PermissionStatusCard status={linuxStatus(false)} />);
+    expect(container.querySelector('[data-testid="power-permission-warning"]')).not.toBeNull();
   });
 
   it('hides the warning banner when write access is present', () => {
-    render(<PermissionStatusCard status={linuxStatus(true)} />);
-    expect(screen.queryByTestId('power-permission-warning')).toBeNull();
+    const { container } = render(<PermissionStatusCard status={linuxStatus(true)} />);
+    expect(container.querySelector('[data-testid="power-permission-warning"]')).toBeNull();
   });
 });
 ```
@@ -255,10 +286,11 @@ Expected: FAIL — cannot resolve the module.
 - [ ] **Step 3: Create the component**
 
 Create `client/src/components/power/PermissionStatusCard.tsx`:
-- Imports: `useTranslation` from `react-i18next`; `AlertTriangle` from `lucide-react`; `type PowerStatusResponse` from `../../api/power-management`.
-- Signature:
-
 ```tsx
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle } from 'lucide-react';
+import type { PowerStatusResponse } from '../../api/power-management';
+
 interface PermissionStatusCardProps {
   status: PowerStatusResponse | null;
 }
@@ -266,16 +298,18 @@ interface PermissionStatusCardProps {
 export function PermissionStatusCard({ status }: PermissionStatusCardProps) {
   const { t } = useTranslation(['system', 'common']);
   if (!status?.is_using_linux_backend || !status.permission_status) return null;
-  const perm = status.permission_status;
   return (
     <>
-      {/* warning banner + status grid (moved) */}
+      {/* Permission Warning Banner — moved from PowerManagement.tsx:583-604 */}
+      {/* Permission Status grid — moved from PowerManagement.tsx:607-659 */}
     </>
   );
 }
 ```
-- **Move the two JSX blocks verbatim** from `PowerManagement.tsx:582-661`: the `{/* Permission Warning Banner */}` block (`status?.is_using_linux_backend && status.permission_status && !status.permission_status.has_write_access && (…)`) and the `{/* Permission Status (Linux backend only) */}` block. Inside the component the outer `status?.is_using_linux_backend && status.permission_status &&` guards are already handled by the early return, so keep only the inner `!status.permission_status.has_write_access &&` guard on the banner (reference `perm` / `status` — both in scope).
-- On the outer `<div>` of the warning banner, add `data-testid="power-permission-warning"`.
+- **Move the warning-banner block** (`PowerManagement.tsx:583-603`, the inner `<div className="mb-4 rounded-xl border border-amber-500/30 …">…</div>`) into the fragment, wrapped so it only shows when write access is missing:
+  `{!status.permission_status.has_write_access && ( <div data-testid="power-permission-warning" className="mb-4 rounded-xl …"> … </div> )}`
+  — i.e. add `data-testid="power-permission-warning"` to that banner's root `<div>` and keep only the `!…has_write_access` guard (the `is_using_linux_backend && permission_status` guards are handled by the early return).
+- **Move the status-grid block** (`PowerManagement.tsx:608-659`, the `<div className="card border-slate-700/50 p-4 sm:p-6"> … </div>`) into the fragment verbatim. All `status.permission_status.*` references stay in scope.
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -293,17 +327,17 @@ git commit -m "refactor(power): extract PermissionStatusCard (#301)"
 
 ### Task 4: `AutoScalingSection` component
 
-Extracts the auto-scaling **config card** (source: `PowerManagement.tsx:456-581`, `{/* Auto-Scaling Config (Admin only) */}` block) plus the edit state and the `handleStartEditAutoScaling` / `handleCancelEditAutoScaling` / `handleSaveAutoScaling` handlers. Uses `isValidAutoScaling` from Task 1.
+Extracts the auto-scaling **config card**. **Source:** `PowerManagement.tsx:456-580` (the `{isAdmin && autoScaling && ( <div className="card …"> … </div> )}` block) plus the edit state (`editingAutoScaling`, `editAutoScaling`) and the handlers `handleStartEditAutoScaling` (`:129-134`), `handleCancelEditAutoScaling` (`:136-139`), `handleSaveAutoScaling` (`:141-169`). Validation via `isValidAutoScaling` (Task 1).
 
 **Files:**
 - Create: `client/src/components/power/AutoScalingSection.tsx`
 - Test: `client/src/__tests__/components/power/AutoScalingSection.test.tsx`
 
 **Interfaces:**
-- Consumes: `isValidAutoScaling` (Task 1).
-- Produces: `AutoScalingSection` (named export) with props
+- Consumes: `isValidAutoScaling` (Task 1); `updateAutoScalingConfig` (api).
+- Produces: named export `AutoScalingSection` with props
   `{ autoScaling: AutoScalingConfig; dimmed: boolean; busy: boolean; onBusyChange: (b: boolean) => void; onRefresh: () => void }`.
-  (`isAdmin` gating stays in the page — page renders the section only when `isAdmin && autoScaling`.)
+  (`isAdmin` gating stays in the page — the page renders the section only when `isAdmin && autoScaling`.)
 
 - [ ] **Step 1: Write the failing test**
 
@@ -329,7 +363,7 @@ const cfg = {
   cooldown_seconds: 15, use_cpu_monitoring: true,
 } as never;
 
-function renderSection(overrides = {}) {
+function renderSection() {
   const onRefresh = vi.fn();
   const onBusyChange = vi.fn();
   render(
@@ -339,7 +373,6 @@ function renderSection(overrides = {}) {
       busy={false}
       onBusyChange={onBusyChange}
       onRefresh={onRefresh}
-      {...overrides}
     />,
   );
   return { onRefresh, onBusyChange };
@@ -348,16 +381,16 @@ function renderSection(overrides = {}) {
 describe('AutoScalingSection', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('renders the current thresholds in display mode', () => {
-    renderSection();
-    expect(screen.getByTestId('auto-scaling-section')).toBeTruthy();
+  it('renders the config card in display mode', () => {
+    const { container } = renderSection();
+    expect(container.querySelector('[data-testid="auto-scaling-section"]')).not.toBeNull();
   });
 
   it('blocks save on an invalid threshold ordering (no API call)', async () => {
     (updateAutoScalingConfig as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
     renderSection();
     fireEvent.click(screen.getByTestId('auto-scaling-edit'));
-    // Set surge below medium → invalid
+    // surge (10) below medium (60) → invalid ordering
     fireEvent.change(screen.getByTestId('auto-scaling-input-surge'), { target: { value: '10' } });
     fireEvent.click(screen.getByTestId('auto-scaling-save'));
     await waitFor(() => {});
@@ -375,6 +408,8 @@ describe('AutoScalingSection', () => {
 });
 ```
 
+> `screen.getByTestId` is used here (React Testing Library resolves it against the document body); the `PermissionStatusCard` test uses `container.querySelector` — both work. Do not depend on `@testing-library/jest-dom` matchers (`.toBeInTheDocument()`); this suite uses plain `.toBeTruthy()`/`.not.toBeNull()`.
+
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `cd client ; npx vitest run src/__tests__/components/power/AutoScalingSection.test.tsx`
@@ -383,40 +418,81 @@ Expected: FAIL — cannot resolve `AutoScalingSection`.
 - [ ] **Step 3: Create the component**
 
 Create `client/src/components/power/AutoScalingSection.tsx`:
-- Imports: `useState` (react); `useTranslation` (react-i18next); `toast` (react-hot-toast); `AdminBadge` from `../ui/AdminBadge`; `updateAutoScalingConfig, type AutoScalingConfig` from `../../api/power-management`; `handleApiError` from `../../lib/errorHandling`; `isValidAutoScaling` from `./utils`.
-- Props interface as in Interfaces above.
-- Internal state: `const [editing, setEditing] = useState(false); const [draft, setDraft] = useState<AutoScalingConfig | null>(null);` (renamed from `editingAutoScaling`/`editAutoScaling`).
-- Handlers (moved from the page, `setBusy`→`onBusyChange`, `refetch`→`onRefresh`, `autoScaling` is the prop, validation via `isValidAutoScaling`):
-
 ```tsx
-const startEdit = () => setDraft({ ...autoScaling });
-const cancelEdit = () => { setEditing(false); setDraft(null); };
-const save = async () => {
-  if (!draft || busy) return;
-  if (!isValidAutoScaling(draft)) {
-    toast.error(t('system:power.autoScaling.validationError'));
-    return;
-  }
-  onBusyChange(true);
-  try {
-    await updateAutoScalingConfig(draft);
-    onRefresh();
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { AdminBadge } from '../ui/AdminBadge';
+import { handleApiError } from '../../lib/errorHandling';
+import { updateAutoScalingConfig, type AutoScalingConfig } from '../../api/power-management';
+import { isValidAutoScaling } from './utils';
+
+interface AutoScalingSectionProps {
+  autoScaling: AutoScalingConfig;
+  dimmed: boolean;
+  busy: boolean;
+  onBusyChange: (b: boolean) => void;
+  onRefresh: () => void;
+}
+
+export function AutoScalingSection({
+  autoScaling, dimmed, busy, onBusyChange, onRefresh,
+}: AutoScalingSectionProps) {
+  const { t } = useTranslation(['system', 'common']);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<AutoScalingConfig | null>(null);
+
+  const startEdit = () => {
+    setDraft({ ...autoScaling });
+    setEditing(true);
+  };
+  const cancelEdit = () => {
     setEditing(false);
     setDraft(null);
-    toast.success(t('system:power.autoScaling.thresholdsSaved'));
-  } catch (err) {
-    handleApiError(err, t('system:power.autoScaling.thresholdsSaveFailed'));
-  } finally {
-    onBusyChange(false);
-  }
-};
-```
-> Note: entering edit mode is `onClick={() => { startEdit(); setEditing(true); }}` on the edit button, matching the old `handleStartEditAutoScaling` (which set both) — keep that combined behavior.
+  };
+  const save = async () => {
+    if (!draft || busy) return;
+    if (!isValidAutoScaling(draft)) {
+      toast.error(t('system:power.autoScaling.validationError'));
+      return;
+    }
+    onBusyChange(true);
+    try {
+      await updateAutoScalingConfig(draft);
+      onRefresh();
+      setEditing(false);
+      setDraft(null);
+      toast.success(t('system:power.autoScaling.thresholdsSaved'));
+    } catch (err) {
+      handleApiError(err, t('system:power.autoScaling.thresholdsSaveFailed'));
+    } finally {
+      onBusyChange(false);
+    }
+  };
 
-- Return: move the `{/* Auto-Scaling Config (Admin only) */}` card JSX from `PowerManagement.tsx:456-581`, but:
-  - Drop the outer `{isAdmin && autoScaling && (` wrapper (page gates it). The root element is the `<div className={\`card border-slate-700/50 p-4 sm:p-6 ${'{'}dimmed ? 'opacity-50 pointer-events-none' : ''{'}'}\`}>` — replace the old `status?.dynamic_mode_enabled` expression with the `dimmed` prop. Add `data-testid="auto-scaling-section"`.
-  - Rename references: `editingAutoScaling` → `editing`, `editAutoScaling` → `draft`, `setEditAutoScaling` → `setDraft`, `handleStartEditAutoScaling` → the combined `() => { startEdit(); setEditing(true); }`, `handleCancelEditAutoScaling` → `cancelEdit`, `handleSaveAutoScaling` → `save`, `autoScaling.` → `autoScaling.` (prop, unchanged), `busy` → `busy` (prop).
-  - Add `data-testid` to: the edit button (`auto-scaling-edit`), the save button (`auto-scaling-save`), and the surge `<input>` (`auto-scaling-input-surge`).
+  return (
+    <div
+      data-testid="auto-scaling-section"
+      className={`card border-slate-700/50 p-4 sm:p-6 ${dimmed ? 'opacity-50 pointer-events-none' : ''}`}
+    >
+      {/* header (title + AdminBadge + edit / cancel+save buttons) and body
+          (edit inputs vs display), moved verbatim from PowerManagement.tsx:459-578 */}
+    </div>
+  );
+}
+```
+Move the **inner** card content from `PowerManagement.tsx:459-578` (everything inside the `<div className="card …">`, i.e. the header `<div className="mb-3 …">…</div>` and the `{editingAutoScaling && editAutoScaling ? (…) : (…)}` body) into this component's `<div>`, applying exactly these renames — nothing else changes:
+- `editingAutoScaling` → `editing`
+- `editAutoScaling` → `draft` (display reads like `draft.cpu_surge_threshold`; the four `setEditAutoScaling({ ...editAutoScaling, … })` onChange calls → `setDraft({ ...draft!, … })`)
+- `handleStartEditAutoScaling` → `startEdit`
+- `handleCancelEditAutoScaling` → `cancelEdit`
+- `handleSaveAutoScaling` → `save`
+- `autoScaling.*` (display-mode reads at `:562/566/570/574/575`) stay as `autoScaling.*` (the prop)
+- `busy` stays `busy` (the prop)
+
+Add three `data-testid`s during the move: `auto-scaling-edit` on the edit button (`:465-474`), `auto-scaling-save` on the save button (`:484-490`), and `auto-scaling-input-surge` on the surge `<input>` (`:501-508`).
+
+> **Draft typing:** the onChange handlers run only inside the `editing && draft` branch, where `draft` is non-null, so `setDraft({ ...draft!, cpu_surge_threshold: Number(e.target.value) })` is safe. tsc in Task 5 confirms.
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -436,6 +512,7 @@ git commit -m "refactor(power): extract AutoScalingSection (#301)"
 
 **Files:**
 - Modify: `client/src/pages/PowerManagement.tsx`
+- Modify: `client/src/components/CLAUDE.md`
 
 **Interfaces:**
 - Consumes: `PowerStatusCards` (Task 2), `PermissionStatusCard` (Task 3), `AutoScalingSection` (Task 4).
@@ -444,13 +521,13 @@ git commit -m "refactor(power): extract AutoScalingSection (#301)"
 
 In `client/src/pages/PowerManagement.tsx`:
 
-1. Add imports near the other `components/power/*` imports:
+1. Add imports alongside the other `components/power/*` imports:
 ```tsx
 import { PowerStatusCards } from '../components/power/PowerStatusCards';
 import { PermissionStatusCard } from '../components/power/PermissionStatusCard';
 import { AutoScalingSection } from '../components/power/AutoScalingSection';
 ```
-2. Replace the `{/* Status Cards */}` block (`:299-345`) with:
+2. Replace the Status-Cards block (`:299-344`, the comment + its `<div className="grid …lg:grid-cols-4">…</div>`) with:
 ```tsx
       {/* Status Cards */}
       <PowerStatusCards
@@ -461,7 +538,7 @@ import { AutoScalingSection } from '../components/power/AutoScalingSection';
         lastUpdated={lastUpdated}
       />
 ```
-3. Replace the whole `{/* Auto-Scaling Config (Admin only) */}` block (`:456-581`) with:
+3. Replace the Auto-Scaling block (`:456-580`, the whole `{isAdmin && autoScaling && ( … )}`) with:
 ```tsx
       {/* Auto-Scaling Config (Admin only) */}
       {isAdmin && autoScaling && (
@@ -474,39 +551,39 @@ import { AutoScalingSection } from '../components/power/AutoScalingSection';
         />
       )}
 ```
-4. Replace the `{/* Permission Warning Banner */}` + `{/* Permission Status (Linux backend only) */}` blocks (`:582-661`) with:
+4. Replace the two permission blocks (`:582-660`) with:
 ```tsx
       {/* Permission panels (Linux backend only) */}
       <PermissionStatusCard status={status} />
 ```
-5. Remove the now-unused page state and handlers: `editingAutoScaling`, `editAutoScaling` (`useState`), `handleStartEditAutoScaling`, `handleCancelEditAutoScaling`, `handleSaveAutoScaling`.
-6. Remove now-unused imports from `PowerManagement.tsx`: `updateAutoScalingConfig` **only if** no longer referenced (it is still used by `handleToggleAutoScaling` — **keep it**), `AlertTriangle` (moved to PermissionStatusCard — remove), `StatCard` (moved — remove), `formatClockSpeed`/`getPresetIcon`/`PROPERTY_INFO`/`PROFILE_INFO` (moved to PowerStatusCards — remove **only if** not used elsewhere in the file; `PROPERTY_INFO`/`PROFILE_INFO`/`getPresetIcon`/`formatClockSpeed` were used only by the status cards — remove). Let eslint/tsc confirm (Steps 3-4).
+5. Remove the now-unused state and handlers from the page: the `editingAutoScaling` and `editAutoScaling` `useState` lines (`:74-75`), and `handleStartEditAutoScaling` (`:129-134`), `handleCancelEditAutoScaling` (`:136-139`), `handleSaveAutoScaling` (`:141-169`).
+6. Remove now-unused imports (Steps 3-4 flag any still referenced): `AlertTriangle` (moved to PermissionStatusCard), `StatCard` (moved to PowerStatusCards), and from `../api/power-management` the symbols now used only by PowerStatusCards — `PROFILE_INFO`, `PROPERTY_INFO`, `formatClockSpeed` — plus `getPresetIcon` (from `../components/power/utils`). **Keep** `updateAutoScalingConfig` (still used by `handleToggleAutoScaling` at `:119`), `AdminBadge` (still used in the preset card / header), `ServicePowerProperty` (still used at `:247`), and the `AutoScalingConfig` type (still referenced by `editAutoScaling`? — those state lines are removed; if `AutoScalingConfig` is no longer referenced anywhere in the file after removal, drop it too — tsc will flag).
 
-> `handleToggleAutoScaling` and the auto-scaling **toggle button** in the preset card stay untouched.
+> `handleToggleAutoScaling` (`:113-127`), the auto-scaling toggle button in the preset card, and the preset editor modal stay untouched.
 
-- [ ] **Step 2: Confirm line count dropped**
+- [ ] **Step 2: Confirm the line count dropped**
 
-Run: `cd client ; (Get-Content src/pages/PowerManagement.tsx | Measure-Object -Line).Lines`  *(PowerShell)*
-Expected: under 500 (target ~380–420).
+Run (PowerShell): `cd client ; (Get-Content src/pages/PowerManagement.tsx | Measure-Object -Line).Lines`
+Expected: under 500 (target ~380-420).
 
-- [ ] **Step 3: eslint the touched files**
-
-Run: `cd client ; npx eslint src/pages/PowerManagement.tsx src/components/power/PowerStatusCards.tsx src/components/power/PermissionStatusCard.tsx src/components/power/AutoScalingSection.tsx src/components/power/utils.ts`
-Expected: no output (0 errors). Fix any unused-import / unused-var errors by removing the dead imports/handlers flagged.
-
-- [ ] **Step 4: Build (typecheck)**
+- [ ] **Step 3: Typecheck + build**
 
 Run: `cd client ; npm run build`
-Expected: `✓ built` twice (tsc -b + vite), no `error TS`.
+Expected: `✓ built` (tsc -b then vite), no `error TS`. Fix any unused-import/var errors by removing the dead imports/handlers flagged in Step 1.6.
 
-- [ ] **Step 5: Full suite**
+- [ ] **Step 4: Full lint gate**
+
+Run: `cd client ; npx eslint .`
+Expected: no output (0 errors — the CI gate is 0-error).
+
+- [ ] **Step 5: Full test suite**
 
 Run: `cd client ; npx vitest run`
-Expected: all green — 603 prior + the new power tests (isValidAutoScaling 6, PowerStatusCards 1, PermissionStatusCard 3, AutoScalingSection 3). No regressions.
+Expected: all green — the prior 603 + the new power tests (isValidAutoScaling 6, PowerStatusCards 1, PermissionStatusCard 3, AutoScalingSection 3). No regressions.
 
 - [ ] **Step 6: Update `components/CLAUDE.md`**
 
-In `client/src/components/CLAUDE.md`, under the `power/` feature-dir note (or the top-level component list), add one line noting the three new power subcomponents extracted from `PowerManagement` (F2/#301). Keep it terse.
+In `client/src/components/CLAUDE.md`, the Feature Subdirectories `power/` row reads "Power profile management". Add a terse note that `PowerManagement` composes `PowerStatusCards`, `PermissionStatusCard`, and `AutoScalingSection` (extracted for F2/#301). Keep it to one line.
 
 - [ ] **Step 7: Commit**
 
@@ -519,6 +596,7 @@ git commit -m "refactor(power): compose PowerManagement from extracted subcompon
 
 ## Notes for the implementer
 
-- Before Task 2 Step 3, read `client/src/components/ui/StatCard.tsx` to confirm whether it forwards arbitrary props (for the `data-testid`); if not, wrap the target card in a `<div data-testid=…>`.
-- The JSX being moved is long but must be **relocated verbatim** — do not "improve" markup, class names, or i18n keys. Any diff beyond variable-name renames (`editingAutoScaling→editing`, `editAutoScaling→draft`) and the `dimmed`/`onRefresh`/`onBusyChange` wiring is out of scope.
-- After each task, the app must still compile; only Task 5 wires the page, so Tasks 2–4 add unused components (that is expected and fine — they are covered by their own tests).
+- The JSX being moved is long but must be **relocated verbatim** — do not "improve" markup, class names, or i18n keys. The only permitted diffs are the variable renames in Task 4 (`editingAutoScaling→editing`, `editAutoScaling→draft`, handler names), the `dimmed`/`onRefresh`/`onBusyChange` wiring, and the added `data-testid`s named in each task. `StatCard` gets no testid (Task 2).
+- Tasks 2-4 add components that are not yet imported anywhere; that is expected — they are covered by their own tests. Only Task 5 wires them into the page.
+- After Task 5, `PowerManagement.tsx` should still render identically; the gate (build + `eslint .` + full vitest) is the proof.
+- Line numbers in this plan are from `PowerManagement.tsx` at 632 lines (spec HEAD). If earlier edits shift them, match on the quoted comment markers / JSX instead.

--- a/docs/superpowers/plans/2026-07-09-f2-powermanagement-decomposition.md
+++ b/docs/superpowers/plans/2026-07-09-f2-powermanagement-decomposition.md
@@ -1,0 +1,524 @@
+# F2 — PowerManagement Decomposition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `client/src/pages/PowerManagement.tsx` (632 lines) into three focused `components/power/` subcomponents + one pure validation helper, bringing the page under 500 lines with no behavior/UX/layout change.
+
+**Architecture:** Pure move-refactor. Extract the auto-scaling threshold config card, the permission panels, and the top status-card row into their own components. The one piece of real logic (auto-scaling validation) becomes a pure function. New components mirror the existing `DynamicModeSection` contract (`useTranslation` internally, `busy`/`onBusyChange`/`onRefresh` props for the stateful one).
+
+**Tech Stack:** React 18 + TypeScript, TanStack Query (already in place), Tailwind, react-i18next, Vitest + React Testing Library.
+
+## Global Constraints
+
+- **No behavior, UX, or layout change.** Rendered output must be identical. The auto-scaling **enable/disable toggle button** stays in the preset-selection card (do NOT move it).
+- New components live in `client/src/components/power/` and use `useTranslation(['system','common'])` **internally** (no `t` prop) — matching `DynamicModeSection`/`OsAutoSuspendCard`.
+- Component tests go in `client/src/__tests__/components/power/`, following the `OsAutoSuspendCard.test.tsx` pattern: `vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k) => k }) }))`, `vi.mock` for api + `react-hot-toast`, assert via `data-testid`.
+- Verification gate (Task 5): full `npx vitest run` green (currently 603), `npx eslint .` 0 errors, `npm run build` green.
+- Windows shell: chain with `;`, never `&&` (see project CLAUDE.md).
+
+---
+
+### Task 1: Pure `isValidAutoScaling` helper
+
+**Files:**
+- Modify: `client/src/components/power/utils.ts` (append)
+- Test: `client/src/__tests__/components/power/isValidAutoScaling.test.ts`
+
+**Interfaces:**
+- Produces: `isValidAutoScaling(cfg: Pick<AutoScalingConfig, 'cpu_surge_threshold' | 'cpu_medium_threshold' | 'cpu_low_threshold' | 'cooldown_seconds'>): boolean` — `true` when `surge > medium > low`, each threshold in `[0,100]`, and `cooldown_seconds >= 0`. (Negation of the inline guard in `PowerManagement.tsx` `handleSaveAutoScaling`.)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/components/power/isValidAutoScaling.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { isValidAutoScaling } from '../../../components/power/utils';
+
+const base = {
+  cpu_surge_threshold: 90,
+  cpu_medium_threshold: 60,
+  cpu_low_threshold: 30,
+  cooldown_seconds: 15,
+};
+
+describe('isValidAutoScaling', () => {
+  it('accepts a correctly ordered config', () => {
+    expect(isValidAutoScaling(base)).toBe(true);
+  });
+
+  it('rejects when surge is not strictly greater than medium', () => {
+    expect(isValidAutoScaling({ ...base, cpu_surge_threshold: 60 })).toBe(false);
+  });
+
+  it('rejects when medium is not strictly greater than low', () => {
+    expect(isValidAutoScaling({ ...base, cpu_medium_threshold: 30 })).toBe(false);
+  });
+
+  it('rejects an out-of-range threshold', () => {
+    expect(isValidAutoScaling({ ...base, cpu_surge_threshold: 120 })).toBe(false);
+    expect(isValidAutoScaling({ ...base, cpu_low_threshold: -1 })).toBe(false);
+  });
+
+  it('rejects a negative cooldown', () => {
+    expect(isValidAutoScaling({ ...base, cooldown_seconds: -5 })).toBe(false);
+  });
+
+  it('accepts boundary values 0 and 100 while preserving ordering', () => {
+    expect(isValidAutoScaling({
+      cpu_surge_threshold: 100, cpu_medium_threshold: 50, cpu_low_threshold: 0, cooldown_seconds: 0,
+    })).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client ; npx vitest run src/__tests__/components/power/isValidAutoScaling.test.ts`
+Expected: FAIL — `isValidAutoScaling` is not exported from `utils.ts`.
+
+- [ ] **Step 3: Append the implementation to `utils.ts`**
+
+Add at the end of `client/src/components/power/utils.ts` (add `AutoScalingConfig` to the existing `import type { ... } from '../../api/power-management'`):
+
+```ts
+import type { AutoScalingConfig } from '../../api/power-management';
+
+/**
+ * Validates auto-scaling CPU thresholds: surge > medium > low, each in [0,100],
+ * cooldown >= 0. Pure — extracted from PowerManagement's save handler.
+ */
+export function isValidAutoScaling(
+  cfg: Pick<AutoScalingConfig, 'cpu_surge_threshold' | 'cpu_medium_threshold' | 'cpu_low_threshold' | 'cooldown_seconds'>,
+): boolean {
+  const inRange = (n: number) => n >= 0 && n <= 100;
+  return (
+    cfg.cpu_surge_threshold > cfg.cpu_medium_threshold &&
+    cfg.cpu_medium_threshold > cfg.cpu_low_threshold &&
+    inRange(cfg.cpu_surge_threshold) &&
+    inRange(cfg.cpu_medium_threshold) &&
+    inRange(cfg.cpu_low_threshold) &&
+    cfg.cooldown_seconds >= 0
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client ; npx vitest run src/__tests__/components/power/isValidAutoScaling.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/power/utils.ts client/src/__tests__/components/power/isValidAutoScaling.test.ts
+git commit -m "refactor(power): extract pure isValidAutoScaling helper (#301)"
+```
+
+---
+
+### Task 2: `PowerStatusCards` component
+
+Extracts the four top `StatCard`s (source: `PowerManagement.tsx:299-345`, the block after `{/* Status Cards */}` up to `{/* Dynamic Mode Section */}`).
+
+**Files:**
+- Create: `client/src/components/power/PowerStatusCards.tsx`
+- Test: `client/src/__tests__/components/power/PowerStatusCards.test.tsx`
+
+**Interfaces:**
+- Produces: `PowerStatusCards` (default or named export — use **named**) with props
+  `{ status: PowerStatusResponse | null; activePreset?: PowerPreset; currentProperty?: ServicePowerProperty; demands: PowerDemandInfo[]; lastUpdated: Date | null }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/components/power/PowerStatusCards.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+import { PowerStatusCards } from '../../../components/power/PowerStatusCards';
+
+describe('PowerStatusCards', () => {
+  it('renders the active demands count', () => {
+    render(
+      <PowerStatusCards
+        status={{ current_frequency_mhz: 3400 } as never}
+        activePreset={{ id: 1, name: 'Balanced', description: 'd' } as never}
+        currentProperty="low"
+        demands={[{ source: 'a', level: 'low' }, { source: 'b', level: 'medium' }] as never}
+        lastUpdated={new Date(0)}
+      />,
+    );
+    expect(screen.getByTestId('power-stat-active-demands').textContent).toContain('2');
+  });
+});
+```
+
+> Note: add `import { vi } from 'vitest';` to the import line if the runner needs it explicitly (match the sibling `OsAutoSuspendCard.test.tsx`, which relies on global `vi`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client ; npx vitest run src/__tests__/components/power/PowerStatusCards.test.tsx`
+Expected: FAIL — cannot resolve `../../../components/power/PowerStatusCards`.
+
+- [ ] **Step 3: Create the component**
+
+Create `client/src/components/power/PowerStatusCards.tsx`:
+- Imports: `useTranslation` from `react-i18next`; `StatCard` from `../ui/StatCard`; `getPresetIcon` from `./utils`; `PROFILE_INFO, PROPERTY_INFO, formatClockSpeed, type PowerStatusResponse, type PowerDemandInfo, type ServicePowerProperty, type PowerPreset` from `../../api/power-management`.
+- Signature: `export function PowerStatusCards({ status, activePreset, currentProperty, demands, lastUpdated }: PowerStatusCardsProps) { const { t } = useTranslation(['system','common']); return (<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"> …four StatCards… </div>); }`
+- **Move the four `<StatCard …/>` elements verbatim from `PowerManagement.tsx:300-345`** (everything between the opening `<div className="grid …lg:grid-cols-4">` and its closing `</div>`). No expression changes — `status`, `activePreset`, `currentProperty`, `demands`, `lastUpdated`, `t`, `PROPERTY_INFO`, `PROFILE_INFO`, `formatClockSpeed`, `getPresetIcon` are all in scope via props/imports.
+- Add `data-testid="power-stat-active-demands"` to the **fourth** `StatCard` (active demands) by wrapping its `value={demands.length}` — pass `data-testid` if `StatCard` forwards it; otherwise wrap the card in a `<div data-testid="power-stat-active-demands">`. Verify by reading `components/ui/StatCard.tsx` whether it spreads extra props; if not, use the wrapping `<div>`.
+
+Define the props interface at the top:
+
+```tsx
+interface PowerStatusCardsProps {
+  status: PowerStatusResponse | null;
+  activePreset?: PowerPreset;
+  currentProperty?: ServicePowerProperty;
+  demands: PowerDemandInfo[];
+  lastUpdated: Date | null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client ; npx vitest run src/__tests__/components/power/PowerStatusCards.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/power/PowerStatusCards.tsx client/src/__tests__/components/power/PowerStatusCards.test.tsx
+git commit -m "refactor(power): extract PowerStatusCards (#301)"
+```
+
+---
+
+### Task 3: `PermissionStatusCard` component
+
+Extracts the permission warning banner + status grid (source: `PowerManagement.tsx:582-661`, `{/* Permission Warning Banner */}` through the end of `{/* Permission Status (Linux backend only) */}`).
+
+**Files:**
+- Create: `client/src/components/power/PermissionStatusCard.tsx`
+- Test: `client/src/__tests__/components/power/PermissionStatusCard.test.tsx`
+
+**Interfaces:**
+- Produces: `PermissionStatusCard` (named export) with props `{ status: PowerStatusResponse | null }`. Renders `null` unless `status?.is_using_linux_backend && status.permission_status`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/components/power/PermissionStatusCard.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+import { PermissionStatusCard } from '../../../components/power/PermissionStatusCard';
+
+const linuxStatus = (writeAccess: boolean) => ({
+  is_using_linux_backend: true,
+  permission_status: {
+    has_write_access: writeAccess, user: 'baluhost',
+    in_cpufreq_group: true, sudo_available: false,
+  },
+}) as never;
+
+describe('PermissionStatusCard', () => {
+  it('renders nothing without a Linux backend', () => {
+    const { container } = render(<PermissionStatusCard status={{ is_using_linux_backend: false } as never} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the warning banner when write access is missing', () => {
+    render(<PermissionStatusCard status={linuxStatus(false)} />);
+    expect(screen.getByTestId('power-permission-warning')).toBeTruthy();
+  });
+
+  it('hides the warning banner when write access is present', () => {
+    render(<PermissionStatusCard status={linuxStatus(true)} />);
+    expect(screen.queryByTestId('power-permission-warning')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client ; npx vitest run src/__tests__/components/power/PermissionStatusCard.test.tsx`
+Expected: FAIL — cannot resolve the module.
+
+- [ ] **Step 3: Create the component**
+
+Create `client/src/components/power/PermissionStatusCard.tsx`:
+- Imports: `useTranslation` from `react-i18next`; `AlertTriangle` from `lucide-react`; `type PowerStatusResponse` from `../../api/power-management`.
+- Signature:
+
+```tsx
+interface PermissionStatusCardProps {
+  status: PowerStatusResponse | null;
+}
+
+export function PermissionStatusCard({ status }: PermissionStatusCardProps) {
+  const { t } = useTranslation(['system', 'common']);
+  if (!status?.is_using_linux_backend || !status.permission_status) return null;
+  const perm = status.permission_status;
+  return (
+    <>
+      {/* warning banner + status grid (moved) */}
+    </>
+  );
+}
+```
+- **Move the two JSX blocks verbatim** from `PowerManagement.tsx:582-661`: the `{/* Permission Warning Banner */}` block (`status?.is_using_linux_backend && status.permission_status && !status.permission_status.has_write_access && (…)`) and the `{/* Permission Status (Linux backend only) */}` block. Inside the component the outer `status?.is_using_linux_backend && status.permission_status &&` guards are already handled by the early return, so keep only the inner `!status.permission_status.has_write_access &&` guard on the banner (reference `perm` / `status` — both in scope).
+- On the outer `<div>` of the warning banner, add `data-testid="power-permission-warning"`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client ; npx vitest run src/__tests__/components/power/PermissionStatusCard.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/power/PermissionStatusCard.tsx client/src/__tests__/components/power/PermissionStatusCard.test.tsx
+git commit -m "refactor(power): extract PermissionStatusCard (#301)"
+```
+
+---
+
+### Task 4: `AutoScalingSection` component
+
+Extracts the auto-scaling **config card** (source: `PowerManagement.tsx:456-581`, `{/* Auto-Scaling Config (Admin only) */}` block) plus the edit state and the `handleStartEditAutoScaling` / `handleCancelEditAutoScaling` / `handleSaveAutoScaling` handlers. Uses `isValidAutoScaling` from Task 1.
+
+**Files:**
+- Create: `client/src/components/power/AutoScalingSection.tsx`
+- Test: `client/src/__tests__/components/power/AutoScalingSection.test.tsx`
+
+**Interfaces:**
+- Consumes: `isValidAutoScaling` (Task 1).
+- Produces: `AutoScalingSection` (named export) with props
+  `{ autoScaling: AutoScalingConfig; dimmed: boolean; busy: boolean; onBusyChange: (b: boolean) => void; onRefresh: () => void }`.
+  (`isAdmin` gating stays in the page — page renders the section only when `isAdmin && autoScaling`.)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/components/power/AutoScalingSection.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('../../../api/power-management', async () => {
+  const actual = await vi.importActual<typeof import('../../../api/power-management')>('../../../api/power-management');
+  return { ...actual, updateAutoScalingConfig: vi.fn() };
+});
+
+import { updateAutoScalingConfig } from '../../../api/power-management';
+import { AutoScalingSection } from '../../../components/power/AutoScalingSection';
+
+const cfg = {
+  enabled: true,
+  cpu_surge_threshold: 90, cpu_medium_threshold: 60, cpu_low_threshold: 30,
+  cooldown_seconds: 15, use_cpu_monitoring: true,
+} as never;
+
+function renderSection(overrides = {}) {
+  const onRefresh = vi.fn();
+  const onBusyChange = vi.fn();
+  render(
+    <AutoScalingSection
+      autoScaling={cfg}
+      dimmed={false}
+      busy={false}
+      onBusyChange={onBusyChange}
+      onRefresh={onRefresh}
+      {...overrides}
+    />,
+  );
+  return { onRefresh, onBusyChange };
+}
+
+describe('AutoScalingSection', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the current thresholds in display mode', () => {
+    renderSection();
+    expect(screen.getByTestId('auto-scaling-section')).toBeTruthy();
+  });
+
+  it('blocks save on an invalid threshold ordering (no API call)', async () => {
+    (updateAutoScalingConfig as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    renderSection();
+    fireEvent.click(screen.getByTestId('auto-scaling-edit'));
+    // Set surge below medium → invalid
+    fireEvent.change(screen.getByTestId('auto-scaling-input-surge'), { target: { value: '10' } });
+    fireEvent.click(screen.getByTestId('auto-scaling-save'));
+    await waitFor(() => {});
+    expect(updateAutoScalingConfig).not.toHaveBeenCalled();
+  });
+
+  it('saves a valid edit: calls the API and onRefresh', async () => {
+    (updateAutoScalingConfig as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    const { onRefresh } = renderSection();
+    fireEvent.click(screen.getByTestId('auto-scaling-edit'));
+    fireEvent.click(screen.getByTestId('auto-scaling-save'));
+    await waitFor(() => expect(updateAutoScalingConfig).toHaveBeenCalledTimes(1));
+    expect(onRefresh).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client ; npx vitest run src/__tests__/components/power/AutoScalingSection.test.tsx`
+Expected: FAIL — cannot resolve `AutoScalingSection`.
+
+- [ ] **Step 3: Create the component**
+
+Create `client/src/components/power/AutoScalingSection.tsx`:
+- Imports: `useState` (react); `useTranslation` (react-i18next); `toast` (react-hot-toast); `AdminBadge` from `../ui/AdminBadge`; `updateAutoScalingConfig, type AutoScalingConfig` from `../../api/power-management`; `handleApiError` from `../../lib/errorHandling`; `isValidAutoScaling` from `./utils`.
+- Props interface as in Interfaces above.
+- Internal state: `const [editing, setEditing] = useState(false); const [draft, setDraft] = useState<AutoScalingConfig | null>(null);` (renamed from `editingAutoScaling`/`editAutoScaling`).
+- Handlers (moved from the page, `setBusy`→`onBusyChange`, `refetch`→`onRefresh`, `autoScaling` is the prop, validation via `isValidAutoScaling`):
+
+```tsx
+const startEdit = () => setDraft({ ...autoScaling });
+const cancelEdit = () => { setEditing(false); setDraft(null); };
+const save = async () => {
+  if (!draft || busy) return;
+  if (!isValidAutoScaling(draft)) {
+    toast.error(t('system:power.autoScaling.validationError'));
+    return;
+  }
+  onBusyChange(true);
+  try {
+    await updateAutoScalingConfig(draft);
+    onRefresh();
+    setEditing(false);
+    setDraft(null);
+    toast.success(t('system:power.autoScaling.thresholdsSaved'));
+  } catch (err) {
+    handleApiError(err, t('system:power.autoScaling.thresholdsSaveFailed'));
+  } finally {
+    onBusyChange(false);
+  }
+};
+```
+> Note: entering edit mode is `onClick={() => { startEdit(); setEditing(true); }}` on the edit button, matching the old `handleStartEditAutoScaling` (which set both) — keep that combined behavior.
+
+- Return: move the `{/* Auto-Scaling Config (Admin only) */}` card JSX from `PowerManagement.tsx:456-581`, but:
+  - Drop the outer `{isAdmin && autoScaling && (` wrapper (page gates it). The root element is the `<div className={\`card border-slate-700/50 p-4 sm:p-6 ${'{'}dimmed ? 'opacity-50 pointer-events-none' : ''{'}'}\`}>` — replace the old `status?.dynamic_mode_enabled` expression with the `dimmed` prop. Add `data-testid="auto-scaling-section"`.
+  - Rename references: `editingAutoScaling` → `editing`, `editAutoScaling` → `draft`, `setEditAutoScaling` → `setDraft`, `handleStartEditAutoScaling` → the combined `() => { startEdit(); setEditing(true); }`, `handleCancelEditAutoScaling` → `cancelEdit`, `handleSaveAutoScaling` → `save`, `autoScaling.` → `autoScaling.` (prop, unchanged), `busy` → `busy` (prop).
+  - Add `data-testid` to: the edit button (`auto-scaling-edit`), the save button (`auto-scaling-save`), and the surge `<input>` (`auto-scaling-input-surge`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client ; npx vitest run src/__tests__/components/power/AutoScalingSection.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/power/AutoScalingSection.tsx client/src/__tests__/components/power/AutoScalingSection.test.tsx
+git commit -m "refactor(power): extract AutoScalingSection (#301)"
+```
+
+---
+
+### Task 5: Wire the three components into `PowerManagement.tsx` + verify
+
+**Files:**
+- Modify: `client/src/pages/PowerManagement.tsx`
+
+**Interfaces:**
+- Consumes: `PowerStatusCards` (Task 2), `PermissionStatusCard` (Task 3), `AutoScalingSection` (Task 4).
+
+- [ ] **Step 1: Replace the three render blocks and remove moved code**
+
+In `client/src/pages/PowerManagement.tsx`:
+
+1. Add imports near the other `components/power/*` imports:
+```tsx
+import { PowerStatusCards } from '../components/power/PowerStatusCards';
+import { PermissionStatusCard } from '../components/power/PermissionStatusCard';
+import { AutoScalingSection } from '../components/power/AutoScalingSection';
+```
+2. Replace the `{/* Status Cards */}` block (`:299-345`) with:
+```tsx
+      {/* Status Cards */}
+      <PowerStatusCards
+        status={status}
+        activePreset={activePreset}
+        currentProperty={currentProperty}
+        demands={demands}
+        lastUpdated={lastUpdated}
+      />
+```
+3. Replace the whole `{/* Auto-Scaling Config (Admin only) */}` block (`:456-581`) with:
+```tsx
+      {/* Auto-Scaling Config (Admin only) */}
+      {isAdmin && autoScaling && (
+        <AutoScalingSection
+          autoScaling={autoScaling}
+          dimmed={!!status?.dynamic_mode_enabled}
+          busy={busy}
+          onBusyChange={setBusy}
+          onRefresh={() => void refetch()}
+        />
+      )}
+```
+4. Replace the `{/* Permission Warning Banner */}` + `{/* Permission Status (Linux backend only) */}` blocks (`:582-661`) with:
+```tsx
+      {/* Permission panels (Linux backend only) */}
+      <PermissionStatusCard status={status} />
+```
+5. Remove the now-unused page state and handlers: `editingAutoScaling`, `editAutoScaling` (`useState`), `handleStartEditAutoScaling`, `handleCancelEditAutoScaling`, `handleSaveAutoScaling`.
+6. Remove now-unused imports from `PowerManagement.tsx`: `updateAutoScalingConfig` **only if** no longer referenced (it is still used by `handleToggleAutoScaling` — **keep it**), `AlertTriangle` (moved to PermissionStatusCard — remove), `StatCard` (moved — remove), `formatClockSpeed`/`getPresetIcon`/`PROPERTY_INFO`/`PROFILE_INFO` (moved to PowerStatusCards — remove **only if** not used elsewhere in the file; `PROPERTY_INFO`/`PROFILE_INFO`/`getPresetIcon`/`formatClockSpeed` were used only by the status cards — remove). Let eslint/tsc confirm (Steps 3-4).
+
+> `handleToggleAutoScaling` and the auto-scaling **toggle button** in the preset card stay untouched.
+
+- [ ] **Step 2: Confirm line count dropped**
+
+Run: `cd client ; (Get-Content src/pages/PowerManagement.tsx | Measure-Object -Line).Lines`  *(PowerShell)*
+Expected: under 500 (target ~380–420).
+
+- [ ] **Step 3: eslint the touched files**
+
+Run: `cd client ; npx eslint src/pages/PowerManagement.tsx src/components/power/PowerStatusCards.tsx src/components/power/PermissionStatusCard.tsx src/components/power/AutoScalingSection.tsx src/components/power/utils.ts`
+Expected: no output (0 errors). Fix any unused-import / unused-var errors by removing the dead imports/handlers flagged.
+
+- [ ] **Step 4: Build (typecheck)**
+
+Run: `cd client ; npm run build`
+Expected: `✓ built` twice (tsc -b + vite), no `error TS`.
+
+- [ ] **Step 5: Full suite**
+
+Run: `cd client ; npx vitest run`
+Expected: all green — 603 prior + the new power tests (isValidAutoScaling 6, PowerStatusCards 1, PermissionStatusCard 3, AutoScalingSection 3). No regressions.
+
+- [ ] **Step 6: Update `components/CLAUDE.md`**
+
+In `client/src/components/CLAUDE.md`, under the `power/` feature-dir note (or the top-level component list), add one line noting the three new power subcomponents extracted from `PowerManagement` (F2/#301). Keep it terse.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add client/src/pages/PowerManagement.tsx client/src/components/CLAUDE.md
+git commit -m "refactor(power): compose PowerManagement from extracted subcomponents (#301)"
+```
+
+---
+
+## Notes for the implementer
+
+- Before Task 2 Step 3, read `client/src/components/ui/StatCard.tsx` to confirm whether it forwards arbitrary props (for the `data-testid`); if not, wrap the target card in a `<div data-testid=…>`.
+- The JSX being moved is long but must be **relocated verbatim** — do not "improve" markup, class names, or i18n keys. Any diff beyond variable-name renames (`editingAutoScaling→editing`, `editAutoScaling→draft`) and the `dimmed`/`onRefresh`/`onBusyChange` wiring is out of scope.
+- After each task, the app must still compile; only Task 5 wires the page, so Tasks 2–4 add unused components (that is expected and fine — they are covered by their own tests).

--- a/docs/superpowers/specs/2026-07-09-f2-powermanagement-decomposition-design.md
+++ b/docs/superpowers/specs/2026-07-09-f2-powermanagement-decomposition-design.md
@@ -1,0 +1,127 @@
+# F2 — PowerManagement Page Decomposition (Design)
+
+**Date:** 2026-07-09
+**Finding:** F2 (#301, part of #298) — 22 non-test components > 500 lines violate the
+`pages/CLAUDE.md` convention ("minimal logic in page files").
+**Scope of this spec:** the first F2 page — `client/src/pages/PowerManagement.tsx`
+(currently 632 lines). One page = one PR. Each subsequent F2 page gets its own
+spec → plan → PR.
+
+## Goal
+
+Bring `PowerManagement.tsx` under 500 lines by extracting three self-contained
+subcomponents into `client/src/components/power/`, and pull the one piece of real
+logic (auto-scaling threshold validation) into a pure, unit-tested function.
+
+This is a **pure move-refactor**: no behavior, UX, or layout changes. The rendered
+output must be identical.
+
+## Current state
+
+`PowerManagement.tsx` (632 lines) already had its data layer migrated to TanStack
+Query (`usePowerManagementData`, #393). What remains oversized is the render tree
+plus the auto-scaling edit logic. The page currently holds:
+
+- Data via `usePowerManagementData()` (status, presets, demands, intensities,
+  history, autoScaling, dynamicConfig, loading, error, lastUpdated, refetch).
+- Local state: `busy`, `editorPreset`, `editingAutoScaling`, `editAutoScaling`.
+- Handlers: `handleRefresh`, `handlePresetSelect`, `handleUnregisterDemand`,
+  `handleToggleAutoScaling`, `handleStartEditAutoScaling`,
+  `handleCancelEditAutoScaling`, `handleSaveAutoScaling` (with inline validation),
+  `handleSwitchBackend`, `handleSavePreset`, `handleDeletePreset`.
+- Render: header (backend indicator + switch + refresh) · 4 StatCards ·
+  `DynamicModeSection` · preset selection card (incl. the auto-scaling **toggle**
+  button) · preset details · service intensity · demands · history ·
+  `GpuPowerCard` · `AuthorityPanel` · `BoostRulesEditor` · auto-scaling **config**
+  card (~120 lines, edit + display) · permission warning banner · permission
+  status card · preset editor modal.
+
+Existing precedent: `DynamicModeSection` is already an extracted subcomponent that
+takes `{ config, isAdmin, busy, onBusyChange, onRefresh }`. The new
+`AutoScalingSection` mirrors this contract.
+
+## Components to extract
+
+### A. `components/power/AutoScalingSection.tsx`
+
+The auto-scaling **config card** (the ~120-line threshold editor: display mode +
+edit mode + save). Owns `editingAutoScaling` / `editAutoScaling` state internally.
+
+- **Props:** `{ autoScaling: AutoScalingConfig; isAdmin: boolean; busy: boolean;
+  onBusyChange: (busy: boolean) => void; onRefresh: () => void; t: TFunction }`
+  (mirrors `DynamicModeSection`).
+- **Behavior:** on save, validates via the pure helper, calls
+  `updateAutoScalingConfig`, toasts, then `onRefresh()`. Uses `onBusyChange` to
+  drive the shared page `busy` flag (so cross-section concurrency stays blocked,
+  exactly as today).
+- **Validation** extracted to a pure function (see below).
+
+> The enable/disable **toggle button** lives in the preset-selection card and stays
+> there (moving it would be a UX change). The small `handleToggleAutoScaling`
+> remains in the page.
+
+### B. `components/power/PermissionStatusCard.tsx`
+
+The permission warning banner **and** the 4-tile permission status grid (shown only
+for the Linux backend). Pure presentational.
+
+- **Props:** `{ status: PowerStatusResponse; t: TFunction }`.
+- Renders nothing / the banner / the grid based on
+  `status.is_using_linux_backend` and `status.permission_status` exactly as today.
+
+### C. `components/power/PowerStatusCards.tsx`
+
+The row of 4 top `StatCard`s (active preset, current property, CPU frequency,
+active demands). Pure presentational.
+
+- **Props:** `{ status: PowerStatusResponse | null; activePreset?: PowerPreset;
+  currentProperty?: ServicePowerProperty; demands: PowerDemandInfo[];
+  lastUpdated: Date | null; t: TFunction }`.
+- The "highest demand" reduce logic moves with the card (kept inline; it is
+  display-only).
+
+## Pure logic: `isValidAutoScaling`
+
+Extract the inline validation from `handleSaveAutoScaling` into a pure function,
+co-located with `AutoScalingSection` (or `components/power/utils`):
+
+```ts
+// true = valid, false = invalid (surge > medium > low, each 0–100, cooldown >= 0)
+export function isValidAutoScaling(cfg: AutoScalingConfig): boolean
+```
+
+This is the only non-trivial logic in the file and the one thing worth TDD-ing
+independently of the DOM.
+
+## Result
+
+`PowerManagement.tsx`: ~632 → **~380–420 lines**. It becomes: the data hook, the
+preset/backend/refresh/toggle handlers, and composition of the extracted pieces.
+
+## Testing (full — component tests requested)
+
+The repo already has an RTL + i18n component-test pattern (`ConfirmDialog.test.tsx`,
+`PowerMenu.test.tsx`, `ConnectedDevicesWidget.test.tsx`), so no new infra.
+
+1. **Pure/TDD:** `isValidAutoScaling` — RED→GREEN, covering the ordering and range
+   rules and the boundary cases.
+2. **Component tests (RTL):**
+   - `AutoScalingSection`: renders display values; entering edit mode shows inputs;
+     an invalid threshold set blocks save (no `updateAutoScalingConfig` call, error
+     toast); a valid save calls `updateAutoScalingConfig` + `onRefresh`.
+   - `PermissionStatusCard`: renders the 4 tiles; the warning banner appears only
+     when `has_write_access` is false; renders nothing without a Linux backend.
+   - `PowerStatusCards`: renders the four cards with the provided values.
+
+## Verification
+
+- New tests green.
+- Full frontend vitest suite green (currently 603) — no regressions.
+- `eslint .` 0 errors; `npm run build` (tsc -b + vite) green.
+
+## Out of scope
+
+- No behavior/UX/layout change (the toggle button stays in the preset card).
+- No changes to the data hook, the preset editor modal, `DynamicModeSection`,
+  `GpuPowerCard`, `AuthorityPanel`, or `BoostRulesEditor`.
+- Other F2 pages (SharesPage, FileManager, …) — each its own later spec/PR.


### PR DESCRIPTION
## F2 — PowerManagement decomposition (#301, part of #298)

Splits the oversized `client/src/pages/PowerManagement.tsx` (**632 → ~397 lines**) into three focused `components/power/` subcomponents plus one pure helper, with full RTL component tests. **Pure move-refactor — no behavior/UX/layout change.** The data layer (`usePowerManagementData`, TanStack Query) was migrated in a prior PR and is untouched here.

First of the F2 pages (god-components >500 lines); each subsequent page gets its own spec → plan → PR.

### What moved
| New file | Extracted from the page |
|---|---|
| `components/power/utils.ts` → `isValidAutoScaling()` | The inline auto-scaling threshold guard (pure: `surge > medium > low`, each `[0,100]`, `cooldown ≥ 0`) |
| `components/power/PowerStatusCards.tsx` | The four top `StatCard`s (verbatim) |
| `components/power/PermissionStatusCard.tsx` | The permission warning banner + 4-tile status grid |
| `components/power/AutoScalingSection.tsx` | The auto-scaling config card (display + edit + save), owning its edit state; mirrors `DynamicModeSection`'s `{busy, onBusyChange, onRefresh}` contract |

The auto-scaling **enable/disable toggle button** stays in the preset card (`handleToggleAutoScaling` stays in the page) — only the config card moved. `DynamicModeSection`, `GpuPowerCard`, `AuthorityPanel`, `BoostRulesEditor`, and the preset editor modal are untouched. Section order, gates (`isAdmin && autoScaling`), and dimming (`dimmed={!!status?.dynamic_mode_enabled}`) are preserved exactly.

### One intentional runtime nuance
`AutoScalingSection.save()` calls `onRefresh()` fire-and-forget (the page wires `() => void refetch()`), whereas the original inline handler did `await refetch()` before closing edit mode. Effect: `busy` releases ~1 API round-trip sooner and the card flips to display mode showing the previous values for that brief window. This is **deliberate** — it aligns the section with the sibling `DynamicModeSection` `{busy, onBusyChange, onRefresh}` contract (which also fire-and-forgets). Imperceptible in practice; no correctness/data impact. Called out here so it isn't mistaken for a stray regression.

### Verification
- New component tests: `isValidAutoScaling` (6), `PowerStatusCards` (1), `PermissionStatusCard` (3), `AutoScalingSection` (3) — all RTL, asserting real behavior.
- Full frontend suite: **124 files / 628 tests green** (no regressions).
- `eslint .` 0 errors · `npm run build` (tsc -b + vite) green.

Built via spec → plan → subagent-driven TDD (5 tasks, per-task spec+quality review, final whole-branch review: *Ready to merge — Yes*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
