### PR TITLE
refactor(plugins): decompose PluginsPage into usePluginManagement + plugin-management/* (#301) [F2]

### DIFF
--- a/client/src/__tests__/components/plugins/plugin-management/PermissionGrantModal.test.tsx
+++ b/client/src/__tests__/components/plugins/plugin-management/PermissionGrantModal.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { PluginDetail, PermissionInfo } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { PermissionGrantModal } from '../../../../components/plugins/plugin-management/PermissionGrantModal';
+
+const plugin: PluginDetail = {
+  name: 'demo', version: '1', display_name: 'Demo', description: '', author: '', category: 'general',
+  dependencies: [], required_permissions: ['files.read', 'files.write'], granted_permissions: [],
+  dangerous_permissions: ['files.write'], is_enabled: false, is_installed: true, has_ui: false, has_routes: false,
+  has_background_tasks: false, has_dashboard_panel: false, dashboard_panel_enabled: false,
+  nav_items: [], dashboard_widgets: [], config: {},
+};
+const perms: PermissionInfo[] = [
+  { name: 'r', value: 'files.read', dangerous: false, description: 'read' },
+  { name: 'w', value: 'files.write', dangerous: true, description: 'write' },
+];
+
+describe('PermissionGrantModal', () => {
+  it('disables the enable button until every required permission is selected', () => {
+    const { rerender } = render(
+      <PermissionGrantModal plugin={plugin} allPermissions={perms} selectedPermissions={['files.read']}
+        onTogglePermission={() => {}} onCancel={() => {}} onConfirm={() => {}} />,
+    );
+    expect(screen.getByText('buttons.enablePlugin').closest('button')).toBeDisabled();
+    rerender(
+      <PermissionGrantModal plugin={plugin} allPermissions={perms} selectedPermissions={['files.read', 'files.write']}
+        onTogglePermission={() => {}} onCancel={() => {}} onConfirm={() => {}} />,
+    );
+    expect(screen.getByText('buttons.enablePlugin').closest('button')).not.toBeDisabled();
+  });
+
+  it('fires onTogglePermission with the permission when a checkbox changes', () => {
+    const onToggle = vi.fn();
+    render(
+      <PermissionGrantModal plugin={plugin} allPermissions={perms} selectedPermissions={[]}
+        onTogglePermission={onToggle} onCancel={() => {}} onConfirm={() => {}} />,
+    );
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    expect(onToggle).toHaveBeenCalledWith('files.read');
+  });
+
+  it('fires onConfirm when the (enabled) enable button is clicked', () => {
+    const onConfirm = vi.fn();
+    render(
+      <PermissionGrantModal plugin={plugin} allPermissions={perms} selectedPermissions={['files.read', 'files.write']}
+        onTogglePermission={() => {}} onCancel={() => {}} onConfirm={onConfirm} />,
+    );
+    fireEvent.click(screen.getByText('buttons.enablePlugin'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/__tests__/components/plugins/plugin-management/PluginActionsCard.test.tsx
+++ b/client/src/__tests__/components/plugins/plugin-management/PluginActionsCard.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { PluginDetail } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('../../../../components/LocalOnlyAction', () => ({ LocalOnlyAction: ({ children }: { children: React.ReactNode }) => <>{children}</> }));
+import { PluginActionsCard } from '../../../../components/plugins/plugin-management/PluginActionsCard';
+
+const detail = (over: Partial<PluginDetail> = {}): PluginDetail => ({
+  name: 'demo', version: '1', display_name: 'Demo', description: '', author: '', category: 'general',
+  dependencies: [], required_permissions: [], granted_permissions: [], dangerous_permissions: [],
+  is_enabled: true, is_installed: true, has_ui: false, has_routes: false, has_background_tasks: false,
+  has_dashboard_panel: false, dashboard_panel_enabled: false, nav_items: [], dashboard_widgets: [], config: {}, ...over,
+});
+
+describe('PluginActionsCard', () => {
+  it('disables the uninstall button while the plugin is enabled', () => {
+    render(<PluginActionsCard plugin={detail({ is_enabled: true })} actionLoading={false} onConfigure={() => {}} onUninstall={() => {}} />);
+    expect(screen.getByText('buttons.uninstall').closest('button')).toBeDisabled();
+  });
+
+  it('fires onUninstall with the plugin name when enabled=false and clicked', () => {
+    const onUninstall = vi.fn();
+    render(<PluginActionsCard plugin={detail({ is_enabled: false })} actionLoading={false} onConfigure={() => {}} onUninstall={onUninstall} />);
+    fireEvent.click(screen.getByText('buttons.uninstall'));
+    expect(onUninstall).toHaveBeenCalledWith('demo');
+  });
+
+  it('fires onConfigure when configure is clicked', () => {
+    const onConfigure = vi.fn();
+    render(<PluginActionsCard plugin={detail()} actionLoading={false} onConfigure={onConfigure} onUninstall={() => {}} />);
+    fireEvent.click(screen.getByText('buttons.configure'));
+    expect(onConfigure).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/__tests__/components/plugins/plugin-management/PluginDashboardPanelCard.test.tsx
+++ b/client/src/__tests__/components/plugins/plugin-management/PluginDashboardPanelCard.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { PluginDetail } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { PluginDashboardPanelCard } from '../../../../components/plugins/plugin-management/PluginDashboardPanelCard';
+
+const detail = (over: Partial<PluginDetail> = {}): PluginDetail => ({
+  name: 'demo', version: '1', display_name: 'Demo', description: '', author: '', category: 'general',
+  dependencies: [], required_permissions: [], granted_permissions: [], dangerous_permissions: [],
+  is_enabled: true, is_installed: true, has_ui: false, has_routes: false, has_background_tasks: false,
+  has_dashboard_panel: true, dashboard_panel_enabled: false, nav_items: [], dashboard_widgets: [], config: {}, ...over,
+});
+
+describe('PluginDashboardPanelCard', () => {
+  it('shows the enable-panel label + inactive state when the panel is off', () => {
+    render(<PluginDashboardPanelCard plugin={detail({ dashboard_panel_enabled: false })} actionLoading={false} onToggle={() => {}} />);
+    expect(screen.getByText('buttons.enablePanel')).toBeInTheDocument();
+    expect(screen.getByText('dashboardPanel.inactive')).toBeInTheDocument();
+  });
+
+  it('fires onToggle when the button is clicked', () => {
+    const onToggle = vi.fn();
+    render(<PluginDashboardPanelCard plugin={detail({ dashboard_panel_enabled: true })} actionLoading={false} onToggle={onToggle} />);
+    fireEvent.click(screen.getByText('buttons.disablePanel'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/__tests__/components/plugins/plugin-management/PluginDetailsCard.test.tsx
+++ b/client/src/__tests__/components/plugins/plugin-management/PluginDetailsCard.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PluginDetail } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('../../../../lib/pluginI18n', () => ({ resolvePluginString: (_t: unknown, _k: string, fb: string) => fb }));
+import { PluginDetailsCard } from '../../../../components/plugins/plugin-management/PluginDetailsCard';
+
+const detail = (over: Partial<PluginDetail> = {}): PluginDetail => ({
+  name: 'demo', version: '2.0.0', display_name: 'Demo', description: '', author: 'Jane',
+  category: 'storage', dependencies: [], required_permissions: [], granted_permissions: [],
+  dangerous_permissions: [], is_enabled: true, is_installed: true, has_ui: false, has_routes: false,
+  has_background_tasks: false, has_dashboard_panel: false, dashboard_panel_enabled: false,
+  nav_items: [], dashboard_widgets: [], config: {}, ...over,
+});
+
+describe('PluginDetailsCard', () => {
+  it('renders version and author', () => {
+    render(<PluginDetailsCard plugin={detail()} />);
+    expect(screen.getByText('2.0.0')).toBeInTheDocument();
+    expect(screen.getByText('Jane')).toBeInTheDocument();
+  });
+
+  it('renders a homepage link only when the url is safe', () => {
+    const { rerender } = render(<PluginDetailsCard plugin={detail({ homepage: 'https://example.com' })} />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://example.com/');
+    rerender(<PluginDetailsCard plugin={detail({ homepage: 'javascript:alert(1)' })} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/plugins/plugin-management/PluginDetailsSidebar.test.tsx
+++ b/client/src/__tests__/components/plugins/plugin-management/PluginDetailsSidebar.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PluginDetail } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+// stub children so this test targets ONLY the sidebar's branching/guards
+vi.mock('../../../../components/plugins/plugin-management/PluginDetailsCard', () => ({ PluginDetailsCard: () => <div data-testid="details" /> }));
+vi.mock('../../../../components/plugins/plugin-management/PluginPermissionsCard', () => ({ PluginPermissionsCard: () => <div data-testid="perms" /> }));
+vi.mock('../../../../components/plugins/plugin-management/PluginDashboardPanelCard', () => ({ PluginDashboardPanelCard: () => <div data-testid="panel" /> }));
+vi.mock('../../../../components/plugins/plugin-management/PluginActionsCard', () => ({ PluginActionsCard: () => <div data-testid="actions" /> }));
+vi.mock('../../../../components/plugins/PluginSettingsSection', () => ({ PluginSettingsSection: () => <div data-testid="settings" /> }));
+import { PluginDetailsSidebar } from '../../../../components/plugins/plugin-management/PluginDetailsSidebar';
+
+const detail = (over: Partial<PluginDetail> = {}): PluginDetail => ({
+  name: 'demo', version: '1', display_name: 'Demo', description: '', author: '', category: 'general',
+  dependencies: [], required_permissions: [], granted_permissions: [], dangerous_permissions: [],
+  is_enabled: true, is_installed: true, has_ui: false, has_routes: false, has_background_tasks: false,
+  has_dashboard_panel: false, dashboard_panel_enabled: false, nav_items: [], dashboard_widgets: [], config: {}, ...over,
+});
+const noop = () => {};
+const props = { detailsLoading: false, actionLoading: false, onToggleDashboardPanel: noop, onConfigure: noop, onUninstall: noop };
+
+describe('PluginDetailsSidebar', () => {
+  it('shows the empty prompt when no plugin is selected', () => {
+    render(<PluginDetailsSidebar plugin={null} {...props} />);
+    expect(screen.getByText('empty.selectPlugin')).toBeInTheDocument();
+    expect(screen.queryByTestId('details')).not.toBeInTheDocument();
+  });
+
+  it('renders details + permissions + actions for a selected plugin', () => {
+    render(<PluginDetailsSidebar plugin={detail()} {...props} />);
+    expect(screen.getByTestId('details')).toBeInTheDocument();
+    expect(screen.getByTestId('perms')).toBeInTheDocument();
+    expect(screen.getByTestId('actions')).toBeInTheDocument();
+  });
+
+  it('renders the dashboard-panel card only when has_dashboard_panel && is_enabled', () => {
+    const { rerender } = render(<PluginDetailsSidebar plugin={detail({ has_dashboard_panel: true, is_enabled: true })} {...props} />);
+    expect(screen.getByTestId('panel')).toBeInTheDocument();
+    rerender(<PluginDetailsSidebar plugin={detail({ has_dashboard_panel: true, is_enabled: false })} {...props} />);
+    expect(screen.queryByTestId('panel')).not.toBeInTheDocument();
+  });
+
+  it('renders the settings section only when config_schema && is_enabled', () => {
+    const { rerender } = render(<PluginDetailsSidebar plugin={detail({ config_schema: { type: 'object' }, is_enabled: true })} {...props} />);
+    expect(screen.getByTestId('settings')).toBeInTheDocument();
+    rerender(<PluginDetailsSidebar plugin={detail({ config_schema: undefined, is_enabled: true })} {...props} />);
+    expect(screen.queryByTestId('settings')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/plugins/plugin-management/PluginList.test.tsx
+++ b/client/src/__tests__/components/plugins/plugin-management/PluginList.test.tsx
@@ -1,0 +1,29 @@
+// PluginList.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PluginInfo } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+// stub the card so this test targets only PluginList's own branching
+vi.mock('../../../../components/plugins/plugin-management/PluginListCard', () => ({
+  PluginListCard: ({ plugin }: { plugin: PluginInfo }) => <div data-testid="card">{plugin.name}</div>,
+}));
+import { PluginList } from '../../../../components/plugins/plugin-management/PluginList';
+
+const p = (name: string): PluginInfo => ({
+  name, version: '1', display_name: name, description: '', author: '', category: 'general',
+  required_permissions: [], dangerous_permissions: [], is_enabled: false, has_ui: false, has_routes: false,
+});
+
+describe('PluginList', () => {
+  it('renders the empty-state when there are no plugins', () => {
+    render(<PluginList plugins={[]} selectedName={null} actionLoading={false} onSelect={() => {}} onToggle={() => {}} />);
+    expect(screen.getByText('empty.noPlugins')).toBeInTheDocument();
+    expect(screen.queryByTestId('card')).not.toBeInTheDocument();
+  });
+
+  it('renders one card per plugin when the list is non-empty', () => {
+    render(<PluginList plugins={[p('a'), p('b')]} selectedName="a" actionLoading={false} onSelect={() => {}} onToggle={() => {}} />);
+    expect(screen.getAllByTestId('card')).toHaveLength(2);
+    expect(screen.queryByText('empty.noPlugins')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/plugins/plugin-management/PluginListCard.test.tsx
+++ b/client/src/__tests__/components/plugins/plugin-management/PluginListCard.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { PluginInfo } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('../../../../lib/pluginI18n', () => ({ resolvePluginString: (_t: unknown, _k: string, fb: string) => fb }));
+import { PluginListCard } from '../../../../components/plugins/plugin-management/PluginListCard';
+
+const base: PluginInfo = {
+  name: 'demo', version: '1.2.3', display_name: 'Demo Plugin', description: 'desc',
+  author: 'a', category: 'monitoring', required_permissions: [], dangerous_permissions: [],
+  is_enabled: false, has_ui: false, has_routes: false,
+};
+
+describe('PluginListCard', () => {
+  it('shows the enable label and the version when disabled', () => {
+    render(<PluginListCard plugin={base} isSelected={false} actionLoading={false} onSelect={() => {}} onToggle={() => {}} />);
+    expect(screen.getByText('buttons.enable')).toBeInTheDocument();
+    expect(screen.getByText('v1.2.3')).toBeInTheDocument();
+  });
+
+  it('shows the active badge and disable label when enabled', () => {
+    render(<PluginListCard plugin={{ ...base, is_enabled: true }} isSelected={false} actionLoading={false} onSelect={() => {}} onToggle={() => {}} />);
+    expect(screen.getByText('status.active')).toBeInTheDocument();
+    expect(screen.getByText('buttons.disable')).toBeInTheDocument();
+  });
+
+  it('clicking the toggle fires onToggle but NOT onSelect (stopPropagation)', () => {
+    const onSelect = vi.fn();
+    const onToggle = vi.fn();
+    render(<PluginListCard plugin={base} isSelected={false} actionLoading={false} onSelect={onSelect} onToggle={onToggle} />);
+    fireEvent.click(screen.getByText('buttons.enable'));
+    expect(onToggle).toHaveBeenCalledWith(base);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('clicking the card body fires onSelect with the plugin name', () => {
+    const onSelect = vi.fn();
+    render(<PluginListCard plugin={base} isSelected={false} actionLoading={false} onSelect={onSelect} onToggle={() => {}} />);
+    fireEvent.click(screen.getByText('Demo Plugin'));
+    expect(onSelect).toHaveBeenCalledWith('demo');
+  });
+});

--- a/client/src/__tests__/components/plugins/plugin-management/PluginPermissionsCard.test.tsx
+++ b/client/src/__tests__/components/plugins/plugin-management/PluginPermissionsCard.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PluginDetail } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { PluginPermissionsCard } from '../../../../components/plugins/plugin-management/PluginPermissionsCard';
+
+const detail = (over: Partial<PluginDetail> = {}): PluginDetail => ({
+  name: 'demo', version: '1', display_name: 'Demo', description: '', author: '',
+  category: 'general', dependencies: [], required_permissions: [], granted_permissions: [],
+  dangerous_permissions: [], is_enabled: true, is_installed: true, has_ui: false, has_routes: false,
+  has_background_tasks: false, has_dashboard_panel: false, dashboard_panel_enabled: false,
+  nav_items: [], dashboard_widgets: [], config: {}, ...over,
+});
+
+describe('PluginPermissionsCard', () => {
+  it('shows the noPermissions text when there are none', () => {
+    render(<PluginPermissionsCard plugin={detail()} />);
+    expect(screen.getByText('permissions.noPermissions')).toBeInTheDocument();
+  });
+
+  it('lists each required permission', () => {
+    render(<PluginPermissionsCard plugin={detail({ required_permissions: ['files.read', 'files.write'], granted_permissions: ['files.read'] })} />);
+    expect(screen.getByText('files.read')).toBeInTheDocument();
+    expect(screen.getByText('files.write')).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/plugins/plugin-management/PluginTabNav.test.tsx
+++ b/client/src/__tests__/components/plugins/plugin-management/PluginTabNav.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { PluginTabNav, TABS } from '../../../../components/plugins/plugin-management/PluginTabNav';
+
+describe('PluginTabNav', () => {
+  it('renders one button per tab', () => {
+    render(<PluginTabNav activeTab="plugins" onSelect={() => {}} />);
+    expect(screen.getAllByRole('button')).toHaveLength(TABS.length);
+  });
+
+  it('fires onSelect with the clicked tab id', () => {
+    const onSelect = vi.fn();
+    render(<PluginTabNav activeTab="plugins" onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('tabs.marketplace'));
+    expect(onSelect).toHaveBeenCalledWith('marketplace');
+  });
+});

--- a/client/src/__tests__/components/plugins/plugin-management/ScopeGrantModal.test.tsx
+++ b/client/src/__tests__/components/plugins/plugin-management/ScopeGrantModal.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { PluginDetail, ScopeInfo } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { ScopeGrantModal } from '../../../../components/plugins/plugin-management/ScopeGrantModal';
+
+const plugin = (over: Partial<PluginDetail> = {}): PluginDetail => ({
+  name: 'demo', version: '1', display_name: 'Demo', description: '', author: '', category: 'general',
+  dependencies: [], required_permissions: [], granted_permissions: [], dangerous_permissions: [],
+  is_enabled: false, is_installed: true, has_ui: false, has_routes: false, has_background_tasks: false,
+  has_dashboard_panel: false, dashboard_panel_enabled: false, nav_items: [], dashboard_widgets: [],
+  config: {}, is_external: true, requested_api_scopes: ['ui.read', 'files.write'], ...over,
+});
+const catalog: ScopeInfo[] = [
+  { key: 'ui.read', tier: 'frontend', dangerous: false },
+  { key: 'files.write', tier: 'backend', dangerous: true },
+];
+
+describe('ScopeGrantModal', () => {
+  it('renders both tier groups with one checkbox per requested+catalog scope', () => {
+    render(<ScopeGrantModal plugin={plugin()} scopeCatalog={catalog} selectedScopes={[]}
+      onToggleScope={() => {}} onCancel={() => {}} onConfirm={() => {}} />);
+    expect(screen.getByText('scopeTiers.frontend')).toBeInTheDocument();
+    expect(screen.getByText('scopeTiers.backend')).toBeInTheDocument();
+    expect(screen.getAllByRole('checkbox')).toHaveLength(2);
+  });
+
+  it('shows the noScopes text when no requested scope is in the catalog', () => {
+    render(<ScopeGrantModal plugin={plugin({ requested_api_scopes: ['unknown'] })} scopeCatalog={catalog}
+      selectedScopes={[]} onToggleScope={() => {}} onCancel={() => {}} onConfirm={() => {}} />);
+    expect(screen.getByText('picker.noScopes')).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  it('fires onToggleScope with the scope key on checkbox change', () => {
+    const onToggleScope = vi.fn();
+    render(<ScopeGrantModal plugin={plugin()} scopeCatalog={catalog} selectedScopes={[]}
+      onToggleScope={onToggleScope} onCancel={() => {}} onConfirm={() => {}} />);
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    expect(onToggleScope).toHaveBeenCalledWith('ui.read');
+  });
+
+  it('fires onConfirm when grant is clicked', () => {
+    const onConfirm = vi.fn();
+    render(<ScopeGrantModal plugin={plugin()} scopeCatalog={catalog} selectedScopes={['ui.read']}
+      onToggleScope={() => {}} onCancel={() => {}} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByText('picker.grant'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/__tests__/components/plugins/plugin-management/pluginCategoryColor.test.ts
+++ b/client/src/__tests__/components/plugins/plugin-management/pluginCategoryColor.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { getCategoryColor } from '../../../../components/plugins/plugin-management/pluginCategoryColor';
+
+describe('getCategoryColor', () => {
+  it('returns the monitoring class string for the monitoring category', () => {
+    expect(getCategoryColor('monitoring')).toContain('blue');
+  });
+
+  it('returns a distinct class string per known category', () => {
+    const known = ['monitoring', 'storage', 'network', 'security', 'general'];
+    const results = known.map(getCategoryColor);
+    // all five map to a non-empty string, and they are not all identical
+    expect(results.every((r) => r.length > 0)).toBe(true);
+    expect(new Set(results).size).toBe(5);
+  });
+
+  it('falls back to the general class string for an unknown category', () => {
+    expect(getCategoryColor('does-not-exist')).toBe(getCategoryColor('general'));
+  });
+});

--- a/client/src/__tests__/hooks/usePluginManagement.test.ts
+++ b/client/src/__tests__/hooks/usePluginManagement.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { PluginInfo, PluginDetail, ScopeInfo } from '../../api/plugins';
+
+const mockRefreshPlugins = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../contexts/PluginContext', () => ({
+  usePlugins: () => ({
+    plugins: [] as PluginInfo[],
+    isLoading: false,
+    error: null,
+    refreshPlugins: mockRefreshPlugins,
+  }),
+}));
+
+const mockConfirm = vi.fn();
+vi.mock('../../hooks/useConfirmDialog', () => ({
+  useConfirmDialog: () => ({ confirm: mockConfirm, dialog: null }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('../../api/plugins', () => ({
+  getPluginDetails: vi.fn(),
+  getScopeCatalog: vi.fn().mockResolvedValue({ scopes: [] }),
+  listPermissions: vi.fn().mockResolvedValue({ permissions: [] }),
+  togglePlugin: vi.fn().mockResolvedValue({}),
+  toggleDashboardPanel: vi.fn().mockResolvedValue({}),
+  uninstallPlugin: vi.fn().mockResolvedValue({}),
+}));
+
+import { usePluginManagement } from '../../hooks/usePluginManagement';
+import * as api from '../../api/plugins';
+
+const internalPlugin: PluginInfo = {
+  name: 'demo', version: '1.0.0', display_name: 'Demo', description: 'd',
+  author: 'a', category: 'general', required_permissions: ['files.read'],
+  dangerous_permissions: [], is_enabled: false, has_ui: false, has_routes: false,
+};
+
+function detail(over: Partial<PluginDetail> = {}): PluginDetail {
+  return {
+    name: 'demo', version: '1.0.0', display_name: 'Demo', description: 'd', author: 'a',
+    category: 'general', dependencies: [], required_permissions: ['files.read'],
+    granted_permissions: [], dangerous_permissions: [], is_enabled: false,
+    is_installed: true, has_ui: false, has_routes: false, has_background_tasks: false,
+    has_dashboard_panel: false, dashboard_panel_enabled: false, nav_items: [],
+    dashboard_widgets: [], config: {}, ...over,
+  };
+}
+
+describe('usePluginManagement', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sets actionError when loadPluginDetails fails and returns null', async () => {
+    vi.mocked(api.getPluginDetails).mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => usePluginManagement());
+    let ret: PluginDetail | null = detail();
+    await act(async () => { ret = await result.current.loadPluginDetails('demo'); });
+    expect(ret).toBeNull();
+    expect(result.current.actionError).toBe('errors.loadDetailsFailed');
+  });
+
+  it('opens the permission modal (not the scope modal) when enabling an internal plugin', async () => {
+    vi.mocked(api.getPluginDetails).mockResolvedValueOnce(detail({ is_external: false }));
+    const { result } = renderHook(() => usePluginManagement());
+    await act(async () => { await result.current.handleTogglePlugin(internalPlugin); });
+    expect(result.current.showPermissionModal).toBe(true);
+    expect(result.current.showScopeModal).toBe(false);
+    expect(result.current.selectedPermissions).toEqual(['files.read']);
+  });
+
+  it('opens the scope modal seeded with catalog-filtered requested scopes for an external plugin', async () => {
+    const catalog: ScopeInfo[] = [{ key: 'ui.read', tier: 'frontend', dangerous: false }];
+    vi.mocked(api.getScopeCatalog).mockResolvedValue({ scopes: catalog });
+    vi.mocked(api.getPluginDetails).mockResolvedValueOnce(
+      detail({ is_external: true, requested_api_scopes: ['ui.read', 'not.in.catalog'] }),
+    );
+    const { result } = renderHook(() => usePluginManagement());
+    await waitFor(() => expect(result.current.scopeCatalog).toHaveLength(1));
+    await act(async () => { await result.current.handleTogglePlugin({ ...internalPlugin, is_external: true }); });
+    expect(result.current.showScopeModal).toBe(true);
+    expect(result.current.showPermissionModal).toBe(false);
+    expect(result.current.selectedScopes).toEqual(['ui.read']); // 'not.in.catalog' filtered out
+  });
+
+  it('does not call uninstallPlugin when the confirm dialog is declined', async () => {
+    mockConfirm.mockResolvedValueOnce(false);
+    const { result } = renderHook(() => usePluginManagement());
+    await act(async () => { await result.current.handleUninstall('demo'); });
+    expect(api.uninstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it('calls uninstallPlugin and refreshes when the confirm dialog is accepted', async () => {
+    mockConfirm.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => usePluginManagement());
+    await act(async () => { await result.current.handleUninstall('demo'); });
+    expect(api.uninstallPlugin).toHaveBeenCalledWith('demo');
+    expect(mockRefreshPlugins).toHaveBeenCalled();
+  });
+
+  it('togglePermission adds then removes a permission', () => {
+    const { result } = renderHook(() => usePluginManagement());
+    act(() => result.current.togglePermission('files.write'));
+    expect(result.current.selectedPermissions).toContain('files.write');
+    act(() => result.current.togglePermission('files.write'));
+    expect(result.current.selectedPermissions).not.toContain('files.write');
+  });
+
+  it('handleEnableWithPermissions posts enabled:true + grant_permissions from the selection', async () => {
+    vi.mocked(api.getPluginDetails).mockResolvedValueOnce(detail({ is_external: false }));
+    const { result } = renderHook(() => usePluginManagement());
+    // seed selectedPlugin + selectedPermissions via the internal-enable branch
+    await act(async () => { await result.current.handleTogglePlugin(internalPlugin); });
+    await act(async () => { await result.current.handleEnableWithPermissions(); });
+    expect(api.togglePlugin).toHaveBeenCalledWith('demo', { enabled: true, grant_permissions: ['files.read'] });
+    expect(result.current.showPermissionModal).toBe(false);
+  });
+
+  it('handleEnableWithScopes posts enabled:true + grant_api_scopes from the catalog-filtered selection', async () => {
+    const catalog: ScopeInfo[] = [{ key: 'ui.read', tier: 'frontend', dangerous: false }];
+    vi.mocked(api.getScopeCatalog).mockResolvedValue({ scopes: catalog });
+    vi.mocked(api.getPluginDetails).mockResolvedValueOnce(
+      detail({ is_external: true, requested_api_scopes: ['ui.read', 'not.in.catalog'] }),
+    );
+    const { result } = renderHook(() => usePluginManagement());
+    await waitFor(() => expect(result.current.scopeCatalog).toHaveLength(1));
+    await act(async () => { await result.current.handleTogglePlugin({ ...internalPlugin, is_external: true }); });
+    await act(async () => { await result.current.handleEnableWithScopes(); });
+    expect(api.togglePlugin).toHaveBeenCalledWith('demo', { enabled: true, grant_api_scopes: ['ui.read'] });
+    expect(result.current.showScopeModal).toBe(false);
+  });
+});

--- a/client/src/__tests__/pages/PluginsPage.test.tsx
+++ b/client/src/__tests__/pages/PluginsPage.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PluginInfo, PluginDetail } from '../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+const hookValue = {
+  plugins: [] as PluginInfo[], isLoading: false, error: null, refreshPlugins: vi.fn(),
+  allPermissions: [], scopeCatalog: [], selectedPlugin: null as PluginDetail | null,
+  detailsLoading: false, actionLoading: false, actionError: null,
+  loadPluginDetails: vi.fn(), handleTogglePlugin: vi.fn(), handleEnableWithPermissions: vi.fn(),
+  handleEnableWithScopes: vi.fn(), handleUninstall: vi.fn(), handleToggleDashboardPanel: vi.fn(),
+  showPermissionModal: false, setShowPermissionModal: vi.fn(), selectedPermissions: [], togglePermission: vi.fn(),
+  showScopeModal: false, setShowScopeModal: vi.fn(), selectedScopes: [], toggleScope: vi.fn(),
+  dialog: null,
+};
+vi.mock('../../hooks/usePluginManagement', () => ({ usePluginManagement: () => hookValue }));
+vi.mock('../../components/plugins/MarketplaceTab', () => ({ default: () => <div data-testid="marketplace" /> }));
+vi.mock('../../components/plugins/PluginDocumentation', () => ({ default: () => <div data-testid="docs" /> }));
+// real plugin-management barrel components render (already unit-tested); make the
+// plugin-name resolver deterministic so PluginListCard shows the raw display_name
+vi.mock('../../lib/pluginI18n', () => ({ resolvePluginString: (_t: unknown, _k: string, fb: string) => fb }));
+
+import PluginsPage from '../../pages/PluginsPage';
+
+describe('PluginsPage', () => {
+  beforeEach(() => { hookValue.plugins = []; hookValue.selectedPlugin = null; });
+
+  it('shows the empty-state on the plugins tab when there are no plugins', () => {
+    render(<PluginsPage />);
+    expect(screen.getByText('empty.noPlugins')).toBeInTheDocument();
+    // sidebar empty prompt is also present
+    expect(screen.getByText('empty.selectPlugin')).toBeInTheDocument();
+  });
+
+  it('renders the plugin list when plugins exist', () => {
+    hookValue.plugins = [{
+      name: 'demo', version: '1', display_name: 'Demo Plugin', description: '', author: '',
+      category: 'general', required_permissions: [], dangerous_permissions: [],
+      is_enabled: false, has_ui: false, has_routes: false,
+    }];
+    render(<PluginsPage />);
+    expect(screen.getByText('Demo Plugin')).toBeInTheDocument();
+    expect(screen.queryByText('empty.noPlugins')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/CLAUDE.md
+++ b/client/src/components/CLAUDE.md
@@ -50,7 +50,7 @@ Reusable, generic building blocks. No business logic, no API calls.
 | `manual/` | User manual article viewer |
 | `monitoring/` | System monitoring charts and cards |
 | `pihole/` | Pi-hole DNS dashboard, `ad-discovery/` |
-| `plugins/` | Plugin management UI |
+| `plugins/` | Plugin management UI — `plugin-management/` holds the `PluginsPage` decomposition: `PluginTabNav`, `PluginList`/`PluginListCard`, `PluginDetailsSidebar` (composing `PluginDetailsCard`/`PluginPermissionsCard`/`PluginDashboardPanelCard`/`PluginActionsCard`), `PermissionGrantModal`, `ScopeGrantModal`, `getCategoryColor` helper — re-exported via `plugin-management/index.ts`; state/actions in `hooks/usePluginManagement.ts` (extracted F2/#301) |
 | `power/` | Power profile management — `PowerManagement` page composes `PowerStatusCards`, `PermissionStatusCard`, `AutoScalingSection` (extracted F2/#301); `SleepConfigPanel` composes ./sleep-config/* (8 section cards + SleepFormControls), form state in useSleepConfigForm/useFritzBoxForm (extracted F2) |
 | `raid/` | RAID status, disk details |
 | `rate-limits/` | Rate limit configuration UI |

--- a/client/src/components/plugins/plugin-management/PermissionGrantModal.tsx
+++ b/client/src/components/plugins/plugin-management/PermissionGrantModal.tsx
@@ -1,0 +1,82 @@
+import { useTranslation } from 'react-i18next';
+import type { PluginDetail, PermissionInfo } from '../../../api/plugins';
+
+export function PermissionGrantModal({
+  plugin,
+  allPermissions,
+  selectedPermissions,
+  onTogglePermission,
+  onCancel,
+  onConfirm,
+}: {
+  plugin: PluginDetail;
+  allPermissions: PermissionInfo[];
+  selectedPermissions: string[];
+  onTogglePermission: (perm: string) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const { t } = useTranslation(['plugins', 'common']);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 w-full max-w-md mx-4 shadow-2xl">
+        <h3 className="text-lg font-medium text-white mb-2">
+          {t('modal.enableTitle', { name: plugin.display_name })}
+        </h3>
+        <p className="text-sm text-slate-400 mb-4">
+          {t('modal.enableDesc')}
+        </p>
+        <div className="space-y-2 mb-6 max-h-64 overflow-y-auto">
+          {plugin.required_permissions.map((perm) => {
+            const permInfo = allPermissions.find((p) => p.value === perm);
+            const isChecked = selectedPermissions.includes(perm);
+            return (
+              <label
+                key={perm}
+                className={`flex items-start gap-3 p-3 rounded-lg cursor-pointer transition ${
+                  permInfo?.dangerous
+                    ? 'bg-amber-500/10 border border-amber-500/20'
+                    : 'bg-slate-800/50 border border-slate-700'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={isChecked}
+                  onChange={() => onTogglePermission(perm)}
+                  className="mt-1 rounded border-slate-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-slate-900"
+                />
+                <div>
+                  <div className={`text-sm font-medium ${permInfo?.dangerous ? 'text-amber-400' : 'text-white'}`}>
+                    {perm}
+                    {permInfo?.dangerous && (
+                      <span className="ml-2 text-xs text-amber-500">({t('permissions.dangerous')})</span>
+                    )}
+                  </div>
+                  {permInfo && (
+                    <p className="text-xs text-slate-500 mt-0.5">{permInfo.description}</p>
+                  )}
+                </div>
+              </label>
+            );
+          })}
+        </div>
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 px-4 py-2 text-sm font-medium rounded-lg border border-slate-700 text-slate-300 hover:border-slate-600 transition-all touch-manipulation active:scale-95"
+          >
+            {t('buttons.cancel')}
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={!plugin.required_permissions.every((p) => selectedPermissions.includes(p))}
+            className="flex-1 px-4 py-2 text-sm font-medium rounded-lg bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-all touch-manipulation active:scale-95"
+          >
+            {t('buttons.enablePlugin')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/plugins/plugin-management/PluginActionsCard.tsx
+++ b/client/src/components/plugins/plugin-management/PluginActionsCard.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from 'react-i18next';
+import { Settings, Trash2 } from 'lucide-react';
+import type { PluginDetail } from '../../../api/plugins';
+import { LocalOnlyAction } from '../../LocalOnlyAction';
+
+export function PluginActionsCard({
+  plugin,
+  actionLoading,
+  onConfigure,
+  onUninstall,
+}: {
+  plugin: PluginDetail;
+  actionLoading: boolean;
+  onConfigure: () => void;
+  onUninstall: (name: string) => void;
+}) {
+  const { t } = useTranslation(['plugins', 'common']);
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 space-y-3">
+      <button
+        onClick={onConfigure}
+        disabled={!plugin.is_enabled}
+        className="w-full px-4 py-2 text-sm font-medium rounded-lg border border-slate-700 text-slate-300 hover:border-slate-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-all touch-manipulation active:scale-95"
+      >
+        <Settings className="h-4 w-4" />
+        {t('buttons.configure')}
+      </button>
+      <LocalOnlyAction>
+        <button
+          onClick={() => onUninstall(plugin.name)}
+          disabled={actionLoading || plugin.is_enabled}
+          className="w-full px-4 py-2 text-sm font-medium rounded-lg border border-red-500/30 text-red-400 hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-all touch-manipulation active:scale-95"
+        >
+          <Trash2 className="h-4 w-4" />
+          {t('buttons.uninstall')}
+        </button>
+      </LocalOnlyAction>
+      {plugin.is_enabled && (
+        <p className="text-xs text-slate-500 text-center">
+          {t('confirm.disableFirst')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/plugins/plugin-management/PluginDashboardPanelCard.tsx
+++ b/client/src/components/plugins/plugin-management/PluginDashboardPanelCard.tsx
@@ -1,0 +1,43 @@
+import { useTranslation } from 'react-i18next';
+import { LayoutDashboard } from 'lucide-react';
+import type { PluginDetail } from '../../../api/plugins';
+
+export function PluginDashboardPanelCard({
+  plugin,
+  actionLoading,
+  onToggle,
+}: {
+  plugin: PluginDetail;
+  actionLoading: boolean;
+  onToggle: () => void;
+}) {
+  const { t } = useTranslation(['plugins', 'common']);
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+      <h4 className="text-sm font-medium text-white mb-3 flex items-center gap-2">
+        <LayoutDashboard className="h-4 w-4" />
+        {t('dashboardPanel.title')}
+      </h4>
+      <p className="text-xs text-slate-500 mb-4">
+        {t('dashboardPanel.description')}
+      </p>
+      <div className="flex items-center justify-between">
+        <span className={`text-sm ${plugin.dashboard_panel_enabled ? 'text-green-400' : 'text-slate-500'}`}>
+          {plugin.dashboard_panel_enabled ? t('dashboardPanel.active') : t('dashboardPanel.inactive')}
+        </span>
+        <button
+          onClick={onToggle}
+          disabled={actionLoading}
+          className={`rounded-lg px-3 py-1.5 text-xs sm:text-sm font-medium transition-all touch-manipulation active:scale-95 border ${
+            plugin.dashboard_panel_enabled
+              ? 'border-slate-700 bg-slate-800 text-slate-300 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/30'
+              : 'border-green-500/30 bg-green-500/20 text-green-400 hover:bg-green-500/30'
+          } disabled:opacity-50 disabled:cursor-not-allowed`}
+        >
+          {plugin.dashboard_panel_enabled ? t('buttons.disablePanel') : t('buttons.enablePanel')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/plugins/plugin-management/PluginDetailsCard.tsx
+++ b/client/src/components/plugins/plugin-management/PluginDetailsCard.tsx
@@ -1,0 +1,60 @@
+import { useTranslation } from 'react-i18next';
+import { ExternalLink } from 'lucide-react';
+import type { PluginDetail } from '../../../api/plugins';
+import { safeExternalUrl } from '../../../lib/safeUrl';
+import { resolvePluginString } from '../../../lib/pluginI18n';
+
+export function PluginDetailsCard({ plugin }: { plugin: PluginDetail }) {
+  const { t } = useTranslation(['plugins', 'common']);
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+      <h3 className="text-lg font-medium text-white mb-4">
+        {resolvePluginString(plugin.translations, 'display_name', plugin.display_name)}
+      </h3>
+      <dl className="space-y-3 text-sm">
+        <div className="flex justify-between">
+          <dt className="text-slate-500">{t('details.version')}</dt>
+          <dd className="text-white">{plugin.version}</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-slate-500">{t('details.author')}</dt>
+          <dd className="text-white">{plugin.author}</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-slate-500">{t('details.category')}</dt>
+          <dd className="text-white capitalize">{plugin.category}</dd>
+        </div>
+        {safeExternalUrl(plugin.homepage) && (
+          <div className="flex justify-between">
+            <dt className="text-slate-500">{t('details.homepage')}</dt>
+            <dd>
+              <a
+                href={safeExternalUrl(plugin.homepage)!}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-400 hover:underline flex items-center gap-1"
+              >
+                {t('details.link')} <ExternalLink className="h-3 w-3" />
+              </a>
+            </dd>
+          </div>
+        )}
+        <div className="flex justify-between">
+          <dt className="text-slate-500">{t('details.status')}</dt>
+          <dd className={plugin.is_enabled ? 'text-green-400' : 'text-slate-400'}>
+            {plugin.is_enabled ? t('status.enabled') : t('status.disabled')}
+          </dd>
+        </div>
+        {plugin.installed_at && (
+          <div className="flex justify-between">
+            <dt className="text-slate-500">{t('details.installed')}</dt>
+            <dd className="text-white">
+              {new Date(plugin.installed_at).toLocaleDateString()}
+            </dd>
+          </div>
+        )}
+      </dl>
+    </div>
+  );
+}

--- a/client/src/components/plugins/plugin-management/PluginDetailsSidebar.tsx
+++ b/client/src/components/plugins/plugin-management/PluginDetailsSidebar.tsx
@@ -1,0 +1,73 @@
+import { useTranslation } from 'react-i18next';
+import { Settings } from 'lucide-react';
+import type { PluginDetail } from '../../../api/plugins';
+import { PluginDetailsCard } from './PluginDetailsCard';
+import { PluginPermissionsCard } from './PluginPermissionsCard';
+import { PluginDashboardPanelCard } from './PluginDashboardPanelCard';
+import { PluginActionsCard } from './PluginActionsCard';
+import { PluginSettingsSection } from '../PluginSettingsSection';
+
+export function PluginDetailsSidebar({
+  plugin,
+  detailsLoading,
+  actionLoading,
+  onToggleDashboardPanel,
+  onConfigure,
+  onUninstall,
+}: {
+  plugin: PluginDetail | null;
+  detailsLoading: boolean;
+  actionLoading: boolean;
+  onToggleDashboardPanel: () => void;
+  onConfigure: () => void;
+  onUninstall: (name: string) => void;
+}) {
+  const { t } = useTranslation(['plugins', 'common']);
+
+  return (
+    <div className="space-y-4">
+      {detailsLoading ? (
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+          <div className="animate-pulse space-y-4">
+            <div className="h-6 bg-slate-800 rounded w-3/4" />
+            <div className="h-4 bg-slate-800 rounded w-1/2" />
+            <div className="h-20 bg-slate-800 rounded" />
+          </div>
+        </div>
+      ) : plugin ? (
+        <>
+          <PluginDetailsCard plugin={plugin} />
+          <PluginPermissionsCard plugin={plugin} />
+          {plugin.has_dashboard_panel && plugin.is_enabled && (
+            <PluginDashboardPanelCard
+              plugin={plugin}
+              actionLoading={actionLoading}
+              onToggle={onToggleDashboardPanel}
+            />
+          )}
+          {plugin?.config_schema && plugin.is_enabled && (
+            <PluginSettingsSection
+              pluginName={plugin.name}
+              configSchema={plugin.config_schema}
+              config={plugin.config ?? {}}
+              translations={plugin.translations ?? undefined}
+            />
+          )}
+          <PluginActionsCard
+            plugin={plugin}
+            actionLoading={actionLoading}
+            onConfigure={onConfigure}
+            onUninstall={onUninstall}
+          />
+        </>
+      ) : (
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 text-center">
+          <Settings className="h-8 w-8 mx-auto text-slate-600 mb-3" />
+          <p className="text-sm text-slate-500">
+            {t('empty.selectPlugin')}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/plugins/plugin-management/PluginList.tsx
+++ b/client/src/components/plugins/plugin-management/PluginList.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'react-i18next';
+import { Plug } from 'lucide-react';
+import type { PluginInfo } from '../../../api/plugins';
+import { PluginListCard } from './PluginListCard';
+
+export function PluginList({
+  plugins,
+  selectedName,
+  actionLoading,
+  onSelect,
+  onToggle,
+}: {
+  plugins: PluginInfo[];
+  selectedName: string | null;
+  actionLoading: boolean;
+  onSelect: (name: string) => void;
+  onToggle: (plugin: PluginInfo) => void;
+}) {
+  const { t } = useTranslation(['plugins', 'common']);
+
+  return (
+    <div className="lg:col-span-2 space-y-4">
+      {plugins.length === 0 ? (
+        <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-8 text-center">
+          <Plug className="h-12 w-12 mx-auto text-slate-600 mb-4" />
+          <h3 className="text-lg font-medium text-slate-300 mb-2">{t('empty.noPlugins')}</h3>
+          <p className="text-sm text-slate-500">
+            {t('empty.noPluginsDesc')}
+          </p>
+        </div>
+      ) : (
+        plugins.map((plugin) => (
+          <PluginListCard
+            key={plugin.name}
+            plugin={plugin}
+            isSelected={selectedName === plugin.name}
+            actionLoading={actionLoading}
+            onSelect={onSelect}
+            onToggle={onToggle}
+          />
+        ))
+      )}
+    </div>
+  );
+}

--- a/client/src/components/plugins/plugin-management/PluginListCard.tsx
+++ b/client/src/components/plugins/plugin-management/PluginListCard.tsx
@@ -1,0 +1,87 @@
+import { useTranslation } from 'react-i18next';
+import { Plug, Shield } from 'lucide-react';
+import type { PluginInfo } from '../../../api/plugins';
+import { resolvePluginString } from '../../../lib/pluginI18n';
+import { getCategoryColor } from './pluginCategoryColor';
+
+export function PluginListCard({
+  plugin,
+  isSelected,
+  actionLoading,
+  onSelect,
+  onToggle,
+}: {
+  plugin: PluginInfo;
+  isSelected: boolean;
+  actionLoading: boolean;
+  onSelect: (name: string) => void;
+  onToggle: (plugin: PluginInfo) => void;
+}) {
+  const { t } = useTranslation(['plugins', 'common']);
+
+  return (
+    <div
+      onClick={() => onSelect(plugin.name)}
+      className={`rounded-xl border p-4 cursor-pointer transition-all ${
+        isSelected
+          ? 'border-blue-500 bg-slate-900/80'
+          : 'border-slate-800 bg-slate-900/50 hover:border-slate-700'
+      }`}
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          <div className={`p-2 rounded-lg ${plugin.is_enabled ? 'bg-green-500/20' : 'bg-slate-800'}`}>
+            <Plug className={`h-5 w-5 ${plugin.is_enabled ? 'text-green-400' : 'text-slate-500'}`} />
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <h3 className="font-medium text-white">{resolvePluginString(plugin.translations, 'display_name', plugin.display_name)}</h3>
+              <span className="text-xs text-slate-500">v{plugin.version}</span>
+              {plugin.is_enabled && (
+                <span className="px-2 py-0.5 text-xs rounded-full bg-green-500/20 text-green-400 border border-green-500/30">
+                  {t('status.active')}
+                </span>
+              )}
+            </div>
+            <p className="text-sm text-slate-400 mt-0.5">{resolvePluginString(plugin.translations, 'description', plugin.description)}</p>
+            <div className="flex items-center gap-2 mt-2">
+              <span className={`px-2 py-0.5 text-xs rounded-full border ${getCategoryColor(plugin.category)}`}>
+                {plugin.category}
+              </span>
+              {plugin.has_ui && (
+                <span className="px-2 py-0.5 text-xs rounded-full bg-purple-500/20 text-purple-400 border border-purple-500/30">
+                  {t('ui')}
+                </span>
+              )}
+              {plugin.dangerous_permissions.length > 0 && (
+                <span className="px-2 py-0.5 text-xs rounded-full bg-amber-500/20 text-amber-400 border border-amber-500/30 flex items-center gap-1">
+                  <Shield className="h-3 w-3" />
+                  {t('permissions.requiresReview')}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggle(plugin);
+          }}
+          disabled={actionLoading}
+          className={`rounded-lg px-3 py-1.5 text-xs sm:text-sm font-medium transition-all touch-manipulation active:scale-95 ${
+            plugin.is_enabled
+              ? 'bg-slate-800 text-slate-300 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/30'
+              : 'bg-blue-500/20 text-blue-400 hover:bg-blue-500/30'
+          } border border-slate-700`}
+        >
+          {plugin.is_enabled ? t('buttons.disable') : t('buttons.enable')}
+        </button>
+      </div>
+      {plugin.error && (
+        <div className="mt-3 p-2 rounded-lg bg-red-500/10 border border-red-500/20 text-xs text-red-400">
+          Error: {plugin.error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/plugins/plugin-management/PluginPermissionsCard.tsx
+++ b/client/src/components/plugins/plugin-management/PluginPermissionsCard.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'react-i18next';
+import { Shield, Check, X } from 'lucide-react';
+import type { PluginDetail } from '../../../api/plugins';
+
+export function PluginPermissionsCard({ plugin }: { plugin: PluginDetail }) {
+  const { t } = useTranslation(['plugins', 'common']);
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+      <h4 className="text-sm font-medium text-white mb-3 flex items-center gap-2">
+        <Shield className="h-4 w-4" />
+        {t('permissions.title')}
+      </h4>
+      {plugin.required_permissions.length === 0 ? (
+        <p className="text-sm text-slate-500">{t('permissions.noPermissions')}</p>
+      ) : (
+        <ul className="space-y-2">
+          {plugin.required_permissions.map((perm) => {
+            const isDangerous = plugin.dangerous_permissions.includes(perm);
+            const isGranted = plugin.granted_permissions.includes(perm);
+            return (
+              <li
+                key={perm}
+                className={`flex items-center justify-between text-sm p-2 rounded-lg ${
+                  isDangerous
+                    ? 'bg-amber-500/10 border border-amber-500/20'
+                    : 'bg-slate-800/50'
+                }`}
+              >
+                <span className={isDangerous ? 'text-amber-400' : 'text-slate-300'}>
+                  {perm}
+                </span>
+                {isGranted ? (
+                  <Check className="h-4 w-4 text-green-400" />
+                ) : (
+                  <X className="h-4 w-4 text-slate-500" />
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/plugins/plugin-management/PluginTabNav.tsx
+++ b/client/src/components/plugins/plugin-management/PluginTabNav.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from 'react-i18next';
+import type { LucideIcon } from 'lucide-react';
+import { Plug, Store, BookOpen } from 'lucide-react';
+
+export type TabType = 'plugins' | 'marketplace' | 'documentation';
+
+export interface PluginTab {
+  id: TabType;
+  labelKey: string;
+  icon: LucideIcon;
+}
+
+export const TABS: PluginTab[] = [
+  { id: 'plugins' as TabType, labelKey: 'tabs.installed', icon: Plug },
+  { id: 'marketplace' as TabType, labelKey: 'tabs.marketplace', icon: Store },
+  { id: 'documentation' as TabType, labelKey: 'tabs.documentation', icon: BookOpen },
+];
+
+export function PluginTabNav({
+  activeTab,
+  onSelect,
+}: {
+  activeTab: TabType;
+  onSelect: (id: TabType) => void;
+}) {
+  const { t } = useTranslation(['plugins', 'common']);
+
+  return (
+    <div className="flex gap-2 border-b border-slate-800 pb-3 overflow-x-auto scrollbar-none">
+      {TABS.map((tab) => (
+        <button
+          key={tab.id}
+          onClick={() => onSelect(tab.id)}
+          className={`flex items-center gap-2 rounded-lg px-3 sm:px-4 py-2 sm:py-2.5 text-xs sm:text-sm font-medium transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
+            activeTab === tab.id
+              ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40'
+              : 'text-slate-400 hover:bg-slate-800/50 hover:text-slate-300 border border-transparent'
+          }`}
+        >
+          <tab.icon className="w-4 h-4" />
+          {t(tab.labelKey)}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/plugins/plugin-management/ScopeGrantModal.tsx
+++ b/client/src/components/plugins/plugin-management/ScopeGrantModal.tsx
@@ -1,0 +1,105 @@
+import { useTranslation } from 'react-i18next';
+import type { PluginDetail, ScopeInfo } from '../../../api/plugins';
+
+export function ScopeGrantModal({
+  plugin,
+  scopeCatalog,
+  selectedScopes,
+  onToggleScope,
+  onCancel,
+  onConfirm,
+}: {
+  plugin: PluginDetail;
+  scopeCatalog: ScopeInfo[];
+  selectedScopes: string[];
+  onToggleScope: (scope: string) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const { t } = useTranslation(['plugins', 'common']);
+
+  const descs = t('scopeDescriptions', { returnObjects: true }) as Record<
+    string,
+    { label: string; description: string }
+  >;
+  const requested = (plugin.requested_api_scopes ?? []).filter((s) =>
+    scopeCatalog.some((c) => c.key === s),
+  );
+  const byTier = (tier: 'frontend' | 'backend') =>
+    requested
+      .map((key) => scopeCatalog.find((c) => c.key === key)!)
+      .filter((c) => c.tier === tier);
+  const renderScope = (scope: ScopeInfo) => {
+    const isChecked = selectedScopes.includes(scope.key);
+    const meta = descs?.[scope.key];
+    return (
+      <label
+        key={scope.key}
+        className={`flex items-start gap-3 p-3 rounded-lg cursor-pointer transition ${
+          scope.dangerous
+            ? 'bg-amber-500/10 border border-amber-500/20'
+            : 'bg-slate-800/50 border border-slate-700'
+        }`}
+      >
+        <input
+          type="checkbox"
+          checked={isChecked}
+          onChange={() => onToggleScope(scope.key)}
+          className="mt-1 rounded border-slate-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-slate-900"
+        />
+        <div>
+          <div className={`text-sm font-medium ${scope.dangerous ? 'text-amber-400' : 'text-white'}`}>
+            {meta?.label ?? scope.key}
+            {scope.dangerous && (
+              <span className="ml-2 text-xs text-amber-500">({t('picker.dangerous')})</span>
+            )}
+          </div>
+          {meta?.description && (
+            <p className="text-xs text-slate-500 mt-0.5">{meta.description}</p>
+          )}
+        </div>
+      </label>
+    );
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 w-full max-w-md mx-4 shadow-2xl">
+        <h3 className="text-lg font-medium text-white mb-2">
+          {t('picker.title', { name: plugin.display_name })}
+        </h3>
+        <p className="text-sm text-slate-400 mb-4">{t('picker.desc')}</p>
+        {requested.length === 0 ? (
+          <p className="text-sm text-slate-500 mb-6">{t('picker.noScopes')}</p>
+        ) : (
+          <div className="space-y-4 mb-6 max-h-72 overflow-y-auto">
+            {(['frontend', 'backend'] as const).map((tier) =>
+              byTier(tier).length === 0 ? null : (
+                <div key={tier} className="space-y-2">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    {t(`scopeTiers.${tier}`)}
+                  </div>
+                  {byTier(tier).map(renderScope)}
+                </div>
+              ),
+            )}
+          </div>
+        )}
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 px-4 py-2 text-sm font-medium rounded-lg border border-slate-700 text-slate-300 hover:border-slate-600 transition-all touch-manipulation active:scale-95"
+          >
+            {t('buttons.cancel')}
+          </button>
+          <button
+            onClick={onConfirm}
+            className="flex-1 px-4 py-2 text-sm font-medium rounded-lg bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-all touch-manipulation active:scale-95"
+          >
+            {t('picker.grant')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/plugins/plugin-management/index.ts
+++ b/client/src/components/plugins/plugin-management/index.ts
@@ -1,0 +1,12 @@
+export { getCategoryColor } from './pluginCategoryColor';
+export { TABS, PluginTabNav } from './PluginTabNav';
+export type { TabType } from './PluginTabNav';
+export { PluginListCard } from './PluginListCard';
+export { PluginList } from './PluginList';
+export { PluginDetailsCard } from './PluginDetailsCard';
+export { PluginPermissionsCard } from './PluginPermissionsCard';
+export { PluginDashboardPanelCard } from './PluginDashboardPanelCard';
+export { PluginActionsCard } from './PluginActionsCard';
+export { PluginDetailsSidebar } from './PluginDetailsSidebar';
+export { PermissionGrantModal } from './PermissionGrantModal';
+export { ScopeGrantModal } from './ScopeGrantModal';

--- a/client/src/components/plugins/plugin-management/pluginCategoryColor.ts
+++ b/client/src/components/plugins/plugin-management/pluginCategoryColor.ts
@@ -1,0 +1,10 @@
+export function getCategoryColor(category: string): string {
+  const colors: Record<string, string> = {
+    monitoring: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
+    storage: 'bg-green-500/20 text-green-400 border-green-500/30',
+    network: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
+    security: 'bg-red-500/20 text-red-400 border-red-500/30',
+    general: 'bg-slate-500/20 text-slate-400 border-slate-500/30',
+  };
+  return colors[category] || colors.general;
+}

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -45,6 +45,7 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useFritzBoxForm.ts` | `api/fritzbox` | Fritz!Box form object + config + toPayload (password only if set, mac||undefined) + test() (connection test + toast). No TanStack. |
 | `usePowerTabData.ts` | `api/smart-devices`, `api/energy` | Power devices/summary + cumulative energy for `PowerTab` via **TanStack Query**: combined `powerTab.summary()` key (5s poll, swallows a 404 when no power plugin, retains last data on error) plus a `powerTab.cumulative()` query gated by `resolveCumulativeArgs`/`cumulativeReady` (custom range needs both dates), 60s poll. Extracted verbatim from `PowerTab.tsx` (F2/#301) |
 | `useEnergyPrice.ts` | `api/energy` | Energy-price editor state (config/editing/input/saving) + save for `PowerTab`'s `EnergyPriceEditor`; fetches once on mount (imperative, no TanStack), validates 0.01–10.0, takes an `onSaved` callback so the caller can refresh the cumulative-energy query after a price change (F2/#301) |
+| `usePluginManagement.ts` | `api/plugins` | State + actions for `PluginsPage` — plugin details load, enable/disable (permission-grant or, for external plugins, scope-grant), uninstall, dashboard-panel toggle; wraps `usePlugins()` (`PluginContext`) for the base list. Imperative (mount-effect loads for permissions/scope catalog), not TanStack Query. Returns the confirm-dialog `dialog` node too (`useConfirmDialog`). Extracted from `PluginsPage.tsx` (F2/#301) |
 
 ## Utility Hooks
 

--- a/client/src/hooks/usePluginManagement.ts
+++ b/client/src/hooks/usePluginManagement.ts
@@ -1,0 +1,239 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { usePlugins } from '../contexts/PluginContext';
+import type {
+  PluginDetail,
+  PluginInfo,
+  PermissionInfo,
+  ScopeInfo,
+} from '../api/plugins';
+import {
+  getPluginDetails,
+  getScopeCatalog,
+  listPermissions,
+  togglePlugin,
+  toggleDashboardPanel,
+  uninstallPlugin,
+} from '../api/plugins';
+import { useConfirmDialog } from './useConfirmDialog';
+import type { ReactNode } from 'react';
+
+export interface UsePluginManagementResult {
+  plugins: PluginInfo[];
+  isLoading: boolean;
+  error: string | null;
+  refreshPlugins: () => Promise<void>;
+  allPermissions: PermissionInfo[];
+  scopeCatalog: ScopeInfo[];
+  selectedPlugin: PluginDetail | null;
+  detailsLoading: boolean;
+  actionLoading: boolean;
+  actionError: string | null;
+  loadPluginDetails: (name: string) => Promise<PluginDetail | null>;
+  handleTogglePlugin: (plugin: PluginInfo) => Promise<void>;
+  handleEnableWithPermissions: () => Promise<void>;
+  handleEnableWithScopes: () => Promise<void>;
+  handleUninstall: (name: string) => Promise<void>;
+  handleToggleDashboardPanel: () => Promise<void>;
+  showPermissionModal: boolean;
+  setShowPermissionModal: (v: boolean) => void;
+  selectedPermissions: string[];
+  togglePermission: (perm: string) => void;
+  showScopeModal: boolean;
+  setShowScopeModal: (v: boolean) => void;
+  selectedScopes: string[];
+  toggleScope: (scope: string) => void;
+  dialog: ReactNode;
+}
+
+export function usePluginManagement(): UsePluginManagementResult {
+  const { t } = useTranslation(['plugins', 'common']);
+  const { confirm, dialog } = useConfirmDialog();
+  const { plugins, isLoading, error, refreshPlugins } = usePlugins();
+  const [selectedPlugin, setSelectedPlugin] = useState<PluginDetail | null>(null);
+  const [allPermissions, setAllPermissions] = useState<PermissionInfo[]>([]);
+  const [detailsLoading, setDetailsLoading] = useState(false);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [showPermissionModal, setShowPermissionModal] = useState(false);
+  const [selectedPermissions, setSelectedPermissions] = useState<string[]>([]);
+  const [scopeCatalog, setScopeCatalog] = useState<ScopeInfo[]>([]);
+  const [showScopeModal, setShowScopeModal] = useState(false);
+  const [selectedScopes, setSelectedScopes] = useState<string[]>([]);
+
+  // Load all permissions on mount
+  useEffect(() => {
+    listPermissions()
+      .then((res) => setAllPermissions(res.permissions))
+      .catch(console.error);
+  }, []);
+
+  // Load scope catalog on mount (for external plugin scope-picker)
+  useEffect(() => {
+    getScopeCatalog()
+      .then((res) => setScopeCatalog(res.scopes))
+      .catch(console.error);
+  }, []);
+
+  const loadPluginDetails = async (name: string): Promise<PluginDetail | null> => {
+    setDetailsLoading(true);
+    setActionError(null);
+    try {
+      const details = await getPluginDetails(name);
+      setSelectedPlugin(details);
+      return details;
+    } catch {
+      setActionError(t('errors.loadDetailsFailed'));
+      return null;
+    } finally {
+      setDetailsLoading(false);
+    }
+  };
+
+  const handleTogglePlugin = async (plugin: PluginInfo) => {
+    if (plugin.is_enabled) {
+      // Disable plugin
+      setActionLoading(true);
+      setActionError(null);
+      try {
+        await togglePlugin(plugin.name, { enabled: false });
+        await refreshPlugins();
+        if (selectedPlugin?.name === plugin.name) {
+          await loadPluginDetails(plugin.name);
+        }
+      } catch {
+        setActionError(t('errors.disableFailed'));
+      } finally {
+        setActionLoading(false);
+      }
+    } else {
+      // Enable: load details to learn tier + requested scopes
+      const details = await loadPluginDetails(plugin.name);
+      if (!details) return;
+      if (details.is_external) {
+        setSelectedScopes(
+          (details.requested_api_scopes ?? []).filter((s) =>
+            scopeCatalog.some((c) => c.key === s),
+          ),
+        );
+        setShowScopeModal(true);
+      } else {
+        setSelectedPermissions(plugin.required_permissions);
+        setShowPermissionModal(true);
+      }
+    }
+  };
+
+  const handleEnableWithPermissions = async () => {
+    if (!selectedPlugin) return;
+
+    setActionLoading(true);
+    setActionError(null);
+    setShowPermissionModal(false);
+
+    try {
+      await togglePlugin(selectedPlugin.name, {
+        enabled: true,
+        grant_permissions: selectedPermissions,
+      });
+      await refreshPlugins();
+      await loadPluginDetails(selectedPlugin.name);
+    } catch {
+      setActionError(t('errors.enableFailed'));
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleEnableWithScopes = async () => {
+    if (!selectedPlugin) return;
+    setActionLoading(true);
+    setActionError(null);
+    setShowScopeModal(false);
+    try {
+      await togglePlugin(selectedPlugin.name, {
+        enabled: true,
+        grant_api_scopes: selectedScopes,
+      });
+      await refreshPlugins();
+      await loadPluginDetails(selectedPlugin.name);
+    } catch {
+      setActionError(t('errors.enableFailed'));
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleUninstall = async (name: string) => {
+    const ok = await confirm(t('confirm.uninstall', { name }), { title: t('buttons.uninstall'), variant: 'danger', confirmLabel: t('buttons.uninstall') });
+    if (!ok) return;
+
+    setActionLoading(true);
+    setActionError(null);
+    try {
+      await uninstallPlugin(name);
+      await refreshPlugins();
+      if (selectedPlugin?.name === name) {
+        setSelectedPlugin(null);
+      }
+    } catch {
+      setActionError(t('errors.uninstallFailed'));
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleToggleDashboardPanel = async () => {
+    if (!selectedPlugin) return;
+    setActionLoading(true);
+    setActionError(null);
+    try {
+      await toggleDashboardPanel(selectedPlugin.name, !selectedPlugin.dashboard_panel_enabled);
+      await loadPluginDetails(selectedPlugin.name);
+    } catch {
+      setActionError(t('dashboardPanel.enableFailed'));
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const togglePermission = (perm: string) => {
+    setSelectedPermissions((prev) =>
+      prev.includes(perm) ? prev.filter((p) => p !== perm) : [...prev, perm],
+    );
+  };
+
+  const toggleScope = (scope: string) => {
+    setSelectedScopes((prev) =>
+      prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope],
+    );
+  };
+
+  return {
+    plugins,
+    isLoading,
+    error,
+    refreshPlugins,
+    allPermissions,
+    scopeCatalog,
+    selectedPlugin,
+    detailsLoading,
+    actionLoading,
+    actionError,
+    loadPluginDetails,
+    handleTogglePlugin,
+    handleEnableWithPermissions,
+    handleEnableWithScopes,
+    handleUninstall,
+    handleToggleDashboardPanel,
+    showPermissionModal,
+    setShowPermissionModal,
+    selectedPermissions,
+    togglePermission,
+    showScopeModal,
+    setShowScopeModal,
+    selectedScopes,
+    toggleScope,
+    dialog,
+  };
+}

--- a/client/src/pages/CLAUDE.md
+++ b/client/src/pages/CLAUDE.md
@@ -30,7 +30,7 @@ Pages are conditionally included based on `__DEVICE_MODE__` build flag:
 | `SchedulerDashboard.tsx` | `/schedulers` | Admin | Background scheduler status and history |
 | `DevicesPage.tsx` | `/devices` | Yes | Desktop/mobile device management |
 | `MobileDevicesPage.tsx` | `/mobile` | Admin | Mobile device registration |
-| `PluginsPage.tsx` | `/plugins` | Admin | Plugin install, toggle, configure |
+| `PluginsPage.tsx` | `/plugins` | Admin | Plugin install, toggle, configure — composes `components/plugins/plugin-management/*` (tab nav, list, details sidebar, permission/scope grant modals), state/actions in `usePluginManagement` (extracted F2/#301) |
 | `SmartDevicesPage.tsx` | `/smart-devices` | Admin | Smart device (Tapo) management |
 | `PiholePage.tsx` | `/pihole` | Admin | Pi-hole DNS management |
 | `CloudImportPage.tsx` | `/cloud` | Yes | Cloud import (Google Drive, Dropbox, etc.) |

--- a/client/src/pages/PluginsPage.tsx
+++ b/client/src/pages/PluginsPage.tsx
@@ -3,188 +3,51 @@
  *
  * Admin-only page for managing installed plugins.
  */
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { safeExternalUrl } from '../lib/safeUrl';
-import { usePlugins } from '../contexts/PluginContext';
-import type {
-  PluginDetail,
-  PluginInfo,
-  PermissionInfo,
-  ScopeInfo,
-} from '../api/plugins';
-import {
-  getPluginDetails,
-  getScopeCatalog,
-  listPermissions,
-  togglePlugin,
-  toggleDashboardPanel,
-  uninstallPlugin,
-} from '../api/plugins';
-import { AlertTriangle, Check, X, Plug, Shield, Settings, Trash2, ExternalLink, BookOpen, LayoutDashboard, Store } from 'lucide-react';
-import { resolvePluginString } from '../lib/pluginI18n';
+import { AlertTriangle } from 'lucide-react';
 import PluginDocumentation from '../components/plugins/PluginDocumentation';
