### PR TITLE
refactor(ssd-cache): decompose SsdFileCacheTab into useSsdFileCache + file-cache/* (#301) [F2]

### DIFF
--- a/client/src/__tests__/components/ssd-cache/SsdFileCacheTab.test.tsx
+++ b/client/src/__tests__/components/ssd-cache/SsdFileCacheTab.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { SSDCacheStats, SSDCacheConfigResponse } from '../../../api/ssd-file-cache';
+import type { UseSsdFileCacheResult } from '../../../hooks/useSsdFileCache';
+
+const stats: SSDCacheStats = {
+  array_name: 'md0', is_enabled: true, cache_path: '/ssd', max_size_bytes: 1024,
+  current_size_bytes: 512, usage_percent: 50, total_entries: 1, valid_entries: 1,
+  total_hits: 5, total_misses: 1, hit_rate_percent: 83.3, total_bytes_served: 100,
+  ssd_available_bytes: 900, ssd_total_bytes: 1024,
+};
+const config: SSDCacheConfigResponse = {
+  array_name: 'md0', is_enabled: true, cache_path: '/ssd', max_size_bytes: 1024,
+  current_size_bytes: 512, eviction_policy: 'lfru', min_file_size_bytes: 1,
+  max_file_size_bytes: 100, sequential_cutoff_bytes: 50, total_hits: 5,
+  total_misses: 1, total_bytes_served_from_cache: 100, updated_at: null,
+};
+
+const hookValue: UseSsdFileCacheResult = {
+  tabView: 'cache', setTabView: vi.fn(), arrays: ['md0'], selectedArray: 'md0',
+  setSelectedArray: vi.fn(), stats, config, health: null, entries: [], entriesTotal: 0,
+  loading: false, error: null, actionLoading: false, configForm: {}, configDirty: false,
+  page: 0, setPage: vi.fn(), pageSize: 20, handleConfigChange: vi.fn(),
+  handleSaveConfig: vi.fn(), resetConfigForm: vi.fn(), handleEvictEntry: vi.fn(),
+  handleTriggerEviction: vi.fn(), handleClearCache: vi.fn(), loadData: vi.fn(),
+  loadEntries: vi.fn(), dialog: null,
+};
+vi.mock('../../../hooks/useSsdFileCache', () => ({ useSsdFileCache: () => hookValue }));
+vi.mock('../../../components/ssd-cache/MigrationPanel', () => ({ default: () => <div data-testid="migration" /> }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (_k: string, fb: string) => fb }) }));
+
+import SsdFileCacheTab from '../../../components/ssd-cache/SsdFileCacheTab';
+
+describe('SsdFileCacheTab', () => {
+  beforeEach(() => {
+    Object.assign(hookValue, { tabView: 'cache', arrays: ['md0'], stats, config, loading: false });
+  });
+
+  it('renders the cache view (stats + config + actions) for a populated fixture', () => {
+    render(<SsdFileCacheTab />);
+    expect(screen.getByText('Enabled')).toBeInTheDocument();      // stats grid
+    expect(screen.getByText('Configuration')).toBeInTheDocument(); // config card
+    expect(screen.getByRole('heading', { name: 'Actions' })).toBeInTheDocument(); // actions card (getByText collides with the entries table's "Actions" column header)
+    expect(screen.queryByTestId('migration')).not.toBeInTheDocument();
+  });
+
+  it('renders MigrationPanel when tabView is migration', () => {
+    hookValue.tabView = 'migration';
+    render(<SsdFileCacheTab />);
+    expect(screen.getByTestId('migration')).toBeInTheDocument();
+    expect(screen.queryByText('Configuration')).not.toBeInTheDocument();
+  });
+
+  it('shows the no-arrays message when there are no arrays', () => {
+    Object.assign(hookValue, { arrays: [], loading: false, stats: null });
+    render(<SsdFileCacheTab />);
+    expect(screen.getByText(/No RAID arrays found/)).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/ssd-cache/file-cache/CacheActionsCard.test.tsx
+++ b/client/src/__tests__/components/ssd-cache/file-cache/CacheActionsCard.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CacheActionsCard } from '../../../../components/ssd-cache/file-cache/CacheActionsCard';
+
+describe('CacheActionsCard', () => {
+  it('fires each action callback on its button', () => {
+    const onTriggerEviction = vi.fn(), onClearCache = vi.fn(), onRefresh = vi.fn();
+    render(<CacheActionsCard actionLoading={false}
+      onTriggerEviction={onTriggerEviction} onClearCache={onClearCache} onRefresh={onRefresh} />);
+    fireEvent.click(screen.getByText('Trigger Eviction'));
+    fireEvent.click(screen.getByText('Clear Cache'));
+    fireEvent.click(screen.getByText('Refresh'));
+    expect(onTriggerEviction).toHaveBeenCalledTimes(1);
+    expect(onClearCache).toHaveBeenCalledTimes(1);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+  it('disables all buttons while an action is loading', () => {
+    render(<CacheActionsCard actionLoading={true}
+      onTriggerEviction={() => {}} onClearCache={() => {}} onRefresh={() => {}} />);
+    for (const label of ['Trigger Eviction', 'Clear Cache', 'Refresh']) {
+      expect(screen.getByText(label).closest('button')).toBeDisabled();
+    }
+  });
+});

--- a/client/src/__tests__/components/ssd-cache/file-cache/CacheArraySelector.test.tsx
+++ b/client/src/__tests__/components/ssd-cache/file-cache/CacheArraySelector.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CacheArraySelector } from '../../../../components/ssd-cache/file-cache/CacheArraySelector';
+
+describe('CacheArraySelector', () => {
+  it('renders one button per array', () => {
+    render(<CacheArraySelector arrays={['md0', 'md1']} selectedArray="md0" onSelect={() => {}} />);
+    expect(screen.getByText('md0')).toBeInTheDocument();
+    expect(screen.getByText('md1')).toBeInTheDocument();
+  });
+  it('fires onSelect with the clicked array name', () => {
+    const onSelect = vi.fn();
+    render(<CacheArraySelector arrays={['md0', 'md1']} selectedArray="md0" onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('md1'));
+    expect(onSelect).toHaveBeenCalledWith('md1');
+  });
+});

--- a/client/src/__tests__/components/ssd-cache/file-cache/CacheConfigCard.test.tsx
+++ b/client/src/__tests__/components/ssd-cache/file-cache/CacheConfigCard.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { SSDCacheConfigUpdate, SSDCacheConfigResponse } from '../../../../api/ssd-file-cache';
+import { CacheConfigCard } from '../../../../components/ssd-cache/file-cache/CacheConfigCard';
+
+const config: SSDCacheConfigResponse = {
+  array_name: 'md0', is_enabled: true, cache_path: '/ssd', max_size_bytes: 1024,
+  current_size_bytes: 512, eviction_policy: 'lfru', min_file_size_bytes: 1,
+  max_file_size_bytes: 100, sequential_cutoff_bytes: 50, total_hits: 0,
+  total_misses: 0, total_bytes_served_from_cache: 0, updated_at: null,
+};
+const form: SSDCacheConfigUpdate = {
+  is_enabled: true, max_size_bytes: 1024, eviction_policy: 'lfru',
+  min_file_size_bytes: 1, max_file_size_bytes: 100, sequential_cutoff_bytes: 50,
+};
+const base = {
+  configForm: form, config, actionLoading: false,
+  onConfigChange: () => {}, onSave: () => {}, onReset: () => {},
+};
+
+describe('CacheConfigCard', () => {
+  it('disables Save when not dirty and enables it when dirty', () => {
+    const { rerender } = render(<CacheConfigCard {...base} configDirty={false} />);
+    expect(screen.getByText('Save Configuration').closest('button')).toBeDisabled();
+    rerender(<CacheConfigCard {...base} configDirty={true} />);
+    expect(screen.getByText('Save Configuration').closest('button')).not.toBeDisabled();
+  });
+  it('shows the Reset button only when dirty', () => {
+    const { rerender } = render(<CacheConfigCard {...base} configDirty={false} />);
+    expect(screen.queryByText('Reset')).not.toBeInTheDocument();
+    rerender(<CacheConfigCard {...base} configDirty={true} />);
+    expect(screen.getByText('Reset')).toBeInTheDocument();
+  });
+  it('fires onConfigChange when the enabled checkbox toggles', () => {
+    const onConfigChange = vi.fn();
+    render(<CacheConfigCard {...base} configDirty={false} onConfigChange={onConfigChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onConfigChange).toHaveBeenCalledWith('is_enabled', false);
+  });
+  it('fires onSave when Save is clicked (dirty)', () => {
+    const onSave = vi.fn();
+    render(<CacheConfigCard {...base} configDirty={true} onSave={onSave} />);
+    fireEvent.click(screen.getByText('Save Configuration'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/__tests__/components/ssd-cache/file-cache/CacheEntriesTable.test.tsx
+++ b/client/src/__tests__/components/ssd-cache/file-cache/CacheEntriesTable.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { SSDCacheEntryResponse } from '../../../../api/ssd-file-cache';
+import { CacheEntriesTable } from '../../../../components/ssd-cache/file-cache/CacheEntriesTable';
+
+const entry = (over: Partial<SSDCacheEntryResponse> = {}): SSDCacheEntryResponse => ({
+  id: 1, array_name: 'md0', source_path: '/data/file.bin', file_size_bytes: 2048,
+  access_count: 7, last_accessed: '2026-07-01T10:00:00Z', first_cached: '2026-06-01T10:00:00Z',
+  is_valid: true, ...over,
+});
+const base = { entriesTotal: 1, page: 0, totalPages: 1, actionLoading: false,
+  onEvict: () => {}, onPrevPage: () => {}, onNextPage: () => {} };
+
+describe('CacheEntriesTable', () => {
+  it('renders the empty-state row when there are no entries', () => {
+    render(<CacheEntriesTable {...base} entries={[]} entriesTotal={0} />);
+    expect(screen.getByText('No cached entries')).toBeInTheDocument();
+  });
+  it('renders a row per entry and fires onEvict with the entry id', () => {
+    const onEvict = vi.fn();
+    render(<CacheEntriesTable {...base} entries={[entry({ id: 42 })]} onEvict={onEvict} />);
+    expect(screen.getByText('/data/file.bin')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Evict'));
+    expect(onEvict).toHaveBeenCalledWith(42);
+  });
+  it('hides pagination when there is only one page', () => {
+    render(<CacheEntriesTable {...base} entries={[entry()]} totalPages={1} />);
+    expect(screen.queryByText(/Page 1 of/)).not.toBeInTheDocument();
+  });
+  it('disables prev on the first page and next on the last page, firing callbacks otherwise', () => {
+    const onPrevPage = vi.fn(), onNextPage = vi.fn();
+    // the Evict button has text; the two pagination controls are icon-only (empty textContent)
+    const iconButtons = () => screen.getAllByRole('button').filter((b) => !b.textContent?.trim());
+    const { rerender } = render(
+      <CacheEntriesTable {...base} entries={[entry()]} page={0} totalPages={3}
+        onPrevPage={onPrevPage} onNextPage={onNextPage} />,
+    );
+    expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument();
+    const [prev0, next0] = iconButtons(); // DOM order: ChevronLeft (prev), ChevronRight (next)
+    expect(prev0).toBeDisabled();          // first page → prev disabled
+    expect(next0).not.toBeDisabled();
+    fireEvent.click(next0);
+    expect(onNextPage).toHaveBeenCalledTimes(1);
+    rerender(
+      <CacheEntriesTable {...base} entries={[entry()]} page={2} totalPages={3}
+        onPrevPage={onPrevPage} onNextPage={onNextPage} />,
+    );
+    expect(screen.getByText(/Page 3 of 3/)).toBeInTheDocument();
+    const [prev2, next2] = iconButtons();
+    expect(next2).toBeDisabled();           // last page → next disabled
+    expect(prev2).not.toBeDisabled();
+  });
+});

--- a/client/src/__tests__/components/ssd-cache/file-cache/CacheHealthCard.test.tsx
+++ b/client/src/__tests__/components/ssd-cache/file-cache/CacheHealthCard.test.tsx
@@ -1,0 +1,22 @@
+// CacheHealthCard.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { CacheHealthResponse } from '../../../../api/ssd-file-cache';
+import { CacheHealthCard } from '../../../../components/ssd-cache/file-cache/CacheHealthCard';
+
+const health = (over: Partial<CacheHealthResponse> = {}): CacheHealthResponse => ({
+  array_name: 'md0', is_mounted: true, ssd_total_bytes: 1024, ssd_available_bytes: 900,
+  ssd_used_percent: 12.5, cache_dir_exists: true, ...over,
+});
+
+describe('CacheHealthCard', () => {
+  it('shows Mounted when the ssd is mounted', () => {
+    render(<CacheHealthCard health={health({ is_mounted: true })} />);
+    expect(screen.getByText('Mounted')).toBeInTheDocument();
+  });
+  it('shows Not Mounted and Missing when unmounted with no cache dir', () => {
+    render(<CacheHealthCard health={health({ is_mounted: false, cache_dir_exists: false })} />);
+    expect(screen.getByText('Not Mounted')).toBeInTheDocument();
+    expect(screen.getByText('Missing')).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/ssd-cache/file-cache/CacheStatsGrid.test.tsx
+++ b/client/src/__tests__/components/ssd-cache/file-cache/CacheStatsGrid.test.tsx
@@ -1,0 +1,27 @@
+// CacheStatsGrid.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { SSDCacheStats } from '../../../../api/ssd-file-cache';
+import { CacheStatsGrid } from '../../../../components/ssd-cache/file-cache/CacheStatsGrid';
+
+const stats = (over: Partial<SSDCacheStats> = {}): SSDCacheStats => ({
+  array_name: 'md0', is_enabled: true, cache_path: '/ssd', max_size_bytes: 1024,
+  current_size_bytes: 512, usage_percent: 50, total_entries: 3, valid_entries: 2,
+  total_hits: 10, total_misses: 5, hit_rate_percent: 66.7, total_bytes_served: 2048,
+  ssd_available_bytes: 900, ssd_total_bytes: 1024, ...over,
+});
+
+describe('CacheStatsGrid', () => {
+  it('shows Enabled status when enabled', () => {
+    render(<CacheStatsGrid stats={stats({ is_enabled: true })} />);
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+  });
+  it('shows Disabled status when disabled', () => {
+    render(<CacheStatsGrid stats={stats({ is_enabled: false })} />);
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+  });
+  it('renders the hit-rate percentage', () => {
+    render(<CacheStatsGrid stats={stats({ hit_rate_percent: 66.7 })} />);
+    expect(screen.getByText('66.7%')).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/ssd-cache/file-cache/CacheViewTabs.test.tsx
+++ b/client/src/__tests__/components/ssd-cache/file-cache/CacheViewTabs.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (_k: string, fb: string) => fb }) }));
+import { CacheViewTabs } from '../../../../components/ssd-cache/file-cache/CacheViewTabs';
+
+describe('CacheViewTabs', () => {
+  it('renders both view tabs', () => {
+    render(<CacheViewTabs tabView="cache" onSelect={() => {}} />);
+    expect(screen.getByText('File Cache')).toBeInTheDocument();
+    expect(screen.getByText('Data Migration')).toBeInTheDocument();
+  });
+  it('fires onSelect with the clicked view', () => {
+    const onSelect = vi.fn();
+    render(<CacheViewTabs tabView="cache" onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('Data Migration'));
+    expect(onSelect).toHaveBeenCalledWith('migration');
+  });
+});

--- a/client/src/__tests__/components/ssd-cache/file-cache/cacheUsageBarColor.test.ts
+++ b/client/src/__tests__/components/ssd-cache/file-cache/cacheUsageBarColor.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { cacheUsageBarColor } from '../../../../components/ssd-cache/file-cache/cacheUsageBarColor';
+
+describe('cacheUsageBarColor', () => {
+  it('returns red at/above 90%', () => {
+    expect(cacheUsageBarColor(95)).toBe('bg-red-500');
+    expect(cacheUsageBarColor(90)).toBe('bg-red-500');
+  });
+  it('returns amber at/above 70% and below 90%', () => {
+    expect(cacheUsageBarColor(75)).toBe('bg-amber-500');
+    expect(cacheUsageBarColor(70)).toBe('bg-amber-500');
+  });
+  it('returns cyan below 70%', () => {
+    expect(cacheUsageBarColor(50)).toBe('bg-cyan-500');
+    expect(cacheUsageBarColor(0)).toBe('bg-cyan-500');
+  });
+});

--- a/client/src/__tests__/hooks/useSsdFileCache.test.ts
+++ b/client/src/__tests__/hooks/useSsdFileCache.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { SSDCacheStats, SSDCacheConfigResponse, CacheHealthResponse } from '../../api/ssd-file-cache';
+
+vi.mock('../../api/raid', () => ({
+  getRaidStatus: vi.fn().mockResolvedValue({ arrays: [{ name: 'md0' }] }),
+}));
+const mockConfirm = vi.fn();
+vi.mock('../../hooks/useConfirmDialog', () => ({
+  useConfirmDialog: () => ({ confirm: mockConfirm, dialog: null }),
+}));
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('../../lib/errorHandling', () => ({
+  getApiErrorMessage: (_e: unknown, fb: string) => fb,
+  handleApiError: vi.fn(),
+}));
+
+// vi.mock factories are hoisted above ordinary top-level `const`s, so the
+// shared fixtures below must go through vi.hoisted() (same pattern as
+// useFileUpload.test.tsx) or the ssd-file-cache mock factory below hits a
+// TDZ ReferenceError on `stats`/`config`/`health`.
+const { stats, config, health } = vi.hoisted(() => {
+  const stats: SSDCacheStats = {
+    array_name: 'md0', is_enabled: true, cache_path: '/ssd', max_size_bytes: 1000,
+    current_size_bytes: 500, usage_percent: 50, total_entries: 3, valid_entries: 3,
+    total_hits: 10, total_misses: 2, hit_rate_percent: 83.3, total_bytes_served: 999,
+    ssd_available_bytes: 800, ssd_total_bytes: 1000,
+  };
+  const config: SSDCacheConfigResponse = {
+    array_name: 'md0', is_enabled: true, cache_path: '/ssd', max_size_bytes: 1000,
+    current_size_bytes: 500, eviction_policy: 'lfru', min_file_size_bytes: 1,
+    max_file_size_bytes: 100, sequential_cutoff_bytes: 50, total_hits: 10,
+    total_misses: 2, total_bytes_served_from_cache: 999, updated_at: null,
+  };
+  const health: CacheHealthResponse = {
+    array_name: 'md0', is_mounted: true, ssd_total_bytes: 1000,
+    ssd_available_bytes: 800, ssd_used_percent: 20, cache_dir_exists: true,
+  };
+  return { stats, config, health };
+});
+
+vi.mock('../../api/ssd-file-cache', () => ({
+  getCacheStats: vi.fn().mockResolvedValue(stats),
+  getCacheConfig: vi.fn().mockResolvedValue(config),
+  getCacheHealth: vi.fn().mockResolvedValue(health),
+  getCacheEntries: vi.fn().mockResolvedValue({ entries: [], total: 0 }),
+  updateCacheConfig: vi.fn().mockResolvedValue(config),
+  evictEntry: vi.fn().mockResolvedValue({ freed_bytes: 10, source_path: '/x' }),
+  triggerEviction: vi.fn().mockResolvedValue({ freed_bytes: 10, deleted_count: 1 }),
+  clearCache: vi.fn().mockResolvedValue({ freed_bytes: 10, deleted_count: 1 }),
+}));
+
+import { useSsdFileCache } from '../../hooks/useSsdFileCache';
+import * as api from '../../api/ssd-file-cache';
+
+describe('useSsdFileCache', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('auto-selects the sole array on mount and loads its data', async () => {
+    const { result } = renderHook(() => useSsdFileCache());
+    await waitFor(() => expect(result.current.selectedArray).toBe('md0'));
+    await waitFor(() => expect(result.current.stats).not.toBeNull());
+    expect(result.current.config).not.toBeNull();
+  });
+
+  it('does not call clearCache when the confirm dialog is declined', async () => {
+    mockConfirm.mockResolvedValueOnce(false);
+    const { result } = renderHook(() => useSsdFileCache('md0'));
+    await waitFor(() => expect(result.current.selectedArray).toBe('md0'));
+    await act(async () => { await result.current.handleClearCache(); });
+    expect(api.clearCache).not.toHaveBeenCalled();
+  });
+
+  it('handleConfigChange marks the form dirty and updates the field', async () => {
+    const { result } = renderHook(() => useSsdFileCache('md0'));
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+    act(() => result.current.handleConfigChange('is_enabled', false));
+    expect(result.current.configDirty).toBe(true);
+    expect(result.current.configForm.is_enabled).toBe(false);
+  });
+
+  it('handleSaveConfig sends the current form to updateCacheConfig', async () => {
+    const { result } = renderHook(() => useSsdFileCache('md0'));
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+    act(() => result.current.handleConfigChange('max_size_bytes', 2048));
+    await act(async () => { await result.current.handleSaveConfig(); });
+    expect(api.updateCacheConfig).toHaveBeenCalledWith(
+      'md0', expect.objectContaining({ max_size_bytes: 2048 }),
+    );
+  });
+});

--- a/client/src/components/CLAUDE.md
+++ b/client/src/components/CLAUDE.md
@@ -61,7 +61,7 @@ Reusable, generic building blocks. No business logic, no API calls.
 | `settings/` | Settings page sections |
 | `shares/` | Share management — `SharesPage` composes `SharesStatCards`, `SharesTabBar`, `SharesToolbar`, `MySharesTable`, `SharedWithMeTable`, `CloudExportsTable` (+ `PermissionBadges`/`FileNameCell`/`CloudStatusBadge` primitives), extracted F2/#301-style |
 | `smart-devices/` | Smart device status and control |
-| `ssd-cache/` | SSD file cache management |
+| `ssd-cache/` | SSD file cache management — `SsdFileCacheTab` composes `file-cache/*`: `CacheViewTabs`, `CacheArraySelector`, `CacheStatsGrid`, `CacheHealthCard`, `CacheConfigCard`, `CacheActionsCard`, `CacheEntriesTable` (+ `cacheUsageBarColor` helper), re-exported via `file-cache/index.ts`; state/effects/handlers in `hooks/useSsdFileCache.ts` (extracted F2/#301) |
 | `system-monitor/` | System monitor detail views — `PowerTab` composes `power-tab/*`: `PowerSummaryCards`, `PowerDeviceCard`, `EnergyPriceEditor`, `ChartDeviceTabs`, `ChartModePeriodControls`, `CustomRangePicker`, `EnergyChartSummary`, `EnergyChart` (+ `CumulativeEnergyChart`/`InstantPowerChart`), `PowerStates`, and the `parseDevicePower` pure helper — extracted F2/#301 |
 | `updates/` | Self-update UI |
 | `user-management/` | User CRUD, 2FA management |

--- a/client/src/components/ssd-cache/SsdFileCacheTab.tsx
+++ b/client/src/components/ssd-cache/SsdFileCacheTab.tsx
@@ -3,241 +3,56 @@
  * Array selector, stats, health, configuration, entries table, and cache actions.
  */
 
