### PR TITLE
refactor(powertab): decompose PowerTab.tsx into hooks + power-tab/* (#301) [F2]

### DIFF
--- a/client/src/__tests__/components/system-monitor/PowerTab.test.tsx
+++ b/client/src/__tests__/components/system-monitor/PowerTab.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '../../helpers/queryClient';
+
+// --- i18n: identity `t`, stable `i18n.language` ---
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}));
+
+// --- Deterministic numeric formatting (dot decimals, no locale dependency) ---
+vi.mock('../../../lib/formatters', async (importActual) => {
+  const actual = await importActual<typeof import('../../../lib/formatters')>();
+  return { ...actual, formatNumber: (v: number, d: number) => v.toFixed(d) };
+});
+
+// --- PluginContext: PowerTab's data hook is mocked, but guard defensively ---
+vi.mock('../../../contexts/PluginContext', () => ({
+  usePlugins: () => ({ plugins: [] }),
+}));
+
+// --- The two data hooks the orchestrator delegates to ---
+vi.mock('../../../hooks/usePowerTabData', () => ({ usePowerTabData: vi.fn() }));
+vi.mock('../../../hooks/useEnergyPrice', () => ({ useEnergyPrice: vi.fn() }));
+
+import { usePowerTabData } from '../../../hooks/usePowerTabData';
+import type { UsePowerTabDataResult } from '../../../hooks/usePowerTabData';
+import { useEnergyPrice } from '../../../hooks/useEnergyPrice';
+import type { UseEnergyPriceResult } from '../../../hooks/useEnergyPrice';
+import type { SmartDevice } from '../../../api/smart-devices';
+import type { CumulativeEnergyResponse, EnergyPriceConfig } from '../../../api/energy';
+import { PowerTab } from '../../../components/system-monitor/PowerTab';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={createTestQueryClient()}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const plugDevice: SmartDevice = {
+  id: 1,
+  name: 'Plug',
+  plugin_name: 'tapo',
+  device_type_id: 'tapo-p110',
+  address: '127.0.0.1',
+  mac_address: null,
+  capabilities: ['power_monitor'],
+  is_active: true,
+  is_online: true,
+  last_seen: null,
+  last_error: null,
+  state: { power_monitor: { watts: 42, voltage: 230, current: 0.18, energy_today_kwh: 0.5 } },
+  created_at: '',
+  updated_at: '',
+};
+
+const cumulativeData: CumulativeEnergyResponse = {
+  device_id: 1,
+  device_name: 'Plug',
+  period: 'today',
+  cost_per_kwh: 0.4,
+  currency: 'EUR',
+  total_kwh: 0.684,
+  total_cost: 0.27,
+  data_points: [
+    { timestamp: '2026-07-11T00:00:00', cumulative_kwh: 0.0, cumulative_cost: 0.0, instant_watts: 25.0 },
+    { timestamp: '2026-07-11T01:00:00', cumulative_kwh: 0.1, cumulative_cost: 0.04, instant_watts: 42.0 },
+  ],
+};
+
+const priceConfig: EnergyPriceConfig = {
+  id: 1,
+  cost_per_kwh: 0.4,
+  currency: 'EUR',
+  updated_at: '',
+  updated_by_user_id: null,
+};
+
+function powerData(overrides: Partial<UsePowerTabDataResult> = {}): UsePowerTabDataResult {
+  return {
+    devices: [plugDevice],
+    powerSummary: { total_watts: 42, device_count: 1, devices: [{ device_id: 1, name: 'Plug', watts: 42 }] },
+    loading: false,
+    error: null,
+    cumulativeData,
+    cumulativeLoading: false,
+    cumulativeReady: true,
+    totalCurrentPower: 42,
+    powerPluginName: 'Tapo',
+    cumulativeKeyArgs: { period: 'today', start: null, end: null },
+    ...overrides,
+  };
+}
+
+const energyPrice: UseEnergyPriceResult = {
+  priceConfig,
+  editingPrice: false,
+  setEditingPrice: vi.fn(),
+  priceInput: '0.4',
+  setPriceInput: vi.fn(),
+  savingPrice: false,
+  savePrice: vi.fn(),
+};
+
+describe('PowerTab', () => {
+  beforeEach(() => {
+    vi.mocked(useEnergyPrice).mockReturnValue(energyPrice);
+  });
+
+  it('renders stat cards, a device card and the chart toolbar', () => {
+    vi.mocked(usePowerTabData).mockReturnValue(powerData());
+
+    render(<PowerTab />, { wrapper });
+
+    // Current-power stat value (formatNumber(42, 1)) — appears in the summary
+    // card and the device card, so assert at least one match.
+    expect(screen.getAllByText('42.0').length).toBeGreaterThan(0);
+    // Device name renders (device card + chart tab)
+    expect(screen.getAllByText('Plug').length).toBeGreaterThan(0);
+  });
+
+  it('shows the empty state when there are no devices', () => {
+    vi.mocked(usePowerTabData).mockReturnValue(powerData({ devices: [], totalCurrentPower: 0 }));
+
+    render(<PowerTab />, { wrapper });
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/smart-devices');
+  });
+});

--- a/client/src/__tests__/components/system-monitor/power-tab/ChartControls.test.tsx
+++ b/client/src/__tests__/components/system-monitor/power-tab/ChartControls.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('react-hot-toast', () => ({ default: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('../../../../lib/dateUtils', () => ({
+  localRangeToUtcIso: vi.fn(() => ({ startIso: 'S', endIso: 'E' })),
+}));
+
+import toast from 'react-hot-toast';
+import { ChartModePeriodControls } from '../../../../components/system-monitor/power-tab/ChartModePeriodControls';
+import { CustomRangePicker } from '../../../../components/system-monitor/power-tab/CustomRangePicker';
+
+describe('ChartModePeriodControls', () => {
+  it('renders mode + period buttons and the customRange node', () => {
+    render(
+      <ChartModePeriodControls
+        chartMode="cumulative"
+        onModeChange={vi.fn()}
+        cumulativePeriod="today"
+        onPeriodChange={vi.fn()}
+        customRange={<div>custom-range-slot</div>}
+      />
+    );
+
+    expect(screen.getByText('monitor.power.modeCumulative')).toBeTruthy();
+    expect(screen.getByText('monitor.power.modeInstant')).toBeTruthy();
+    expect(screen.getByText('monitor.power.periodToday')).toBeTruthy();
+    expect(screen.getByText('monitor.power.periodWeek')).toBeTruthy();
+    expect(screen.getByText('monitor.power.periodMonth')).toBeTruthy();
+    expect(screen.getByText('custom-range-slot')).toBeTruthy();
+  });
+
+  it('fires onPeriodChange("week") when the week button is clicked', () => {
+    const onPeriodChange = vi.fn();
+    render(
+      <ChartModePeriodControls
+        chartMode="cumulative"
+        onModeChange={vi.fn()}
+        cumulativePeriod="today"
+        onPeriodChange={onPeriodChange}
+        customRange={<div>custom-range-slot</div>}
+      />
+    );
+
+    fireEvent.click(screen.getByText('monitor.power.periodWeek'));
+    expect(onPeriodChange).toHaveBeenCalledWith('week');
+  });
+
+  it('fires onModeChange("instant") when the instant button is clicked', () => {
+    const onModeChange = vi.fn();
+    render(
+      <ChartModePeriodControls
+        chartMode="cumulative"
+        onModeChange={onModeChange}
+        cumulativePeriod="today"
+        onPeriodChange={vi.fn()}
+        customRange={<div>custom-range-slot</div>}
+      />
+    );
+
+    fireEvent.click(screen.getByText('monitor.power.modeInstant'));
+    expect(onModeChange).toHaveBeenCalledWith('instant');
+  });
+});
+
+describe('CustomRangePicker', () => {
+  it('opens the popover when the Custom button is clicked', () => {
+    render(<CustomRangePicker active={false} onApply={vi.fn()} />);
+
+    expect(screen.queryByText('monitor.power.customApply')).toBeNull();
+    fireEvent.click(screen.getByText('monitor.power.periodCustom'));
+    expect(screen.getByText('monitor.power.customApply')).toBeTruthy();
+  });
+
+  it('shows a toast error and does not call onApply when drafts are empty', () => {
+    const onApply = vi.fn();
+    render(<CustomRangePicker active={false} onApply={onApply} />);
+
+    fireEvent.click(screen.getByText('monitor.power.periodCustom'));
+    fireEvent.click(screen.getByText('monitor.power.customApply'));
+
+    expect(toast.error).toHaveBeenCalledWith('monitor.power.customInvalidRange');
+    expect(onApply).not.toHaveBeenCalled();
+  });
+
+  it('calls onApply with the ISO range returned by localRangeToUtcIso once both dates are set', () => {
+    const onApply = vi.fn();
+    const { container } = render(<CustomRangePicker active={false} onApply={onApply} />);
+
+    fireEvent.click(screen.getByText('monitor.power.periodCustom'));
+    const dateInputs = container.querySelectorAll('input[type="date"]');
+    expect(dateInputs.length).toBe(2);
+    fireEvent.change(dateInputs[0], { target: { value: '2026-07-01' } });
+    fireEvent.change(dateInputs[1], { target: { value: '2026-07-05' } });
+    fireEvent.click(screen.getByText('monitor.power.customApply'));
+
+    expect(onApply).toHaveBeenCalledWith('S', 'E');
+  });
+});

--- a/client/src/__tests__/components/system-monitor/power-tab/ChartDeviceTabs.test.tsx
+++ b/client/src/__tests__/components/system-monitor/power-tab/ChartDeviceTabs.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+import { ChartDeviceTabs } from '../../../../components/system-monitor/power-tab/ChartDeviceTabs';
+import type { SmartDevice } from '../../../../api/smart-devices';
+
+function makeDevice(overrides: Partial<SmartDevice>): SmartDevice {
+  return {
+    id: 1,
+    name: 'Test Device',
+    plugin_name: 'test-plugin',
+    device_type_id: 'test-type',
+    address: '127.0.0.1',
+    mac_address: null,
+    capabilities: [],
+    is_active: true,
+    is_online: true,
+    last_seen: null,
+    last_error: null,
+    state: null,
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  };
+}
+
+describe('ChartDeviceTabs', () => {
+  const activeDevice = makeDevice({ id: 1, name: 'Living Room Plug', is_active: true, capabilities: ['power_monitor'] });
+  const inactiveDevice = makeDevice({ id: 2, name: 'Inactive Plug', is_active: false, capabilities: ['power_monitor'] });
+
+  it('renders Total and only active power_monitor devices', () => {
+    render(
+      <ChartDeviceTabs devices={[activeDevice, inactiveDevice]} selectedDeviceId={null} onSelect={vi.fn()} />
+    );
+
+    expect(screen.getByText('monitor.power.total')).toBeTruthy();
+    expect(screen.getByText('Living Room Plug')).toBeTruthy();
+    expect(screen.queryByText('Inactive Plug')).toBeNull();
+  });
+
+  it('calls onSelect with device id when a device tab is clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <ChartDeviceTabs devices={[activeDevice, inactiveDevice]} selectedDeviceId={null} onSelect={onSelect} />
+    );
+
+    fireEvent.click(screen.getByText('Living Room Plug'));
+    expect(onSelect).toHaveBeenCalledWith(1);
+  });
+
+  it('calls onSelect with null when Total is clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <ChartDeviceTabs devices={[activeDevice, inactiveDevice]} selectedDeviceId={1} onSelect={onSelect} />
+    );
+
+    fireEvent.click(screen.getByText('monitor.power.total'));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+});

--- a/client/src/__tests__/components/system-monitor/power-tab/EnergyChart.test.tsx
+++ b/client/src/__tests__/components/system-monitor/power-tab/EnergyChart.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('recharts', () => new Proxy({}, {
+  has: () => true,
+  get: (_target, prop) => {
+    if (prop === 'then' || typeof prop === 'symbol') return undefined;
+    return (props: { children?: unknown }) => props?.children ?? null;
+  },
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string, fallback?: string) => fallback ?? k }) }));
+
+import { EnergyChart } from '../../../../components/system-monitor/power-tab/EnergyChart';
+import type { CumulativeEnergyResponse } from '../../../../api/energy';
+
+const baseCumulativeData: CumulativeEnergyResponse = {
+  device_id: 1,
+  device_name: 'Total',
+  period: 'today',
+  cost_per_kwh: 0.3,
+  currency: 'EUR',
+  total_kwh: 1.234,
+  total_cost: 0.37,
+  data_points: [
+    { timestamp: '2026-01-01T00:00:00', cumulative_kwh: 0, cumulative_cost: 0, instant_watts: 10 },
+  ],
+};
+
+describe('EnergyChart', () => {
+  it('shows the loading spinner (no empty-state text) while cumulativeLoading is true', () => {
+    render(
+      <EnergyChart
+        chartMode="cumulative"
+        cumulativeData={null}
+        cumulativeLoading={true}
+        cumulativePeriod="today"
+        language="en"
+      />
+    );
+    expect(screen.queryByText('monitor.noDataForPeriod')).toBeNull();
+  });
+
+  it('shows the empty state when data_points is empty and not loading', () => {
+    render(
+      <EnergyChart
+        chartMode="cumulative"
+        cumulativeData={{ ...baseCumulativeData, data_points: [] }}
+        cumulativeLoading={false}
+        cumulativePeriod="today"
+        language="en"
+      />
+    );
+    expect(screen.getByText('monitor.noDataForPeriod')).toBeTruthy();
+  });
+
+  it('renders the chart without the empty state when a data point exists (cumulative mode)', () => {
+    expect(() =>
+      render(
+        <EnergyChart
+          chartMode="cumulative"
+          cumulativeData={baseCumulativeData}
+          cumulativeLoading={false}
+          cumulativePeriod="today"
+          language="en"
+        />
+      )
+    ).not.toThrow();
+    expect(screen.queryByText('monitor.noDataForPeriod')).toBeNull();
+  });
+
+  it('renders the chart without the empty state when a data point exists (instant mode)', () => {
+    expect(() =>
+      render(
+        <EnergyChart
+          chartMode="instant"
+          cumulativeData={baseCumulativeData}
+          cumulativeLoading={false}
+          cumulativePeriod="today"
+          language="en"
+        />
+      )
+    ).not.toThrow();
+    expect(screen.queryByText('monitor.noDataForPeriod')).toBeNull();
+  });
+});

--- a/client/src/__tests__/components/system-monitor/power-tab/EnergyChartSummary.test.tsx
+++ b/client/src/__tests__/components/system-monitor/power-tab/EnergyChartSummary.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string, fallback?: string) => fallback ?? k }) }));
+vi.mock('../../../../lib/formatters', () => ({ formatNumber: (value: number, decimals: number) => value.toFixed(decimals) }));
+
+import { EnergyChartSummary } from '../../../../components/system-monitor/power-tab/EnergyChartSummary';
+import type { CumulativeEnergyResponse } from '../../../../api/energy';
+
+const baseCumulativeData: CumulativeEnergyResponse = {
+  device_id: 1,
+  device_name: 'Total',
+  period: 'today',
+  cost_per_kwh: 0.3,
+  currency: 'EUR',
+  total_kwh: 1.234,
+  total_cost: 0.37,
+  data_points: [
+    { timestamp: '2026-01-01T00:00:00', cumulative_kwh: 0, cumulative_cost: 0, instant_watts: 10 },
+    { timestamp: '2026-01-01T01:00:00', cumulative_kwh: 0.1, cumulative_cost: 0.03, instant_watts: 20 },
+    { timestamp: '2026-01-01T02:00:00', cumulative_kwh: 0.2, cumulative_cost: 0.06, instant_watts: 30 },
+  ],
+};
+
+describe('EnergyChartSummary', () => {
+  it('renders total, costs, and price in cumulative mode', () => {
+    render(<EnergyChartSummary chartMode="cumulative" cumulativeData={baseCumulativeData} />);
+    expect(screen.getByText('1.234')).toBeTruthy();
+    expect(screen.getByText('0.37')).toBeTruthy();
+    expect(screen.getByText('0.30')).toBeTruthy();
+    expect(screen.getByText('3')).toBeTruthy();
+  });
+
+  it('renders avg/max/min watts in instant mode', () => {
+    render(<EnergyChartSummary chartMode="instant" cumulativeData={baseCumulativeData} />);
+    expect(screen.getByText('20.0')).toBeTruthy();
+    expect(screen.getByText('30.0')).toBeTruthy();
+    expect(screen.getByText('10.0')).toBeTruthy();
+    expect(screen.getByText('3')).toBeTruthy();
+  });
+});

--- a/client/src/__tests__/components/system-monitor/power-tab/EnergyPriceEditor.test.tsx
+++ b/client/src/__tests__/components/system-monitor/power-tab/EnergyPriceEditor.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('../../../../lib/formatters', () => ({ formatNumber: (value: number, decimals: number) => value.toFixed(decimals) }));
+
+import { EnergyPriceEditor } from '../../../../components/system-monitor/power-tab/EnergyPriceEditor';
+import type { EnergyPriceConfig } from '../../../../api/energy';
+
+const priceConfig: EnergyPriceConfig = {
+  id: 1,
+  cost_per_kwh: 0.4,
+  currency: 'EUR',
+  updated_at: '2026-01-01T00:00:00Z',
+  updated_by_user_id: null,
+};
+
+describe('EnergyPriceEditor', () => {
+  it('view mode: shows price text and clicking pencil button fires onEdit', () => {
+    const onEdit = vi.fn();
+    render(
+      <EnergyPriceEditor
+        priceConfig={priceConfig}
+        editing={false}
+        priceInput="0.40"
+        saving={false}
+        onEdit={onEdit}
+        onInputChange={vi.fn()}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('0.40 EUR/kWh')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('edit mode: input reflects priceInput, change fires onInputChange, save/cancel buttons fire callbacks', () => {
+    const onInputChange = vi.fn();
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <EnergyPriceEditor
+        priceConfig={priceConfig}
+        editing={true}
+        priceInput="0.45"
+        saving={false}
+        onEdit={vi.fn()}
+        onInputChange={onInputChange}
+        onSave={onSave}
+        onCancel={onCancel}
+      />,
+    );
+
+    const input = screen.getByDisplayValue('0.45') as HTMLInputElement;
+    expect(input).toBeTruthy();
+
+    fireEvent.change(input, { target: { value: '0.55' } });
+    expect(onInputChange).toHaveBeenCalledWith('0.55');
+
+    fireEvent.click(screen.getByText('✓'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('✕'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('edit mode: shows "..." on save button and disables inputs/buttons while saving', () => {
+    render(
+      <EnergyPriceEditor
+        priceConfig={priceConfig}
+        editing={true}
+        priceInput="0.45"
+        saving={true}
+        onEdit={vi.fn()}
+        onInputChange={vi.fn()}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('...')).toBeTruthy();
+    const input = screen.getByDisplayValue('0.45') as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+  });
+});

--- a/client/src/__tests__/components/system-monitor/power-tab/PowerDeviceCard.test.tsx
+++ b/client/src/__tests__/components/system-monitor/power-tab/PowerDeviceCard.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string, fallback?: string) => fallback ?? k }) }));
+vi.mock('../../../../lib/formatters', () => ({ formatNumber: (value: number, decimals: number) => value.toFixed(decimals) }));
+
+import { PowerDeviceCard } from '../../../../components/system-monitor/power-tab/PowerDeviceCard';
+import type { SmartDevice } from '../../../../api/smart-devices';
+
+function makeDevice(overrides: Partial<SmartDevice>): SmartDevice {
+  return {
+    id: 1,
+    name: 'Test Device',
+    plugin_name: 'test-plugin',
+    device_type_id: 'test-type',
+    address: '127.0.0.1',
+    mac_address: null,
+    capabilities: [],
+    is_active: true,
+    is_online: true,
+    last_seen: null,
+    last_error: null,
+    state: null,
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  };
+}
+
+describe('PowerDeviceCard', () => {
+  it('renders device name, online badge, and power metrics', () => {
+    const device = makeDevice({
+      name: 'Living Room Plug',
+      is_online: true,
+      state: {
+        power_monitor: { watts: 12.5, voltage: 230, current: 0.05, energy_today_kwh: 1.2 },
+      },
+    });
+
+    render(<PowerDeviceCard device={device} />);
+
+    expect(screen.getByText('Living Room Plug')).toBeTruthy();
+    expect(screen.getByText('Online')).toBeTruthy();
+    expect(screen.getByText('12.5')).toBeTruthy();
+    expect(screen.getByText('230.0')).toBeTruthy();
+    expect(screen.getByText('0.050')).toBeTruthy();
+    expect(screen.getByText('1.20')).toBeTruthy();
+  });
+
+  it('renders offline badge and dash fallbacks when state is missing', () => {
+    const device = makeDevice({
+      name: 'Offline Plug',
+      is_online: false,
+      state: null,
+    });
+
+    render(<PowerDeviceCard device={device} />);
+
+    expect(screen.getByText('Offline Plug')).toBeTruthy();
+    expect(screen.getByText('Offline')).toBeTruthy();
+    expect(screen.getAllByText('-')).toHaveLength(4);
+  });
+});

--- a/client/src/__tests__/components/system-monitor/power-tab/PowerStates.test.tsx
+++ b/client/src/__tests__/components/system-monitor/power-tab/PowerStates.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PowerError, PowerEmptyState } from '../../../../components/system-monitor/power-tab/PowerStates';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string, d?: string) => (typeof d === 'string' ? d : k) }) }));
+
+describe('PowerStates', () => {
+  it('PowerError shows the message', () => {
+    render(<PowerError error="boom" />);
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+  it('PowerEmptyState links to smart devices', () => {
+    render(<MemoryRouter><PowerEmptyState /></MemoryRouter>);
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/smart-devices');
+    expect(screen.getByText(/No smart devices/)).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/system-monitor/power-tab/PowerSummaryCards.test.tsx
+++ b/client/src/__tests__/components/system-monitor/power-tab/PowerSummaryCards.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string, fallback?: string) => fallback ?? k }) }));
+vi.mock('../../../../lib/formatters', () => ({ formatNumber: (value: number, decimals: number) => value.toFixed(decimals) }));
+
+import { PowerSummaryCards } from '../../../../components/system-monitor/power-tab/PowerSummaryCards';
+
+describe('PowerSummaryCards', () => {
+  it('renders current power, online count, and device count', () => {
+    render(
+      <PowerSummaryCards totalCurrentPower={42.4} onlineCount={2} deviceCount={3} />,
+    );
+    expect(screen.getByText('42.4')).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy();
+    expect(screen.getByText('/ 3')).toBeTruthy();
+  });
+});

--- a/client/src/__tests__/components/system-monitor/power-tab/parseDevicePower.test.ts
+++ b/client/src/__tests__/components/system-monitor/power-tab/parseDevicePower.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { parseDevicePower } from '../../../../components/system-monitor/power-tab/parseDevicePower';
+import type { SmartDevice } from '../../../../api/smart-devices';
+
+function dev(power_monitor: Record<string, unknown> | undefined): SmartDevice {
+  return {
+    id: 1, name: 'Plug', plugin_name: 'p', device_type_id: 't', address: 'a', mac_address: null,
+    capabilities: ['power_monitor'], is_active: true, is_online: true, last_seen: null, last_error: null,
+    state: power_monitor ? { power_monitor } : null, created_at: '', updated_at: '',
+  };
+}
+
+describe('parseDevicePower', () => {
+  it('prefers watts and current/energy in base units', () => {
+    expect(parseDevicePower(dev({ watts: 12.5, voltage: 230, current: 0.05, energy_today_kwh: 1.2 })))
+      .toEqual({ watts: 12.5, voltage: 230, currentA: 0.05, energyToday: 1.2 });
+  });
+  it('falls back to current_power, current_ma/1000, energy_today_wh/1000', () => {
+    expect(parseDevicePower(dev({ current_power: 9, current_ma: 250, energy_today_wh: 800 })))
+      .toEqual({ watts: 9, voltage: undefined, currentA: 0.25, energyToday: 0.8 });
+  });
+  it('returns all-undefined when power_monitor missing', () => {
+    expect(parseDevicePower(dev(undefined))).toEqual({ watts: undefined, voltage: undefined, currentA: undefined, energyToday: undefined });
+  });
+});

--- a/client/src/__tests__/hooks/useEnergyPrice.test.tsx
+++ b/client/src/__tests__/hooks/useEnergyPrice.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('../../api/energy', () => ({ getEnergyPriceConfig: vi.fn(), updateEnergyPriceConfig: vi.fn() }));
+
+import toast from 'react-hot-toast';
+import { getEnergyPriceConfig, updateEnergyPriceConfig } from '../../api/energy';
+import { useEnergyPrice } from '../../hooks/useEnergyPrice';
+
+const cfg = { id: 1, cost_per_kwh: 0.3, currency: 'EUR', updated_at: '', updated_by_user_id: null };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getEnergyPriceConfig as any).mockResolvedValue(cfg);
+  (updateEnergyPriceConfig as any).mockResolvedValue({ ...cfg, cost_per_kwh: 0.4 });
+});
+
+describe('useEnergyPrice', () => {
+  it('seeds config on mount', async () => {
+    const { result } = renderHook(() => useEnergyPrice());
+    await waitFor(() => expect(result.current.priceConfig?.cost_per_kwh).toBe(0.3));
+    expect(result.current.priceInput).toBe('0.3');
+  });
+
+  it('rejects out-of-range price (no update, error toast)', async () => {
+    const { result } = renderHook(() => useEnergyPrice());
+    await waitFor(() => expect(result.current.priceConfig).not.toBeNull());
+    act(() => result.current.setPriceInput('99'));
+    await act(async () => { await result.current.savePrice(); });
+    expect(updateEnergyPriceConfig).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it('saves in-range price and calls onSaved', async () => {
+    const onSaved = vi.fn();
+    const { result } = renderHook(() => useEnergyPrice(onSaved));
+    await waitFor(() => expect(result.current.priceConfig).not.toBeNull());
+    act(() => result.current.setPriceInput('0.4'));
+    await act(async () => { await result.current.savePrice(); });
+    expect(updateEnergyPriceConfig).toHaveBeenCalledWith({ cost_per_kwh: 0.4, currency: 'EUR' });
+    expect(onSaved).toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/hooks/usePowerTabData.test.tsx
+++ b/client/src/__tests__/hooks/usePowerTabData.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+
+vi.mock('../../api/smart-devices', () => ({ smartDevicesApi: { list: vi.fn(), getPowerSummary: vi.fn() } }));
+vi.mock('../../api/energy', () => ({ getCumulativeEnergy: vi.fn(), getCumulativeEnergyTotal: vi.fn() }));
+vi.mock('../../contexts/PluginContext', () => ({ usePlugins: () => ({ plugins: [] }) }));
+
+import { smartDevicesApi } from '../../api/smart-devices';
+import { getCumulativeEnergyTotal } from '../../api/energy';
+import { usePowerTabData } from '../../hooks/usePowerTabData';
+
+const device = { id: 1, name: 'Plug', plugin_name: 'p', device_type_id: 't', address: 'a', mac_address: null, capabilities: ['power_monitor'], is_active: true, is_online: true, last_seen: null, last_error: null, state: null, created_at: '', updated_at: '' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (smartDevicesApi.list as any).mockResolvedValue({ data: { devices: [device] } });
+  (smartDevicesApi.getPowerSummary as any).mockResolvedValue({ data: { total_watts: 42 } });
+  (getCumulativeEnergyTotal as any).mockResolvedValue({ device_id: 0, device_name: '', period: 'today', cost_per_kwh: 0.3, currency: 'EUR', total_kwh: 1, total_cost: 0.3, data_points: [] });
+});
+
+const base = { selectedDeviceId: null, cumulativePeriod: 'today' as const, customStart: null, customEnd: null };
+
+describe('usePowerTabData', () => {
+  it('exposes devices, totalCurrentPower and cumulative data', async () => {
+    const { result } = renderHook(() => usePowerTabData(base), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.devices).toHaveLength(1);
+    expect(result.current.totalCurrentPower).toBe(42);
+    await waitFor(() => expect(result.current.cumulativeData?.total_kwh).toBe(1));
+    expect(result.current.cumulativeReady).toBe(true);
+  });
+
+  it('cumulativeReady false for custom with no applied range', () => {
+    const { result } = renderHook(() => usePowerTabData({ ...base, cumulativePeriod: 'custom' }), { wrapper: createQueryWrapper() });
+    expect(result.current.cumulativeReady).toBe(false);
+  });
+});

--- a/client/src/components/CLAUDE.md
+++ b/client/src/components/CLAUDE.md
@@ -62,7 +62,7 @@ Reusable, generic building blocks. No business logic, no API calls.
 | `shares/` | Share management — `SharesPage` composes `SharesStatCards`, `SharesTabBar`, `SharesToolbar`, `MySharesTable`, `SharedWithMeTable`, `CloudExportsTable` (+ `PermissionBadges`/`FileNameCell`/`CloudStatusBadge` primitives), extracted F2/#301-style |
 | `smart-devices/` | Smart device status and control |
 | `ssd-cache/` | SSD file cache management |
-| `system-monitor/` | System monitor detail views |
+| `system-monitor/` | System monitor detail views — `PowerTab` composes `power-tab/*`: `PowerSummaryCards`, `PowerDeviceCard`, `EnergyPriceEditor`, `ChartDeviceTabs`, `ChartModePeriodControls`, `CustomRangePicker`, `EnergyChartSummary`, `EnergyChart` (+ `CumulativeEnergyChart`/`InstantPowerChart`), `PowerStates`, and the `parseDevicePower` pure helper — extracted F2/#301 |
 | `updates/` | Self-update UI |
 | `user-management/` | User CRUD, 2FA management |
 | `setup/` | Setup wizard step components |

--- a/client/src/components/system-monitor/PowerTab.tsx
+++ b/client/src/components/system-monitor/PowerTab.tsx
@@ -1,308 +1,84 @@
 /**
- * PowerTab -- Power/energy monitoring tab with smart device integration.
+ * PowerTab -- Power/energy monitoring tab.
+ *
+ * Thin orchestrator: owns the chart selection state, delegates data to
+ * `usePowerTabData` + `useEnergyPrice`, and composes the `power-tab/*` units.
  */
 