-import { PluginSettingsSection } from '../components/plugins/PluginSettingsSection';
 import MarketplaceTab from '../components/plugins/MarketplaceTab';
-import { LocalOnlyAction } from '../components/LocalOnlyAction';
-import { useConfirmDialog } from '../hooks/useConfirmDialog';
-
-type TabType = 'plugins' | 'marketplace' | 'documentation';
-
-const TABS = [
-  { id: 'plugins' as TabType, labelKey: 'tabs.installed', icon: Plug },
-  { id: 'marketplace' as TabType, labelKey: 'tabs.marketplace', icon: Store },
-  { id: 'documentation' as TabType, labelKey: 'tabs.documentation', icon: BookOpen },
-];
+import { usePluginManagement } from '../hooks/usePluginManagement';
+import type { TabType } from '../components/plugins/plugin-management';
+import {
+  PluginTabNav,
+  PluginList,
+  PluginDetailsSidebar,
+  PermissionGrantModal,
+  ScopeGrantModal,
+} from '../components/plugins/plugin-management';
 
 export default function PluginsPage() {
   const { t } = useTranslation(['plugins', 'common']);
-  const { confirm, dialog } = useConfirmDialog();
-  const { plugins, isLoading, error, refreshPlugins } = usePlugins();
-  const [selectedPlugin, setSelectedPlugin] = useState<PluginDetail | null>(null);
-  const [allPermissions, setAllPermissions] = useState<PermissionInfo[]>([]);
-  const [detailsLoading, setDetailsLoading] = useState(false);
-  const [actionLoading, setActionLoading] = useState(false);
-  const [actionError, setActionError] = useState<string | null>(null);
-  const [showPermissionModal, setShowPermissionModal] = useState(false);
-  const [selectedPermissions, setSelectedPermissions] = useState<string[]>([]);
   const [activeTab, setActiveTab] = useState<TabType>('plugins');
-  const [scopeCatalog, setScopeCatalog] = useState<ScopeInfo[]>([]);
-  const [showScopeModal, setShowScopeModal] = useState(false);
-  const [selectedScopes, setSelectedScopes] = useState<string[]>([]);
-
-  // Load all permissions on mount
-  useEffect(() => {
-    listPermissions()
-      .then((res) => setAllPermissions(res.permissions))
-      .catch(console.error);
-  }, []);
-
-  // Load scope catalog on mount (for external plugin scope-picker)
-  useEffect(() => {
-    getScopeCatalog()
-      .then((res) => setScopeCatalog(res.scopes))
-      .catch(console.error);
-  }, []);
-
-  const loadPluginDetails = async (name: string): Promise<PluginDetail | null> => {
-    setDetailsLoading(true);
-    setActionError(null);
-    try {
-      const details = await getPluginDetails(name);
-      setSelectedPlugin(details);
-      return details;
-    } catch {
-      setActionError(t('errors.loadDetailsFailed'));
-      return null;
-    } finally {
-      setDetailsLoading(false);
-    }
-  };
-
-  const handleTogglePlugin = async (plugin: PluginInfo) => {
-    if (plugin.is_enabled) {
-      // Disable plugin
-      setActionLoading(true);
-      setActionError(null);
-      try {
-        await togglePlugin(plugin.name, { enabled: false });
-        await refreshPlugins();
-        if (selectedPlugin?.name === plugin.name) {
-          await loadPluginDetails(plugin.name);
-        }
-      } catch {
-        setActionError(t('errors.disableFailed'));
-      } finally {
-        setActionLoading(false);
-      }
-    } else {
-      // Enable: load details to learn tier + requested scopes
-      const details = await loadPluginDetails(plugin.name);
-      if (!details) return;
-      if (details.is_external) {
-        setSelectedScopes(
-          (details.requested_api_scopes ?? []).filter((s) =>
-            scopeCatalog.some((c) => c.key === s),
-          ),
-        );
-        setShowScopeModal(true);
-      } else {
-        setSelectedPermissions(plugin.required_permissions);
-        setShowPermissionModal(true);
-      }
-    }
-  };
-
-  const handleEnableWithPermissions = async () => {
-    if (!selectedPlugin) return;
-
-    setActionLoading(true);
-    setActionError(null);
-    setShowPermissionModal(false);
-
-    try {
-      await togglePlugin(selectedPlugin.name, {
-        enabled: true,
-        grant_permissions: selectedPermissions,
-      });
-      await refreshPlugins();
-      await loadPluginDetails(selectedPlugin.name);
-    } catch {
-      setActionError(t('errors.enableFailed'));
-    } finally {
-      setActionLoading(false);
-    }
-  };
-
-  const handleEnableWithScopes = async () => {
-    if (!selectedPlugin) return;
-    setActionLoading(true);
-    setActionError(null);
-    setShowScopeModal(false);
-    try {
-      await togglePlugin(selectedPlugin.name, {
-        enabled: true,
-        grant_api_scopes: selectedScopes,
-      });
-      await refreshPlugins();
-      await loadPluginDetails(selectedPlugin.name);
-    } catch {
-      setActionError(t('errors.enableFailed'));
-    } finally {
-      setActionLoading(false);
-    }
-  };
-
-  const handleUninstall = async (name: string) => {
-    const ok = await confirm(t('confirm.uninstall', { name }), { title: t('buttons.uninstall'), variant: 'danger', confirmLabel: t('buttons.uninstall') });
-    if (!ok) return;
-
-    setActionLoading(true);
-    setActionError(null);
-    try {
-      await uninstallPlugin(name);
-      await refreshPlugins();
-      if (selectedPlugin?.name === name) {
-        setSelectedPlugin(null);
-      }
-    } catch {
-      setActionError(t('errors.uninstallFailed'));
-    } finally {
-      setActionLoading(false);
-    }
-  };
-
-  const getCategoryColor = (category: string) => {
-    const colors: Record<string, string> = {
-      monitoring: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
-      storage: 'bg-green-500/20 text-green-400 border-green-500/30',
-      network: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
-      security: 'bg-red-500/20 text-red-400 border-red-500/30',
-      general: 'bg-slate-500/20 text-slate-400 border-slate-500/30',
-    };
-    return colors[category] || colors.general;
-  };
+  const {
+    plugins,
+    isLoading,
+    error,
+    refreshPlugins,
+    allPermissions,
+    scopeCatalog,
+    selectedPlugin,
+    detailsLoading,
+    actionLoading,
+    actionError,
+    loadPluginDetails,
+    handleTogglePlugin,
+    handleEnableWithPermissions,
+    handleEnableWithScopes,
+    handleUninstall,
+    handleToggleDashboardPanel,
+    showPermissionModal,
+    setShowPermissionModal,
+    selectedPermissions,
+    togglePermission,
+    showScopeModal,
+    setShowScopeModal,
+    selectedScopes,
+    toggleScope,
+    dialog,
+  } = usePluginManagement();
 
   if (isLoading) {
     return (
@@ -215,22 +78,7 @@ export default function PluginsPage() {
       </div>
 
       {/* Tab Navigation */}
-      <div className="flex gap-2 border-b border-slate-800 pb-3 overflow-x-auto scrollbar-none">
-        {TABS.map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className={`flex items-center gap-2 rounded-lg px-3 sm:px-4 py-2 sm:py-2.5 text-xs sm:text-sm font-medium transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
-              activeTab === tab.id
-                ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40'
-                : 'text-slate-400 hover:bg-slate-800/50 hover:text-slate-300 border border-transparent'
-            }`}
-          >
-            <tab.icon className="w-4 h-4" />
-            {t(tab.labelKey)}
-          </button>
-        ))}
-      </div>
+      <PluginTabNav activeTab={activeTab} onSelect={setActiveTab} />
 
       {error && (
         <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400">
@@ -255,435 +103,51 @@ export default function PluginsPage() {
 
       {/* Plugins Tab */}
       {activeTab === 'plugins' && (
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Plugin List */}
-        <div className="lg:col-span-2 space-y-4">
-          {plugins.length === 0 ? (
-            <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-8 text-center">
-              <Plug className="h-12 w-12 mx-auto text-slate-600 mb-4" />
-              <h3 className="text-lg font-medium text-slate-300 mb-2">{t('empty.noPlugins')}</h3>
-              <p className="text-sm text-slate-500">
-                {t('empty.noPluginsDesc')}
-              </p>
-            </div>
-          ) : (
-            plugins.map((plugin) => (
-              <div
-                key={plugin.name}
-                onClick={() => loadPluginDetails(plugin.name)}
-                className={`rounded-xl border p-4 cursor-pointer transition-all ${
-                  selectedPlugin?.name === plugin.name
-                    ? 'border-blue-500 bg-slate-900/80'
-                    : 'border-slate-800 bg-slate-900/50 hover:border-slate-700'
-                }`}
-              >
-                <div className="flex items-start justify-between">
-                  <div className="flex items-center gap-3">
-                    <div className={`p-2 rounded-lg ${plugin.is_enabled ? 'bg-green-500/20' : 'bg-slate-800'}`}>
-                      <Plug className={`h-5 w-5 ${plugin.is_enabled ? 'text-green-400' : 'text-slate-500'}`} />
-                    </div>
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <h3 className="font-medium text-white">{resolvePluginString(plugin.translations, 'display_name', plugin.display_name)}</h3>
-                        <span className="text-xs text-slate-500">v{plugin.version}</span>
-                        {plugin.is_enabled && (
-                          <span className="px-2 py-0.5 text-xs rounded-full bg-green-500/20 text-green-400 border border-green-500/30">
-                            {t('status.active')}
-                          </span>
-                        )}
-                      </div>
-                      <p className="text-sm text-slate-400 mt-0.5">{resolvePluginString(plugin.translations, 'description', plugin.description)}</p>
-                      <div className="flex items-center gap-2 mt-2">
-                        <span className={`px-2 py-0.5 text-xs rounded-full border ${getCategoryColor(plugin.category)}`}>
-                          {plugin.category}
-                        </span>
-                        {plugin.has_ui && (
-                          <span className="px-2 py-0.5 text-xs rounded-full bg-purple-500/20 text-purple-400 border border-purple-500/30">
-                            {t('ui')}
-                          </span>
-                        )}
-                        {plugin.dangerous_permissions.length > 0 && (
-                          <span className="px-2 py-0.5 text-xs rounded-full bg-amber-500/20 text-amber-400 border border-amber-500/30 flex items-center gap-1">
-                            <Shield className="h-3 w-3" />
-                            {t('permissions.requiresReview')}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleTogglePlugin(plugin);
-                    }}
-                    disabled={actionLoading}
-                    className={`rounded-lg px-3 py-1.5 text-xs sm:text-sm font-medium transition-all touch-manipulation active:scale-95 ${
-                      plugin.is_enabled
-                        ? 'bg-slate-800 text-slate-300 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/30'
-                        : 'bg-blue-500/20 text-blue-400 hover:bg-blue-500/30'
-                    } border border-slate-700`}
-                  >
-                    {plugin.is_enabled ? t('buttons.disable') : t('buttons.enable')}
-                  </button>
-                </div>
-                {plugin.error && (
-                  <div className="mt-3 p-2 rounded-lg bg-red-500/10 border border-red-500/20 text-xs text-red-400">
-                    Error: {plugin.error}
-                  </div>
-                )}
-              </div>
-            ))
-          )}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2 space-y-4">
+            <PluginList
+              plugins={plugins}
+              selectedName={selectedPlugin?.name ?? null}
+              actionLoading={actionLoading}
+              onSelect={loadPluginDetails}
+              onToggle={handleTogglePlugin}
+            />
+          </div>
+          <PluginDetailsSidebar
+            plugin={selectedPlugin}
+            detailsLoading={detailsLoading}
+            actionLoading={actionLoading}
+            onToggleDashboardPanel={handleToggleDashboardPanel}
+            onConfigure={() => setShowPermissionModal(true)}
+            onUninstall={handleUninstall}
+          />
         </div>
-
-        {/* Plugin Details Sidebar */}
-        <div className="space-y-4">
-          {detailsLoading ? (
-            <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
-              <div className="animate-pulse space-y-4">
-                <div className="h-6 bg-slate-800 rounded w-3/4" />
-                <div className="h-4 bg-slate-800 rounded w-1/2" />
-                <div className="h-20 bg-slate-800 rounded" />
-              </div>
-            </div>
-          ) : selectedPlugin ? (
-            <>
-              {/* Details Card */}
-              <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
-                <h3 className="text-lg font-medium text-white mb-4">
-                  {resolvePluginString(selectedPlugin.translations, 'display_name', selectedPlugin.display_name)}
-                </h3>
-                <dl className="space-y-3 text-sm">
-                  <div className="flex justify-between">
-                    <dt className="text-slate-500">{t('details.version')}</dt>
-                    <dd className="text-white">{selectedPlugin.version}</dd>
-                  </div>
-                  <div className="flex justify-between">
-                    <dt className="text-slate-500">{t('details.author')}</dt>
-                    <dd className="text-white">{selectedPlugin.author}</dd>
-                  </div>
-                  <div className="flex justify-between">
-                    <dt className="text-slate-500">{t('details.category')}</dt>
-                    <dd className="text-white capitalize">{selectedPlugin.category}</dd>
-                  </div>
-                  {safeExternalUrl(selectedPlugin.homepage) && (
-                    <div className="flex justify-between">
-                      <dt className="text-slate-500">{t('details.homepage')}</dt>
-                      <dd>
-                        <a
-                          href={safeExternalUrl(selectedPlugin.homepage)!}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-blue-400 hover:underline flex items-center gap-1"
-                        >
-                          {t('details.link')} <ExternalLink className="h-3 w-3" />
-                        </a>
-                      </dd>
-                    </div>
-                  )}
-                  <div className="flex justify-between">
-                    <dt className="text-slate-500">{t('details.status')}</dt>
-                    <dd className={selectedPlugin.is_enabled ? 'text-green-400' : 'text-slate-400'}>
-                      {selectedPlugin.is_enabled ? t('status.enabled') : t('status.disabled')}
-                    </dd>
-                  </div>
-                  {selectedPlugin.installed_at && (
-                    <div className="flex justify-between">
-                      <dt className="text-slate-500">{t('details.installed')}</dt>
-                      <dd className="text-white">
-                        {new Date(selectedPlugin.installed_at).toLocaleDateString()}
-                      </dd>
-                    </div>
-                  )}
-                </dl>
-              </div>
-
-              {/* Permissions Card */}
-              <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
-                <h4 className="text-sm font-medium text-white mb-3 flex items-center gap-2">
-                  <Shield className="h-4 w-4" />
-                  {t('permissions.title')}
-                </h4>
-                {selectedPlugin.required_permissions.length === 0 ? (
-                  <p className="text-sm text-slate-500">{t('permissions.noPermissions')}</p>
-                ) : (
-                  <ul className="space-y-2">
-                    {selectedPlugin.required_permissions.map((perm) => {
-                      const isDangerous = selectedPlugin.dangerous_permissions.includes(perm);
-                      const isGranted = selectedPlugin.granted_permissions.includes(perm);
-                      return (
-                        <li
-                          key={perm}
-                          className={`flex items-center justify-between text-sm p-2 rounded-lg ${
-                            isDangerous
-                              ? 'bg-amber-500/10 border border-amber-500/20'
-                              : 'bg-slate-800/50'
-                          }`}
-                        >
-                          <span className={isDangerous ? 'text-amber-400' : 'text-slate-300'}>
-                            {perm}
-                          </span>
-                          {isGranted ? (
-                            <Check className="h-4 w-4 text-green-400" />
-                          ) : (
-                            <X className="h-4 w-4 text-slate-500" />
-                          )}
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </div>
-
-              {/* Dashboard Panel Card */}
-              {selectedPlugin.has_dashboard_panel && selectedPlugin.is_enabled && (
-                <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
-                  <h4 className="text-sm font-medium text-white mb-3 flex items-center gap-2">
-                    <LayoutDashboard className="h-4 w-4" />
-                    {t('dashboardPanel.title')}
-                  </h4>
-                  <p className="text-xs text-slate-500 mb-4">
-                    {t('dashboardPanel.description')}
-                  </p>
-                  <div className="flex items-center justify-between">
-                    <span className={`text-sm ${selectedPlugin.dashboard_panel_enabled ? 'text-green-400' : 'text-slate-500'}`}>
-                      {selectedPlugin.dashboard_panel_enabled ? t('dashboardPanel.active') : t('dashboardPanel.inactive')}
-                    </span>
-                    <button
-                      onClick={async () => {
-                        setActionLoading(true);
-                        setActionError(null);
-                        try {
-                          await toggleDashboardPanel(selectedPlugin.name, !selectedPlugin.dashboard_panel_enabled);
-                          await loadPluginDetails(selectedPlugin.name);
-                        } catch {
-                          setActionError(t('dashboardPanel.enableFailed'));
-                        } finally {
-                          setActionLoading(false);
-                        }
-                      }}
-                      disabled={actionLoading}
-                      className={`rounded-lg px-3 py-1.5 text-xs sm:text-sm font-medium transition-all touch-manipulation active:scale-95 border ${
-                        selectedPlugin.dashboard_panel_enabled
-                          ? 'border-slate-700 bg-slate-800 text-slate-300 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/30'
-                          : 'border-green-500/30 bg-green-500/20 text-green-400 hover:bg-green-500/30'
-                      } disabled:opacity-50 disabled:cursor-not-allowed`}
-                    >
-                      {selectedPlugin.dashboard_panel_enabled ? t('buttons.disablePanel') : t('buttons.enablePanel')}
-                    </button>
-                  </div>
-                </div>
-              )}
-
-              {/* Plugin Settings Section */}
-              {selectedPlugin?.config_schema && selectedPlugin.is_enabled && (
-                <PluginSettingsSection
-                  pluginName={selectedPlugin.name}
-                  configSchema={selectedPlugin.config_schema}
-                  config={selectedPlugin.config ?? {}}
-                  translations={selectedPlugin.translations ?? undefined}
-                />
-              )}
-
-              {/* Actions Card */}
-              <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 space-y-3">
-                <button
-                  onClick={() => setShowPermissionModal(true)}
-                  disabled={!selectedPlugin.is_enabled}
-                  className="w-full px-4 py-2 text-sm font-medium rounded-lg border border-slate-700 text-slate-300 hover:border-slate-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-all touch-manipulation active:scale-95"
-                >
-                  <Settings className="h-4 w-4" />
-                  {t('buttons.configure')}
-                </button>
-                <LocalOnlyAction>
-                  <button
-                    onClick={() => handleUninstall(selectedPlugin.name)}
-                    disabled={actionLoading || selectedPlugin.is_enabled}
-                    className="w-full px-4 py-2 text-sm font-medium rounded-lg border border-red-500/30 text-red-400 hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 transition-all touch-manipulation active:scale-95"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                    {t('buttons.uninstall')}
-                  </button>
-                </LocalOnlyAction>
-                {selectedPlugin.is_enabled && (
-                  <p className="text-xs text-slate-500 text-center">
-                    {t('confirm.disableFirst')}
-                  </p>
-                )}
-              </div>
-            </>
-          ) : (
-            <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 text-center">
-              <Settings className="h-8 w-8 mx-auto text-slate-600 mb-3" />
-              <p className="text-sm text-slate-500">
-                {t('empty.selectPlugin')}
-              </p>
-            </div>
-          )}
-        </div>
-      </div>
       )}
 
       {/* Permission Grant Modal */}
       {showPermissionModal && selectedPlugin && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-          <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 w-full max-w-md mx-4 shadow-2xl">
-            <h3 className="text-lg font-medium text-white mb-2">
-              {t('modal.enableTitle', { name: selectedPlugin.display_name })}
-            </h3>
-            <p className="text-sm text-slate-400 mb-4">
-              {t('modal.enableDesc')}
-            </p>
-            <div className="space-y-2 mb-6 max-h-64 overflow-y-auto">
-              {selectedPlugin.required_permissions.map((perm) => {
-                const permInfo = allPermissions.find((p) => p.value === perm);
-                const isChecked = selectedPermissions.includes(perm);
-                return (
-                  <label
-                    key={perm}
-                    className={`flex items-start gap-3 p-3 rounded-lg cursor-pointer transition ${
-                      permInfo?.dangerous
-                        ? 'bg-amber-500/10 border border-amber-500/20'
-                        : 'bg-slate-800/50 border border-slate-700'
-                    }`}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={isChecked}
-                      onChange={(e) => {
-                        if (e.target.checked) {
-                          setSelectedPermissions([...selectedPermissions, perm]);
-                        } else {
-                          setSelectedPermissions(selectedPermissions.filter((p) => p !== perm));
-                        }
-                      }}
-                      className="mt-1 rounded border-slate-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-slate-900"
-                    />
-                    <div>
-                      <div className={`text-sm font-medium ${permInfo?.dangerous ? 'text-amber-400' : 'text-white'}`}>
-                        {perm}
-                        {permInfo?.dangerous && (
-                          <span className="ml-2 text-xs text-amber-500">({t('permissions.dangerous')})</span>
-                        )}
-                      </div>
-                      {permInfo && (
-                        <p className="text-xs text-slate-500 mt-0.5">{permInfo.description}</p>
-                      )}
-                    </div>
-                  </label>
-                );
-              })}
-            </div>
-            <div className="flex gap-3">
-              <button
-                onClick={() => setShowPermissionModal(false)}
-                className="flex-1 px-4 py-2 text-sm font-medium rounded-lg border border-slate-700 text-slate-300 hover:border-slate-600 transition-all touch-manipulation active:scale-95"
-              >
-                {t('buttons.cancel')}
-              </button>
-              <button
-                onClick={handleEnableWithPermissions}
-                disabled={!selectedPlugin.required_permissions.every((p) => selectedPermissions.includes(p))}
-                className="flex-1 px-4 py-2 text-sm font-medium rounded-lg bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-all touch-manipulation active:scale-95"
-              >
-                {t('buttons.enablePlugin')}
-              </button>
-            </div>
-          </div>
-        </div>
+        <PermissionGrantModal
+          plugin={selectedPlugin}
+          allPermissions={allPermissions}
+          selectedPermissions={selectedPermissions}
+          onTogglePermission={togglePermission}
+          onCancel={() => setShowPermissionModal(false)}
+          onConfirm={handleEnableWithPermissions}
+        />
       )}
+
       {/* Scope Grant Modal (external plugins only) */}
-      {showScopeModal && selectedPlugin && (() => {
-        const descs = t('scopeDescriptions', { returnObjects: true }) as Record<
-          string,
-          { label: string; description: string }
-        >;
-        const requested = (selectedPlugin.requested_api_scopes ?? []).filter((s) =>
-          scopeCatalog.some((c) => c.key === s),
-        );
-        const byTier = (tier: 'frontend' | 'backend') =>
-          requested
-            .map((key) => scopeCatalog.find((c) => c.key === key)!)
-            .filter((c) => c.tier === tier);
-        const renderScope = (scope: ScopeInfo) => {
-          const isChecked = selectedScopes.includes(scope.key);
-          const meta = descs?.[scope.key];
-          return (
-            <label
-              key={scope.key}
-              className={`flex items-start gap-3 p-3 rounded-lg cursor-pointer transition ${
-                scope.dangerous
-                  ? 'bg-amber-500/10 border border-amber-500/20'
-                  : 'bg-slate-800/50 border border-slate-700'
-              }`}
-            >
-              <input
-                type="checkbox"
-                checked={isChecked}
-                onChange={(e) => {
-                  if (e.target.checked) {
-                    setSelectedScopes([...selectedScopes, scope.key]);
-                  } else {
-                    setSelectedScopes(selectedScopes.filter((s) => s !== scope.key));
-                  }
-                }}
-                className="mt-1 rounded border-slate-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-slate-900"
-              />
-              <div>
-                <div className={`text-sm font-medium ${scope.dangerous ? 'text-amber-400' : 'text-white'}`}>
-                  {meta?.label ?? scope.key}
-                  {scope.dangerous && (
-                    <span className="ml-2 text-xs text-amber-500">({t('picker.dangerous')})</span>
-                  )}
-                </div>
-                {meta?.description && (
-                  <p className="text-xs text-slate-500 mt-0.5">{meta.description}</p>
-                )}
-              </div>
-            </label>
-          );
-        };
-        return (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-            <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 w-full max-w-md mx-4 shadow-2xl">
-              <h3 className="text-lg font-medium text-white mb-2">
-                {t('picker.title', { name: selectedPlugin.display_name })}
-              </h3>
-              <p className="text-sm text-slate-400 mb-4">{t('picker.desc')}</p>
-              {requested.length === 0 ? (
-                <p className="text-sm text-slate-500 mb-6">{t('picker.noScopes')}</p>
-              ) : (
-                <div className="space-y-4 mb-6 max-h-72 overflow-y-auto">
-                  {(['frontend', 'backend'] as const).map((tier) =>
-                    byTier(tier).length === 0 ? null : (
-                      <div key={tier} className="space-y-2">
-                        <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                          {t(`scopeTiers.${tier}`)}
-                        </div>
-                        {byTier(tier).map(renderScope)}
-                      </div>
-                    ),
-                  )}
-                </div>
-              )}
-              <div className="flex gap-3">
-                <button
-                  onClick={() => setShowScopeModal(false)}
-                  className="flex-1 px-4 py-2 text-sm font-medium rounded-lg border border-slate-700 text-slate-300 hover:border-slate-600 transition-all touch-manipulation active:scale-95"
-                >
-                  {t('buttons.cancel')}
-                </button>
-                <button
-                  onClick={handleEnableWithScopes}
-                  className="flex-1 px-4 py-2 text-sm font-medium rounded-lg bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-all touch-manipulation active:scale-95"
-                >
-                  {t('picker.grant')}
-                </button>
-              </div>
-            </div>
-          </div>
-        );
-      })()}
+      {showScopeModal && selectedPlugin && (
+        <ScopeGrantModal
+          plugin={selectedPlugin}
+          scopeCatalog={scopeCatalog}
+          selectedScopes={selectedScopes}
+          onToggleScope={toggleScope}
+          onCancel={() => setShowScopeModal(false)}
+          onConfirm={handleEnableWithScopes}
+        />
+      )}
+
       {dialog}
     </div>
   );

--- a/client/src/pages/PluginsPage.tsx
+++ b/client/src/pages/PluginsPage.tsx
@@ -104,15 +104,13 @@ export default function PluginsPage() {
       {/* Plugins Tab */}
       {activeTab === 'plugins' && (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2 space-y-4">
-            <PluginList
-              plugins={plugins}
-              selectedName={selectedPlugin?.name ?? null}
-              actionLoading={actionLoading}
-              onSelect={loadPluginDetails}
-              onToggle={handleTogglePlugin}
-            />
-          </div>
+          <PluginList
+            plugins={plugins}
+            selectedName={selectedPlugin?.name ?? null}
+            actionLoading={actionLoading}
+            onSelect={loadPluginDetails}
+            onToggle={handleTogglePlugin}
+          />
           <PluginDetailsSidebar
             plugin={selectedPlugin}
             detailsLoading={detailsLoading}

--- a/docs/superpowers/plans/2026-07-11-pluginspage-decomposition-f2.md
+++ b/docs/superpowers/plans/2026-07-11-pluginspage-decomposition-f2.md
@@ -1,0 +1,1066 @@
+# PluginsPage.tsx Decomposition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Behavior-preserving decomposition of `client/src/pages/PluginsPage.tsx` (691 lines) into one data/state hook, one pure helper, and a `components/plugins/plugin-management/` directory of presentational components, leaving the page a thin ~130-line orchestrator.
+
+**Architecture:** All fetching/state moves into `hooks/usePluginManagement.ts`. Presentational components take props + callbacks only. Moved markup is byte-identical (same JSX, same Tailwind, same i18n keys); the page keeps its default export and path so the router/lazy-load is untouched. Already-extracted `MarketplaceTab`, `PluginDocumentation`, `PluginSettingsSection`, and `usePlugins()` are reused unmodified.
+
+**Tech Stack:** React 18 + TypeScript (strict, `verbatimModuleSyntax`) + Vite + Tailwind + react-i18next + lucide-react + Vitest + @testing-library/react.
+
+## Global Constraints
+
+- **`verbatimModuleSyntax`:** every type-only import MUST use `import type { ... }`. `tsc -b` (CI `npm run build`) enforces this; vitest/esbuild does NOT catch it. Run `npx tsc -b` before each commit.
+- **Behavior byte-identical:** same API calls (`getPluginDetails`, `getScopeCatalog`, `listPermissions`, `togglePlugin`, `toggleDashboardPanel`, `uninstallPlugin`), same `.catch(console.error)` swallow on the two mount effects, same `t('errors.*')`/`t('dashboardPanel.enableFailed')` keys, same external/internal enable branching, same modal enable-disabled guards, same `safeExternalUrl`/`resolvePluginString` usage.
+- **Test hygiene (T7):** assert on role/text/title, never Tailwind class names. Mock `react-i18next` with `useTranslation: () => ({ t: (k: string) => k })`. Fixtures are complete objects of the real API types (`PluginInfo`, `PluginDetail`, `PermissionInfo`, `ScopeInfo`) from `../api/plugins`. Each test asserts the SPECIFIC targeted behavior of its unit (a branch taken, a callback fired with the right arg, a guard enforced) — not incidental rendering.
+- **No dependency changes, no i18n-key changes, no endpoint changes.**
+- Source of truth for every moved block: the current `client/src/pages/PluginsPage.tsx` at branch base. Line numbers below refer to that file.
+- New component dir: `client/src/components/plugins/plugin-management/`. New tests dir: `client/src/__tests__/components/plugins/plugin-management/` and `client/src/__tests__/hooks/`.
+
+---
+
+### Task 1: `pluginCategoryColor` pure helper
+
+**Files:**
+- Create: `client/src/components/plugins/plugin-management/pluginCategoryColor.ts`
+- Test: `client/src/__tests__/components/plugins/plugin-management/pluginCategoryColor.test.ts`
+
+**Interfaces:**
+- Produces: `export function getCategoryColor(category: string): string`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// client/src/__tests__/components/plugins/plugin-management/pluginCategoryColor.test.ts
+import { describe, it, expect } from 'vitest';
+import { getCategoryColor } from '../../../../components/plugins/plugin-management/pluginCategoryColor';
+
+describe('getCategoryColor', () => {
+  it('returns the monitoring class string for the monitoring category', () => {
+    expect(getCategoryColor('monitoring')).toContain('blue');
+  });
+
+  it('returns a distinct class string per known category', () => {
+    const known = ['monitoring', 'storage', 'network', 'security', 'general'];
+    const results = known.map(getCategoryColor);
+    // all five map to a non-empty string, and they are not all identical
+    expect(results.every((r) => r.length > 0)).toBe(true);
+    expect(new Set(results).size).toBe(5);
+  });
+
+  it('falls back to the general class string for an unknown category', () => {
+    expect(getCategoryColor('does-not-exist')).toBe(getCategoryColor('general'));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && npx vitest run src/__tests__/components/plugins/plugin-management/pluginCategoryColor.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Write the implementation**
+
+Move the `getCategoryColor` body verbatim from `PluginsPage.tsx:178-187`:
+
+```ts
+// client/src/components/plugins/plugin-management/pluginCategoryColor.ts
+export function getCategoryColor(category: string): string {
+  const colors: Record<string, string> = {
+    monitoring: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
+    storage: 'bg-green-500/20 text-green-400 border-green-500/30',
+    network: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
+    security: 'bg-red-500/20 text-red-400 border-red-500/30',
+    general: 'bg-slate-500/20 text-slate-400 border-slate-500/30',
+  };
+  return colors[category] || colors.general;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client && npx vitest run src/__tests__/components/plugins/plugin-management/pluginCategoryColor.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/plugins/plugin-management/pluginCategoryColor.ts client/src/__tests__/components/plugins/plugin-management/pluginCategoryColor.test.ts
+git commit -m "feat(plugins): extract getCategoryColor helper (F2, #301)"
+```
+
+---
+
+### Task 2: `usePluginManagement` hook
+
+**Files:**
+- Create: `client/src/hooks/usePluginManagement.ts`
+- Test: `client/src/__tests__/hooks/usePluginManagement.test.ts`
+
+**Interfaces:**
+- Consumes: `usePlugins()` from `../contexts/PluginContext` (`{ plugins, isLoading, error, refreshPlugins }`), `useConfirmDialog()` from `./useConfirmDialog` (`{ confirm, dialog }`), all named functions from `../api/plugins`.
+- Produces: `usePluginManagement(): UsePluginManagementResult` (full shape below). Consumed by Tasks 5, 8, 9, 10, 11.
+
+```ts
+import type { PluginDetail, PluginInfo, PermissionInfo, ScopeInfo } from '../api/plugins';
+import type { ReactNode } from 'react';
+
+export interface UsePluginManagementResult {
+  plugins: PluginInfo[];
+  isLoading: boolean;
+  error: string | null;
+  refreshPlugins: () => Promise<void>;
+  allPermissions: PermissionInfo[];
+  scopeCatalog: ScopeInfo[];
+  selectedPlugin: PluginDetail | null;
+  detailsLoading: boolean;
+  actionLoading: boolean;
+  actionError: string | null;
+  loadPluginDetails: (name: string) => Promise<PluginDetail | null>;
+  handleTogglePlugin: (plugin: PluginInfo) => Promise<void>;
+  handleEnableWithPermissions: () => Promise<void>;
+  handleEnableWithScopes: () => Promise<void>;
+  handleUninstall: (name: string) => Promise<void>;
+  handleToggleDashboardPanel: () => Promise<void>;
+  showPermissionModal: boolean;
+  setShowPermissionModal: (v: boolean) => void;
+  selectedPermissions: string[];
+  togglePermission: (perm: string) => void;
+  showScopeModal: boolean;
+  setShowScopeModal: (v: boolean) => void;
+  selectedScopes: string[];
+  toggleScope: (scope: string) => void;
+  dialog: ReactNode;
+}
+```
+
+**Porting notes (byte-identical to source):**
+- State + mount effects: `PluginsPage.tsx:44-68` (11 `useState` except `activeTab` which STAYS in the page; both mount effects with `.catch(console.error)`).
+- `loadPluginDetails`: `70-83` verbatim.
+- `handleTogglePlugin`: `85-117` verbatim (internal→`setSelectedPermissions(plugin.required_permissions)` + `setShowPermissionModal(true)`; external→filtered `setSelectedScopes` + `setShowScopeModal(true)`).
+- `handleEnableWithPermissions`: `119-138` verbatim.
+- `handleEnableWithScopes`: `140-157` verbatim.
+- `handleUninstall`: `159-176` verbatim (uses `confirm` from `useConfirmDialog`).
+- `handleToggleDashboardPanel`: extract the inline onClick at `453-464` — guard `if (!selectedPlugin) return;`, `setActionLoading(true)`, `setActionError(null)`, `await toggleDashboardPanel(selectedPlugin.name, !selectedPlugin.dashboard_panel_enabled)`, `await loadPluginDetails(selectedPlugin.name)`, catch → `setActionError(t('dashboardPanel.enableFailed'))`, finally `setActionLoading(false)`.
+- `togglePermission(perm)`: replaces the inline checkbox add/remove at `553-559` — `setSelectedPermissions(prev => prev.includes(perm) ? prev.filter(p => p !== perm) : [...prev, perm])`.
+- `toggleScope(scope)`: replaces `623-628` — same pattern on `selectedScopes`.
+- `useTranslation(['plugins', 'common'])` inside the hook for the error strings.
+- Return the full object above, threading `plugins/isLoading/error/refreshPlugins` from `usePlugins()` and `dialog` from `useConfirmDialog()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// client/src/__tests__/hooks/usePluginManagement.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { PluginInfo, PluginDetail, ScopeInfo } from '../../api/plugins';
+
+const mockRefreshPlugins = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../contexts/PluginContext', () => ({
+  usePlugins: () => ({
+    plugins: [] as PluginInfo[],
+    isLoading: false,
+    error: null,
+    refreshPlugins: mockRefreshPlugins,
+  }),
+}));
+
+const mockConfirm = vi.fn();
+vi.mock('../../hooks/useConfirmDialog', () => ({
+  useConfirmDialog: () => ({ confirm: mockConfirm, dialog: null }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('../../api/plugins', () => ({
+  getPluginDetails: vi.fn(),
+  getScopeCatalog: vi.fn().mockResolvedValue({ scopes: [] }),
+  listPermissions: vi.fn().mockResolvedValue({ permissions: [] }),
+  togglePlugin: vi.fn().mockResolvedValue({}),
+  toggleDashboardPanel: vi.fn().mockResolvedValue({}),
+  uninstallPlugin: vi.fn().mockResolvedValue({}),
+}));
+
+import { usePluginManagement } from '../../hooks/usePluginManagement';
+import * as api from '../../api/plugins';
+
+const internalPlugin: PluginInfo = {
+  name: 'demo', version: '1.0.0', display_name: 'Demo', description: 'd',
+  author: 'a', category: 'general', required_permissions: ['files.read'],
+  dangerous_permissions: [], is_enabled: false, has_ui: false, has_routes: false,
+};
+
+function detail(over: Partial<PluginDetail> = {}): PluginDetail {
+  return {
+    name: 'demo', version: '1.0.0', display_name: 'Demo', description: 'd', author: 'a',
+    category: 'general', dependencies: [], required_permissions: ['files.read'],
+    granted_permissions: [], dangerous_permissions: [], is_enabled: false,
+    is_installed: true, has_ui: false, has_routes: false, has_background_tasks: false,
+    has_dashboard_panel: false, dashboard_panel_enabled: false, nav_items: [],
+    dashboard_widgets: [], config: {}, ...over,
+  };
+}
+
+describe('usePluginManagement', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sets actionError when loadPluginDetails fails and returns null', async () => {
+    vi.mocked(api.getPluginDetails).mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => usePluginManagement());
+    let ret: PluginDetail | null = detail();
+    await act(async () => { ret = await result.current.loadPluginDetails('demo'); });
+    expect(ret).toBeNull();
+    expect(result.current.actionError).toBe('errors.loadDetailsFailed');
+  });
+
+  it('opens the permission modal (not the scope modal) when enabling an internal plugin', async () => {
+    vi.mocked(api.getPluginDetails).mockResolvedValueOnce(detail({ is_external: false }));
+    const { result } = renderHook(() => usePluginManagement());
+    await act(async () => { await result.current.handleTogglePlugin(internalPlugin); });
+    expect(result.current.showPermissionModal).toBe(true);
+    expect(result.current.showScopeModal).toBe(false);
+    expect(result.current.selectedPermissions).toEqual(['files.read']);
+  });
+
+  it('opens the scope modal seeded with catalog-filtered requested scopes for an external plugin', async () => {
+    const catalog: ScopeInfo[] = [{ key: 'ui.read', tier: 'frontend', dangerous: false }];
+    vi.mocked(api.getScopeCatalog).mockResolvedValue({ scopes: catalog });
+    vi.mocked(api.getPluginDetails).mockResolvedValueOnce(
+      detail({ is_external: true, requested_api_scopes: ['ui.read', 'not.in.catalog'] }),
+    );
+    const { result } = renderHook(() => usePluginManagement());
+    await waitFor(() => expect(result.current.scopeCatalog).toHaveLength(1));
+    await act(async () => { await result.current.handleTogglePlugin({ ...internalPlugin, is_external: true }); });
+    expect(result.current.showScopeModal).toBe(true);
+    expect(result.current.showPermissionModal).toBe(false);
+    expect(result.current.selectedScopes).toEqual(['ui.read']); // 'not.in.catalog' filtered out
+  });
+
+  it('does not call uninstallPlugin when the confirm dialog is declined', async () => {
+    mockConfirm.mockResolvedValueOnce(false);
+    const { result } = renderHook(() => usePluginManagement());
+    await act(async () => { await result.current.handleUninstall('demo'); });
+    expect(api.uninstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it('calls uninstallPlugin and refreshes when the confirm dialog is accepted', async () => {
+    mockConfirm.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => usePluginManagement());
+    await act(async () => { await result.current.handleUninstall('demo'); });
+    expect(api.uninstallPlugin).toHaveBeenCalledWith('demo');
+    expect(mockRefreshPlugins).toHaveBeenCalled();
+  });
+
+  it('togglePermission adds then removes a permission', () => {
+    const { result } = renderHook(() => usePluginManagement());
+    act(() => result.current.togglePermission('files.write'));
+    expect(result.current.selectedPermissions).toContain('files.write');
+    act(() => result.current.togglePermission('files.write'));
+    expect(result.current.selectedPermissions).not.toContain('files.write');
+  });
+
+  it('handleEnableWithPermissions posts enabled:true + grant_permissions from the selection', async () => {
+    vi.mocked(api.getPluginDetails).mockResolvedValueOnce(detail({ is_external: false }));
+    const { result } = renderHook(() => usePluginManagement());
+    // seed selectedPlugin + selectedPermissions via the internal-enable branch
+    await act(async () => { await result.current.handleTogglePlugin(internalPlugin); });
+    await act(async () => { await result.current.handleEnableWithPermissions(); });
+    expect(api.togglePlugin).toHaveBeenCalledWith('demo', { enabled: true, grant_permissions: ['files.read'] });
+    expect(result.current.showPermissionModal).toBe(false);
+  });
+
+  it('handleEnableWithScopes posts enabled:true + grant_api_scopes from the catalog-filtered selection', async () => {
+    const catalog: ScopeInfo[] = [{ key: 'ui.read', tier: 'frontend', dangerous: false }];
+    vi.mocked(api.getScopeCatalog).mockResolvedValue({ scopes: catalog });
+    vi.mocked(api.getPluginDetails).mockResolvedValueOnce(
+      detail({ is_external: true, requested_api_scopes: ['ui.read', 'not.in.catalog'] }),
+    );
+    const { result } = renderHook(() => usePluginManagement());
+    await waitFor(() => expect(result.current.scopeCatalog).toHaveLength(1));
+    await act(async () => { await result.current.handleTogglePlugin({ ...internalPlugin, is_external: true }); });
+    await act(async () => { await result.current.handleEnableWithScopes(); });
+    expect(api.togglePlugin).toHaveBeenCalledWith('demo', { enabled: true, grant_api_scopes: ['ui.read'] });
+    expect(result.current.showScopeModal).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && npx vitest run src/__tests__/hooks/usePluginManagement.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Write the hook** per the porting notes above (move each handler verbatim from the cited source lines; add `togglePermission`/`toggleScope`/`handleToggleDashboardPanel`; return the full result object).
+
+- [ ] **Step 4: Run test + typecheck**
+
+Run: `cd client && npx vitest run src/__tests__/hooks/usePluginManagement.test.ts`
+Expected: PASS (6 tests).
+Run: `cd client && npx tsc -b`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/hooks/usePluginManagement.ts client/src/__tests__/hooks/usePluginManagement.test.ts
+git commit -m "feat(plugins): add usePluginManagement hook (state + actions) (F2, #301)"
+```
+
+---
+
+### Task 3: `PluginTabNav`
+
+**Files:**
+- Create: `client/src/components/plugins/plugin-management/PluginTabNav.tsx`
+- Test: `client/src/__tests__/components/plugins/plugin-management/PluginTabNav.test.tsx`
+
+**Interfaces:**
+- Produces:
+```ts
+import type { LucideIcon } from 'lucide-react';
+export type TabType = 'plugins' | 'marketplace' | 'documentation';
+export interface PluginTab { id: TabType; labelKey: string; icon: LucideIcon }
+export const TABS: PluginTab[];
+export function PluginTabNav(props: {
+  activeTab: TabType;
+  onSelect: (id: TabType) => void;
+}): JSX.Element;
+```
+- Consumed by Task 11 (page).
+
+**Porting notes:** Move the `TABS` const from `PluginsPage.tsx:34-38` and the `TabType` from `32`. Render the tab bar markup verbatim from `218-233` (the `<div className="flex gap-2 border-b ...">` map), using `activeTab`/`onSelect`. `useTranslation(['plugins', 'common'])` internally.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// PluginTabNav.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { PluginTabNav, TABS } from '../../../../components/plugins/plugin-management/PluginTabNav';
+
+describe('PluginTabNav', () => {
+  it('renders one button per tab', () => {
+    render(<PluginTabNav activeTab="plugins" onSelect={() => {}} />);
+    expect(screen.getAllByRole('button')).toHaveLength(TABS.length);
+  });
+
+  it('fires onSelect with the clicked tab id', () => {
+    const onSelect = vi.fn();
+    render(<PluginTabNav activeTab="plugins" onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('tabs.marketplace'));
+    expect(onSelect).toHaveBeenCalledWith('marketplace');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail.** `cd client && npx vitest run src/__tests__/components/plugins/plugin-management/PluginTabNav.test.tsx` → FAIL.
+- [ ] **Step 3: Write the component** per porting notes.
+- [ ] **Step 4: Run test + `npx tsc -b`.** Expected: PASS (2 tests), no type errors.
+- [ ] **Step 5: Commit** `feat(plugins): extract PluginTabNav (F2, #301)`.
+
+---
+
+### Task 4: `PluginListCard`
+
+**Files:**
+- Create: `client/src/components/plugins/plugin-management/PluginListCard.tsx`
+- Test: `client/src/__tests__/components/plugins/plugin-management/PluginListCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `getCategoryColor` (Task 1), `PluginInfo`.
+- Produces:
+```ts
+import type { PluginInfo } from '../../../api/plugins';
+export function PluginListCard(props: {
+  plugin: PluginInfo;
+  isSelected: boolean;
+  actionLoading: boolean;
+  onSelect: (name: string) => void;
+  onToggle: (plugin: PluginInfo) => void;
+}): JSX.Element;
+```
+- Consumed by Task 5.
+
+**Porting notes:** Move one card verbatim from `PluginsPage.tsx:271-334`. Replace the outer `onClick={() => loadPluginDetails(plugin.name)}` with `onClick={() => onSelect(plugin.name)}`; the selected-highlight condition uses `isSelected` (was `selectedPlugin?.name === plugin.name`). The toggle button keeps `e.stopPropagation()` then `onToggle(plugin)` (was `handleTogglePlugin`), `disabled={actionLoading}`. Keep `resolvePluginString`, `getCategoryColor`, all badges/error box, `useTranslation` internally.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// PluginListCard.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { PluginInfo } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('../../../../lib/pluginI18n', () => ({ resolvePluginString: (_t: unknown, _k: string, fb: string) => fb }));
+import { PluginListCard } from '../../../../components/plugins/plugin-management/PluginListCard';
+
+const base: PluginInfo = {
+  name: 'demo', version: '1.2.3', display_name: 'Demo Plugin', description: 'desc',
+  author: 'a', category: 'monitoring', required_permissions: [], dangerous_permissions: [],
+  is_enabled: false, has_ui: false, has_routes: false,
+};
+
+describe('PluginListCard', () => {
+  it('shows the enable label and the version when disabled', () => {
+    render(<PluginListCard plugin={base} isSelected={false} actionLoading={false} onSelect={() => {}} onToggle={() => {}} />);
+    expect(screen.getByText('buttons.enable')).toBeInTheDocument();
+    expect(screen.getByText('v1.2.3')).toBeInTheDocument();
+  });
+
+  it('shows the active badge and disable label when enabled', () => {
+    render(<PluginListCard plugin={{ ...base, is_enabled: true }} isSelected={false} actionLoading={false} onSelect={() => {}} onToggle={() => {}} />);
+    expect(screen.getByText('status.active')).toBeInTheDocument();
+    expect(screen.getByText('buttons.disable')).toBeInTheDocument();
+  });
+
+  it('clicking the toggle fires onToggle but NOT onSelect (stopPropagation)', () => {
+    const onSelect = vi.fn();
+    const onToggle = vi.fn();
+    render(<PluginListCard plugin={base} isSelected={false} actionLoading={false} onSelect={onSelect} onToggle={onToggle} />);
+    fireEvent.click(screen.getByText('buttons.enable'));
+    expect(onToggle).toHaveBeenCalledWith(base);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('clicking the card body fires onSelect with the plugin name', () => {
+    const onSelect = vi.fn();
+    render(<PluginListCard plugin={base} isSelected={false} actionLoading={false} onSelect={onSelect} onToggle={() => {}} />);
+    fireEvent.click(screen.getByText('Demo Plugin'));
+    expect(onSelect).toHaveBeenCalledWith('demo');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** → FAIL.
+- [ ] **Step 3: Write the component** per porting notes.
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (4 tests), no type errors.
+- [ ] **Step 5: Commit** `feat(plugins): extract PluginListCard (F2, #301)`.
+
+---
+
+### Task 5: `PluginList`
+
+**Files:**
+- Create: `client/src/components/plugins/plugin-management/PluginList.tsx`
+- Test: `client/src/__tests__/components/plugins/plugin-management/PluginList.test.tsx`
+
+**Interfaces:**
+- Consumes: `PluginListCard` (Task 4), `PluginInfo`.
+- Produces:
+```ts
+import type { PluginInfo } from '../../../api/plugins';
+export function PluginList(props: {
+  plugins: PluginInfo[];
+  selectedName: string | null;
+  actionLoading: boolean;
+  onSelect: (name: string) => void;
+  onToggle: (plugin: PluginInfo) => void;
+}): JSX.Element;
+```
+- Consumed by Task 11.
+
+**Porting notes:** Move the empty-state + map from `PluginsPage.tsx:260-337`. Empty-state markup verbatim (`262-268`). Otherwise map `plugins` to `PluginListCard` passing `isSelected={selectedName === plugin.name}` + the callbacks. `useTranslation` internally for the empty-state strings.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// PluginList.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PluginInfo } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+// stub the card so this test targets only PluginList's own branching
+vi.mock('../../../../components/plugins/plugin-management/PluginListCard', () => ({
+  PluginListCard: ({ plugin }: { plugin: PluginInfo }) => <div data-testid="card">{plugin.name}</div>,
+}));
+import { PluginList } from '../../../../components/plugins/plugin-management/PluginList';
+
+const p = (name: string): PluginInfo => ({
+  name, version: '1', display_name: name, description: '', author: '', category: 'general',
+  required_permissions: [], dangerous_permissions: [], is_enabled: false, has_ui: false, has_routes: false,
+});
+
+describe('PluginList', () => {
+  it('renders the empty-state when there are no plugins', () => {
+    render(<PluginList plugins={[]} selectedName={null} actionLoading={false} onSelect={() => {}} onToggle={() => {}} />);
+    expect(screen.getByText('empty.noPlugins')).toBeInTheDocument();
+    expect(screen.queryByTestId('card')).not.toBeInTheDocument();
+  });
+
+  it('renders one card per plugin when the list is non-empty', () => {
+    render(<PluginList plugins={[p('a'), p('b')]} selectedName="a" actionLoading={false} onSelect={() => {}} onToggle={() => {}} />);
+    expect(screen.getAllByTestId('card')).toHaveLength(2);
+    expect(screen.queryByText('empty.noPlugins')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** → FAIL.
+- [ ] **Step 3: Write the component.**
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (2 tests).
+- [ ] **Step 5: Commit** `feat(plugins): extract PluginList (F2, #301)`.
+
+---
+
+### Task 6: `PluginDetailsCard` + `PluginPermissionsCard`
+
+**Files:**
+- Create: `client/src/components/plugins/plugin-management/PluginDetailsCard.tsx`
+- Create: `client/src/components/plugins/plugin-management/PluginPermissionsCard.tsx`
+- Test: `client/src/__tests__/components/plugins/plugin-management/PluginDetailsCard.test.tsx`
+- Test: `client/src/__tests__/components/plugins/plugin-management/PluginPermissionsCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `PluginDetail`, `safeExternalUrl`, `resolvePluginString`.
+- Produces:
+```ts
+import type { PluginDetail } from '../../../api/plugins';
+export function PluginDetailsCard(props: { plugin: PluginDetail }): JSX.Element;
+export function PluginPermissionsCard(props: { plugin: PluginDetail }): JSX.Element;
+```
+- Consumed by Task 8.
+
+**Porting notes:** `PluginDetailsCard` = the details `<div>` verbatim from `PluginsPage.tsx:352-399` (version/author/category/homepage via `safeExternalUrl`/status/installed; `resolvePluginString` for the title). `PluginPermissionsCard` = the permissions `<div>` verbatim from `402-436` (noPermissions text or the required-perms `<ul>` with dangerous/granted markers). `useTranslation` internally in both.
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// PluginDetailsCard.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PluginDetail } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('../../../../lib/pluginI18n', () => ({ resolvePluginString: (_t: unknown, _k: string, fb: string) => fb }));
+import { PluginDetailsCard } from '../../../../components/plugins/plugin-management/PluginDetailsCard';
+
+const detail = (over: Partial<PluginDetail> = {}): PluginDetail => ({
+  name: 'demo', version: '2.0.0', display_name: 'Demo', description: '', author: 'Jane',
+  category: 'storage', dependencies: [], required_permissions: [], granted_permissions: [],
+  dangerous_permissions: [], is_enabled: true, is_installed: true, has_ui: false, has_routes: false,
+  has_background_tasks: false, has_dashboard_panel: false, dashboard_panel_enabled: false,
+  nav_items: [], dashboard_widgets: [], config: {}, ...over,
+});
+
+describe('PluginDetailsCard', () => {
+  it('renders version and author', () => {
+    render(<PluginDetailsCard plugin={detail()} />);
+    expect(screen.getByText('2.0.0')).toBeInTheDocument();
+    expect(screen.getByText('Jane')).toBeInTheDocument();
+  });
+
+  it('renders a homepage link only when the url is safe', () => {
+    const { rerender } = render(<PluginDetailsCard plugin={detail({ homepage: 'https://example.com' })} />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://example.com/');
+    rerender(<PluginDetailsCard plugin={detail({ homepage: 'javascript:alert(1)' })} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});
+```
+
+```tsx
+// PluginPermissionsCard.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PluginDetail } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { PluginPermissionsCard } from '../../../../components/plugins/plugin-management/PluginPermissionsCard';
+
+const detail = (over: Partial<PluginDetail> = {}): PluginDetail => ({
+  name: 'demo', version: '1', display_name: 'Demo', description: '', author: '',
+  category: 'general', dependencies: [], required_permissions: [], granted_permissions: [],
+  dangerous_permissions: [], is_enabled: true, is_installed: true, has_ui: false, has_routes: false,
+  has_background_tasks: false, has_dashboard_panel: false, dashboard_panel_enabled: false,
+  nav_items: [], dashboard_widgets: [], config: {}, ...over,
+});
+
+describe('PluginPermissionsCard', () => {
+  it('shows the noPermissions text when there are none', () => {
+    render(<PluginPermissionsCard plugin={detail()} />);
+    expect(screen.getByText('permissions.noPermissions')).toBeInTheDocument();
+  });
+
+  it('lists each required permission', () => {
+    render(<PluginPermissionsCard plugin={detail({ required_permissions: ['files.read', 'files.write'], granted_permissions: ['files.read'] })} />);
+    expect(screen.getByText('files.read')).toBeInTheDocument();
+    expect(screen.getByText('files.write')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run both to verify fail** → FAIL.
+- [ ] **Step 3: Write both components** per porting notes.
+- [ ] **Step 4: Run both tests + `npx tsc -b`** → PASS (4 tests total).
+- [ ] **Step 5: Commit** `feat(plugins): extract PluginDetailsCard + PluginPermissionsCard (F2, #301)`.
+
+---
+
+### Task 7: `PluginDashboardPanelCard` + `PluginActionsCard`
+
+**Files:**
+- Create: `client/src/components/plugins/plugin-management/PluginDashboardPanelCard.tsx`
+- Create: `client/src/components/plugins/plugin-management/PluginActionsCard.tsx`
+- Test: `client/src/__tests__/components/plugins/plugin-management/PluginDashboardPanelCard.test.tsx`
+- Test: `client/src/__tests__/components/plugins/plugin-management/PluginActionsCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `PluginDetail`, `LocalOnlyAction` from `../../LocalOnlyAction`.
+- Produces:
+```ts
+import type { PluginDetail } from '../../../api/plugins';
+export function PluginDashboardPanelCard(props: {
+  plugin: PluginDetail; actionLoading: boolean; onToggle: () => void;
+}): JSX.Element;
+export function PluginActionsCard(props: {
+  plugin: PluginDetail; actionLoading: boolean;
+  onConfigure: () => void; onUninstall: (name: string) => void;
+}): JSX.Element;
+```
+- Consumed by Task 8.
+
+**Porting notes:** `PluginDashboardPanelCard` = the panel `<div>` verbatim from `PluginsPage.tsx:440-475` (the inline onClick becomes `onClick={onToggle}`; keep the active/inactive label + enable/disable-panel button + `disabled={actionLoading}`). Render unconditionally — the `has_dashboard_panel && is_enabled` guard stays in the sidebar (Task 8). `PluginActionsCard` = the actions `<div>` verbatim from `489-513`: configure button (`onClick={onConfigure}`, `disabled={!plugin.is_enabled}`), `LocalOnlyAction` wrapping the uninstall button (`onClick={() => onUninstall(plugin.name)}`, `disabled={actionLoading || plugin.is_enabled}`), and the disable-first hint (`508-512`). `useTranslation` internally in both.
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// PluginDashboardPanelCard.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { PluginDetail } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { PluginDashboardPanelCard } from '../../../../components/plugins/plugin-management/PluginDashboardPanelCard';
+
+const detail = (over: Partial<PluginDetail> = {}): PluginDetail => ({
+  name: 'demo', version: '1', display_name: 'Demo', description: '', author: '', category: 'general',
+  dependencies: [], required_permissions: [], granted_permissions: [], dangerous_permissions: [],
+  is_enabled: true, is_installed: true, has_ui: false, has_routes: false, has_background_tasks: false,
+  has_dashboard_panel: true, dashboard_panel_enabled: false, nav_items: [], dashboard_widgets: [], config: {}, ...over,
+});
+
+describe('PluginDashboardPanelCard', () => {
+  it('shows the enable-panel label + inactive state when the panel is off', () => {
+    render(<PluginDashboardPanelCard plugin={detail({ dashboard_panel_enabled: false })} actionLoading={false} onToggle={() => {}} />);
+    expect(screen.getByText('buttons.enablePanel')).toBeInTheDocument();
+    expect(screen.getByText('dashboardPanel.inactive')).toBeInTheDocument();
+  });
+
+  it('fires onToggle when the button is clicked', () => {
+    const onToggle = vi.fn();
+    render(<PluginDashboardPanelCard plugin={detail({ dashboard_panel_enabled: true })} actionLoading={false} onToggle={onToggle} />);
+    fireEvent.click(screen.getByText('buttons.disablePanel'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+```tsx
+// PluginActionsCard.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { PluginDetail } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('../../../../components/LocalOnlyAction', () => ({ LocalOnlyAction: ({ children }: { children: React.ReactNode }) => <>{children}</> }));
+import { PluginActionsCard } from '../../../../components/plugins/plugin-management/PluginActionsCard';
+
+const detail = (over: Partial<PluginDetail> = {}): PluginDetail => ({
+  name: 'demo', version: '1', display_name: 'Demo', description: '', author: '', category: 'general',
+  dependencies: [], required_permissions: [], granted_permissions: [], dangerous_permissions: [],
+  is_enabled: true, is_installed: true, has_ui: false, has_routes: false, has_background_tasks: false,
+  has_dashboard_panel: false, dashboard_panel_enabled: false, nav_items: [], dashboard_widgets: [], config: {}, ...over,
+});
+
+describe('PluginActionsCard', () => {
+  it('disables the uninstall button while the plugin is enabled', () => {
+    render(<PluginActionsCard plugin={detail({ is_enabled: true })} actionLoading={false} onConfigure={() => {}} onUninstall={() => {}} />);
+    expect(screen.getByText('buttons.uninstall').closest('button')).toBeDisabled();
+  });
+
+  it('fires onUninstall with the plugin name when enabled=false and clicked', () => {
+    const onUninstall = vi.fn();
+    render(<PluginActionsCard plugin={detail({ is_enabled: false })} actionLoading={false} onConfigure={() => {}} onUninstall={onUninstall} />);
+    fireEvent.click(screen.getByText('buttons.uninstall'));
+    expect(onUninstall).toHaveBeenCalledWith('demo');
+  });
+
+  it('fires onConfigure when configure is clicked', () => {
+    const onConfigure = vi.fn();
+    render(<PluginActionsCard plugin={detail()} actionLoading={false} onConfigure={onConfigure} onUninstall={() => {}} />);
+    fireEvent.click(screen.getByText('buttons.configure'));
+    expect(onConfigure).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run both to verify fail** → FAIL.
+- [ ] **Step 3: Write both components** per porting notes.
+- [ ] **Step 4: Run both tests + `npx tsc -b`** → PASS (5 tests total).
+- [ ] **Step 5: Commit** `feat(plugins): extract PluginDashboardPanelCard + PluginActionsCard (F2, #301)`.
+
+---
+
+### Task 8: `PluginDetailsSidebar`
+
+**Files:**
+- Create: `client/src/components/plugins/plugin-management/PluginDetailsSidebar.tsx`
+- Test: `client/src/__tests__/components/plugins/plugin-management/PluginDetailsSidebar.test.tsx`
+
+**Interfaces:**
+- Consumes: `PluginDetailsCard`, `PluginPermissionsCard`, `PluginDashboardPanelCard`, `PluginActionsCard` (Tasks 6–7), `PluginSettingsSection` from `../PluginSettingsSection`, `PluginDetail`.
+- Produces:
+```ts
+import type { PluginDetail } from '../../../api/plugins';
+export function PluginDetailsSidebar(props: {
+  plugin: PluginDetail | null;
+  detailsLoading: boolean;
+  actionLoading: boolean;
+  onToggleDashboardPanel: () => void;
+  onConfigure: () => void;
+  onUninstall: (name: string) => void;
+}): JSX.Element;
+```
+- Consumed by Task 11.
+
+**Porting notes:** Move the sidebar `<div className="space-y-4">` container from `PluginsPage.tsx:340-523`. Three branches verbatim: loading skeleton (`341-348`); `plugin` present → `<>` with `PluginDetailsCard`, `PluginPermissionsCard`, conditional `PluginDashboardPanelCard` (guard `plugin.has_dashboard_panel && plugin.is_enabled`, pass `onToggle={onToggleDashboardPanel}`), conditional `PluginSettingsSection` (guard `plugin.config_schema && plugin.is_enabled`, same props as `479-485`), `PluginActionsCard` (pass `onConfigure`/`onUninstall`); empty branch (`515-521`). Prop name in source was `detailsLoading`/`selectedPlugin` — here `detailsLoading`/`plugin`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// PluginDetailsSidebar.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PluginDetail } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+// stub children so this test targets ONLY the sidebar's branching/guards
+vi.mock('../../../../components/plugins/plugin-management/PluginDetailsCard', () => ({ PluginDetailsCard: () => <div data-testid="details" /> }));
+vi.mock('../../../../components/plugins/plugin-management/PluginPermissionsCard', () => ({ PluginPermissionsCard: () => <div data-testid="perms" /> }));
+vi.mock('../../../../components/plugins/plugin-management/PluginDashboardPanelCard', () => ({ PluginDashboardPanelCard: () => <div data-testid="panel" /> }));
+vi.mock('../../../../components/plugins/plugin-management/PluginActionsCard', () => ({ PluginActionsCard: () => <div data-testid="actions" /> }));
+vi.mock('../../../../components/plugins/PluginSettingsSection', () => ({ PluginSettingsSection: () => <div data-testid="settings" /> }));
+import { PluginDetailsSidebar } from '../../../../components/plugins/plugin-management/PluginDetailsSidebar';
+
+const detail = (over: Partial<PluginDetail> = {}): PluginDetail => ({
+  name: 'demo', version: '1', display_name: 'Demo', description: '', author: '', category: 'general',
+  dependencies: [], required_permissions: [], granted_permissions: [], dangerous_permissions: [],
+  is_enabled: true, is_installed: true, has_ui: false, has_routes: false, has_background_tasks: false,
+  has_dashboard_panel: false, dashboard_panel_enabled: false, nav_items: [], dashboard_widgets: [], config: {}, ...over,
+});
+const noop = () => {};
+const props = { detailsLoading: false, actionLoading: false, onToggleDashboardPanel: noop, onConfigure: noop, onUninstall: noop };
+
+describe('PluginDetailsSidebar', () => {
+  it('shows the empty prompt when no plugin is selected', () => {
+    render(<PluginDetailsSidebar plugin={null} {...props} />);
+    expect(screen.getByText('empty.selectPlugin')).toBeInTheDocument();
+    expect(screen.queryByTestId('details')).not.toBeInTheDocument();
+  });
+
+  it('renders details + permissions + actions for a selected plugin', () => {
+    render(<PluginDetailsSidebar plugin={detail()} {...props} />);
+    expect(screen.getByTestId('details')).toBeInTheDocument();
+    expect(screen.getByTestId('perms')).toBeInTheDocument();
+    expect(screen.getByTestId('actions')).toBeInTheDocument();
+  });
+
+  it('renders the dashboard-panel card only when has_dashboard_panel && is_enabled', () => {
+    const { rerender } = render(<PluginDetailsSidebar plugin={detail({ has_dashboard_panel: true, is_enabled: true })} {...props} />);
+    expect(screen.getByTestId('panel')).toBeInTheDocument();
+    rerender(<PluginDetailsSidebar plugin={detail({ has_dashboard_panel: true, is_enabled: false })} {...props} />);
+    expect(screen.queryByTestId('panel')).not.toBeInTheDocument();
+  });
+
+  it('renders the settings section only when config_schema && is_enabled', () => {
+    const { rerender } = render(<PluginDetailsSidebar plugin={detail({ config_schema: { type: 'object' }, is_enabled: true })} {...props} />);
+    expect(screen.getByTestId('settings')).toBeInTheDocument();
+    rerender(<PluginDetailsSidebar plugin={detail({ config_schema: undefined, is_enabled: true })} {...props} />);
+    expect(screen.queryByTestId('settings')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** → FAIL.
+- [ ] **Step 3: Write the component** per porting notes.
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (4 tests).
+- [ ] **Step 5: Commit** `feat(plugins): extract PluginDetailsSidebar (F2, #301)`.
+
+---
+
+### Task 9: `PermissionGrantModal`
+
+**Files:**
+- Create: `client/src/components/plugins/plugin-management/PermissionGrantModal.tsx`
+- Test: `client/src/__tests__/components/plugins/plugin-management/PermissionGrantModal.test.tsx`
+
+**Interfaces:**
+- Consumes: `PluginDetail`, `PermissionInfo`.
+- Produces:
+```ts
+import type { PluginDetail, PermissionInfo } from '../../../api/plugins';
+export function PermissionGrantModal(props: {
+  plugin: PluginDetail;
+  allPermissions: PermissionInfo[];
+  selectedPermissions: string[];
+  onTogglePermission: (perm: string) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+}): JSX.Element;
+```
+- Consumed by Task 11.
+
+**Porting notes:** Move the modal `<div className="fixed inset-0 ...">` verbatim from `PluginsPage.tsx:529-593` (the outer `showPermissionModal && selectedPlugin` guard stays in the page). The checkbox `onChange` becomes `onTogglePermission(perm)`; cancel button → `onCancel`; enable button → `onConfirm`, keeping the exact disabled guard `disabled={!plugin.required_permissions.every((p) => selectedPermissions.includes(p))}`. `useTranslation` internally.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// PermissionGrantModal.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { PluginDetail, PermissionInfo } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { PermissionGrantModal } from '../../../../components/plugins/plugin-management/PermissionGrantModal';
+
+const plugin: PluginDetail = {
+  name: 'demo', version: '1', display_name: 'Demo', description: '', author: '', category: 'general',
+  dependencies: [], required_permissions: ['files.read', 'files.write'], granted_permissions: [],
+  dangerous_permissions: ['files.write'], is_enabled: false, is_installed: true, has_ui: false, has_routes: false,
+  has_background_tasks: false, has_dashboard_panel: false, dashboard_panel_enabled: false,
+  nav_items: [], dashboard_widgets: [], config: {},
+};
+const perms: PermissionInfo[] = [
+  { name: 'r', value: 'files.read', dangerous: false, description: 'read' },
+  { name: 'w', value: 'files.write', dangerous: true, description: 'write' },
+];
+
+describe('PermissionGrantModal', () => {
+  it('disables the enable button until every required permission is selected', () => {
+    const { rerender } = render(
+      <PermissionGrantModal plugin={plugin} allPermissions={perms} selectedPermissions={['files.read']}
+        onTogglePermission={() => {}} onCancel={() => {}} onConfirm={() => {}} />,
+    );
+    expect(screen.getByText('buttons.enablePlugin').closest('button')).toBeDisabled();
+    rerender(
+      <PermissionGrantModal plugin={plugin} allPermissions={perms} selectedPermissions={['files.read', 'files.write']}
+        onTogglePermission={() => {}} onCancel={() => {}} onConfirm={() => {}} />,
+    );
+    expect(screen.getByText('buttons.enablePlugin').closest('button')).not.toBeDisabled();
+  });
+
+  it('fires onTogglePermission with the permission when a checkbox changes', () => {
+    const onToggle = vi.fn();
+    render(
+      <PermissionGrantModal plugin={plugin} allPermissions={perms} selectedPermissions={[]}
+        onTogglePermission={onToggle} onCancel={() => {}} onConfirm={() => {}} />,
+    );
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    expect(onToggle).toHaveBeenCalledWith('files.read');
+  });
+
+  it('fires onConfirm when the (enabled) enable button is clicked', () => {
+    const onConfirm = vi.fn();
+    render(
+      <PermissionGrantModal plugin={plugin} allPermissions={perms} selectedPermissions={['files.read', 'files.write']}
+        onTogglePermission={() => {}} onCancel={() => {}} onConfirm={onConfirm} />,
+    );
+    fireEvent.click(screen.getByText('buttons.enablePlugin'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** → FAIL.
+- [ ] **Step 3: Write the component** per porting notes.
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (3 tests).
+- [ ] **Step 5: Commit** `feat(plugins): extract PermissionGrantModal (F2, #301)`.
+
+---
+
+### Task 10: `ScopeGrantModal`
+
+**Files:**
+- Create: `client/src/components/plugins/plugin-management/ScopeGrantModal.tsx`
+- Test: `client/src/__tests__/components/plugins/plugin-management/ScopeGrantModal.test.tsx`
+
+**Interfaces:**
+- Consumes: `PluginDetail`, `ScopeInfo`.
+- Produces:
+```ts
+import type { PluginDetail, ScopeInfo } from '../../../api/plugins';
+export function ScopeGrantModal(props: {
+  plugin: PluginDetail;
+  scopeCatalog: ScopeInfo[];
+  selectedScopes: string[];
+  onToggleScope: (scope: string) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+}): JSX.Element;
+```
+- Consumed by Task 11.
+
+**Porting notes:** Convert the IIFE at `PluginsPage.tsx:596-686` into a component. The inner consts become in-component: `const descs = t('scopeDescriptions', { returnObjects: true }) as Record<string, { label: string; description: string }>`; `const requested = (plugin.requested_api_scopes ?? []).filter((s) => scopeCatalog.some((c) => c.key === s))`; `byTier(tier)` and `renderScope(scope)` as inner functions (the checkbox `onChange` → `onToggleScope(scope.key)`). Modal markup verbatim from `647-684` (cancel → `onCancel`, grant → `onConfirm`; noScopes branch when `requested.length === 0`). `useTranslation(['plugins','common'])` internally.
+> Note: under the `t: (k) => k` mock, `t('scopeDescriptions', { returnObjects: true })` returns the string `'scopeDescriptions'`; indexing it yields `undefined`, so `meta?.label ?? scope.key` falls back to the scope key — the component must not assume `descs` is an object (the `?.` guards already handle this).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// ScopeGrantModal.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { PluginDetail, ScopeInfo } from '../../../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { ScopeGrantModal } from '../../../../components/plugins/plugin-management/ScopeGrantModal';
+
+const plugin = (over: Partial<PluginDetail> = {}): PluginDetail => ({
+  name: 'demo', version: '1', display_name: 'Demo', description: '', author: '', category: 'general',
+  dependencies: [], required_permissions: [], granted_permissions: [], dangerous_permissions: [],
+  is_enabled: false, is_installed: true, has_ui: false, has_routes: false, has_background_tasks: false,
+  has_dashboard_panel: false, dashboard_panel_enabled: false, nav_items: [], dashboard_widgets: [],
+  config: {}, is_external: true, requested_api_scopes: ['ui.read', 'files.write'], ...over,
+});
+const catalog: ScopeInfo[] = [
+  { key: 'ui.read', tier: 'frontend', dangerous: false },
+  { key: 'files.write', tier: 'backend', dangerous: true },
+];
+
+describe('ScopeGrantModal', () => {
+  it('renders both tier groups with one checkbox per requested+catalog scope', () => {
+    render(<ScopeGrantModal plugin={plugin()} scopeCatalog={catalog} selectedScopes={[]}
+      onToggleScope={() => {}} onCancel={() => {}} onConfirm={() => {}} />);
+    expect(screen.getByText('scopeTiers.frontend')).toBeInTheDocument();
+    expect(screen.getByText('scopeTiers.backend')).toBeInTheDocument();
+    expect(screen.getAllByRole('checkbox')).toHaveLength(2);
+  });
+
+  it('shows the noScopes text when no requested scope is in the catalog', () => {
+    render(<ScopeGrantModal plugin={plugin({ requested_api_scopes: ['unknown'] })} scopeCatalog={catalog}
+      selectedScopes={[]} onToggleScope={() => {}} onCancel={() => {}} onConfirm={() => {}} />);
+    expect(screen.getByText('picker.noScopes')).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  it('fires onToggleScope with the scope key on checkbox change', () => {
+    const onToggleScope = vi.fn();
+    render(<ScopeGrantModal plugin={plugin()} scopeCatalog={catalog} selectedScopes={[]}
+      onToggleScope={onToggleScope} onCancel={() => {}} onConfirm={() => {}} />);
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    expect(onToggleScope).toHaveBeenCalledWith('ui.read');
+  });
+
+  it('fires onConfirm when grant is clicked', () => {
+    const onConfirm = vi.fn();
+    render(<ScopeGrantModal plugin={plugin()} scopeCatalog={catalog} selectedScopes={['ui.read']}
+      onToggleScope={() => {}} onCancel={() => {}} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByText('picker.grant'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** → FAIL.
+- [ ] **Step 3: Write the component** per porting notes.
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (4 tests).
+- [ ] **Step 5: Commit** `feat(plugins): extract ScopeGrantModal (F2, #301)`.
+
+---
+
+### Task 11: Barrel + `PluginsPage.tsx` orchestrator + integration test
+
+**Files:**
+- Create: `client/src/components/plugins/plugin-management/index.ts`
+- Modify: `client/src/pages/PluginsPage.tsx` (full rewrite to orchestrator)
+- Test: `client/src/__tests__/pages/PluginsPage.test.tsx`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–10 via the barrel, `usePluginManagement` (Task 2), `MarketplaceTab`/`PluginDocumentation`/`PluginSettingsSection` (unchanged).
+
+**Barrel** `index.ts` re-exports: `getCategoryColor`, `TABS`, `type TabType`, `PluginTabNav`, `PluginListCard`, `PluginList`, `PluginDetailsCard`, `PluginPermissionsCard`, `PluginDashboardPanelCard`, `PluginActionsCard`, `PluginDetailsSidebar`, `PermissionGrantModal`, `ScopeGrantModal`.
+
+**Page rewrite:** keep the file header comment + default export `PluginsPage`. Keep ONLY `activeTab` state (`useState<TabType>('plugins')`). Everything else from `usePluginManagement()`. Structure:
+1. `if (isLoading) return <spinner/>` (verbatim `189-195`).
+2. Header (verbatim `199-215`, refresh button → `refreshPlugins`).
+3. `<PluginTabNav activeTab={activeTab} onSelect={setActiveTab} />`.
+4. Error banner (`235-239`) + plugins-tab actionError banner (`241-246`).
+5. `{activeTab === 'marketplace' && <MarketplaceTab />}`, `{activeTab === 'documentation' && <PluginDocumentation permissions={allPermissions} scopeCatalog={scopeCatalog} />}`.
+6. `{activeTab === 'plugins' && (<div className="grid grid-cols-1 lg:grid-cols-3 gap-6"><div className="lg:col-span-2 space-y-4"><PluginList .../></div><PluginDetailsSidebar .../></div>)}` — `PluginList` gets `plugins`, `selectedName={selectedPlugin?.name ?? null}`, `actionLoading`, `onSelect={loadPluginDetails}`, `onToggle={handleTogglePlugin}`; `PluginDetailsSidebar` gets `plugin={selectedPlugin}`, `detailsLoading`, `actionLoading`, `onToggleDashboardPanel={handleToggleDashboardPanel}`, `onConfigure={() => setShowPermissionModal(true)}`, `onUninstall={handleUninstall}`.
+7. `{showPermissionModal && selectedPlugin && <PermissionGrantModal ... />}` (props: `plugin={selectedPlugin}`, `allPermissions`, `selectedPermissions`, `onTogglePermission={togglePermission}`, `onCancel={() => setShowPermissionModal(false)}`, `onConfirm={handleEnableWithPermissions}`).
+8. `{showScopeModal && selectedPlugin && <ScopeGrantModal ... />}` (props: `plugin={selectedPlugin}`, `scopeCatalog`, `selectedScopes`, `onToggleScope={toggleScope}`, `onCancel={() => setShowScopeModal(false)}`, `onConfirm={handleEnableWithScopes}`).
+9. `{dialog}` at the end.
+
+Delete all now-unused imports (the api functions, lucide icons only used by moved markup, `safeExternalUrl`, `resolvePluginString`, `useConfirmDialog`, `LocalOnlyAction`, `useEffect`). Keep `useState`, `useTranslation`, the three reused components, `usePluginManagement`, and the barrel imports. Run eslint to catch leftover unused imports.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```tsx
+// client/src/__tests__/pages/PluginsPage.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PluginInfo, PluginDetail } from '../../api/plugins';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+const hookValue = {
+  plugins: [] as PluginInfo[], isLoading: false, error: null, refreshPlugins: vi.fn(),
+  allPermissions: [], scopeCatalog: [], selectedPlugin: null as PluginDetail | null,
+  detailsLoading: false, actionLoading: false, actionError: null,
+  loadPluginDetails: vi.fn(), handleTogglePlugin: vi.fn(), handleEnableWithPermissions: vi.fn(),
+  handleEnableWithScopes: vi.fn(), handleUninstall: vi.fn(), handleToggleDashboardPanel: vi.fn(),
+  showPermissionModal: false, setShowPermissionModal: vi.fn(), selectedPermissions: [], togglePermission: vi.fn(),
+  showScopeModal: false, setShowScopeModal: vi.fn(), selectedScopes: [], toggleScope: vi.fn(),
+  dialog: null,
+};
+vi.mock('../../hooks/usePluginManagement', () => ({ usePluginManagement: () => hookValue }));
+vi.mock('../../components/plugins/MarketplaceTab', () => ({ default: () => <div data-testid="marketplace" /> }));
+vi.mock('../../components/plugins/PluginDocumentation', () => ({ default: () => <div data-testid="docs" /> }));
+// real plugin-management barrel components render (already unit-tested); make the
+// plugin-name resolver deterministic so PluginListCard shows the raw display_name
+vi.mock('../../lib/pluginI18n', () => ({ resolvePluginString: (_t: unknown, _k: string, fb: string) => fb }));
+
+import PluginsPage from '../../pages/PluginsPage';
+
+describe('PluginsPage', () => {
+  beforeEach(() => { hookValue.plugins = []; hookValue.selectedPlugin = null; });
+
+  it('shows the empty-state on the plugins tab when there are no plugins', () => {
+    render(<PluginsPage />);
+    expect(screen.getByText('empty.noPlugins')).toBeInTheDocument();
+    // sidebar empty prompt is also present
+    expect(screen.getByText('empty.selectPlugin')).toBeInTheDocument();
+  });
+
+  it('renders the plugin list when plugins exist', () => {
+    hookValue.plugins = [{
+      name: 'demo', version: '1', display_name: 'Demo Plugin', description: '', author: '',
+      category: 'general', required_permissions: [], dangerous_permissions: [],
+      is_enabled: false, has_ui: false, has_routes: false,
+    }];
+    render(<PluginsPage />);
+    expect(screen.getByText('Demo Plugin')).toBeInTheDocument();
+    expect(screen.queryByText('empty.noPlugins')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** → FAIL (page still in old shape / test imports barrel not yet built).
+- [ ] **Step 3: Write the barrel, then rewrite `PluginsPage.tsx`** per the structure above.
+- [ ] **Step 4: Full verification**
+
+Run: `cd client && npx vitest run src/__tests__/pages/PluginsPage.test.tsx`
+Expected: PASS (2 tests).
+Run: `cd client && node -e "console.log(require('fs').readFileSync('src/pages/PluginsPage.tsx','utf8').split(/\r?\n/).length)"`
+Expected: < 500 (target ~130).
+Run: `cd client && npx tsc -b`
+Expected: no errors.
+Run: `cd client && npx eslint src/pages/PluginsPage.tsx src/components/plugins/plugin-management src/hooks/usePluginManagement.ts`
+Expected: 0 errors (no unused imports).
+
+- [ ] **Step 5: Commit** `refactor(plugins): compose PluginsPage from usePluginManagement + plugin-management/* (F2, #301)`.
+
+---
+
+## Final Verification (after all tasks)
+
+- [ ] `cd client && npx eslint .` → 0 errors.
+- [ ] `cd client && npm run build` → green (tsc -b + vite).
+- [ ] `cd client && npx vitest run` → full suite green.
+- [ ] `PluginsPage.tsx` < 500 lines.
+- [ ] Update `client/src/components/CLAUDE.md` (or `pages/CLAUDE.md`) if it catalogs plugin components — add the `plugin-management/` dir; keep docs in sync per CLAUDE.md rules. (Docs-only, fold into the Task 11 commit or a trailing `docs(plugins): ...` commit.)
+- [ ] Multi-agent whole-branch review — READY TO MERGE (field-for-field audit of every moved block, especially the two enable branches in `usePluginManagement` and the two modal guards).

--- a/docs/superpowers/specs/2026-07-11-pluginspage-decomposition-f2-design.md
+++ b/docs/superpowers/specs/2026-07-11-pluginspage-decomposition-f2-design.md
@@ -1,0 +1,178 @@
+# PluginsPage.tsx Decomposition — Design (F2 / #301)
+
+**Date:** 2026-07-11
+**Finding:** F2 (components > 500 lines), umbrella issue #301.
+**Target:** `client/src/pages/PluginsPage.tsx` — currently **691 lines**.
+
+## Goal
+
+Behavior-preserving decomposition of `PluginsPage.tsx` (the admin plugin
+management page) into one data/state hook, one pure helper, and a directory of
+presentational components under a new `components/plugins/plugin-management/`.
+
+**Non-goals:** no change to queries, endpoints, the `usePlugins()` context, i18n
+keys, copy, Tailwind styling, modal behavior, `safeExternalUrl` usage, or any
+computed value. The page keeps its path (`pages/PluginsPage.tsx`, **default
+export** `PluginsPage`) so the router / lazy-load in `App.tsx` is untouched. The
+already-extracted `MarketplaceTab`, `PluginDocumentation`, and
+`PluginSettingsSection` are reused as-is — not modified.
+
+## Constraints
+
+- Every extracted value is **byte-identical** in behavior: same API calls
+  (`getPluginDetails`, `getScopeCatalog`, `listPermissions`, `togglePlugin`,
+  `toggleDashboardPanel`, `uninstallPlugin`), same `.catch(console.error)`
+  swallow on the two mount effects, same error-string i18n keys, same
+  external/internal enable branching, same modal enable-disabled guards.
+- Extracted components are **presentational**: props in, callbacks in, no data
+  fetching. The extracted hook owns all fetching/state.
+- Tests are T7-conform: assert on role/text/title, never Tailwind classes;
+  fixtures are complete objects of the real API types (`PluginInfo`,
+  `PluginDetail`, `PermissionInfo`, `ScopeInfo`).
+
+## Current inline blocks (what moves)
+
+| Block | Current lines | Destination |
+|---|---|---|
+| 11 `useState` + 2 mount effects + all handlers (`loadPluginDetails`, `handleTogglePlugin`, `handleEnableWithPermissions`, `handleEnableWithScopes`, `handleUninstall`) | 44–176 | `hooks/usePluginManagement.ts` |
+| `getCategoryColor` | 178–187 | `plugin-management/pluginCategoryColor.ts` (pure) |
+| Tab navigation (TABS const + bar) | 34–38, 218–233 | `plugin-management/PluginTabNav.tsx` |
+| Plugin list card | 271–334 | `plugin-management/PluginListCard.tsx` |
+| Plugin list (empty-state + map) | 260–337 | `plugin-management/PluginList.tsx` |
+| Details card | 352–399 | `plugin-management/PluginDetailsCard.tsx` |
+| Permissions card | 402–436 | `plugin-management/PluginPermissionsCard.tsx` |
+| Dashboard-panel card | 439–476 | `plugin-management/PluginDashboardPanelCard.tsx` |
+| Actions card | 489–513 | `plugin-management/PluginActionsCard.tsx` |
+| Sidebar container (loading / selected / empty; hosts the 4 cards + `PluginSettingsSection`) | 340–523 | `plugin-management/PluginDetailsSidebar.tsx` |
+| Permission grant modal | 528–594 | `plugin-management/PermissionGrantModal.tsx` |
+| Scope grant modal (IIFE + `byTier`/`renderScope`) | 596–686 | `plugin-management/ScopeGrantModal.tsx` |
+
+## New units & interfaces
+
+### `hooks/usePluginManagement.ts`
+
+```ts
+import type {
+  PluginDetail, PluginInfo, PermissionInfo, ScopeInfo,
+} from '../api/plugins';
+
+export interface UsePluginManagementResult {
+  // passthrough from usePlugins()
+  plugins: PluginInfo[];
+  isLoading: boolean;
+  error: string | null;
+  refreshPlugins: () => Promise<void>;
+  // catalog (mount-loaded)
+  allPermissions: PermissionInfo[];
+  scopeCatalog: ScopeInfo[];
+  // selection + details
+  selectedPlugin: PluginDetail | null;
+  detailsLoading: boolean;
+  actionLoading: boolean;
+  actionError: string | null;
+  loadPluginDetails: (name: string) => Promise<PluginDetail | null>;
+  // toggle / enable / uninstall
+  handleTogglePlugin: (plugin: PluginInfo) => Promise<void>;
+  handleEnableWithPermissions: () => Promise<void>;
+  handleEnableWithScopes: () => Promise<void>;
+  handleUninstall: (name: string) => Promise<void>;
+  handleToggleDashboardPanel: () => Promise<void>;
+  // permission modal
+  showPermissionModal: boolean;
+  setShowPermissionModal: (v: boolean) => void;
+  selectedPermissions: string[];
+  togglePermission: (perm: string) => void;
+  // scope modal
+  showScopeModal: boolean;
+  setShowScopeModal: (v: boolean) => void;
+  selectedScopes: string[];
+  toggleScope: (scope: string) => void;
+  // confirm dialog element (from useConfirmDialog)
+  dialog: React.ReactNode;
+}
+
+export function usePluginManagement(): UsePluginManagementResult;
+```
+
+Body ports every handler verbatim (same `setActionLoading`/`setActionError`
+sequencing, same `refreshPlugins()` + `loadPluginDetails()` follow-ups, same
+`t('errors.*')` keys). `handleToggleDashboardPanel` extracts the inline onClick
+at 453–464 (guards on `selectedPlugin`, calls `toggleDashboardPanel(name,
+!enabled)`, then `loadPluginDetails`, `t('dashboardPanel.enableFailed')` on
+error). `togglePermission`/`toggleScope` replace the inline checkbox
+add/remove logic. The `confirm` + `dialog` come from `useConfirmDialog()`
+inside the hook. `useTranslation(['plugins','common'])` internally for error
+strings.
+
+### `plugin-management/pluginCategoryColor.ts` (pure)
+
+```ts
+export function getCategoryColor(category: string): string;
+```
+
+Verbatim from 178–187: the `Record<string,string>` of Tailwind class strings
+per category (monitoring/storage/network/security/general) with `|| general`
+fallback.
+
+### Presentational components (`components/plugins/plugin-management/`)
+
+- **`PluginTabNav.tsx`** — `{ tabs: { id: TabType; labelKey: string; icon: LucideIcon }[]; activeTab: TabType; onSelect: (id: TabType) => void }`. Renders the tab bar (218–233). `TabType` exported from here; `TABS` const moves here too. `useTranslation` internally.
+- **`PluginListCard.tsx`** — `{ plugin: PluginInfo; isSelected: boolean; actionLoading: boolean; onSelect: (name: string) => void; onToggle: (plugin: PluginInfo) => void }`. One card (271–334): icon, name/version/active badge, description, category (`getCategoryColor`) + UI + review badges, toggle button (with `stopPropagation`), error box. `resolvePluginString` + `useTranslation` internally.
+- **`PluginList.tsx`** — `{ plugins: PluginInfo[]; selectedName: string | null; actionLoading: boolean; onSelect; onToggle }`. Empty-state (262–268) or map of `PluginListCard` (260–337).
+- **`PluginDetailsCard.tsx`** — `{ plugin: PluginDetail }`. The `<dl>` (352–399): version/author/category/homepage(`safeExternalUrl`)/status/installed. `useTranslation` internally.
+- **`PluginPermissionsCard.tsx`** — `{ plugin: PluginDetail }`. Permissions list (402–436), dangerous/granted markers.
+- **`PluginDashboardPanelCard.tsx`** — `{ plugin: PluginDetail; actionLoading: boolean; onToggle: () => void }`. Card (439–476); only rendered when `has_dashboard_panel && is_enabled` (guard stays in the sidebar).
+- **`PluginActionsCard.tsx`** — `{ plugin: PluginDetail; actionLoading: boolean; onConfigure: () => void; onUninstall: (name: string) => void }`. Configure + uninstall (inside `LocalOnlyAction`) + disable-first hint (489–513).
+- **`PluginDetailsSidebar.tsx`** — `{ plugin: PluginDetail | null; detailsLoading: boolean; actionLoading: boolean; onToggleDashboardPanel: () => void; onConfigure: () => void; onUninstall: (name: string) => void }`. Loading skeleton (341–348) / selected (`PluginDetailsCard`, `PluginPermissionsCard`, conditional `PluginDashboardPanelCard`, conditional `PluginSettingsSection`, `PluginActionsCard`) / empty (515–521).
+- **`PermissionGrantModal.tsx`** — `{ plugin: PluginDetail; allPermissions: PermissionInfo[]; selectedPermissions: string[]; onTogglePermission: (perm: string) => void; onCancel: () => void; onConfirm: () => void }`. Modal (528–594); the enable button stays disabled until every `required_permissions` is in `selectedPermissions` (verbatim guard).
+- **`ScopeGrantModal.tsx`** — `{ plugin: PluginDetail; scopeCatalog: ScopeInfo[]; selectedScopes: string[]; onToggleScope: (scope: string) => void; onCancel: () => void; onConfirm: () => void }`. Modal (596–686); the IIFE's `descs`/`requested`/`byTier`/`renderScope` become in-component consts/functions. `scopeDescriptions` via `t(..., { returnObjects: true })` verbatim.
+
+### `plugin-management/index.ts`
+
+Barrel exporting all components + `getCategoryColor` + `TabType`.
+
+### `PluginsPage.tsx` (after)
+
+Calls `usePluginManagement()`. Keeps only `activeTab` state (tab selection is
+pure view state, no data) — everything else comes from the hook. Renders:
+header (title + conditional refresh button), `PluginTabNav`, error banners,
+tab switch (`MarketplaceTab` / `PluginDocumentation` unchanged; `plugins` tab =
+`PluginList` + `PluginDetailsSidebar` in the `grid lg:grid-cols-3` layout),
+`PermissionGrantModal`, `ScopeGrantModal`, `{dialog}`. Target: **~130 lines**
+(from 691).
+
+## Testing
+
+Broad + integration (Vitest, T7-conform):
+
+- **`pluginCategoryColor`** — each known category returns its class string;
+  unknown category falls back to `general`.
+- **`usePluginManagement`** — `renderHook`: `loadPluginDetails` failure sets
+  `actionError` to `errors.loadDetailsFailed` and returns null; enabling an
+  external plugin (`is_external: true`) opens the scope modal seeded with
+  catalog-filtered requested scopes; enabling an internal plugin opens the
+  permission modal; `handleUninstall` with `confirm` resolving `false` makes no
+  `uninstallPlugin` call. Mock `../api/plugins`, `usePlugins`,
+  `useConfirmDialog`.
+- **Component renders** — `PluginListCard` (active badge when enabled, toggle
+  fires with `stopPropagation` not selecting), `PluginList` (empty-state text),
+  `PluginDetailsCard` (values + no homepage row when url unsafe),
+  `PluginPermissionsCard` (noPermissions text; granted vs not),
+  `PluginDashboardPanelCard` (active/inactive label, toggle fires),
+  `PluginActionsCard` (uninstall disabled while enabled), `PluginTabNav`
+  (select fires), `PermissionGrantModal` (enable disabled until all required
+  checked, confirm fires), `ScopeGrantModal` (frontend/backend tier groups
+  render, noScopes branch, grant fires).
+- **Integration** (`__tests__/pages/PluginsPage.test.tsx`) — mock the hook;
+  assert list + sidebar render for a populated fixture; empty `plugins` →
+  empty-state; tab switch shows Marketplace/Documentation.
+
+## Verification gates
+
+- `PluginsPage.tsx` < 500 lines (target ~130).
+- `eslint .` — 0 errors.
+- `npm run build` (tsc -b + vite) — green (mind `import type` for all type-only
+  imports — `verbatimModuleSyntax` is enforced by `tsc -b`, not vitest).
+- `vitest run` — full suite green.
+- Multi-agent whole-branch review — READY TO MERGE (field-for-field audit of
+  every moved block, especially the two enable branches and the modal guards).


### PR DESCRIPTION
## F2 — PluginsPage.tsx zerlegen (#301)

Verhaltenserhaltende Zerlegung von `client/src/pages/PluginsPage.tsx` — **691 → 153 Zeilen** — in einen Daten-/State-Hook, einen pure Helper und 10 Präsentations-Komponenten unter `components/plugins/plugin-management/`.

### Aufbau

| Unit | Rolle |
|---|---|
| `hooks/usePluginManagement.ts` | Aller State + Handler (load/toggle/enable×2/uninstall/dashboard-panel) + `useConfirmDialog`; kapselt beide Mount-Effects |
| `plugin-management/pluginCategoryColor.ts` | pure Helper (Kategorie→Klassen-Map) |
| `PluginTabNav` | Tab-Leiste |
| `PluginListCard` / `PluginList` | Karte + Liste (Empty-State) |
| `PluginDetailsCard` / `PluginPermissionsCard` / `PluginDashboardPanelCard` / `PluginActionsCard` | die 4 Sidebar-Karten |
| `PluginDetailsSidebar` | orchestriert die 4 Karten + `PluginSettingsSection` + Loading/Empty-Zweige |
| `PermissionGrantModal` / `ScopeGrantModal` | die zwei Modals (Scope-IIFE → sauberes Component) |
| `index.ts` | Barrel |

`PluginsPage.tsx` behält nur `activeTab` (reiner View-State), alles andere aus dem Hook. `MarketplaceTab`/`PluginDocumentation`/`PluginSettingsSection` unverändert wiederverwendet.

### Verhalten byte-identisch

Gleiche API-Calls, gleiche `.catch(console.error)`-Mount-Effects, gleiche i18n-Keys, gleiche external-vs-intern-Enable-Verzweigung (external → Scope-Modal mit katalog-gefilterten `requested_api_scopes`; intern → Permission-Modal), gleiche Enable-Payloads (`grant_permissions`/`grant_api_scopes`), gleiche Modal-disabled-Guards und Sidebar-Guards. DOM/Tailwind unverändert (ein redundanter col-span-Wrapper wurde entfernt, damit die Grid exakt zwei Kinder hat wie im Original).

### Tests & Gates

Jede Unit hat eigene Vitest-Abdeckung (T7-konform: role/text/title, keine Tailwind-Assertions; vollständige Fixtures der echten API-Typen; Tests zielen auf konkrete Zweige/Callbacks/Guards — inkl. der beiden Enable-Payloads und beider Modal-Guards).

- `eslint .` — 0 Fehler
- `npm run build` (tsc -b + vite) — grün
- `vitest run` — **186 Dateien / 834 Tests grün**
- Multi-Agent Whole-Branch-Review (opus) — **READY TO MERGE** (0 Critical/Important; feldweise gegen das Original geprüft)

Teil des F2-Umbrella #301 (God-Components > 500 Zeilen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
