### PR TITLE
refactor(vcl): decompose VCLSettings into useVclSettings + vcl-settings/* (#301) [F2]

### DIFF
--- a/client/src/__tests__/components/vcl/VCLSettings.test.tsx
+++ b/client/src/__tests__/components/vcl/VCLSettings.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { AdminVCLOverview, UserVCLStats } from '../../../types/vcl';
+import type { UseVclSettingsResult } from '../../../hooks/useVclSettings';
+
+const overview: AdminVCLOverview = {
+  total_versions: 10, total_size_bytes: 1000, total_compressed_bytes: 400, total_blobs: 5,
+  unique_blobs: 4, deduplication_savings_bytes: 100, compression_savings_bytes: 200,
+  total_savings_bytes: 300, compression_ratio: 2.5, priority_count: 1, cached_versions_count: 2,
+  total_users: 3, last_cleanup_at: null, last_priority_mode_at: null, updated_at: null,
+};
+const users: UserVCLStats[] = [{ user_id: 1, username: 'alice', max_size_bytes: 1000, current_usage_bytes: 500, usage_percent: 50, total_versions: 4, is_enabled: true, vcl_mode: 'automatic' }];
+
+const hookValue: UseVclSettingsResult = {
+  overview, storageInfo: null, users, loading: false, actionLoading: false, error: null,
+  successMessage: null, editingUser: null, editForm: {}, setEditForm: vi.fn(),
+  reconPreview: null, reconLoading: false, forceOverQuota: false, setForceOverQuota: vi.fn(),
+  loadData: vi.fn(), handleCleanup: vi.fn(), handleScanMismatches: vi.fn(),
+  handleApplyReconciliation: vi.fn(), handleEditUser: vi.fn(), handleSaveUserSettings: vi.fn(),
+  setEditingUser: vi.fn(),
+};
+vi.mock('../../../hooks/useVclSettings', () => ({ useVclSettings: () => hookValue }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string, fb?: string) => fb ?? k }) }));
+
+import VCLSettings from '../../../components/vcl/VCLSettings';
+
+describe('VCLSettings', () => {
+  beforeEach(() => { Object.assign(hookValue, { loading: false, overview, users }); });
+
+  it('renders the stats grid + user table for a populated fixture', () => {
+    render(<VCLSettings />);
+    expect(screen.getByText('alice')).toBeInTheDocument();           // user table
+    expect(screen.getByText('Ownership Reconciliation')).toBeInTheDocument(); // recon card
+  });
+
+  it('renders none of the dashboard content while loading (early-return spinner)', () => {
+    hookValue.loading = true;
+    render(<VCLSettings />);
+    expect(screen.queryByText('alice')).not.toBeInTheDocument();
+    expect(screen.queryByText('Ownership Reconciliation')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when overview is null (and not loading)', () => {
+    Object.assign(hookValue, { loading: false, overview: null });
+    const { container } = render(<VCLSettings />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/client/src/__tests__/components/vcl/vcl-settings/VclEditUserModal.test.tsx
+++ b/client/src/__tests__/components/vcl/vcl-settings/VclEditUserModal.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { UserVCLStats, VCLSettingsUpdate } from '../../../../types/vcl';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { VclEditUserModal } from '../../../../components/vcl/vcl-settings/VclEditUserModal';
+
+const editingUser: UserVCLStats = {
+  user_id: 1, username: 'alice', max_size_bytes: 1000, current_usage_bytes: 500,
+  usage_percent: 50, total_versions: 4, is_enabled: true, vcl_mode: 'automatic',
+};
+const editForm: VCLSettingsUpdate = { max_size_bytes: 1000, is_enabled: true };
+const base = { editingUser, editForm, actionLoading: false,
+  onMaxSizeChange: () => {}, onEnabledChange: () => {}, onCancel: () => {}, onSave: () => {} };
+
+describe('VclEditUserModal', () => {
+  it('fires onSave and onCancel from the footer buttons', () => {
+    const onSave = vi.fn(), onCancel = vi.fn();
+    render(<VclEditUserModal {...base} onSave={onSave} onCancel={onCancel} />);
+    fireEvent.click(screen.getByText('common.save'));
+    fireEvent.click(screen.getByText('common.cancel'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+  it('fires onEnabledChange when the enable checkbox toggles', () => {
+    const onEnabledChange = vi.fn();
+    render(<VclEditUserModal {...base} onEnabledChange={onEnabledChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onEnabledChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/client/src/__tests__/components/vcl/vcl-settings/VclMaintenanceCard.test.tsx
+++ b/client/src/__tests__/components/vcl/vcl-settings/VclMaintenanceCard.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { VclMaintenanceCard } from '../../../../components/vcl/vcl-settings/VclMaintenanceCard';
+
+describe('VclMaintenanceCard', () => {
+  it('fires each callback on its button', () => {
+    const onDryRunCleanup = vi.fn(), onTriggerCleanup = vi.fn(), onRefresh = vi.fn();
+    render(<VclMaintenanceCard actionLoading={false}
+      onDryRunCleanup={onDryRunCleanup} onTriggerCleanup={onTriggerCleanup} onRefresh={onRefresh} />);
+    fireEvent.click(screen.getByText('vcl.maintenance.dryRunCleanup'));
+    fireEvent.click(screen.getByText('vcl.maintenance.triggerCleanup'));
+    fireEvent.click(screen.getByText('vcl.maintenance.refreshStats'));
+    expect(onDryRunCleanup).toHaveBeenCalledTimes(1);
+    expect(onTriggerCleanup).toHaveBeenCalledTimes(1);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+  it('disables all buttons while an action is loading', () => {
+    render(<VclMaintenanceCard actionLoading={true}
+      onDryRunCleanup={() => {}} onTriggerCleanup={() => {}} onRefresh={() => {}} />);
+    for (const k of ['vcl.maintenance.dryRunCleanup', 'vcl.maintenance.triggerCleanup', 'vcl.maintenance.refreshStats']) {
+      expect(screen.getByText(k).closest('button')).toBeDisabled();
+    }
+  });
+});

--- a/client/src/__tests__/components/vcl/vcl-settings/VclMessageBanners.test.tsx
+++ b/client/src/__tests__/components/vcl/vcl-settings/VclMessageBanners.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { VclMessageBanners } from '../../../../components/vcl/vcl-settings/VclMessageBanners';
+
+describe('VclMessageBanners', () => {
+  it('renders only the error when only error is set', () => {
+    render(<VclMessageBanners error="boom" successMessage={null} />);
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+  it('renders only the success when only success is set', () => {
+    render(<VclMessageBanners error={null} successMessage="done" />);
+    expect(screen.getByText('done')).toBeInTheDocument();
+  });
+  it('renders nothing when both are null', () => {
+    const { container } = render(<VclMessageBanners error={null} successMessage={null} />);
+    expect(container.textContent).toBe('');
+  });
+});

--- a/client/src/__tests__/components/vcl/vcl-settings/VclReconciliationCard.test.tsx
+++ b/client/src/__tests__/components/vcl/vcl-settings/VclReconciliationCard.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { ReconciliationPreview } from '../../../../types/vcl';
+import { VclReconciliationCard } from '../../../../components/vcl/vcl-settings/VclReconciliationCard';
+
+const preview = (over: Partial<ReconciliationPreview> = {}): ReconciliationPreview => ({
+  total_mismatches: 0, mismatches: [], affected_users: [], ...over,
+});
+const base = { reconLoading: false, forceOverQuota: false, onScan: () => {}, onForceChange: () => {}, onApply: () => {} };
+
+describe('VclReconciliationCard', () => {
+  it('fires onScan when Scan for Mismatches is clicked', () => {
+    const onScan = vi.fn();
+    render(<VclReconciliationCard {...base} reconPreview={null} onScan={onScan} />);
+    fireEvent.click(screen.getByText('Scan for Mismatches'));
+    expect(onScan).toHaveBeenCalledTimes(1);
+  });
+  it('hides Apply + force checkbox when there are no mismatches', () => {
+    render(<VclReconciliationCard {...base} reconPreview={preview({ total_mismatches: 0 })} />);
+    expect(screen.queryByText(/^Apply \(/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+  it('shows Apply with the mismatch count when there are mismatches', () => {
+    render(<VclReconciliationCard {...base} reconPreview={preview({
+      total_mismatches: 2,
+      mismatches: [
+        { file_id: 1, file_path: '/a/b.txt', version_id: 11, version_number: 3, current_version_user_id: 1, current_version_username: 'alice', current_file_owner_id: 2, current_file_owner_username: 'bob', compressed_size: 100 },
+      ],
+      affected_users: [{ user_id: 2, username: 'bob', quota_delta: 100, current_usage: 0, max_size: 1000, would_exceed_quota: false }],
+    })} />);
+    expect(screen.getByText('Apply (2 versions)')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    expect(screen.getByText('b.txt')).toBeInTheDocument();
+  });
+  it('fires onForceChange when the force checkbox toggles', () => {
+    const onForceChange = vi.fn();
+    render(<VclReconciliationCard {...base} onForceChange={onForceChange}
+      reconPreview={preview({ total_mismatches: 1, mismatches: [], affected_users: [] })} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onForceChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/client/src/__tests__/components/vcl/vcl-settings/VclStatsGrid.test.tsx
+++ b/client/src/__tests__/components/vcl/vcl-settings/VclStatsGrid.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { AdminVCLOverview } from '../../../../types/vcl';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { VclStatsGrid } from '../../../../components/vcl/vcl-settings/VclStatsGrid';
+
+const overview = (over: Partial<AdminVCLOverview> = {}): AdminVCLOverview => ({
+  total_versions: 1234, total_size_bytes: 1000, total_compressed_bytes: 400, total_blobs: 5,
+  unique_blobs: 4, deduplication_savings_bytes: 100, compression_savings_bytes: 200,
+  total_savings_bytes: 300, compression_ratio: 2.5, priority_count: 1, cached_versions_count: 2,
+  total_users: 7, last_cleanup_at: null, last_priority_mode_at: null, updated_at: null, ...over,
+});
+
+describe('VclStatsGrid', () => {
+  it('renders the total-versions count and the active-users count', () => {
+    render(<VclStatsGrid overview={overview()} totalSavings={300} savingsPercent={30} />);
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/vcl/vcl-settings/VclStatsGrid.test.tsx
+++ b/client/src/__tests__/components/vcl/vcl-settings/VclStatsGrid.test.tsx
@@ -12,9 +12,12 @@ const overview = (over: Partial<AdminVCLOverview> = {}): AdminVCLOverview => ({
 });
 
 describe('VclStatsGrid', () => {
-  it('renders the total-versions count and the active-users count', () => {
+  it('renders the four stat labels and the active-users count', () => {
     render(<VclStatsGrid overview={overview()} totalSavings={300} savingsPercent={30} />);
-    expect(screen.getByText('1,234')).toBeInTheDocument();
-    expect(screen.getByText('7')).toBeInTheDocument();
+    // locale-independent assertions (avoid Number.toLocaleString separator, which
+    // differs de-DE vs en-US across dev machines / CI)
+    expect(screen.getByText('vcl.stats.totalVersions')).toBeInTheDocument();
+    expect(screen.getByText('vcl.stats.activeUsers')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument(); // total_users, plain number
   });
 });

--- a/client/src/__tests__/components/vcl/vcl-settings/VclStorageDetailsCard.test.tsx
+++ b/client/src/__tests__/components/vcl/vcl-settings/VclStorageDetailsCard.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { AdminVCLOverview } from '../../../../types/vcl';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { VclStorageDetailsCard } from '../../../../components/vcl/vcl-settings/VclStorageDetailsCard';
+
+const overview = (over: Partial<AdminVCLOverview> = {}): AdminVCLOverview => ({
+  total_versions: 10, total_size_bytes: 1000, total_compressed_bytes: 400, total_blobs: 8,
+  unique_blobs: 6, deduplication_savings_bytes: 100, compression_savings_bytes: 200,
+  total_savings_bytes: 300, compression_ratio: 2.5, priority_count: 3, cached_versions_count: 2,
+  total_users: 3, last_cleanup_at: null, last_priority_mode_at: null, updated_at: null, ...over,
+});
+
+describe('VclStorageDetailsCard', () => {
+  it('renders unique/total blobs and the never-cleanup fallback', () => {
+    render(<VclStorageDetailsCard overview={overview()} compressionRatio={2.5} />);
+    expect(screen.getByText('6 / 8')).toBeInTheDocument();
+    // last_cleanup_at is null → the 'never' i18n key renders (appears twice: cleanup + priority mode)
+    expect(screen.getAllByText('vcl.storageDetails.never').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/client/src/__tests__/components/vcl/vcl-settings/VclStorageInfoCard.test.tsx
+++ b/client/src/__tests__/components/vcl/vcl-settings/VclStorageInfoCard.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { VCLStorageInfo } from '../../../../types/vcl';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (_k: string, fb?: string) => fb ?? _k }) }));
+import { VclStorageInfoCard } from '../../../../components/vcl/vcl-settings/VclStorageInfoCard';
+
+const info = (over: Partial<VCLStorageInfo> = {}): VCLStorageInfo => ({
+  storage_path: '/mnt/vcl', is_custom_path: false, blob_count: 42,
+  total_compressed_bytes: 1000, disk_total_bytes: 2000, disk_available_bytes: 1500,
+  disk_used_percent: 25, ...over,
+});
+
+describe('VclStorageInfoCard', () => {
+  it('renders the storage path', () => {
+    render(<VclStorageInfoCard storageInfo={info()} />);
+    expect(screen.getByText('/mnt/vcl')).toBeInTheDocument();
+  });
+  it('shows the Custom Path badge only when is_custom_path', () => {
+    const { rerender } = render(<VclStorageInfoCard storageInfo={info({ is_custom_path: false })} />);
+    expect(screen.queryByText('Custom Path')).not.toBeInTheDocument();
+    rerender(<VclStorageInfoCard storageInfo={info({ is_custom_path: true })} />);
+    expect(screen.getByText('Custom Path')).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/vcl/vcl-settings/VclUserQuotasTable.test.tsx
+++ b/client/src/__tests__/components/vcl/vcl-settings/VclUserQuotasTable.test.tsx
@@ -1,0 +1,29 @@
+// VclUserQuotasTable.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { UserVCLStats } from '../../../../types/vcl';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { VclUserQuotasTable } from '../../../../components/vcl/vcl-settings/VclUserQuotasTable';
+
+const user = (over: Partial<UserVCLStats> = {}): UserVCLStats => ({
+  user_id: 1, username: 'alice', max_size_bytes: 1000, current_usage_bytes: 500,
+  usage_percent: 50, total_versions: 4, is_enabled: true, vcl_mode: 'automatic', ...over,
+});
+
+describe('VclUserQuotasTable', () => {
+  it('renders the empty-state row when there are no users', () => {
+    render(<VclUserQuotasTable users={[]} onEditUser={() => {}} />);
+    expect(screen.getByText('vcl.userQuotas.noUsers')).toBeInTheDocument();
+  });
+  it('renders a row per user and fires onEditUser with the user', () => {
+    const onEditUser = vi.fn();
+    render(<VclUserQuotasTable users={[user({ user_id: 9, username: 'zoe' })]} onEditUser={onEditUser} />);
+    expect(screen.getByText('zoe')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('common.edit'));
+    expect(onEditUser).toHaveBeenCalledWith(expect.objectContaining({ user_id: 9 }));
+  });
+  it('shows the Manual badge for manual-mode users', () => {
+    render(<VclUserQuotasTable users={[user({ vcl_mode: 'manual' })]} onEditUser={() => {}} />);
+    expect(screen.getByText('Manual')).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/vcl/vcl-settings/usageBarColor.test.ts
+++ b/client/src/__tests__/components/vcl/vcl-settings/usageBarColor.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { usageBarColor } from '../../../../components/vcl/vcl-settings/usageBarColor';
+
+describe('usageBarColor', () => {
+  it('returns red at/above the crit threshold', () => {
+    expect(usageBarColor(95, 80, 95)).toBe('bg-red-500');
+    expect(usageBarColor(90, 70, 90)).toBe('bg-red-500');
+  });
+  it('returns amber at/above warn and below crit', () => {
+    expect(usageBarColor(85, 80, 95)).toBe('bg-amber-500');
+    expect(usageBarColor(70, 70, 90)).toBe('bg-amber-500');
+  });
+  it('returns sky below warn', () => {
+    expect(usageBarColor(50, 80, 95)).toBe('bg-sky-500');
+    expect(usageBarColor(10, 70, 90)).toBe('bg-sky-500');
+  });
+});

--- a/client/src/__tests__/hooks/useVclSettings.test.ts
+++ b/client/src/__tests__/hooks/useVclSettings.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const { overview, users, storage } = vi.hoisted(() => ({
+  overview: {
+    total_versions: 10, total_size_bytes: 1000, total_compressed_bytes: 400, total_blobs: 5,
+    unique_blobs: 4, deduplication_savings_bytes: 100, compression_savings_bytes: 200,
+    total_savings_bytes: 300, compression_ratio: 2.5, priority_count: 1, cached_versions_count: 2,
+    total_users: 3, last_cleanup_at: null, last_priority_mode_at: null, updated_at: null,
+  },
+  users: [{ user_id: 1, username: 'alice', max_size_bytes: 1000, current_usage_bytes: 500, usage_percent: 50, total_versions: 4, is_enabled: true, vcl_mode: 'automatic' as const }],
+  storage: null,
+}));
+
+vi.mock('../../api/vcl', () => ({
+  getAdminOverview: vi.fn().mockResolvedValue(overview),
+  getAdminUsers: vi.fn().mockResolvedValue({ users, total: 1 }),
+  getStorageInfo: vi.fn().mockResolvedValue(storage),
+  updateUserSettingsAdmin: vi.fn().mockResolvedValue({}),
+  triggerCleanup: vi.fn().mockResolvedValue({ deleted_versions: 0, freed_bytes: 0 }),
+  getReconciliationPreview: vi.fn().mockResolvedValue({ total_mismatches: 0, mismatches: [], affected_users: [] }),
+  applyReconciliation: vi.fn().mockResolvedValue({ message: 'ok' }),
+  formatBytes: (n: number) => `${n}B`,
+}));
+vi.mock('../../lib/errorHandling', () => ({ getApiErrorMessage: (_e: unknown, fb: string) => fb }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+import { useVclSettings } from '../../hooks/useVclSettings';
+import * as api from '../../api/vcl';
+
+describe('useVclSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  it('loads overview + users on mount', async () => {
+    const { result } = renderHook(() => useVclSettings());
+    await waitFor(() => expect(result.current.overview).not.toBeNull());
+    expect(result.current.users).toHaveLength(1);
+    expect(api.getStorageInfo).toHaveBeenCalled();
+  });
+
+  it('does not call triggerCleanup when the confirm is declined (non-dry-run)', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const { result } = renderHook(() => useVclSettings());
+    await waitFor(() => expect(result.current.overview).not.toBeNull());
+    await act(async () => { await result.current.handleCleanup(false); });
+    expect(api.triggerCleanup).not.toHaveBeenCalled();
+  });
+
+  it('sets the no-mismatches success message when the scan finds none', async () => {
+    const { result } = renderHook(() => useVclSettings());
+    await waitFor(() => expect(result.current.overview).not.toBeNull());
+    await act(async () => { await result.current.handleScanMismatches(); });
+    expect(result.current.successMessage).toBe('No ownership mismatches found');
+  });
+
+  it('handleSaveUserSettings sends the edit form for the editing user', async () => {
+    const { result } = renderHook(() => useVclSettings());
+    await waitFor(() => expect(result.current.overview).not.toBeNull());
+    act(() => result.current.handleEditUser(users[0]));
+    await act(async () => { await result.current.handleSaveUserSettings(); });
+    expect(api.updateUserSettingsAdmin).toHaveBeenCalledWith(
+      1, expect.objectContaining({ max_size_bytes: 1000, is_enabled: true }),
+    );
+  });
+});

--- a/client/src/components/CLAUDE.md
+++ b/client/src/components/CLAUDE.md
@@ -66,7 +66,7 @@ Reusable, generic building blocks. No business logic, no API calls.
 | `updates/` | Self-update UI |
 | `user-management/` | User CRUD, 2FA management |
 | `setup/` | Setup wizard step components |
-| `vcl/` | File versioning UI |
+| `vcl/` | File versioning UI — `VCLSettings` (admin) composes `vcl-settings/*`: `VclMessageBanners`, `VclStorageInfoCard`, `VclStatsGrid`, `VclStorageDetailsCard`, `VclMaintenanceCard`, `VclReconciliationCard`, `VclUserQuotasTable`, `VclEditUserModal` (+ `usageBarColor` helper), all re-exported via `vcl-settings/index.ts`; state/handlers in `hooks/useVclSettings.ts` (extracted F2/#301) |
 | `webdav/` | WebDAV server control |
 | `balupi/` | BaluPi-specific compact UI components |
 | `nfs/` | NFS share management components |

--- a/client/src/components/vcl/VCLSettings.tsx
+++ b/client/src/components/vcl/VCLSettings.tsx
@@ -3,168 +3,42 @@
  * Global VCL settings, per-user limits, stats dashboard, maintenance
  */
 