-import { useState, useEffect } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
-import {
-  ComposedChart,
-  Area,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  Legend,
-} from 'recharts';
-import toast from 'react-hot-toast';
-import { getApiErrorMessage } from '../../lib/errorHandling';
-import { formatTimeForRange, parseUtcTimestamp, localRangeToUtcIso } from '../../lib/dateUtils';
-import type { ChartTimeRange } from '../../lib/dateUtils';
-import { smartDevicesApi } from '../../api/smart-devices';
-import {
-  getEnergyPriceConfig,
-  updateEnergyPriceConfig,
-  getCumulativeEnergy,
-  getCumulativeEnergyTotal,
-  type EnergyPriceConfig,
-} from '../../api/energy';
-import { StatCard } from '../ui/StatCard';
 import { PluginBadge } from '../ui/PluginBadge';
-import { formatNumber } from '../../lib/formatters';
 import { queryKeys } from '../../lib/queryKeys';
-import { resolveCumulativeArgs } from '../../lib/energyPolling';
-import { usePlugins } from '../../contexts/PluginContext';
+import { usePowerTabData } from '../../hooks/usePowerTabData';
+import { useEnergyPrice } from '../../hooks/useEnergyPrice';
+import {
+  PowerLoading,
+  PowerError,
+  PowerEmptyState,
+  PowerSummaryCards,
+  PowerDeviceCard,
+  EnergyPriceEditor,
+  ChartDeviceTabs,
+  ChartModePeriodControls,
+  CustomRangePicker,
+  EnergyChartSummary,
+  EnergyChart,
+} from './power-tab';
 
 type CumulativePeriod = 'today' | 'week' | 'month' | 'custom';
 type ChartMode = 'cumulative' | 'instant';
 
 export function PowerTab() {
   const { t, i18n } = useTranslation(['system', 'common']);
-  const { plugins } = usePlugins();
   const queryClient = useQueryClient();
 
-  // Energy price config state (fetched once on mount; edited locally)
-  const [priceConfig, setPriceConfig] = useState<EnergyPriceConfig | null>(null);
-  const [editingPrice, setEditingPrice] = useState(false);
-  const [priceInput, setPriceInput] = useState('');
-  const [savingPrice, setSavingPrice] = useState(false);
-
   // Chart selection state
+  const [chartMode, setChartMode] = useState<ChartMode>('cumulative');
   const [cumulativePeriod, setCumulativePeriod] = useState<CumulativePeriod>('today');
   const [selectedDeviceId, setSelectedDeviceId] = useState<number | null>(null);
-  const [chartMode, setChartMode] = useState<ChartMode>('cumulative');
-
-  // Custom range (applied values drive fetching; drafts live in the popover)
+  // Custom range (applied values drive fetching; drafts live in CustomRangePicker)
   const [customStart, setCustomStart] = useState<string | null>(null);
   const [customEnd, setCustomEnd] = useState<string | null>(null);
-  const [showRangePicker, setShowRangePicker] = useState(false);
-  const [draftStart, setDraftStart] = useState('');
-  const [draftEnd, setDraftEnd] = useState('');
 
-  // Devices + power summary — query-backed (#299), 5s poll (per-device live watts
-  // come from the device list). A 404 (no power plugin) is swallowed like before;
-  // the last successful data is retained on any error.
-  const powerQuery = useQuery({
-    queryKey: queryKeys.powerTab.summary(),
-    queryFn: async () => {
-      const [listRes, summaryRes] = await Promise.all([
-        smartDevicesApi.list(),
-        smartDevicesApi.getPowerSummary(),
-      ]);
-      const powerDevices = listRes.data.devices.filter((d) => d.capabilities?.includes('power_monitor'));
-      return { devices: powerDevices, powerSummary: summaryRes.data };
-    },
-    refetchInterval: 5000,
-  });
-  const devices = powerQuery.data?.devices ?? [];
-  const powerSummary = powerQuery.data?.powerSummary ?? null;
-  const loading = powerQuery.isLoading;
-  const errorStatus =
-    powerQuery.error && typeof powerQuery.error === 'object' && 'response' in powerQuery.error
-      ? (powerQuery.error as { response?: { status?: number } }).response?.status
-      : undefined;
-  const error =
-    powerQuery.isError && errorStatus !== 404
-      ? getApiErrorMessage(powerQuery.error, 'Failed to load power data')
-      : null;
+  const data = usePowerTabData({ selectedDeviceId, cumulativePeriod, customStart, customEnd });
+  const price = useEnergyPrice(() =>
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.powerTab.cumulative(
+        selectedDeviceId,
+        data.cumulativeKeyArgs.period,
+        data.cumulativeKeyArgs.start,
+        data.cumulativeKeyArgs.end,
+      ),
+    }),
+  );
 
