### PR TITLE
refactor(files): FileManager browser-core via useFileBrowser + TanStack Query (#301, PR-1)

### DIFF
--- a/client/src/__tests__/components/file-manager/utils.test.ts
+++ b/client/src/__tests__/components/file-manager/utils.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { mapApiFileItem, getFullPath, toRelativePath, parentPath } from '../../../components/file-manager/utils';
+import type { ApiFileItem, StorageMountpoint } from '../../../components/file-manager/types';
+
+const raid: StorageMountpoint = {
+  id: 'a', name: 'Main', type: 'raid', path: '/mnt/main',
+  size_bytes: 100, used_bytes: 40, available_bytes: 60, status: 'ok', is_default: true,
+};
+const dev: StorageMountpoint = { ...raid, id: 'd', type: 'dev-storage', path: 'dev-storage' };
+
+describe('mapApiFileItem', () => {
+  it('maps a full API item incl. sync_info and snake_case fallbacks', () => {
+    const raw: ApiFileItem = {
+      name: 'a.txt', path: 'docs/a.txt', size: 12, type: 'file',
+      modified_at: '2026-01-01T00:00:00Z', owner_id: 7, owner_name: 'bob', file_id: 3,
+      sync_info: [{ device_name: 'pc', platform: 'windows', sync_direction: 'push', last_reported_at: 't' }],
+      can_read: true, can_write: false, can_delete: true,
+    };
+    expect(mapApiFileItem(raw)).toEqual({
+      name: 'a.txt', path: 'docs/a.txt', size: 12, type: 'file',
+      modifiedAt: '2026-01-01T00:00:00Z', ownerId: 7, ownerName: 'bob', file_id: 3,
+      syncInfo: [{ deviceName: 'pc', platform: 'windows', syncDirection: 'push', lastReportedAt: 't' }],
+      canRead: true, canWrite: false, canDelete: true,
+    });
+  });
+
+  it('falls back mtime->modifiedAt and leaves a timestamp when none given', () => {
+    const m = mapApiFileItem({ name: 'x', path: 'x', size: 0, type: 'directory', mtime: 'm1' });
+    expect(m.modifiedAt).toBe('m1');
+    const n = mapApiFileItem({ name: 'y', path: 'y', size: 0, type: 'file' });
+    expect(typeof n.modifiedAt).toBe('string');
+    expect(n.syncInfo).toBeUndefined();
+  });
+});
+
+describe('getFullPath', () => {
+  it('passes the relative path through for dev-storage', () => {
+    expect(getFullPath(dev, 'docs')).toBe('docs');
+  });
+  it('joins under the mountpoint path for real mounts', () => {
+    expect(getFullPath(raid, 'docs')).toBe('/mnt/main/docs');
+    expect(getFullPath(raid, '/docs')).toBe('/mnt/main/docs');
+  });
+  it('returns the mountpoint path for an empty relative path', () => {
+    expect(getFullPath(raid, '')).toBe('/mnt/main');
+  });
+  it('returns the relative path unchanged with no mountpoint', () => {
+    expect(getFullPath(null, 'docs')).toBe('docs');
+  });
+});
+
+describe('toRelativePath', () => {
+  it('strips the mountpoint prefix for real mounts', () => {
+    expect(toRelativePath(raid, '/mnt/main/docs')).toBe('docs');
+  });
+  it('returns unchanged for dev-storage or a non-matching prefix', () => {
+    expect(toRelativePath(dev, 'docs')).toBe('docs');
+    expect(toRelativePath(raid, '/other/docs')).toBe('/other/docs');
+  });
+});
+
+describe('parentPath', () => {
+  it('drops the last segment', () => {
+    expect(parentPath('a/b/c')).toBe('a/b');
+  });
+  it('returns empty for a single segment or empty input', () => {
+    expect(parentPath('a')).toBe('');
+    expect(parentPath('')).toBe('');
+  });
+});

--- a/client/src/__tests__/hooks/useFileBrowser.test.tsx
+++ b/client/src/__tests__/hooks/useFileBrowser.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string, d?: string) => d ?? k }) }));
+vi.mock('../../api/files', () => ({
+  getMountpoints: vi.fn(),
+  listFiles: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  renameFile: vi.fn(),
+  downloadFileBlob: vi.fn(),
+}));
+
+import * as filesApi from '../../api/files';
+import { useFileBrowser } from '../../hooks/useFileBrowser';
+
+const mp = { id: 'a', name: 'Main', type: 'raid', path: '/mnt/main', size_bytes: 100, used_bytes: 40, available_bytes: 60, status: 'ok', is_default: true };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(filesApi.getMountpoints).mockResolvedValue({ mountpoints: [mp] } as never);
+  vi.mocked(filesApi.listFiles).mockResolvedValue({ files: [{ name: 'a.txt', path: 'a.txt', size: 1, type: 'file', modified_at: '2026-01-01T00:00:00Z' }] } as never);
+  vi.mocked(filesApi.createFolder).mockResolvedValue({} as never);
+  vi.mocked(filesApi.deleteFile).mockResolvedValue({} as never);
+  vi.mocked(filesApi.renameFile).mockResolvedValue({} as never);
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('useFileBrowser', () => {
+  it('auto-selects the default mountpoint and lists its root', async () => {
+    const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.selectedMountpoint?.id).toBe('a'));
+    expect(result.current.currentPath).toBe('');
+    await waitFor(() => expect(result.current.files).toHaveLength(1));
+    expect(filesApi.listFiles).toHaveBeenCalledWith('/mnt/main');
+    expect(result.current.files[0].name).toBe('a.txt');
+    expect(result.current.storageInfo).toEqual({ totalBytes: 100, usedBytes: 40, availableBytes: 60 });
+  });
+
+  it('does not list before a mountpoint is selected', async () => {
+    vi.mocked(filesApi.getMountpoints).mockResolvedValue({ mountpoints: [] } as never);
+    const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    // Wait until mountpoints have actually resolved (empty) — proves the empty
+    // result does not select a mountpoint and therefore never lists.
+    await waitFor(() => expect(filesApi.getMountpoints).toHaveBeenCalled());
+    await act(async () => { await Promise.resolve(); });
+    expect(result.current.selectedMountpoint).toBeNull();
+    expect(filesApi.listFiles).not.toHaveBeenCalled();
+  });
+
+  it('navigateToFolder re-lists the new full path', async () => {
+    const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.selectedMountpoint?.id).toBe('a'));
+    act(() => result.current.navigateToFolder('/mnt/main/docs'));
+    await waitFor(() => expect(result.current.currentPath).toBe('docs'));
+    await waitFor(() => expect(filesApi.listFiles).toHaveBeenCalledWith('/mnt/main/docs'));
+  });
+
+  it('createFolder posts and invalidates the listing', async () => {
+    const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.files).toHaveLength(1));
+    expect(filesApi.listFiles).toHaveBeenCalledTimes(1);
+    let ok = false;
+    await act(async () => { ok = await result.current.createFolder('New'); });
+    expect(ok).toBe(true);
+    expect(filesApi.createFolder).toHaveBeenCalledWith({ path: '/mnt/main', name: 'New' });
+    await waitFor(() => expect(filesApi.listFiles).toHaveBeenCalledTimes(2));
+  });
+
+  it('createFolder rejects an empty name without calling the API', async () => {
+    const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.selectedMountpoint?.id).toBe('a'));
+    let ok = true;
+    await act(async () => { ok = await result.current.createFolder('   '); });
+    expect(ok).toBe(false);
+    expect(filesApi.createFolder).not.toHaveBeenCalled();
+  });
+
+  it('deleteFile and renameFile call the API with the file path', async () => {
+    const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.files).toHaveLength(1));
+    await act(async () => { await result.current.deleteFile(result.current.files[0]); });
+    expect(filesApi.deleteFile).toHaveBeenCalledWith('a.txt');
+    await act(async () => { await result.current.renameFile(result.current.files[0], 'b.txt'); });
+    expect(filesApi.renameFile).toHaveBeenCalledWith({ old_path: 'a.txt', new_name: 'b.txt' });
+  });
+});

--- a/client/src/__tests__/hooks/useFileBrowser.test.tsx
+++ b/client/src/__tests__/hooks/useFileBrowser.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../../api/files', () => ({
 }));
 
 import * as filesApi from '../../api/files';
+import toast from 'react-hot-toast';
 import { useFileBrowser } from '../../hooks/useFileBrowser';
 
 const mp = { id: 'a', name: 'Main', type: 'raid', path: '/mnt/main', size_bytes: 100, used_bytes: 40, available_bytes: 60, status: 'ok', is_default: true };