-import { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useVclSettings } from '../../hooks/useVclSettings';
 import {
-  HardDrive,
-  Users,
-  TrendingUp,
-  RefreshCw,
-  Trash2,
-  AlertCircle,
-  Check,
-  Star,
-  Clock,
-  Database,
-  FolderOpen,
-  Search,
-  ArrowRight,
-  AlertTriangle,
-} from 'lucide-react';
-import { getApiErrorMessage } from '../../lib/errorHandling';
-import {
-  getAdminOverview,
-  getAdminUsers,
-  getStorageInfo,
-  updateUserSettingsAdmin,
-  triggerCleanup,
-  getReconciliationPreview,
-  applyReconciliation,
-  formatBytes,
-} from '../../api/vcl';
-import { formatNumber } from '../../lib/formatters';
-import { ByteSizeInput } from '../ui/ByteSizeInput';
-import type {
-  AdminVCLOverview,
-  UserVCLStats,
-  VCLSettingsUpdate,
-  VCLStorageInfo,
-  ReconciliationPreview,
-} from '../../types/vcl';
+  VclMessageBanners,
+  VclStorageInfoCard,
+  VclStatsGrid,
+  VclStorageDetailsCard,
+  VclMaintenanceCard,
+  VclReconciliationCard,
+  VclUserQuotasTable,
+  VclEditUserModal,
+} from './vcl-settings';
 
 export default function VCLSettings() {
-  const [overview, setOverview] = useState<AdminVCLOverview | null>(null);
-  const [storageInfo, setStorageInfo] = useState<VCLStorageInfo | null>(null);
-  const [users, setUsers] = useState<UserVCLStats[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [actionLoading, setActionLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  
-  // Edit modal state
-  const [editingUser, setEditingUser] = useState<UserVCLStats | null>(null);
-  const [editForm, setEditForm] = useState<VCLSettingsUpdate>({});
-  const { t } = useTranslation('admin');
-
-  // Reconciliation state
-  const [reconPreview, setReconPreview] = useState<ReconciliationPreview | null>(null);
-  const [reconLoading, setReconLoading] = useState(false);
-  const [forceOverQuota, setForceOverQuota] = useState(false);
-
-  useEffect(() => {
-    loadData();
-  }, []);
-
-  const loadData = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const [overviewData, usersData, storageData] = await Promise.all([
-        getAdminOverview(),
-        getAdminUsers(100, 0),
-        getStorageInfo().catch(() => null),
-      ]);
-      setOverview(overviewData);
-      setUsers(usersData?.users || []);
-      setStorageInfo(storageData);
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, t('vcl.errors.loadFailed')));
-      // Set empty arrays on error
-      setUsers([]);
-      setOverview(null);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleCleanup = async (dryRun: boolean = false) => {
-    if (!dryRun && !confirm(t('vcl.maintenance.confirmCleanup'))) return;
-
-    try {
-      setActionLoading(true);
-      setError(null);
-      const result = await triggerCleanup({ dry_run: dryRun });
-      setSuccessMessage(
-        t(dryRun ? 'vcl.cleanup.dryRunResult' : 'vcl.cleanup.result', { versions: result.deleted_versions, freed: formatBytes(result.freed_bytes) })
-      );
-      setTimeout(() => setSuccessMessage(null), 5000);
-      if (!dryRun) loadData(); // Reload stats
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, t('vcl.errors.cleanupFailed')));
-    } finally {
-      setActionLoading(false);
-    }
-  };
-
-  const handleScanMismatches = async () => {
-    try {
-      setReconLoading(true);
-      setError(null);
-      const preview = await getReconciliationPreview({});
-      setReconPreview(preview);
-      if (preview.total_mismatches === 0) {
-        setSuccessMessage('No ownership mismatches found');
-        setTimeout(() => setSuccessMessage(null), 3000);
-      }
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, 'Failed to scan for mismatches'));
-    } finally {
-      setReconLoading(false);
-    }
-  };
-
-  const handleApplyReconciliation = async () => {
-    if (!confirm('Apply ownership reconciliation? This will update version ownership to match file ownership.')) return;
-    try {
-      setReconLoading(true);
-      setError(null);
-      const result = await applyReconciliation({ force_over_quota: forceOverQuota });
-      setSuccessMessage(result.message);
-      setTimeout(() => setSuccessMessage(null), 5000);
-      setReconPreview(null);
-      loadData();
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, 'Failed to apply reconciliation'));
-    } finally {
-      setReconLoading(false);
-    }
-  };
-
-  const handleEditUser = (user: UserVCLStats) => {
-    setEditingUser(user);
-    setEditForm({
-      max_size_bytes: user.max_size_bytes,
-      is_enabled: user.is_enabled,
-    });
-  };
-
-  const handleSaveUserSettings = async () => {
-    if (!editingUser) return;
-
-    try {
-      setActionLoading(true);
-      setError(null);
-      await updateUserSettingsAdmin(editingUser.user_id, editForm);
-      setSuccessMessage(t('vcl.settingsUpdated', { username: editingUser.username }));
-      setTimeout(() => setSuccessMessage(null), 3000);
-      setEditingUser(null);
-      loadData(); // Reload
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, t('vcl.errors.updateFailed')));
-    } finally {
-      setActionLoading(false);
-    }
-  };
+  const {
+    overview,
+    storageInfo,
+    users,
+    loading,
+    actionLoading,
+    error,
+    successMessage,
+    editingUser,
+    editForm,
+    setEditForm,
+    reconPreview,
+    reconLoading,
+    forceOverQuota,
+    setForceOverQuota,
+    loadData,
+    handleCleanup,
+    handleScanMismatches,
+    handleApplyReconciliation,
+    handleEditUser,
+    handleSaveUserSettings,
+    setEditingUser,
+  } = useVclSettings();
 
   if (loading) {
     return (
@@ -184,448 +58,42 @@ export default function VCLSettings() {
 
   return (
     <div className="space-y-6">
-      {/* Messages */}
-      {error && (
-        <div className="p-4 bg-red-500/10 border border-red-500/30 rounded-lg flex items-center gap-2 text-red-400">
-          <AlertCircle className="w-5 h-5 flex-shrink-0" />
-          <span className="text-sm">{error}</span>
-        </div>
-      )}
-      {successMessage && (
-        <div className="p-4 bg-green-500/10 border border-green-500/30 rounded-lg flex items-center gap-2 text-green-400">
-          <Check className="w-5 h-5 flex-shrink-0" />
-          <span className="text-sm">{successMessage}</span>
-        </div>
-      )}
+      <VclMessageBanners error={error} successMessage={successMessage} />
 
-      {/* VCL Storage Info */}
-      {storageInfo && (
-        <div className="card border-slate-800/60 bg-slate-900/55">
-          <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
-            <FolderOpen className="w-5 h-5 text-sky-400" />
-            {t('vcl.storageInfo.title', 'Storage Location')}
-          </h3>
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-            <div>
-              <p className="text-slate-400">{t('vcl.storageInfo.path', 'Storage Path')}</p>
-              <p className="text-white font-semibold mt-1 truncate" title={storageInfo.storage_path}>
-                {storageInfo.storage_path}
-              </p>
-              {storageInfo.is_custom_path && (
-                <span className="mt-1 inline-block px-2 py-0.5 rounded-full text-[10px] font-medium bg-violet-500/20 text-violet-300">
-                  Custom Path
-                </span>
-              )}
-            </div>
-            <div>
-              <p className="text-slate-400">{t('vcl.storageInfo.blobCount', 'Blob Count')}</p>
-              <p className="text-white font-semibold mt-1">{storageInfo.blob_count.toLocaleString()}</p>
-            </div>
-            <div>
-              <p className="text-slate-400">{t('vcl.storageInfo.compressedSize', 'Compressed Size')}</p>
-              <p className="text-white font-semibold mt-1">{formatBytes(storageInfo.total_compressed_bytes)}</p>
-            </div>
-            <div>
-              <p className="text-slate-400">{t('vcl.storageInfo.diskUsage', 'Disk Usage')}</p>
-              <p className="text-white font-semibold mt-1">
-                {formatNumber(storageInfo.disk_used_percent, 1)}%
-              </p>
-              <div className="h-1.5 w-full mt-1.5 overflow-hidden rounded-full bg-slate-800 max-w-[120px]">
-                <div
-                  className={`h-full rounded-full transition-all ${
-                    storageInfo.disk_used_percent >= 90 ? 'bg-red-500' : storageInfo.disk_used_percent >= 70 ? 'bg-amber-500' : 'bg-sky-500'
-                  }`}
-                  style={{ width: `${Math.min(storageInfo.disk_used_percent, 100)}%` }}
-                />
-              </div>
-              <p className="text-xs text-slate-500 mt-1">
-                {formatBytes(storageInfo.disk_available_bytes)} {t('vcl.storageInfo.free', 'free')} / {formatBytes(storageInfo.disk_total_bytes)}
-              </p>
-            </div>
-          </div>
-        </div>
-      )}
+      {storageInfo && <VclStorageInfoCard storageInfo={storageInfo} />}
 
-      {/* Stats Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <div className="card border-slate-800/60 bg-slate-900/55">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-slate-400 text-sm">{t('vcl.stats.totalVersions')}</p>
-              <p className="text-2xl font-bold text-white mt-1">{overview.total_versions.toLocaleString()}</p>
-            </div>
-            <Clock className="w-10 h-10 text-sky-400 opacity-50" />
-          </div>
-        </div>
+      <VclStatsGrid overview={overview} totalSavings={totalSavings} savingsPercent={savingsPercent} />
 
-        <div className="card border-slate-800/60 bg-slate-900/55">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-slate-400 text-sm">{t('vcl.stats.storageUsed')}</p>
-              <p className="text-2xl font-bold text-white mt-1">{formatBytes(overview.total_compressed_bytes)}</p>
-              <p className="text-xs text-slate-500 mt-1">{formatBytes(overview.total_size_bytes)} {t('vcl.stats.original')}</p>
-            </div>
-            <HardDrive className="w-10 h-10 text-violet-400 opacity-50" />
-          </div>
-        </div>
+      <VclStorageDetailsCard overview={overview} compressionRatio={compressionRatio} />
 
-        <div className="card border-slate-800/60 bg-slate-900/55">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-slate-400 text-sm">{t('vcl.stats.totalSavings')}</p>
-              <p className="text-2xl font-bold text-white mt-1">{formatNumber(savingsPercent, 1)}%</p>
-              <p className="text-xs text-slate-500 mt-1">{formatBytes(totalSavings)} {t('vcl.stats.saved')}</p>
-            </div>
-            <TrendingUp className="w-10 h-10 text-green-400 opacity-50" />
-          </div>
-        </div>
+      <VclMaintenanceCard
+        actionLoading={actionLoading}
+        onDryRunCleanup={() => handleCleanup(true)}
+        onTriggerCleanup={() => handleCleanup(false)}
+        onRefresh={loadData}
+      />
 
-        <div className="card border-slate-800/60 bg-slate-900/55">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-slate-400 text-sm">{t('vcl.stats.activeUsers')}</p>
-              <p className="text-2xl font-bold text-white mt-1">{overview.total_users}</p>
-              <p className="text-xs text-slate-500 mt-1">{overview.cached_versions_count} {t('vcl.stats.cached')}</p>
-            </div>
-            <Users className="w-10 h-10 text-amber-400 opacity-50" />
-          </div>
-        </div>
-      </div>
+      <VclReconciliationCard
+        reconPreview={reconPreview}
+        reconLoading={reconLoading}
+        forceOverQuota={forceOverQuota}
+        onScan={handleScanMismatches}
+        onForceChange={setForceOverQuota}
+        onApply={handleApplyReconciliation}
+      />
 
-      {/* Detailed Stats */}
-      <div className="card border-slate-800/60 bg-slate-900/55">
-        <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
-          <Database className="w-5 h-5 text-sky-400" />
-          {t('vcl.storageDetails.title')}
-        </h3>
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-          <div>
-            <p className="text-slate-400">{t('vcl.storageDetails.compressionRatio')}</p>
-            <p className="text-white font-semibold mt-1">{formatNumber(compressionRatio, 2)}x</p>
-          </div>
-          <div>
-            <p className="text-slate-400">{t('vcl.storageDetails.compressionSavings')}</p>
-            <p className="text-white font-semibold mt-1">{formatBytes(overview.compression_savings_bytes)}</p>
-          </div>
-          <div>
-            <p className="text-slate-400">{t('vcl.storageDetails.dedupSavings')}</p>
-            <p className="text-white font-semibold mt-1">{formatBytes(overview.deduplication_savings_bytes)}</p>
-          </div>
-          <div>
-            <p className="text-slate-400">{t('vcl.storageDetails.uniqueBlobs')}</p>
-            <p className="text-white font-semibold mt-1">{overview.unique_blobs} / {overview.total_blobs}</p>
-          </div>
-          <div>
-            <p className="text-slate-400">{t('vcl.storageDetails.priorityVersions')}</p>
-            <p className="text-white font-semibold mt-1 flex items-center gap-1">
-              <Star className="w-4 h-4 text-amber-400 fill-amber-400" />
-              {overview.priority_count}
-            </p>
-          </div>
-          <div>
-            <p className="text-slate-400">{t('vcl.storageDetails.lastCleanup')}</p>
-            <p className="text-white font-semibold mt-1">
-              {overview.last_cleanup_at ? new Date(overview.last_cleanup_at).toLocaleDateString() : t('vcl.storageDetails.never')}
-            </p>
-          </div>
-          <div>
-            <p className="text-slate-400">{t('vcl.storageDetails.lastPriorityMode')}</p>
-            <p className="text-white font-semibold mt-1">
-              {overview.last_priority_mode_at ? new Date(overview.last_priority_mode_at).toLocaleDateString() : t('vcl.storageDetails.never')}
-            </p>
-          </div>
-          <div>
-            <p className="text-slate-400">{t('vcl.storageDetails.updated')}</p>
-            <p className="text-white font-semibold mt-1">
-              {overview.updated_at ? new Date(overview.updated_at).toLocaleTimeString() : t('common.na')}
-            </p>
-          </div>
-        </div>
-      </div>
+      <VclUserQuotasTable users={users} onEditUser={handleEditUser} />
 
-      {/* Maintenance Actions */}
-      <div className="card border-slate-800/60 bg-slate-900/55">
-        <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
-          <RefreshCw className="w-5 h-5 text-sky-400" />
-          {t('vcl.maintenance.title')}
-        </h3>
-        <div className="flex flex-wrap gap-3">
-          <button
-            onClick={() => handleCleanup(true)}
-            disabled={actionLoading}
-            className="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
-          >
-            <RefreshCw className="w-4 h-4" />
-            {t('vcl.maintenance.dryRunCleanup')}
-          </button>
-          <button
-            onClick={() => handleCleanup(false)}
-            disabled={actionLoading}
-            className="px-4 py-2 bg-amber-500 hover:bg-amber-600 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
-          >
-            <Trash2 className="w-4 h-4" />
-            {t('vcl.maintenance.triggerCleanup')}
-          </button>
-          <button
-            onClick={loadData}
-            disabled={actionLoading}
-            className="px-4 py-2 bg-sky-500 hover:bg-sky-600 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
-          >
-            <RefreshCw className={`w-4 h-4 ${actionLoading ? 'animate-spin' : ''}`} />
-            {t('vcl.maintenance.refreshStats')}
-          </button>
-        </div>
-      </div>
-
-      {/* Ownership Reconciliation */}
-      <div className="card border-slate-800/60 bg-slate-900/55">
-        <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
-          <Search className="w-5 h-5 text-sky-400" />
-          Ownership Reconciliation
-        </h3>
-        <p className="text-sm text-slate-400 mb-4">
-          Scan for version ownership mismatches (e.g. after file transfers) and fix them.
-        </p>
-        <div className="flex flex-wrap items-center gap-3 mb-4">
-          <button
-            onClick={handleScanMismatches}
-            disabled={reconLoading}
-            className="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
-          >
-            <Search className={`w-4 h-4 ${reconLoading ? 'animate-spin' : ''}`} />
-            Scan for Mismatches
-          </button>
-          {reconPreview && reconPreview.total_mismatches > 0 && (
-            <>
-              <label className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={forceOverQuota}
-                  onChange={(e) => setForceOverQuota(e.target.checked)}
-                  className="w-4 h-4 rounded border-slate-700 bg-slate-800"
-                />
-                Force even if quota exceeded
-              </label>
-              <button
-                onClick={handleApplyReconciliation}
-                disabled={reconLoading}
-                className="px-4 py-2 bg-amber-500 hover:bg-amber-600 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
-              >
-                <Check className="w-4 h-4" />
-                Apply ({reconPreview.total_mismatches} versions)
-              </button>
-            </>
-          )}
-        </div>
-
-        {reconPreview && reconPreview.total_mismatches > 0 && (
-          <div className="space-y-4">
-            {/* Affected Users Summary */}
-            {reconPreview.affected_users.length > 0 && (
-              <div className="space-y-2">
-                <h4 className="text-sm font-medium text-slate-300">Quota Impact</h4>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                  {reconPreview.affected_users.map((u) => (
-                    <div
-                      key={u.user_id}
-                      className={`p-3 rounded-lg border text-sm ${
-                        u.would_exceed_quota
-                          ? 'border-amber-500/30 bg-amber-500/10'
-                          : 'border-slate-800 bg-slate-800/50'
-                      }`}
-                    >
-                      <span className="font-medium text-white">{u.username}</span>
-                      <span className="text-slate-400 ml-2">
-                        {u.quota_delta > 0 ? '+' : ''}{formatBytes(Math.abs(u.quota_delta))}
-                      </span>
-                      {u.would_exceed_quota && (
-                        <span className="ml-2 text-amber-400 text-xs flex items-center gap-1 inline-flex">
-                          <AlertTriangle className="w-3 h-3" /> exceeds quota
-                        </span>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Mismatch Table */}
-            <div className="overflow-x-auto max-h-64 overflow-y-auto">
-              <table className="w-full text-xs">
-                <thead className="sticky top-0 bg-slate-900">
-                  <tr className="text-left border-b border-slate-800">
-                    <th className="pb-2 text-slate-400 font-medium">File</th>
-                    <th className="pb-2 text-slate-400 font-medium">Version</th>
-                    <th className="pb-2 text-slate-400 font-medium">Current Owner</th>
-                    <th className="pb-2 text-slate-400 font-medium"></th>
-                    <th className="pb-2 text-slate-400 font-medium">File Owner</th>
-                    <th className="pb-2 text-slate-400 font-medium">Size</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {reconPreview.mismatches.slice(0, 100).map((m) => (
-                    <tr key={m.version_id} className="border-b border-slate-800/30">
-                      <td className="py-1.5 text-slate-300 max-w-[200px] truncate" title={m.file_path}>
-                        {m.file_path.split('/').pop()}
-                      </td>
-                      <td className="py-1.5 text-slate-400">v{m.version_number}</td>
-                      <td className="py-1.5 text-red-300">{m.current_version_username}</td>
-                      <td className="py-1.5 text-slate-500"><ArrowRight className="w-3 h-3" /></td>
-                      <td className="py-1.5 text-green-300">{m.current_file_owner_username}</td>
-                      <td className="py-1.5 text-slate-400">{formatBytes(m.compressed_size)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              {reconPreview.total_mismatches > 100 && (
-                <p className="text-xs text-slate-500 mt-2">
-                  Showing 100 of {reconPreview.total_mismatches} mismatches
-                </p>
-              )}
-            </div>
-          </div>
-        )}
-      </div>
-
-      {/* User Limits Table */}
-      <div className="card border-slate-800/60 bg-slate-900/55">
-        <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
-          <Users className="w-5 h-5 text-sky-400" />
-          {t('vcl.userQuotas.title')}
-        </h3>
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left border-b border-slate-800">
-                <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.user')}</th>
-                <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.maxSize')}</th>
-                <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.used')}</th>
-                <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.usage')}</th>
-                <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.versions')}</th>
-                <th className="pb-3 text-slate-400 font-medium">Mode</th>
-                <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.status')}</th>
-                <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.actions')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {users && users.length > 0 ? users.map((user) => {
-                const usagePercent = user.usage_percent;
-                const isWarning = usagePercent >= 80;
-                const isCritical = usagePercent >= 95;
-
-                return (
-                  <tr key={user.user_id} className="border-b border-slate-800/50">
-                    <td className="py-3 text-white font-medium">{user.username}</td>
-                    <td className="py-3 text-slate-300">{formatBytes(user.max_size_bytes)}</td>
-                    <td className="py-3 text-slate-300">{formatBytes(user.current_usage_bytes)}</td>
-                    <td className="py-3">
-                      <div className="flex items-center gap-2">
-                        <div className="flex-1 h-2 bg-slate-700 rounded-full overflow-hidden max-w-[100px]">
-                          <div
-                            className={`h-full transition-all ${
-                              isCritical ? 'bg-red-500' : isWarning ? 'bg-amber-500' : 'bg-sky-500'
-                            }`}
-                            style={{ width: `${Math.min(usagePercent, 100)}%` }}
-                          />
-                        </div>
-                        <span className={`${isCritical ? 'text-red-400' : isWarning ? 'text-amber-400' : 'text-slate-300'}`}>
-                          {formatNumber(usagePercent, 1)}%
-                        </span>
-                      </div>
-                    </td>
-                    <td className="py-3 text-slate-300">{user.total_versions}</td>
-                    <td className="py-3">
-                      <span className={`px-2 py-1 rounded-full text-xs font-medium ${
-                        user.vcl_mode === 'manual'
-                          ? 'bg-violet-500/20 text-violet-300'
-                          : 'bg-sky-500/20 text-sky-300'
-                      }`}>
-                        {user.vcl_mode === 'manual' ? 'Manual' : 'Auto'}
-                      </span>
-                    </td>
-                    <td className="py-3">
-                      <span
-                        className={`px-2 py-1 rounded-full text-xs font-medium ${
-                          user.is_enabled
-                            ? 'bg-green-500/20 text-green-400'
-                            : 'bg-red-500/20 text-red-400'
-                        }`}
-                      >
-                        {user.is_enabled ? t('common.enabled') : t('common.disabled')}
-                      </span>
-                    </td>
-                    <td className="py-3">
-                      <button
-                        onClick={() => handleEditUser(user)}
-                        className="text-sky-400 hover:text-sky-300 transition-colors"
-                      >
-                        {t('common.edit')}
-                      </button>
-                    </td>
-                  </tr>
-                );
-              }) : (
-                <tr>
-                  <td colSpan={8} className="py-8 text-center text-slate-500">
-                    {t('vcl.userQuotas.noUsers')}
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      {/* Edit User Modal */}
       {editingUser && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
-          <div className="bg-slate-900 rounded-xl shadow-2xl border border-slate-800 w-full max-w-md">
-            <div className="p-6 border-b border-slate-800">
-              <h3 className="text-lg font-semibold text-white">
-                {t('vcl.editModal.title', { username: editingUser.username })}
-              </h3>
-            </div>
-            <div className="p-6 space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-slate-300 mb-2">
-                  {t('vcl.editModal.maxSizeLabel')}
-                </label>
-                <ByteSizeInput
-                  value={editForm.max_size_bytes || 0}
-                  onChange={(bytes) => setEditForm({ ...editForm, max_size_bytes: bytes })}
-                />
-              </div>
-              <div>
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={editForm.is_enabled ?? true}
-                    onChange={(e) =>
-                      setEditForm({ ...editForm, is_enabled: e.target.checked })
-                    }
-                    className="w-4 h-4 rounded border-slate-700 bg-slate-800"
-                  />
-                  <span className="text-sm text-slate-300">{t('vcl.editModal.enableVcl')}</span>
-                </label>
-              </div>
-            </div>
-            <div className="p-6 border-t border-slate-800 flex justify-end gap-3">
-              <button
-                onClick={() => setEditingUser(null)}
-                className="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors"
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={handleSaveUserSettings}
-                disabled={actionLoading}
-                className="px-4 py-2 bg-sky-500 hover:bg-sky-600 text-white rounded-lg transition-colors disabled:opacity-50"
-              >
-                {t('common.save')}
-              </button>
-            </div>
-          </div>
-        </div>
+        <VclEditUserModal
+          editingUser={editingUser}
+          editForm={editForm}
+          actionLoading={actionLoading}
+          onMaxSizeChange={(bytes) => setEditForm({ ...editForm, max_size_bytes: bytes })}
+          onEnabledChange={(v) => setEditForm({ ...editForm, is_enabled: v })}
+          onCancel={() => setEditingUser(null)}
+          onSave={handleSaveUserSettings}
+        />
       )}
     </div>
   );

--- a/client/src/components/vcl/vcl-settings/VclEditUserModal.tsx
+++ b/client/src/components/vcl/vcl-settings/VclEditUserModal.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from 'react-i18next';
+import { ByteSizeInput } from '../../ui/ByteSizeInput';
+import type { UserVCLStats, VCLSettingsUpdate } from '../../../types/vcl';
+
+export function VclEditUserModal({
+  editingUser,
+  editForm,
+  actionLoading,
+  onMaxSizeChange,
+  onEnabledChange,
+  onCancel,
+  onSave,
+}: {
+  editingUser: UserVCLStats;
+  editForm: VCLSettingsUpdate;
+  actionLoading: boolean;
+  onMaxSizeChange: (bytes: number) => void;
+  onEnabledChange: (v: boolean) => void;
+  onCancel: () => void;
+  onSave: () => void;
+}) {
+  const { t } = useTranslation('admin');
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
+      <div className="bg-slate-900 rounded-xl shadow-2xl border border-slate-800 w-full max-w-md">
+        <div className="p-6 border-b border-slate-800">
+          <h3 className="text-lg font-semibold text-white">
+            {t('vcl.editModal.title', { username: editingUser.username })}
+          </h3>
+        </div>
+        <div className="p-6 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-300 mb-2">
+              {t('vcl.editModal.maxSizeLabel')}
+            </label>
+            <ByteSizeInput
+              value={editForm.max_size_bytes || 0}
+              onChange={(bytes) => onMaxSizeChange(bytes)}
+            />
+          </div>
+          <div>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={editForm.is_enabled ?? true}
+                onChange={(e) => onEnabledChange(e.target.checked)}
+                className="w-4 h-4 rounded border-slate-700 bg-slate-800"
+              />
+              <span className="text-sm text-slate-300">{t('vcl.editModal.enableVcl')}</span>
+            </label>
+          </div>
+        </div>
+        <div className="p-6 border-t border-slate-800 flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={onSave}
+            disabled={actionLoading}
+            className="px-4 py-2 bg-sky-500 hover:bg-sky-600 text-white rounded-lg transition-colors disabled:opacity-50"
+          >
+            {t('common.save')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/vcl/vcl-settings/VclMaintenanceCard.tsx
+++ b/client/src/components/vcl/vcl-settings/VclMaintenanceCard.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next';
+import { RefreshCw, Trash2 } from 'lucide-react';
+
+export function VclMaintenanceCard({
+  actionLoading,
+  onDryRunCleanup,
+  onTriggerCleanup,
+  onRefresh,
+}: {
+  actionLoading: boolean;
+  onDryRunCleanup: () => void;
+  onTriggerCleanup: () => void;
+  onRefresh: () => void;
+}) {
+  const { t } = useTranslation('admin');
+
+  return (
+    <div className="card border-slate-800/60 bg-slate-900/55">
+      <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+        <RefreshCw className="w-5 h-5 text-sky-400" />
+        {t('vcl.maintenance.title')}
+      </h3>
+      <div className="flex flex-wrap gap-3">
+        <button
+          onClick={onDryRunCleanup}
+          disabled={actionLoading}
+          className="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+        >
+          <RefreshCw className="w-4 h-4" />
+          {t('vcl.maintenance.dryRunCleanup')}
+        </button>
+        <button
+          onClick={onTriggerCleanup}
+          disabled={actionLoading}
+          className="px-4 py-2 bg-amber-500 hover:bg-amber-600 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+        >
+          <Trash2 className="w-4 h-4" />
+          {t('vcl.maintenance.triggerCleanup')}
+        </button>
+        <button
+          onClick={onRefresh}
+          disabled={actionLoading}
+          className="px-4 py-2 bg-sky-500 hover:bg-sky-600 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+        >
+          <RefreshCw className={`w-4 h-4 ${actionLoading ? 'animate-spin' : ''}`} />
+          {t('vcl.maintenance.refreshStats')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/vcl/vcl-settings/VclMessageBanners.tsx
+++ b/client/src/components/vcl/vcl-settings/VclMessageBanners.tsx
@@ -1,0 +1,26 @@
+import { AlertCircle, Check } from 'lucide-react';
+
+export function VclMessageBanners({
+  error,
+  successMessage,
+}: {
+  error: string | null;
+  successMessage: string | null;
+}) {
+  return (
+    <>
+      {error && (
+        <div className="p-4 bg-red-500/10 border border-red-500/30 rounded-lg flex items-center gap-2 text-red-400">
+          <AlertCircle className="w-5 h-5 flex-shrink-0" />
+          <span className="text-sm">{error}</span>
+        </div>
+      )}
+      {successMessage && (
+        <div className="p-4 bg-green-500/10 border border-green-500/30 rounded-lg flex items-center gap-2 text-green-400">
+          <Check className="w-5 h-5 flex-shrink-0" />
+          <span className="text-sm">{successMessage}</span>
+        </div>
+      )}
+    </>
+  );
+}

--- a/client/src/components/vcl/vcl-settings/VclReconciliationCard.tsx
+++ b/client/src/components/vcl/vcl-settings/VclReconciliationCard.tsx
@@ -1,0 +1,130 @@
+import { Search, Check, ArrowRight, AlertTriangle } from 'lucide-react';
+import { formatBytes } from '../../../api/vcl';
+import type { ReconciliationPreview } from '../../../types/vcl';
+
+export function VclReconciliationCard({
+  reconPreview,
+  reconLoading,
+  forceOverQuota,
+  onScan,
+  onForceChange,
+  onApply,
+}: {
+  reconPreview: ReconciliationPreview | null;
+  reconLoading: boolean;
+  forceOverQuota: boolean;
+  onScan: () => void;
+  onForceChange: (v: boolean) => void;
+  onApply: () => void;
+}) {
+  return (
+    <div className="card border-slate-800/60 bg-slate-900/55">
+      <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+        <Search className="w-5 h-5 text-sky-400" />
+        Ownership Reconciliation
+      </h3>
+      <p className="text-sm text-slate-400 mb-4">
+        Scan for version ownership mismatches (e.g. after file transfers) and fix them.
+      </p>
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <button
+          onClick={onScan}
+          disabled={reconLoading}
+          className="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+        >
+          <Search className={`w-4 h-4 ${reconLoading ? 'animate-spin' : ''}`} />
+          Scan for Mismatches
+        </button>
+        {reconPreview && reconPreview.total_mismatches > 0 && (
+          <>
+            <label className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={forceOverQuota}
+                onChange={(e) => onForceChange(e.target.checked)}
+                className="w-4 h-4 rounded border-slate-700 bg-slate-800"
+              />
+              Force even if quota exceeded
+            </label>
+            <button
+              onClick={onApply}
+              disabled={reconLoading}
+              className="px-4 py-2 bg-amber-500 hover:bg-amber-600 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+            >
+              <Check className="w-4 h-4" />
+              Apply ({reconPreview.total_mismatches} versions)
+            </button>
+          </>
+        )}
+      </div>
+
+      {reconPreview && reconPreview.total_mismatches > 0 && (
+        <div className="space-y-4">
+          {/* Affected Users Summary */}
+          {reconPreview.affected_users.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium text-slate-300">Quota Impact</h4>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {reconPreview.affected_users.map((u) => (
+                  <div
+                    key={u.user_id}
+                    className={`p-3 rounded-lg border text-sm ${
+                      u.would_exceed_quota
+                        ? 'border-amber-500/30 bg-amber-500/10'
+                        : 'border-slate-800 bg-slate-800/50'
+                    }`}
+                  >
+                    <span className="font-medium text-white">{u.username}</span>
+                    <span className="text-slate-400 ml-2">
+                      {u.quota_delta > 0 ? '+' : ''}{formatBytes(Math.abs(u.quota_delta))}
+                    </span>
+                    {u.would_exceed_quota && (
+                      <span className="ml-2 text-amber-400 text-xs flex items-center gap-1 inline-flex">
+                        <AlertTriangle className="w-3 h-3" /> exceeds quota
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Mismatch Table */}
+          <div className="overflow-x-auto max-h-64 overflow-y-auto">
+            <table className="w-full text-xs">
+              <thead className="sticky top-0 bg-slate-900">
+                <tr className="text-left border-b border-slate-800">
+                  <th className="pb-2 text-slate-400 font-medium">File</th>
+                  <th className="pb-2 text-slate-400 font-medium">Version</th>
+                  <th className="pb-2 text-slate-400 font-medium">Current Owner</th>
+                  <th className="pb-2 text-slate-400 font-medium"></th>
+                  <th className="pb-2 text-slate-400 font-medium">File Owner</th>
+                  <th className="pb-2 text-slate-400 font-medium">Size</th>
+                </tr>
+              </thead>
+              <tbody>
+                {reconPreview.mismatches.slice(0, 100).map((m) => (
+                  <tr key={m.version_id} className="border-b border-slate-800/30">
+                    <td className="py-1.5 text-slate-300 max-w-[200px] truncate" title={m.file_path}>
+                      {m.file_path.split('/').pop()}
+                    </td>
+                    <td className="py-1.5 text-slate-400">v{m.version_number}</td>
+                    <td className="py-1.5 text-red-300">{m.current_version_username}</td>
+                    <td className="py-1.5 text-slate-500"><ArrowRight className="w-3 h-3" /></td>
+                    <td className="py-1.5 text-green-300">{m.current_file_owner_username}</td>
+                    <td className="py-1.5 text-slate-400">{formatBytes(m.compressed_size)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {reconPreview.total_mismatches > 100 && (
+              <p className="text-xs text-slate-500 mt-2">
+                Showing 100 of {reconPreview.total_mismatches} mismatches
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/vcl/vcl-settings/VclStatsGrid.tsx
+++ b/client/src/components/vcl/vcl-settings/VclStatsGrid.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from 'react-i18next';
+import { HardDrive, Users, TrendingUp, Clock } from 'lucide-react';
+import { formatBytes } from '../../../api/vcl';
+import { formatNumber } from '../../../lib/formatters';
+import type { AdminVCLOverview } from '../../../types/vcl';
+
+export function VclStatsGrid({
+  overview,
+  totalSavings,
+  savingsPercent,
+}: {
+  overview: AdminVCLOverview;
+  totalSavings: number;
+  savingsPercent: number;
+}) {
+  const { t } = useTranslation('admin');
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="card border-slate-800/60 bg-slate-900/55">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-slate-400 text-sm">{t('vcl.stats.totalVersions')}</p>
+            <p className="text-2xl font-bold text-white mt-1">{overview.total_versions.toLocaleString()}</p>
+          </div>
+          <Clock className="w-10 h-10 text-sky-400 opacity-50" />
+        </div>
+      </div>
+
+      <div className="card border-slate-800/60 bg-slate-900/55">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-slate-400 text-sm">{t('vcl.stats.storageUsed')}</p>
+            <p className="text-2xl font-bold text-white mt-1">{formatBytes(overview.total_compressed_bytes)}</p>
+            <p className="text-xs text-slate-500 mt-1">{formatBytes(overview.total_size_bytes)} {t('vcl.stats.original')}</p>
+          </div>
+          <HardDrive className="w-10 h-10 text-violet-400 opacity-50" />
+        </div>
+      </div>
+
+      <div className="card border-slate-800/60 bg-slate-900/55">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-slate-400 text-sm">{t('vcl.stats.totalSavings')}</p>
+            <p className="text-2xl font-bold text-white mt-1">{formatNumber(savingsPercent, 1)}%</p>
+            <p className="text-xs text-slate-500 mt-1">{formatBytes(totalSavings)} {t('vcl.stats.saved')}</p>
+          </div>
+          <TrendingUp className="w-10 h-10 text-green-400 opacity-50" />
+        </div>
+      </div>
+
+      <div className="card border-slate-800/60 bg-slate-900/55">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-slate-400 text-sm">{t('vcl.stats.activeUsers')}</p>
+            <p className="text-2xl font-bold text-white mt-1">{overview.total_users}</p>
+            <p className="text-xs text-slate-500 mt-1">{overview.cached_versions_count} {t('vcl.stats.cached')}</p>
+          </div>
+          <Users className="w-10 h-10 text-amber-400 opacity-50" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/vcl/vcl-settings/VclStorageDetailsCard.tsx
+++ b/client/src/components/vcl/vcl-settings/VclStorageDetailsCard.tsx
@@ -1,0 +1,67 @@
+import { useTranslation } from 'react-i18next';
+import { Database, Star } from 'lucide-react';
+import { formatBytes } from '../../../api/vcl';
+import { formatNumber } from '../../../lib/formatters';
+import type { AdminVCLOverview } from '../../../types/vcl';
+
+export function VclStorageDetailsCard({
+  overview,
+  compressionRatio,
+}: {
+  overview: AdminVCLOverview;
+  compressionRatio: number;
+}) {
+  const { t } = useTranslation('admin');
+
+  return (
+    <div className="card border-slate-800/60 bg-slate-900/55">
+      <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+        <Database className="w-5 h-5 text-sky-400" />
+        {t('vcl.storageDetails.title')}
+      </h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+        <div>
+          <p className="text-slate-400">{t('vcl.storageDetails.compressionRatio')}</p>
+          <p className="text-white font-semibold mt-1">{formatNumber(compressionRatio, 2)}x</p>
+        </div>
+        <div>
+          <p className="text-slate-400">{t('vcl.storageDetails.compressionSavings')}</p>
+          <p className="text-white font-semibold mt-1">{formatBytes(overview.compression_savings_bytes)}</p>
+        </div>
+        <div>
+          <p className="text-slate-400">{t('vcl.storageDetails.dedupSavings')}</p>
+          <p className="text-white font-semibold mt-1">{formatBytes(overview.deduplication_savings_bytes)}</p>
+        </div>
+        <div>
+          <p className="text-slate-400">{t('vcl.storageDetails.uniqueBlobs')}</p>
+          <p className="text-white font-semibold mt-1">{overview.unique_blobs} / {overview.total_blobs}</p>
+        </div>
+        <div>
+          <p className="text-slate-400">{t('vcl.storageDetails.priorityVersions')}</p>
+          <p className="text-white font-semibold mt-1 flex items-center gap-1">
+            <Star className="w-4 h-4 text-amber-400 fill-amber-400" />
+            {overview.priority_count}
+          </p>
+        </div>
+        <div>
+          <p className="text-slate-400">{t('vcl.storageDetails.lastCleanup')}</p>
+          <p className="text-white font-semibold mt-1">
+            {overview.last_cleanup_at ? new Date(overview.last_cleanup_at).toLocaleDateString() : t('vcl.storageDetails.never')}
+          </p>
+        </div>
+        <div>
+          <p className="text-slate-400">{t('vcl.storageDetails.lastPriorityMode')}</p>
+          <p className="text-white font-semibold mt-1">
+            {overview.last_priority_mode_at ? new Date(overview.last_priority_mode_at).toLocaleDateString() : t('vcl.storageDetails.never')}
+          </p>
+        </div>
+        <div>
+          <p className="text-slate-400">{t('vcl.storageDetails.updated')}</p>
+          <p className="text-white font-semibold mt-1">
+            {overview.updated_at ? new Date(overview.updated_at).toLocaleTimeString() : t('common.na')}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/vcl/vcl-settings/VclStorageInfoCard.tsx
+++ b/client/src/components/vcl/vcl-settings/VclStorageInfoCard.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next';
+import { FolderOpen } from 'lucide-react';
+import { formatBytes } from '../../../api/vcl';
+import { formatNumber } from '../../../lib/formatters';
+import type { VCLStorageInfo } from '../../../types/vcl';
+import { usageBarColor } from './usageBarColor';
+
+export function VclStorageInfoCard({ storageInfo }: { storageInfo: VCLStorageInfo }) {
+  const { t } = useTranslation('admin');
+
+  return (
+    <div className="card border-slate-800/60 bg-slate-900/55">
+      <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+        <FolderOpen className="w-5 h-5 text-sky-400" />
+        {t('vcl.storageInfo.title', 'Storage Location')}
+      </h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+        <div>
+          <p className="text-slate-400">{t('vcl.storageInfo.path', 'Storage Path')}</p>
+          <p className="text-white font-semibold mt-1 truncate" title={storageInfo.storage_path}>
+            {storageInfo.storage_path}
+          </p>
+          {storageInfo.is_custom_path && (
+            <span className="mt-1 inline-block px-2 py-0.5 rounded-full text-[10px] font-medium bg-violet-500/20 text-violet-300">
+              Custom Path
+            </span>
+          )}
+        </div>
+        <div>
+          <p className="text-slate-400">{t('vcl.storageInfo.blobCount', 'Blob Count')}</p>
+          <p className="text-white font-semibold mt-1">{storageInfo.blob_count.toLocaleString()}</p>
+        </div>
+        <div>
+          <p className="text-slate-400">{t('vcl.storageInfo.compressedSize', 'Compressed Size')}</p>
+          <p className="text-white font-semibold mt-1">{formatBytes(storageInfo.total_compressed_bytes)}</p>
+        </div>
+        <div>
+          <p className="text-slate-400">{t('vcl.storageInfo.diskUsage', 'Disk Usage')}</p>
+          <p className="text-white font-semibold mt-1">
+            {formatNumber(storageInfo.disk_used_percent, 1)}%
+          </p>
+          <div className="h-1.5 w-full mt-1.5 overflow-hidden rounded-full bg-slate-800 max-w-[120px]">
+            <div
+              className={`h-full rounded-full transition-all ${usageBarColor(storageInfo.disk_used_percent, 70, 90)}`}
+              style={{ width: `${Math.min(storageInfo.disk_used_percent, 100)}%` }}
+            />
+          </div>
+          <p className="text-xs text-slate-500 mt-1">
+            {formatBytes(storageInfo.disk_available_bytes)} {t('vcl.storageInfo.free', 'free')} / {formatBytes(storageInfo.disk_total_bytes)}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/vcl/vcl-settings/VclUserQuotasTable.tsx
+++ b/client/src/components/vcl/vcl-settings/VclUserQuotasTable.tsx
@@ -1,0 +1,104 @@
+import { useTranslation } from 'react-i18next';
+import { Users } from 'lucide-react';
+import { formatBytes } from '../../../api/vcl';
+import { formatNumber } from '../../../lib/formatters';
+import { usageBarColor } from './usageBarColor';
+import type { UserVCLStats } from '../../../types/vcl';
+
+export function VclUserQuotasTable({
+  users,
+  onEditUser,
+}: {
+  users: UserVCLStats[];
+  onEditUser: (user: UserVCLStats) => void;
+}) {
+  const { t } = useTranslation('admin');
+
+  return (
+    <div className="card border-slate-800/60 bg-slate-900/55">
+      <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+        <Users className="w-5 h-5 text-sky-400" />
+        {t('vcl.userQuotas.title')}
+      </h3>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left border-b border-slate-800">
+              <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.user')}</th>
+              <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.maxSize')}</th>
+              <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.used')}</th>
+              <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.usage')}</th>
+              <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.versions')}</th>
+              <th className="pb-3 text-slate-400 font-medium">Mode</th>
+              <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.status')}</th>
+              <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.actions')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users && users.length > 0 ? users.map((user) => {
+              const usagePercent = user.usage_percent;
+              const isWarning = usagePercent >= 80;
+              const isCritical = usagePercent >= 95;
+
+              return (
+                <tr key={user.user_id} className="border-b border-slate-800/50">
+                  <td className="py-3 text-white font-medium">{user.username}</td>
+                  <td className="py-3 text-slate-300">{formatBytes(user.max_size_bytes)}</td>
+                  <td className="py-3 text-slate-300">{formatBytes(user.current_usage_bytes)}</td>
+                  <td className="py-3">
+                    <div className="flex items-center gap-2">
+                      <div className="flex-1 h-2 bg-slate-700 rounded-full overflow-hidden max-w-[100px]">
+                        <div
+                          className={`h-full transition-all ${usageBarColor(usagePercent, 80, 95)}`}
+                          style={{ width: `${Math.min(usagePercent, 100)}%` }}
+                        />
+                      </div>
+                      <span className={`${isCritical ? 'text-red-400' : isWarning ? 'text-amber-400' : 'text-slate-300'}`}>
+                        {formatNumber(usagePercent, 1)}%
+                      </span>
+                    </div>
+                  </td>
+                  <td className="py-3 text-slate-300">{user.total_versions}</td>
+                  <td className="py-3">
+                    <span className={`px-2 py-1 rounded-full text-xs font-medium ${
+                      user.vcl_mode === 'manual'
+                        ? 'bg-violet-500/20 text-violet-300'
+                        : 'bg-sky-500/20 text-sky-300'
+                    }`}>
+                      {user.vcl_mode === 'manual' ? 'Manual' : 'Auto'}
+                    </span>
+                  </td>
+                  <td className="py-3">
+                    <span
+                      className={`px-2 py-1 rounded-full text-xs font-medium ${
+                        user.is_enabled
+                          ? 'bg-green-500/20 text-green-400'
+                          : 'bg-red-500/20 text-red-400'
+                      }`}
+                    >
+                      {user.is_enabled ? t('common.enabled') : t('common.disabled')}
+                    </span>
+                  </td>
+                  <td className="py-3">
+                    <button
+                      onClick={() => onEditUser(user)}
+                      className="text-sky-400 hover:text-sky-300 transition-colors"
+                    >
+                      {t('common.edit')}
+                    </button>
+                  </td>
+                </tr>
+              );
+            }) : (
+              <tr>
+                <td colSpan={8} className="py-8 text-center text-slate-500">
+                  {t('vcl.userQuotas.noUsers')}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/vcl/vcl-settings/index.ts
+++ b/client/src/components/vcl/vcl-settings/index.ts
@@ -1,0 +1,9 @@
+export { usageBarColor } from './usageBarColor';
+export { VclMessageBanners } from './VclMessageBanners';
+export { VclStorageInfoCard } from './VclStorageInfoCard';
+export { VclStatsGrid } from './VclStatsGrid';
+export { VclStorageDetailsCard } from './VclStorageDetailsCard';
+export { VclMaintenanceCard } from './VclMaintenanceCard';
+export { VclReconciliationCard } from './VclReconciliationCard';
+export { VclUserQuotasTable } from './VclUserQuotasTable';
+export { VclEditUserModal } from './VclEditUserModal';

--- a/client/src/components/vcl/vcl-settings/usageBarColor.ts
+++ b/client/src/components/vcl/vcl-settings/usageBarColor.ts
@@ -1,0 +1,3 @@
+export function usageBarColor(percent: number, warn: number, crit: number): string {
+  return percent >= crit ? 'bg-red-500' : percent >= warn ? 'bg-amber-500' : 'bg-sky-500';
+}

--- a/client/src/hooks/useVclSettings.ts
+++ b/client/src/hooks/useVclSettings.ts
@@ -1,0 +1,201 @@
+/**
+ * useVclSettings
+ * Data/state hook for VCL Settings (Admin) — owns all state, the mount
+ * effect, and every handler used by VCLSettings.tsx.
+ */
+
+import { useState, useEffect } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getApiErrorMessage } from '../lib/errorHandling';
+import {
+  getAdminOverview,
+  getAdminUsers,
+  getStorageInfo,
+  updateUserSettingsAdmin,
+  triggerCleanup,
+  getReconciliationPreview,
+  applyReconciliation,
+  formatBytes,
+} from '../api/vcl';
+import type {
+  AdminVCLOverview,
+  UserVCLStats,
+  VCLSettingsUpdate,
+  VCLStorageInfo,
+  ReconciliationPreview,
+} from '../types/vcl';
+
+export interface UseVclSettingsResult {
+  overview: AdminVCLOverview | null;
+  storageInfo: VCLStorageInfo | null;
+  users: UserVCLStats[];
+  loading: boolean;
+  actionLoading: boolean;
+  error: string | null;
+  successMessage: string | null;
+  editingUser: UserVCLStats | null;
+  editForm: VCLSettingsUpdate;
+  setEditForm: Dispatch<SetStateAction<VCLSettingsUpdate>>;
+  reconPreview: ReconciliationPreview | null;
+  reconLoading: boolean;
+  forceOverQuota: boolean;
+  setForceOverQuota: Dispatch<SetStateAction<boolean>>;
+  loadData: () => Promise<void>;
+  handleCleanup: (dryRun?: boolean) => Promise<void>;
+  handleScanMismatches: () => Promise<void>;
+  handleApplyReconciliation: () => Promise<void>;
+  handleEditUser: (user: UserVCLStats) => void;
+  handleSaveUserSettings: () => Promise<void>;
+  setEditingUser: Dispatch<SetStateAction<UserVCLStats | null>>;
+}
+
+export function useVclSettings(): UseVclSettingsResult {
+  const [overview, setOverview] = useState<AdminVCLOverview | null>(null);
+  const [storageInfo, setStorageInfo] = useState<VCLStorageInfo | null>(null);
+  const [users, setUsers] = useState<UserVCLStats[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  // Edit modal state
+  const [editingUser, setEditingUser] = useState<UserVCLStats | null>(null);
+  const [editForm, setEditForm] = useState<VCLSettingsUpdate>({});
+  const { t } = useTranslation('admin');
+
+  // Reconciliation state
+  const [reconPreview, setReconPreview] = useState<ReconciliationPreview | null>(null);
+  const [reconLoading, setReconLoading] = useState(false);
+  const [forceOverQuota, setForceOverQuota] = useState(false);
+
+  useEffect(() => {
+    loadData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const loadData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const [overviewData, usersData, storageData] = await Promise.all([
+        getAdminOverview(),
+        getAdminUsers(100, 0),
+        getStorageInfo().catch(() => null),
+      ]);
+      setOverview(overviewData);
+      setUsers(usersData?.users || []);
+      setStorageInfo(storageData);
+    } catch (err: unknown) {
+      setError(getApiErrorMessage(err, t('vcl.errors.loadFailed')));
+      // Set empty arrays on error
+      setUsers([]);
+      setOverview(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCleanup = async (dryRun: boolean = false) => {
+    if (!dryRun && !confirm(t('vcl.maintenance.confirmCleanup'))) return;
+
+    try {
+      setActionLoading(true);
+      setError(null);
+      const result = await triggerCleanup({ dry_run: dryRun });
+      setSuccessMessage(
+        t(dryRun ? 'vcl.cleanup.dryRunResult' : 'vcl.cleanup.result', { versions: result.deleted_versions, freed: formatBytes(result.freed_bytes) })
+      );
+      setTimeout(() => setSuccessMessage(null), 5000);
+      if (!dryRun) loadData(); // Reload stats
+    } catch (err: unknown) {
+      setError(getApiErrorMessage(err, t('vcl.errors.cleanupFailed')));
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleScanMismatches = async () => {
+    try {
+      setReconLoading(true);
+      setError(null);
+      const preview = await getReconciliationPreview({});
+      setReconPreview(preview);
+      if (preview.total_mismatches === 0) {
+        setSuccessMessage('No ownership mismatches found');
+        setTimeout(() => setSuccessMessage(null), 3000);
+      }
+    } catch (err: unknown) {
+      setError(getApiErrorMessage(err, 'Failed to scan for mismatches'));
+    } finally {
+      setReconLoading(false);
+    }
+  };
+
+  const handleApplyReconciliation = async () => {
+    if (!confirm('Apply ownership reconciliation? This will update version ownership to match file ownership.')) return;
+    try {
+      setReconLoading(true);
+      setError(null);
+      const result = await applyReconciliation({ force_over_quota: forceOverQuota });
+      setSuccessMessage(result.message);
+      setTimeout(() => setSuccessMessage(null), 5000);
+      setReconPreview(null);
+      loadData();
+    } catch (err: unknown) {
+      setError(getApiErrorMessage(err, 'Failed to apply reconciliation'));
+    } finally {
+      setReconLoading(false);
+    }
+  };
+
+  const handleEditUser = (user: UserVCLStats) => {
+    setEditingUser(user);
+    setEditForm({
+      max_size_bytes: user.max_size_bytes,
+      is_enabled: user.is_enabled,
+    });
+  };
+
+  const handleSaveUserSettings = async () => {
+    if (!editingUser) return;
+
+    try {
+      setActionLoading(true);
+      setError(null);
+      await updateUserSettingsAdmin(editingUser.user_id, editForm);
+      setSuccessMessage(t('vcl.settingsUpdated', { username: editingUser.username }));
+      setTimeout(() => setSuccessMessage(null), 3000);
+      setEditingUser(null);
+      loadData(); // Reload
+    } catch (err: unknown) {
+      setError(getApiErrorMessage(err, t('vcl.errors.updateFailed')));
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  return {
+    overview,
+    storageInfo,
+    users,
+    loading,
+    actionLoading,
+    error,
+    successMessage,
+    editingUser,
+    editForm,
+    setEditForm,
+    reconPreview,
+    reconLoading,
+    forceOverQuota,
+    setForceOverQuota,
+    loadData,
+    handleCleanup,
+    handleScanMismatches,
+    handleApplyReconciliation,
+    handleEditUser,
+    handleSaveUserSettings,
+    setEditingUser,
+  };
+}

--- a/docs/superpowers/plans/2026-07-11-vclsettings-decomposition-f2.md
+++ b/docs/superpowers/plans/2026-07-11-vclsettings-decomposition-f2.md
@@ -1,0 +1,718 @@
+# VCLSettings.tsx Decomposition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Behavior-preserving decomposition of `client/src/components/vcl/VCLSettings.tsx` (633 lines) into one data/state hook, one pure helper, and a `components/vcl/vcl-settings/` directory of presentational components, leaving the component a thin ~120-line orchestrator.
+
+**Architecture:** All fetching/state moves into `hooks/useVclSettings.ts`. Presentational components take props + callbacks only. Moved markup is byte-identical (same JSX, same Tailwind, same mixed `t()`/hard-coded English copy). The component keeps its default export + path so the `vcl` barrel and consumers are untouched.
+
+**Tech Stack:** React 18 + TypeScript (strict, `verbatimModuleSyntax`) + Vite + Tailwind + react-i18next (`admin` namespace) + lucide-react + Vitest + @testing-library/react.
+
+## Global Constraints
+
+- **`verbatimModuleSyntax`:** every type-only import MUST use `import type { ... }`. `tsc -b` (CI `npm run build`) enforces this; vitest/esbuild does NOT. Run `npx tsc -b` before each commit.
+- **Behavior byte-identical:** same API calls (`getAdminOverview`, `getAdminUsers`, `getStorageInfo`, `updateUserSettingsAdmin`, `triggerCleanup`, `getReconciliationPreview`, `applyReconciliation`), same `Promise.all` with `getStorageInfo().catch(() => null)`, same `confirm(...)` strings, same `t('vcl.*')`/`t('common.*')` keys (with existing fallback args), same `setTimeout(..., 5000|3000)` timers, same derived values, same `slice(0, 100)` mismatch cap.
+- **DO NOT introduce/change i18n or copy.** The file mixes `t('vcl.*')` (namespace `admin`) with hard-coded English strings (mostly the Ownership-Reconciliation section) — preserve BOTH verbatim. The i18n gap is tracked in issue #406.
+- **Test hygiene (T7):** assert on role/text/title, never Tailwind class names. Fixtures are complete objects of the real types (`AdminVCLOverview`, `UserVCLStats`, `VCLStorageInfo`, `ReconciliationPreview`, `AffectedUser`, `ReconciliationMismatch`, `VCLSettingsUpdate`) from `../types/vcl`. Each test asserts the SPECIFIC targeted behavior of its unit.
+- Source of truth for every moved block: the current `client/src/components/vcl/VCLSettings.tsx` at branch base. Line numbers below refer to that file.
+- New component dir: `client/src/components/vcl/vcl-settings/`. New tests: `client/src/__tests__/components/vcl/vcl-settings/` and `client/src/__tests__/hooks/`.
+- Import note: `formatBytes` comes from `../../api/vcl` (NOT lib/formatters); `formatNumber` from `../../lib/formatters`; types from `../../types/vcl`. From a component in `vcl-settings/`, these are `../../../api/vcl`, `../../../lib/formatters`, `../../../types/vcl`, and `ByteSizeInput` is `../../ui/ByteSizeInput`.
+
+---
+
+### Task 1: `usageBarColor` pure helper
+
+**Files:**
+- Create: `client/src/components/vcl/vcl-settings/usageBarColor.ts`
+- Test: `client/src/__tests__/components/vcl/vcl-settings/usageBarColor.test.ts`
+
+**Interfaces:**
+- Produces: `export function usageBarColor(percent: number, warn: number, crit: number): string`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// usageBarColor.test.ts
+import { describe, it, expect } from 'vitest';
+import { usageBarColor } from '../../../../components/vcl/vcl-settings/usageBarColor';
+
+describe('usageBarColor', () => {
+  it('returns red at/above the crit threshold', () => {
+    expect(usageBarColor(95, 80, 95)).toBe('bg-red-500');
+    expect(usageBarColor(90, 70, 90)).toBe('bg-red-500');
+  });
+  it('returns amber at/above warn and below crit', () => {
+    expect(usageBarColor(85, 80, 95)).toBe('bg-amber-500');
+    expect(usageBarColor(70, 70, 90)).toBe('bg-amber-500');
+  });
+  it('returns sky below warn', () => {
+    expect(usageBarColor(50, 80, 95)).toBe('bg-sky-500');
+    expect(usageBarColor(10, 70, 90)).toBe('bg-sky-500');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail.** `cd client ; npx vitest run src/__tests__/components/vcl/vcl-settings/usageBarColor.test.ts` → FAIL.
+- [ ] **Step 3: Write the implementation** (covers the two inline ternaries at lines 236 + 526):
+
+```ts
+// usageBarColor.ts
+export function usageBarColor(percent: number, warn: number, crit: number): string {
+  return percent >= crit ? 'bg-red-500' : percent >= warn ? 'bg-amber-500' : 'bg-sky-500';
+}
+```
+
+- [ ] **Step 4: Run to verify pass** → PASS (3 tests).
+- [ ] **Step 5: Commit** `feat(vcl): extract usageBarColor helper (F2, #301)`.
+
+---
+
+### Task 2: `useVclSettings` hook
+
+**Files:**
+- Create: `client/src/hooks/useVclSettings.ts`
+- Test: `client/src/__tests__/hooks/useVclSettings.test.ts`
+
+**Interfaces:**
+- Consumes: the seven functions + `formatBytes` from `../api/vcl`; `getApiErrorMessage` from `../lib/errorHandling`; types from `../types/vcl`; `useTranslation`.
+- Produces: `useVclSettings(): UseVclSettingsResult` (full shape below). Consumed by Task 9.
+
+```ts
+import type {
+  AdminVCLOverview, UserVCLStats, VCLSettingsUpdate,
+  VCLStorageInfo, ReconciliationPreview,
+} from '../types/vcl';
+import type { Dispatch, SetStateAction } from 'react';
+
+export interface UseVclSettingsResult {
+  overview: AdminVCLOverview | null;
+  storageInfo: VCLStorageInfo | null;
+  users: UserVCLStats[];
+  loading: boolean;
+  actionLoading: boolean;
+  error: string | null;
+  successMessage: string | null;
+  editingUser: UserVCLStats | null;
+  editForm: VCLSettingsUpdate;
+  setEditForm: Dispatch<SetStateAction<VCLSettingsUpdate>>;
+  reconPreview: ReconciliationPreview | null;
+  reconLoading: boolean;
+  forceOverQuota: boolean;
+  setForceOverQuota: Dispatch<SetStateAction<boolean>>;
+  loadData: () => Promise<void>;
+  handleCleanup: (dryRun?: boolean) => Promise<void>;
+  handleScanMismatches: () => Promise<void>;
+  handleApplyReconciliation: () => Promise<void>;
+  handleEditUser: (user: UserVCLStats) => void;
+  handleSaveUserSettings: () => Promise<void>;
+  setEditingUser: Dispatch<SetStateAction<UserVCLStats | null>>;
+}
+
+export function useVclSettings(): UseVclSettingsResult;
+```
+
+**Porting notes (byte-identical):** move lines 46–167 verbatim — the 12 `useState`, `useTranslation('admin')`, the mount effect (`loadData`), and every handler. Preserve: `loadData`'s `Promise.all([getAdminOverview(), getAdminUsers(100, 0), getStorageInfo().catch(() => null)])`, the `setUsers(usersData?.users || [])`, the catch that sets empty users + null overview; `handleCleanup`'s `confirm(t('vcl.maintenance.confirmCleanup'))` guard, the `t(dryRun ? 'vcl.cleanup.dryRunResult' : 'vcl.cleanup.result', {...})` message, the `setTimeout(..., 5000)`, the `if (!dryRun) loadData()`; `handleScanMismatches`'s `'No ownership mismatches found'` + `setTimeout(..., 3000)`; `handleApplyReconciliation`'s `confirm('Apply ownership reconciliation? ...')` + hard-coded fallbacks; `handleEditUser`; `handleSaveUserSettings`'s `updateUserSettingsAdmin(editingUser.user_id, editForm)` + `t('vcl.settingsUpdated', {...})`. Expose `setEditForm`, `setEditingUser`, `setForceOverQuota`. `getApiErrorMessage` fallbacks verbatim (mix of `t(...)` and hard-coded English).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// useVclSettings.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const { overview, users, storage } = vi.hoisted(() => ({
+  overview: {
+    total_versions: 10, total_size_bytes: 1000, total_compressed_bytes: 400, total_blobs: 5,
+    unique_blobs: 4, deduplication_savings_bytes: 100, compression_savings_bytes: 200,
+    total_savings_bytes: 300, compression_ratio: 2.5, priority_count: 1, cached_versions_count: 2,
+    total_users: 3, last_cleanup_at: null, last_priority_mode_at: null, updated_at: null,
+  },
+  users: [{ user_id: 1, username: 'alice', max_size_bytes: 1000, current_usage_bytes: 500, usage_percent: 50, total_versions: 4, is_enabled: true, vcl_mode: 'automatic' }],
+  storage: null,
+}));
+
+vi.mock('../../api/vcl', () => ({
+  getAdminOverview: vi.fn().mockResolvedValue(overview),
+  getAdminUsers: vi.fn().mockResolvedValue({ users, total: 1 }),
+  getStorageInfo: vi.fn().mockResolvedValue(storage),
+  updateUserSettingsAdmin: vi.fn().mockResolvedValue({}),
+  triggerCleanup: vi.fn().mockResolvedValue({ deleted_versions: 0, freed_bytes: 0 }),
+  getReconciliationPreview: vi.fn().mockResolvedValue({ total_mismatches: 0, mismatches: [], affected_users: [] }),
+  applyReconciliation: vi.fn().mockResolvedValue({ message: 'ok' }),
+  formatBytes: (n: number) => `${n}B`,
+}));
+vi.mock('../../lib/errorHandling', () => ({ getApiErrorMessage: (_e: unknown, fb: string) => fb }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+import { useVclSettings } from '../../hooks/useVclSettings';
+import * as api from '../../api/vcl';
+
+describe('useVclSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  it('loads overview + users on mount', async () => {
+    const { result } = renderHook(() => useVclSettings());
+    await waitFor(() => expect(result.current.overview).not.toBeNull());
+    expect(result.current.users).toHaveLength(1);
+    expect(api.getStorageInfo).toHaveBeenCalled();
+  });
+
+  it('does not call triggerCleanup when the confirm is declined (non-dry-run)', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const { result } = renderHook(() => useVclSettings());
+    await waitFor(() => expect(result.current.overview).not.toBeNull());
+    await act(async () => { await result.current.handleCleanup(false); });
+    expect(api.triggerCleanup).not.toHaveBeenCalled();
+  });
+
+  it('sets the no-mismatches success message when the scan finds none', async () => {
+    const { result } = renderHook(() => useVclSettings());
+    await waitFor(() => expect(result.current.overview).not.toBeNull());
+    await act(async () => { await result.current.handleScanMismatches(); });
+    expect(result.current.successMessage).toBe('No ownership mismatches found');
+  });
+
+  it('handleSaveUserSettings sends the edit form for the editing user', async () => {
+    const { result } = renderHook(() => useVclSettings());
+    await waitFor(() => expect(result.current.overview).not.toBeNull());
+    act(() => result.current.handleEditUser(users[0]));
+    await act(async () => { await result.current.handleSaveUserSettings(); });
+    expect(api.updateUserSettingsAdmin).toHaveBeenCalledWith(
+      1, expect.objectContaining({ max_size_bytes: 1000, is_enabled: true }),
+    );
+  });
+});
+```
+> Note: fixtures are declared via `vi.hoisted()` so the `vi.mock` factory can reference them without hitting vitest's hoisting TDZ (any const referenced inside a `vi.mock` factory must be hoisted).
+
+- [ ] **Step 2: Run to verify fail** → FAIL (module not found).
+- [ ] **Step 3: Write the hook** per the porting notes (move 46–167 verbatim; return the full object).
+- [ ] **Step 4: Run test + gates**
+
+Run: `cd client ; npx vitest run src/__tests__/hooks/useVclSettings.test.ts` → PASS (4 tests).
+Run: `cd client ; npx tsc -b` → no errors.
+Run: `cd client ; npx eslint src/hooks/useVclSettings.ts` → 0 errors (add `// eslint-disable-next-line react-hooks/exhaustive-deps` on the mount effect ONLY if eslint flags it, preserving the original `[]` deps).
+
+- [ ] **Step 5: Commit** `feat(vcl): add useVclSettings hook (state + actions) (F2, #301)`.
+
+---
+
+### Task 3: `VclMessageBanners` + `VclStatsGrid` + `VclStorageDetailsCard`
+
+**Files:**
+- Create: `client/src/components/vcl/vcl-settings/VclMessageBanners.tsx`
+- Create: `client/src/components/vcl/vcl-settings/VclStatsGrid.tsx`
+- Create: `client/src/components/vcl/vcl-settings/VclStorageDetailsCard.tsx`
+- Test: `client/src/__tests__/components/vcl/vcl-settings/VclMessageBanners.test.tsx`
+- Test: `client/src/__tests__/components/vcl/vcl-settings/VclStatsGrid.test.tsx`
+- Test: `client/src/__tests__/components/vcl/vcl-settings/VclStorageDetailsCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `formatBytes` (`../../../api/vcl`), `formatNumber` (`../../../lib/formatters`), `AdminVCLOverview`.
+- Produces:
+```ts
+import type { AdminVCLOverview } from '../../../types/vcl';
+export function VclMessageBanners(props: { error: string | null; successMessage: string | null }): JSX.Element;
+export function VclStatsGrid(props: { overview: AdminVCLOverview; totalSavings: number; savingsPercent: number }): JSX.Element;
+export function VclStorageDetailsCard(props: { overview: AdminVCLOverview; compressionRatio: number }): JSX.Element;
+```
+- Consumed by Task 9.
+
+**Porting notes:** `VclMessageBanners` = the two banners verbatim from `VCLSettings.tsx:188-199` (each guarded by its prop). `VclStatsGrid` = the 4 stat cards verbatim from `250-293` (uses `overview`, `savingsPercent`, `totalSavings`; `formatBytes`/`formatNumber`; `useTranslation('admin')`). `VclStorageDetailsCard` = the detailed-stats card verbatim from `296-344` (uses `overview`, `compressionRatio`; `useTranslation('admin')`; keeps the `last_cleanup_at ? ... : t('vcl.storageDetails.never')` and `updated_at ? ... : t('common.na')` fallbacks).
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// VclMessageBanners.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { VclMessageBanners } from '../../../../components/vcl/vcl-settings/VclMessageBanners';
+
+describe('VclMessageBanners', () => {
+  it('renders only the error when only error is set', () => {
+    render(<VclMessageBanners error="boom" successMessage={null} />);
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+  it('renders only the success when only success is set', () => {
+    render(<VclMessageBanners error={null} successMessage="done" />);
+    expect(screen.getByText('done')).toBeInTheDocument();
+  });
+  it('renders nothing when both are null', () => {
+    const { container } = render(<VclMessageBanners error={null} successMessage={null} />);
+    expect(container.textContent).toBe('');
+  });
+});
+```
+
+```tsx
+// VclStatsGrid.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { AdminVCLOverview } from '../../../../types/vcl';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { VclStatsGrid } from '../../../../components/vcl/vcl-settings/VclStatsGrid';
+
+const overview = (over: Partial<AdminVCLOverview> = {}): AdminVCLOverview => ({
+  total_versions: 1234, total_size_bytes: 1000, total_compressed_bytes: 400, total_blobs: 5,
+  unique_blobs: 4, deduplication_savings_bytes: 100, compression_savings_bytes: 200,
+  total_savings_bytes: 300, compression_ratio: 2.5, priority_count: 1, cached_versions_count: 2,
+  total_users: 7, last_cleanup_at: null, last_priority_mode_at: null, updated_at: null, ...over,
+});
+
+describe('VclStatsGrid', () => {
+  it('renders the total-versions count and the active-users count', () => {
+    render(<VclStatsGrid overview={overview()} totalSavings={300} savingsPercent={30} />);
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+});
+```
+
+```tsx
+// VclStorageDetailsCard.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { AdminVCLOverview } from '../../../../types/vcl';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { VclStorageDetailsCard } from '../../../../components/vcl/vcl-settings/VclStorageDetailsCard';
+
+const overview = (over: Partial<AdminVCLOverview> = {}): AdminVCLOverview => ({
+  total_versions: 10, total_size_bytes: 1000, total_compressed_bytes: 400, total_blobs: 8,
+  unique_blobs: 6, deduplication_savings_bytes: 100, compression_savings_bytes: 200,
+  total_savings_bytes: 300, compression_ratio: 2.5, priority_count: 3, cached_versions_count: 2,
+  total_users: 3, last_cleanup_at: null, last_priority_mode_at: null, updated_at: null, ...over,
+});
+
+describe('VclStorageDetailsCard', () => {
+  it('renders unique/total blobs and the never-cleanup fallback', () => {
+    render(<VclStorageDetailsCard overview={overview()} compressionRatio={2.5} />);
+    expect(screen.getByText('6 / 8')).toBeInTheDocument();
+    // last_cleanup_at is null → the 'never' i18n key renders (appears twice: cleanup + priority mode)
+    expect(screen.getAllByText('vcl.storageDetails.never').length).toBeGreaterThanOrEqual(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run all three → FAIL.**
+- [ ] **Step 3: Write all three components** per porting notes.
+- [ ] **Step 4: Run all three tests + `npx tsc -b`** → PASS (5 tests total).
+- [ ] **Step 5: Commit** `feat(vcl): extract VclMessageBanners + VclStatsGrid + VclStorageDetailsCard (F2, #301)`.
+
+---
+
+### Task 4: `VclStorageInfoCard`
+
+**Files:**
+- Create: `client/src/components/vcl/vcl-settings/VclStorageInfoCard.tsx`
+- Test: `client/src/__tests__/components/vcl/vcl-settings/VclStorageInfoCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `formatBytes`, `formatNumber`, `usageBarColor` (Task 1), `VCLStorageInfo`.
+- Produces: `export function VclStorageInfoCard(props: { storageInfo: VCLStorageInfo }): JSX.Element;`
+- Consumed by Task 9.
+
+**Porting notes:** Move the storage-info card verbatim from `VCLSettings.tsx:203-246` (the outer `{storageInfo && ...}` guard stays in the orchestrator). The inline disk-bar color ternary at line 236 becomes `usageBarColor(storageInfo.disk_used_percent, 70, 90)`. Keep `formatBytes` (`../../../api/vcl`), `formatNumber` (`../../../lib/formatters`), the `t('vcl.storageInfo.*', 'fallback')` calls + the hard-coded "Custom Path" badge, the `Math.min(..., 100)` bar width. `useTranslation('admin')` internally.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// VclStorageInfoCard.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { VCLStorageInfo } from '../../../../types/vcl';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (_k: string, fb?: string) => fb ?? _k }) }));
+import { VclStorageInfoCard } from '../../../../components/vcl/vcl-settings/VclStorageInfoCard';
+
+const info = (over: Partial<VCLStorageInfo> = {}): VCLStorageInfo => ({
+  storage_path: '/mnt/vcl', is_custom_path: false, blob_count: 42,
+  total_compressed_bytes: 1000, disk_total_bytes: 2000, disk_available_bytes: 1500,
+  disk_used_percent: 25, ...over,
+});
+
+describe('VclStorageInfoCard', () => {
+  it('renders the storage path', () => {
+    render(<VclStorageInfoCard storageInfo={info()} />);
+    expect(screen.getByText('/mnt/vcl')).toBeInTheDocument();
+  });
+  it('shows the Custom Path badge only when is_custom_path', () => {
+    const { rerender } = render(<VclStorageInfoCard storageInfo={info({ is_custom_path: false })} />);
+    expect(screen.queryByText('Custom Path')).not.toBeInTheDocument();
+    rerender(<VclStorageInfoCard storageInfo={info({ is_custom_path: true })} />);
+    expect(screen.getByText('Custom Path')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Write the component.**
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (2 tests).
+- [ ] **Step 5: Commit** `feat(vcl): extract VclStorageInfoCard (F2, #301)`.
+
+---
+
+### Task 5: `VclMaintenanceCard`
+
+**Files:**
+- Create: `client/src/components/vcl/vcl-settings/VclMaintenanceCard.tsx`
+- Test: `client/src/__tests__/components/vcl/vcl-settings/VclMaintenanceCard.test.tsx`
+
+**Interfaces:**
+- Produces:
+```ts
+export function VclMaintenanceCard(props: {
+  actionLoading: boolean;
+  onDryRunCleanup: () => void;
+  onTriggerCleanup: () => void;
+  onRefresh: () => void;
+}): JSX.Element;
+```
+- Consumed by Task 9.
+
+**Porting notes:** Move the maintenance card verbatim from `VCLSettings.tsx:347-378`: dry-run button (`onClick={onDryRunCleanup}`), trigger button (`onClick={onTriggerCleanup}`), refresh button (`onClick={onRefresh}`), each `disabled={actionLoading}`, keep the `RefreshCw` spin class on refresh + the `t('vcl.maintenance.*')` keys. `useTranslation('admin')` internally.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// VclMaintenanceCard.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { VclMaintenanceCard } from '../../../../components/vcl/vcl-settings/VclMaintenanceCard';
+
+describe('VclMaintenanceCard', () => {
+  it('fires each callback on its button', () => {
+    const onDryRunCleanup = vi.fn(), onTriggerCleanup = vi.fn(), onRefresh = vi.fn();
+    render(<VclMaintenanceCard actionLoading={false}
+      onDryRunCleanup={onDryRunCleanup} onTriggerCleanup={onTriggerCleanup} onRefresh={onRefresh} />);
+    fireEvent.click(screen.getByText('vcl.maintenance.dryRunCleanup'));
+    fireEvent.click(screen.getByText('vcl.maintenance.triggerCleanup'));
+    fireEvent.click(screen.getByText('vcl.maintenance.refreshStats'));
+    expect(onDryRunCleanup).toHaveBeenCalledTimes(1);
+    expect(onTriggerCleanup).toHaveBeenCalledTimes(1);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+  it('disables all buttons while an action is loading', () => {
+    render(<VclMaintenanceCard actionLoading={true}
+      onDryRunCleanup={() => {}} onTriggerCleanup={() => {}} onRefresh={() => {}} />);
+    for (const k of ['vcl.maintenance.dryRunCleanup', 'vcl.maintenance.triggerCleanup', 'vcl.maintenance.refreshStats']) {
+      expect(screen.getByText(k).closest('button')).toBeDisabled();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Write the component.**
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (2 tests).
+- [ ] **Step 5: Commit** `feat(vcl): extract VclMaintenanceCard (F2, #301)`.
+
+---
+
+### Task 6: `VclReconciliationCard`
+
+**Files:**
+- Create: `client/src/components/vcl/vcl-settings/VclReconciliationCard.tsx`
+- Test: `client/src/__tests__/components/vcl/vcl-settings/VclReconciliationCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `formatBytes`, `ReconciliationPreview`.
+- Produces:
+```ts
+import type { ReconciliationPreview } from '../../../types/vcl';
+export function VclReconciliationCard(props: {
+  reconPreview: ReconciliationPreview | null;
+  reconLoading: boolean;
+  forceOverQuota: boolean;
+  onScan: () => void;
+  onForceChange: (v: boolean) => void;
+  onApply: () => void;
+}): JSX.Element;
+```
+- Consumed by Task 9.
+
+**Porting notes:** Move the whole reconciliation card verbatim from `VCLSettings.tsx:381-488`: the scan button (`onClick={onScan}`, `disabled={reconLoading}`), the `{reconPreview && reconPreview.total_mismatches > 0 && (...)}` block containing the force checkbox (`onChange={(e) => onForceChange(e.target.checked)}`) + apply button (`onClick={onApply}`, `Apply ({reconPreview.total_mismatches} versions)`), the affected-users summary (`affected_users.map`), and the mismatch table (`mismatches.slice(0, 100).map`, `ArrowRight`, `formatBytes`) + the `{total_mismatches > 100 && "Showing 100 of N"}` note. All hard-coded English strings verbatim. No `useTranslation` needed (this card is fully hard-coded English).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// VclReconciliationCard.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { ReconciliationPreview } from '../../../../types/vcl';
+import { VclReconciliationCard } from '../../../../components/vcl/vcl-settings/VclReconciliationCard';
+
+const preview = (over: Partial<ReconciliationPreview> = {}): ReconciliationPreview => ({
+  total_mismatches: 0, mismatches: [], affected_users: [], ...over,
+});
+const base = { reconLoading: false, forceOverQuota: false, onScan: () => {}, onForceChange: () => {}, onApply: () => {} };
+
+describe('VclReconciliationCard', () => {
+  it('fires onScan when Scan for Mismatches is clicked', () => {
+    const onScan = vi.fn();
+    render(<VclReconciliationCard {...base} reconPreview={null} onScan={onScan} />);
+    fireEvent.click(screen.getByText('Scan for Mismatches'));
+    expect(onScan).toHaveBeenCalledTimes(1);
+  });
+  it('hides Apply + force checkbox when there are no mismatches', () => {
+    render(<VclReconciliationCard {...base} reconPreview={preview({ total_mismatches: 0 })} />);
+    expect(screen.queryByText(/^Apply \(/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+  it('shows Apply with the mismatch count when there are mismatches', () => {
+    render(<VclReconciliationCard {...base} reconPreview={preview({
+      total_mismatches: 2,
+      mismatches: [
+        { file_id: 1, file_path: '/a/b.txt', version_id: 11, version_number: 3, current_version_user_id: 1, current_version_username: 'alice', current_file_owner_id: 2, current_file_owner_username: 'bob', compressed_size: 100 },
+      ],
+      affected_users: [{ user_id: 2, username: 'bob', quota_delta: 100, current_usage: 0, max_size: 1000, would_exceed_quota: false }],
+    })} />);
+    expect(screen.getByText('Apply (2 versions)')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    expect(screen.getByText('b.txt')).toBeInTheDocument();
+  });
+  it('fires onForceChange when the force checkbox toggles', () => {
+    const onForceChange = vi.fn();
+    render(<VclReconciliationCard {...base} onForceChange={onForceChange}
+      reconPreview={preview({ total_mismatches: 1, mismatches: [], affected_users: [] })} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onForceChange).toHaveBeenCalledWith(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Write the component.**
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (4 tests).
+- [ ] **Step 5: Commit** `feat(vcl): extract VclReconciliationCard (F2, #301)`.
+
+---
+
+### Task 7: `VclUserQuotasTable`
+
+**Files:**
+- Create: `client/src/components/vcl/vcl-settings/VclUserQuotasTable.tsx`
+- Test: `client/src/__tests__/components/vcl/vcl-settings/VclUserQuotasTable.test.tsx`
+
+**Interfaces:**
+- Consumes: `formatBytes`, `formatNumber`, `usageBarColor` (Task 1), `UserVCLStats`.
+- Produces:
+```ts
+import type { UserVCLStats } from '../../../types/vcl';
+export function VclUserQuotasTable(props: { users: UserVCLStats[]; onEditUser: (user: UserVCLStats) => void }): JSX.Element;
+```
+- Consumed by Task 9.
+
+**Porting notes:** Move the user-limits table verbatim from `VCLSettings.tsx:491-577`. The inline usage-bar color ternary at line 526 becomes `usageBarColor(usagePercent, 80, 95)` (keep `isWarning`/`isCritical` for the inline TEXT-color ternary — that stays inline, different classes). Keep the Mode/Manual/Auto + status badges, the edit button (`onClick={() => onEditUser(user)}`), the empty-row (`colSpan={8}`), `formatBytes`/`formatNumber`, and all `t('vcl.userQuotas.*')`/`t('common.*')` keys. `useTranslation('admin')` internally.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// VclUserQuotasTable.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { UserVCLStats } from '../../../../types/vcl';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { VclUserQuotasTable } from '../../../../components/vcl/vcl-settings/VclUserQuotasTable';
+
+const user = (over: Partial<UserVCLStats> = {}): UserVCLStats => ({
+  user_id: 1, username: 'alice', max_size_bytes: 1000, current_usage_bytes: 500,
+  usage_percent: 50, total_versions: 4, is_enabled: true, vcl_mode: 'automatic', ...over,
+});
+
+describe('VclUserQuotasTable', () => {
+  it('renders the empty-state row when there are no users', () => {
+    render(<VclUserQuotasTable users={[]} onEditUser={() => {}} />);
+    expect(screen.getByText('vcl.userQuotas.noUsers')).toBeInTheDocument();
+  });
+  it('renders a row per user and fires onEditUser with the user', () => {
+    const onEditUser = vi.fn();
+    render(<VclUserQuotasTable users={[user({ user_id: 9, username: 'zoe' })]} onEditUser={onEditUser} />);
+    expect(screen.getByText('zoe')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('common.edit'));
+    expect(onEditUser).toHaveBeenCalledWith(expect.objectContaining({ user_id: 9 }));
+  });
+  it('shows the Manual badge for manual-mode users', () => {
+    render(<VclUserQuotasTable users={[user({ vcl_mode: 'manual' })]} onEditUser={() => {}} />);
+    expect(screen.getByText('Manual')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Write the component.**
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (3 tests).
+- [ ] **Step 5: Commit** `feat(vcl): extract VclUserQuotasTable (F2, #301)`.
+
+---
+
+### Task 8: `VclEditUserModal`
+
+**Files:**
+- Create: `client/src/components/vcl/vcl-settings/VclEditUserModal.tsx`
+- Test: `client/src/__tests__/components/vcl/vcl-settings/VclEditUserModal.test.tsx`
+
+**Interfaces:**
+- Consumes: `ByteSizeInput` (`../../ui/ByteSizeInput`), `UserVCLStats`, `VCLSettingsUpdate`.
+- Produces:
+```ts
+import type { UserVCLStats, VCLSettingsUpdate } from '../../../types/vcl';
+export function VclEditUserModal(props: {
+  editingUser: UserVCLStats;
+  editForm: VCLSettingsUpdate;
+  actionLoading: boolean;
+  onMaxSizeChange: (bytes: number) => void;
+  onEnabledChange: (v: boolean) => void;
+  onCancel: () => void;
+  onSave: () => void;
+}): JSX.Element;
+```
+- Consumed by Task 9.
+
+**Porting notes:** Move the modal verbatim from `VCLSettings.tsx:581-629` (the outer `{editingUser && ...}` guard stays in the orchestrator). The `ByteSizeInput` `onChange` → `onMaxSizeChange(bytes)` (was `setEditForm({ ...editForm, max_size_bytes: bytes })`); the enable checkbox `onChange` → `onEnabledChange(e.target.checked)`; cancel → `onCancel`; save → `onSave` (`disabled={actionLoading}`). Keep `editForm.max_size_bytes || 0`, `editForm.is_enabled ?? true`, and all `t('vcl.editModal.*')`/`t('common.*')` keys. `useTranslation('admin')` internally.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// VclEditUserModal.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { UserVCLStats, VCLSettingsUpdate } from '../../../../types/vcl';
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+import { VclEditUserModal } from '../../../../components/vcl/vcl-settings/VclEditUserModal';
+
+const editingUser: UserVCLStats = {
+  user_id: 1, username: 'alice', max_size_bytes: 1000, current_usage_bytes: 500,
+  usage_percent: 50, total_versions: 4, is_enabled: true, vcl_mode: 'automatic',
+};
+const editForm: VCLSettingsUpdate = { max_size_bytes: 1000, is_enabled: true };
+const base = { editingUser, editForm, actionLoading: false,
+  onMaxSizeChange: () => {}, onEnabledChange: () => {}, onCancel: () => {}, onSave: () => {} };
+
+describe('VclEditUserModal', () => {
+  it('fires onSave and onCancel from the footer buttons', () => {
+    const onSave = vi.fn(), onCancel = vi.fn();
+    render(<VclEditUserModal {...base} onSave={onSave} onCancel={onCancel} />);
+    fireEvent.click(screen.getByText('common.save'));
+    fireEvent.click(screen.getByText('common.cancel'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+  it('fires onEnabledChange when the enable checkbox toggles', () => {
+    const onEnabledChange = vi.fn();
+    render(<VclEditUserModal {...base} onEnabledChange={onEnabledChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onEnabledChange).toHaveBeenCalledWith(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Write the component.**
+- [ ] **Step 4: Run test + `npx tsc -b`** → PASS (2 tests).
+- [ ] **Step 5: Commit** `feat(vcl): extract VclEditUserModal (F2, #301)`.
+
+---
+
+### Task 9: Barrel + `VCLSettings.tsx` orchestrator + integration test
+
+**Files:**
+- Create: `client/src/components/vcl/vcl-settings/index.ts`
+- Modify: `client/src/components/vcl/VCLSettings.tsx` (full rewrite to orchestrator)
+- Test: `client/src/__tests__/components/vcl/VCLSettings.test.tsx`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–8 via the barrel, `useVclSettings` (Task 2).
+
+**Barrel** `index.ts` re-exports: `usageBarColor`, `VclMessageBanners`, `VclStorageInfoCard`, `VclStatsGrid`, `VclStorageDetailsCard`, `VclMaintenanceCard`, `VclReconciliationCard`, `VclUserQuotasTable`, `VclEditUserModal`.
+
+**Orchestrator rewrite:** keep the file header comment + default export `VCLSettings`. Call `useVclSettings()`. Keep the `if (loading) return <spinner/>` (169–175) and `if (!overview) return null` (177) verbatim, and the derived `const compressionRatio = overview.compression_ratio; const totalSavings = overview.total_savings_bytes; const savingsPercent = overview.total_size_bytes > 0 ? ((totalSavings / overview.total_size_bytes) * 100) : 0;` (179–183). Structure inside `<div className="space-y-6">`:
+1. `<VclMessageBanners error={error} successMessage={successMessage} />`
+2. `{storageInfo && <VclStorageInfoCard storageInfo={storageInfo} />}`
+3. `<VclStatsGrid overview={overview} totalSavings={totalSavings} savingsPercent={savingsPercent} />`
+4. `<VclStorageDetailsCard overview={overview} compressionRatio={compressionRatio} />`
+5. `<VclMaintenanceCard actionLoading={actionLoading} onDryRunCleanup={() => handleCleanup(true)} onTriggerCleanup={() => handleCleanup(false)} onRefresh={loadData} />`
+6. `<VclReconciliationCard reconPreview={reconPreview} reconLoading={reconLoading} forceOverQuota={forceOverQuota} onScan={handleScanMismatches} onForceChange={setForceOverQuota} onApply={handleApplyReconciliation} />`
+7. `<VclUserQuotasTable users={users} onEditUser={handleEditUser} />`
+8. `{editingUser && <VclEditUserModal editingUser={editingUser} editForm={editForm} actionLoading={actionLoading} onMaxSizeChange={(bytes) => setEditForm({ ...editForm, max_size_bytes: bytes })} onEnabledChange={(v) => setEditForm({ ...editForm, is_enabled: v })} onCancel={() => setEditingUser(null)} onSave={handleSaveUserSettings} />}`
+
+Delete all now-unused imports (the API functions, `useState`/`useEffect`, `getApiErrorMessage`, `ByteSizeInput`, `formatBytes`/`formatNumber`, `useTranslation` if unused, and the lucide icons only used by moved markup). Keep `useVclSettings` + the barrel imports. Run eslint to catch leftovers.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```tsx
+// client/src/__tests__/components/vcl/VCLSettings.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { AdminVCLOverview, UserVCLStats } from '../../../types/vcl';
+import type { UseVclSettingsResult } from '../../../hooks/useVclSettings';
+
+const overview: AdminVCLOverview = {
+  total_versions: 10, total_size_bytes: 1000, total_compressed_bytes: 400, total_blobs: 5,
+  unique_blobs: 4, deduplication_savings_bytes: 100, compression_savings_bytes: 200,
+  total_savings_bytes: 300, compression_ratio: 2.5, priority_count: 1, cached_versions_count: 2,
+  total_users: 3, last_cleanup_at: null, last_priority_mode_at: null, updated_at: null,
+};
+const users: UserVCLStats[] = [{ user_id: 1, username: 'alice', max_size_bytes: 1000, current_usage_bytes: 500, usage_percent: 50, total_versions: 4, is_enabled: true, vcl_mode: 'automatic' }];
+
+const hookValue: UseVclSettingsResult = {
+  overview, storageInfo: null, users, loading: false, actionLoading: false, error: null,
+  successMessage: null, editingUser: null, editForm: {}, setEditForm: vi.fn(),
+  reconPreview: null, reconLoading: false, forceOverQuota: false, setForceOverQuota: vi.fn(),
+  loadData: vi.fn(), handleCleanup: vi.fn(), handleScanMismatches: vi.fn(),
+  handleApplyReconciliation: vi.fn(), handleEditUser: vi.fn(), handleSaveUserSettings: vi.fn(),
+  setEditingUser: vi.fn(),
+};
+vi.mock('../../../hooks/useVclSettings', () => ({ useVclSettings: () => hookValue }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string, fb?: string) => fb ?? k }) }));
+
+import VCLSettings from '../../../components/vcl/VCLSettings';
+
+describe('VCLSettings', () => {
+  beforeEach(() => { Object.assign(hookValue, { loading: false, overview, users }); });
+
+  it('renders the stats grid + user table for a populated fixture', () => {
+    render(<VCLSettings />);
+    expect(screen.getByText('alice')).toBeInTheDocument();           // user table
+    expect(screen.getByText('Ownership Reconciliation')).toBeInTheDocument(); // recon card
+  });
+
+  it('renders none of the dashboard content while loading (early-return spinner)', () => {
+    hookValue.loading = true;
+    render(<VCLSettings />);
+    expect(screen.queryByText('alice')).not.toBeInTheDocument();
+    expect(screen.queryByText('Ownership Reconciliation')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when overview is null (and not loading)', () => {
+    Object.assign(hookValue, { loading: false, overview: null });
+    const { container } = render(<VCLSettings />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+```
+> Note: `overview: null` is not assignable to the `UseVclSettingsResult.overview` type as a plain reassignment via `Object.assign` on a typed const is fine (widening at runtime); if TS complains, cast the override object `as Partial<UseVclSettingsResult>`.
+
+- [ ] **Step 2: Run to verify fail** → FAIL (old shape / barrel not built).
+- [ ] **Step 3: Write the barrel, then rewrite `VCLSettings.tsx`** per the structure above.
+- [ ] **Step 4: Full verification**
+
+Run: `cd client ; npx vitest run src/__tests__/components/vcl/VCLSettings.test.tsx` → PASS (3 tests).
+Run: `cd client ; node -e "console.log(require('fs').readFileSync('src/components/vcl/VCLSettings.tsx','utf8').split(/\r?\n/).length)"` → under 500 (target ~120).
+Run: `cd client ; npx tsc -b` → no errors.
+Run: `cd client ; npx eslint src/components/vcl/VCLSettings.tsx src/components/vcl/vcl-settings src/hooks/useVclSettings.ts` → 0 errors (no unused imports).
+
+- [ ] **Step 5: Commit** `refactor(vcl): compose VCLSettings from useVclSettings + vcl-settings/* (F2, #301)`.
+
+---
+
+## Final Verification (after all tasks)
+
+- [ ] `cd client ; npx eslint .` → 0 errors.
+- [ ] `cd client ; npm run build` → green (tsc -b + vite).
+- [ ] `cd client ; npx vitest run` → full suite green.
+- [ ] `VCLSettings.tsx` < 500 lines.
+- [ ] Update `client/src/components/CLAUDE.md` `vcl/` row to note the `vcl-settings/` decomposition + `useVclSettings` hook (docs-only; fold into the Task 9 commit or a trailing `docs(vcl): ...` commit).
+- [ ] Multi-agent whole-branch review — READY TO MERGE (field-for-field audit of every moved block, especially `loadData`'s `Promise.all`, the reconciliation handlers, and the derived-value computation).

--- a/docs/superpowers/specs/2026-07-11-vclsettings-decomposition-f2-design.md
+++ b/docs/superpowers/specs/2026-07-11-vclsettings-decomposition-f2-design.md
@@ -1,0 +1,203 @@
+# VCLSettings.tsx Decomposition — Design (F2 / #301)
+
+**Date:** 2026-07-11
+**Finding:** F2 (components > 500 lines), umbrella issue #301.
+**Target:** `client/src/components/vcl/VCLSettings.tsx` — currently **633 lines**.
+
+## Goal
+
+Behavior-preserving decomposition of `VCLSettings.tsx` (the admin VCL settings /
+stats / maintenance / reconciliation dashboard) into one data/state hook, one
+pure helper, and a directory of presentational components under a new
+`components/vcl/vcl-settings/`.
+
+**Non-goals:** no change to API calls, endpoints, i18n keys, copy (the file
+mixes `t('vcl.*')` in the `admin` namespace with hard-coded English strings,
+mostly in the Ownership-Reconciliation section — both stay **verbatim**; do NOT
+introduce or change i18n, that is scope creep tracked in issue #406), Tailwind
+styling, `confirm(...)` wording, `setTimeout(... , 5000/3000)` success-message
+timers, or any computed value. The component keeps its path
+(`components/vcl/VCLSettings.tsx`, **default export** `VCLSettings`) so the
+`vcl/index.ts` barrel and consumers are untouched. `VCLTrackingPanel` and
+`VersionHistoryModal` (siblings in `vcl/`) are unrelated and untouched.
+
+## Constraints
+
+- Every extracted value is **byte-identical** in behavior: same seven vcl API
+  calls, same `Promise.all` (`getStorageInfo().catch(() => null)`), same
+  error/success handling + timers, same `confirm(...)` strings, same derived
+  values (`compressionRatio`, `totalSavings`, `savingsPercent`), same
+  `slice(0, 100)` mismatch cap + "Showing 100 of N" note, same
+  `formatBytes`/`formatNumber` usage.
+- Extracted components are **presentational**: props in, callbacks in, no data
+  fetching. The extracted hook owns all fetching/state.
+- Tests are T7-conform: assert on role/text/title, never Tailwind classes;
+  fixtures are complete objects of the real types (`AdminVCLOverview`,
+  `UserVCLStats`, `VCLStorageInfo`, `ReconciliationPreview`, `VCLSettingsUpdate`).
+- Hard-coded English strings preserved verbatim; the `t('vcl.*')` / `t('common.*')`
+  calls stay as `t()` (with their existing fallback second args where present).
+
+## Current inline blocks (what moves)
+
+| Block | Current lines | Destination |
+|---|---|---|
+| 12 `useState` + `useTranslation('admin')` + mount effect + all handlers (`loadData`, `handleCleanup`, `handleScanMismatches`, `handleApplyReconciliation`, `handleEditUser`, `handleSaveUserSettings`) | 46–167 | `hooks/useVclSettings.ts` |
+| Disk/quota usage-bar color ternary (`>= crit red : >= warn amber : sky`) | 236, 526 | `vcl-settings/usageBarColor.ts` (pure) |
+| Error + success banners | 188–199 | `vcl-settings/VclMessageBanners.tsx` |
+| Storage info card | 202–247 | `vcl-settings/VclStorageInfoCard.tsx` |
+| Stats grid (4 cards) | 250–293 | `vcl-settings/VclStatsGrid.tsx` |
+| Detailed stats card (8 fields) | 296–344 | `vcl-settings/VclStorageDetailsCard.tsx` |
+| Maintenance actions card | 347–378 | `vcl-settings/VclMaintenanceCard.tsx` |
+| Ownership reconciliation card (controls + affected-users + mismatch table) | 381–488 | `vcl-settings/VclReconciliationCard.tsx` |
+| User limits table | 491–577 | `vcl-settings/VclUserQuotasTable.tsx` |
+| Edit user modal | 580–629 | `vcl-settings/VclEditUserModal.tsx` |
+
+## New units & interfaces
+
+### `hooks/useVclSettings.ts`
+
+```ts
+import type {
+  AdminVCLOverview, UserVCLStats, VCLSettingsUpdate,
+  VCLStorageInfo, ReconciliationPreview,
+} from '../types/vcl';
+import type { Dispatch, SetStateAction } from 'react';
+
+export interface UseVclSettingsResult {
+  overview: AdminVCLOverview | null;
+  storageInfo: VCLStorageInfo | null;
+  users: UserVCLStats[];
+  loading: boolean;
+  actionLoading: boolean;
+  error: string | null;
+  successMessage: string | null;
+  editingUser: UserVCLStats | null;
+  editForm: VCLSettingsUpdate;
+  setEditForm: Dispatch<SetStateAction<VCLSettingsUpdate>>;
+  reconPreview: ReconciliationPreview | null;
+  reconLoading: boolean;
+  forceOverQuota: boolean;
+  setForceOverQuota: Dispatch<SetStateAction<boolean>>;
+  loadData: () => Promise<void>;
+  handleCleanup: (dryRun?: boolean) => Promise<void>;
+  handleScanMismatches: () => Promise<void>;
+  handleApplyReconciliation: () => Promise<void>;
+  handleEditUser: (user: UserVCLStats) => void;
+  handleSaveUserSettings: () => Promise<void>;
+  setEditingUser: Dispatch<SetStateAction<UserVCLStats | null>>;
+}
+
+export function useVclSettings(): UseVclSettingsResult;
+```
+
+Body ports lines 46–167 verbatim: the 12 `useState`, `useTranslation('admin')`,
+the mount effect (`loadData`), and every handler (same `Promise.all`, same
+`confirm(...)` strings, same `t('vcl.*')` message keys, same `setTimeout` timers,
+same `getApiErrorMessage` fallbacks incl. the hard-coded English ones for the
+reconciliation handlers). `setEditForm`, `setEditingUser`, `setForceOverQuota`
+are exposed so the presentational modal/reconciliation card can drive their form
+state through orchestrator-wired callbacks.
+
+### `vcl-settings/usageBarColor.ts` (pure)
+
+```ts
+export function usageBarColor(percent: number, warn: number, crit: number): string;
+```
+
+Returns `percent >= crit ? 'bg-red-500' : percent >= warn ? 'bg-amber-500' :
+'bg-sky-500'`. Covers both inline bar ternaries: storage disk bar =
+`usageBarColor(disk_used_percent, 70, 90)` (line 236); user-quota bar =
+`usageBarColor(usage_percent, 80, 95)` (line 526). The user-row **text**-color
+ternary (`text-red-400`/`text-amber-400`/`text-slate-300`, different classes)
+stays inline in `VclUserQuotasTable`.
+
+### Presentational components (`components/vcl/vcl-settings/`)
+
+- **`VclMessageBanners.tsx`** — `{ error: string | null; successMessage: string | null }`.
+  The two banners (188–199); each renders only when its prop is set.
+- **`VclStorageInfoCard.tsx`** — `{ storageInfo: VCLStorageInfo }`. Storage card
+  (203–246), using `formatBytes` (from `../../../api/vcl`), `formatNumber` (from
+  `../../../lib/formatters`), `usageBarColor(storageInfo.disk_used_percent, 70, 90)`,
+  and the two `t('vcl.storageInfo.*', 'fallback')` calls + the hard-coded
+  "Custom Path" badge. `useTranslation('admin')` internally. The `{storageInfo && }`
+  guard stays in the orchestrator.
+- **`VclStatsGrid.tsx`** — `{ overview: AdminVCLOverview; totalSavings: number;
+  savingsPercent: number }`. The 4 stat cards (250–293).
+- **`VclStorageDetailsCard.tsx`** — `{ overview: AdminVCLOverview;
+  compressionRatio: number }`. The detailed-stats card (296–344).
+- **`VclMaintenanceCard.tsx`** — `{ actionLoading: boolean; onDryRunCleanup:
+  () => void; onTriggerCleanup: () => void; onRefresh: () => void }`. The
+  maintenance card (347–378).
+- **`VclReconciliationCard.tsx`** — `{ reconPreview: ReconciliationPreview | null;
+  reconLoading: boolean; forceOverQuota: boolean; onScan: () => void;
+  onForceChange: (v: boolean) => void; onApply: () => void }`. The whole
+  reconciliation card (381–488): scan button, force checkbox, apply button,
+  affected-users summary, and the mismatch table (`slice(0, 100)` + "Showing 100
+  of N"). All hard-coded English strings verbatim. `formatBytes` used.
+- **`VclUserQuotasTable.tsx`** — `{ users: UserVCLStats[]; onEditUser:
+  (user: UserVCLStats) => void }`. The user-limits table (491–577), using
+  `formatBytes`/`formatNumber`, `usageBarColor(usage_percent, 80, 95)` for the
+  bar, the inline text-color ternary, the Mode/Manual/Auto + status badges, and
+  the empty-row (`colSpan={8}`). `useTranslation('admin')` internally.
+- **`VclEditUserModal.tsx`** — `{ editingUser: UserVCLStats; editForm:
+  VCLSettingsUpdate; actionLoading: boolean; onMaxSizeChange: (bytes: number) =>
+  void; onEnabledChange: (v: boolean) => void; onCancel: () => void; onSave:
+  () => void }`. The modal (581–629) with `ByteSizeInput`. The
+  `{editingUser && }` guard stays in the orchestrator.
+
+### `vcl-settings/index.ts`
+
+Barrel exporting all components + `usageBarColor`.
+
+### `VCLSettings.tsx` (after)
+
+Calls `useVclSettings()`. Keeps the `if (loading) return <spinner/>` (169–175)
+and `if (!overview) return null` (177) early-returns verbatim, and the derived
+`compressionRatio`/`totalSavings`/`savingsPercent` (179–183). Composes
+`VclMessageBanners`, `{storageInfo && <VclStorageInfoCard .../>}`, `VclStatsGrid`,
+`VclStorageDetailsCard`, `VclMaintenanceCard` (`onDryRunCleanup={() =>
+handleCleanup(true)}`, `onTriggerCleanup={() => handleCleanup(false)}`,
+`onRefresh={loadData}`), `VclReconciliationCard` (`onScan={handleScanMismatches}`,
+`onForceChange={setForceOverQuota}`, `onApply={handleApplyReconciliation}`),
+`VclUserQuotasTable` (`onEditUser={handleEditUser}`), and
+`{editingUser && <VclEditUserModal ... onMaxSizeChange={(bytes) =>
+setEditForm({ ...editForm, max_size_bytes: bytes })} onEnabledChange={(v) =>
+setEditForm({ ...editForm, is_enabled: v })} onCancel={() =>
+setEditingUser(null)} onSave={handleSaveUserSettings} />}`. Target: **~120
+lines** (from 633).
+
+## Testing
+
+Broad + integration (Vitest, T7-conform):
+
+- **`usageBarColor`** — `(95, 80, 95) → red`, `(85, 80, 95) → amber`,
+  `(50, 80, 95) → sky`; storage thresholds `(90, 70, 90) → red`,
+  `(70, 70, 90) → amber`, `(10, 70, 90) → sky`.
+- **`useVclSettings`** — `renderHook`: mount loads overview/users/storage
+  (`Promise.all`); `handleCleanup(false)` with `confirm` returning `false` makes
+  no `triggerCleanup` call; `handleScanMismatches` with 0 mismatches sets the
+  "No ownership mismatches found" success message; `handleSaveUserSettings`
+  calls `updateUserSettingsAdmin(editingUser.user_id, editForm)`. Mock
+  `../api/vcl`, `../lib/errorHandling`, and `window.confirm`.
+- **Component renders** — `VclMessageBanners` (error only / success only / both),
+  `VclStorageInfoCard` (path + Custom Path badge when `is_custom_path`),
+  `VclStatsGrid` (totals + savings %), `VclStorageDetailsCard` (compression ratio,
+  "Never" when no last-cleanup), `VclMaintenanceCard` (each callback fires),
+  `VclReconciliationCard` (scan fires; apply + force-checkbox shown only when
+  `total_mismatches > 0`; "Showing 100 of N" when > 100), `VclUserQuotasTable`
+  (row per user, empty-row when none, edit fires with user, Manual/Auto badge),
+  `VclEditUserModal` (save/cancel fire, enabled checkbox fires onEnabledChange).
+- **Integration** (`__tests__/components/vcl/VCLSettings.test.tsx`) — mock the
+  hook; assert stats grid + user table render for a populated fixture; `loading`
+  → spinner; `overview: null` → renders nothing.
+
+## Verification gates
+
+- `VCLSettings.tsx` < 500 lines (target ~120).
+- `eslint .` — 0 errors.
+- `npm run build` (tsc -b + vite) — green (`import type` for type-only imports —
+  `verbatimModuleSyntax` enforced by `tsc -b`, not vitest).
+- `vitest run` — full suite green.
+- Multi-agent whole-branch review — READY TO MERGE (field-for-field audit of
+  every moved block, especially `loadData`'s `Promise.all`, the reconciliation
+  handlers, and the derived-value computation).


### PR DESCRIPTION
## F2 — VCLSettings.tsx zerlegen (#301)

Verhaltenserhaltende Zerlegung von `client/src/components/vcl/VCLSettings.tsx` — **633 → 101 Zeilen** — in einen Daten-/State-Hook, einen pure Helper und 8 Präsentations-Komponenten unter `components/vcl/vcl-settings/`.

### Aufbau

| Unit | Rolle |
|---|---|
| `hooks/useVclSettings.ts` | Aller State (12 `useState`) + Mount-Effect + alle Handler (load/cleanup/scan/apply-recon/edit/save) |
| `vcl-settings/usageBarColor.ts` | pure Helper `(percent, warn, crit)` — deckt beide Usage-Bar-Ternaries (Storage 70/90, Quota 80/95) ab |
| `VclMessageBanners` | Error/Success-Banner |
| `VclStorageInfoCard` | Storage-Location-Card |
| `VclStatsGrid` | die 4 Stat-Karten |
| `VclStorageDetailsCard` | Detailed-Stats (8 Felder) |
| `VclMaintenanceCard` | Cleanup/Trigger/Refresh |
| `VclReconciliationCard` | Ownership-Reconciliation (Scan/Force/Apply + Affected-Users + Mismatch-Tabelle) |
| `VclUserQuotasTable` | User-Limits-Tabelle |
| `VclEditUserModal` | Edit-User-Modal |
| `vcl-settings/index.ts` | Barrel |

`VCLSettings.tsx` bleibt Orchestrator (loading-Spinner, `!overview`-Guard, abgeleitete Werte, Komposition).

### Verhalten byte-identisch

Gleiche API-Calls, `Promise.all` (+ `getStorageInfo().catch(() => null)`), Confirm-Strings, `t(...)`-Keys, Success-Timer (5000/3000), abgeleitete Werte (compressionRatio/totalSavings/savingsPercent), `slice(0,100)`-Mismatch-Cap. Die User-Row-Text-Farb-Ternary bleibt inline (andere Klassen als der Bar-Helper). DOM/Tailwind unverändert.

**Bewusst NICHT geändert:** der Mix aus `t()` und hartcodierten englischen Strings bleibt verbatim (u. a. die komplette Reconciliation-Sektion) — kein i18n eingeführt. Die fehlenden i18n-Keys sind im Sammel-Issue **#406** erfasst.

### Tests & Gates

Jede Unit hat eigene Vitest-Abdeckung (T7-konform: role/text/title, keine Tailwind-Assertions; vollständige Fixtures der echten Typen; gezielt auf Zweige/Callbacks/Guards). Der `VclStatsGrid`-Test meidet bewusst `Number.toLocaleString()`-Assertions (Tausender-Trenner differiert de-DE vs en-US).

- `eslint .` — 0 Fehler
- `npm run build` (tsc -b + vite) — grün
- `vitest run` — volle Suite grün
- Multi-Agent Whole-Branch-Review (opus) — **READY TO MERGE** (0 Findings, feldweise gegen das Original geprüft)

Teil des F2-Umbrella #301 (God-Components > 500 Zeilen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