-  // Cumulative energy — query-backed 60s poll. `resolveCumulativeArgs` (tested)
-  // maps the custom range; a custom period with nothing applied stays disabled.
-  const rangeArgs = resolveCumulativeArgs(cumulativePeriod, customStart, customEnd);
-  const cumulativeReady = !(cumulativePeriod === 'custom' && (!rangeArgs.start || !rangeArgs.end));
-  const cumulativeQuery = useQuery({
-    queryKey: queryKeys.powerTab.cumulative(
-      selectedDeviceId,
-      rangeArgs.period,
-      rangeArgs.start ?? null,
-      rangeArgs.end ?? null,
-    ),
-    queryFn: () =>
-      selectedDeviceId === null
-        ? getCumulativeEnergyTotal(rangeArgs.period, rangeArgs.start, rangeArgs.end)
-        : getCumulativeEnergy(selectedDeviceId, rangeArgs.period, rangeArgs.start, rangeArgs.end),
-    enabled: cumulativeReady,
-    refetchInterval: 60000,
-  });
-  const cumulativeData = cumulativeQuery.data ?? null;
-  // First-load spinner only — the old code re-showed it on every 60s poll.
-  const cumulativeLoading = cumulativeQuery.isLoading;
-
-  // Fetch price config on mount
-  useEffect(() => {
-    const fetchPriceConfig = async () => {
-      try {
-        const config = await getEnergyPriceConfig();
-        setPriceConfig(config);
-        setPriceInput(config.cost_per_kwh.toString());
-      } catch {
-        // Non-critical: price config will remain null
-      }
-    };
-    fetchPriceConfig();
-  }, []);
-
-  const handleSavePrice = async () => {
-    const newPrice = parseFloat(priceInput);
-    if (isNaN(newPrice) || newPrice < 0.01 || newPrice > 10.0) {
-      toast.error(t('monitor.power.priceMustBeBetween'));
-      return;
-    }
-
-    setSavingPrice(true);
-    try {
-      const updated = await updateEnergyPriceConfig({
-        cost_per_kwh: newPrice,
-        currency: priceConfig?.currency || 'EUR',
-      });
-      setPriceConfig(updated);
-      setEditingPrice(false);
-      toast.success(t('monitor.power.priceUpdated'));
-      // Refresh cumulative data with the new price (active range key).
-      await queryClient.invalidateQueries({
-        queryKey: queryKeys.powerTab.cumulative(
-          selectedDeviceId,
-          rangeArgs.period,
-          rangeArgs.start ?? null,
-          rangeArgs.end ?? null,
-        ),
-      });
-    } catch (err: unknown) {
-      toast.error(getApiErrorMessage(err, t('monitor.power.saveError')));
-    } finally {
-      setSavingPrice(false);
-    }
-  };
-
-  const totalCurrentPower = powerSummary?.total_watts ?? 0;
-  const powerPluginName = devices.length > 0
-    ? plugins.find(p => p.name === devices[0].plugin_name)?.display_name
-    : undefined;
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center py-12">
-        <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-slate-600 border-t-blue-500" />
-      </div>
-    );
-  }
-
-  if (error) {
-    return <div className="text-red-400 text-center py-8">{error}</div>;
-  }
-
-  if (devices.length === 0) {
-    return (
-      <div className="text-center py-12">
-        <svg
-          className="mx-auto h-16 w-16 text-slate-600"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M13 10V3L4 14h7v7l9-11h-9z"
-          />
-        </svg>
-        <p className="mt-4 text-slate-400">{t('monitor.power.noSmartDevices', 'No smart devices with power monitoring configured')}</p>
-        <Link
-          to="/smart-devices"
-          className="inline-block mt-4 px-4 py-2 text-sm bg-sky-500/20 text-sky-400 hover:bg-sky-500/30 border border-sky-500/40 rounded-lg transition-colors"
-        >
-          {t('monitor.power.configureSmartDevices', 'Configure Smart Devices')} →
-        </Link>
-      </div>
-    );
-  }
+  if (data.loading) return <PowerLoading />;
+  if (data.error) return <PowerError error={data.error} />;
+  if (data.devices.length === 0) return <PowerEmptyState />;
 
   return (
     <div className="space-y-4 sm:space-y-6 min-w-0">
       {/* Total Power Stats */}
-      <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-3 sm:gap-5 lg:grid-cols-4">
-        <StatCard
-          label={t('monitor.power.currentPower')}
-          value={formatNumber(totalCurrentPower, 1)}
-          unit="W"
-          color="yellow"
-          icon={<span className="text-yellow-400 text-base sm:text-xl">⚡</span>}
-        />
-        <StatCard
-          label={t('monitor.power.onlineDevices', 'Online')}
-          value={devices.filter(d => d.is_online).length}
-          unit={`/ ${devices.length}`}
-          color="green"
-          icon={<span className="text-green-400 text-base sm:text-xl">📊</span>}
-        />
-        <StatCard
-          label={t('monitor.power.devices')}
-          value={devices.length}
-          color="blue"
-          icon={<span className="text-blue-400 text-base sm:text-xl">#</span>}
-        />
-      </div>
+      <PowerSummaryCards
+        totalCurrentPower={data.totalCurrentPower}
+        onlineCount={data.devices.filter((d) => d.is_online).length}
+        deviceCount={data.devices.length}
+      />
 
       {/* Per-device stats */}
-      {devices.map((device) => {
-        const pm = device.state?.power_monitor as { watts?: number; current_power?: number; voltage?: number; current?: number; current_ma?: number; energy_today_kwh?: number; energy_today_wh?: number } | undefined;
-        const watts = pm?.watts ?? pm?.current_power;
-        const voltage = pm?.voltage;
-        const currentA = pm?.current ?? (pm?.current_ma != null ? pm.current_ma / 1000 : undefined);
-        const energyToday = pm?.energy_today_kwh ?? (pm?.energy_today_wh != null ? pm.energy_today_wh / 1000 : undefined);
-
-        return (
-          <div key={device.id} className="card border-slate-800/60 bg-slate-900/55 p-4 sm:p-6">
-            <div className="flex items-center justify-between mb-3 sm:mb-4">
-              <h3 className="text-base sm:text-lg font-semibold text-white">{device.name}</h3>
-              <span className={`text-xs px-2 py-0.5 rounded-full ${device.is_online ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'}`}>
-                {device.is_online ? t('monitor.power.online', 'Online') : t('monitor.power.offline', 'Offline')}
-              </span>
-            </div>
-            <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
-              <div>
-                <p className="text-[10px] sm:text-xs text-slate-400">{t('monitor.power.powerLabel')}</p>
-                <p className="text-lg sm:text-xl font-semibold text-white">
-                  {watts != null ? formatNumber(watts, 1) : '-'} <span className="text-sm sm:text-base text-slate-400">W</span>
-                </p>
-              </div>
-              <div>
-                <p className="text-[10px] sm:text-xs text-slate-400">{t('monitor.power.voltage')}</p>
-                <p className="text-lg sm:text-xl font-semibold text-white">
-                  {voltage != null ? formatNumber(voltage, 1) : '-'} <span className="text-sm sm:text-base text-slate-400">V</span>
-                </p>
-              </div>
-              <div>
-                <p className="text-[10px] sm:text-xs text-slate-400">{t('monitor.power.current')}</p>
-                <p className="text-lg sm:text-xl font-semibold text-white">
-                  {currentA != null ? formatNumber(currentA, 3) : '-'} <span className="text-sm sm:text-base text-slate-400">A</span>
-                </p>
-              </div>
-              <div>
-                <p className="text-[10px] sm:text-xs text-slate-400">{t('monitor.power.today')}</p>
-                <p className="text-lg sm:text-xl font-semibold text-white">
-                  {energyToday != null ? formatNumber(energyToday, 2) : '-'} <span className="text-sm sm:text-base text-slate-400">kWh</span>
-                </p>
-              </div>
-            </div>
-          </div>
-        );
-      })}
+      {data.devices.map((device) => (
+        <PowerDeviceCard key={device.id} device={device} />
+      ))}
 
       {/* Cumulative Energy Chart Section */}
       <div className="card border-slate-800/60 bg-slate-900/55 p-4 sm:p-6">
         {/* Device tabs for chart */}
-        <div className="flex items-center gap-1 overflow-x-auto pb-2">
-          <button
-            onClick={() => setSelectedDeviceId(null)}
-            className={`shrink-0 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-              selectedDeviceId === null
-                ? 'bg-blue-600 text-white'
-                : 'bg-gray-700/50 text-gray-400 hover:text-gray-200'
-            }`}
-          >
-            {t('monitor.power.total')}
-          </button>
-          {devices
-            .filter(d => d.is_active && d.capabilities?.includes('power_monitor'))
-            .map(device => (
-              <button
-                key={device.id}
-                onClick={() => setSelectedDeviceId(device.id)}
-                className={`shrink-0 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-                  selectedDeviceId === device.id
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-700/50 text-gray-400 hover:text-gray-200'
-                }`}
-              >
-                {device.name}
-              </button>
-            ))}
-        </div>
+        <ChartDeviceTabs
+          devices={data.devices}
+          selectedDeviceId={selectedDeviceId}
+          onSelect={setSelectedDeviceId}
+        />
 
         {/* Header with Price Config */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
@@ -311,379 +87,57 @@ export function PowerTab() {
               {chartMode === 'cumulative'
                 ? t('monitor.power.cumulativeConsumptionCosts')
                 : t('monitor.power.instantPowerConsumption')}
-              <PluginBadge pluginName={powerPluginName} size="sm" className="ml-2" />
+              <PluginBadge pluginName={data.powerPluginName} size="sm" className="ml-2" />
             </h3>
-            {priceConfig && (
-              <div className="flex items-center gap-2">
-                {editingPrice ? (
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="number"
-                      step="0.01"
-                      min="0.01"
-                      max="10"
-                      value={priceInput}
-                      onChange={(e) => setPriceInput(e.target.value)}
-                      className="w-20 px-2 py-1 text-sm bg-slate-800 border border-slate-700 rounded text-white focus:border-blue-500 focus:outline-none"
-                      disabled={savingPrice}
-                    />
-                    <span className="text-slate-400 text-sm">{priceConfig.currency}/kWh</span>
-                    <button
-                      onClick={handleSavePrice}
-                      disabled={savingPrice}
-                      className="px-2 py-1 text-xs bg-green-600 hover:bg-green-700 text-white rounded disabled:opacity-50"
-                    >
-                      {savingPrice ? '...' : '✓'}
-                    </button>
-                    <button
-                      onClick={() => {
-                        setEditingPrice(false);
-                        setPriceInput(priceConfig.cost_per_kwh.toString());
-                      }}
-                      disabled={savingPrice}
-                      className="px-2 py-1 text-xs bg-slate-700 hover:bg-slate-600 text-white rounded disabled:opacity-50"
-                    >
-                      ✕
-                    </button>
-                  </div>
-                ) : (
-                  <button
-                    onClick={() => setEditingPrice(true)}
-                    className="flex items-center gap-1 px-2 py-1 text-xs bg-slate-800 hover:bg-slate-700 text-slate-300 rounded border border-slate-700"
-                  >
-                    <span>{formatNumber(priceConfig.cost_per_kwh, 2)} {priceConfig.currency}/kWh</span>
-                    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-                    </svg>
-                  </button>
-                )}
-              </div>
+            {price.priceConfig && (
+              <EnergyPriceEditor
+                priceConfig={price.priceConfig}
+                editing={price.editingPrice}
+                priceInput={price.priceInput}
+                saving={price.savingPrice}
+                onEdit={() => price.setEditingPrice(true)}
+                onInputChange={price.setPriceInput}
+                onSave={price.savePrice}
+                onCancel={() => {
+                  price.setEditingPrice(false);
+                  price.setPriceInput(price.priceConfig!.cost_per_kwh.toString());
+                }}
+              />
             )}
           </div>
 
           {/* Mode Toggle + Period Selector */}
-          <div className="flex gap-1 sm:gap-2 flex-wrap">
-            {/* Chart Mode Toggle */}
-            {(['cumulative', 'instant'] as ChartMode[]).map((mode) => (
-              <button
-                key={mode}
-                onClick={() => setChartMode(mode)}
-                className={`px-3 py-1.5 text-xs sm:text-sm rounded-md transition-colors ${
-                  chartMode === mode
-                    ? 'bg-amber-500/20 text-amber-400 border border-amber-500/40'
-                    : 'bg-slate-800 text-slate-400 hover:bg-slate-700 border border-transparent'
-                }`}
-              >
-                {mode === 'cumulative' ? t('monitor.power.modeCumulative') : t('monitor.power.modeInstant')}
-              </button>
-            ))}
-
-            <div className="w-px bg-slate-700 mx-1 self-stretch" />
-
-            {/* Period Selector */}
-            {(['today', 'week', 'month'] as CumulativePeriod[]).map((period) => (
-              <button
-                key={period}
-                onClick={() => setCumulativePeriod(period)}
-                className={`px-3 py-1.5 text-xs sm:text-sm rounded-md transition-colors ${
-                  cumulativePeriod === period
-                    ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40'
-                    : 'bg-slate-800 text-slate-400 hover:bg-slate-700 border border-transparent'
-                }`}
-              >
-                {period === 'today' ? t('monitor.power.periodToday') : period === 'week' ? t('monitor.power.periodWeek') : t('monitor.power.periodMonth')}
-              </button>
-            ))}
-            <div className="relative">
-              <button
-                onClick={() => setShowRangePicker((v) => !v)}
-                className={`px-3 py-1.5 text-xs sm:text-sm rounded-md transition-colors ${
-                  cumulativePeriod === 'custom'
-                    ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40'
-                    : 'bg-slate-800 text-slate-400 hover:bg-slate-700 border border-transparent'
-                }`}
-              >
-                {t('monitor.power.periodCustom')}
-              </button>
-              {showRangePicker && (
-                <div
-                  className="absolute right-0 z-20 mt-2 w-64 rounded-lg border border-slate-700 bg-slate-900 p-3 shadow-xl"
-                  onKeyDown={(e) => { if (e.key === 'Escape') setShowRangePicker(false); }}
-                >
-                  <label className="block text-xs text-slate-400 mb-1">{t('monitor.power.customFrom')}</label>
-                  <input
-                    type="date"
-                    value={draftStart}
-                    max={draftEnd || undefined}
-                    onChange={(e) => setDraftStart(e.target.value)}
-                    className="w-full mb-2 px-2 py-1 text-sm bg-slate-800 border border-slate-700 rounded text-white focus:border-blue-500 focus:outline-none"
-                  />
-                  <label className="block text-xs text-slate-400 mb-1">{t('monitor.power.customTo')}</label>
-                  <input
-                    type="date"
-                    value={draftEnd}
-                    min={draftStart || undefined}
-                    onChange={(e) => setDraftEnd(e.target.value)}
-                    className="w-full mb-3 px-2 py-1 text-sm bg-slate-800 border border-slate-700 rounded text-white focus:border-blue-500 focus:outline-none"
-                  />
-                  <button
-                    onClick={() => {
-                      if (!draftStart || !draftEnd || draftStart > draftEnd) {
-                        toast.error(t('monitor.power.customInvalidRange'));
-                        return;
-                      }
-                      const { startIso, endIso } = localRangeToUtcIso(draftStart, draftEnd, Date.now());
-                      setCustomStart(startIso);
-                      setCustomEnd(endIso);
-                      setCumulativePeriod('custom');
-                      setShowRangePicker(false);
-                    }}
-                    className="w-full px-2 py-1.5 text-xs bg-blue-600 hover:bg-blue-700 text-white rounded"
-                  >
-                    {t('monitor.power.customApply')}
-                  </button>
-                </div>
-              )}
-            </div>
-          </div>
+          <ChartModePeriodControls
+            chartMode={chartMode}
+            onModeChange={setChartMode}
+            cumulativePeriod={cumulativePeriod}
+            onPeriodChange={setCumulativePeriod}
+            customRange={
+              <CustomRangePicker
+                active={cumulativePeriod === 'custom'}
+                onApply={(startIso, endIso) => {
+                  setCustomStart(startIso);
+                  setCustomEnd(endIso);
+                  setCumulativePeriod('custom');
+                }}
+              />
+            }
+          />
         </div>
 
         {/* Summary Stats */}
-        {cumulativeData && (() => {
-          if (chartMode === 'instant') {
-            const wattsValues = cumulativeData.data_points.map(dp => dp.instant_watts);
-            const avgWatts = wattsValues.length > 0 ? wattsValues.reduce((a, b) => a + b, 0) / wattsValues.length : 0;
-            const maxWatts = wattsValues.length > 0 ? Math.max(...wattsValues) : 0;
-            const minWatts = wattsValues.length > 0 ? Math.min(...wattsValues) : 0;
-            return (
-              <div className="grid grid-cols-1 min-[400px]:grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
-                <div className="bg-slate-800/50 rounded-lg p-3">
-                  <p className="text-xs text-slate-400">{t('monitor.power.avgPower')}</p>
-                  <p className="text-lg font-semibold text-amber-400">
-                    {formatNumber(avgWatts, 1)} <span className="text-sm text-slate-400">W</span>
-                  </p>
-                </div>
-                <div className="bg-slate-800/50 rounded-lg p-3">
-                  <p className="text-xs text-slate-400">{t('monitor.power.maxPower')}</p>
-                  <p className="text-lg font-semibold text-red-400">
-                    {formatNumber(maxWatts, 1)} <span className="text-sm text-slate-400">W</span>
-                  </p>
-                </div>
-                <div className="bg-slate-800/50 rounded-lg p-3">
-                  <p className="text-xs text-slate-400">{t('monitor.power.minPower')}</p>
-                  <p className="text-lg font-semibold text-emerald-400">
-                    {formatNumber(minWatts, 1)} <span className="text-sm text-slate-400">W</span>
-                  </p>
-                </div>
-                <div className="bg-slate-800/50 rounded-lg p-3">
-                  <p className="text-xs text-slate-400">{t('monitor.power.dataPoints')}</p>
-                  <p className="text-lg font-semibold text-slate-300">
-                    {cumulativeData.data_points.length}
-                  </p>
-                </div>
-              </div>
-            );
-          }
-          return (
-            <div className="grid grid-cols-1 min-[400px]:grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
-              <div className="bg-slate-800/50 rounded-lg p-3">
-                <p className="text-xs text-slate-400">{t('monitor.power.totalConsumption')}</p>
-                <p className="text-lg font-semibold text-emerald-400">
-                  {formatNumber(cumulativeData.total_kwh, 3)} <span className="text-sm text-slate-400">kWh</span>
-                </p>
-              </div>
-              <div className="bg-slate-800/50 rounded-lg p-3">
-                <p className="text-xs text-slate-400">{t('monitor.power.totalCosts')}</p>
-                <p className="text-lg font-semibold text-orange-400">
-                  {formatNumber(cumulativeData.total_cost, 2)} <span className="text-sm text-slate-400">{cumulativeData.currency}</span>
-                </p>
-              </div>
-              <div className="bg-slate-800/50 rounded-lg p-3">
-                <p className="text-xs text-slate-400">{t('monitor.power.electricityPrice')}</p>
-                <p className="text-lg font-semibold text-slate-300">
-                  {formatNumber(cumulativeData.cost_per_kwh, 2)} <span className="text-sm text-slate-400">{cumulativeData.currency}/kWh</span>
-                </p>
-              </div>
-              <div className="bg-slate-800/50 rounded-lg p-3">
-                <p className="text-xs text-slate-400">{t('monitor.power.dataPoints')}</p>
-                <p className="text-lg font-semibold text-slate-300">
-                  {cumulativeData.data_points.length}
-                </p>
-              </div>
-            </div>
-          );
-        })()}
+        {data.cumulativeData && (
+          <EnergyChartSummary chartMode={chartMode} cumulativeData={data.cumulativeData} />
+        )}
 
         {/* Chart */}
-        {cumulativeLoading ? (
-          <div className="flex items-center justify-center py-12">
-            <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-slate-600 border-t-blue-500" />
-          </div>
-        ) : cumulativeData && cumulativeData.data_points.length > 0 ? (
-          <div className="h-[300px] sm:h-[350px]">
-            <ResponsiveContainer width="100%" height="100%">
-              {chartMode === 'cumulative' ? (
-                <ComposedChart
-                  data={cumulativeData.data_points.map((dp) => ({
-                    time: formatTimeForRange(dp.timestamp, cumulativePeriod as ChartTimeRange, i18n.language),
-                    fullTime: parseUtcTimestamp(dp.timestamp).toLocaleString(i18n.language),
-                    kwh: dp.cumulative_kwh,
-                    cost: dp.cumulative_cost,
-                    watts: dp.instant_watts,
-                  }))}
-                  margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
-                >
-                  <defs>
-                    <linearGradient id="colorKwh" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="#10b981" stopOpacity={0.3} />
-                      <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
-                  <XAxis
-                    dataKey="time"
-                    stroke="#64748b"
-                    fontSize={11}
-                    tickLine={false}
-                    interval="preserveStartEnd"
-                    minTickGap={cumulativePeriod === 'week' ? 70 : 40}
-                  />
-                  <YAxis
-                    yAxisId="left"
-                    stroke="#10b981"
-                    fontSize={11}
-                    tickLine={false}
-                    axisLine={false}
-                    tickFormatter={(v) => formatNumber(v, 2)}
-                    label={{ value: 'kWh', angle: -90, position: 'insideLeft', fill: '#10b981', fontSize: 11 }}
-                  />
-                  <YAxis
-                    yAxisId="right"
-                    orientation="right"
-                    stroke="#f97316"
-                    fontSize={11}
-                    tickLine={false}
-                    axisLine={false}
-                    tickFormatter={(v) => formatNumber(v, 2)}
-                    label={{ value: cumulativeData.currency, angle: 90, position: 'insideRight', fill: '#f97316', fontSize: 11 }}
-                  />
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: '#1e293b',
-                      border: '1px solid #334155',
-                      borderRadius: '8px',
-                      fontSize: '12px',
-                    }}
-                    labelStyle={{ color: '#94a3b8' }}
-                    formatter={(value: number, name: string) => {
-                      if (name === 'kwh') return [`${formatNumber(value, 4)} kWh`, t('monitor.power.consumption')];
-                      if (name === 'cost') return [`${formatNumber(value, 4)} ${cumulativeData.currency}`, t('monitor.power.costsLabel')];
-                      if (name === 'watts') return [`${formatNumber(value, 1)} W`, t('monitor.power.powerLabel')];
-                      return [value, name];
-                    }}
-                    labelFormatter={(label, payload) => {
-                      if (payload && payload[0]) {
-                        return payload[0].payload.fullTime;
-                      }
-                      return label;
-                    }}
-                  />
-                  <Legend
-                    wrapperStyle={{ fontSize: '12px' }}
-                    formatter={(value) => {
-                      if (value === 'kwh') return t('monitor.power.consumptionKwh');
-                      if (value === 'cost') return `${t('monitor.power.costsLabel')} (${cumulativeData.currency})`;
-                      return value;
-                    }}
-                  />
-                  <Area
-                    yAxisId="left"
-                    type="monotone"
-                    dataKey="kwh"
-                    stroke="#10b981"
-                    strokeWidth={2}
-                    fill="url(#colorKwh)"
-                    name="kwh"
-                  />
-                  <Line
-                    yAxisId="right"
-                    type="monotone"
-                    dataKey="cost"
-                    stroke="#f97316"
-                    strokeWidth={2}
-                    dot={false}
-                    name="cost"
-                  />
-                </ComposedChart>
-              ) : (
-                <ComposedChart
-                  data={cumulativeData.data_points.map((dp) => ({
-                    time: formatTimeForRange(dp.timestamp, cumulativePeriod as ChartTimeRange, i18n.language),
-                    fullTime: parseUtcTimestamp(dp.timestamp).toLocaleString(i18n.language),
-                    watts: dp.instant_watts,
-                  }))}
-                  margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
-                >
-                  <defs>
-                    <linearGradient id="colorWatts" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="#f59e0b" stopOpacity={0.3} />
-                      <stop offset="95%" stopColor="#f59e0b" stopOpacity={0} />
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
-                  <XAxis
-                    dataKey="time"
-                    stroke="#64748b"
-                    fontSize={11}
-                    tickLine={false}
-                    interval="preserveStartEnd"
-                    minTickGap={cumulativePeriod === 'week' ? 70 : 40}
-                  />
-                  <YAxis
-                    stroke="#f59e0b"
-                    fontSize={11}
-                    tickLine={false}
-                    axisLine={false}
-                    tickFormatter={(v) => formatNumber(v, 1)}
-                    label={{ value: 'W', angle: -90, position: 'insideLeft', fill: '#f59e0b', fontSize: 11 }}
-                  />
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: '#1e293b',
-                      border: '1px solid #334155',
-                      borderRadius: '8px',
-                      fontSize: '12px',
-                    }}
-                    labelStyle={{ color: '#94a3b8' }}
-                    formatter={(value: number) => [`${formatNumber(value, 1)} W`, t('monitor.power.powerLabel')]}
-                    labelFormatter={(label, payload) => {
-                      if (payload && payload[0]) {
-                        return payload[0].payload.fullTime;
-                      }
-                      return label;
-                    }}
-                  />
-                  <Legend
-                    wrapperStyle={{ fontSize: '12px' }}
-                    formatter={() => t('monitor.power.powerWatts')}
-                  />
-                  <Area
-                    type="monotone"
-                    dataKey="watts"
-                    stroke="#f59e0b"
-                    strokeWidth={2}
-                    fill="url(#colorWatts)"
-                    name="watts"
-                  />
-                </ComposedChart>
-              )}
-            </ResponsiveContainer>
-          </div>
-        ) : (
-          <div className="text-center py-8 text-slate-400">
-            {t('monitor.noDataForPeriod')}
-          </div>
-        )}
+        <EnergyChart
+          chartMode={chartMode}
+          cumulativeData={data.cumulativeData}
+          cumulativeLoading={data.cumulativeLoading}
+          cumulativePeriod={cumulativePeriod}
+          language={i18n.language}
+        />
       </div>
     </div>
   );

--- a/client/src/components/system-monitor/power-tab/ChartDeviceTabs.tsx
+++ b/client/src/components/system-monitor/power-tab/ChartDeviceTabs.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next';
+import type { SmartDevice } from '../../../api/smart-devices';
+
+interface ChartDeviceTabsProps {
+  devices: SmartDevice[];
+  selectedDeviceId: number | null;
+  onSelect: (id: number | null) => void;
+}
+
+export function ChartDeviceTabs({ devices, selectedDeviceId, onSelect }: ChartDeviceTabsProps) {
+  const { t } = useTranslation(['system', 'common']);
+
+  return (
+    <div className="flex items-center gap-1 overflow-x-auto pb-2">
+      <button
+        onClick={() => onSelect(null)}
+        className={`shrink-0 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+          selectedDeviceId === null
+            ? 'bg-blue-600 text-white'
+            : 'bg-gray-700/50 text-gray-400 hover:text-gray-200'
+        }`}
+      >
+        {t('monitor.power.total')}
+      </button>
+      {devices
+        .filter(d => d.is_active && d.capabilities?.includes('power_monitor'))
+        .map(device => (
+          <button
+            key={device.id}
+            onClick={() => onSelect(device.id)}
+            className={`shrink-0 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+              selectedDeviceId === device.id
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-700/50 text-gray-400 hover:text-gray-200'
+            }`}
+          >
+            {device.name}
+          </button>
+        ))}
+    </div>
+  );
+}

--- a/client/src/components/system-monitor/power-tab/ChartModePeriodControls.tsx
+++ b/client/src/components/system-monitor/power-tab/ChartModePeriodControls.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from 'react-i18next';
+
+type ChartMode = 'cumulative' | 'instant';
+type CumulativePeriod = 'today' | 'week' | 'month' | 'custom';
+
+interface ChartModePeriodControlsProps {
+  chartMode: ChartMode;
+  onModeChange: (m: ChartMode) => void;
+  cumulativePeriod: CumulativePeriod;
+  onPeriodChange: (p: CumulativePeriod) => void;
+  customRange: React.ReactNode;
+}
+
+export function ChartModePeriodControls({
+  chartMode,
+  onModeChange,
+  cumulativePeriod,
+  onPeriodChange,
+  customRange,
+}: ChartModePeriodControlsProps) {
+  const { t } = useTranslation(['system', 'common']);
+
+  return (
+    <div className="flex gap-1 sm:gap-2 flex-wrap">
+      {/* Chart Mode Toggle */}
+      {(['cumulative', 'instant'] as ChartMode[]).map((mode) => (
+        <button
+          key={mode}
+          onClick={() => onModeChange(mode)}
+          className={`px-3 py-1.5 text-xs sm:text-sm rounded-md transition-colors ${
+            chartMode === mode
+              ? 'bg-amber-500/20 text-amber-400 border border-amber-500/40'
+              : 'bg-slate-800 text-slate-400 hover:bg-slate-700 border border-transparent'
+          }`}
+        >
+          {mode === 'cumulative' ? t('monitor.power.modeCumulative') : t('monitor.power.modeInstant')}
+        </button>
+      ))}
+
+      <div className="w-px bg-slate-700 mx-1 self-stretch" />
+
+      {/* Period Selector */}
+      {(['today', 'week', 'month'] as CumulativePeriod[]).map((period) => (
+        <button
+          key={period}
+          onClick={() => onPeriodChange(period)}
+          className={`px-3 py-1.5 text-xs sm:text-sm rounded-md transition-colors ${
+            cumulativePeriod === period
+              ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40'
+              : 'bg-slate-800 text-slate-400 hover:bg-slate-700 border border-transparent'
+          }`}
+        >
+          {period === 'today' ? t('monitor.power.periodToday') : period === 'week' ? t('monitor.power.periodWeek') : t('monitor.power.periodMonth')}
+        </button>
+      ))}
+      {customRange}
+    </div>
+  );
+}

--- a/client/src/components/system-monitor/power-tab/CumulativeEnergyChart.tsx
+++ b/client/src/components/system-monitor/power-tab/CumulativeEnergyChart.tsx
@@ -1,0 +1,120 @@
+import { useTranslation } from 'react-i18next';
+import {
+  ComposedChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts';
+import { formatTimeForRange, parseUtcTimestamp } from '../../../lib/dateUtils';
+import type { ChartTimeRange } from '../../../lib/dateUtils';
+import type { CumulativeEnergyResponse } from '../../../api/energy';
+import { formatNumber } from '../../../lib/formatters';
+
+interface CumulativeEnergyChartProps {
+  cumulativeData: CumulativeEnergyResponse;
+  cumulativePeriod: 'today' | 'week' | 'month' | 'custom';
+  language: string;
+}
+
+export function CumulativeEnergyChart({ cumulativeData, cumulativePeriod, language }: CumulativeEnergyChartProps) {
+  const { t } = useTranslation(['system', 'common']);
+
+  return (
+    <ComposedChart
+      data={cumulativeData.data_points.map((dp) => ({
+        time: formatTimeForRange(dp.timestamp, cumulativePeriod as ChartTimeRange, language),
+        fullTime: parseUtcTimestamp(dp.timestamp).toLocaleString(language),
+        kwh: dp.cumulative_kwh,
+        cost: dp.cumulative_cost,
+        watts: dp.instant_watts,
+      }))}
+      margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
+    >
+      <defs>
+        <linearGradient id="colorKwh" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="5%" stopColor="#10b981" stopOpacity={0.3} />
+          <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+      <XAxis
+        dataKey="time"
+        stroke="#64748b"
+        fontSize={11}
+        tickLine={false}
+        interval="preserveStartEnd"
+        minTickGap={cumulativePeriod === 'week' ? 70 : 40}
+      />
+      <YAxis
+        yAxisId="left"
+        stroke="#10b981"
+        fontSize={11}
+        tickLine={false}
+        axisLine={false}
+        tickFormatter={(v) => formatNumber(v, 2)}
+        label={{ value: 'kWh', angle: -90, position: 'insideLeft', fill: '#10b981', fontSize: 11 }}
+      />
+      <YAxis
+        yAxisId="right"
+        orientation="right"
+        stroke="#f97316"
+        fontSize={11}
+        tickLine={false}
+        axisLine={false}
+        tickFormatter={(v) => formatNumber(v, 2)}
+        label={{ value: cumulativeData.currency, angle: 90, position: 'insideRight', fill: '#f97316', fontSize: 11 }}
+      />
+      <Tooltip
+        contentStyle={{
+          backgroundColor: '#1e293b',
+          border: '1px solid #334155',
+          borderRadius: '8px',
+          fontSize: '12px',
+        }}
+        labelStyle={{ color: '#94a3b8' }}
+        formatter={(value: number, name: string) => {
+          if (name === 'kwh') return [`${formatNumber(value, 4)} kWh`, t('monitor.power.consumption')];
+          if (name === 'cost') return [`${formatNumber(value, 4)} ${cumulativeData.currency}`, t('monitor.power.costsLabel')];
+          if (name === 'watts') return [`${formatNumber(value, 1)} W`, t('monitor.power.powerLabel')];
+          return [value, name];
+        }}
+        labelFormatter={(label, payload) => {
+          if (payload && payload[0]) {
+            return payload[0].payload.fullTime;
+          }
+          return label;
+        }}
+      />
+      <Legend
+        wrapperStyle={{ fontSize: '12px' }}
+        formatter={(value) => {
+          if (value === 'kwh') return t('monitor.power.consumptionKwh');
+          if (value === 'cost') return `${t('monitor.power.costsLabel')} (${cumulativeData.currency})`;
+          return value;
+        }}
+      />
+      <Area
+        yAxisId="left"
+        type="monotone"
+        dataKey="kwh"
+        stroke="#10b981"
+        strokeWidth={2}
+        fill="url(#colorKwh)"
+        name="kwh"
+      />
+      <Line
+        yAxisId="right"
+        type="monotone"
+        dataKey="cost"
+        stroke="#f97316"
+        strokeWidth={2}
+        dot={false}
+        name="cost"
+      />
+    </ComposedChart>
+  );
+}

--- a/client/src/components/system-monitor/power-tab/CustomRangePicker.tsx
+++ b/client/src/components/system-monitor/power-tab/CustomRangePicker.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { localRangeToUtcIso } from '../../../lib/dateUtils';
+
+interface CustomRangePickerProps {
+  active: boolean;
+  onApply: (startIso: string, endIso: string) => void;
+}
+
+export function CustomRangePicker({ active, onApply }: CustomRangePickerProps) {
+  const { t } = useTranslation(['system', 'common']);
+  const [showRangePicker, setShowRangePicker] = useState(false);
+  const [draftStart, setDraftStart] = useState('');
+  const [draftEnd, setDraftEnd] = useState('');
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setShowRangePicker((v) => !v)}
+        className={`px-3 py-1.5 text-xs sm:text-sm rounded-md transition-colors ${
+          active
+            ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40'
+            : 'bg-slate-800 text-slate-400 hover:bg-slate-700 border border-transparent'
+        }`}
+      >
+        {t('monitor.power.periodCustom')}
+      </button>
+      {showRangePicker && (
+        <div
+          className="absolute right-0 z-20 mt-2 w-64 rounded-lg border border-slate-700 bg-slate-900 p-3 shadow-xl"
+          onKeyDown={(e) => { if (e.key === 'Escape') setShowRangePicker(false); }}
+        >
+          <label className="block text-xs text-slate-400 mb-1">{t('monitor.power.customFrom')}</label>
+          <input
+            type="date"
+            value={draftStart}
+            max={draftEnd || undefined}
+            onChange={(e) => setDraftStart(e.target.value)}
+            className="w-full mb-2 px-2 py-1 text-sm bg-slate-800 border border-slate-700 rounded text-white focus:border-blue-500 focus:outline-none"
+          />
+          <label className="block text-xs text-slate-400 mb-1">{t('monitor.power.customTo')}</label>
+          <input
+            type="date"
+            value={draftEnd}
+            min={draftStart || undefined}
+            onChange={(e) => setDraftEnd(e.target.value)}
+            className="w-full mb-3 px-2 py-1 text-sm bg-slate-800 border border-slate-700 rounded text-white focus:border-blue-500 focus:outline-none"
+          />
+          <button
+            onClick={() => {
+              if (!draftStart || !draftEnd || draftStart > draftEnd) {
+                toast.error(t('monitor.power.customInvalidRange'));
+                return;
+              }
+              const { startIso, endIso } = localRangeToUtcIso(draftStart, draftEnd, Date.now());
+              onApply(startIso, endIso);
+              setShowRangePicker(false);
+            }}
+            className="w-full px-2 py-1.5 text-xs bg-blue-600 hover:bg-blue-700 text-white rounded"
+          >
+            {t('monitor.power.customApply')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/system-monitor/power-tab/EnergyChart.tsx
+++ b/client/src/components/system-monitor/power-tab/EnergyChart.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'react-i18next';
+import { ResponsiveContainer } from 'recharts';
+import type { CumulativeEnergyResponse } from '../../../api/energy';
+import { CumulativeEnergyChart } from './CumulativeEnergyChart';
+import { InstantPowerChart } from './InstantPowerChart';
+
+interface EnergyChartProps {
+  chartMode: 'cumulative' | 'instant';
+  cumulativeData: CumulativeEnergyResponse | null;
+  cumulativeLoading: boolean;
+  cumulativePeriod: 'today' | 'week' | 'month' | 'custom';
+  language: string;
+}
+
+export function EnergyChart({ chartMode, cumulativeData, cumulativeLoading, cumulativePeriod, language }: EnergyChartProps) {
+  const { t } = useTranslation(['system', 'common']);
+
+  return cumulativeLoading ? (
+    <div className="flex items-center justify-center py-12">
+      <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-slate-600 border-t-blue-500" />
+    </div>
+  ) : cumulativeData && cumulativeData.data_points.length > 0 ? (
+    <div className="h-[300px] sm:h-[350px]">
+      <ResponsiveContainer width="100%" height="100%">
+        {chartMode === 'cumulative' ? (
+          <CumulativeEnergyChart
+            cumulativeData={cumulativeData}
+            cumulativePeriod={cumulativePeriod}
+            language={language}
+          />
+        ) : (
+          <InstantPowerChart
+            cumulativeData={cumulativeData}
+            cumulativePeriod={cumulativePeriod}
+            language={language}
+          />
+        )}
+      </ResponsiveContainer>
+    </div>
+  ) : (
+    <div className="text-center py-8 text-slate-400">
+      {t('monitor.noDataForPeriod')}
+    </div>
+  );
+}

--- a/client/src/components/system-monitor/power-tab/EnergyChartSummary.tsx
+++ b/client/src/components/system-monitor/power-tab/EnergyChartSummary.tsx
@@ -1,0 +1,75 @@
+import { useTranslation } from 'react-i18next';
+import type { CumulativeEnergyResponse } from '../../../api/energy';
+import { formatNumber } from '../../../lib/formatters';
+
+interface EnergyChartSummaryProps {
+  chartMode: 'cumulative' | 'instant';
+  cumulativeData: CumulativeEnergyResponse;
+}
+
+export function EnergyChartSummary({ chartMode, cumulativeData }: EnergyChartSummaryProps) {
+  const { t } = useTranslation(['system', 'common']);
+
+  if (chartMode === 'instant') {
+    const wattsValues = cumulativeData.data_points.map(dp => dp.instant_watts);
+    const avgWatts = wattsValues.length > 0 ? wattsValues.reduce((a, b) => a + b, 0) / wattsValues.length : 0;
+    const maxWatts = wattsValues.length > 0 ? Math.max(...wattsValues) : 0;
+    const minWatts = wattsValues.length > 0 ? Math.min(...wattsValues) : 0;
+    return (
+      <div className="grid grid-cols-1 min-[400px]:grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+        <div className="bg-slate-800/50 rounded-lg p-3">
+          <p className="text-xs text-slate-400">{t('monitor.power.avgPower')}</p>
+          <p className="text-lg font-semibold text-amber-400">
+            {formatNumber(avgWatts, 1)} <span className="text-sm text-slate-400">W</span>
+          </p>
+        </div>
+        <div className="bg-slate-800/50 rounded-lg p-3">
+          <p className="text-xs text-slate-400">{t('monitor.power.maxPower')}</p>
+          <p className="text-lg font-semibold text-red-400">
+            {formatNumber(maxWatts, 1)} <span className="text-sm text-slate-400">W</span>
+          </p>
+        </div>
+        <div className="bg-slate-800/50 rounded-lg p-3">
+          <p className="text-xs text-slate-400">{t('monitor.power.minPower')}</p>
+          <p className="text-lg font-semibold text-emerald-400">
+            {formatNumber(minWatts, 1)} <span className="text-sm text-slate-400">W</span>
+          </p>
+        </div>
+        <div className="bg-slate-800/50 rounded-lg p-3">
+          <p className="text-xs text-slate-400">{t('monitor.power.dataPoints')}</p>
+          <p className="text-lg font-semibold text-slate-300">
+            {cumulativeData.data_points.length}
+          </p>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="grid grid-cols-1 min-[400px]:grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+      <div className="bg-slate-800/50 rounded-lg p-3">
+        <p className="text-xs text-slate-400">{t('monitor.power.totalConsumption')}</p>
+        <p className="text-lg font-semibold text-emerald-400">
+          {formatNumber(cumulativeData.total_kwh, 3)} <span className="text-sm text-slate-400">kWh</span>
+        </p>
+      </div>
+      <div className="bg-slate-800/50 rounded-lg p-3">
+        <p className="text-xs text-slate-400">{t('monitor.power.totalCosts')}</p>
+        <p className="text-lg font-semibold text-orange-400">
+          {formatNumber(cumulativeData.total_cost, 2)} <span className="text-sm text-slate-400">{cumulativeData.currency}</span>
+        </p>
+      </div>
+      <div className="bg-slate-800/50 rounded-lg p-3">
+        <p className="text-xs text-slate-400">{t('monitor.power.electricityPrice')}</p>
+        <p className="text-lg font-semibold text-slate-300">
+          {formatNumber(cumulativeData.cost_per_kwh, 2)} <span className="text-sm text-slate-400">{cumulativeData.currency}/kWh</span>
+        </p>
+      </div>
+      <div className="bg-slate-800/50 rounded-lg p-3">
+        <p className="text-xs text-slate-400">{t('monitor.power.dataPoints')}</p>
+        <p className="text-lg font-semibold text-slate-300">
+          {cumulativeData.data_points.length}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/system-monitor/power-tab/EnergyPriceEditor.tsx
+++ b/client/src/components/system-monitor/power-tab/EnergyPriceEditor.tsx
@@ -1,0 +1,68 @@
+import { EnergyPriceConfig } from '../../../api/energy';
+import { formatNumber } from '../../../lib/formatters';
+
+interface EnergyPriceEditorProps {
+  priceConfig: EnergyPriceConfig;
+  editing: boolean;
+  priceInput: string;
+  saving: boolean;
+  onEdit: () => void;
+  onInputChange: (v: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+export function EnergyPriceEditor({
+  priceConfig,
+  editing,
+  priceInput,
+  saving,
+  onEdit,
+  onInputChange,
+  onSave,
+  onCancel,
+}: EnergyPriceEditorProps) {
+  return (
+    <div className="flex items-center gap-2">
+      {editing ? (
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            step="0.01"
+            min="0.01"
+            max="10"
+            value={priceInput}
+            onChange={(e) => onInputChange(e.target.value)}
+            className="w-20 px-2 py-1 text-sm bg-slate-800 border border-slate-700 rounded text-white focus:border-blue-500 focus:outline-none"
+            disabled={saving}
+          />
+          <span className="text-slate-400 text-sm">{priceConfig.currency}/kWh</span>
+          <button
+            onClick={onSave}
+            disabled={saving}
+            className="px-2 py-1 text-xs bg-green-600 hover:bg-green-700 text-white rounded disabled:opacity-50"
+          >
+            {saving ? '...' : '✓'}
+          </button>
+          <button
+            onClick={onCancel}
+            disabled={saving}
+            className="px-2 py-1 text-xs bg-slate-700 hover:bg-slate-600 text-white rounded disabled:opacity-50"
+          >
+            ✕
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={onEdit}
+          className="flex items-center gap-1 px-2 py-1 text-xs bg-slate-800 hover:bg-slate-700 text-slate-300 rounded border border-slate-700"
+        >
+          <span>{formatNumber(priceConfig.cost_per_kwh, 2)} {priceConfig.currency}/kWh</span>
+          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/system-monitor/power-tab/EnergyPriceEditor.tsx
+++ b/client/src/components/system-monitor/power-tab/EnergyPriceEditor.tsx
@@ -1,4 +1,4 @@
-import { EnergyPriceConfig } from '../../../api/energy';
+import type { EnergyPriceConfig } from '../../../api/energy';
 import { formatNumber } from '../../../lib/formatters';
 
 interface EnergyPriceEditorProps {

--- a/client/src/components/system-monitor/power-tab/InstantPowerChart.tsx
+++ b/client/src/components/system-monitor/power-tab/InstantPowerChart.tsx
@@ -1,0 +1,87 @@
+import { useTranslation } from 'react-i18next';
+import {
+  ComposedChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts';
+import { formatTimeForRange, parseUtcTimestamp } from '../../../lib/dateUtils';
+import type { ChartTimeRange } from '../../../lib/dateUtils';
+import type { CumulativeEnergyResponse } from '../../../api/energy';
+import { formatNumber } from '../../../lib/formatters';
+
+interface InstantPowerChartProps {
+  cumulativeData: CumulativeEnergyResponse;
+  cumulativePeriod: 'today' | 'week' | 'month' | 'custom';
+  language: string;
+}
+
+export function InstantPowerChart({ cumulativeData, cumulativePeriod, language }: InstantPowerChartProps) {
+  const { t } = useTranslation(['system', 'common']);
+
+  return (
+    <ComposedChart
+      data={cumulativeData.data_points.map((dp) => ({
+        time: formatTimeForRange(dp.timestamp, cumulativePeriod as ChartTimeRange, language),
+        fullTime: parseUtcTimestamp(dp.timestamp).toLocaleString(language),
+        watts: dp.instant_watts,
+      }))}
+      margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
+    >
+      <defs>
+        <linearGradient id="colorWatts" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="5%" stopColor="#f59e0b" stopOpacity={0.3} />
+          <stop offset="95%" stopColor="#f59e0b" stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+      <XAxis
+        dataKey="time"
+        stroke="#64748b"
+        fontSize={11}
+        tickLine={false}
+        interval="preserveStartEnd"
+        minTickGap={cumulativePeriod === 'week' ? 70 : 40}
+      />
+      <YAxis
+        stroke="#f59e0b"
+        fontSize={11}
+        tickLine={false}
+        axisLine={false}
+        tickFormatter={(v) => formatNumber(v, 1)}
+        label={{ value: 'W', angle: -90, position: 'insideLeft', fill: '#f59e0b', fontSize: 11 }}
+      />
+      <Tooltip
+        contentStyle={{
+          backgroundColor: '#1e293b',
+          border: '1px solid #334155',
+          borderRadius: '8px',
+          fontSize: '12px',
+        }}
+        labelStyle={{ color: '#94a3b8' }}
+        formatter={(value: number) => [`${formatNumber(value, 1)} W`, t('monitor.power.powerLabel')]}
+        labelFormatter={(label, payload) => {
+          if (payload && payload[0]) {
+            return payload[0].payload.fullTime;
+          }
+          return label;
+        }}
+      />
+      <Legend
+        wrapperStyle={{ fontSize: '12px' }}
+        formatter={() => t('monitor.power.powerWatts')}
+      />
+      <Area
+        type="monotone"
+        dataKey="watts"
+        stroke="#f59e0b"
+        strokeWidth={2}
+        fill="url(#colorWatts)"
+        name="watts"
+      />
+    </ComposedChart>
+  );
+}

--- a/client/src/components/system-monitor/power-tab/PowerDeviceCard.tsx
+++ b/client/src/components/system-monitor/power-tab/PowerDeviceCard.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next';
+import type { SmartDevice } from '../../../api/smart-devices';
+import { parseDevicePower } from './parseDevicePower';
+import { formatNumber } from '../../../lib/formatters';
+
+interface PowerDeviceCardProps {
+  device: SmartDevice;
+}
+
+export function PowerDeviceCard({ device }: PowerDeviceCardProps) {
+  const { t } = useTranslation(['system', 'common']);
+  const { watts, voltage, currentA, energyToday } = parseDevicePower(device);
+
+  return (
+    <div className="card border-slate-800/60 bg-slate-900/55 p-4 sm:p-6">
+      <div className="flex items-center justify-between mb-3 sm:mb-4">
+        <h3 className="text-base sm:text-lg font-semibold text-white">{device.name}</h3>
+        <span className={`text-xs px-2 py-0.5 rounded-full ${device.is_online ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'}`}>
+          {device.is_online ? t('monitor.power.online', 'Online') : t('monitor.power.offline', 'Offline')}
+        </span>
+      </div>
+      <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
+        <div>
+          <p className="text-[10px] sm:text-xs text-slate-400">{t('monitor.power.powerLabel')}</p>
+          <p className="text-lg sm:text-xl font-semibold text-white">
+            {watts != null ? formatNumber(watts, 1) : '-'} <span className="text-sm sm:text-base text-slate-400">W</span>
+          </p>
+        </div>
+        <div>
+          <p className="text-[10px] sm:text-xs text-slate-400">{t('monitor.power.voltage')}</p>
+          <p className="text-lg sm:text-xl font-semibold text-white">
+            {voltage != null ? formatNumber(voltage, 1) : '-'} <span className="text-sm sm:text-base text-slate-400">V</span>
+          </p>
+        </div>
+        <div>
+          <p className="text-[10px] sm:text-xs text-slate-400">{t('monitor.power.current')}</p>
+          <p className="text-lg sm:text-xl font-semibold text-white">
+            {currentA != null ? formatNumber(currentA, 3) : '-'} <span className="text-sm sm:text-base text-slate-400">A</span>
+          </p>
+        </div>
+        <div>
+          <p className="text-[10px] sm:text-xs text-slate-400">{t('monitor.power.today')}</p>
+          <p className="text-lg sm:text-xl font-semibold text-white">
+            {energyToday != null ? formatNumber(energyToday, 2) : '-'} <span className="text-sm sm:text-base text-slate-400">kWh</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/system-monitor/power-tab/PowerStates.tsx
+++ b/client/src/components/system-monitor/power-tab/PowerStates.tsx
@@ -1,0 +1,47 @@
+/**
+ * PowerStates -- presentational loading/error/empty states for PowerTab.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+
+export function PowerLoading() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-slate-600 border-t-blue-500" />
+    </div>
+  );
+}
+
+export function PowerError({ error }: { error: string }) {
+  return <div className="text-red-400 text-center py-8">{error}</div>;
+}
+
+export function PowerEmptyState() {
+  const { t } = useTranslation(['system', 'common']);
+
+  return (
+    <div className="text-center py-12">
+      <svg
+        className="mx-auto h-16 w-16 text-slate-600"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M13 10V3L4 14h7v7l9-11h-9z"
+        />
+      </svg>
+      <p className="mt-4 text-slate-400">{t('monitor.power.noSmartDevices', 'No smart devices with power monitoring configured')}</p>
+      <Link
+        to="/smart-devices"
+        className="inline-block mt-4 px-4 py-2 text-sm bg-sky-500/20 text-sky-400 hover:bg-sky-500/30 border border-sky-500/40 rounded-lg transition-colors"
+      >
+        {t('monitor.power.configureSmartDevices', 'Configure Smart Devices')} →
+      </Link>
+    </div>
+  );
+}

--- a/client/src/components/system-monitor/power-tab/PowerSummaryCards.tsx
+++ b/client/src/components/system-monitor/power-tab/PowerSummaryCards.tsx
@@ -1,0 +1,38 @@
+import { useTranslation } from 'react-i18next';
+import { StatCard } from '../../ui/StatCard';
+import { formatNumber } from '../../../lib/formatters';
+
+interface PowerSummaryCardsProps {
+  totalCurrentPower: number;
+  onlineCount: number;
+  deviceCount: number;
+}
+
+export function PowerSummaryCards({ totalCurrentPower, onlineCount, deviceCount }: PowerSummaryCardsProps) {
+  const { t } = useTranslation(['system', 'common']);
+
+  return (
+    <div className="grid grid-cols-1 min-[400px]:grid-cols-2 gap-3 sm:gap-5 lg:grid-cols-4">
+      <StatCard
+        label={t('monitor.power.currentPower')}
+        value={formatNumber(totalCurrentPower, 1)}
+        unit="W"
+        color="yellow"
+        icon={<span className="text-yellow-400 text-base sm:text-xl">⚡</span>}
+      />
+      <StatCard
+        label={t('monitor.power.onlineDevices', 'Online')}
+        value={onlineCount}
+        unit={`/ ${deviceCount}`}
+        color="green"
+        icon={<span className="text-green-400 text-base sm:text-xl">📊</span>}
+      />
+      <StatCard
+        label={t('monitor.power.devices')}
+        value={deviceCount}
+        color="blue"
+        icon={<span className="text-blue-400 text-base sm:text-xl">#</span>}
+      />
+    </div>
+  );
+}

--- a/client/src/components/system-monitor/power-tab/index.ts
+++ b/client/src/components/system-monitor/power-tab/index.ts
@@ -1,0 +1,14 @@
+/**
+ * power-tab barrel -- presentational units + helpers composed by PowerTab.tsx.
+ */
+
+export { PowerLoading, PowerError, PowerEmptyState } from './PowerStates';
+export { PowerSummaryCards } from './PowerSummaryCards';
+export { PowerDeviceCard } from './PowerDeviceCard';
+export { EnergyPriceEditor } from './EnergyPriceEditor';
+export { ChartDeviceTabs } from './ChartDeviceTabs';
+export { ChartModePeriodControls } from './ChartModePeriodControls';
+export { CustomRangePicker } from './CustomRangePicker';
+export { EnergyChartSummary } from './EnergyChartSummary';
+export { EnergyChart } from './EnergyChart';
+export { parseDevicePower, type DevicePower } from './parseDevicePower';

--- a/client/src/components/system-monitor/power-tab/parseDevicePower.ts
+++ b/client/src/components/system-monitor/power-tab/parseDevicePower.ts
@@ -1,0 +1,19 @@
+import type { SmartDevice } from '../../../api/smart-devices';
+
+export interface DevicePower {
+  watts?: number;
+  voltage?: number;
+  currentA?: number;
+  energyToday?: number;
+}
+
+export function parseDevicePower(device: SmartDevice): DevicePower {
+  const pm = device.state?.power_monitor as
+    | { watts?: number; current_power?: number; voltage?: number; current?: number; current_ma?: number; energy_today_kwh?: number; energy_today_wh?: number }
+    | undefined;
+  const watts = pm?.watts ?? pm?.current_power;
+  const voltage = pm?.voltage;
+  const currentA = pm?.current ?? (pm?.current_ma != null ? pm.current_ma / 1000 : undefined);
+  const energyToday = pm?.energy_today_kwh ?? (pm?.energy_today_wh != null ? pm.energy_today_wh / 1000 : undefined);
+  return { watts, voltage, currentA, energyToday };
+}

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -43,6 +43,8 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useFileUpload.ts` | `contexts/UploadContext` | Drag/drop + upload handlers for FileManager (F2/#301 PR-2) — owns `dragActive`, wraps `useUpload().startUpload`; `traverseFileTree` internal |
 | `useSleepConfigForm.ts` | — | Consolidates SleepConfigPanel's 20 sleep-config form fields into one object + update/syncFromResponse/toPayload (SleepConfigUpdate). No TanStack (user-triggered config). |
 | `useFritzBoxForm.ts` | `api/fritzbox` | Fritz!Box form object + config + toPayload (password only if set, mac||undefined) + test() (connection test + toast). No TanStack. |
+| `usePowerTabData.ts` | `api/smart-devices`, `api/energy` | Power devices/summary + cumulative energy for `PowerTab` via **TanStack Query**: combined `powerTab.summary()` key (5s poll, swallows a 404 when no power plugin, retains last data on error) plus a `powerTab.cumulative()` query gated by `resolveCumulativeArgs`/`cumulativeReady` (custom range needs both dates), 60s poll. Extracted verbatim from `PowerTab.tsx` (F2/#301) |
+| `useEnergyPrice.ts` | `api/energy` | Energy-price editor state (config/editing/input/saving) + save for `PowerTab`'s `EnergyPriceEditor`; fetches once on mount (imperative, no TanStack), validates 0.01–10.0, takes an `onSaved` callback so the caller can refresh the cumulative-energy query after a price change (F2/#301) |
 
 ## Utility Hooks
 

--- a/client/src/hooks/useEnergyPrice.ts
+++ b/client/src/hooks/useEnergyPrice.ts
@@ -1,0 +1,71 @@
+/**
+ * useEnergyPrice -- energy price editor state (config/editing/input/saving),
+ * mount fetch, and save. Extracted from PowerTab (#301).
+ */
+
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { getApiErrorMessage } from '../lib/errorHandling';
+import { getEnergyPriceConfig, updateEnergyPriceConfig, type EnergyPriceConfig } from '../api/energy';
+
+export interface UseEnergyPriceResult {
+  priceConfig: EnergyPriceConfig | null;
+  editingPrice: boolean;
+  setEditingPrice: (v: boolean) => void;
+  priceInput: string;
+  setPriceInput: (v: string) => void;
+  savingPrice: boolean;
+  savePrice: () => Promise<void>;
+}
+
+export function useEnergyPrice(onSaved?: () => void | Promise<void>): UseEnergyPriceResult {
+  const { t } = useTranslation(['system', 'common']);
+
+  // Energy price config state (fetched once on mount; edited locally)
+  const [priceConfig, setPriceConfig] = useState<EnergyPriceConfig | null>(null);
+  const [editingPrice, setEditingPrice] = useState(false);
+  const [priceInput, setPriceInput] = useState('');
+  const [savingPrice, setSavingPrice] = useState(false);
+
+  // Fetch price config on mount
+  useEffect(() => {
+    const fetchPriceConfig = async () => {
+      try {
+        const config = await getEnergyPriceConfig();
+        setPriceConfig(config);
+        setPriceInput(config.cost_per_kwh.toString());
+      } catch {
+        // Non-critical: price config will remain null
+      }
+    };
+    fetchPriceConfig();
+  }, []);
+
+  const savePrice = async () => {
+    const newPrice = parseFloat(priceInput);
+    if (isNaN(newPrice) || newPrice < 0.01 || newPrice > 10.0) {
+      toast.error(t('monitor.power.priceMustBeBetween'));
+      return;
+    }
+
+    setSavingPrice(true);
+    try {
+      const updated = await updateEnergyPriceConfig({
+        cost_per_kwh: newPrice,
+        currency: priceConfig?.currency || 'EUR',
+      });
+      setPriceConfig(updated);
+      setEditingPrice(false);
+      toast.success(t('monitor.power.priceUpdated'));
+      // Refresh cumulative data with the new price (active range key).
+      await onSaved?.();
+    } catch (err: unknown) {
+      toast.error(getApiErrorMessage(err, t('monitor.power.saveError')));
+    } finally {
+      setSavingPrice(false);
+    }
+  };
+
+  return { priceConfig, editingPrice, setEditingPrice, priceInput, setPriceInput, savingPrice, savePrice };
+}

--- a/client/src/hooks/usePowerTabData.ts
+++ b/client/src/hooks/usePowerTabData.ts
@@ -1,0 +1,117 @@
+/**
+ * usePowerTabData -- data hook for SystemMonitor's PowerTab.
+ *
+ * Owns the two React Query calls (power devices/summary + cumulative energy)
+ * and the derived read-values. Extracted verbatim from PowerTab.tsx (F2/#301).
+ */
+import { useQuery } from '@tanstack/react-query';
+import { smartDevicesApi, type SmartDevice, type PowerSummary } from '../api/smart-devices';
+import { getCumulativeEnergy, getCumulativeEnergyTotal, type CumulativeEnergyResponse } from '../api/energy';
+import { queryKeys } from '../lib/queryKeys';
+import { resolveCumulativeArgs } from '../lib/energyPolling';
+import { getApiErrorMessage } from '../lib/errorHandling';
+import { usePlugins } from '../contexts/PluginContext';
+
+export interface UsePowerTabDataInput {
+  selectedDeviceId: number | null;
+  cumulativePeriod: 'today' | 'week' | 'month' | 'custom';
+  customStart: string | null;
+  customEnd: string | null;
+}
+
+export interface CumulativeKeyArgs {
+  period: string;
+  start: string | null;
+  end: string | null;
+}
+
+export interface UsePowerTabDataResult {
+  devices: SmartDevice[];
+  powerSummary: PowerSummary | null;
+  loading: boolean;
+  error: string | null;
+  cumulativeData: CumulativeEnergyResponse | null;
+  cumulativeLoading: boolean;
+  cumulativeReady: boolean;
+  totalCurrentPower: number;
+  powerPluginName: string | undefined;
+  cumulativeKeyArgs: CumulativeKeyArgs;
+}
+
+export function usePowerTabData(input: UsePowerTabDataInput): UsePowerTabDataResult {
+  const { selectedDeviceId, cumulativePeriod, customStart, customEnd } = input;
+  const { plugins } = usePlugins();
+
+  // Devices + power summary — query-backed (#299), 5s poll (per-device live watts
+  // come from the device list). A 404 (no power plugin) is swallowed like before;
+  // the last successful data is retained on any error.
+  const powerQuery = useQuery({
+    queryKey: queryKeys.powerTab.summary(),
+    queryFn: async () => {
+      const [listRes, summaryRes] = await Promise.all([
+        smartDevicesApi.list(),
+        smartDevicesApi.getPowerSummary(),
+      ]);
+      const powerDevices = listRes.data.devices.filter((d) => d.capabilities?.includes('power_monitor'));
+      return { devices: powerDevices, powerSummary: summaryRes.data };
+    },
+    refetchInterval: 5000,
+  });
+  const devices = powerQuery.data?.devices ?? [];
+  const powerSummary = powerQuery.data?.powerSummary ?? null;
+  const loading = powerQuery.isLoading;
+  const errorStatus =
+    powerQuery.error && typeof powerQuery.error === 'object' && 'response' in powerQuery.error
+      ? (powerQuery.error as { response?: { status?: number } }).response?.status
+      : undefined;
+  const error =
+    powerQuery.isError && errorStatus !== 404
+      ? getApiErrorMessage(powerQuery.error, 'Failed to load power data')
+      : null;
+
+  // Cumulative energy — query-backed 60s poll. `resolveCumulativeArgs` (tested)
+  // maps the custom range; a custom period with nothing applied stays disabled.
+  const rangeArgs = resolveCumulativeArgs(cumulativePeriod, customStart, customEnd);
+  const cumulativeReady = !(cumulativePeriod === 'custom' && (!rangeArgs.start || !rangeArgs.end));
+  const cumulativeQuery = useQuery({
+    queryKey: queryKeys.powerTab.cumulative(
+      selectedDeviceId,
+      rangeArgs.period,
+      rangeArgs.start ?? null,
+      rangeArgs.end ?? null,
+    ),
+    queryFn: () =>
+      selectedDeviceId === null
+        ? getCumulativeEnergyTotal(rangeArgs.period, rangeArgs.start, rangeArgs.end)
+        : getCumulativeEnergy(selectedDeviceId, rangeArgs.period, rangeArgs.start, rangeArgs.end),
+    enabled: cumulativeReady,
+    refetchInterval: 60000,
+  });
+  const cumulativeData = cumulativeQuery.data ?? null;
+  // First-load spinner only — the old code re-showed it on every 60s poll.
+  const cumulativeLoading = cumulativeQuery.isLoading;
+
+  const totalCurrentPower = powerSummary?.total_watts ?? 0;
+  const powerPluginName = devices.length > 0
+    ? plugins.find(p => p.name === devices[0].plugin_name)?.display_name
+    : undefined;
+
+  const cumulativeKeyArgs: CumulativeKeyArgs = {
+    period: rangeArgs.period,
+    start: rangeArgs.start ?? null,
+    end: rangeArgs.end ?? null,
+  };
+
+  return {
+    devices,
+    powerSummary,
+    loading,
+    error,
+    cumulativeData,
+    cumulativeLoading,
+    cumulativeReady,
+    totalCurrentPower,
+    powerPluginName,
+    cumulativeKeyArgs,
+  };
+}

--- a/docs/superpowers/plans/2026-07-11-powertab-decomposition-f2.md
+++ b/docs/superpowers/plans/2026-07-11-powertab-decomposition-f2.md
@@ -367,7 +367,7 @@ describe('PowerStates', () => {
 
 **Note:** markup verbatim (239–272); `const { watts, voltage, currentA, energyToday } = parseDevicePower(device);` replaces the inline `pm` block. `-` fallbacks and `formatNumber` precisions (1/1/3/2) verbatim. Online badge from `device.is_online`.
 
-- [ ] **Step 1: failing test** — device with `state.power_monitor = { watts: 12.5, voltage: 230, current: 0.05, energy_today_kwh: 1.2 }`; assert name, online badge text, `12.5`, `230`, `0.050`, `1.20`. A second device with `state: null` → four `-`. Mock i18n.
+- [ ] **Step 1: failing test** — device with `state.power_monitor = { watts: 12.5, voltage: 230, current: 0.05, energy_today_kwh: 1.2 }`; assert name, online badge text, `12.5`, `230`, `0.050`, `1.20`. A second device (separate render) with `state: null` → `expect(screen.getAllByText('-')).toHaveLength(4)`. Mock i18n.
 - [ ] **Step 2: fail** → FAIL.
 - [ ] **Step 3: implement** (verbatim).
 - [ ] **Step 4: pass** → PASS.
@@ -443,7 +443,13 @@ describe('PowerStates', () => {
     customRange: React.ReactNode;
   }
   ```
-  Mode toggle (367–379) + period buttons `today/week/month` (384–396) verbatim; renders `{customRange}` where the custom picker sits (397). Period buttons call `onPeriodChange`.
+  This component **is** the whole right-hand controls cluster — the outer
+  `<div className="flex gap-1 sm:gap-2 flex-wrap">` (365) containing, in order:
+  the mode toggle (367–379), the vertical divider `<div className="w-px
+  bg-slate-700 mx-1 self-stretch" />` (381) **verbatim — do not drop it**, the
+  period buttons `today/week/month` (384–396), then `{customRange}` in the slot
+  where the custom `<div className="relative">` picker sat (397). Period buttons
+  call `onPeriodChange`; mode buttons call `onModeChange`.
 
 - [ ] **Step 1: failing test** (`ChartControls.test.tsx`, mock i18n + `react-hot-toast` + `../../../lib/dateUtils`'s `localRangeToUtcIso` → returns `{ startIso: 'S', endIso: 'E' }`):
   - `ChartModePeriodControls`: renders mode + period buttons; clicking `week` fires `onPeriodChange('week')`; clicking `instant` fires `onModeChange('instant')`; `customRange` node renders.
@@ -497,7 +503,10 @@ describe('PowerStates', () => {
 
 **Note:** `import type { ChartTimeRange }` and `formatTimeForRange`/`parseUtcTimestamp` from `../../../lib/dateUtils`; `formatNumber` from `../../../lib/formatters`; recharts imports as in the original.
 
-- [ ] **Step 1: failing test** (mock recharts per Global Constraints; mock i18n) — `EnergyChart` with `cumulativeLoading: true` → spinner present (no chart); with `cumulativeData: { …, data_points: [] }` → `getByText('monitor.noDataForPeriod')`; with one data point + `chartMode:'cumulative'` → renders without throwing (recharts mocked). Keep assertions coarse (recharts is stubbed).
+- [ ] **Step 1: failing test** (mock recharts per Global Constraints; mock i18n) — the spinner has no text/role (T7 forbids class assertions), so key the states off the empty-state text:
+  - `cumulativeLoading: true` (data null) → `expect(screen.queryByText('monitor.noDataForPeriod')).toBeNull()` (loading ≠ empty), render does not throw.
+  - `cumulativeData: { …, data_points: [] }`, not loading → `getByText('monitor.noDataForPeriod')`.
+  - one data point + `chartMode: 'cumulative'`, not loading → `queryByText('monitor.noDataForPeriod')` is null and render does not throw (recharts stubbed — do not assert chart internals).
 - [ ] **Step 2: fail** → FAIL.
 - [ ] **Step 3: implement** the three files (charts verbatim, `EnergyChart` selects by mode).
 - [ ] **Step 4: pass** → PASS.
@@ -523,7 +532,7 @@ describe('PowerStates', () => {
   }));
   ```
   Early returns: `if (data.loading) return <PowerLoading/>;` `if (data.error) return <PowerError error={data.error}/>;` `if (data.devices.length === 0) return <PowerEmptyState/>;`
-  Then composes: `PowerSummaryCards` (`onlineCount = data.devices.filter(d=>d.is_online).length`, `deviceCount = data.devices.length`), `data.devices.map(d => <PowerDeviceCard key={d.id} device={d}/>)`, and the chart card: `ChartDeviceTabs`, header (`chartMode` title + `PluginBadge pluginName={data.powerPluginName}` + `{price.priceConfig && <EnergyPriceEditor .../>}`), `ChartModePeriodControls` with `customRange={<CustomRangePicker active={cumulativePeriod==='custom'} onApply={(s,e)=>{ setCustomStart(s); setCustomEnd(e); setCumulativePeriod('custom'); }}/>}`, `{data.cumulativeData && <EnergyChartSummary chartMode={chartMode} cumulativeData={data.cumulativeData}/>}`, `<EnergyChart chartMode={chartMode} cumulativeData={data.cumulativeData} cumulativeLoading={data.cumulativeLoading} cumulativePeriod={cumulativePeriod} language={i18n.language}/>`.
+  Then composes: `PowerSummaryCards` (`onlineCount = data.devices.filter(d=>d.is_online).length`, `deviceCount = data.devices.length`), `data.devices.map(d => <PowerDeviceCard key={d.id} device={d}/>)`, and the chart card (`<div className="card …">`): `ChartDeviceTabs`, then the header row **verbatim wrapper** `<div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">` (308) containing BOTH sides — **left** `<div className="flex items-center gap-3 flex-wrap">` with the `chartMode` title (`t('monitor.power.cumulativeConsumptionCosts')` vs `instantPowerConsumption`) + `<PluginBadge pluginName={data.powerPluginName} size="sm" className="ml-2" />` + `{price.priceConfig && <EnergyPriceEditor .../>}`, and **right** `<ChartModePeriodControls … customRange={<CustomRangePicker active={cumulativePeriod==='custom'} onApply={(s,e)=>{ setCustomStart(s); setCustomEnd(e); setCumulativePeriod('custom'); }}/>} />`. Then `{data.cumulativeData && <EnergyChartSummary chartMode={chartMode} cumulativeData={data.cumulativeData}/>}` and `<EnergyChart chartMode={chartMode} cumulativeData={data.cumulativeData} cumulativeLoading={data.cumulativeLoading} cumulativePeriod={cumulativePeriod} language={i18n.language}/>`. Keep the section-order and the `space-y-4 sm:space-y-6 min-w-0` outer wrapper (205) verbatim.
   - `EnergyPriceEditor` wiring: `editing={price.editingPrice}`, `priceInput={price.priceInput}`, `saving={price.savingPrice}`, `onEdit={() => price.setEditingPrice(true)}`, `onInputChange={price.setPriceInput}`, `onSave={price.savePrice}`, `onCancel={() => { price.setEditingPrice(false); price.setPriceInput(price.priceConfig!.cost_per_kwh.toString()); }}`.
   - Keep the outer card wrappers, header title branch (`t('monitor.power.cumulativeConsumptionCosts')` vs `instantPowerConsumption`), `useTranslation(['system','common'])`, `i18n.language`.
 

--- a/docs/superpowers/plans/2026-07-11-powertab-decomposition-f2.md
+++ b/docs/superpowers/plans/2026-07-11-powertab-decomposition-f2.md
@@ -1,0 +1,581 @@
+# PowerTab.tsx Decomposition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `client/src/components/system-monitor/PowerTab.tsx` (690 lines) into two data/state hooks, one pure helper, and a `power-tab/` directory of presentational components, behavior-preserving, dropping the tab to ~150 lines.
+
+**Architecture:** `usePowerTabData` owns both queries + derived read-values; `useEnergyPrice` owns the price editor state + save; `parseDevicePower` is a pure helper; presentational components under `components/system-monitor/power-tab/` receive props + callbacks. PowerTab keeps the selection state and composes everything.
+
+**Tech Stack:** React 18 + TypeScript (strict), Vite, Tailwind, react-i18next, @tanstack/react-query, recharts, react-hot-toast, Vitest + @testing-library/react.
+
+## Global Constraints
+
+- **Behavior-preserving:** every moved value is byte-identical — same query keys (`queryKeys.powerTab.summary()` / `.cumulative(...)`), `refetchInterval` (5000 / 60000), 404-swallow, `resolveCumulativeArgs`, validation bounds (0.01–10.0), i18n keys, recharts props, Tailwind classes.
+- **Tab stays at path:** `components/system-monitor/PowerTab.tsx`, named `export function PowerTab()`. The `system-monitor/index.ts` barrel line is unchanged.
+- **Presentational components** are props-in/callbacks-in, no fetch. **Hooks** own fetch/state and call `useTranslation`/`usePlugins`/`useQueryClient` internally as needed.
+- **i18n test mock (verbatim):**
+  ```ts
+  vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (k: string, d?: string) => (typeof d === 'string' ? d : k), i18n: { language: 'en' } }),
+  }));
+  ```
+  (PowerTab uses `t(key, defaultString)` in several places — returning the default when present keeps those assertions meaningful; assert on the returned string.)
+- **recharts mock** for chart tests (no real chart dims in jsdom):
+  ```ts
+  vi.mock('recharts', () => new Proxy({}, { get: () => (props: { children?: unknown }) => props?.children ?? null }));
+  ```
+- **T7:** assert on role/text/title, never Tailwind classes. Fixtures are complete objects of the real API types (`SmartDevice`, `CumulativeEnergyResponse`, `EnergyPriceConfig`, `PowerSummary`).
+- **QueryClient tests:** use `__tests__/helpers/queryClient.tsx` (`createQueryWrapper`, `renderWithQueryClient`).
+- **Windows/CRLF:** LF→CRLF warning on commit is expected.
+- **Commit trailer** on every commit:
+  ```
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_017SpZfCSw8idoeYBoci5rZD
+  ```
+
+## Reference types (already in the codebase)
+
+```ts
+// api/smart-devices.ts
+interface SmartDevice { id: number; name: string; plugin_name: string; capabilities: string[]; is_active: boolean; is_online: boolean; state: Record<string, unknown> | null; /* …others… */ }
+interface PowerSummary { total_watts: number; }
+smartDevicesApi.list() // -> { data: { devices: SmartDevice[] } }
+smartDevicesApi.getPowerSummary() // -> { data: PowerSummary }
+// api/energy.ts
+interface CumulativeEnergyResponse { device_id: number; device_name: string; period: string; cost_per_kwh: number; currency: string; total_kwh: number; total_cost: number; data_points: CumulativeDataPoint[]; }
+interface CumulativeDataPoint { timestamp: string; cumulative_kwh: number; cumulative_cost: number; instant_watts: number; }
+interface EnergyPriceConfig { id: number; cost_per_kwh: number; currency: string; updated_at: string; updated_by_user_id: number | null; }
+// queryKeys.powerTab.summary() / .cumulative(deviceId, period, start, end)
+// lib/energyPolling.ts: resolveCumulativeArgs(period, customStart, customEnd) -> { period, start?, end? }
+```
+
+## File Structure
+
+- Create `client/src/components/system-monitor/power-tab/parseDevicePower.ts`
+- Create `client/src/hooks/usePowerTabData.ts`
+- Create `client/src/hooks/useEnergyPrice.ts`
+- Create `client/src/components/system-monitor/power-tab/PowerStates.tsx`
+- Create `client/src/components/system-monitor/power-tab/PowerSummaryCards.tsx`
+- Create `client/src/components/system-monitor/power-tab/PowerDeviceCard.tsx`
+- Create `client/src/components/system-monitor/power-tab/EnergyPriceEditor.tsx`
+- Create `client/src/components/system-monitor/power-tab/ChartDeviceTabs.tsx`
+- Create `client/src/components/system-monitor/power-tab/CustomRangePicker.tsx`
+- Create `client/src/components/system-monitor/power-tab/ChartModePeriodControls.tsx`
+- Create `client/src/components/system-monitor/power-tab/EnergyChartSummary.tsx`
+- Create `client/src/components/system-monitor/power-tab/CumulativeEnergyChart.tsx`
+- Create `client/src/components/system-monitor/power-tab/InstantPowerChart.tsx`
+- Create `client/src/components/system-monitor/power-tab/EnergyChart.tsx`
+- Create `client/src/components/system-monitor/power-tab/index.ts`
+- Modify `client/src/components/system-monitor/PowerTab.tsx`
+- Tests mirror source under `client/src/__tests__/...`
+- Docs: `client/src/components/CLAUDE.md`, `client/src/hooks/CLAUDE.md`
+
+All extractions copy from the current `client/src/components/system-monitor/PowerTab.tsx` (HEAD of this branch); line ranges are given per task.
+
+---
+
+### Task 1: `parseDevicePower` pure helper
+
+**Files:**
+- Create: `client/src/components/system-monitor/power-tab/parseDevicePower.ts`
+- Test: `client/src/__tests__/components/system-monitor/power-tab/parseDevicePower.test.ts`
+
+**Interfaces:**
+- Consumes: `SmartDevice` from `../../../api/smart-devices`.
+- Produces:
+  ```ts
+  export interface DevicePower { watts?: number; voltage?: number; currentA?: number; energyToday?: number; }
+  export function parseDevicePower(device: SmartDevice): DevicePower;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { parseDevicePower } from '../../../../components/system-monitor/power-tab/parseDevicePower';
+import type { SmartDevice } from '../../../../api/smart-devices';
+
+function dev(power_monitor: Record<string, unknown> | undefined): SmartDevice {
+  return {
+    id: 1, name: 'Plug', plugin_name: 'p', device_type_id: 't', address: 'a', mac_address: null,
+    capabilities: ['power_monitor'], is_active: true, is_online: true, last_seen: null, last_error: null,
+    state: power_monitor ? { power_monitor } : null, created_at: '', updated_at: '',
+  };
+}
+
+describe('parseDevicePower', () => {
+  it('prefers watts and current/energy in base units', () => {
+    expect(parseDevicePower(dev({ watts: 12.5, voltage: 230, current: 0.05, energy_today_kwh: 1.2 })))
+      .toEqual({ watts: 12.5, voltage: 230, currentA: 0.05, energyToday: 1.2 });
+  });
+  it('falls back to current_power, current_ma/1000, energy_today_wh/1000', () => {
+    expect(parseDevicePower(dev({ current_power: 9, current_ma: 250, energy_today_wh: 800 })))
+      .toEqual({ watts: 9, voltage: undefined, currentA: 0.25, energyToday: 0.8 });
+  });
+  it('returns all-undefined when power_monitor missing', () => {
+    expect(parseDevicePower(dev(undefined))).toEqual({ watts: undefined, voltage: undefined, currentA: undefined, energyToday: undefined });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** — `cd client ; npx vitest run src/__tests__/components/system-monitor/power-tab/parseDevicePower.test.ts` → FAIL (module not found).
+- [ ] **Step 3: Implement** (verbatim logic from PowerTab.tsx 232–236):
+
+```ts
+import type { SmartDevice } from '../../../api/smart-devices';
+
+export interface DevicePower {
+  watts?: number;
+  voltage?: number;
+  currentA?: number;
+  energyToday?: number;
+}
+
+export function parseDevicePower(device: SmartDevice): DevicePower {
+  const pm = device.state?.power_monitor as
+    | { watts?: number; current_power?: number; voltage?: number; current?: number; current_ma?: number; energy_today_kwh?: number; energy_today_wh?: number }
+    | undefined;
+  const watts = pm?.watts ?? pm?.current_power;
+  const voltage = pm?.voltage;
+  const currentA = pm?.current ?? (pm?.current_ma != null ? pm.current_ma / 1000 : undefined);
+  const energyToday = pm?.energy_today_kwh ?? (pm?.energy_today_wh != null ? pm.energy_today_wh / 1000 : undefined);
+  return { watts, voltage, currentA, energyToday };
+}
+```
+
+- [ ] **Step 4: Run to verify pass** → PASS (3/3).
+- [ ] **Step 5: Commit** — `feat(powertab): extract parseDevicePower pure helper (#301)`
+
+---
+
+### Task 2: `usePowerTabData` hook
+
+**Files:**
+- Create: `client/src/hooks/usePowerTabData.ts`
+- Test: `client/src/__tests__/hooks/usePowerTabData.test.tsx`
+
+**Interfaces:**
+- Consumes: `smartDevicesApi` (`../api/smart-devices`), `getCumulativeEnergy`/`getCumulativeEnergyTotal` + `CumulativeEnergyResponse` (`../api/energy`), `queryKeys` (`../lib/queryKeys`), `resolveCumulativeArgs` (`../lib/energyPolling`), `getApiErrorMessage` (`../lib/errorHandling`), `usePlugins` (`../contexts/PluginContext`), `SmartDevice`/`PowerSummary` (`../api/smart-devices`).
+- Produces:
+  ```ts
+  export interface UsePowerTabDataInput { selectedDeviceId: number | null; cumulativePeriod: 'today'|'week'|'month'|'custom'; customStart: string | null; customEnd: string | null; }
+  export interface CumulativeKeyArgs { period: string; start: string | null; end: string | null; }
+  export interface UsePowerTabDataResult {
+    devices: SmartDevice[]; powerSummary: PowerSummary | null; loading: boolean; error: string | null;
+    cumulativeData: CumulativeEnergyResponse | null; cumulativeLoading: boolean; cumulativeReady: boolean;
+    totalCurrentPower: number; powerPluginName: string | undefined; cumulativeKeyArgs: CumulativeKeyArgs;
+  }
+  export function usePowerTabData(input: UsePowerTabDataInput): UsePowerTabDataResult;
+  ```
+
+**Note:** port `powerQuery` (68–90), `rangeArgs`/`cumulativeReady`/`cumulativeQuery` (92–112), `totalCurrentPower`/`powerPluginName` (160–163) verbatim. `cumulativeKeyArgs = { period: rangeArgs.period, start: rangeArgs.start ?? null, end: rangeArgs.end ?? null }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createQueryWrapper } from '../helpers/queryClient';
+
+vi.mock('../../api/smart-devices', () => ({ smartDevicesApi: { list: vi.fn(), getPowerSummary: vi.fn() } }));
+vi.mock('../../api/energy', () => ({ getCumulativeEnergy: vi.fn(), getCumulativeEnergyTotal: vi.fn() }));
+vi.mock('../../contexts/PluginContext', () => ({ usePlugins: () => ({ plugins: [] }) }));
+
+import { smartDevicesApi } from '../../api/smart-devices';
+import { getCumulativeEnergyTotal } from '../../api/energy';
+import { usePowerTabData } from '../../hooks/usePowerTabData';
+
+const device = { id: 1, name: 'Plug', plugin_name: 'p', device_type_id: 't', address: 'a', mac_address: null, capabilities: ['power_monitor'], is_active: true, is_online: true, last_seen: null, last_error: null, state: null, created_at: '', updated_at: '' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (smartDevicesApi.list as any).mockResolvedValue({ data: { devices: [device] } });
+  (smartDevicesApi.getPowerSummary as any).mockResolvedValue({ data: { total_watts: 42 } });
+  (getCumulativeEnergyTotal as any).mockResolvedValue({ device_id: 0, device_name: '', period: 'today', cost_per_kwh: 0.3, currency: 'EUR', total_kwh: 1, total_cost: 0.3, data_points: [] });
+});
+
+const base = { selectedDeviceId: null, cumulativePeriod: 'today' as const, customStart: null, customEnd: null };
+
+describe('usePowerTabData', () => {
+  it('exposes devices, totalCurrentPower and cumulative data', async () => {
+    const { result } = renderHook(() => usePowerTabData(base), { wrapper: createQueryWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.devices).toHaveLength(1);
+    expect(result.current.totalCurrentPower).toBe(42);
+    await waitFor(() => expect(result.current.cumulativeData?.total_kwh).toBe(1));
+    expect(result.current.cumulativeReady).toBe(true);
+  });
+
+  it('cumulativeReady false for custom with no applied range', () => {
+    const { result } = renderHook(() => usePowerTabData({ ...base, cumulativePeriod: 'custom' }), { wrapper: createQueryWrapper() });
+    expect(result.current.cumulativeReady).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** → FAIL.
+- [ ] **Step 3: Implement** — port the two queries + derived verbatim; `usePlugins()` internally for `powerPluginName`. `error` = 404-swallow logic (83–90).
+- [ ] **Step 4: Run to verify pass** → PASS (2/2).
+- [ ] **Step 5: Commit** — `feat(powertab): extract usePowerTabData hook (#301)`
+
+---
+
+### Task 3: `useEnergyPrice` hook
+
+**Files:**
+- Create: `client/src/hooks/useEnergyPrice.ts`
+- Test: `client/src/__tests__/hooks/useEnergyPrice.test.tsx`
+
+**Interfaces:**
+- Consumes: `getEnergyPriceConfig`/`updateEnergyPriceConfig`/`EnergyPriceConfig` (`../api/energy`), `getApiErrorMessage` (`../lib/errorHandling`), `toast` (`react-hot-toast`), `useTranslation`.
+- Produces:
+  ```ts
+  export interface UseEnergyPriceResult { priceConfig: EnergyPriceConfig | null; editingPrice: boolean; setEditingPrice: (v: boolean) => void; priceInput: string; setPriceInput: (v: string) => void; savingPrice: boolean; savePrice: () => Promise<void>; }
+  export function useEnergyPrice(onSaved?: () => void | Promise<void>): UseEnergyPriceResult;
+  ```
+
+**Note:** port the mount `useEffect` fetch (114–126) and `handleSavePrice` (128–158) verbatim, replacing the inline `invalidateQueries` call with `await onSaved?.()`. `useTranslation(['system','common'])` internally.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('../../api/energy', () => ({ getEnergyPriceConfig: vi.fn(), updateEnergyPriceConfig: vi.fn() }));
+
+import toast from 'react-hot-toast';
+import { getEnergyPriceConfig, updateEnergyPriceConfig } from '../../api/energy';
+import { useEnergyPrice } from '../../hooks/useEnergyPrice';
+
+const cfg = { id: 1, cost_per_kwh: 0.3, currency: 'EUR', updated_at: '', updated_by_user_id: null };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getEnergyPriceConfig as any).mockResolvedValue(cfg);
+  (updateEnergyPriceConfig as any).mockResolvedValue({ ...cfg, cost_per_kwh: 0.4 });
+});
+
+describe('useEnergyPrice', () => {
+  it('seeds config on mount', async () => {
+    const { result } = renderHook(() => useEnergyPrice());
+    await waitFor(() => expect(result.current.priceConfig?.cost_per_kwh).toBe(0.3));
+    expect(result.current.priceInput).toBe('0.3');
+  });
+
+  it('rejects out-of-range price (no update, error toast)', async () => {
+    const { result } = renderHook(() => useEnergyPrice());
+    await waitFor(() => expect(result.current.priceConfig).not.toBeNull());
+    act(() => result.current.setPriceInput('99'));
+    await act(async () => { await result.current.savePrice(); });
+    expect(updateEnergyPriceConfig).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it('saves in-range price and calls onSaved', async () => {
+    const onSaved = vi.fn();
+    const { result } = renderHook(() => useEnergyPrice(onSaved));
+    await waitFor(() => expect(result.current.priceConfig).not.toBeNull());
+    act(() => result.current.setPriceInput('0.4'));
+    await act(async () => { await result.current.savePrice(); });
+    expect(updateEnergyPriceConfig).toHaveBeenCalledWith({ cost_per_kwh: 0.4, currency: 'EUR' });
+    expect(onSaved).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** → FAIL.
+- [ ] **Step 3: Implement** — verbatim mount fetch + save logic; `await onSaved?.()` in place of the query invalidation; toast keys verbatim.
+- [ ] **Step 4: Run to verify pass** → PASS (3/3).
+- [ ] **Step 5: Commit** — `feat(powertab): extract useEnergyPrice hook (#301)`
+
+---
+
+### Task 4: `PowerStates` (loading / error / empty)
+
+**Files:**
+- Create: `client/src/components/system-monitor/power-tab/PowerStates.tsx`
+- Test: `client/src/__tests__/components/system-monitor/power-tab/PowerStates.test.tsx`
+
+**Interfaces:**
+- Consumes: `Link` (`react-router-dom`), `useTranslation`.
+- Produces: `export function PowerLoading(): JSX.Element;` `export function PowerError({ error }: { error: string }): JSX.Element;` `export function PowerEmptyState(): JSX.Element;`
+
+**Note:** markup verbatim — `PowerLoading` from 166–170, `PowerError` from 174, `PowerEmptyState` from 178–201 (icon + `t('monitor.power.noSmartDevices', 'No smart devices…')` + `Link to="/smart-devices"` + `t('monitor.power.configureSmartDevices', 'Configure Smart Devices')`). `useTranslation(['system','common'])`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PowerError, PowerEmptyState } from '../../../../components/system-monitor/power-tab/PowerStates';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string, d?: string) => (typeof d === 'string' ? d : k) }) }));
+
+describe('PowerStates', () => {
+  it('PowerError shows the message', () => {
+    render(<PowerError error="boom" />);
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+  it('PowerEmptyState links to smart devices', () => {
+    render(<MemoryRouter><PowerEmptyState /></MemoryRouter>);
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/smart-devices');
+    expect(screen.getByText(/No smart devices/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** → FAIL.
+- [ ] **Step 3: Implement** the three renders (markup verbatim).
+- [ ] **Step 4: Run to verify pass** → PASS.
+- [ ] **Step 5: Commit** — `feat(powertab): extract PowerStates (loading/error/empty) (#301)`
+
+---
+
+### Task 5: `PowerSummaryCards`
+
+**Files:**
+- Create: `client/src/components/system-monitor/power-tab/PowerSummaryCards.tsx`
+- Test: `client/src/__tests__/components/system-monitor/power-tab/PowerSummaryCards.test.tsx`
+
+**Interfaces:**
+- Consumes: `StatCard` (`../../ui/StatCard`), `formatNumber` (`../../../lib/formatters`), `useTranslation`.
+- Produces: `interface PowerSummaryCardsProps { totalCurrentPower: number; onlineCount: number; deviceCount: number; }` `export function PowerSummaryCards(props): JSX.Element;`
+
+**Note:** the 3 `StatCard`s (207–228). Current power = `formatNumber(totalCurrentPower, 1)` W; online = `onlineCount` unit `/ ${deviceCount}`; devices = `deviceCount`. i18n keys verbatim (`currentPower`, `onlineDevices`, `devices`).
+
+- [ ] **Step 1: failing test** — render with `{ totalCurrentPower: 42.4, onlineCount: 2, deviceCount: 3 }`; assert `getByText('42.4')`, `getByText('2')`, `getByText('/ 3')`. Mock i18n. Mock `StatCard`? No — use the real `StatCard` (a ui primitive); assert on the rendered value/unit text.
+- [ ] **Step 2: fail** → FAIL.
+- [ ] **Step 3: implement** (markup verbatim; `devices.filter(d=>d.is_online).length` becomes the `onlineCount` prop, computed by the caller).
+- [ ] **Step 4: pass** → PASS.
+- [ ] **Step 5: commit** — `feat(powertab): extract PowerSummaryCards (#301)`
+
+---
+
+### Task 6: `PowerDeviceCard`
+
+**Files:**
+- Create: `client/src/components/system-monitor/power-tab/PowerDeviceCard.tsx`
+- Test: `client/src/__tests__/components/system-monitor/power-tab/PowerDeviceCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `SmartDevice` (`../../../api/smart-devices`), `parseDevicePower` (`./parseDevicePower`), `formatNumber` (`../../../lib/formatters`), `useTranslation`.
+- Produces: `interface PowerDeviceCardProps { device: SmartDevice; }` `export function PowerDeviceCard({ device }): JSX.Element;`
+
+**Note:** markup verbatim (239–272); `const { watts, voltage, currentA, energyToday } = parseDevicePower(device);` replaces the inline `pm` block. `-` fallbacks and `formatNumber` precisions (1/1/3/2) verbatim. Online badge from `device.is_online`.
+
+- [ ] **Step 1: failing test** — device with `state.power_monitor = { watts: 12.5, voltage: 230, current: 0.05, energy_today_kwh: 1.2 }`; assert name, online badge text, `12.5`, `230`, `0.050`, `1.20`. A second device with `state: null` → four `-`. Mock i18n.
+- [ ] **Step 2: fail** → FAIL.
+- [ ] **Step 3: implement** (verbatim).
+- [ ] **Step 4: pass** → PASS.
+- [ ] **Step 5: commit** — `feat(powertab): extract PowerDeviceCard (#301)`
+
+---
+
+### Task 7: `EnergyPriceEditor`
+
+**Files:**
+- Create: `client/src/components/system-monitor/power-tab/EnergyPriceEditor.tsx`
+- Test: `client/src/__tests__/components/system-monitor/power-tab/EnergyPriceEditor.test.tsx`
+
+**Interfaces:**
+- Consumes: `EnergyPriceConfig` (`../../../api/energy`), `formatNumber` (`../../../lib/formatters`).
+- Produces:
+  ```ts
+  interface EnergyPriceEditorProps {
+    priceConfig: EnergyPriceConfig; editing: boolean; priceInput: string; saving: boolean;
+    onEdit: () => void; onInputChange: (v: string) => void; onSave: () => void; onCancel: () => void;
+  }
+  export function EnergyPriceEditor(props): JSX.Element;
+  ```
+
+**Note:** markup verbatim (316–361). The whole block is gated by `priceConfig` in the parent, so this component assumes a non-null `priceConfig`. View mode shows `formatNumber(priceConfig.cost_per_kwh, 2) {currency}/kWh` + edit pencil (`onEdit`); edit mode shows the number input (`onInputChange`), save (`onSave`, `✓`/`...`), cancel (`onCancel`, resets input in the parent).
+
+- [ ] **Step 1: failing test** — view mode (`editing=false`): shows price text, click pencil button → `onEdit`. Edit mode (`editing=true`): input value = `priceInput`, change fires `onInputChange`, `✓` fires `onSave`, `✕` fires `onCancel`. No i18n keys here except none — component has no `t()`; assert on values/roles.
+- [ ] **Step 2: fail** → FAIL.
+- [ ] **Step 3: implement** (verbatim; note the cancel button in the original also resets `priceInput` — that reset happens in the parent's `onCancel`).
+- [ ] **Step 4: pass** → PASS.
+- [ ] **Step 5: commit** — `feat(powertab): extract EnergyPriceEditor (#301)`
+
+---
+
+### Task 8: `ChartDeviceTabs`
+
+**Files:**
+- Create: `client/src/components/system-monitor/power-tab/ChartDeviceTabs.tsx`
+- Test: `client/src/__tests__/components/system-monitor/power-tab/ChartDeviceTabs.test.tsx`
+
+**Interfaces:**
+- Consumes: `SmartDevice` (`../../../api/smart-devices`), `useTranslation`.
+- Produces: `interface ChartDeviceTabsProps { devices: SmartDevice[]; selectedDeviceId: number | null; onSelect: (id: number | null) => void; }`
+
+**Note:** markup verbatim (279–305): Total button (`onSelect(null)`, `t('monitor.power.total')`) + one button per `devices.filter(d => d.is_active && d.capabilities?.includes('power_monitor'))` (`onSelect(device.id)`, `device.name`). Active styling by `selectedDeviceId`.
+
+- [ ] **Step 1: failing test** — two devices (one active w/ power_monitor, one inactive); assert Total + the active device name render; click device → `onSelect(id)`; click Total → `onSelect(null)`.
+- [ ] **Step 2: fail** → FAIL. **Step 3: implement** (verbatim). **Step 4: pass** → PASS. **Step 5: commit** — `feat(powertab): extract ChartDeviceTabs (#301)`
+
+---
+
+### Task 9: `CustomRangePicker` + `ChartModePeriodControls`
+
+**Files:**
+- Create: `client/src/components/system-monitor/power-tab/CustomRangePicker.tsx`
+- Create: `client/src/components/system-monitor/power-tab/ChartModePeriodControls.tsx`
+- Test: `client/src/__tests__/components/system-monitor/power-tab/ChartControls.test.tsx`
+
+**Interfaces:**
+- `CustomRangePicker` consumes `localRangeToUtcIso` (`../../../lib/dateUtils`), `toast` (`react-hot-toast`), `useTranslation`. Produces:
+  ```ts
+  interface CustomRangePickerProps { active: boolean; onApply: (startIso: string, endIso: string) => void; }
+  export function CustomRangePicker({ active, onApply }): JSX.Element;
+  ```
+  Owns `showRangePicker`/`draftStart`/`draftEnd` internally (from 61–63). The `Custom` toggle button (398–407) + popover (408–446) verbatim; Apply validates (`!draftStart || !draftEnd || draftStart > draftEnd` → `toast.error(t('monitor.power.customInvalidRange'))`), else `localRangeToUtcIso(draftStart, draftEnd, Date.now())` → `onApply(startIso, endIso)` + close. `active` drives the button's selected styling (was `cumulativePeriod === 'custom'`).
+- `ChartModePeriodControls` consumes `useTranslation`. Produces:
+  ```ts
+  type ChartMode = 'cumulative' | 'instant';
+  type CumulativePeriod = 'today' | 'week' | 'month' | 'custom';
+  interface ChartModePeriodControlsProps {
+    chartMode: ChartMode; onModeChange: (m: ChartMode) => void;
+    cumulativePeriod: CumulativePeriod; onPeriodChange: (p: CumulativePeriod) => void;
+    customRange: React.ReactNode;
+  }
+  ```
+  Mode toggle (367–379) + period buttons `today/week/month` (384–396) verbatim; renders `{customRange}` where the custom picker sits (397). Period buttons call `onPeriodChange`.
+
+- [ ] **Step 1: failing test** (`ChartControls.test.tsx`, mock i18n + `react-hot-toast` + `../../../lib/dateUtils`'s `localRangeToUtcIso` → returns `{ startIso: 'S', endIso: 'E' }`):
+  - `ChartModePeriodControls`: renders mode + period buttons; clicking `week` fires `onPeriodChange('week')`; clicking `instant` fires `onModeChange('instant')`; `customRange` node renders.
+  - `CustomRangePicker`: click Custom → popover opens; Apply with empty drafts → `toast.error`, no `onApply`; set both dates via `fireEvent.change`, Apply → `onApply('S','E')`.
+- [ ] **Step 2: fail** → FAIL. **Step 3: implement** both. **Step 4: pass** → PASS. **Step 5: commit** — `feat(powertab): extract chart mode/period controls + custom range picker (#301)`
+
+---
+
+### Task 10: `EnergyChartSummary`
+
+**Files:**
+- Create: `client/src/components/system-monitor/power-tab/EnergyChartSummary.tsx`
+- Test: `client/src/__tests__/components/system-monitor/power-tab/EnergyChartSummary.test.tsx`
+
+**Interfaces:**
+- Consumes: `CumulativeEnergyResponse` (`../../../api/energy`), `formatNumber` (`../../../lib/formatters`), `useTranslation`.
+- Produces: `interface EnergyChartSummaryProps { chartMode: 'cumulative' | 'instant'; cumulativeData: CumulativeEnergyResponse; }`
+
+**Note:** the summary grids (452–515) verbatim. Instant branch computes avg/max/min from `data_points.map(dp => dp.instant_watts)` + `data_points.length`; cumulative branch shows `total_kwh` (3), `total_cost` (2) + currency, `cost_per_kwh` (2), `data_points.length`. i18n keys verbatim. (The parent only renders this when `cumulativeData` is truthy — prop is non-null.)
+
+- [ ] **Step 1: failing test** — cumulative mode with `total_kwh: 1.234, total_cost: 0.37, currency:'EUR', cost_per_kwh:0.3, data_points:[…]` → assert `1.234`, `0.37`, `0.30`; instant mode with data_points `instant_watts:[10,20,30]` → assert avg `20.0`, max `30.0`, min `10.0`. Mock i18n.
+- [ ] **Step 2: fail** → FAIL. **Step 3: implement** (verbatim). **Step 4: pass** → PASS. **Step 5: commit** — `feat(powertab): extract EnergyChartSummary (#301)`
+
+---
+
+### Task 11: `CumulativeEnergyChart` + `InstantPowerChart` + `EnergyChart`
+
+**Files:**
+- Create: `client/src/components/system-monitor/power-tab/CumulativeEnergyChart.tsx`
+- Create: `client/src/components/system-monitor/power-tab/InstantPowerChart.tsx`
+- Create: `client/src/components/system-monitor/power-tab/EnergyChart.tsx`
+- Test: `client/src/__tests__/components/system-monitor/power-tab/EnergyChart.test.tsx`
+
+**Interfaces:**
+- Shared prop shape:
+  ```ts
+  interface ChartProps { cumulativeData: CumulativeEnergyResponse; cumulativePeriod: 'today'|'week'|'month'|'custom'; language: string; }
+  ```
+  `CumulativeEnergyChart(props: ChartProps)` = the cumulative `ComposedChart` (526–617) verbatim (data mapping via `formatTimeForRange(dp.timestamp, cumulativePeriod as ChartTimeRange, language)` + `parseUtcTimestamp`, gradients, axes, tooltip, legend, Area+Line). `InstantPowerChart(props: ChartProps)` = the instant `ComposedChart` (619–678) verbatim.
+- `EnergyChart`:
+  ```ts
+  interface EnergyChartProps {
+    chartMode: 'cumulative' | 'instant';
+    cumulativeData: CumulativeEnergyResponse | null;
+    cumulativeLoading: boolean;
+    cumulativePeriod: 'today'|'week'|'month'|'custom';
+    language: string;
+  }
+  ```
+  Renders the loading spinner (518–521) / empty `t('monitor.noDataForPeriod')` (683–685) / the `ResponsiveContainer` wrapping `CumulativeEnergyChart` or `InstantPowerChart` by `chartMode` (522–681). Uses `useTranslation`, imports `formatTimeForRange`/`parseUtcTimestamp`/`ChartTimeRange` in the chart subcomponents.
+
+**Note:** `import type { ChartTimeRange }` and `formatTimeForRange`/`parseUtcTimestamp` from `../../../lib/dateUtils`; `formatNumber` from `../../../lib/formatters`; recharts imports as in the original.
+
+- [ ] **Step 1: failing test** (mock recharts per Global Constraints; mock i18n) — `EnergyChart` with `cumulativeLoading: true` → spinner present (no chart); with `cumulativeData: { …, data_points: [] }` → `getByText('monitor.noDataForPeriod')`; with one data point + `chartMode:'cumulative'` → renders without throwing (recharts mocked). Keep assertions coarse (recharts is stubbed).
+- [ ] **Step 2: fail** → FAIL.
+- [ ] **Step 3: implement** the three files (charts verbatim, `EnergyChart` selects by mode).
+- [ ] **Step 4: pass** → PASS.
+- [ ] **Step 5: commit** — `feat(powertab): extract EnergyChart + cumulative/instant charts (#301)`
+
+---
+
+### Task 12: Barrel + PowerTab.tsx orchestrator rewrite + integration test
+
+**Files:**
+- Create: `client/src/components/system-monitor/power-tab/index.ts`
+- Modify: `client/src/components/system-monitor/PowerTab.tsx`
+- Test: `client/src/__tests__/components/system-monitor/PowerTab.test.tsx`
+
+**Interfaces:**
+- `index.ts` re-exports every `power-tab/*` component + `parseDevicePower`/`DevicePower`.
+- `PowerTab.tsx` keeps state `chartMode`, `cumulativePeriod`, `selectedDeviceId`, `customStart`, `customEnd`. Calls:
+  ```ts
+  const data = usePowerTabData({ selectedDeviceId, cumulativePeriod, customStart, customEnd });
+  const queryClient = useQueryClient();
+  const price = useEnergyPrice(() => queryClient.invalidateQueries({
+    queryKey: queryKeys.powerTab.cumulative(selectedDeviceId, data.cumulativeKeyArgs.period, data.cumulativeKeyArgs.start, data.cumulativeKeyArgs.end),
+  }));
+  ```
+  Early returns: `if (data.loading) return <PowerLoading/>;` `if (data.error) return <PowerError error={data.error}/>;` `if (data.devices.length === 0) return <PowerEmptyState/>;`
+  Then composes: `PowerSummaryCards` (`onlineCount = data.devices.filter(d=>d.is_online).length`, `deviceCount = data.devices.length`), `data.devices.map(d => <PowerDeviceCard key={d.id} device={d}/>)`, and the chart card: `ChartDeviceTabs`, header (`chartMode` title + `PluginBadge pluginName={data.powerPluginName}` + `{price.priceConfig && <EnergyPriceEditor .../>}`), `ChartModePeriodControls` with `customRange={<CustomRangePicker active={cumulativePeriod==='custom'} onApply={(s,e)=>{ setCustomStart(s); setCustomEnd(e); setCumulativePeriod('custom'); }}/>}`, `{data.cumulativeData && <EnergyChartSummary chartMode={chartMode} cumulativeData={data.cumulativeData}/>}`, `<EnergyChart chartMode={chartMode} cumulativeData={data.cumulativeData} cumulativeLoading={data.cumulativeLoading} cumulativePeriod={cumulativePeriod} language={i18n.language}/>`.
+  - `EnergyPriceEditor` wiring: `editing={price.editingPrice}`, `priceInput={price.priceInput}`, `saving={price.savingPrice}`, `onEdit={() => price.setEditingPrice(true)}`, `onInputChange={price.setPriceInput}`, `onSave={price.savePrice}`, `onCancel={() => { price.setEditingPrice(false); price.setPriceInput(price.priceConfig!.cost_per_kwh.toString()); }}`.
+  - Keep the outer card wrappers, header title branch (`t('monitor.power.cumulativeConsumptionCosts')` vs `instantPowerConsumption`), `useTranslation(['system','common'])`, `i18n.language`.
+
+- [ ] **Step 1: Write the failing integration test** (`PowerTab.test.tsx`) — model on the repo's page tests. Mock `../../../hooks/usePowerTabData` and `../../../hooks/useEnergyPrice`, `react-i18next`, and `../../../contexts/PluginContext` (`usePlugins`), wrap in `MemoryRouter` + a QueryClient (PowerTab uses `useQueryClient`). Complete fixtures.
+  ```tsx
+  // populated: usePowerTabData returns 1 device (power_monitor state), totalCurrentPower 42,
+  // cumulativeData with data_points; useEnergyPrice returns priceConfig.
+  it('renders stat cards, a device card and the chart toolbar', () => {
+    render(<PowerTab />, { wrapper });
+    expect(screen.getByText('42.0')).toBeInTheDocument();       // current power
+    expect(screen.getByText('Plug')).toBeInTheDocument();       // device card + tab
+  });
+  it('shows the empty state when there are no devices', () => {
+    // usePowerTabData returns devices: []
+    render(<PowerTab />, { wrapper });
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/smart-devices');
+  });
+  ```
+- [ ] **Step 2: Run to verify fail** → FAIL.
+- [ ] **Step 3: Add barrel + rewrite PowerTab.tsx** per the composition above. Remove now-unused imports (recharts, StatCard, PluginBadge stays if used in header, dateUtils, energy api, smartDevicesApi, resolveCumulativeArgs, etc. — verify against the final file). Keep `useState`, `useQueryClient`, `queryKeys`, `PluginBadge`, `useTranslation`, and the `power-tab` + hook imports.
+- [ ] **Step 4: Run to verify pass** → PASS.
+- [ ] **Step 5: Verify page size + full gates**
+
+```bash
+cd client
+node -e "console.log(require('fs').readFileSync('src/components/system-monitor/PowerTab.tsx','utf8').split(/\r?\n/).length)"   # expect < 500 (~150)
+npx eslint .
+npm run build
+npx vitest run
+```
+Expected: < 500 lines; eslint 0 errors; build green; full suite green.
+
+- [ ] **Step 6: Commit** — `refactor(powertab): compose PowerTab from extracted hooks + power-tab/* (#301)`
+
+---
+
+### Task 13: Docs + final line-count
+
+**Files:**
+- Modify: `client/src/components/CLAUDE.md` (add a `system-monitor/power-tab/*` note to the components table's system-monitor row, mentioning the extracted pieces + `parseDevicePower` and F2/#301)
+- Modify: `client/src/hooks/CLAUDE.md` (add `usePowerTabData`, `useEnergyPrice`)
+
+- [ ] **Step 1: Update both CLAUDE.md files** (match surrounding one-line style).
+- [ ] **Step 2: Confirm final page size** — `cd client ; node -e "console.log(require('fs').readFileSync('src/components/system-monitor/PowerTab.tsx','utf8').split(/\r?\n/).length)"` → < 500.
+- [ ] **Step 3: Commit** — `docs(powertab): document extracted hooks + power-tab components (#301)`
+
+---
+
+## Self-Review
+
+**Spec coverage:** every spec unit maps to a task — parseDevicePower (T1), usePowerTabData (T2), useEnergyPrice (T3), PowerStates (T4), PowerSummaryCards (T5), PowerDeviceCard (T6), EnergyPriceEditor (T7), ChartDeviceTabs (T8), CustomRangePicker+ChartModePeriodControls (T9), EnergyChartSummary (T10), Cumulative/Instant/EnergyChart (T11), barrel+PowerTab+integration (T12), docs (T13).
+
+**Placeholder scan:** verbatim markup is referenced by exact source line ranges (charts, toolbar, cards); complete code is given for the pure helper and the hook/test scaffolding. No vague TODOs.
+
+**Type consistency:** `DevicePower`/`parseDevicePower` defined T1, consumed T6. `CumulativeKeyArgs`/`usePowerTabData` result (T2) consumed by the orchestrator's `onSaved` invalidation (T12). `useEnergyPrice` result (T3) wired into `EnergyPriceEditor` props (T7) by the orchestrator (T12). `ChartProps`/`EnergyChartProps` (T11) consumed by T12. `CumulativeEnergyResponse`/`SmartDevice`/`EnergyPriceConfig`/`PowerSummary` are the real API types used consistently.

--- a/docs/superpowers/specs/2026-07-11-powertab-decomposition-f2-design.md
+++ b/docs/superpowers/specs/2026-07-11-powertab-decomposition-f2-design.md
@@ -1,0 +1,208 @@
+# PowerTab.tsx Decomposition — Design (F2 / #301)
+
+**Date:** 2026-07-11
+**Finding:** F2 (components > 500 lines), umbrella issue #301.
+**Target:** `client/src/components/system-monitor/PowerTab.tsx` — currently **690 lines**.
+
+## Goal
+
+Behavior-preserving decomposition of `PowerTab.tsx` (the smart-device energy
+monitoring tab) into two data/state hooks, one pure helper, and a directory of
+presentational components under a new `components/system-monitor/power-tab/`.
+
+**Non-goals:** no change to queries, endpoints, polling intervals (5s power /
+60s cumulative), i18n keys, copy, Tailwind styling, recharts configuration, or
+any computed value. The tab stays at its path
+(`components/system-monitor/PowerTab.tsx`, named export `PowerTab`) so the
+`system-monitor/index.ts` barrel and `SystemMonitor` consumer are untouched.
+This is distinct from `components/power/` (CPU power **profiles**) — do not
+merge the two.
+
+## Constraints
+
+- Every extracted value is **byte-identical** in behavior: same query keys,
+  same `refetchInterval`, same 404-swallow, same `resolveCumulativeArgs` usage,
+  same validation bounds, same i18n keys, same recharts props.
+- Extracted components are **presentational**: props in, callbacks in, no data
+  fetching. Extracted hooks own the fetching/state.
+- Tests are T7-conform: assert on role/text/title, never Tailwind classes;
+  recharts is mocked; fixtures are complete objects of the real API types
+  (`SmartDevice`, `CumulativeEnergyResponse`, `EnergyPriceConfig`).
+
+## Current inline blocks (what moves)
+
+| Block | Current lines | Destination |
+|---|---|---|
+| `powerQuery` + `cumulativeQuery` + derived (`devices`, `powerSummary`, `loading`, `error`, `cumulativeData`, `cumulativeLoading`, `cumulativeReady`, `totalCurrentPower`, `powerPluginName`, `rangeArgs`) | 68–163 | `hooks/usePowerTabData.ts` |
+| Energy-price state (4 `useState`) + mount fetch + `handleSavePrice` | 48–51, 114–158 | `hooks/useEnergyPrice.ts` |
+| `pm` parsing (`watts`/`voltage`/`currentA`/`energyToday` with `current_ma`/`energy_today_wh` fallbacks) | 232–236 | `power-tab/parseDevicePower.ts` (pure) |
+| Loading / error / empty-state (icon + `/smart-devices` link) | 165–202 | `power-tab/PowerStates.tsx` |
+| Top StatCards (3×) | 207–228 | `power-tab/PowerSummaryCards.tsx` |
+| Per-device card | 231–274 | `power-tab/PowerDeviceCard.tsx` |
+| Inline price editor | 307–361 | `power-tab/EnergyPriceEditor.tsx` |
+| Chart device tabs | 279–305 | `power-tab/ChartDeviceTabs.tsx` |
+| Mode toggle + period selector + custom picker | 364–448 | `power-tab/ChartModePeriodControls.tsx` + `CustomRangePicker.tsx` |
+| Summary stats (instant vs cumulative) | 451–515 | `power-tab/EnergyChartSummary.tsx` |
+| Chart block (2 ComposedCharts) | 517–686 | `power-tab/EnergyChart.tsx` → `CumulativeEnergyChart.tsx` + `InstantPowerChart.tsx` |
+
+## New units & interfaces
+
+### `hooks/usePowerTabData.ts`
+
+```ts
+import type { SmartDevice } from '../api/smart-devices';
+import type { CumulativeEnergyResponse } from '../api/energy';
+
+export interface UsePowerTabDataInput {
+  selectedDeviceId: number | null;
+  cumulativePeriod: 'today' | 'week' | 'month' | 'custom';
+  customStart: string | null;
+  customEnd: string | null;
+}
+export interface UsePowerTabDataResult {
+  devices: SmartDevice[];
+  powerSummary: { total_watts?: number } | null;
+  loading: boolean;
+  error: string | null;
+  cumulativeData: CumulativeEnergyResponse | null;
+  cumulativeLoading: boolean;
+  cumulativeReady: boolean;
+  totalCurrentPower: number;
+  powerPluginName: string | undefined;
+}
+export function usePowerTabData(input: UsePowerTabDataInput): UsePowerTabDataResult;
+```
+
+Body ports `powerQuery` (key `queryKeys.powerTab.summary()`, 5s poll, filters
+`capabilities?.includes('power_monitor')`), the 404-swallow error logic, the
+`resolveCumulativeArgs` + `cumulativeReady` gate, `cumulativeQuery` (key
+`queryKeys.powerTab.cumulative(...)`, 60s poll, total-vs-device branch), and the
+derived `totalCurrentPower` / `powerPluginName` (via `usePlugins()` internally).
+The `rangeArgs` object is internal but its `period/start/end` must be
+reachable by the orchestrator for the price-save invalidation — expose a
+`cumulativeKeyArgs: { period, start: string | null, end: string | null }` field
+too (used only to rebuild the invalidation key).
+
+### `hooks/useEnergyPrice.ts`
+
+```ts
+import type { EnergyPriceConfig } from '../api/energy';
+
+export interface UseEnergyPriceResult {
+  priceConfig: EnergyPriceConfig | null;
+  editingPrice: boolean;
+  setEditingPrice: (v: boolean) => void;
+  priceInput: string;
+  setPriceInput: (v: string) => void;
+  savingPrice: boolean;
+  savePrice: () => Promise<void>;
+}
+export function useEnergyPrice(onSaved?: () => void | Promise<void>): UseEnergyPriceResult;
+```
+
+Ports the mount `useEffect` fetch (best-effort, sets `priceConfig` +
+`priceInput`), and `handleSavePrice`: `parseFloat`, bounds `0.01–10.0`
+(`toast.error(t('monitor.power.priceMustBeBetween'))` on invalid),
+`updateEnergyPriceConfig({ cost_per_kwh, currency: priceConfig?.currency || 'EUR' })`,
+success toast, then `await onSaved?.()`. `useTranslation(['system','common'])`
+internally. The queryClient invalidation lives in the orchestrator's `onSaved`
+callback (hook stays queryKey-decoupled).
+
+### `power-tab/parseDevicePower.ts` (pure)
+
+```ts
+import type { SmartDevice } from '../../api/smart-devices';
+
+export interface DevicePower {
+  watts?: number; voltage?: number; currentA?: number; energyToday?: number;
+}
+export function parseDevicePower(device: SmartDevice): DevicePower;
+```
+
+Verbatim from 232–236: reads `device.state?.power_monitor`, `watts = pm.watts ??
+pm.current_power`, `voltage = pm.voltage`, `currentA = pm.current ?? (pm.current_ma
+!= null ? pm.current_ma / 1000 : undefined)`, `energyToday = pm.energy_today_kwh ??
+(pm.energy_today_wh != null ? pm.energy_today_wh / 1000 : undefined)`.
+
+### Presentational components (`power-tab/`)
+
+- **`PowerStates.tsx`** — exposes three named renders: `PowerLoading()` (spinner),
+  `PowerError({ error })` (error text), and `PowerEmptyState()` (icon +
+  `t('monitor.power.noSmartDevices')` + `Link` to `/smart-devices`). The
+  orchestrator early-returns each. Markup verbatim (165–202).
+- **`PowerSummaryCards.tsx`** — `{ totalCurrentPower, onlineCount, deviceCount }`
+  → the 3 `StatCard`s (207–228). i18n keys verbatim.
+- **`PowerDeviceCard.tsx`** — `{ device }` → one card; calls `parseDevicePower`
+  internally; markup verbatim (239–272). `useTranslation` internally.
+- **`EnergyPriceEditor.tsx`** — `{ priceConfig, editing, priceInput, saving,
+  onEdit, onInputChange, onSave, onCancel }` → the inline editor (316–361).
+- **`ChartDeviceTabs.tsx`** — `{ devices, selectedDeviceId, onSelect }` → the
+  Total + per-active-device tab buttons (279–305).
+- **`ChartModePeriodControls.tsx`** — `{ chartMode, onModeChange, cumulativePeriod,
+  onPeriodChange, customRangeSlot }` → mode toggle + period buttons (364–396),
+  rendering `customRangeSlot` (the `CustomRangePicker`) in the custom slot.
+- **`CustomRangePicker.tsx`** — `{ active, onApply }` where
+  `onApply(startIso: string, endIso: string)` — owns `showRangePicker`,
+  `draftStart`, `draftEnd` internally; the
+  Apply button validates (`draftStart > draftEnd` → `toast.error`) and calls
+  `localRangeToUtcIso(draftStart, draftEnd, Date.now())` then `onApply`. Markup
+  verbatim (397–447). The `Date.now()` call stays here.
+- **`EnergyChartSummary.tsx`** — `{ chartMode, cumulativeData }` → the instant
+  (avg/max/min/dataPoints) vs cumulative (total kWh/cost/price/dataPoints)
+  summary grids (451–515).
+- **`EnergyChart.tsx`** — `{ chartMode, cumulativeData, cumulativeLoading,
+  cumulativePeriod, language }` → loading spinner / empty (`t('monitor.noDataForPeriod')`)
+  / picks `CumulativeEnergyChart` or `InstantPowerChart` (517–686).
+- **`CumulativeEnergyChart.tsx`** / **`InstantPowerChart.tsx`** — `{ cumulativeData,
+  cumulativePeriod, language }` → the two `ComposedChart`s verbatim (525–617 /
+  619–679), including the data mapping (`formatTimeForRange`, `parseUtcTimestamp`),
+  gradients, axes, tooltips, legends, all recharts props and i18n keys.
+
+### `power-tab/index.ts`
+
+Barrel exporting all the above components + `parseDevicePower`/`DevicePower`.
+
+### `PowerTab.tsx` (after)
+
+Keeps the selection state (`chartMode`, `cumulativePeriod`, `selectedDeviceId`,
+`customStart`, `customEnd`). Calls `usePowerTabData({...})` and
+`useEnergyPrice(onSaved)` where `onSaved` invalidates
+`queryKeys.powerTab.cumulative(selectedDeviceId, keyArgs.period, keyArgs.start,
+keyArgs.end)`. Early-returns via `PowerLoading`/`PowerError`/`PowerEmptyState`.
+Composes `PowerSummaryCards`, `PowerDeviceCard` map, and the chart card
+(`ChartDeviceTabs`, header with `EnergyPriceEditor` + `PluginBadge`,
+`ChartModePeriodControls` wrapping `CustomRangePicker`, `EnergyChartSummary`,
+`EnergyChart`). Target: **~150 lines** (from 690).
+
+## Testing
+
+Broad + integration (Vitest, T7-conform, recharts mocked):
+
+- **`parseDevicePower`** — watts (`watts` vs `current_power`), voltage, current
+  (`current` vs `current_ma/1000`), energyToday (`energy_today_kwh` vs
+  `energy_today_wh/1000`), and all-undefined when `power_monitor` absent.
+- **`usePowerTabData`** — `renderHook` (wrapped in QueryClient): 404 swallowed to
+  `error: null`; `cumulativeReady` false for `custom` with no applied range;
+  `totalCurrentPower` from `powerSummary.total_watts`. Mock `smartDevicesApi` +
+  energy api + `usePlugins`.
+- **`useEnergyPrice`** — mount fetch seeds config; `savePrice` rejects out-of-range
+  (toast, no call), accepts in-range (calls `updateEnergyPriceConfig`, toast,
+  `onSaved`). Mock energy api + `react-hot-toast`.
+- **Component render tests** — `PowerSummaryCards`, `PowerDeviceCard` (values +
+  `-` fallbacks), `EnergyPriceEditor` (view/edit/save/cancel), `ChartDeviceTabs`
+  (select fires), `ChartModePeriodControls` (mode/period fire), `CustomRangePicker`
+  (invalid range toast, apply fires with iso), `EnergyChartSummary` (both
+  branches), `EnergyChart` (loading/empty/mode selection with recharts mocked),
+  `PowerStates`.
+- **Integration** (`__tests__/components/system-monitor/PowerTab.test.tsx`) — mock
+  both hooks; assert StatCards + a device card + toolbar render for a populated
+  fixture; empty `devices` → empty-state link.
+
+## Verification gates
+
+- `PowerTab.tsx` < 500 lines (target ~150).
+- `eslint .` — 0 errors.
+- `npm run build` (tsc -b + vite) — green.
+- `vitest run` — full suite green.
+- Multi-agent whole-branch review — READY TO MERGE (field-for-field audit of
+  every moved block, esp. the recharts config and the two query definitions).


### PR DESCRIPTION
## Was & Warum

Zerlegt `components/system-monitor/PowerTab.tsx` (**690 → 145 Zeilen**) in zwei Hooks, einen puren Helper und ein Verzeichnis `components/system-monitor/power-tab/`. Teil von **#301 [F2]** (Komponenten > 500 Zeilen).

Verhaltenserhaltend: keine Änderung an Queries, Endpoints, Polling (5s Power / 60s Cumulative), i18n-Keys, Copy, Tailwind, recharts-Konfig oder berechneten Werten. Tab bleibt am Pfad (`PowerTab`-Export, `system-monitor/index.ts`-Barrel unverändert). Getrennt von `components/power/` (CPU-Power-Profile).

## Struktur

**Hooks** (`hooks/`):
- `usePowerTabData` — beide Queries (Devices/Summary 5s + Cumulative-Energy 60s inkl. `resolveCumulativeArgs`/`cumulativeReady`-Gate + 404-Swallow) + Derived (`totalCurrentPower`, `powerPluginName`, `cumulativeKeyArgs`).
- `useEnergyPrice(onSaved)` — Price-Editor-State + Mount-Fetch + `savePrice` (Validierung 0.01–10.0, Toast); `onSaved()` macht die Cumulative-Invalidierung im Orchestrator (Hook queryKey-entkoppelt).

**Purer Helper**: `power-tab/parseDevicePower` — `power_monitor`-Parsing (watts/voltage/currentA/energyToday inkl. `current_ma/1000`- & `energy_today_wh/1000`-Fallbacks), unit-getestet.

**Präsentations-Komponenten** (`power-tab/`, Props rein): `PowerStates` (Loading/Error/Empty), `PowerSummaryCards`, `PowerDeviceCard`, `EnergyPriceEditor`, `ChartDeviceTabs`, `ChartModePeriodControls` + `CustomRangePicker` (Popover besitzt Draft-State selbst), `EnergyChartSummary`, und der Chart-Block als `EnergyChart` → `CumulativeEnergyChart` / `InstantPowerChart`.

`PowerTab.tsx` bleibt schlanker Orchestrator (**145 Zeilen**): hält Auswahl-State, komponiert Hooks + Komponenten.

## Tests

Breit + Integration (T7-konform, recharts gemockt, vollständige Fixtures):
- `parseDevicePower`-Units (alle Fallback-Pfade) — das Kern-Risiko
- `usePowerTabData` (404-Swallow, `cumulativeReady` bei custom) · `useEnergyPrice` (Validierungsgrenzen, Save-Flow, `onSaved`)
- Render/Interaktion je Komponente (Tabs, Mode/Period-Controls, Custom-Range-Validierung, Price-Editor, Device-Card-Fallbacks, Chart-States)
- PowerTab-Integrationstest (populiert → Cards/Device; leer → Empty-State-Link)

## Verifikation

- `PowerTab.tsx` **145 Zeilen** (von 690; Ziel < 500)
- `tsc -b` + `eslint .` — **0 Fehler** · `npm run build` grün
- `vitest run` — **173 Dateien / 793 Tests** grün
- Multi-Agent-Whole-Branch-Review (Opus): **READY TO MERGE** (0 Critical, 0 Important; Feld-für-Feld-Audit beider Queries, der `cumulativeKeyArgs`-Invalidierung, beider recharts-Configs, Layout/Divider/State-Ownership gegen das Original)

Hinweis: Bei der Ausführung fiel ein `verbatimModuleSyntax`-Type-Import-Fehler in einer extrahierten Komponente auf (von Vitest/esbuild nicht gefangen, aber vom CI-`tsc -b`) und wurde per Fixup korrigiert — Grund, warum die Tests jetzt zusätzlich `tsc -b` vor Commit prüfen.

## Doku

`components/CLAUDE.md` (system-monitor-Zeile) + `hooks/CLAUDE.md` (zwei Hooks) ergänzt. Spec + Plan unter `docs/superpowers/{specs,plans}/2026-07-11-powertab-decomposition-f2*`.

Teil von #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