-import { useState, useEffect } from 'react';
-import {
-  Zap,
-  HardDrive,
-  Activity,
-  BarChart3,
-  Settings,
-  Trash2,
-  RefreshCw,
-  AlertCircle,
-  Check,
-  X,
-  ChevronLeft,
-  ChevronRight,
-  Heart,
-  ArrowRightLeft,
-} from 'lucide-react';
-import toast from 'react-hot-toast';
-import { getApiErrorMessage, handleApiError } from '../../lib/errorHandling';
-import { useTranslation } from 'react-i18next';
-import { formatBytes } from '../../lib/formatters';
-import { ByteSizeInput } from '../ui/ByteSizeInput';
-import { useConfirmDialog } from '../../hooks/useConfirmDialog';
+import { AlertCircle } from 'lucide-react';
 import MigrationPanel from './MigrationPanel';
-import { getRaidStatus } from '../../api/raid';
+import { useSsdFileCache } from '../../hooks/useSsdFileCache';
 import {
-  getCacheStats,
-  getCacheConfig,
-  updateCacheConfig,
-  getCacheEntries,
-  evictEntry,
-  triggerEviction,
-  clearCache,
-  getCacheHealth,
-} from '../../api/ssd-file-cache';
-import type {
-  SSDCacheStats,
-  SSDCacheConfigResponse,
-  SSDCacheConfigUpdate,
-  SSDCacheEntryResponse,
-  CacheHealthResponse,
-} from '../../api/ssd-file-cache';
+  CacheViewTabs,
+  CacheArraySelector,
+  CacheStatsGrid,
+  CacheHealthCard,
+  CacheConfigCard,
+  CacheActionsCard,
+  CacheEntriesTable,
+} from './file-cache';
 
 interface SsdFileCacheTabProps {
   /** Pre-select a specific array (e.g. from RAID card link) */
   initialArray?: string;
 }
 