@@ -29,6 +30,13 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe('useFileBrowser', () => {
+  it('surfaces a toast when the directory listing fails', async () => {
+    vi.mocked(filesApi.listFiles).mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.selectedMountpoint?.id).toBe('a'));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('boom'));
+  });
+
   it('auto-selects the default mountpoint and lists its root', async () => {
     const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
     await waitFor(() => expect(result.current.selectedMountpoint?.id).toBe('a'));

--- a/client/src/api/files.ts
+++ b/client/src/api/files.ts
@@ -3,6 +3,7 @@
  */
 
 import { apiClient } from '../lib/api';
+import type { ApiFileItem, StorageMountpoint } from '../components/file-manager/types';
 
 // --- Duplicate Check API ---
 
@@ -115,5 +116,37 @@ export async function enforceResidency(
 
 export async function getUserRootUsage(): Promise<UserRootUsage> {
   const res = await apiClient.get('/api/files/user/root-usage');
+  return res.data;
+}
+
+// --- Browser-core (list, mountpoints, folder CRUD, download) ---
+
+export async function getMountpoints(): Promise<{ mountpoints: StorageMountpoint[] }> {
+  const res = await apiClient.get('/api/files/mountpoints');
+  return res.data;
+}
+
+export async function listFiles(fullPath: string): Promise<{ files: ApiFileItem[] }> {
+  const res = await apiClient.get('/api/files/list', { params: { path: fullPath } });
+  return res.data;
+}
+
+export async function createFolder(params: { path: string; name: string }): Promise<unknown> {
+  const res = await apiClient.post('/api/files/folder', params);
+  return res.data;
+}
+
+export async function deleteFile(path: string): Promise<unknown> {
+  const res = await apiClient.delete(`/api/files/${encodeURIComponent(path)}`);
+  return res.data;
+}
+
+export async function renameFile(params: { old_path: string; new_name: string }): Promise<unknown> {
+  const res = await apiClient.put('/api/files/rename', params);
+  return res.data;
+}
+
+export async function downloadFileBlob(path: string): Promise<Blob> {
+  const res = await apiClient.get(`/api/files/download/${encodeURIComponent(path)}`, { responseType: 'blob' });
   return res.data;
 }

--- a/client/src/components/file-manager/utils.ts
+++ b/client/src/components/file-manager/utils.ts
@@ -1,0 +1,50 @@
+import type { ApiFileItem, FileItem, StorageMountpoint } from './types';
+
+/** Maps a raw API file item to the UI `FileItem` shape (moved from FileManager.loadFiles). */
+export function mapApiFileItem(file: ApiFileItem): FileItem {
+  return {
+    name: file.name,
+    path: file.path,
+    size: file.size,
+    type: file.type,
+    modifiedAt: file.modified_at ?? file.mtime ?? new Date().toISOString(),
+    ownerId: file.ownerId ?? file.owner_id,
+    ownerName: file.ownerName ?? file.owner_name,
+    file_id: file.file_id,
+    syncInfo: file.sync_info?.map((si) => ({
+      deviceName: si.device_name,
+      platform: si.platform as 'windows' | 'mac' | 'linux',
+      syncDirection: si.sync_direction as 'bidirectional' | 'push' | 'pull',
+      lastReportedAt: si.last_reported_at,
+    })),
+    canRead: file.can_read ?? undefined,
+    canWrite: file.can_write ?? undefined,
+    canDelete: file.can_delete ?? undefined,
+  };
+}
+
+/** Resolves a relative browser path to the backend full path for a mountpoint. */
+export function getFullPath(mountpoint: StorageMountpoint | null, relativePath: string): string {
+  if (!mountpoint) return relativePath;
+  if (mountpoint.type === 'dev-storage') return relativePath;
+  const clean = relativePath.startsWith('/') ? relativePath.slice(1) : relativePath;
+  return clean ? `${mountpoint.path}/${clean}` : mountpoint.path;
+}
+
+/** Inverse of getFullPath for navigation: strips the mountpoint prefix (real mounts only). */
+export function toRelativePath(mountpoint: StorageMountpoint | null, folderPath: string): string {
+  if (mountpoint && mountpoint.type !== 'dev-storage') {
+    const prefix = mountpoint.path;
+    if (folderPath.startsWith(prefix)) {
+      return folderPath.slice(prefix.length).replace(/^\//, '');
+    }
+  }
+  return folderPath;
+}
+
+/** Parent of a relative path (drops the last segment). */
+export function parentPath(currentPath: string): string {
+  const parts = currentPath.split('/').filter(Boolean);
+  parts.pop();
+  return parts.join('/');
+}

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -36,6 +36,7 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useNetworkStatus.ts` | `api/monitoring` | Current network I/O for `NetworkWidget` via **TanStack Query** (`useQuery`, default 3s poll via `refreshInterval`→`refetchInterval`, `queryKeys.monitoring.networkCurrent()` key). Shares that key with `useNetworkMonitoring` → the two former pollers of the same endpoint collapse to one cache entry + one poll (#299). Public shape unchanged (`{ status, loading, error, refetch }`); `formatNetworkSpeed` helper co-located |
 | `useUptimeData.ts` | `api/monitoring` | Uptime current + history for the SystemMonitor `UptimeTab` via **TanStack Query** (`useQuery`, default 10s poll, `monitoring.uptimeCurrent()` / `uptimeHistory(range)` keys). Replaced the tab's hand-rolled `setInterval`; returns `{ current, history, sleepEvents, error }` (keeps last value on transient errors — TanStack default). The tab's 1s live-counter tick stays in the component (animation, not a fetch) |
 | `useOpenApiSchema.ts` | — | OpenAPI schema for API docs page |
+| `useFileBrowser.ts` | `api/files` | Browsing core for `FileManager` via **TanStack Query**: mountpoints + directory listing (`files.list(fullPath)` key), navigation (`selectMountpoint`/`navigateToFolder`/`goBack`/`goHome`), derived `storageInfo`, and create/delete/rename mutations that `refresh()` (invalidate the listing). Replaces the page's hand-rolled `sessionStorage` file cache (F2/#301, PR-1) |
 
 ## Utility Hooks
 

--- a/client/src/hooks/useFileBrowser.ts
+++ b/client/src/hooks/useFileBrowser.ts
@@ -89,6 +89,14 @@ export function useFileBrowser(): UseFileBrowserResult {
   const files = filesQuery.data ?? EMPTY_FILES;
   const loading = filesQuery.isFetching;
 
+  // Preserve the original loadFiles() error toast. File listing is user-initiated
+  // navigation, so a failed listing must surface (not silently keep the last value).
+  useEffect(() => {
+    if (filesQuery.isError) {
+      toast.error(filesQuery.error instanceof Error ? filesQuery.error.message : 'Failed to load files');
+    }
+  }, [filesQuery.isError, filesQuery.error]);
+
   const storageInfo: StorageInfo | null = selectedMountpoint
     ? {
         totalBytes: selectedMountpoint.size_bytes,

--- a/client/src/hooks/useFileBrowser.ts
+++ b/client/src/hooks/useFileBrowser.ts
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { queryKeys } from '../lib/queryKeys';
+import {
+  getMountpoints,
+  listFiles,
+  createFolder as apiCreateFolder,
+  deleteFile as apiDeleteFile,
+  renameFile as apiRenameFile,
+  downloadFileBlob,
+} from '../api/files';
+import { getFullPath, mapApiFileItem, parentPath, toRelativePath } from '../components/file-manager/utils';
+import type { FileItem, StorageInfo, StorageMountpoint } from '../components/file-manager/types';
+
+// Stable empty-array references. IMPORTANT: the page has effects keyed on `files`
+// (e.g. the owner-name cache in FileManager.tsx). Returning a fresh `[]` on every
+// render while the query has no data yet would re-fire those effects every render
+// (setUserCache → re-render → new [] → …), an infinite loop. Keep these stable.
+const EMPTY_FILES: FileItem[] = [];
+const EMPTY_MOUNTPOINTS: StorageMountpoint[] = [];
+
+const getErrorMessage = (error: unknown): string => {
+  if (!error || typeof error !== 'object') return 'Unknown error';
+  const obj = error as Record<string, unknown>;
+  return String(obj.error ?? obj.detail ?? 'Unknown error');
+};
+const errDetail = (err: unknown) => (err as { response?: { data?: unknown } })?.response?.data ?? err;
+
+export interface UseFileBrowserResult {
+  mountpoints: StorageMountpoint[];
+  selectedMountpoint: StorageMountpoint | null;
+  selectMountpoint: (mp: StorageMountpoint) => void;
+  currentPath: string;
+  getFullPath: (path?: string) => string;
+  navigateToFolder: (folderPath: string) => void;
+  goBack: () => void;
+  goHome: () => void;
+  files: FileItem[];
+  loading: boolean;
+  storageInfo: StorageInfo | null;
+  createFolder: (name: string) => Promise<boolean>;
+  deleteFile: (file: FileItem) => Promise<boolean>;
+  renameFile: (file: FileItem, newName: string) => Promise<boolean>;
+  downloadFile: (file: FileItem) => Promise<void>;
+  refresh: () => void;
+}
+
+export function useFileBrowser(): UseFileBrowserResult {
+  const { t } = useTranslation(['fileManager', 'common']);
+  const queryClient = useQueryClient();
+  const [selectedMountpoint, setSelectedMountpoint] = useState<StorageMountpoint | null>(null);
+  const [currentPath, setCurrentPath] = useState('');
+
+  const mountpointsQuery = useQuery({ queryKey: queryKeys.files.mountpoints(), queryFn: getMountpoints });
+
+  // Auto-select the default mountpoint once loaded (matches the old loadMountpoints()).
+  useEffect(() => {
+    if (selectedMountpoint || !mountpointsQuery.data) return;
+    const mps = mountpointsQuery.data.mountpoints;
+    const def = mps.find((mp) => mp.is_default) ?? mps[0];
+    if (def) {
+      setSelectedMountpoint(def);
+      setCurrentPath('');
+    }
+  }, [mountpointsQuery.data, selectedMountpoint]);
+
+  // Preserve the original toast on a mountpoints load failure.
+  useEffect(() => {
+    if (mountpointsQuery.isError) toast.error('Failed to load storage devices');
+  }, [mountpointsQuery.isError]);
+
+  const resolveFullPath = useCallback(
+    (path: string = currentPath) => getFullPath(selectedMountpoint, path),
+    [selectedMountpoint, currentPath],
+  );
+  const fullPath = resolveFullPath();
+
+  const filesQuery = useQuery({
+    queryKey: queryKeys.files.list(fullPath),
+    queryFn: async () => {
+      const data = await listFiles(fullPath);
+      return Array.isArray(data.files) ? data.files.map(mapApiFileItem) : [];
+    },
+    enabled: !!selectedMountpoint,
+  });
+
+  const files = filesQuery.data ?? EMPTY_FILES;
+  const loading = filesQuery.isFetching;
+
+  const storageInfo: StorageInfo | null = selectedMountpoint
+    ? {
+        totalBytes: selectedMountpoint.size_bytes,
+        usedBytes: selectedMountpoint.used_bytes,
+        availableBytes: selectedMountpoint.available_bytes,
+      }
+    : null;
+
+  const refresh = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: queryKeys.files.list(fullPath) });
+  }, [queryClient, fullPath]);
+
+  const selectMountpoint = useCallback((mp: StorageMountpoint) => {
+    setSelectedMountpoint(mp);
+    setCurrentPath('');
+  }, []);
+
+  const navigateToFolder = useCallback(
+    (folderPath: string) => setCurrentPath(toRelativePath(selectedMountpoint, folderPath)),
+    [selectedMountpoint],
+  );
+  const goBack = useCallback(() => setCurrentPath((p) => parentPath(p)), []);
+  const goHome = useCallback(() => setCurrentPath(''), []);
+
+  const createFolder = useCallback(
+    async (name: string): Promise<boolean> => {
+      if (!name.trim()) {
+        toast.error(t('fileManager:messages.enterFolderName', 'Please enter a folder name'));
+        return false;
+      }
+      try {
+        await apiCreateFolder({ path: resolveFullPath(), name });
+        toast.success(t('fileManager:messages.folderCreated', 'Folder created successfully'));
+        refresh();
+        return true;
+      } catch (err) {
+        toast.error(`${t('fileManager:messages.folderError', 'Failed to create folder')}: ${getErrorMessage(errDetail(err))}`);
+        return false;
+      }
+    },
+    [t, resolveFullPath, refresh],
+  );
+
+  const deleteFile = useCallback(
+    async (file: FileItem): Promise<boolean> => {
+      try {
+        await apiDeleteFile(file.path);
+        toast.success(t('fileManager:messages.deleteSuccess'));
+        refresh();
+        return true;
+      } catch (err) {
+        toast.error(`${t('fileManager:messages.deleteError')}: ${getErrorMessage(errDetail(err))}`);
+        return false;
+      }
+    },
+    [t, refresh],
+  );
+
+  const renameFile = useCallback(
+    async (file: FileItem, newName: string): Promise<boolean> => {
+      if (!newName.trim()) {
+        toast.error(t('fileManager:messages.enterFileName', 'Please enter a valid file name'));
+        return false;
+      }
+      try {
+        await apiRenameFile({ old_path: file.path, new_name: newName });
+        toast.success(t('fileManager:messages.renameSuccess'));
+        refresh();
+        return true;
+      } catch (err) {
+        toast.error(`${t('fileManager:messages.renameError')}: ${getErrorMessage(errDetail(err))}`);
+        return false;
+      }
+    },
+    [t, refresh],
+  );
+
+  const downloadFile = useCallback(
+    async (file: FileItem): Promise<void> => {
+      if (file.type === 'directory') return;
+      try {
+        const blob = await downloadFileBlob(file.path);
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = file.name;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        window.URL.revokeObjectURL(url);
+      } catch {
+        toast.error(t('fileManager:messages.downloadError', 'Download failed'));
+      }
+    },
+    [t],
+  );
+
+  return {
+    mountpoints: mountpointsQuery.data?.mountpoints ?? EMPTY_MOUNTPOINTS,
+    selectedMountpoint,
+    selectMountpoint,
+    currentPath,
+    getFullPath: resolveFullPath,
+    navigateToFolder,
+    goBack,
+    goHome,
+    files,
+    loading,
+    storageInfo,
+    createFolder,
+    deleteFile,
+    renameFile,
+    downloadFile,
+    refresh,
+  };
+}

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -40,6 +40,12 @@ export const queryKeys = {
   backups: {
     list: () => ['backups', 'list'] as const,
   },
+  files: {
+    all: () => ['files'] as const,
+    mountpoints: () => ['files', 'mountpoints'] as const,
+    /** Directory listing; the resolved backend full path is part of the key. */
+    list: (fullPath: string) => ['files', 'list', fullPath] as const,
+  },
   cloudImport: {
     connections: () => ['cloud-import', 'connections'] as const,
     /** Import jobs; polled while any job is running/pending (see useCloudImportData). */

--- a/client/src/pages/FileManager.tsx
+++ b/client/src/pages/FileManager.tsx
@@ -10,7 +10,6 @@ import {
   Loader2,
 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
-import { apiClient } from '../lib/api';
 import { getFilePermissions, getUserRootUsage, setFilePermissions } from '../api/files';
 import { getShareableUsers } from '../api/shares';
 import { VersionHistoryModal } from '../components/vcl/VersionHistoryModal';
@@ -26,7 +25,8 @@ import { DeleteDialog } from '../components/file-manager/DeleteDialog';
 import { RenameDialog } from '../components/file-manager/RenameDialog';
 import { useUpload } from '../contexts/UploadContext';
 import ShareFileModal from '../components/ShareFileModal';
-import type { StorageInfo, StorageMountpoint, FileItem, ApiFileItem, PermissionRule } from '../components/file-manager/types';
+import { useFileBrowser } from '../hooks/useFileBrowser';
+import type { FileItem, PermissionRule } from '../components/file-manager/types';
 
 export default function FileManager() {
   const { user } = useAuth();
@@ -81,9 +81,12 @@ export default function FileManager() {
 
   // User cache for owner names
   const [userCache, setUserCache] = useState<Record<string, string>>({});
-  const [files, setFiles] = useState<FileItem[]>([]);
-  const [currentPath, setCurrentPath] = useState('');
-  const [loading, setLoading] = useState(false);
+  const {
+    mountpoints, selectedMountpoint, selectMountpoint,
+    currentPath, getFullPath, navigateToFolder, goBack, goHome,
+    files, loading, storageInfo,
+    createFolder, deleteFile, renameFile, downloadFile, refresh,
+  } = useFileBrowser();
   const { startUpload, isUploading, onUploadsComplete } = useUpload();
   const [showNewFolderDialog, setShowNewFolderDialog] = useState(false);
   const [newFolderName, setNewFolderName] = useState('');
@@ -94,9 +97,6 @@ export default function FileManager() {
   const [newFileName, setNewFileName] = useState('');
   const [dragActive, setDragActive] = useState(false);
   const [viewingFile, setViewingFile] = useState<FileItem | null>(null);
-  const [storageInfo, setStorageInfo] = useState<StorageInfo | null>(null);
-  const [mountpoints, setMountpoints] = useState<StorageMountpoint[]>([]);
-  const [selectedMountpoint, setSelectedMountpoint] = useState<StorageMountpoint | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const folderInputRef = useRef<HTMLInputElement>(null);
 
@@ -114,14 +114,7 @@ export default function FileManager() {
   } | null>(null);
   const [userRootUsageBytes, setUserRootUsageBytes] = useState<number | null>(null);
 
-  const getErrorMessage = (error: unknown): string => {
-    if (!error || typeof error !== 'object') return 'Unknown error';
-    const obj = error as Record<string, unknown>;
-    return String(obj.error ?? obj.detail ?? 'Unknown error');
-  };
-
   useEffect(() => {
-    loadMountpoints();
     loadVclQuota();
     loadUserRootUsage();
   }, []);
@@ -129,21 +122,11 @@ export default function FileManager() {
   // Reload files + storage when uploads complete
   useEffect(() => {
     return onUploadsComplete(() => {
-      sessionStorage.removeItem(`files_cache_${currentPath}`);
-      sessionStorage.removeItem('storage_info_cache');
-      loadFiles(currentPath, false);
-      loadStorageInfo();
+      refresh();
       loadVclQuota();
       loadUserRootUsage();
     });
-  }, [currentPath, onUploadsComplete]);
-
-  useEffect(() => {
-    if (selectedMountpoint) {
-      loadFiles(currentPath);
-      loadStorageInfo();
-    }
-  }, [currentPath, selectedMountpoint]);
+  }, [onUploadsComplete, refresh]);
 
   // Load VCL Quota
   const loadVclQuota = async () => {
@@ -268,99 +251,6 @@ export default function FileManager() {
 
   if (!user) return null;
 
-  const loadMountpoints = async () => {
-    try {
-      const { data } = await apiClient.get('/api/files/mountpoints');
-      setMountpoints(data.mountpoints || []);
-
-      const defaultMp = data.mountpoints.find((mp: StorageMountpoint) => mp.is_default)
-                       || data.mountpoints[0];
-      if (defaultMp) {
-        setSelectedMountpoint(defaultMp);
-        setCurrentPath('');
-      }
-    } catch {
-      toast.error('Failed to load storage devices');
-    }
-  };
-
-  const loadStorageInfo = async () => {
-    if (!selectedMountpoint) return;
-
-    const info = {
-      totalBytes: selectedMountpoint.size_bytes,
-      usedBytes: selectedMountpoint.used_bytes,
-      availableBytes: selectedMountpoint.available_bytes
-    };
-    setStorageInfo(info);
-  };
-
-  const getFullPath = (relativePath: string = currentPath): string => {
-    if (!selectedMountpoint) return relativePath;
-
-    if (selectedMountpoint.type === 'dev-storage') {
-      return relativePath;
-    }
-
-    const cleanRelativePath = relativePath.startsWith('/') ? relativePath.slice(1) : relativePath;
-    return cleanRelativePath ? `${selectedMountpoint.path}/${cleanRelativePath}` : selectedMountpoint.path;
-  };
-
-  const loadFiles = async (path: string, useCache = true) => {
-    if (!selectedMountpoint) return;
-
-    const fullPath = getFullPath(path);
-
-    if (useCache) {
-      const cacheKey = `files_cache_${fullPath}`;
-      const cachedData = sessionStorage.getItem(cacheKey);
-      if (cachedData) {
-        try {
-          const cached = JSON.parse(cachedData);
-          setFiles(cached.files);
-        } catch {
-          // ignore cache parse errors
-        }
-      }
-    }
-
-    setLoading(true);
-
-    try {
-      const { data } = await apiClient.get('/api/files/list', { params: { path: fullPath } });
-      if (Array.isArray(data.files)) {
-        const mappedFiles: FileItem[] = (data.files as ApiFileItem[]).map((file) => ({
-          name: file.name,
-          path: file.path,
-          size: file.size,
-          type: file.type,
-          modifiedAt: file.modified_at ?? file.mtime ?? new Date().toISOString(),
-          ownerId: file.ownerId ?? file.owner_id,
-          ownerName: file.ownerName ?? file.owner_name,
-          file_id: file.file_id,
-          syncInfo: file.sync_info?.map(si => ({
-            deviceName: si.device_name,
-            platform: si.platform as 'windows' | 'mac' | 'linux',
-            syncDirection: si.sync_direction as 'bidirectional' | 'push' | 'pull',
-            lastReportedAt: si.last_reported_at,
-          })),
-          canRead: file.can_read ?? undefined,
-          canWrite: file.can_write ?? undefined,
-          canDelete: file.can_delete ?? undefined,
-        }));
-        setFiles(mappedFiles);
-
-        const cacheKey = `files_cache_${fullPath}`;
-        sessionStorage.setItem(cacheKey, JSON.stringify({ files: mappedFiles, timestamp: Date.now() }));
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to load files';
-      toast.error(msg);
-    } finally {
-      setLoading(false);
-    }
-  };
-
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const fileList = e.target.files;
     if (!fileList) return;
@@ -375,98 +265,15 @@ export default function FileManager() {
     e.target.value = '';
   };
 
-  const handleDownload = async (file: FileItem) => {
-    if (file.type === 'directory') return;
-
-    try {
-      const { data: blob } = await apiClient.get(`/api/files/download/${encodeURIComponent(file.path)}`, {
-        responseType: 'blob',
-      });
-      const downloadUrl = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = downloadUrl;
-      a.download = file.name;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      window.URL.revokeObjectURL(downloadUrl);
-    } catch {
-      toast.error(t('fileManager:messages.downloadError', 'Download failed'));
-    }
-  };
-
-  const handleCreateFolder = async () => {
-    if (!newFolderName.trim()) {
-      toast.error(t('fileManager:messages.enterFolderName', 'Please enter a folder name'));
-      return;
-    }
-
-    try {
-      await apiClient.post('/api/files/folder', {
-        path: getFullPath(),
-        name: newFolderName,
-      });
-      toast.success(t('fileManager:messages.folderCreated', 'Folder created successfully'));
-      setShowNewFolderDialog(false);
-      setNewFolderName('');
-      sessionStorage.removeItem(`files_cache_${currentPath}`);
-      loadFiles(currentPath, false);
-    } catch (err: unknown) {
-      const detail = (err as { response?: { data?: unknown } })?.response?.data;
-      toast.error(`${t('fileManager:messages.folderError', 'Failed to create folder')}: ${getErrorMessage(detail ?? err)}`);
-    }
-  };
-
   const confirmDelete = (file: FileItem) => {
     setFileToDelete(file);
     setShowDeleteDialog(true);
-  };
-
-  const handleDelete = async () => {
-    if (!fileToDelete) return;
-
-    try {
-      await apiClient.delete(`/api/files/${encodeURIComponent(fileToDelete.path)}`);
-      toast.success(t('fileManager:messages.deleteSuccess'));
-      setShowDeleteDialog(false);
-      setFileToDelete(null);
-      sessionStorage.removeItem(`files_cache_${currentPath}`);
-      sessionStorage.removeItem('storage_info_cache');
-      loadFiles(currentPath, false);
-      loadStorageInfo();
-    } catch (err: unknown) {
-      const detail = (err as { response?: { data?: unknown } })?.response?.data;
-      toast.error(`${t('fileManager:messages.deleteError')}: ${getErrorMessage(detail ?? err)}`);
-    }
   };
 
   const startRename = (file: FileItem) => {
     setFileToRename(file);
     setNewFileName(file.name);
     setShowRenameDialog(true);
-  };
-
-  const handleRename = async () => {
-    if (!fileToRename || !newFileName.trim()) {
-      toast.error(t('fileManager:messages.enterFileName', 'Please enter a valid file name'));
-      return;
-    }
-
-    try {
-      await apiClient.put('/api/files/rename', {
-        old_path: fileToRename.path,
-        new_name: newFileName,
-      });
-      toast.success(t('fileManager:messages.renameSuccess'));
-      setShowRenameDialog(false);
-      setFileToRename(null);
-      setNewFileName('');
-      sessionStorage.removeItem(`files_cache_${currentPath}`);
-      loadFiles(currentPath, false);
-    } catch (err: unknown) {
-      const detail = (err as { response?: { data?: unknown } })?.response?.data;
-      toast.error(`${t('fileManager:messages.renameError')}: ${getErrorMessage(detail ?? err)}`);
-    }
   };
 
   const handleDrag = (e: React.DragEvent) => {
@@ -542,25 +349,6 @@ export default function FileManager() {
 
   const handleViewFile = (file: FileItem) => {
     setViewingFile(file);
-  };
-
-  const navigateToFolder = (folderPath: string) => {
-    if (selectedMountpoint && selectedMountpoint.type !== 'dev-storage') {
-      const mountpointPrefix = selectedMountpoint.path;
-      if (folderPath.startsWith(mountpointPrefix)) {
-        const relativePath = folderPath.slice(mountpointPrefix.length).replace(/^\//, '');
-        setCurrentPath(relativePath);
-        return;
-      }
-    }
-    setCurrentPath(folderPath);
-  };
-
-  const goBack = () => {
-    const parts = currentPath.split('/').filter(Boolean);
-    parts.pop();
-    const parentPath = parts.join('/');
-    setCurrentPath(parentPath);
   };
 
   const handleEditPermissionsClick = async (file: FileItem) => {
@@ -742,17 +530,14 @@ export default function FileManager() {
       <StorageSelector
         mountpoints={mountpoints}
         selectedMountpoint={selectedMountpoint}
-        onSelect={(mp) => {
-          setSelectedMountpoint(mp);
-          setCurrentPath('');
-        }}
+        onSelect={selectMountpoint}
       />
 
       {/* Breadcrumb Navigation */}
       <div className="card border-slate-800/60 bg-slate-900/55">
         <div className="flex flex-wrap items-center gap-2 sm:gap-3 text-xs sm:text-sm text-slate-400">
           <button
-            onClick={() => setCurrentPath('')}
+            onClick={goHome}
             className="rounded-full border border-slate-700/70 bg-slate-950/70 px-2.5 sm:px-3 py-1.5 text-[10px] sm:text-xs font-medium uppercase tracking-[0.15em] sm:tracking-[0.2em] text-slate-300 transition hover:border-slate-600 hover:text-white touch-manipulation active:scale-95"
           >
             {t('fileManager:labels.home', 'Home')}
@@ -790,7 +575,7 @@ export default function FileManager() {
           isCurrentUserOwnerOrAdmin={isCurrentUserOwnerOrAdmin}
           onNavigate={navigateToFolder}
           onView={handleViewFile}
-          onDownload={handleDownload}
+          onDownload={downloadFile}
           onRename={startRename}
           onDelete={confirmDelete}
           onVersionHistory={handleVersionHistory}
@@ -812,7 +597,7 @@ export default function FileManager() {
         <NewFolderDialog
           folderName={newFolderName}
           onFolderNameChange={setNewFolderName}
-          onCreate={handleCreateFolder}
+          onCreate={async () => { if (await createFolder(newFolderName)) { setShowNewFolderDialog(false); setNewFolderName(''); } }}
           onClose={() => { setShowNewFolderDialog(false); setNewFolderName(''); }}
         />
       )}
@@ -821,7 +606,7 @@ export default function FileManager() {
       {showDeleteDialog && fileToDelete && (
         <DeleteDialog
           file={fileToDelete}
-          onConfirm={handleDelete}
+          onConfirm={async () => { if (fileToDelete && await deleteFile(fileToDelete)) { setShowDeleteDialog(false); setFileToDelete(null); } }}
           onClose={() => { setShowDeleteDialog(false); setFileToDelete(null); }}
         />
       )}
@@ -832,7 +617,7 @@ export default function FileManager() {
           file={fileToRename}
           newName={newFileName}
           onNameChange={setNewFileName}
-          onRename={handleRename}
+          onRename={async () => { if (fileToRename && await renameFile(fileToRename, newFileName)) { setShowRenameDialog(false); setFileToRename(null); setNewFileName(''); } }}
           onClose={() => { setShowRenameDialog(false); setFileToRename(null); setNewFileName(''); }}
         />
       )}
@@ -852,7 +637,7 @@ export default function FileManager() {
             setVersionHistoryFile(null);
           }}
           onVersionRestored={() => {
-            loadFiles(currentPath, false);
+            refresh();
           }}
         />
       )}
@@ -890,7 +675,7 @@ export default function FileManager() {
             }));
             setShowOwnershipModal(false);
             setFileToTransfer(null);
-            loadFiles(currentPath, false);
+            refresh();
           }}
         />
       )}

--- a/docs/superpowers/plans/2026-07-09-f2-filemanager-browser-core.md
+++ b/docs/superpowers/plans/2026-07-09-f2-filemanager-browser-core.md
@@ -1,0 +1,701 @@
+# F2 — FileManager Browser-Core (PR-1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the FileManager browsing core (mountpoints, file list, navigation, file CRUD) into one query-backed hook `useFileBrowser` + pure helpers, replacing the hand-rolled `sessionStorage` file cache with TanStack Query.
+
+**Architecture:** New pure helpers in `components/file-manager/utils.ts`; new typed api functions in `api/files.ts`; new `hooks/useFileBrowser.ts` owning two `useQuery`s (mountpoints, list) + three mutations (create/delete/rename); page composes the hook. VCL, upload/drag-drop, and the permission/ownership/share modals stay untouched for PR-2.
+
+**Tech Stack:** React 18 + TypeScript, TanStack Query v5, react-i18next, react-hot-toast, Vitest + React Testing Library (`renderHook` + `createQueryWrapper`).
+
+## Global Constraints
+
+- **Behavior-preserving except the intended cache swap.** Same listings, same navigation, same CRUD toasts (exact i18n keys), a refetch after each mutation / upload-complete / version-restore. The only deliberate change: the manual `sessionStorage` file cache (`files_cache_*`) is gone — the list is a `useQuery`, instant-paint now comes from the app-wide persister.
+- **No UX/layout change. No new dependencies.**
+- `loading` = the list query's `isFetching` (the original set `loading` true on every `loadFiles` call).
+- `storageInfo` is **derived** from `selectedMountpoint` (no fetch). `storage_info_cache` sessionStorage is dead — remove it.
+- Hooks call **typed `api/*` functions**, never `apiClient` directly (`api/CLAUDE.md`). Add the browser-core functions to `api/files.ts`.
+- Test pattern: `renderHook` + `createQueryWrapper` from `src/__tests__/helpers/queryClient` (mock `api/files`, `react-hot-toast`, `react-i18next`); pure helpers get plain unit tests.
+- Windows shell: chain with `;`, never `&&`.
+- Scope is PR-1 only. Do NOT touch VCL (quota/user-root-usage/version-counts/tracking), upload/drag-drop, or the permission/ownership/share modals — they stay and keep reading the hook's `files`.
+
+---
+
+### Task 1: Pure helpers in `components/file-manager/utils.ts`
+
+**Files:**
+- Create: `client/src/components/file-manager/utils.ts`
+- Test: `client/src/__tests__/components/file-manager/utils.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `mapApiFileItem(raw: ApiFileItem): FileItem`
+  - `getFullPath(mountpoint: StorageMountpoint | null, relativePath: string): string`
+  - `toRelativePath(mountpoint: StorageMountpoint | null, folderPath: string): string`
+  - `parentPath(currentPath: string): string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/components/file-manager/utils.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { mapApiFileItem, getFullPath, toRelativePath, parentPath } from '../../../components/file-manager/utils';
+import type { ApiFileItem, StorageMountpoint } from '../../../components/file-manager/types';
+
+const raid: StorageMountpoint = {
+  id: 'a', name: 'Main', type: 'raid', path: '/mnt/main',
+  size_bytes: 100, used_bytes: 40, available_bytes: 60, status: 'ok', is_default: true,
+};
+const dev: StorageMountpoint = { ...raid, id: 'd', type: 'dev-storage', path: 'dev-storage' };
+
+describe('mapApiFileItem', () => {
+  it('maps a full API item incl. sync_info and snake_case fallbacks', () => {
+    const raw: ApiFileItem = {
+      name: 'a.txt', path: 'docs/a.txt', size: 12, type: 'file',
+      modified_at: '2026-01-01T00:00:00Z', owner_id: 7, owner_name: 'bob', file_id: 3,
+      sync_info: [{ device_name: 'pc', platform: 'windows', sync_direction: 'push', last_reported_at: 't' }],
+      can_read: true, can_write: false, can_delete: true,
+    };
+    expect(mapApiFileItem(raw)).toEqual({
+      name: 'a.txt', path: 'docs/a.txt', size: 12, type: 'file',
+      modifiedAt: '2026-01-01T00:00:00Z', ownerId: 7, ownerName: 'bob', file_id: 3,
+      syncInfo: [{ deviceName: 'pc', platform: 'windows', syncDirection: 'push', lastReportedAt: 't' }],
+      canRead: true, canWrite: false, canDelete: true,
+    });
+  });
+
+  it('falls back mtime->modifiedAt and leaves a timestamp when none given', () => {
+    const m = mapApiFileItem({ name: 'x', path: 'x', size: 0, type: 'directory', mtime: 'm1' });
+    expect(m.modifiedAt).toBe('m1');
+    const n = mapApiFileItem({ name: 'y', path: 'y', size: 0, type: 'file' });
+    expect(typeof n.modifiedAt).toBe('string');
+    expect(n.syncInfo).toBeUndefined();
+  });
+});
+
+describe('getFullPath', () => {
+  it('passes the relative path through for dev-storage', () => {
+    expect(getFullPath(dev, 'docs')).toBe('docs');
+  });
+  it('joins under the mountpoint path for real mounts', () => {
+    expect(getFullPath(raid, 'docs')).toBe('/mnt/main/docs');
+    expect(getFullPath(raid, '/docs')).toBe('/mnt/main/docs');
+  });
+  it('returns the mountpoint path for an empty relative path', () => {
+    expect(getFullPath(raid, '')).toBe('/mnt/main');
+  });
+  it('returns the relative path unchanged with no mountpoint', () => {
+    expect(getFullPath(null, 'docs')).toBe('docs');
+  });
+});
+
+describe('toRelativePath', () => {
+  it('strips the mountpoint prefix for real mounts', () => {
+    expect(toRelativePath(raid, '/mnt/main/docs')).toBe('docs');
+  });
+  it('returns unchanged for dev-storage or a non-matching prefix', () => {
+    expect(toRelativePath(dev, 'docs')).toBe('docs');
+    expect(toRelativePath(raid, '/other/docs')).toBe('/other/docs');
+  });
+});
+
+describe('parentPath', () => {
+  it('drops the last segment', () => {
+    expect(parentPath('a/b/c')).toBe('a/b');
+  });
+  it('returns empty for a single segment or empty input', () => {
+    expect(parentPath('a')).toBe('');
+    expect(parentPath('')).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client ; npx vitest run src/__tests__/components/file-manager/utils.test.ts`
+Expected: FAIL — cannot resolve `../../../components/file-manager/utils`.
+
+- [ ] **Step 3: Create the helpers**
+
+Create `client/src/components/file-manager/utils.ts`:
+
+```ts
+import type { ApiFileItem, FileItem, StorageMountpoint } from './types';
+
+/** Maps a raw API file item to the UI `FileItem` shape (moved from FileManager.loadFiles). */
+export function mapApiFileItem(file: ApiFileItem): FileItem {
+  return {
+    name: file.name,
+    path: file.path,
+    size: file.size,
+    type: file.type,
+    modifiedAt: file.modified_at ?? file.mtime ?? new Date().toISOString(),
+    ownerId: file.ownerId ?? file.owner_id,
+    ownerName: file.ownerName ?? file.owner_name,
+    file_id: file.file_id,
+    syncInfo: file.sync_info?.map((si) => ({
+      deviceName: si.device_name,
+      platform: si.platform as 'windows' | 'mac' | 'linux',
+      syncDirection: si.sync_direction as 'bidirectional' | 'push' | 'pull',
+      lastReportedAt: si.last_reported_at,
+    })),
+    canRead: file.can_read ?? undefined,
+    canWrite: file.can_write ?? undefined,
+    canDelete: file.can_delete ?? undefined,
+  };
+}
+
+/** Resolves a relative browser path to the backend full path for a mountpoint. */
+export function getFullPath(mountpoint: StorageMountpoint | null, relativePath: string): string {
+  if (!mountpoint) return relativePath;
+  if (mountpoint.type === 'dev-storage') return relativePath;
+  const clean = relativePath.startsWith('/') ? relativePath.slice(1) : relativePath;
+  return clean ? `${mountpoint.path}/${clean}` : mountpoint.path;
+}
+
+/** Inverse of getFullPath for navigation: strips the mountpoint prefix (real mounts only). */
+export function toRelativePath(mountpoint: StorageMountpoint | null, folderPath: string): string {
+  if (mountpoint && mountpoint.type !== 'dev-storage') {
+    const prefix = mountpoint.path;
+    if (folderPath.startsWith(prefix)) {
+      return folderPath.slice(prefix.length).replace(/^\//, '');
+    }
+  }
+  return folderPath;
+}
+
+/** Parent of a relative path (drops the last segment). */
+export function parentPath(currentPath: string): string {
+  const parts = currentPath.split('/').filter(Boolean);
+  parts.pop();
+  return parts.join('/');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client ; npx vitest run src/__tests__/components/file-manager/utils.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/file-manager/utils.ts client/src/__tests__/components/file-manager/utils.test.ts
+git commit -m "refactor(files): extract pure file-manager path/mapping helpers (#301)"
+```
+
+---
+
+### Task 2: `queryKeys.files` domain + browser-core api functions
+
+**Files:**
+- Modify: `client/src/lib/queryKeys.ts`
+- Modify: `client/src/api/files.ts`
+
+**Interfaces:**
+- Produces:
+  - `queryKeys.files.all()`, `queryKeys.files.mountpoints()`, `queryKeys.files.list(fullPath)`
+  - `getMountpoints(): Promise<{ mountpoints: StorageMountpoint[] }>`
+  - `listFiles(fullPath: string): Promise<{ files: ApiFileItem[] }>`
+  - `createFolder(params: { path: string; name: string }): Promise<unknown>`
+  - `deleteFile(path: string): Promise<unknown>`
+  - `renameFile(params: { old_path: string; new_name: string }): Promise<unknown>`
+  - `downloadFileBlob(path: string): Promise<Blob>`
+
+> No dedicated api-wrapper tests: these are thin `apiClient` transcriptions (assessment T4 flags such tests as tautological). They are exercised through the mocked `api/files` in Task 3's hook test.
+
+- [ ] **Step 1: Add the `files` domain to `queryKeys.ts`**
+
+In `client/src/lib/queryKeys.ts`, add a `files` block (e.g. right after the `backups` block):
+
+```ts
+  files: {
+    all: () => ['files'] as const,
+    mountpoints: () => ['files', 'mountpoints'] as const,
+    /** Directory listing; the resolved backend full path is part of the key. */
+    list: (fullPath: string) => ['files', 'list', fullPath] as const,
+  },
+```
+
+- [ ] **Step 2: Add the browser-core functions to `api/files.ts`**
+
+At the top of `client/src/api/files.ts`, extend the imports with the shared types (type-only cross-import — these types are the canonical file-manager shapes):
+
+```ts
+import type { ApiFileItem, StorageMountpoint } from '../components/file-manager/types';
+```
+
+Append these functions to `client/src/api/files.ts`:
+
+```ts
+// --- Browser-core (list, mountpoints, folder CRUD, download) ---
+
+export async function getMountpoints(): Promise<{ mountpoints: StorageMountpoint[] }> {
+  const res = await apiClient.get('/api/files/mountpoints');
+  return res.data;
+}
+
+export async function listFiles(fullPath: string): Promise<{ files: ApiFileItem[] }> {
+  const res = await apiClient.get('/api/files/list', { params: { path: fullPath } });
+  return res.data;
+}
+
+export async function createFolder(params: { path: string; name: string }): Promise<unknown> {
+  const res = await apiClient.post('/api/files/folder', params);
+  return res.data;
+}
+
+export async function deleteFile(path: string): Promise<unknown> {
+  const res = await apiClient.delete(`/api/files/${encodeURIComponent(path)}`);
+  return res.data;
+}
+
+export async function renameFile(params: { old_path: string; new_name: string }): Promise<unknown> {
+  const res = await apiClient.put('/api/files/rename', params);
+  return res.data;
+}
+
+export async function downloadFileBlob(path: string): Promise<Blob> {
+  const res = await apiClient.get(`/api/files/download/${encodeURIComponent(path)}`, { responseType: 'blob' });
+  return res.data;
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd client ; npx tsc -b`
+Expected: no errors (verifies the new exports + the type import compile).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/lib/queryKeys.ts client/src/api/files.ts
+git commit -m "feat(files): add files query-key domain + browser-core api functions (#301)"
+```
+
+---
+
+### Task 3: `useFileBrowser` hook
+
+**Files:**
+- Create: `client/src/hooks/useFileBrowser.ts`
+- Test: `client/src/__tests__/hooks/useFileBrowser.test.tsx`
+
+**Interfaces:**
+- Consumes: the Task 1 helpers, the Task 2 api functions + query keys.
+- Produces: `useFileBrowser(): UseFileBrowserResult` with the surface in the code below.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/hooks/useFileBrowser.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string, d?: string) => d ?? k }) }));
+vi.mock('../../api/files', () => ({
+  getMountpoints: vi.fn(),
+  listFiles: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFile: vi.fn(),
+  renameFile: vi.fn(),
+  downloadFileBlob: vi.fn(),
+}));
+
+import * as filesApi from '../../api/files';
+import { useFileBrowser } from '../../hooks/useFileBrowser';
+
+const mp = { id: 'a', name: 'Main', type: 'raid', path: '/mnt/main', size_bytes: 100, used_bytes: 40, available_bytes: 60, status: 'ok', is_default: true };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(filesApi.getMountpoints).mockResolvedValue({ mountpoints: [mp] } as never);
+  vi.mocked(filesApi.listFiles).mockResolvedValue({ files: [{ name: 'a.txt', path: 'a.txt', size: 1, type: 'file', modified_at: '2026-01-01T00:00:00Z' }] } as never);
+  vi.mocked(filesApi.createFolder).mockResolvedValue({} as never);
+  vi.mocked(filesApi.deleteFile).mockResolvedValue({} as never);
+  vi.mocked(filesApi.renameFile).mockResolvedValue({} as never);
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('useFileBrowser', () => {
+  it('auto-selects the default mountpoint and lists its root', async () => {
+    const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.selectedMountpoint?.id).toBe('a'));
+    expect(result.current.currentPath).toBe('');
+    await waitFor(() => expect(result.current.files).toHaveLength(1));
+    expect(filesApi.listFiles).toHaveBeenCalledWith('/mnt/main');
+    expect(result.current.files[0].name).toBe('a.txt');
+    expect(result.current.storageInfo).toEqual({ totalBytes: 100, usedBytes: 40, availableBytes: 60 });
+  });
+
+  it('does not list before a mountpoint is selected', async () => {
+    vi.mocked(filesApi.getMountpoints).mockResolvedValue({ mountpoints: [] } as never);
+    renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    await act(async () => { await Promise.resolve(); });
+    expect(filesApi.listFiles).not.toHaveBeenCalled();
+  });
+
+  it('navigateToFolder re-lists the new full path', async () => {
+    const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.selectedMountpoint?.id).toBe('a'));
+    act(() => result.current.navigateToFolder('/mnt/main/docs'));
+    await waitFor(() => expect(result.current.currentPath).toBe('docs'));
+    await waitFor(() => expect(filesApi.listFiles).toHaveBeenCalledWith('/mnt/main/docs'));
+  });
+
+  it('createFolder posts and invalidates the listing', async () => {
+    const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.files).toHaveLength(1));
+    expect(filesApi.listFiles).toHaveBeenCalledTimes(1);
+    let ok = false;
+    await act(async () => { ok = await result.current.createFolder('New'); });
+    expect(ok).toBe(true);
+    expect(filesApi.createFolder).toHaveBeenCalledWith({ path: '/mnt/main', name: 'New' });
+    await waitFor(() => expect(filesApi.listFiles).toHaveBeenCalledTimes(2));
+  });
+
+  it('createFolder rejects an empty name without calling the API', async () => {
+    const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.selectedMountpoint?.id).toBe('a'));
+    let ok = true;
+    await act(async () => { ok = await result.current.createFolder('   '); });
+    expect(ok).toBe(false);
+    expect(filesApi.createFolder).not.toHaveBeenCalled();
+  });
+
+  it('deleteFile and renameFile call the API with the file path', async () => {
+    const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.files).toHaveLength(1));
+    await act(async () => { await result.current.deleteFile(result.current.files[0]); });
+    expect(filesApi.deleteFile).toHaveBeenCalledWith('a.txt');
+    await act(async () => { await result.current.renameFile(result.current.files[0], 'b.txt'); });
+    expect(filesApi.renameFile).toHaveBeenCalledWith({ old_path: 'a.txt', new_name: 'b.txt' });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client ; npx vitest run src/__tests__/hooks/useFileBrowser.test.tsx`
+Expected: FAIL — cannot resolve `../../hooks/useFileBrowser`.
+
+- [ ] **Step 3: Create the hook**
+
+Create `client/src/hooks/useFileBrowser.ts`:
+
+```ts
+import { useCallback, useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { queryKeys } from '../lib/queryKeys';
+import {
+  getMountpoints,
+  listFiles,
+  createFolder as apiCreateFolder,
+  deleteFile as apiDeleteFile,
+  renameFile as apiRenameFile,
+  downloadFileBlob,
+} from '../api/files';
+import { getFullPath, mapApiFileItem, parentPath, toRelativePath } from '../components/file-manager/utils';
+import type { FileItem, StorageInfo, StorageMountpoint } from '../components/file-manager/types';
+
+const getErrorMessage = (error: unknown): string => {
+  if (!error || typeof error !== 'object') return 'Unknown error';
+  const obj = error as Record<string, unknown>;
+  return String(obj.error ?? obj.detail ?? 'Unknown error');
+};
+const errDetail = (err: unknown) => (err as { response?: { data?: unknown } })?.response?.data ?? err;
+
+export interface UseFileBrowserResult {
+  mountpoints: StorageMountpoint[];
+  selectedMountpoint: StorageMountpoint | null;
+  selectMountpoint: (mp: StorageMountpoint) => void;
+  currentPath: string;
+  getFullPath: (path?: string) => string;
+  navigateToFolder: (folderPath: string) => void;
+  goBack: () => void;
+  goHome: () => void;
+  files: FileItem[];
+  loading: boolean;
+  storageInfo: StorageInfo | null;
+  createFolder: (name: string) => Promise<boolean>;
+  deleteFile: (file: FileItem) => Promise<boolean>;
+  renameFile: (file: FileItem, newName: string) => Promise<boolean>;
+  downloadFile: (file: FileItem) => Promise<void>;
+  refresh: () => void;
+}
+
+export function useFileBrowser(): UseFileBrowserResult {
+  const { t } = useTranslation(['fileManager', 'common']);
+  const queryClient = useQueryClient();
+  const [selectedMountpoint, setSelectedMountpoint] = useState<StorageMountpoint | null>(null);
+  const [currentPath, setCurrentPath] = useState('');
+
+  const mountpointsQuery = useQuery({ queryKey: queryKeys.files.mountpoints(), queryFn: getMountpoints });
+
+  // Auto-select the default mountpoint once loaded (matches the old loadMountpoints()).
+  useEffect(() => {
+    if (selectedMountpoint || !mountpointsQuery.data) return;
+    const mps = mountpointsQuery.data.mountpoints;
+    const def = mps.find((mp) => mp.is_default) ?? mps[0];
+    if (def) {
+      setSelectedMountpoint(def);
+      setCurrentPath('');
+    }
+  }, [mountpointsQuery.data, selectedMountpoint]);
+
+  // Preserve the original toast on a mountpoints load failure.
+  useEffect(() => {
+    if (mountpointsQuery.isError) toast.error('Failed to load storage devices');
+  }, [mountpointsQuery.isError]);
+
+  const resolveFullPath = useCallback(
+    (path: string = currentPath) => getFullPath(selectedMountpoint, path),
+    [selectedMountpoint, currentPath],
+  );
+  const fullPath = resolveFullPath();
+
+  const filesQuery = useQuery({
+    queryKey: queryKeys.files.list(fullPath),
+    queryFn: async () => {
+      const data = await listFiles(fullPath);
+      return Array.isArray(data.files) ? data.files.map(mapApiFileItem) : [];
+    },
+    enabled: !!selectedMountpoint,
+  });
+
+  const files = filesQuery.data ?? [];
+  const loading = filesQuery.isFetching;
+
+  const storageInfo: StorageInfo | null = selectedMountpoint
+    ? {
+        totalBytes: selectedMountpoint.size_bytes,
+        usedBytes: selectedMountpoint.used_bytes,
+        availableBytes: selectedMountpoint.available_bytes,
+      }
+    : null;
+
+  const refresh = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: queryKeys.files.list(fullPath) });
+  }, [queryClient, fullPath]);
+
+  const selectMountpoint = useCallback((mp: StorageMountpoint) => {
+    setSelectedMountpoint(mp);
+    setCurrentPath('');
+  }, []);
+
+  const navigateToFolder = useCallback(
+    (folderPath: string) => setCurrentPath(toRelativePath(selectedMountpoint, folderPath)),
+    [selectedMountpoint],
+  );
+  const goBack = useCallback(() => setCurrentPath((p) => parentPath(p)), []);
+  const goHome = useCallback(() => setCurrentPath(''), []);
+
+  const createFolder = useCallback(
+    async (name: string): Promise<boolean> => {
+      if (!name.trim()) {
+        toast.error(t('fileManager:messages.enterFolderName', 'Please enter a folder name'));
+        return false;
+      }
+      try {
+        await apiCreateFolder({ path: resolveFullPath(), name });
+        toast.success(t('fileManager:messages.folderCreated', 'Folder created successfully'));
+        refresh();
+        return true;
+      } catch (err) {
+        toast.error(`${t('fileManager:messages.folderError', 'Failed to create folder')}: ${getErrorMessage(errDetail(err))}`);
+        return false;
+      }
+    },
+    [t, resolveFullPath, refresh],
+  );
+
+  const deleteFile = useCallback(
+    async (file: FileItem): Promise<boolean> => {
+      try {
+        await apiDeleteFile(file.path);
+        toast.success(t('fileManager:messages.deleteSuccess'));
+        refresh();
+        return true;
+      } catch (err) {
+        toast.error(`${t('fileManager:messages.deleteError')}: ${getErrorMessage(errDetail(err))}`);
+        return false;
+      }
+    },
+    [t, refresh],
+  );
+
+  const renameFile = useCallback(
+    async (file: FileItem, newName: string): Promise<boolean> => {
+      if (!newName.trim()) {
+        toast.error(t('fileManager:messages.enterFileName', 'Please enter a valid file name'));
+        return false;
+      }
+      try {
+        await apiRenameFile({ old_path: file.path, new_name: newName });
+        toast.success(t('fileManager:messages.renameSuccess'));
+        refresh();
+        return true;
+      } catch (err) {
+        toast.error(`${t('fileManager:messages.renameError')}: ${getErrorMessage(errDetail(err))}`);
+        return false;
+      }
+    },
+    [t, refresh],
+  );
+
+  const downloadFile = useCallback(
+    async (file: FileItem): Promise<void> => {
+      if (file.type === 'directory') return;
+      try {
+        const blob = await downloadFileBlob(file.path);
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = file.name;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        window.URL.revokeObjectURL(url);
+      } catch {
+        toast.error(t('fileManager:messages.downloadError', 'Download failed'));
+      }
+    },
+    [t],
+  );
+
+  return {
+    mountpoints: mountpointsQuery.data?.mountpoints ?? [],
+    selectedMountpoint,
+    selectMountpoint,
+    currentPath,
+    getFullPath: resolveFullPath,
+    navigateToFolder,
+    goBack,
+    goHome,
+    files,
+    loading,
+    storageInfo,
+    createFolder,
+    deleteFile,
+    renameFile,
+    downloadFile,
+    refresh,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client ; npx vitest run src/__tests__/hooks/useFileBrowser.test.tsx`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/hooks/useFileBrowser.ts client/src/__tests__/hooks/useFileBrowser.test.tsx
+git commit -m "feat(files): add useFileBrowser query-backed browsing hook (#301)"
+```
+
+---
+
+### Task 4: Wire `useFileBrowser` into `FileManager.tsx` + verify
+
+**Files:**
+- Modify: `client/src/pages/FileManager.tsx`
+- Modify: `client/src/hooks/CLAUDE.md`
+
+**Interfaces:**
+- Consumes: `useFileBrowser` (Task 3).
+
+- [ ] **Step 1: Add the hook and remove the migrated browser-core code**
+
+In `client/src/pages/FileManager.tsx`:
+
+1. Add the import next to the other hook imports:
+```tsx
+import { useFileBrowser } from '../hooks/useFileBrowser';
+```
+2. At the top of the component (with the other hooks, before `if (!user) return null`), add:
+```tsx
+  const {
+    mountpoints, selectedMountpoint, selectMountpoint,
+    currentPath, getFullPath, navigateToFolder, goBack, goHome,
+    files, loading, storageInfo,
+    createFolder, deleteFile, renameFile, downloadFile, refresh,
+  } = useFileBrowser();
+```
+3. **Remove** these `useState` lines (now owned by the hook): `files`, `currentPath`, `loading`, `storageInfo`, `mountpoints`, `selectedMountpoint` (the `:84-99` subset — keep `userCache`, the dialog state `showNewFolderDialog`/`newFolderName`/`showDeleteDialog`/`fileToDelete`/`showRenameDialog`/`fileToRename`/`newFileName`, `dragActive`, `viewingFile`, `fileInputRef`, `folderInputRef`).
+4. **Remove** the local functions now on the hook: `loadMountpoints` (`:271-285`), `loadStorageInfo` (`:287-296`), `getFullPath` (`:298-307`), `loadFiles` (`:309-362`), `handleDownload` (`:378-396`), `handleCreateFolder` (`:398-418`), `handleDelete` (`:425-441`), `handleRename` (`:449-470`), the local `navigateToFolder` (`:547-557`), the local `goBack` (`:559-564`), and the local `getErrorMessage` (`:117-121`, only used by the three removed handlers).
+5. **Remove** the browser-core effects: the `[currentPath, selectedMountpoint]` load effect (`:141-146`) entirely; and drop `loadMountpoints()` from the mount effect (`:123-127`) so it becomes:
+```tsx
+  useEffect(() => {
+    loadVclQuota();
+    loadUserRootUsage();
+  }, []);
+```
+6. **Rewrite** the `onUploadsComplete` effect (`:130-139`) to use `refresh()` and drop the dead sessionStorage/`loadStorageInfo` lines:
+```tsx
+  useEffect(() => {
+    return onUploadsComplete(() => {
+      refresh();
+      loadVclQuota();
+      loadUserRootUsage();
+    });
+  }, [onUploadsComplete, refresh]);
+```
+7. **Rewire** the render/handlers (only these — leave everything else, incl. VCL/upload/permission/ownership/share, untouched):
+   - `StorageSelector` `onSelect`: `(mp) => { setSelectedMountpoint(mp); setCurrentPath(''); }` → `selectMountpoint`.
+   - Breadcrumb **Home** button (`:754-759`): `onClick={() => setCurrentPath('')}` → `onClick={goHome}`. **Back** button (`:763-768`): `onClick={goBack}` (unchanged name, now the hook's).
+   - `FileListView`: `onNavigate={navigateToFolder}`, `onDownload={downloadFile}` (both now the hook's — same names, no change needed), and `files={files}` / `loading={loading}` now come from the hook.
+   - `NewFolderDialog` `onCreate`: replace `handleCreateFolder` with
+     `onCreate={async () => { if (await createFolder(newFolderName)) { setShowNewFolderDialog(false); setNewFolderName(''); } }}`.
+   - `DeleteDialog` `onConfirm`: replace `handleDelete` with
+     `onConfirm={async () => { if (fileToDelete && await deleteFile(fileToDelete)) { setShowDeleteDialog(false); setFileToDelete(null); } }}`.
+   - `RenameDialog` `onRename`: replace `handleRename` with
+     `onRename={async () => { if (fileToRename && await renameFile(fileToRename, newFileName)) { setShowRenameDialog(false); setFileToRename(null); setNewFileName(''); } }}`.
+   - `VersionHistoryModal` `onVersionRestored` (`:854-856`): `() => { loadFiles(currentPath, false); }` → `() => { refresh(); }`.
+   - `OwnershipTransferModal` `onSuccess` (`:885-894`): change the trailing `loadFiles(currentPath, false);` to `refresh();` (leave the rest of that callback as-is).
+8. **Leave unchanged** (they now read the hook's values via the destructure — same identifiers): `handleUpload`/`handleFolderUpload`/`handleDrop` (use `getFullPath()` + `storageInfo?.availableBytes`), `confirmDelete`/`startRename` (open dialogs), the `files`-driven effects (version-counts/tracking/owner-cache), and all VCL/permission/ownership/share handlers.
+
+- [ ] **Step 2: Build (typecheck) — fix any dangling references**
+
+Run: `cd client ; npm run build`
+Expected: `✓ built` (tsc -b + vite), no `error TS`. If tsc flags an unused import (e.g. `apiClient` if no longer referenced — note `apiClient` is still used by nothing after removal? verify: it was used by loadMountpoints/loadFiles/handleDownload/create/delete/rename — all removed, so `apiClient` import is now dead → remove it) or an unused symbol, remove exactly the dead ones it names.
+
+> Likely now-dead imports to remove from `FileManager.tsx`: `apiClient` (all its uses moved to the hook/api); and from the `../components/file-manager/types` import, `StorageInfo`, `StorageMountpoint`, and `ApiFileItem` are now only used inside the hook (the page's `selectedMountpoint`/`storageInfo` are typed via the hook's return) — trim the type import to `import type { FileItem, PermissionRule } from '../components/file-manager/types'`. Keep everything still referenced by PR-2 code (`getFilePermissions`/`setFilePermissions`/`getUserRootUsage`, `vclApi`/tracking fns, `getShareableUsers`, the icons, `formatBytes`/`formatNumber`, all modal components, `FileItem`/`PermissionRule` types). Let tsc/eslint be the final authority on exactly which to remove.
+
+- [ ] **Step 3: Lint**
+
+Run: `cd client ; npx eslint .`
+Expected: 0 errors. Remove any unused-var/import the linter names (dead code from the removal), nothing else.
+
+- [ ] **Step 4: Full test suite**
+
+Run: `cd client ; npx vitest run`
+Expected: all green — the prior suite + the new `utils.test.ts` (helpers) and `useFileBrowser.test.tsx` (6). Report the exact file/test counts. If any pre-existing/unrelated test fails, report it (name + output) as DONE_WITH_CONCERNS rather than fixing out-of-scope code.
+
+- [ ] **Step 5: Update `hooks/CLAUDE.md`**
+
+Add a row to the Data Fetching Hooks table in `client/src/hooks/CLAUDE.md` for `useFileBrowser.ts` (api module `api/files`): browsing core for `FileManager` via TanStack Query — mountpoints + directory listing (`files.list(fullPath)` key), navigation, derived `storageInfo`, and create/delete/rename mutations that invalidate the listing; replaces the page's hand-rolled `sessionStorage` file cache (F2/#301, PR-1). Keep it one line, matching the table's style.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/pages/FileManager.tsx client/src/hooks/CLAUDE.md
+git commit -m "refactor(files): FileManager browsing core via useFileBrowser (#301)"
+```
+
+---
+
+## Notes for the implementer
+
+- This is PR-1 of two. Do **not** touch VCL (quota, user-root-usage, version-counts, tracking + toggle), upload/drag-drop, or the permission/ownership/share modals — they stay and keep reading the hook's `files`/`currentPath`/`getFullPath`/`storageInfo`. The page will still be ~700 lines after this PR; PR-2 finishes the job.
+- The only intended behavior change is the cache mechanism (manual `sessionStorage` → TanStack Query + app-wide persister). Everything else — listings, navigation, CRUD toasts, refetch-after-mutation — must be identical.
+- Line numbers are from `FileManager.tsx` at 914 lines. If edits shift them, match on the quoted markers (`{/* Storage Drive Selector */}`, `{/* Breadcrumb Navigation */}`, `{/* New Folder Dialog */}`, etc.) and the function names.
+- After Task 3, `useFileBrowser` is not yet imported anywhere — expected; it is covered by its own test. Only Task 4 wires it into the page.

--- a/docs/superpowers/plans/2026-07-09-f2-filemanager-browser-core.md
+++ b/docs/superpowers/plans/2026-07-09-f2-filemanager-browser-core.md
@@ -334,8 +334,12 @@ describe('useFileBrowser', () => {
 
   it('does not list before a mountpoint is selected', async () => {
     vi.mocked(filesApi.getMountpoints).mockResolvedValue({ mountpoints: [] } as never);
-    renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    const { result } = renderHook(() => useFileBrowser(), { wrapper: createQueryWrapper() });
+    // Wait until mountpoints have actually resolved (empty) — proves the empty
+    // result does not select a mountpoint and therefore never lists.
+    await waitFor(() => expect(filesApi.getMountpoints).toHaveBeenCalled());
     await act(async () => { await Promise.resolve(); });
+    expect(result.current.selectedMountpoint).toBeNull();
     expect(filesApi.listFiles).not.toHaveBeenCalled();
   });
 
@@ -404,6 +408,13 @@ import {
 import { getFullPath, mapApiFileItem, parentPath, toRelativePath } from '../components/file-manager/utils';
 import type { FileItem, StorageInfo, StorageMountpoint } from '../components/file-manager/types';
 
+// Stable empty-array references. IMPORTANT: the page has effects keyed on `files`
+// (e.g. the owner-name cache in FileManager.tsx). Returning a fresh `[]` on every
+// render while the query has no data yet would re-fire those effects every render
+// (setUserCache → re-render → new [] → …), an infinite loop. Keep these stable.
+const EMPTY_FILES: FileItem[] = [];
+const EMPTY_MOUNTPOINTS: StorageMountpoint[] = [];
+
 const getErrorMessage = (error: unknown): string => {
   if (!error || typeof error !== 'object') return 'Unknown error';
   const obj = error as Record<string, unknown>;
@@ -469,7 +480,7 @@ export function useFileBrowser(): UseFileBrowserResult {
     enabled: !!selectedMountpoint,
   });
 
-  const files = filesQuery.data ?? [];
+  const files = filesQuery.data ?? EMPTY_FILES;
   const loading = filesQuery.isFetching;
 
   const storageInfo: StorageInfo | null = selectedMountpoint
@@ -570,7 +581,7 @@ export function useFileBrowser(): UseFileBrowserResult {
   );
 
   return {
-    mountpoints: mountpointsQuery.data?.mountpoints ?? [],
+    mountpoints: mountpointsQuery.data?.mountpoints ?? EMPTY_MOUNTPOINTS,
     selectedMountpoint,
     selectMountpoint,
     currentPath,

--- a/docs/superpowers/specs/2026-07-09-f2-filemanager-browser-core-design.md
+++ b/docs/superpowers/specs/2026-07-09-f2-filemanager-browser-core-design.md
@@ -1,0 +1,184 @@
+# F2 — FileManager Browser-Core Decomposition + Query Migration (PR-1, Design)
+
+**Date:** 2026-07-09
+**Finding:** F2 (#301, part of #298) — 22 non-test components > 500 lines violate the
+`pages/CLAUDE.md` "minimal logic in page files" convention. Also closes the
+FileManager slice of F1 (#299): `FileManager.tsx` still hand-rolls a
+`sessionStorage` file cache instead of using TanStack Query + the app-wide persister.
+**Scope of this spec:** the FIRST of **two stacked PRs** for `client/src/pages/FileManager.tsx`
+(currently 914 lines). This PR = the **browser core**. PR-2 (VCL slice + upload/drag-drop
+hook + final page cleanup) gets its own spec → plan → PR.
+
+## Goal
+
+Move the browsing core — mountpoints, the file list, navigation, and file CRUD —
+out of the page into one cohesive **query-backed hook** (`useFileBrowser`) plus
+**pure helpers**, and replace the hand-rolled `sessionStorage` file cache
+(`files_cache_${fullPath}`) with `useQuery`. The app-wide query persister
+(`queryPersister.ts`) then provides F5 instant-paint for free.
+
+This is behavior-preserving **except** the intended cache-mechanism swap
+(manual `sessionStorage` → TanStack Query cache/persister).
+
+## Why FileManager is different from PowerManagement
+
+The page's JSX is **already** componentized: all 8 modals (`NewFolderDialog`,
+`DeleteDialog`, `RenameDialog`, `FileViewer`, `VersionHistoryModal`,
+`PermissionEditor`, `OwnershipTransferModal`, `ShareFileModal`) plus `FileListView`
+and `StorageSelector` are extracted into `components/file-manager/`. The 914 lines
+are almost entirely **logic**: ~28 `useState`, ~8 `useEffect`, file CRUD,
+drag-drop directory traversal, the sessionStorage cache, and a self-contained
+VCL/versioning slice. So the decomposition unit here is the **custom hook +
+pure helper**, not presentational components.
+
+## Current state (relevant facts, verified against the code)
+
+- `storageInfo` is **derived**, not fetched: `loadStorageInfo` (`:287-296`) just
+  copies `selectedMountpoint.{size,used,available}_bytes`. The
+  `sessionStorage.removeItem('storage_info_cache')` calls reference a key that is
+  never set or read — dead. So the only real reads in the browser core are
+  **mountpoints** (`GET /api/files/mountpoints`, once on mount) and the **file
+  list** (`GET /api/files/list?path=fullPath`).
+- `loadFiles` (`:309-362`) caches each listing under `files_cache_${fullPath}`
+  and re-reads it for instant paint. This is the manual cache being replaced.
+- `mountpoints` load auto-selects the default mountpoint (`is_default` or `[0]`)
+  and resets `currentPath` to `''`.
+- Navigation: `getFullPath` (`:298-307`), `navigateToFolder` (`:547-557`),
+  `goBack` (`:559-564`).
+- Browser-core mutations: `handleCreateFolder` (`:398-418`), `handleDelete`
+  (`:425-441`), `handleRename` (`:449-470`) — each posts/deletes/puts then
+  `sessionStorage.removeItem(...)` + `loadFiles(currentPath, false)`.
+  `handleDownload` (`:378-396`) streams a blob (no cache effect).
+- The `queryKeys.files` domain does **not** exist yet.
+
+## In scope (PR-1)
+
+### 1. `lib/queryKeys.ts` — new `files` domain
+
+```ts
+files: {
+  all: () => ['files'] as const,
+  mountpoints: () => ['files', 'mountpoints'] as const,
+  /** Directory listing; the resolved full path is part of the key. */
+  list: (fullPath: string) => ['files', 'list', fullPath] as const,
+}
+```
+
+### 2. `components/file-manager/utils.ts` — pure helpers (new file, unit-tested)
+
+- `mapApiFileItem(raw: ApiFileItem): FileItem` — the exact mapping currently
+  inline in `loadFiles` (`:332-350`), including the `sync_info` remap and the
+  `modified_at ?? mtime ?? now` / `ownerId ?? owner_id` / `can_*` fallbacks.
+- `getFullPath(mountpoint: StorageMountpoint | null, relativePath: string): string`
+  — pure form of `:298-307` (dev-storage passthrough; otherwise
+  `${mountpoint.path}/${clean}` or `mountpoint.path`).
+- `toRelativePath(mountpoint: StorageMountpoint | null, folderPath: string): string`
+  — the `navigateToFolder` transform (`:547-557`): strip the mountpoint prefix
+  for non-dev-storage, else return `folderPath` unchanged.
+- `parentPath(currentPath: string): string` — the `goBack` transform (`:559-564`).
+
+> `mapApiFileItem` references `ApiFileItem`/`FileItem` from
+> `components/file-manager/types.ts`. To avoid depending on `new Date()` (banned
+> in some contexts but fine in the browser), it keeps the existing
+> `?? new Date().toISOString()` fallback — this runs in the browser, not a
+> workflow script, so it is allowed.
+
+### 3. `hooks/useFileBrowser.ts` — the browser-core hook (new file)
+
+Owns and returns:
+- `mountpoints` via `useQuery(queryKeys.files.mountpoints(), …)`;
+  `selectedMountpoint` state auto-set to the default once mountpoints load;
+  `selectMountpoint(mp)` sets it and resets `currentPath` to `''`.
+- `currentPath` state; `navigateToFolder(folderPath)` (via `toRelativePath`);
+  `goBack()` (via `parentPath`).
+- `fullPath` = `getFullPath(selectedMountpoint, currentPath)` (memoized).
+- `files` via `useQuery(queryKeys.files.list(fullPath), …, { enabled: !!selectedMountpoint })`,
+  mapping the response with `mapApiFileItem`. Replaces the sessionStorage cache.
+- `storageInfo` derived from `selectedMountpoint` (or `null`).
+- `loading` = the list query's `isFetching`. The original set `loading` true on
+  **every** `loadFiles` call (start → `finally`), so `isFetching` is the exact
+  match (`isLoading` is true only on the first uncached load). The page's spinner
+  (`loading && files.length === 0`) and `FileListView`'s `loading` prop both keep
+  working; with a fresh (unpersisted) folder key `files` is `[]` and `isFetching`
+  is true → spinner shows, matching the old no-cache path; with a persisted key
+  `files` paints instantly while a background refetch runs.
+- Mutations (`useMutation`, each `onSuccess` invalidates `files.list(fullPath)`):
+  `createFolder(name)`, `deleteFile(file)`, `renameFile({ file, newName })`.
+  They preserve the existing toast keys and error extraction (`getErrorMessage` +
+  the `err.response.data` unwrap).
+- `downloadFile(file)` — passthrough (blob stream), unchanged.
+- `refresh()` — `invalidateQueries(files.list(fullPath))`, for the page's
+  `onUploadsComplete` and the version-restore callback.
+
+Public shape is designed so the page and `FileListView` consume it without prop
+churn (`files`, `loading`, `storageInfo`, `mountpoints`, `selectedMountpoint`,
+`currentPath`, and the handlers above).
+
+### 4. `pages/FileManager.tsx` — wire the hook
+
+- Replace the browser-core state (`files`, `currentPath`, `loading`,
+  `mountpoints`, `selectedMountpoint`, `storageInfo`) and the functions
+  `loadFiles`/`loadMountpoints`/`loadStorageInfo`/`getFullPath`/
+  `navigateToFolder`/`goBack`/`handleCreateFolder`/`handleDelete`/
+  `handleRename`/`handleDownload` with `useFileBrowser()`.
+- Delete the mount-load `useEffect` and the `[currentPath, selectedMountpoint]`
+  load-effect (query-driven now) and all `files_cache_*` / `storage_info_cache`
+  `sessionStorage` lines.
+- Modal open/close + input state (new-folder name, `fileToDelete`,
+  `fileToRename` + `newFileName`) **stays in the page** and calls the hook's
+  mutations. `StorageSelector`'s `onSelect` calls `selectMountpoint`.
+- `onUploadsComplete` calls `refresh()` for the list; its VCL reloads
+  (`loadVclQuota`, `loadUserRootUsage`) stay untouched (PR-2).
+
+## Out of scope (PR-2, untouched here)
+
+VCL (quota, user-root-usage, per-file version-counts, tracking rules + toggle),
+upload + drag-drop handlers (`handleUpload`/`handleFolderUpload`/`handleDrag`/
+`traverseFileTree`/`handleDrop`/`dragActive`), the permission/ownership/share
+modals and their handlers, and the `files`-driven effects (version-counts,
+tracking, owner-name cache) — these keep reading the hook's `files` in the
+interim. No UX/layout change. No new dependencies.
+
+After PR-1 the page is ~700 lines (down from 914); PR-2 finishes it to ~450.
+
+## Testing
+
+The house pattern for query-backed hooks is `renderHook` + a real
+`createQueryWrapper` (used across the F1 migrations this session), plus plain
+unit tests for pure helpers. That is the "full" testing equivalent for a
+hook-shaped change; whole-page RTL is not attempted (the missing `renderWithProviders`/MSW
+infra — assessment T2 — makes it costly and low-value).
+
+1. **`__tests__/components/file-manager/utils.test.ts`** (pure):
+   - `mapApiFileItem`: maps a full API item (incl. `sync_info`, `owner_id`
+     fallback, `can_*`), and the minimal item (fallback timestamp path).
+   - `getFullPath`: dev-storage passthrough; non-dev prefix join; empty path →
+     `mountpoint.path`; leading-slash cleanup; `null` mountpoint → relativePath.
+   - `toRelativePath`: strips the mountpoint prefix (non-dev), returns unchanged
+     for dev-storage / non-matching prefix.
+   - `parentPath`: nested → parent; single segment → `''`; `''` → `''`.
+2. **`__tests__/hooks/useFileBrowser.test.tsx`** (`renderHook` + `createQueryWrapper`,
+   api modules mocked):
+   - mountpoints load → `selectedMountpoint` is the default; `currentPath === ''`.
+   - the list query is keyed on the resolved `fullPath`; `files` are mapped;
+     `navigateToFolder` changes `currentPath` → a new listing is requested.
+   - `createFolder`/`deleteFile`/`renameFile` call the right endpoint and
+     invalidate `files.list(fullPath)` (assert a refetch / `invalidateQueries`).
+   - `enabled` gating: no list request before a mountpoint is selected.
+
+## Verification
+
+- New tests green.
+- Full frontend `vitest run` green (no regressions).
+- `eslint .` 0 errors; `npm run build` (tsc -b + vite) green.
+
+## Notes / risks
+
+- FileManager has **no existing tests** and is the NAS core. The hook tests +
+  helper tests are the safety net for the cache-mechanism swap. The behavior
+  contract to preserve: same listings, same navigation, same CRUD toasts, and
+  a refetch after each mutation / upload-complete / version-restore.
+- `staleTime` stays at the app default (0) — the list refetches on mount/param
+  change, matching the current always-fetch behavior; the persister supplies the
+  instant-paint the old `sessionStorage` cache used to. No polling is introduced
+  (FileManager never polled).


### PR DESCRIPTION
## F2 — FileManager browser-core → TanStack Query (#301, PR-1 of 2)

First of **two stacked PRs** decomposing `client/src/pages/FileManager.tsx` (914 lines). This PR extracts the **browsing core** — mountpoints, the file list, navigation, and file CRUD — into a query-backed hook + pure helpers, and **replaces the hand-rolled `sessionStorage` file cache with TanStack Query** (F5 instant-paint now comes from the app-wide persister). Also closes the FileManager slice of F1/#299.

`FileManager.tsx`: **914 → 700 lines.** PR-2 (VCL slice + upload/drag-drop hook + final cleanup) will take it the rest of the way.

Unlike PowerManagement, FileManager's JSX was already componentized (all 8 modals + `FileListView` + `StorageSelector`), so the bulk was **logic** — hence the extraction unit here is a **custom hook + pure helpers**, not presentational components.

### What moved
| New artifact | From |
|---|---|
| `components/file-manager/utils.ts` — `mapApiFileItem`, `getFullPath`, `toRelativePath`, `parentPath` (pure, unit-tested) | the inline `loadFiles` mapping + path/nav logic |
| `queryKeys.files.{mountpoints, list(fullPath)}` + browser-core `api/files` functions | raw `apiClient` calls in the page |
| `hooks/useFileBrowser.ts` — 2 `useQuery`s + 3 mutations + `downloadFile`/`refresh` | ~180 lines of page state/handlers |

The page now composes the hook; `create`/`delete`/`rename` invalidate the listing; `onUploadsComplete` / version-restore / ownership-transfer call `refresh()`.

### Behavior-preserving except the cache swap
Same listings, navigation, CRUD toasts (exact i18n keys + `getErrorMessage(response.data ?? err)` format), and a refetch after each mutation/upload-complete/version-restore. The only intended change is the cache mechanism.

**Strictly out of scope (PR-2, untouched):** VCL (quota, user-root-usage, version-counts, tracking + toggle), upload/drag-drop handlers, and the permission/ownership/share modals — they stay and keep reading the hook's `files`/`currentPath`/`getFullPath`/`storageInfo`.

### Two correctness notes worth calling out
- **Stable empty-array refs.** The hook returns module-level `EMPTY_FILES`/`EMPTY_MOUNTPOINTS`, not a fresh `?? []` — the page has effects keyed on `files` (owner-name cache) that would infinite-loop on a new array each render. Caught in the pre-dispatch critical review.
- **List-error toast restored.** The `useQuery` migration initially dropped `loadFiles`' error toast, making a failed directory listing silent. Restored via an `isError` effect (mirroring the mountpoints-error path) since file listing is user-initiated navigation, not a background poll. Caught in the final whole-branch review.

### Verification
- New tests: `utils.test.ts` (10), `useFileBrowser.test.tsx` (7, incl. the list-error path) — `renderHook` + `createQueryWrapper`, asserting real behavior.
- Full frontend suite: **122 files / 632 tests green** (no regressions).
- `eslint .` 0 errors · `npm run build` (tsc -b + vite) green.

Built via spec → plan → subagent-driven TDD (4 tasks), with a pre-dispatch critical plan review and a final opus whole-branch review (one Important finding, fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