-type TabView = 'cache' | 'migration';
-
 export default function SsdFileCacheTab({ initialArray }: SsdFileCacheTabProps) {
-  const { t } = useTranslation();
-  const [tabView, setTabView] = useState<TabView>('cache');
-  const [arrays, setArrays] = useState<string[]>([]);
-  const [selectedArray, setSelectedArray] = useState<string>(initialArray ?? '');
-  const [stats, setStats] = useState<SSDCacheStats | null>(null);
-  const [config, setConfig] = useState<SSDCacheConfigResponse | null>(null);
-  const [health, setHealth] = useState<CacheHealthResponse | null>(null);
-  const [entries, setEntries] = useState<SSDCacheEntryResponse[]>([]);
-  const [entriesTotal, setEntriesTotal] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [actionLoading, setActionLoading] = useState(false);
+  const {
+    tabView,
+    setTabView,
+    arrays,
+    selectedArray,
+    setSelectedArray,
+    stats,
+    config,
+    health,
+    entries,
+    entriesTotal,
+    loading,
+    error,
+    actionLoading,
+    configForm,
+    configDirty,
+    page,
+    setPage,
+    pageSize,
+    handleConfigChange,
+    handleSaveConfig,
+    resetConfigForm,
+    handleEvictEntry,
+    handleTriggerEviction,
+    handleClearCache,
+    loadData,
+    loadEntries,
+    dialog,
+  } = useSsdFileCache(initialArray);
 
-  // Config form
-  const [configForm, setConfigForm] = useState<SSDCacheConfigUpdate>({});
-  const [configDirty, setConfigDirty] = useState(false);
-
-  // Pagination
-  const [page, setPage] = useState(0);
-  const pageSize = 20;
-
-  const { confirm, dialog } = useConfirmDialog();
-
-  // Load available arrays on mount
-  useEffect(() => {
-    loadArrays();
-  }, []);
-
-  // Load data when selected array changes
-  useEffect(() => {
-    if (selectedArray) {
-      loadData();
-      setPage(0);
-    }
-  }, [selectedArray]);
-
-  useEffect(() => {
-    if (selectedArray) {
-      loadEntries();
-    }
-  }, [page, selectedArray]);
-
-  const loadArrays = async () => {
-    try {
-      const status = await getRaidStatus();
-      const arrayNames = (status.arrays ?? []).map((a) => a.name);
-      setArrays(arrayNames);
-
-      // Auto-select
-      if (initialArray && arrayNames.includes(initialArray)) {
-        setSelectedArray(initialArray);
-      } else if (arrayNames.length === 1) {
-        setSelectedArray(arrayNames[0]);
-      } else if (arrayNames.length > 0 && !selectedArray) {
-        setSelectedArray(arrayNames[0]);
-      }
-    } catch {
-      setError('Failed to load RAID arrays');
-      setLoading(false);
-    }
-  };
-
-  const loadData = async () => {
-    if (!selectedArray) return;
-    try {
-      setLoading(true);
-      setError(null);
-      const [statsData, configData, healthData] = await Promise.all([
-        getCacheStats(selectedArray),
-        getCacheConfig(selectedArray),
-        getCacheHealth(selectedArray),
-      ]);
-      setStats(statsData);
-      setConfig(configData);
-      setHealth(healthData);
-      resetConfigForm(configData);
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, 'Failed to load SSD cache data'));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const loadEntries = async () => {
-    if (!selectedArray) return;
-    try {
-      const data = await getCacheEntries(selectedArray, pageSize, page * pageSize);
-      setEntries(data.entries);
-      setEntriesTotal(data.total);
-    } catch {
-      // Stats/config already showed error if needed
-    }
-  };
-
-  const resetConfigForm = (cfg: SSDCacheConfigResponse) => {
-    setConfigForm({
-      is_enabled: cfg.is_enabled,
-      max_size_bytes: cfg.max_size_bytes,
-      eviction_policy: cfg.eviction_policy as 'lfru' | 'lru' | 'lfu',
-      min_file_size_bytes: cfg.min_file_size_bytes,
-      max_file_size_bytes: cfg.max_file_size_bytes,
-      sequential_cutoff_bytes: cfg.sequential_cutoff_bytes,
-    });
-    setConfigDirty(false);
-  };
-
-  const handleConfigChange = (key: keyof SSDCacheConfigUpdate, value: unknown) => {
-    setConfigForm((prev) => ({ ...prev, [key]: value }));
-    setConfigDirty(true);
-  };
-
-  const handleSaveConfig = async () => {
-    if (!selectedArray) return;
-    try {
-      setActionLoading(true);
-      const updated = await updateCacheConfig(selectedArray, configForm);
-      setConfig(updated);
-      resetConfigForm(updated);
-      toast.success('Cache configuration saved');
-      const newStats = await getCacheStats(selectedArray);
-      setStats(newStats);
-    } catch (err: unknown) {
-      handleApiError(err, 'Failed to save configuration');
-    } finally {
-      setActionLoading(false);
-    }
-  };
-
-  const handleEvictEntry = async (entryId: number) => {
-    if (!selectedArray) return;
-    try {
-      setActionLoading(true);
-      const result = await evictEntry(selectedArray, entryId);
-      toast.success(`Evicted: ${result.source_path} (${formatBytes(result.freed_bytes)} freed)`);
-      loadEntries();
-      const newStats = await getCacheStats(selectedArray);
-      setStats(newStats);
-    } catch (err: unknown) {
-      handleApiError(err, 'Failed to evict entry');
-    } finally {
-      setActionLoading(false);
-    }
-  };
-
-  const handleTriggerEviction = async () => {
-    if (!selectedArray) return;
-    try {
-      setActionLoading(true);
-      const result = await triggerEviction(selectedArray);
-      toast.success(`Eviction complete: ${result.deleted_count} entries removed, ${formatBytes(result.freed_bytes)} freed`);
-      loadData();
-      loadEntries();
-    } catch (err: unknown) {
-      handleApiError(err, 'Eviction failed');
-    } finally {
-      setActionLoading(false);
-    }
-  };
-
-  const handleClearCache = async () => {
-    if (!selectedArray) return;
-    const ok = await confirm(
-      `This will delete all cached files for ${selectedArray} from the SSD. This action cannot be undone.`,
-      {
-        title: 'Clear Entire Cache',
-        variant: 'danger',
-        confirmLabel: 'Clear Cache',
-      }
-    );
-    if (!ok) return;
-
-    try {
-      setActionLoading(true);
-      const result = await clearCache(selectedArray);
-      toast.success(`Cache cleared: ${result.deleted_count} entries removed, ${formatBytes(result.freed_bytes)} freed`);
-      loadData();
-      setPage(0);
-      loadEntries();
-    } catch (err: unknown) {
-      handleApiError(err, 'Failed to clear cache');
-    } finally {
-      setActionLoading(false);
-    }
-  };
+  const totalPages = Math.ceil(entriesTotal / pageSize);
 
   if (loading && !selectedArray) {
     return (
@@ -267,60 +82,16 @@ export default function SsdFileCacheTab({ initialArray }: SsdFileCacheTabProps) 
     );
   }
 
-  const totalPages = Math.ceil(entriesTotal / pageSize);
-
   return (
     <div className="space-y-6">
-      {/* View Tabs */}
-      <div className="flex items-center gap-2">
-        <button
-          onClick={() => setTabView('cache')}
-          className={`px-3 py-1.5 rounded-lg text-sm font-medium transition flex items-center gap-1.5 ${
-            tabView === 'cache'
-              ? 'bg-sky-500/20 text-sky-300 border border-sky-500/40'
-              : 'bg-slate-800/60 text-slate-400 border border-slate-700/50 hover:border-slate-600'
-          }`}
-        >
-          <Zap className="w-4 h-4" />
-          {t('ssdCache.migration.cacheTab', 'File Cache')}
-        </button>
-        <button
-          onClick={() => setTabView('migration')}
-          className={`px-3 py-1.5 rounded-lg text-sm font-medium transition flex items-center gap-1.5 ${
-            tabView === 'migration'
-              ? 'bg-sky-500/20 text-sky-300 border border-sky-500/40'
-              : 'bg-slate-800/60 text-slate-400 border border-slate-700/50 hover:border-slate-600'
-          }`}
-        >
-          <ArrowRightLeft className="w-4 h-4" />
-          {t('ssdCache.migration.title', 'Data Migration')}
-        </button>
-      </div>
+      <CacheViewTabs tabView={tabView} onSelect={setTabView} />
 
       {tabView === 'migration' ? (
         <MigrationPanel />
       ) : (
       <>
-      {/* Array Selector */}
       {arrays.length > 1 && (
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-slate-400">Array:</span>
-          <div className="flex gap-1.5">
-            {arrays.map((name) => (
-              <button
-                key={name}
-                onClick={() => setSelectedArray(name)}
-                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition ${
-                  name === selectedArray
-                    ? 'bg-sky-500/20 text-sky-300 border border-sky-500/40'
-                    : 'bg-slate-800/60 text-slate-400 border border-slate-700/50 hover:border-slate-600'
-                }`}
-              >
-                {name}
-              </button>
-            ))}
-          </div>
-        </div>
+        <CacheArraySelector arrays={arrays} selectedArray={selectedArray} onSelect={setSelectedArray} />
       )}
 
       {loading ? (
@@ -329,322 +100,37 @@ export default function SsdFileCacheTab({ initialArray }: SsdFileCacheTabProps) 
         </div>
       ) : stats && config ? (
         <>
-          {/* Stats Grid */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-            {/* Status */}
-            <div className="card border-slate-800/60 bg-slate-900/55">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-slate-400 text-sm">Status</p>
-                  <div className="flex items-center gap-2 mt-1">
-                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
-                      stats.is_enabled
-                        ? 'bg-emerald-500/20 text-emerald-300'
-                        : 'bg-red-500/20 text-red-300'
-                    }`}>
-                      {stats.is_enabled ? 'Enabled' : 'Disabled'}
-                    </span>
-                  </div>
-                  <p className="text-xs text-slate-500 mt-1">{stats.total_entries} entries ({stats.valid_entries} valid)</p>
-                </div>
-                <Zap className="w-10 h-10 text-cyan-400 opacity-50" />
-              </div>
-            </div>
+          <CacheStatsGrid stats={stats} />
 
-            {/* Cache Usage */}
-            <div className="card border-slate-800/60 bg-slate-900/55">
-              <div className="flex items-center justify-between">
-                <div className="flex-1">
-                  <p className="text-slate-400 text-sm">Cache Usage</p>
-                  <p className="text-2xl font-bold text-white mt-1">{formatBytes(stats.current_size_bytes)}</p>
-                  <p className="text-xs text-slate-500 mt-1">of {formatBytes(stats.max_size_bytes)}</p>
-                  <div className="h-1.5 w-full mt-2 overflow-hidden rounded-full bg-slate-800">
-                    <div
-                      className={`h-full rounded-full transition-all ${
-                        stats.usage_percent >= 90 ? 'bg-red-500' : stats.usage_percent >= 70 ? 'bg-amber-500' : 'bg-cyan-500'
-                      }`}
-                      style={{ width: `${Math.min(stats.usage_percent, 100)}%` }}
-                    />
-                  </div>
-                </div>
-                <HardDrive className="w-10 h-10 text-violet-400 opacity-50 flex-shrink-0 ml-3" />
-              </div>
-            </div>
+          {health && <CacheHealthCard health={health} />}
 
-            {/* Hit Rate */}
-            <div className="card border-slate-800/60 bg-slate-900/55">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-slate-400 text-sm">Hit Rate</p>
-                  <p className="text-2xl font-bold text-white mt-1">{stats.hit_rate_percent.toFixed(1)}%</p>
-                  <p className="text-xs text-slate-500 mt-1">
-                    {stats.total_hits.toLocaleString()} hits / {stats.total_misses.toLocaleString()} misses
-                  </p>
-                </div>
-                <BarChart3 className="w-10 h-10 text-green-400 opacity-50" />
-              </div>
-            </div>
+          <CacheConfigCard
+            configForm={configForm}
+            config={config}
+            configDirty={configDirty}
+            actionLoading={actionLoading}
+            onConfigChange={handleConfigChange}
+            onSave={handleSaveConfig}
+            onReset={resetConfigForm}
+          />
 
-            {/* Bytes Served */}
-            <div className="card border-slate-800/60 bg-slate-900/55">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-slate-400 text-sm">Bytes Served</p>
-                  <p className="text-2xl font-bold text-white mt-1">{formatBytes(stats.total_bytes_served)}</p>
-                  <p className="text-xs text-slate-500 mt-1">from SSD cache</p>
-                </div>
-                <Activity className="w-10 h-10 text-amber-400 opacity-50" />
-              </div>
-            </div>
-          </div>
+          <CacheActionsCard
+            actionLoading={actionLoading}
+            onTriggerEviction={handleTriggerEviction}
+            onClearCache={handleClearCache}
+            onRefresh={() => { loadData(); loadEntries(); }}
+          />
 
-          {/* Health Card */}
-          {health && (
-            <div className="card border-slate-800/60 bg-slate-900/55">
-              <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
-                <Heart className="w-5 h-5 text-sky-400" />
-                SSD Health
-              </h3>
-              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-                <div>
-                  <p className="text-slate-400">SSD Mount</p>
-                  <p className={`font-semibold mt-1 flex items-center gap-1 ${health.is_mounted ? 'text-emerald-400' : 'text-red-400'}`}>
-                    {health.is_mounted ? <Check className="w-4 h-4" /> : <X className="w-4 h-4" />}
-                    {health.is_mounted ? 'Mounted' : 'Not Mounted'}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-slate-400">Disk Free</p>
-                  <p className="text-white font-semibold mt-1">{formatBytes(health.ssd_available_bytes)}</p>
-                </div>
-                <div>
-                  <p className="text-slate-400">Disk Used</p>
-                  <p className="text-white font-semibold mt-1">{health.ssd_used_percent.toFixed(1)}% of {formatBytes(health.ssd_total_bytes)}</p>
-                </div>
-                <div>
-                  <p className="text-slate-400">Cache Directory</p>
-                  <p className={`font-semibold mt-1 flex items-center gap-1 ${health.cache_dir_exists ? 'text-emerald-400' : 'text-red-400'}`}>
-                    {health.cache_dir_exists ? <Check className="w-4 h-4" /> : <X className="w-4 h-4" />}
-                    {health.cache_dir_exists ? 'Exists' : 'Missing'}
-                  </p>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Config Card */}
-          <div className="card border-slate-800/60 bg-slate-900/55">
-            <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
-              <Settings className="w-5 h-5 text-sky-400" />
-              Configuration
-            </h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {/* Enable/Disable */}
-              <div>
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={configForm.is_enabled ?? false}
-                    onChange={(e) => handleConfigChange('is_enabled', e.target.checked)}
-                    className="w-4 h-4 rounded border-slate-700 bg-slate-800"
-                  />
-                  <span className="text-sm text-slate-300">Cache Enabled</span>
-                </label>
-              </div>
-
-              {/* Max Size */}
-              <div>
-                <ByteSizeInput
-                  label="Max Size"
-                  value={configForm.max_size_bytes ?? 0}
-                  onChange={(bytes) => handleConfigChange('max_size_bytes', bytes)}
-                />
-              </div>
-
-              {/* Eviction Policy */}
-              <div>
-                <label className="block text-sm text-slate-400 mb-1">Eviction Policy</label>
-                <select
-                  value={configForm.eviction_policy ?? 'lfru'}
-                  onChange={(e) => handleConfigChange('eviction_policy', e.target.value)}
-                  className="w-full px-3 py-1.5 bg-slate-800 border border-slate-700 rounded-lg text-white text-sm"
-                >
-                  <option value="lfru">LFRU (Least Frequently + Recently Used)</option>
-                  <option value="lru">LRU (Least Recently Used)</option>
-                  <option value="lfu">LFU (Least Frequently Used)</option>
-                </select>
-              </div>
-
-              {/* Min File Size */}
-              <div>
-                <ByteSizeInput
-                  label="Min File Size"
-                  value={configForm.min_file_size_bytes ?? 0}
-                  onChange={(bytes) => handleConfigChange('min_file_size_bytes', bytes)}
-                />
-              </div>
-
-              {/* Max File Size */}
-              <div>
-                <ByteSizeInput
-                  label="Max File Size"
-                  value={configForm.max_file_size_bytes ?? 0}
-                  onChange={(bytes) => handleConfigChange('max_file_size_bytes', bytes)}
-                />
-              </div>
-
-              {/* Sequential Cutoff */}
-              <div>
-                <ByteSizeInput
-                  label="Sequential Cutoff"
-                  value={configForm.sequential_cutoff_bytes ?? 0}
-                  onChange={(bytes) => handleConfigChange('sequential_cutoff_bytes', bytes)}
-                />
-              </div>
-            </div>
-
-            {/* Save / Reset */}
-            <div className="flex gap-3 mt-4 pt-4 border-t border-slate-800/60">
-              <button
-                onClick={handleSaveConfig}
-                disabled={actionLoading || !configDirty}
-                className="px-4 py-2 bg-sky-500 hover:bg-sky-600 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2 text-sm"
-              >
-                <Check className="w-4 h-4" />
-                Save Configuration
-              </button>
-              {configDirty && config && (
-                <button
-                  onClick={() => resetConfigForm(config)}
-                  className="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors text-sm"
-                >
-                  Reset
-                </button>
-              )}
-            </div>
-          </div>
-
-          {/* Actions */}
-          <div className="card border-slate-800/60 bg-slate-900/55">
-            <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
-              <RefreshCw className="w-5 h-5 text-sky-400" />
-              Actions
-            </h3>
-            <div className="flex flex-wrap gap-3">
-              <button
-                onClick={handleTriggerEviction}
-                disabled={actionLoading}
-                className="px-4 py-2 bg-amber-500 hover:bg-amber-600 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2 text-sm"
-              >
-                <RefreshCw className={`w-4 h-4 ${actionLoading ? 'animate-spin' : ''}`} />
-                Trigger Eviction
-              </button>
-              <button
-                onClick={handleClearCache}
-                disabled={actionLoading}
-                className="px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2 text-sm"
-              >
-                <Trash2 className="w-4 h-4" />
-                Clear Cache
-              </button>
-              <button
-                onClick={() => { loadData(); loadEntries(); }}
-                disabled={actionLoading}
-                className="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2 text-sm"
-              >
-                <RefreshCw className={`w-4 h-4 ${actionLoading ? 'animate-spin' : ''}`} />
-                Refresh
-              </button>
-            </div>
-          </div>
-
-          {/* Entries Table */}
-          <div className="card border-slate-800/60 bg-slate-900/55">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-white flex items-center gap-2">
-                <HardDrive className="w-5 h-5 text-sky-400" />
-                Cached Entries
-                <span className="text-sm font-normal text-slate-400">({entriesTotal})</span>
-              </h3>
-            </div>
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="text-left border-b border-slate-800">
-                    <th className="pb-3 text-slate-400 font-medium">Source Path</th>
-                    <th className="pb-3 text-slate-400 font-medium">Size</th>
-                    <th className="pb-3 text-slate-400 font-medium">Accesses</th>
-                    <th className="pb-3 text-slate-400 font-medium">Last Accessed</th>
-                    <th className="pb-3 text-slate-400 font-medium">Status</th>
-                    <th className="pb-3 text-slate-400 font-medium">Actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {entries.length > 0 ? entries.map((entry) => (
-                    <tr key={entry.id} className="border-b border-slate-800/50">
-                      <td className="py-3 text-slate-300 max-w-xs truncate" title={entry.source_path}>
-                        {entry.source_path}
-                      </td>
-                      <td className="py-3 text-slate-300">{formatBytes(entry.file_size_bytes)}</td>
-                      <td className="py-3 text-slate-300">{entry.access_count}</td>
-                      <td className="py-3 text-slate-300">
-                        {new Date(entry.last_accessed).toLocaleString()}
-                      </td>
-                      <td className="py-3">
-                        <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
-                          entry.is_valid
-                            ? 'bg-emerald-500/20 text-emerald-400'
-                            : 'bg-red-500/20 text-red-400'
-                        }`}>
-                          {entry.is_valid ? 'Valid' : 'Invalid'}
-                        </span>
-                      </td>
-                      <td className="py-3">
-                        <button
-                          onClick={() => handleEvictEntry(entry.id)}
-                          disabled={actionLoading}
-                          className="text-red-400 hover:text-red-300 transition-colors disabled:opacity-50 text-xs"
-                        >
-                          Evict
-                        </button>
-                      </td>
-                    </tr>
-                  )) : (
-                    <tr>
-                      <td colSpan={6} className="py-8 text-center text-slate-500">
-                        No cached entries
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
-
-            {/* Pagination */}
-            {totalPages > 1 && (
-              <div className="flex items-center justify-between mt-4 pt-4 border-t border-slate-800/60">
-                <p className="text-sm text-slate-400">
-                  Page {page + 1} of {totalPages}
-                </p>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => setPage((p) => Math.max(0, p - 1))}
-                    disabled={page === 0}
-                    className="p-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-300 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                  >
-                    <ChevronLeft className="w-4 h-4" />
-                  </button>
-                  <button
-                    onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-                    disabled={page >= totalPages - 1}
-                    className="p-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-300 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                  >
-                    <ChevronRight className="w-4 h-4" />
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
+          <CacheEntriesTable
+            entries={entries}
+            entriesTotal={entriesTotal}
+            page={page}
+            totalPages={totalPages}
+            actionLoading={actionLoading}
+            onEvict={handleEvictEntry}
+            onPrevPage={() => setPage((p) => Math.max(0, p - 1))}
+            onNextPage={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+          />
         </>
       ) : null}
 

--- a/client/src/components/ssd-cache/file-cache/CacheActionsCard.tsx
+++ b/client/src/components/ssd-cache/file-cache/CacheActionsCard.tsx
@@ -1,0 +1,44 @@
+import { Trash2, RefreshCw } from 'lucide-react';
+
+export function CacheActionsCard(props: {
+  actionLoading: boolean;
+  onTriggerEviction: () => void;
+  onClearCache: () => void;
+  onRefresh: () => void;
+}) {
+  const { actionLoading, onTriggerEviction, onClearCache, onRefresh } = props;
+  return (
+    <div className="card border-slate-800/60 bg-slate-900/55">
+      <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+        <RefreshCw className="w-5 h-5 text-sky-400" />
+        Actions
+      </h3>
+      <div className="flex flex-wrap gap-3">
+        <button
+          onClick={onTriggerEviction}
+          disabled={actionLoading}
+          className="px-4 py-2 bg-amber-500 hover:bg-amber-600 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2 text-sm"
+        >
+          <RefreshCw className={`w-4 h-4 ${actionLoading ? 'animate-spin' : ''}`} />
+          Trigger Eviction
+        </button>
+        <button
+          onClick={onClearCache}
+          disabled={actionLoading}
+          className="px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2 text-sm"
+        >
+          <Trash2 className="w-4 h-4" />
+          Clear Cache
+        </button>
+        <button
+          onClick={onRefresh}
+          disabled={actionLoading}
+          className="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2 text-sm"
+        >
+          <RefreshCw className={`w-4 h-4 ${actionLoading ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/ssd-cache/file-cache/CacheArraySelector.tsx
+++ b/client/src/components/ssd-cache/file-cache/CacheArraySelector.tsx
@@ -1,0 +1,30 @@
+export function CacheArraySelector({
+  arrays,
+  selectedArray,
+  onSelect,
+}: {
+  arrays: string[];
+  selectedArray: string;
+  onSelect: (name: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-slate-400">Array:</span>
+      <div className="flex gap-1.5">
+        {arrays.map((name) => (
+          <button
+            key={name}
+            onClick={() => onSelect(name)}
+            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition ${
+              name === selectedArray
+                ? 'bg-sky-500/20 text-sky-300 border border-sky-500/40'
+                : 'bg-slate-800/60 text-slate-400 border border-slate-700/50 hover:border-slate-600'
+            }`}
+          >
+            {name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/ssd-cache/file-cache/CacheConfigCard.tsx
+++ b/client/src/components/ssd-cache/file-cache/CacheConfigCard.tsx
@@ -1,0 +1,108 @@
+import { Settings, Check } from 'lucide-react';
+import { ByteSizeInput } from '../../ui/ByteSizeInput';
+import type { SSDCacheConfigUpdate, SSDCacheConfigResponse } from '../../../api/ssd-file-cache';
+
+export function CacheConfigCard(props: {
+  configForm: SSDCacheConfigUpdate;
+  config: SSDCacheConfigResponse;
+  configDirty: boolean;
+  actionLoading: boolean;
+  onConfigChange: (key: keyof SSDCacheConfigUpdate, value: unknown) => void;
+  onSave: () => void;
+  onReset: (cfg: SSDCacheConfigResponse) => void;
+}) {
+  const { configForm, config, configDirty, actionLoading, onConfigChange, onSave, onReset } = props;
+
+  return (
+    <div className="card border-slate-800/60 bg-slate-900/55">
+      <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+        <Settings className="w-5 h-5 text-sky-400" />
+        Configuration
+      </h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {/* Enable/Disable */}
+        <div>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={configForm.is_enabled ?? false}
+              onChange={(e) => onConfigChange('is_enabled', e.target.checked)}
+              className="w-4 h-4 rounded border-slate-700 bg-slate-800"
+            />
+            <span className="text-sm text-slate-300">Cache Enabled</span>
+          </label>
+        </div>
+
+        {/* Max Size */}
+        <div>
+          <ByteSizeInput
+            label="Max Size"
+            value={configForm.max_size_bytes ?? 0}
+            onChange={(bytes) => onConfigChange('max_size_bytes', bytes)}
+          />
+        </div>
+
+        {/* Eviction Policy */}
+        <div>
+          <label className="block text-sm text-slate-400 mb-1">Eviction Policy</label>
+          <select
+            value={configForm.eviction_policy ?? 'lfru'}
+            onChange={(e) => onConfigChange('eviction_policy', e.target.value)}
+            className="w-full px-3 py-1.5 bg-slate-800 border border-slate-700 rounded-lg text-white text-sm"
+          >
+            <option value="lfru">LFRU (Least Frequently + Recently Used)</option>
+            <option value="lru">LRU (Least Recently Used)</option>
+            <option value="lfu">LFU (Least Frequently Used)</option>
+          </select>
+        </div>
+
+        {/* Min File Size */}
+        <div>
+          <ByteSizeInput
+            label="Min File Size"
+            value={configForm.min_file_size_bytes ?? 0}
+            onChange={(bytes) => onConfigChange('min_file_size_bytes', bytes)}
+          />
+        </div>
+
+        {/* Max File Size */}
+        <div>
+          <ByteSizeInput
+            label="Max File Size"
+            value={configForm.max_file_size_bytes ?? 0}
+            onChange={(bytes) => onConfigChange('max_file_size_bytes', bytes)}
+          />
+        </div>
+
+        {/* Sequential Cutoff */}
+        <div>
+          <ByteSizeInput
+            label="Sequential Cutoff"
+            value={configForm.sequential_cutoff_bytes ?? 0}
+            onChange={(bytes) => onConfigChange('sequential_cutoff_bytes', bytes)}
+          />
+        </div>
+      </div>
+
+      {/* Save / Reset */}
+      <div className="flex gap-3 mt-4 pt-4 border-t border-slate-800/60">
+        <button
+          onClick={onSave}
+          disabled={actionLoading || !configDirty}
+          className="px-4 py-2 bg-sky-500 hover:bg-sky-600 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2 text-sm"
+        >
+          <Check className="w-4 h-4" />
+          Save Configuration
+        </button>
+        {configDirty && config && (
+          <button
+            onClick={() => onReset(config)}
+            className="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors text-sm"
+          >
+            Reset
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/ssd-cache/file-cache/CacheEntriesTable.tsx
+++ b/client/src/components/ssd-cache/file-cache/CacheEntriesTable.tsx
@@ -1,0 +1,112 @@
+import { HardDrive, ChevronLeft, ChevronRight } from 'lucide-react';
+import { formatBytes } from '../../../lib/formatters';
+import type { SSDCacheEntryResponse } from '../../../api/ssd-file-cache';
+
+export function CacheEntriesTable({
+  entries,
+  entriesTotal,
+  page,
+  totalPages,
+  actionLoading,
+  onEvict,
+  onPrevPage,
+  onNextPage,
+}: {
+  entries: SSDCacheEntryResponse[];
+  entriesTotal: number;
+  page: number;
+  totalPages: number;
+  actionLoading: boolean;
+  onEvict: (entryId: number) => void;
+  onPrevPage: () => void;
+  onNextPage: () => void;
+}) {
+  return (
+    <div className="card border-slate-800/60 bg-slate-900/55">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-white flex items-center gap-2">
+          <HardDrive className="w-5 h-5 text-sky-400" />
+          Cached Entries
+          <span className="text-sm font-normal text-slate-400">({entriesTotal})</span>
+        </h3>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left border-b border-slate-800">
+              <th className="pb-3 text-slate-400 font-medium">Source Path</th>
+              <th className="pb-3 text-slate-400 font-medium">Size</th>
+              <th className="pb-3 text-slate-400 font-medium">Accesses</th>
+              <th className="pb-3 text-slate-400 font-medium">Last Accessed</th>
+              <th className="pb-3 text-slate-400 font-medium">Status</th>
+              <th className="pb-3 text-slate-400 font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.length > 0 ? entries.map((entry) => (
+              <tr key={entry.id} className="border-b border-slate-800/50">
+                <td className="py-3 text-slate-300 max-w-xs truncate" title={entry.source_path}>
+                  {entry.source_path}
+                </td>
+                <td className="py-3 text-slate-300">{formatBytes(entry.file_size_bytes)}</td>
+                <td className="py-3 text-slate-300">{entry.access_count}</td>
+                <td className="py-3 text-slate-300">
+                  {new Date(entry.last_accessed).toLocaleString()}
+                </td>
+                <td className="py-3">
+                  <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                    entry.is_valid
+                      ? 'bg-emerald-500/20 text-emerald-400'
+                      : 'bg-red-500/20 text-red-400'
+                  }`}>
+                    {entry.is_valid ? 'Valid' : 'Invalid'}
+                  </span>
+                </td>
+                <td className="py-3">
+                  <button
+                    onClick={() => onEvict(entry.id)}
+                    disabled={actionLoading}
+                    className="text-red-400 hover:text-red-300 transition-colors disabled:opacity-50 text-xs"
+                  >
+                    Evict
+                  </button>
+                </td>
+              </tr>
+            )) : (
+              <tr>
+                <td colSpan={6} className="py-8 text-center text-slate-500">
+                  No cached entries
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-4 pt-4 border-t border-slate-800/60">
+          <p className="text-sm text-slate-400">
+            Page {page + 1} of {totalPages}
+          </p>
+          <div className="flex gap-2">
+            <button
+              onClick={onPrevPage}
+              disabled={page === 0}
+              className="p-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-300 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <button
+              onClick={onNextPage}
+              disabled={page >= totalPages - 1}
+              className="p-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-300 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/ssd-cache/file-cache/CacheHealthCard.tsx
+++ b/client/src/components/ssd-cache/file-cache/CacheHealthCard.tsx
@@ -1,0 +1,38 @@
+import { Check, X, Heart } from 'lucide-react';
+import { formatBytes } from '../../../lib/formatters';
+import type { CacheHealthResponse } from '../../../api/ssd-file-cache';
+
+export function CacheHealthCard({ health }: { health: CacheHealthResponse }) {
+  return (
+    <div className="card border-slate-800/60 bg-slate-900/55">
+      <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+        <Heart className="w-5 h-5 text-sky-400" />
+        SSD Health
+      </h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+        <div>
+          <p className="text-slate-400">SSD Mount</p>
+          <p className={`font-semibold mt-1 flex items-center gap-1 ${health.is_mounted ? 'text-emerald-400' : 'text-red-400'}`}>
+            {health.is_mounted ? <Check className="w-4 h-4" /> : <X className="w-4 h-4" />}
+            {health.is_mounted ? 'Mounted' : 'Not Mounted'}
+          </p>
+        </div>
+        <div>
+          <p className="text-slate-400">Disk Free</p>
+          <p className="text-white font-semibold mt-1">{formatBytes(health.ssd_available_bytes)}</p>
+        </div>
+        <div>
+          <p className="text-slate-400">Disk Used</p>
+          <p className="text-white font-semibold mt-1">{health.ssd_used_percent.toFixed(1)}% of {formatBytes(health.ssd_total_bytes)}</p>
+        </div>
+        <div>
+          <p className="text-slate-400">Cache Directory</p>
+          <p className={`font-semibold mt-1 flex items-center gap-1 ${health.cache_dir_exists ? 'text-emerald-400' : 'text-red-400'}`}>
+            {health.cache_dir_exists ? <Check className="w-4 h-4" /> : <X className="w-4 h-4" />}
+            {health.cache_dir_exists ? 'Exists' : 'Missing'}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/ssd-cache/file-cache/CacheStatsGrid.tsx
+++ b/client/src/components/ssd-cache/file-cache/CacheStatsGrid.tsx
@@ -1,0 +1,74 @@
+import { Zap, HardDrive, BarChart3, Activity } from 'lucide-react';
+import type { SSDCacheStats } from '../../../api/ssd-file-cache';
+import { formatBytes } from '../../../lib/formatters';
+import { cacheUsageBarColor } from './cacheUsageBarColor';
+
+export function CacheStatsGrid({ stats }: { stats: SSDCacheStats }): JSX.Element {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      {/* Status */}
+      <div className="card border-slate-800/60 bg-slate-900/55">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-slate-400 text-sm">Status</p>
+            <div className="flex items-center gap-2 mt-1">
+              <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                stats.is_enabled
+                  ? 'bg-emerald-500/20 text-emerald-300'
+                  : 'bg-red-500/20 text-red-300'
+              }`}>
+                {stats.is_enabled ? 'Enabled' : 'Disabled'}
+              </span>
+            </div>
+            <p className="text-xs text-slate-500 mt-1">{stats.total_entries} entries ({stats.valid_entries} valid)</p>
+          </div>
+          <Zap className="w-10 h-10 text-cyan-400 opacity-50" />
+        </div>
+      </div>
+
+      {/* Cache Usage */}
+      <div className="card border-slate-800/60 bg-slate-900/55">
+        <div className="flex items-center justify-between">
+          <div className="flex-1">
+            <p className="text-slate-400 text-sm">Cache Usage</p>
+            <p className="text-2xl font-bold text-white mt-1">{formatBytes(stats.current_size_bytes)}</p>
+            <p className="text-xs text-slate-500 mt-1">of {formatBytes(stats.max_size_bytes)}</p>
+            <div className="h-1.5 w-full mt-2 overflow-hidden rounded-full bg-slate-800">
+              <div
+                className={`h-full rounded-full transition-all ${cacheUsageBarColor(stats.usage_percent)}`}
+                style={{ width: `${Math.min(stats.usage_percent, 100)}%` }}
+              />
+            </div>
+          </div>
+          <HardDrive className="w-10 h-10 text-violet-400 opacity-50 flex-shrink-0 ml-3" />
+        </div>
+      </div>
+
+      {/* Hit Rate */}
+      <div className="card border-slate-800/60 bg-slate-900/55">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-slate-400 text-sm">Hit Rate</p>
+            <p className="text-2xl font-bold text-white mt-1">{stats.hit_rate_percent.toFixed(1)}%</p>
+            <p className="text-xs text-slate-500 mt-1">
+              {stats.total_hits.toLocaleString()} hits / {stats.total_misses.toLocaleString()} misses
+            </p>
+          </div>
+          <BarChart3 className="w-10 h-10 text-green-400 opacity-50" />
+        </div>
+      </div>
+
+      {/* Bytes Served */}
+      <div className="card border-slate-800/60 bg-slate-900/55">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-slate-400 text-sm">Bytes Served</p>
+            <p className="text-2xl font-bold text-white mt-1">{formatBytes(stats.total_bytes_served)}</p>
+            <p className="text-xs text-slate-500 mt-1">from SSD cache</p>
+          </div>
+          <Activity className="w-10 h-10 text-amber-400 opacity-50" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/ssd-cache/file-cache/CacheViewTabs.tsx
+++ b/client/src/components/ssd-cache/file-cache/CacheViewTabs.tsx
@@ -1,0 +1,40 @@
+import { Zap, ArrowRightLeft } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { TabView } from '../../../hooks/useSsdFileCache';
+
+export function CacheViewTabs({
+  tabView,
+  onSelect,
+}: {
+  tabView: TabView;
+  onSelect: (v: TabView) => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={() => onSelect('cache')}
+        className={`px-3 py-1.5 rounded-lg text-sm font-medium transition flex items-center gap-1.5 ${
+          tabView === 'cache'
+            ? 'bg-sky-500/20 text-sky-300 border border-sky-500/40'
+            : 'bg-slate-800/60 text-slate-400 border border-slate-700/50 hover:border-slate-600'
+        }`}
+      >
+        <Zap className="w-4 h-4" />
+        {t('ssdCache.migration.cacheTab', 'File Cache')}
+      </button>
+      <button
+        onClick={() => onSelect('migration')}
+        className={`px-3 py-1.5 rounded-lg text-sm font-medium transition flex items-center gap-1.5 ${
+          tabView === 'migration'
+            ? 'bg-sky-500/20 text-sky-300 border border-sky-500/40'
+            : 'bg-slate-800/60 text-slate-400 border border-slate-700/50 hover:border-slate-600'
+        }`}
+      >
+        <ArrowRightLeft className="w-4 h-4" />
+        {t('ssdCache.migration.title', 'Data Migration')}
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/ssd-cache/file-cache/cacheUsageBarColor.ts
+++ b/client/src/components/ssd-cache/file-cache/cacheUsageBarColor.ts
@@ -1,0 +1,3 @@
+export function cacheUsageBarColor(usagePercent: number): string {
+  return usagePercent >= 90 ? 'bg-red-500' : usagePercent >= 70 ? 'bg-amber-500' : 'bg-cyan-500';
+}

--- a/client/src/components/ssd-cache/file-cache/index.ts
+++ b/client/src/components/ssd-cache/file-cache/index.ts
@@ -1,0 +1,9 @@
+export { cacheUsageBarColor } from './cacheUsageBarColor';
+export { CacheViewTabs } from './CacheViewTabs';
+export { CacheArraySelector } from './CacheArraySelector';
+export { CacheStatsGrid } from './CacheStatsGrid';
+export { CacheHealthCard } from './CacheHealthCard';
+export { CacheConfigCard } from './CacheConfigCard';
+export { CacheActionsCard } from './CacheActionsCard';
+export { CacheEntriesTable } from './CacheEntriesTable';
+export type { TabView } from '../../../hooks/useSsdFileCache';

--- a/client/src/hooks/useSsdFileCache.ts
+++ b/client/src/hooks/useSsdFileCache.ts
@@ -1,0 +1,280 @@
+/**
+ * SSD File Cache Admin data/state hook (per-array)
+ * Owns all state, effects, and handlers for SsdFileCacheTab.
+ */
+
+import { useState, useEffect } from 'react';
+import toast from 'react-hot-toast';
+import { getApiErrorMessage, handleApiError } from '../lib/errorHandling';
+import { formatBytes } from '../lib/formatters';
+import { useConfirmDialog } from './useConfirmDialog';
+import { getRaidStatus } from '../api/raid';
+import {
+  getCacheStats,
+  getCacheConfig,
+  updateCacheConfig,
+  getCacheEntries,
+  evictEntry,
+  triggerEviction,
+  clearCache,
+  getCacheHealth,
+} from '../api/ssd-file-cache';
+import type {
+  SSDCacheStats,
+  SSDCacheConfigResponse,
+  SSDCacheConfigUpdate,
+  SSDCacheEntryResponse,
+  CacheHealthResponse,
+} from '../api/ssd-file-cache';
+import type { Dispatch, SetStateAction, ReactNode } from 'react';
+
+export type TabView = 'cache' | 'migration';
+
+export interface UseSsdFileCacheResult {
+  tabView: TabView;
+  setTabView: (v: TabView) => void;
+  arrays: string[];
+  selectedArray: string;
+  setSelectedArray: (name: string) => void;
+  stats: SSDCacheStats | null;
+  config: SSDCacheConfigResponse | null;
+  health: CacheHealthResponse | null;
+  entries: SSDCacheEntryResponse[];
+  entriesTotal: number;
+  loading: boolean;
+  error: string | null;
+  actionLoading: boolean;
+  configForm: SSDCacheConfigUpdate;
+  configDirty: boolean;
+  page: number;
+  setPage: Dispatch<SetStateAction<number>>;
+  pageSize: number;
+  handleConfigChange: (key: keyof SSDCacheConfigUpdate, value: unknown) => void;
+  handleSaveConfig: () => Promise<void>;
+  resetConfigForm: (cfg: SSDCacheConfigResponse) => void;
+  handleEvictEntry: (entryId: number) => Promise<void>;
+  handleTriggerEviction: () => Promise<void>;
+  handleClearCache: () => Promise<void>;
+  loadData: () => Promise<void>;
+  loadEntries: () => Promise<void>;
+  dialog: ReactNode;
+}
+
+export function useSsdFileCache(initialArray?: string): UseSsdFileCacheResult {
+  const [tabView, setTabView] = useState<TabView>('cache');
+  const [arrays, setArrays] = useState<string[]>([]);
+  const [selectedArray, setSelectedArray] = useState<string>(initialArray ?? '');
+  const [stats, setStats] = useState<SSDCacheStats | null>(null);
+  const [config, setConfig] = useState<SSDCacheConfigResponse | null>(null);
+  const [health, setHealth] = useState<CacheHealthResponse | null>(null);
+  const [entries, setEntries] = useState<SSDCacheEntryResponse[]>([]);
+  const [entriesTotal, setEntriesTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState(false);
+
+  // Config form
+  const [configForm, setConfigForm] = useState<SSDCacheConfigUpdate>({});
+  const [configDirty, setConfigDirty] = useState(false);
+
+  // Pagination
+  const [page, setPage] = useState(0);
+  const pageSize = 20;
+
+  const { confirm, dialog } = useConfirmDialog();
+
+  // Load available arrays on mount
+  useEffect(() => {
+    loadArrays();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Load data when selected array changes
+  useEffect(() => {
+    if (selectedArray) {
+      loadData();
+      setPage(0);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedArray]);
+
+  useEffect(() => {
+    if (selectedArray) {
+      loadEntries();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, selectedArray]);
+
+  const loadArrays = async () => {
+    try {
+      const status = await getRaidStatus();
+      const arrayNames = (status.arrays ?? []).map((a) => a.name);
+      setArrays(arrayNames);
+
+      // Auto-select
+      if (initialArray && arrayNames.includes(initialArray)) {
+        setSelectedArray(initialArray);
+      } else if (arrayNames.length === 1) {
+        setSelectedArray(arrayNames[0]);
+      } else if (arrayNames.length > 0 && !selectedArray) {
+        setSelectedArray(arrayNames[0]);
+      }
+    } catch {
+      setError('Failed to load RAID arrays');
+      setLoading(false);
+    }
+  };
+
+  const loadData = async () => {
+    if (!selectedArray) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const [statsData, configData, healthData] = await Promise.all([
+        getCacheStats(selectedArray),
+        getCacheConfig(selectedArray),
+        getCacheHealth(selectedArray),
+      ]);
+      setStats(statsData);
+      setConfig(configData);
+      setHealth(healthData);
+      resetConfigForm(configData);
+    } catch (err: unknown) {
+      setError(getApiErrorMessage(err, 'Failed to load SSD cache data'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadEntries = async () => {
+    if (!selectedArray) return;
+    try {
+      const data = await getCacheEntries(selectedArray, pageSize, page * pageSize);
+      setEntries(data.entries);
+      setEntriesTotal(data.total);
+    } catch {
+      // Stats/config already showed error if needed
+    }
+  };
+
+  const resetConfigForm = (cfg: SSDCacheConfigResponse) => {
+    setConfigForm({
+      is_enabled: cfg.is_enabled,
+      max_size_bytes: cfg.max_size_bytes,
+      eviction_policy: cfg.eviction_policy as 'lfru' | 'lru' | 'lfu',
+      min_file_size_bytes: cfg.min_file_size_bytes,
+      max_file_size_bytes: cfg.max_file_size_bytes,
+      sequential_cutoff_bytes: cfg.sequential_cutoff_bytes,
+    });
+    setConfigDirty(false);
+  };
+
+  const handleConfigChange = (key: keyof SSDCacheConfigUpdate, value: unknown) => {
+    setConfigForm((prev) => ({ ...prev, [key]: value }));
+    setConfigDirty(true);
+  };
+
+  const handleSaveConfig = async () => {
+    if (!selectedArray) return;
+    try {
+      setActionLoading(true);
+      const updated = await updateCacheConfig(selectedArray, configForm);
+      setConfig(updated);
+      resetConfigForm(updated);
+      toast.success('Cache configuration saved');
+      const newStats = await getCacheStats(selectedArray);
+      setStats(newStats);
+    } catch (err: unknown) {
+      handleApiError(err, 'Failed to save configuration');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleEvictEntry = async (entryId: number) => {
+    if (!selectedArray) return;
+    try {
+      setActionLoading(true);
+      const result = await evictEntry(selectedArray, entryId);
+      toast.success(`Evicted: ${result.source_path} (${formatBytes(result.freed_bytes)} freed)`);
+      loadEntries();
+      const newStats = await getCacheStats(selectedArray);
+      setStats(newStats);
+    } catch (err: unknown) {
+      handleApiError(err, 'Failed to evict entry');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleTriggerEviction = async () => {
+    if (!selectedArray) return;
+    try {
+      setActionLoading(true);
+      const result = await triggerEviction(selectedArray);
+      toast.success(`Eviction complete: ${result.deleted_count} entries removed, ${formatBytes(result.freed_bytes)} freed`);
+      loadData();
+      loadEntries();
+    } catch (err: unknown) {
+      handleApiError(err, 'Eviction failed');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleClearCache = async () => {
+    if (!selectedArray) return;
+    const ok = await confirm(
+      `This will delete all cached files for ${selectedArray} from the SSD. This action cannot be undone.`,
+      {
+        title: 'Clear Entire Cache',
+        variant: 'danger',
+        confirmLabel: 'Clear Cache',
+      }
+    );
+    if (!ok) return;
+
+    try {
+      setActionLoading(true);
+      const result = await clearCache(selectedArray);
+      toast.success(`Cache cleared: ${result.deleted_count} entries removed, ${formatBytes(result.freed_bytes)} freed`);
+      loadData();
+      setPage(0);
+      loadEntries();
+    } catch (err: unknown) {
+      handleApiError(err, 'Failed to clear cache');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  return {
+    tabView,
+    setTabView,
+    arrays,
+    selectedArray,
+    setSelectedArray,
+    stats,
+    config,
+    health,
+    entries,
+    entriesTotal,
+    loading,
+    error,
+    actionLoading,
+    configForm,
+    configDirty,
+    page,
+    setPage,
+    pageSize,
+    handleConfigChange,
+    handleSaveConfig,
+    resetConfigForm,
+    handleEvictEntry,
+    handleTriggerEviction,
+    handleClearCache,
+    loadData,
+    loadEntries,
+    dialog,
+  };
+}

--- a/docs/superpowers/plans/2026-07-11-ssdfilecachetab-decomposition-f2.md
+++ b/docs/superpowers/plans/2026-07-11-ssdfilecachetab-decomposition-f2.md
@@ -1,0 +1,741 @@
+# SsdFileCacheTab.tsx Decomposition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Behavior-preserving decomposition of `client/src/components/ssd-cache/SsdFileCacheTab.tsx` (657 lines) into one data/state hook, one pure helper, and a `components/ssd-cache/file-cache/` directory of presentational components, leaving the tab a thin ~130-line orchestrator.
+
+**Architecture:** All fetching/state moves into `hooks/useSsdFileCache.ts`. Presentational components take props + callbacks only. Moved markup is byte-identical (same JSX, same Tailwind, same hard-coded English copy, same toast strings). The component keeps its default export + path + `initialArray` prop so consumers and the `ssd-cache` barrel are untouched. `MigrationPanel` is reused unmodified.
+
+**Tech Stack:** React 18 + TypeScript (strict, `verbatimModuleSyntax`) + Vite + Tailwind + react-i18next (only 2 existing `t()` calls) + react-hot-toast + lucide-react + Vitest + @testing-library/react.
+
+## Global Constraints
+
+- **`verbatimModuleSyntax`:** every type-only import MUST use `import type { ... }`. `tsc -b` (CI `npm run build`) enforces this; vitest/esbuild does NOT. Run `npx tsc -b` before each commit.
+- **Behavior byte-identical:** same API calls (`getRaidStatus`, `getCacheStats`, `getCacheConfig`, `getCacheHealth`, `getCacheEntries`, `updateCacheConfig`, `evictEntry`, `triggerEviction`, `clearCache`), same `Promise.all` in `loadData`, same array auto-select logic, same 3 effects, same toast strings, same `confirm(...)` clear-cache wording, same `getApiErrorMessage`/`handleApiError` targets, same `loadEntries` empty-catch, same `pageSize = 20`.
+- **DO NOT introduce i18n / change copy.** This file renders mostly hard-coded English strings ON PURPOSE for this refactor — preserve them verbatim. The i18n gap is tracked separately in issue #406. Only the two existing `t('ssdCache.migration.cacheTab', 'File Cache')` / `t('ssdCache.migration.title', 'Data Migration')` calls stay as `t()`.
+- **Test hygiene (T7):** assert on role/text/title, never Tailwind class names. Fixtures are complete objects of the real API types (`SSDCacheStats`, `SSDCacheConfigResponse`, `CacheHealthResponse`, `SSDCacheEntryResponse`, `SSDCacheConfigUpdate`) from `../api/ssd-file-cache`. Each test asserts the SPECIFIC targeted behavior of its unit.
+- Source of truth for every moved block: the current `client/src/components/ssd-cache/SsdFileCacheTab.tsx` at branch base. Line numbers below refer to that file.
+- New component dir: `client/src/components/ssd-cache/file-cache/`. New tests: `client/src/__tests__/components/ssd-cache/file-cache/` and `client/src/__tests__/hooks/`.
+
+---
+
+### Task 1: `cacheUsageBarColor` pure helper
+
+**Files:**
+- Create: `client/src/components/ssd-cache/file-cache/cacheUsageBarColor.ts`
+- Test: `client/src/__tests__/components/ssd-cache/file-cache/cacheUsageBarColor.test.ts`
+
+**Interfaces:**
+- Produces: `export function cacheUsageBarColor(usagePercent: number): string`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// cacheUsageBarColor.test.ts
+import { describe, it, expect } from 'vitest';
+import { cacheUsageBarColor } from '../../../../components/ssd-cache/file-cache/cacheUsageBarColor';
+
+describe('cacheUsageBarColor', () => {
+  it('returns red at/above 90%', () => {
+    expect(cacheUsageBarColor(95)).toBe('bg-red-500');
+    expect(cacheUsageBarColor(90)).toBe('bg-red-500');
+  });
+  it('returns amber at/above 70% and below 90%', () => {
+    expect(cacheUsageBarColor(75)).toBe('bg-amber-500');
+    expect(cacheUsageBarColor(70)).toBe('bg-amber-500');
+  });
+  it('returns cyan below 70%', () => {
+    expect(cacheUsageBarColor(50)).toBe('bg-cyan-500');
+    expect(cacheUsageBarColor(0)).toBe('bg-cyan-500');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail.** `cd client ; npx vitest run src/__tests__/components/ssd-cache/file-cache/cacheUsageBarColor.test.ts` → FAIL (module not found).
+- [ ] **Step 3: Write the implementation** (thresholds verbatim from `SsdFileCacheTab.tsx:363-365`):
+
+```ts
+// cacheUsageBarColor.ts
+export function cacheUsageBarColor(usagePercent: number): string {
+  return usagePercent >= 90 ? 'bg-red-500' : usagePercent >= 70 ? 'bg-amber-500' : 'bg-cyan-500';
+}
+```
+
+- [ ] **Step 4: Run to verify pass** → PASS (3 tests).
+- [ ] **Step 5: Commit** `feat(ssd-cache): extract cacheUsageBarColor helper (F2, #301)`.
+
+---
+
+### Task 2: `useSsdFileCache` hook
+
+**Files:**
+- Create: `client/src/hooks/useSsdFileCache.ts`
+- Test: `client/src/__tests__/hooks/useSsdFileCache.test.ts`
+
+**Interfaces:**
+- Consumes: `getRaidStatus` from `../api/raid`; the eight cache functions + types from `../api/ssd-file-cache`; `useConfirmDialog` from `./useConfirmDialog`; `toast` from `react-hot-toast`; `getApiErrorMessage`/`handleApiError` from `../lib/errorHandling`; `formatBytes` from `../lib/formatters`.
+- Produces: `useSsdFileCache(initialArray?: string): UseSsdFileCacheResult` (full shape below). Consumed by Task 9.
+
+```ts
+import type {
+  SSDCacheStats, SSDCacheConfigResponse, SSDCacheConfigUpdate,
+  SSDCacheEntryResponse, CacheHealthResponse,
+} from '../api/ssd-file-cache';
+import type { Dispatch, SetStateAction, ReactNode } from 'react';
+
+export type TabView = 'cache' | 'migration';
+
+export interface UseSsdFileCacheResult {
+  tabView: TabView;
+  setTabView: (v: TabView) => void;
+  arrays: string[];
+  selectedArray: string;
+  setSelectedArray: (name: string) => void;
+  stats: SSDCacheStats | null;
+  config: SSDCacheConfigResponse | null;
+  health: CacheHealthResponse | null;
+  entries: SSDCacheEntryResponse[];
+  entriesTotal: number;
+  loading: boolean;
+  error: string | null;
+  actionLoading: boolean;
+  configForm: SSDCacheConfigUpdate;
+  configDirty: boolean;
+  page: number;
+  setPage: Dispatch<SetStateAction<number>>;
+  pageSize: number;
+  handleConfigChange: (key: keyof SSDCacheConfigUpdate, value: unknown) => void;
+  handleSaveConfig: () => Promise<void>;
+  resetConfigForm: (cfg: SSDCacheConfigResponse) => void;
+  handleEvictEntry: (entryId: number) => Promise<void>;
+  handleTriggerEviction: () => Promise<void>;
+  handleClearCache: () => Promise<void>;
+  loadData: () => Promise<void>;
+  loadEntries: () => Promise<void>;
+  dialog: ReactNode;
+}
+
+export function useSsdFileCache(initialArray?: string): UseSsdFileCacheResult;
+```
+
+**Porting notes (byte-identical):** move lines 56–240 verbatim — the 13 `useState`, the `pageSize = 20` const, `useConfirmDialog()`, the three effects (deps unchanged: `[]`, `[selectedArray]`, `[page, selectedArray]`), and every handler (`loadArrays`, `loadData`, `loadEntries`, `resetConfigForm`, `handleConfigChange`, `handleSaveConfig`, `handleEvictEntry`, `handleTriggerEviction`, `handleClearCache`). Keep `loadArrays` internal (not exported). Preserve the `cfg.eviction_policy as 'lfru' | 'lru' | 'lfu'` cast, the `Promise.all`, all toast strings, the clear-cache `confirm(...)` wording, and the `loadEntries` empty catch. Return the full object above.
+
+> ESLint note: the original disables no rules for the effect deps; keep the same `// eslint-disable-next-line` comments IF the original had them — it does NOT (the effects intentionally omit function deps). If eslint flags `react-hooks/exhaustive-deps` on the moved effects, add `// eslint-disable-next-line react-hooks/exhaustive-deps` to match the original's behavior WITHOUT changing deps. Verify against `npx eslint` in Step 4.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// useSsdFileCache.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { SSDCacheStats, SSDCacheConfigResponse, CacheHealthResponse } from '../../api/ssd-file-cache';
+
+vi.mock('../../api/raid', () => ({
+  getRaidStatus: vi.fn().mockResolvedValue({ arrays: [{ name: 'md0' }] }),
+}));
+const mockConfirm = vi.fn();
+vi.mock('../../hooks/useConfirmDialog', () => ({
+  useConfirmDialog: () => ({ confirm: mockConfirm, dialog: null }),
+}));
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('../../lib/errorHandling', () => ({
+  getApiErrorMessage: (_e: unknown, fb: string) => fb,
+  handleApiError: vi.fn(),
+}));
+
+const stats: SSDCacheStats = {
+  array_name: 'md0', is_enabled: true, cache_path: '/ssd', max_size_bytes: 1000,
+  current_size_bytes: 500, usage_percent: 50, total_entries: 3, valid_entries: 3,
+  total_hits: 10, total_misses: 2, hit_rate_percent: 83.3, total_bytes_served: 999,
+  ssd_available_bytes: 800, ssd_total_bytes: 1000,
+};
+const config: SSDCacheConfigResponse = {
+  array_name: 'md0', is_enabled: true, cache_path: '/ssd', max_size_bytes: 1000,
+  current_size_bytes: 500, eviction_policy: 'lfru', min_file_size_bytes: 1,
+  max_file_size_bytes: 100, sequential_cutoff_bytes: 50, total_hits: 10,
+  total_misses: 2, total_bytes_served_from_cache: 999, updated_at: null,
+};
+const health: CacheHealthResponse = {
+  array_name: 'md0', is_mounted: true, ssd_total_bytes: 1000,
+  ssd_available_bytes: 800, ssd_used_percent: 20, cache_dir_exists: true,
+};
+
+vi.mock('../../api/ssd-file-cache', () => ({
+  getCacheStats: vi.fn().mockResolvedValue(stats),
+  getCacheConfig: vi.fn().mockResolvedValue(config),
+  getCacheHealth: vi.fn().mockResolvedValue(health),
+  getCacheEntries: vi.fn().mockResolvedValue({ entries: [], total: 0 }),
+  updateCacheConfig: vi.fn().mockResolvedValue(config),
+  evictEntry: vi.fn().mockResolvedValue({ freed_bytes: 10, source_path: '/x' }),
+  triggerEviction: vi.fn().mockResolvedValue({ freed_bytes: 10, deleted_count: 1 }),
+  clearCache: vi.fn().mockResolvedValue({ freed_bytes: 10, deleted_count: 1 }),
+}));
+
+import { useSsdFileCache } from '../../hooks/useSsdFileCache';
+import * as api from '../../api/ssd-file-cache';
+
+describe('useSsdFileCache', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('auto-selects the sole array on mount and loads its data', async () => {
+    const { result } = renderHook(() => useSsdFileCache());
+    await waitFor(() => expect(result.current.selectedArray).toBe('md0'));
+    await waitFor(() => expect(result.current.stats).not.toBeNull());
+    expect(result.current.config).not.toBeNull();
+  });
+
+  it('does not call clearCache when the confirm dialog is declined', async () => {
+    mockConfirm.mockResolvedValueOnce(false);
+    const { result } = renderHook(() => useSsdFileCache('md0'));
+    await waitFor(() => expect(result.current.selectedArray).toBe('md0'));
+    await act(async () => { await result.current.handleClearCache(); });
+    expect(api.clearCache).not.toHaveBeenCalled();
+  });
+
+  it('handleConfigChange marks the form dirty and updates the field', async () => {
+    const { result } = renderHook(() => useSsdFileCache('md0'));
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+    act(() => result.current.handleConfigChange('is_enabled', false));
+    expect(result.current.configDirty).toBe(true);
+    expect(result.current.configForm.is_enabled).toBe(false);
+  });
+
+  it('handleSaveConfig sends the current form to updateCacheConfig', async () => {
+    const { result } = renderHook(() => useSsdFileCache('md0'));
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+    act(() => result.current.handleConfigChange('max_size_bytes', 2048));
+    await act(async () => { await result.current.handleSaveConfig(); });
+    expect(api.updateCacheConfig).toHaveBeenCalledWith(
+      'md0', expect.objectContaining({ max_size_bytes: 2048 }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** → FAIL (module not found).
+- [ ] **Step 3: Write the hook** per the porting notes (move 56–240 verbatim; return the full object).
+- [ ] **Step 4: Run test + gates**
+
+Run: `cd client ; npx vitest run src/__tests__/hooks/useSsdFileCache.test.ts` → PASS (4 tests).
+Run: `cd client ; npx tsc -b` → no errors.
+Run: `cd client ; npx eslint src/hooks/useSsdFileCache.ts` → 0 errors.
+
+- [ ] **Step 5: Commit** `feat(ssd-cache): add useSsdFileCache hook (state + actions) (F2, #301)`.
+
+---
+
+### Task 3: `CacheViewTabs` + `CacheArraySelector`
+
+**Files:**
+- Create: `client/src/components/ssd-cache/file-cache/CacheViewTabs.tsx`
+- Create: `client/src/components/ssd-cache/file-cache/CacheArraySelector.tsx`
+- Test: `client/src/__tests__/components/ssd-cache/file-cache/CacheViewTabs.test.tsx`
+- Test: `client/src/__tests__/components/ssd-cache/file-cache/CacheArraySelector.test.tsx`
+
+**Interfaces:**
+- Produces:
+```ts
+import type { TabView } from '../../../hooks/useSsdFileCache';
+export function CacheViewTabs(props: { tabView: TabView; onSelect: (v: TabView) => void }): JSX.Element;
+export function CacheArraySelector(props: { arrays: string[]; selectedArray: string; onSelect: (name: string) => void }): JSX.Element;
+```
+- Consumed by Task 9.
+
+**Porting notes:** `CacheViewTabs` = the two view-tab buttons verbatim from `SsdFileCacheTab.tsx:274-298` (keep the two `t('ssdCache.migration.*', 'fallback')` calls; `useTranslation()` internally; `Zap`/`ArrowRightLeft` icons). `CacheArraySelector` = the selector row verbatim from `304-324` (the `arrays.length > 1` guard stays in the orchestrator — this component just renders the row).
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// CacheViewTabs.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (_k: string, fb: string) => fb }) }));
+import { CacheViewTabs } from '../../../../components/ssd-cache/file-cache/CacheViewTabs';
+
+describe('CacheViewTabs', () => {
+  it('renders both view tabs', () => {
+    render(<CacheViewTabs tabView="cache" onSelect={() => {}} />);
+    expect(screen.getByText('File Cache')).toBeInTheDocument();
+    expect(screen.getByText('Data Migration')).toBeInTheDocument();
+  });
+  it('fires onSelect with the clicked view', () => {
+    const onSelect = vi.fn();
+    render(<CacheViewTabs tabView="cache" onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('Data Migration'));
+    expect(onSelect).toHaveBeenCalledWith('migration');
+  });
+});
+```
+
+```tsx
+// CacheArraySelector.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CacheArraySelector } from '../../../../components/ssd-cache/file-cache/CacheArraySelector';
+
+describe('CacheArraySelector', () => {
+  it('renders one button per array', () => {
+    render(<CacheArraySelector arrays={['md0', 'md1']} selectedArray="md0" onSelect={() => {}} />);
+    expect(screen.getByText('md0')).toBeInTheDocument();
+    expect(screen.getByText('md1')).toBeInTheDocument();
+  });
+  it('fires onSelect with the clicked array name', () => {
+    const onSelect = vi.fn();
+    render(<CacheArraySelector arrays={['md0', 'md1']} selectedArray="md0" onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('md1'));
+    expect(onSelect).toHaveBeenCalledWith('md1');
+  });
+});
+```
+
+- [ ] **Step 2: Run both → FAIL.**
+- [ ] **Step 3: Write both components** per porting notes.
+- [ ] **Step 4: Run both tests + `npx tsc -b`** → PASS (4 tests total).
+- [ ] **Step 5: Commit** `feat(ssd-cache): extract CacheViewTabs + CacheArraySelector (F2, #301)`.
+
+---
+
+### Task 4: `CacheStatsGrid`
+
+**Files:**
+- Create: `client/src/components/ssd-cache/file-cache/CacheStatsGrid.tsx`
+- Test: `client/src/__tests__/components/ssd-cache/file-cache/CacheStatsGrid.test.tsx`
+
+**Interfaces:**
+- Consumes: `cacheUsageBarColor` (Task 1), `formatBytes` from `../../../lib/formatters`, `SSDCacheStats`.
+- Produces: `export function CacheStatsGrid(props: { stats: SSDCacheStats }): JSX.Element;`
+- Consumed by Task 9.
+
+**Porting notes:** Move the 4 stat cards verbatim from `SsdFileCacheTab.tsx:332-399` (Status / Cache Usage / Hit Rate / Bytes Served). The usage-bar inline color ternary at 363-365 becomes `cacheUsageBarColor(stats.usage_percent)`. Keep `formatBytes`, all icons, the `Math.min(stats.usage_percent, 100)` width.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// CacheStatsGrid.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { SSDCacheStats } from '../../../../api/ssd-file-cache';
+import { CacheStatsGrid } from '../../../../components/ssd-cache/file-cache/CacheStatsGrid';
+
+const stats = (over: Partial<SSDCacheStats> = {}): SSDCacheStats => ({
+  array_name: 'md0', is_enabled: true, cache_path: '/ssd', max_size_bytes: 1024,
+  current_size_bytes: 512, usage_percent: 50, total_entries: 3, valid_entries: 2,
+  total_hits: 10, total_misses: 5, hit_rate_percent: 66.7, total_bytes_served: 2048,
+  ssd_available_bytes: 900, ssd_total_bytes: 1024, ...over,
+});
+
+describe('CacheStatsGrid', () => {
+  it('shows Enabled status when enabled', () => {
+    render(<CacheStatsGrid stats={stats({ is_enabled: true })} />);
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+  });
+  it('shows Disabled status when disabled', () => {
+    render(<CacheStatsGrid stats={stats({ is_enabled: false })} />);
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+  });
+  it('renders the hit-rate percentage', () => {
+    render(<CacheStatsGrid stats={stats({ hit_rate_percent: 66.7 })} />);
+    expect(screen.getByText('66.7%')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Write the component.**
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (3 tests).
+- [ ] **Step 5: Commit** `feat(ssd-cache): extract CacheStatsGrid (F2, #301)`.
+
+---
+
+### Task 5: `CacheHealthCard`
+
+**Files:**
+- Create: `client/src/components/ssd-cache/file-cache/CacheHealthCard.tsx`
+- Test: `client/src/__tests__/components/ssd-cache/file-cache/CacheHealthCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `formatBytes`, `CacheHealthResponse`.
+- Produces: `export function CacheHealthCard(props: { health: CacheHealthResponse }): JSX.Element;`
+- Consumed by Task 9.
+
+**Porting notes:** Move the health card verbatim from `SsdFileCacheTab.tsx:401-433` (the outer `{health && ...}` guard stays in the orchestrator — this component always renders given a `health` prop). Keep `Check`/`X`/`Heart` icons, `formatBytes`, the `ssd_used_percent.toFixed(1)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// CacheHealthCard.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { CacheHealthResponse } from '../../../../api/ssd-file-cache';
+import { CacheHealthCard } from '../../../../components/ssd-cache/file-cache/CacheHealthCard';
+
+const health = (over: Partial<CacheHealthResponse> = {}): CacheHealthResponse => ({
+  array_name: 'md0', is_mounted: true, ssd_total_bytes: 1024, ssd_available_bytes: 900,
+  ssd_used_percent: 12.5, cache_dir_exists: true, ...over,
+});
+
+describe('CacheHealthCard', () => {
+  it('shows Mounted when the ssd is mounted', () => {
+    render(<CacheHealthCard health={health({ is_mounted: true })} />);
+    expect(screen.getByText('Mounted')).toBeInTheDocument();
+  });
+  it('shows Not Mounted and Missing when unmounted with no cache dir', () => {
+    render(<CacheHealthCard health={health({ is_mounted: false, cache_dir_exists: false })} />);
+    expect(screen.getByText('Not Mounted')).toBeInTheDocument();
+    expect(screen.getByText('Missing')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Write the component.**
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (2 tests).
+- [ ] **Step 5: Commit** `feat(ssd-cache): extract CacheHealthCard (F2, #301)`.
+
+---
+
+### Task 6: `CacheConfigCard`
+
+**Files:**
+- Create: `client/src/components/ssd-cache/file-cache/CacheConfigCard.tsx`
+- Test: `client/src/__tests__/components/ssd-cache/file-cache/CacheConfigCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `ByteSizeInput` from `../ui/ByteSizeInput`, `SSDCacheConfigUpdate`, `SSDCacheConfigResponse`.
+- Produces:
+```ts
+import type { SSDCacheConfigUpdate, SSDCacheConfigResponse } from '../../../api/ssd-file-cache';
+export function CacheConfigCard(props: {
+  configForm: SSDCacheConfigUpdate;
+  config: SSDCacheConfigResponse;
+  configDirty: boolean;
+  actionLoading: boolean;
+  onConfigChange: (key: keyof SSDCacheConfigUpdate, value: unknown) => void;
+  onSave: () => void;
+  onReset: (cfg: SSDCacheConfigResponse) => void;
+}): JSX.Element;
+```
+- Consumed by Task 9.
+
+**Porting notes:** Move the config card verbatim from `SsdFileCacheTab.tsx:435-525`: enable checkbox (`onChange` → `onConfigChange('is_enabled', e.target.checked)`), the four `ByteSizeInput`s (`onChange` → `onConfigChange('<field>', bytes)`), the eviction-policy `<select>` (`onChange` → `onConfigChange('eviction_policy', e.target.value)`), the save button (`disabled={actionLoading || !configDirty}`, `onClick={onSave}`), and the conditional reset button (`{configDirty && config && (...)}`, `onClick={() => onReset(config)}`). Copy verbatim, incl. the three `<option>` texts.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// CacheConfigCard.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { SSDCacheConfigUpdate, SSDCacheConfigResponse } from '../../../../api/ssd-file-cache';
+import { CacheConfigCard } from '../../../../components/ssd-cache/file-cache/CacheConfigCard';
+
+const config: SSDCacheConfigResponse = {
+  array_name: 'md0', is_enabled: true, cache_path: '/ssd', max_size_bytes: 1024,
+  current_size_bytes: 512, eviction_policy: 'lfru', min_file_size_bytes: 1,
+  max_file_size_bytes: 100, sequential_cutoff_bytes: 50, total_hits: 0,
+  total_misses: 0, total_bytes_served_from_cache: 0, updated_at: null,
+};
+const form: SSDCacheConfigUpdate = {
+  is_enabled: true, max_size_bytes: 1024, eviction_policy: 'lfru',
+  min_file_size_bytes: 1, max_file_size_bytes: 100, sequential_cutoff_bytes: 50,
+};
+const base = {
+  configForm: form, config, actionLoading: false,
+  onConfigChange: () => {}, onSave: () => {}, onReset: () => {},
+};
+
+describe('CacheConfigCard', () => {
+  it('disables Save when not dirty and enables it when dirty', () => {
+    const { rerender } = render(<CacheConfigCard {...base} configDirty={false} />);
+    expect(screen.getByText('Save Configuration').closest('button')).toBeDisabled();
+    rerender(<CacheConfigCard {...base} configDirty={true} />);
+    expect(screen.getByText('Save Configuration').closest('button')).not.toBeDisabled();
+  });
+  it('shows the Reset button only when dirty', () => {
+    const { rerender } = render(<CacheConfigCard {...base} configDirty={false} />);
+    expect(screen.queryByText('Reset')).not.toBeInTheDocument();
+    rerender(<CacheConfigCard {...base} configDirty={true} />);
+    expect(screen.getByText('Reset')).toBeInTheDocument();
+  });
+  it('fires onConfigChange when the enabled checkbox toggles', () => {
+    const onConfigChange = vi.fn();
+    render(<CacheConfigCard {...base} configDirty={false} onConfigChange={onConfigChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onConfigChange).toHaveBeenCalledWith('is_enabled', false);
+  });
+  it('fires onSave when Save is clicked (dirty)', () => {
+    const onSave = vi.fn();
+    render(<CacheConfigCard {...base} configDirty={true} onSave={onSave} />);
+    fireEvent.click(screen.getByText('Save Configuration'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Write the component.**
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (4 tests).
+- [ ] **Step 5: Commit** `feat(ssd-cache): extract CacheConfigCard (F2, #301)`.
+
+---
+
+### Task 7: `CacheActionsCard`
+
+**Files:**
+- Create: `client/src/components/ssd-cache/file-cache/CacheActionsCard.tsx`
+- Test: `client/src/__tests__/components/ssd-cache/file-cache/CacheActionsCard.test.tsx`
+
+**Interfaces:**
+- Produces:
+```ts
+export function CacheActionsCard(props: {
+  actionLoading: boolean;
+  onTriggerEviction: () => void;
+  onClearCache: () => void;
+  onRefresh: () => void;
+}): JSX.Element;
+```
+- Consumed by Task 9.
+
+**Porting notes:** Move the actions card verbatim from `SsdFileCacheTab.tsx:527-559`: Trigger Eviction (`onClick={onTriggerEviction}`), Clear Cache (`onClick={onClearCache}`), Refresh (`onClick={onRefresh}`), each `disabled={actionLoading}`, keep the `RefreshCw` spin class `${actionLoading ? 'animate-spin' : ''}` and `Trash2` icon.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// CacheActionsCard.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CacheActionsCard } from '../../../../components/ssd-cache/file-cache/CacheActionsCard';
+
+describe('CacheActionsCard', () => {
+  it('fires each action callback on its button', () => {
+    const onTriggerEviction = vi.fn(), onClearCache = vi.fn(), onRefresh = vi.fn();
+    render(<CacheActionsCard actionLoading={false}
+      onTriggerEviction={onTriggerEviction} onClearCache={onClearCache} onRefresh={onRefresh} />);
+    fireEvent.click(screen.getByText('Trigger Eviction'));
+    fireEvent.click(screen.getByText('Clear Cache'));
+    fireEvent.click(screen.getByText('Refresh'));
+    expect(onTriggerEviction).toHaveBeenCalledTimes(1);
+    expect(onClearCache).toHaveBeenCalledTimes(1);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+  it('disables all buttons while an action is loading', () => {
+    render(<CacheActionsCard actionLoading={true}
+      onTriggerEviction={() => {}} onClearCache={() => {}} onRefresh={() => {}} />);
+    for (const label of ['Trigger Eviction', 'Clear Cache', 'Refresh']) {
+      expect(screen.getByText(label).closest('button')).toBeDisabled();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Write the component.**
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (2 tests).
+- [ ] **Step 5: Commit** `feat(ssd-cache): extract CacheActionsCard (F2, #301)`.
+
+---
+
+### Task 8: `CacheEntriesTable`
+
+**Files:**
+- Create: `client/src/components/ssd-cache/file-cache/CacheEntriesTable.tsx`
+- Test: `client/src/__tests__/components/ssd-cache/file-cache/CacheEntriesTable.test.tsx`
+
+**Interfaces:**
+- Consumes: `formatBytes`, `SSDCacheEntryResponse`.
+- Produces:
+```ts
+import type { SSDCacheEntryResponse } from '../../../api/ssd-file-cache';
+export function CacheEntriesTable(props: {
+  entries: SSDCacheEntryResponse[];
+  entriesTotal: number;
+  page: number;
+  totalPages: number;
+  actionLoading: boolean;
+  onEvict: (entryId: number) => void;
+  onPrevPage: () => void;
+  onNextPage: () => void;
+}): JSX.Element;
+```
+- Consumed by Task 9.
+
+**Porting notes:** Move the entries table + pagination verbatim from `SsdFileCacheTab.tsx:561-647`: the header (`Cached Entries` + `({entriesTotal})`), the table with the 6 columns, the row map (evict button `onClick={() => onEvict(entry.id)}`, `disabled={actionLoading}`), the empty-row (`colSpan={6}` "No cached entries"), and the pagination block guarded `{totalPages > 1 && (...)}` (prev `onClick={onPrevPage}` `disabled={page === 0}`, next `onClick={onNextPage}` `disabled={page >= totalPages - 1}`, "Page {page + 1} of {totalPages}"). Keep `formatBytes`, `new Date(entry.last_accessed).toLocaleString()`, all icons.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// CacheEntriesTable.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { SSDCacheEntryResponse } from '../../../../api/ssd-file-cache';
+import { CacheEntriesTable } from '../../../../components/ssd-cache/file-cache/CacheEntriesTable';
+
+const entry = (over: Partial<SSDCacheEntryResponse> = {}): SSDCacheEntryResponse => ({
+  id: 1, array_name: 'md0', source_path: '/data/file.bin', file_size_bytes: 2048,
+  access_count: 7, last_accessed: '2026-07-01T10:00:00Z', first_cached: '2026-06-01T10:00:00Z',
+  is_valid: true, ...over,
+});
+const base = { entriesTotal: 1, page: 0, totalPages: 1, actionLoading: false,
+  onEvict: () => {}, onPrevPage: () => {}, onNextPage: () => {} };
+
+describe('CacheEntriesTable', () => {
+  it('renders the empty-state row when there are no entries', () => {
+    render(<CacheEntriesTable {...base} entries={[]} entriesTotal={0} />);
+    expect(screen.getByText('No cached entries')).toBeInTheDocument();
+  });
+  it('renders a row per entry and fires onEvict with the entry id', () => {
+    const onEvict = vi.fn();
+    render(<CacheEntriesTable {...base} entries={[entry({ id: 42 })]} onEvict={onEvict} />);
+    expect(screen.getByText('/data/file.bin')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Evict'));
+    expect(onEvict).toHaveBeenCalledWith(42);
+  });
+  it('hides pagination when there is only one page', () => {
+    render(<CacheEntriesTable {...base} entries={[entry()]} totalPages={1} />);
+    expect(screen.queryByText(/Page 1 of/)).not.toBeInTheDocument();
+  });
+  it('disables prev on the first page and next on the last page, firing callbacks otherwise', () => {
+    const onPrevPage = vi.fn(), onNextPage = vi.fn();
+    // the Evict button has text; the two pagination controls are icon-only (empty textContent)
+    const iconButtons = () => screen.getAllByRole('button').filter((b) => !b.textContent?.trim());
+    const { rerender } = render(
+      <CacheEntriesTable {...base} entries={[entry()]} page={0} totalPages={3}
+        onPrevPage={onPrevPage} onNextPage={onNextPage} />,
+    );
+    expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument();
+    const [prev0, next0] = iconButtons(); // DOM order: ChevronLeft (prev), ChevronRight (next)
+    expect(prev0).toBeDisabled();          // first page → prev disabled
+    expect(next0).not.toBeDisabled();
+    fireEvent.click(next0);
+    expect(onNextPage).toHaveBeenCalledTimes(1);
+    rerender(
+      <CacheEntriesTable {...base} entries={[entry()]} page={2} totalPages={3}
+        onPrevPage={onPrevPage} onNextPage={onNextPage} />,
+    );
+    expect(screen.getByText(/Page 3 of 3/)).toBeInTheDocument();
+    const [prev2, next2] = iconButtons();
+    expect(next2).toBeDisabled();           // last page → next disabled
+    expect(prev2).not.toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Write the component.**
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS.
+- [ ] **Step 5: Commit** `feat(ssd-cache): extract CacheEntriesTable (F2, #301)`.
+
+---
+
+### Task 9: Barrel + `SsdFileCacheTab.tsx` orchestrator + integration test
+
+**Files:**
+- Create: `client/src/components/ssd-cache/file-cache/index.ts`
+- Modify: `client/src/components/ssd-cache/SsdFileCacheTab.tsx` (full rewrite to orchestrator)
+- Test: `client/src/__tests__/components/ssd-cache/SsdFileCacheTab.test.tsx`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–8 via the barrel, `useSsdFileCache` (Task 2), `MigrationPanel` (unchanged).
+
+**Barrel** `index.ts` re-exports: `cacheUsageBarColor`, `type TabView` (re-export from the hook OR define canonical here — keep the hook as the canonical source and `export type { TabView } from '../../../hooks/useSsdFileCache'`), `CacheViewTabs`, `CacheArraySelector`, `CacheStatsGrid`, `CacheHealthCard`, `CacheConfigCard`, `CacheActionsCard`, `CacheEntriesTable`.
+
+**Orchestrator rewrite:** keep the file header comment + default export `SsdFileCacheTab({ initialArray })`. Call `useSsdFileCache(initialArray)`. Compute `const totalPages = Math.ceil(entriesTotal / pageSize)`. Structure:
+1. Early returns verbatim: initial spinner (`loading && !selectedArray`, 242–248), no-arrays (`arrays.length === 0 && !loading`, 250–256), error (`error && !stats`, 258–268 — the `Retry` button keeps `onClick={loadData}`).
+2. `<div className="space-y-6">` → `<CacheViewTabs tabView={tabView} onSelect={setTabView} />`.
+3. `{tabView === 'migration' ? <MigrationPanel /> : (<> ... </>)}`.
+4. Inside the cache fragment: `{arrays.length > 1 && <CacheArraySelector arrays={arrays} selectedArray={selectedArray} onSelect={setSelectedArray} />}`, then `{loading ? <spinner/> : stats && config ? (<> <CacheStatsGrid stats={stats}/> {health && <CacheHealthCard health={health}/>} <CacheConfigCard .../> <CacheActionsCard .../> <CacheEntriesTable .../> </>) : null}`.
+5. `{dialog}`: preserve the EXACT original nesting (lines 651-653) — `{dialog}` lives INSIDE the migration-ternary's else-branch fragment (`tabView === 'migration' ? <MigrationPanel/> : (<> ...cache view... {dialog} </>)`), i.e. it renders only in the cache view, after the loading/stats block, NOT at the top `space-y-6` level. Do not move it outside the ternary.
+
+Wire the callbacks:
+- `CacheConfigCard`: `configForm`, `config={config}`, `configDirty`, `actionLoading`, `onConfigChange={handleConfigChange}`, `onSave={handleSaveConfig}`, `onReset={resetConfigForm}`.
+- `CacheActionsCard`: `actionLoading`, `onTriggerEviction={handleTriggerEviction}`, `onClearCache={handleClearCache}`, `onRefresh={() => { loadData(); loadEntries(); }}`.
+- `CacheEntriesTable`: `entries`, `entriesTotal`, `page`, `totalPages`, `actionLoading`, `onEvict={handleEvictEntry}`, `onPrevPage={() => setPage((p) => Math.max(0, p - 1))}`, `onNextPage={() => setPage((p) => Math.min(totalPages - 1, p + 1))}`.
+
+Delete all now-unused imports (the API functions, `getRaidStatus`, `useState`/`useEffect`, `useConfirmDialog`, `toast`, `getApiErrorMessage`/`handleApiError`, `ByteSizeInput`, `formatBytes`, and the lucide icons only used by moved markup — keep only icons still used by the early-returns, e.g. `AlertCircle`). Keep `useTranslation`? The orchestrator no longer calls `t()` directly (tabs moved out) — remove it if unused. Keep `MigrationPanel`, `useSsdFileCache`, the barrel imports. Run eslint to catch leftovers.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```tsx
+// client/src/__tests__/components/ssd-cache/SsdFileCacheTab.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { SSDCacheStats, SSDCacheConfigResponse } from '../../../api/ssd-file-cache';
+import type { UseSsdFileCacheResult } from '../../../hooks/useSsdFileCache';
+
+const stats: SSDCacheStats = {
+  array_name: 'md0', is_enabled: true, cache_path: '/ssd', max_size_bytes: 1024,
+  current_size_bytes: 512, usage_percent: 50, total_entries: 1, valid_entries: 1,
+  total_hits: 5, total_misses: 1, hit_rate_percent: 83.3, total_bytes_served: 100,
+  ssd_available_bytes: 900, ssd_total_bytes: 1024,
+};
+const config: SSDCacheConfigResponse = {
+  array_name: 'md0', is_enabled: true, cache_path: '/ssd', max_size_bytes: 1024,
+  current_size_bytes: 512, eviction_policy: 'lfru', min_file_size_bytes: 1,
+  max_file_size_bytes: 100, sequential_cutoff_bytes: 50, total_hits: 5,
+  total_misses: 1, total_bytes_served_from_cache: 100, updated_at: null,
+};
+
+const hookValue: UseSsdFileCacheResult = {
+  tabView: 'cache', setTabView: vi.fn(), arrays: ['md0'], selectedArray: 'md0',
+  setSelectedArray: vi.fn(), stats, config, health: null, entries: [], entriesTotal: 0,
+  loading: false, error: null, actionLoading: false, configForm: {}, configDirty: false,
+  page: 0, setPage: vi.fn(), pageSize: 20, handleConfigChange: vi.fn(),
+  handleSaveConfig: vi.fn(), resetConfigForm: vi.fn(), handleEvictEntry: vi.fn(),
+  handleTriggerEviction: vi.fn(), handleClearCache: vi.fn(), loadData: vi.fn(),
+  loadEntries: vi.fn(), dialog: null,
+};
+vi.mock('../../../hooks/useSsdFileCache', () => ({ useSsdFileCache: () => hookValue }));
+vi.mock('../../../components/ssd-cache/MigrationPanel', () => ({ default: () => <div data-testid="migration" /> }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (_k: string, fb: string) => fb }) }));
+
+import SsdFileCacheTab from '../../../components/ssd-cache/SsdFileCacheTab';
+
+describe('SsdFileCacheTab', () => {
+  beforeEach(() => {
+    Object.assign(hookValue, { tabView: 'cache', arrays: ['md0'], stats, config, loading: false });
+  });
+
+  it('renders the cache view (stats + config + actions) for a populated fixture', () => {
+    render(<SsdFileCacheTab />);
+    expect(screen.getByText('Enabled')).toBeInTheDocument();      // stats grid
+    expect(screen.getByText('Configuration')).toBeInTheDocument(); // config card
+    expect(screen.getByText('Actions')).toBeInTheDocument();       // actions card
+    expect(screen.queryByTestId('migration')).not.toBeInTheDocument();
+  });
+
+  it('renders MigrationPanel when tabView is migration', () => {
+    hookValue.tabView = 'migration';
+    render(<SsdFileCacheTab />);
+    expect(screen.getByTestId('migration')).toBeInTheDocument();
+    expect(screen.queryByText('Configuration')).not.toBeInTheDocument();
+  });
+
+  it('shows the no-arrays message when there are no arrays', () => {
+    Object.assign(hookValue, { arrays: [], loading: false, stats: null });
+    render(<SsdFileCacheTab />);
+    expect(screen.getByText(/No RAID arrays found/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** → FAIL (old shape / barrel not built).
+- [ ] **Step 3: Write the barrel, then rewrite `SsdFileCacheTab.tsx`** per the structure above.
+- [ ] **Step 4: Full verification**
+
+Run: `cd client ; npx vitest run src/__tests__/components/ssd-cache/SsdFileCacheTab.test.tsx` → PASS (3 tests).
+Run: `cd client ; node -e "console.log(require('fs').readFileSync('src/components/ssd-cache/SsdFileCacheTab.tsx','utf8').split(/\r?\n/).length)"` → under 500 (target ~130).
+Run: `cd client ; npx tsc -b` → no errors.
+Run: `cd client ; npx eslint src/components/ssd-cache/SsdFileCacheTab.tsx src/components/ssd-cache/file-cache src/hooks/useSsdFileCache.ts` → 0 errors (no unused imports).
+
+- [ ] **Step 5: Commit** `refactor(ssd-cache): compose SsdFileCacheTab from useSsdFileCache + file-cache/* (F2, #301)`.
+
+---
+
+## Final Verification (after all tasks)
+
+- [ ] `cd client ; npx eslint .` → 0 errors.
+- [ ] `cd client ; npm run build` → green (tsc -b + vite).
+- [ ] `cd client ; npx vitest run` → full suite green.
+- [ ] `SsdFileCacheTab.tsx` < 500 lines.
+- [ ] Update `client/src/components/CLAUDE.md` `ssd-cache/` row to note the `file-cache/` decomposition + `useSsdFileCache` hook (docs-only; fold into the Task 9 commit or a trailing `docs(ssd-cache): ...` commit).
+- [ ] Multi-agent whole-branch review — READY TO MERGE (field-for-field audit of every moved block, especially the three effects, the array auto-select in `loadArrays`, and the config save→refresh-stats sequence).

--- a/docs/superpowers/specs/2026-07-11-ssdfilecachetab-decomposition-f2-design.md
+++ b/docs/superpowers/specs/2026-07-11-ssdfilecachetab-decomposition-f2-design.md
@@ -13,7 +13,8 @@ of presentational components under a new
 
 **Non-goals:** no change to API calls, endpoints, the copy (this file uses
 mostly hard-coded English strings — they stay verbatim; do NOT introduce i18n,
-that is scope creep), Tailwind styling, toast messages, `useConfirmDialog`
+that is scope creep — the i18n gap is tracked separately in the collective
+issue #406), Tailwind styling, toast messages, `useConfirmDialog`
 wording, pagination size (20), or any computed value. The component keeps its
 path (`components/ssd-cache/SsdFileCacheTab.tsx`, **default export**
 `SsdFileCacheTab`, prop `initialArray?: string`) so consumers and the

--- a/docs/superpowers/specs/2026-07-11-ssdfilecachetab-decomposition-f2-design.md
+++ b/docs/superpowers/specs/2026-07-11-ssdfilecachetab-decomposition-f2-design.md
@@ -1,0 +1,198 @@
+# SsdFileCacheTab.tsx Decomposition — Design (F2 / #301)
+
+**Date:** 2026-07-11
+**Finding:** F2 (components > 500 lines), umbrella issue #301.
+**Target:** `client/src/components/ssd-cache/SsdFileCacheTab.tsx` — currently **657 lines**.
+
+## Goal
+
+Behavior-preserving decomposition of `SsdFileCacheTab.tsx` (the admin per-array
+SSD file-cache tab) into one data/state hook, one pure helper, and a directory
+of presentational components under a new
+`components/ssd-cache/file-cache/`.
+
+**Non-goals:** no change to API calls, endpoints, the copy (this file uses
+mostly hard-coded English strings — they stay verbatim; do NOT introduce i18n,
+that is scope creep), Tailwind styling, toast messages, `useConfirmDialog`
+wording, pagination size (20), or any computed value. The component keeps its
+path (`components/ssd-cache/SsdFileCacheTab.tsx`, **default export**
+`SsdFileCacheTab`, prop `initialArray?: string`) so consumers and the
+`ssd-cache` barrel are untouched. The already-extracted `MigrationPanel` is
+reused as-is.
+
+## Constraints
+
+- Every extracted value is **byte-identical** in behavior: same six cache API
+  calls + `getRaidStatus`, same `Promise.all` in `loadData`, same array
+  auto-select logic, same three effects (mount → `loadArrays`; `[selectedArray]`
+  → `loadData` + `setPage(0)`; `[page, selectedArray]` → `loadEntries`), same
+  toast strings, same `confirm(...)` clear-cache wording, same
+  `getApiErrorMessage`/`handleApiError` usage, same error-swallow on
+  `loadEntries`.
+- Extracted components are **presentational**: props in, callbacks in, no data
+  fetching. The extracted hook owns all fetching/state.
+- Tests are T7-conform: assert on role/text/title, never Tailwind classes;
+  fixtures are complete objects of the real API types (`SSDCacheStats`,
+  `SSDCacheConfigResponse`, `CacheHealthResponse`, `SSDCacheEntryResponse`).
+- Hard-coded English strings are preserved verbatim; the two `t(...)` calls
+  (`ssdCache.migration.cacheTab`, `ssdCache.migration.title`) stay as `t()`.
+
+## Current inline blocks (what moves)
+
+| Block | Current lines | Destination |
+|---|---|---|
+| 13 `useState` + `pageSize` const + `useConfirmDialog` + 3 effects + all handlers (`loadArrays`, `loadData`, `loadEntries`, `resetConfigForm`, `handleConfigChange`, `handleSaveConfig`, `handleEvictEntry`, `handleTriggerEviction`, `handleClearCache`) | 56–240 | `hooks/useSsdFileCache.ts` |
+| Usage-bar color (`usage_percent >= 90 ? red : >= 70 ? amber : cyan`) | 363–365 | `file-cache/cacheUsageBarColor.ts` (pure) |
+| View tabs (cache / migration) | 274–298 | `file-cache/CacheViewTabs.tsx` |
+| Array selector | 304–324 | `file-cache/CacheArraySelector.tsx` |
+| Stats grid (4 cards) | 332–399 | `file-cache/CacheStatsGrid.tsx` |
+| Health card | 401–433 | `file-cache/CacheHealthCard.tsx` |
+| Config card (form + save/reset) | 435–525 | `file-cache/CacheConfigCard.tsx` |
+| Actions card | 527–559 | `file-cache/CacheActionsCard.tsx` |
+| Entries table + pagination | 561–647 | `file-cache/CacheEntriesTable.tsx` |
+
+## New units & interfaces
+
+### `hooks/useSsdFileCache.ts`
+
+```ts
+import type {
+  SSDCacheStats, SSDCacheConfigResponse, SSDCacheConfigUpdate,
+  SSDCacheEntryResponse, CacheHealthResponse,
+} from '../api/ssd-file-cache';
+import type { ReactNode } from 'react';
+
+export type TabView = 'cache' | 'migration';
+
+export interface UseSsdFileCacheResult {
+  tabView: TabView;
+  setTabView: (v: TabView) => void;
+  arrays: string[];
+  selectedArray: string;
+  setSelectedArray: (name: string) => void;
+  stats: SSDCacheStats | null;
+  config: SSDCacheConfigResponse | null;
+  health: CacheHealthResponse | null;
+  entries: SSDCacheEntryResponse[];
+  entriesTotal: number;
+  loading: boolean;
+  error: string | null;
+  actionLoading: boolean;
+  configForm: SSDCacheConfigUpdate;
+  configDirty: boolean;
+  page: number;
+  setPage: (updater: number | ((p: number) => number)) => void;
+  pageSize: number;
+  handleConfigChange: (key: keyof SSDCacheConfigUpdate, value: unknown) => void;
+  handleSaveConfig: () => Promise<void>;
+  resetConfigForm: (cfg: SSDCacheConfigResponse) => void;
+  handleEvictEntry: (entryId: number) => Promise<void>;
+  handleTriggerEviction: () => Promise<void>;
+  handleClearCache: () => Promise<void>;
+  loadData: () => Promise<void>;
+  loadEntries: () => Promise<void>;
+  dialog: ReactNode;
+}
+
+export function useSsdFileCache(initialArray?: string): UseSsdFileCacheResult;
+```
+
+Body ports lines 56–240 verbatim: the state, the `pageSize = 20` const, the
+three effects (unchanged deps), and every handler (same `Promise.all`, same
+toast strings, same `confirm` wording, same `getApiErrorMessage`/`handleApiError`
+targets, same `loadEntries` empty-catch, same `resetConfigForm` cast
+`cfg.eviction_policy as 'lfru' | 'lru' | 'lfu'`). `useConfirmDialog()` lives
+inside; `dialog` is returned. `loadArrays` stays internal (only the mount effect
+calls it). `page`'s setter must accept the functional-updater form used by the
+pagination buttons (`setPage((p) => ...)`).
+
+### `file-cache/cacheUsageBarColor.ts` (pure)
+
+```ts
+export function cacheUsageBarColor(usagePercent: number): string;
+```
+
+Verbatim thresholds from 363–365: `>= 90` → `'bg-red-500'`, `>= 70` →
+`'bg-amber-500'`, else `'bg-cyan-500'`.
+
+### Presentational components (`components/ssd-cache/file-cache/`)
+
+- **`CacheViewTabs.tsx`** — `{ tabView: TabView; onSelect: (v: TabView) => void }`.
+  The two view-tab buttons (274–298). `useTranslation()` internally (keeps the
+  two `t('ssdCache.migration.*', 'fallback')` calls verbatim).
+- **`CacheArraySelector.tsx`** — `{ arrays: string[]; selectedArray: string;
+  onSelect: (name: string) => void }`. The selector row (304–324). The
+  `arrays.length > 1` guard stays in the orchestrator.
+- **`CacheStatsGrid.tsx`** — `{ stats: SSDCacheStats }`. The 4 cards verbatim
+  (332–399), using `formatBytes` + `cacheUsageBarColor` for the usage bar.
+- **`CacheHealthCard.tsx`** — `{ health: CacheHealthResponse }`. Health card
+  (401–433). The `{health && ...}` guard stays in the orchestrator (render only
+  when health present).
+- **`CacheConfigCard.tsx`** — `{ configForm: SSDCacheConfigUpdate; config:
+  SSDCacheConfigResponse; configDirty: boolean; actionLoading: boolean;
+  onConfigChange: (key: keyof SSDCacheConfigUpdate, value: unknown) => void;
+  onSave: () => void; onReset: (cfg: SSDCacheConfigResponse) => void }`. The
+  form (435–525): enable checkbox, `ByteSizeInput`s, eviction-policy select,
+  save button (`disabled={actionLoading || !configDirty}`), conditional reset
+  button (`configDirty && config`).
+- **`CacheActionsCard.tsx`** — `{ actionLoading: boolean; onTriggerEviction:
+  () => void; onClearCache: () => void; onRefresh: () => void }`. The three
+  action buttons (527–559).
+- **`CacheEntriesTable.tsx`** — `{ entries: SSDCacheEntryResponse[];
+  entriesTotal: number; page: number; totalPages: number; actionLoading:
+  boolean; onEvict: (entryId: number) => void; onPrevPage: () => void;
+  onNextPage: () => void }`. The table + pagination (561–647), including the
+  empty-row (`colSpan={6}`) and the `totalPages > 1` pagination guard.
+
+### `file-cache/index.ts`
+
+Barrel exporting all components + `cacheUsageBarColor` + `TabView`.
+
+### `SsdFileCacheTab.tsx` (after)
+
+Calls `useSsdFileCache(initialArray)`. Computes `totalPages = Math.ceil(
+entriesTotal / pageSize)`. Keeps the three early-returns verbatim (initial
+spinner 242–248, no-arrays 250–256, error 258–268 with its `Retry` → `loadData`).
+Renders `CacheViewTabs`, then the migration branch (`MigrationPanel`) vs the
+cache view: `CacheArraySelector` (guarded `arrays.length > 1`), the inner
+loading spinner, then `stats && config` → `CacheStatsGrid`, `{health && }`
+`CacheHealthCard`, `CacheConfigCard`, `CacheActionsCard`, `CacheEntriesTable`
+(passing `onRefresh={() => { loadData(); loadEntries(); }}`, `onPrevPage={() =>
+setPage((p) => Math.max(0, p - 1))}`, `onNextPage={() => setPage((p) =>
+Math.min(totalPages - 1, p + 1))}`), and `{dialog}`. Target: **~130 lines**
+(from 657).
+
+## Testing
+
+Broad + integration (Vitest, T7-conform):
+
+- **`cacheUsageBarColor`** — `95 → bg-red-500`, `75 → bg-amber-500`,
+  `50 → bg-cyan-500`; boundaries `90 → red`, `70 → amber`.
+- **`useSsdFileCache`** — `renderHook`: mount loads arrays and auto-selects the
+  sole array; `handleClearCache` with `confirm` resolving `false` makes no
+  `clearCache` call; `handleSaveConfig` calls `updateCacheConfig` with the
+  current `configForm` then refreshes stats; `handleConfigChange` sets
+  `configDirty`. Mock `../api/ssd-file-cache`, `../api/raid`,
+  `../hooks/useConfirmDialog`, `react-hot-toast`.
+- **Component renders** — `CacheViewTabs` (select fires), `CacheArraySelector`
+  (one button per array, select fires), `CacheStatsGrid` (enabled/disabled
+  status label, hit-rate value), `CacheHealthCard` (mounted vs not),
+  `CacheConfigCard` (save disabled until dirty, reset shown only when dirty,
+  onConfigChange fires on checkbox/select), `CacheActionsCard` (each callback
+  fires), `CacheEntriesTable` (empty-state row when no entries; evict fires with
+  id; prev disabled on page 0, next disabled on last page).
+- **Integration** (`__tests__/components/ssd-cache/SsdFileCacheTab.test.tsx`) —
+  mock the hook; assert the migration branch renders `MigrationPanel` when
+  `tabView === 'migration'`; the cache view renders stats grid + config + table
+  for a populated fixture; the no-arrays early-return.
+
+## Verification gates
+
+- `SsdFileCacheTab.tsx` < 500 lines (target ~130).
+- `eslint .` — 0 errors.
+- `npm run build` (tsc -b + vite) — green (`import type` for type-only imports —
+  `verbatimModuleSyntax` enforced by `tsc -b`, not vitest).
+- `vitest run` — full suite green.
+- Multi-agent whole-branch review — READY TO MERGE (field-for-field audit of
+  every moved block, especially the three effects, the array auto-select, and
+  the config save/refresh sequence).


### PR DESCRIPTION
## F2 — SsdFileCacheTab.tsx zerlegen (#301)

Verhaltenserhaltende Zerlegung von `client/src/components/ssd-cache/SsdFileCacheTab.tsx` — **657 → 143 Zeilen** — in einen Daten-/State-Hook, einen pure Helper und 7 Präsentations-Komponenten unter `components/ssd-cache/file-cache/`.

### Aufbau

| Unit | Rolle |
|---|---|
| `hooks/useSsdFileCache.ts` | Aller State (13 `useState`) + 3 Effects + alle Handler (load/save/evict/trigger/clear) + `useConfirmDialog` |
| `file-cache/cacheUsageBarColor.ts` | pure Helper (Usage-Bar-Farbschwellen ≥90/≥70) |
| `CacheViewTabs` | cache/migration-View-Tabs (die zwei bestehenden `t()`-Labels) |
| `CacheArraySelector` | Array-Auswahl-Buttons |
| `CacheStatsGrid` | die 4 Stat-Karten (Status/Usage/HitRate/BytesServed) |
| `CacheHealthCard` | SSD-Health-Card |
| `CacheConfigCard` | Config-Form + Save/Reset |
| `CacheActionsCard` | Trigger-Eviction/Clear/Refresh |
| `CacheEntriesTable` | Entries-Tabelle + Pagination |
| `file-cache/index.ts` | Barrel |

`SsdFileCacheTab.tsx` bleibt Orchestrator (View-Tabs + Migration-Branch + 3 Early-Returns + Komposition). `MigrationPanel` unverändert wiederverwendet.

### Verhalten byte-identisch

Gleiche API-Calls, `Promise.all` in `loadData`, Array-Auto-Select-Logik, die 3 Effects (inkl. `setPage(0)` bei Array-Wechsel), `loadEntries`-Empty-Catch, Toast-Strings, Clear-Cache-Confirm-Wording, `eviction_policy`-Cast, `pageSize=20`, Save→Refresh-Stats-Sequenz, Pagination-Grenzen, `{dialog}`-Nesting (nur in der Cache-View). DOM/Tailwind unverändert.

**Bewusst NICHT geändert:** die hartcodierten englischen Strings bleiben verbatim — kein i18n eingeführt (das ist ein eigener, verhaltensändernder Task, getrackt in **#406**).

### Tests & Gates

Jede Unit hat eigene Vitest-Abdeckung (T7-konform: role/text/title, keine Tailwind-Assertions; vollständige Fixtures der echten API-Typen; gezielt auf Zweige/Callbacks/Guards — Config-Save-disabled-until-dirty, Clear-Confirm-Ablehnung, Pagination-Grenzen, Usage-Bar-Schwellen, Array-Auto-Select).

- `eslint .` — 0 Fehler
- `npm run build` (tsc -b + vite) — grün
- `vitest run` — **196 Dateien / 863 Tests grün**
- Multi-Agent Whole-Branch-Review (opus) — **READY TO MERGE** (0 Findings, feldweise gegen das Original geprüft)

Teil des F2-Umbrella #301 (God-Components > 500 Zeilen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
