### PR TITLE
refactor(api-ref): decompose ApiReferenceTab into api-reference/* + useApiReference (#301) [F2]

### DIFF
--- a/client/src/__tests__/components/manual/api-reference/ApiCategoryTabs.test.tsx
+++ b/client/src/__tests__/components/manual/api-reference/ApiCategoryTabs.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ApiCategoryTabs } from '../../../../components/manual/api-reference/ApiCategoryTabs'
+import type { ApiSection } from '../../../../data/api-endpoints/types'
+import type { ApiCategory } from '../../../../lib/openapi-transform'
+
+const t = (k: string) => k
+const section = (title: string): ApiSection => ({ title, icon: null, endpoints: [
+  { method: 'GET', path: `/api/${title}`, description: '', requiresAuth: false },
+] })
+const apiSections: ApiSection[] = [section('files'), section('auth')]
+const apiCategories: ApiCategory[] = [{ id: 'core', label: 'Core', sections: [section('files')] }]
+
+describe('ApiCategoryTabs', () => {
+  it('renders the "all" pill with the total endpoint count and per-category pills', () => {
+    render(<ApiCategoryTabs apiSections={apiSections} apiCategories={apiCategories}
+      selectedCategory={null} selectedSection={null} currentCategorySections={[]}
+      onSelectCategory={vi.fn()} onSelectSection={vi.fn()} t={t} />)
+    expect(screen.getByText('Core')).toBeInTheDocument()
+    expect(screen.getByText('(2)')).toBeInTheDocument() // total endpoints across all sections
+  })
+
+  it('calls onSelectCategory when a category pill is clicked', () => {
+    const onSelectCategory = vi.fn()
+    render(<ApiCategoryTabs apiSections={apiSections} apiCategories={apiCategories}
+      selectedCategory={null} selectedSection={null} currentCategorySections={[]}
+      onSelectCategory={onSelectCategory} onSelectSection={vi.fn()} t={t} />)
+    fireEvent.click(screen.getByText('Core'))
+    expect(onSelectCategory).toHaveBeenCalledWith('core')
+  })
+})

--- a/client/src/__tests__/components/manual/api-reference/ApiSectionList.test.tsx
+++ b/client/src/__tests__/components/manual/api-reference/ApiSectionList.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ApiSectionList } from '../../../../components/manual/api-reference/ApiSectionList'
+import type { ApiSection } from '../../../../data/api-endpoints/types'
+
+const t = (k: string) => k
+const sections: ApiSection[] = [{
+  title: 'Files', icon: null,
+  endpoints: [{ method: 'GET', path: '/api/files/list', description: 'List', requiresAuth: false }],
+}]
+
+describe('ApiSectionList', () => {
+  it('renders a section header and its endpoint cards', () => {
+    render(<ApiSectionList sections={sections} rateLimits={{}} t={t} />)
+    expect(screen.getByText('Files')).toBeInTheDocument()
+    expect(screen.getByText('/api/files/list')).toBeInTheDocument()
+  })
+})

--- a/client/src/__tests__/components/manual/api-reference/EndpointCard.test.tsx
+++ b/client/src/__tests__/components/manual/api-reference/EndpointCard.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { EndpointCard } from '../../../../components/manual/api-reference/EndpointCard'
+import type { ApiEndpoint } from '../../../../data/api-endpoints'
+
+const t = (k: string) => k
+const endpoint: ApiEndpoint = {
+  method: 'POST', path: '/api/auth/login', description: 'Log in',
+  requiresAuth: true,
+  params: [], body: [], response: '{"token":"x"}',
+} as ApiEndpoint
+
+describe('EndpointCard', () => {
+  beforeEach(() => {
+    Object.assign(navigator, { clipboard: { writeText: vi.fn() } })
+  })
+
+  it('renders method, path and the auth shield', () => {
+    render(<EndpointCard endpoint={endpoint} rateLimits={{}} t={t} />)
+    expect(screen.getByText('POST')).toBeInTheDocument()
+    expect(screen.getByText('/api/auth/login')).toBeInTheDocument()
+    expect(screen.getByTitle('system:apiCenter.authRequired')).toBeInTheDocument()
+  })
+
+  it('shows the rate-limit badge when a matching config exists', () => {
+    const rl = {
+      auth_login: { id: 1, endpoint_type: 'auth_login', limit_string: '5/min',
+        description: null, enabled: true, created_at: '', updated_at: null, updated_by: null },
+    }
+    render(<EndpointCard endpoint={endpoint} rateLimits={rl} t={t} />)
+    expect(screen.getByText('5/min')).toBeInTheDocument()
+  })
+
+  it('expands to show the response and copies it', () => {
+    render(<EndpointCard endpoint={endpoint} rateLimits={{}} t={t} />)
+    // collapsed: response not shown
+    expect(screen.queryByText('{"token":"x"}')).toBeNull()
+    fireEvent.click(screen.getByText('/api/auth/login'))
+    expect(screen.getByText('{"token":"x"}')).toBeInTheDocument()
+    // after expansion the copy button is the only <button> in the card
+    // (the header toggle is a <div onClick>, not a button)
+    fireEvent.click(screen.getByRole('button'))
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('{"token":"x"}')
+  })
+})

--- a/client/src/__tests__/hooks/useApiReference.test.tsx
+++ b/client/src/__tests__/hooks/useApiReference.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+
+// Controlled schema so the hook doesn't hit /openapi.json.
+const mkSection = (title: string, paths: string[]) => ({
+  title, icon: null,
+  endpoints: paths.map(p => ({ method: 'GET', path: p, description: `${p} desc`, requiresAuth: false })),
+})
+const SECTIONS = [mkSection('Files', ['/api/files/list']), mkSection('Auth', ['/api/auth/me'])]
+const CATEGORIES = [{ id: 'core', label: 'Core', sections: [SECTIONS[0]] }]
+
+vi.mock('../../hooks/useOpenApiSchema', () => ({
+  useOpenApiSchema: () => ({
+    sections: SECTIONS, categories: CATEGORIES,
+    loading: false, error: null, refetch: vi.fn(),
+  }),
+}))
+
+import { useApiReference } from '../../hooks/useApiReference'
+
+describe('useApiReference', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('non-admin skips the rate-limit fetch and clears loading', async () => {
+    const { result } = renderHook(() => useApiReference({ isAdmin: false, token: 't' }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetch).not.toHaveBeenCalled()
+    expect(result.current.rateLimits).toEqual({})
+  })
+
+  it('admin loads rate limits and maps them by endpoint_type', async () => {
+    const configs = [
+      { id: 1, endpoint_type: 'auth_login', limit_string: '5/min', description: null,
+        enabled: true, created_at: '', updated_at: null, updated_by: null },
+    ]
+    ;(fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true, json: async () => ({ configs }),
+    })
+    const { result } = renderHook(() => useApiReference({ isAdmin: true, token: 'tok' }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(result.current.rateLimits.auth_login.limit_string).toBe('5/min')
+  })
+
+  it('visibleSections: no filter returns all sections', () => {
+    const { result } = renderHook(() => useApiReference({ isAdmin: false, token: null }))
+    expect(result.current.visibleSections.map(s => s.title)).toEqual(['Files', 'Auth'])
+  })
+
+  it('visibleSections: search filters endpoints by path/description', () => {
+    const { result } = renderHook(() => useApiReference({ isAdmin: false, token: null }))
+    act(() => result.current.setSearchQuery('files'))
+    // only the "Files" section survives the /api/files/list path match
+    expect(result.current.visibleSections.map(s => s.title)).toEqual(['Files'])
+  })
+
+  it('visibleSections: selecting a category narrows to its sections', () => {
+    const { result } = renderHook(() => useApiReference({ isAdmin: false, token: null }))
+    act(() => result.current.setSelectedCategory('core'))
+    expect(result.current.visibleSections.map(s => s.title)).toEqual(['Files'])
+  })
+})

--- a/client/src/__tests__/lib/apiRateLimitMatch.test.ts
+++ b/client/src/__tests__/lib/apiRateLimitMatch.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { matchEndpointToRateLimitType } from '../../lib/apiRateLimitMatch'
+
+describe('matchEndpointToRateLimitType', () => {
+  it('matches specific auth endpoints before the auth catch-all', () => {
+    expect(matchEndpointToRateLimitType('POST', '/api/auth/login')).toBe('auth_login')
+    expect(matchEndpointToRateLimitType('POST', '/api/auth/register')).toBe('auth_register')
+    expect(matchEndpointToRateLimitType('POST', '/api/auth/change-password')).toBe('auth_password_change')
+    expect(matchEndpointToRateLimitType('POST', '/api/auth/refresh')).toBe('auth_refresh')
+    expect(matchEndpointToRateLimitType('POST', '/api/auth/verify-2fa')).toBe('auth_2fa_verify')
+    expect(matchEndpointToRateLimitType('POST', '/api/auth/2fa/setup')).toBe('auth_2fa_setup')
+    // generic auth path falls through to the catch-all
+    expect(matchEndpointToRateLimitType('GET', '/api/auth/me')).toBe('user_operations')
+  })
+
+  it('is case-insensitive on method and path', () => {
+    expect(matchEndpointToRateLimitType('post', '/API/AUTH/LOGIN')).toBe('auth_login')
+  })
+
+  it('matches files specific-before-generic', () => {
+    expect(matchEndpointToRateLimitType('POST', '/api/files/upload/chunked/init')).toBe('file_chunked')
+    expect(matchEndpointToRateLimitType('POST', '/api/files/upload')).toBe('file_upload')
+    expect(matchEndpointToRateLimitType('GET', '/api/files/download/x')).toBe('file_download')
+    expect(matchEndpointToRateLimitType('GET', '/api/files/list')).toBe('file_list')
+    expect(matchEndpointToRateLimitType('DELETE', '/api/files/x')).toBe('file_delete')
+    expect(matchEndpointToRateLimitType('PUT', '/api/files/x')).toBe('file_write')
+  })
+
+  it('matches activity as file_list', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/activity/feed')).toBe('file_list')
+  })
+
+  it('matches shares by write-method vs read', () => {
+    expect(matchEndpointToRateLimitType('POST', '/api/shares')).toBe('share_create')
+    expect(matchEndpointToRateLimitType('PATCH', '/api/shares/1')).toBe('share_create')
+    expect(matchEndpointToRateLimitType('DELETE', '/api/shares/1')).toBe('share_create')
+    expect(matchEndpointToRateLimitType('GET', '/api/shares')).toBe('share_list')
+  })
+
+  it('matches mobile + desktop-pairing endpoints', () => {
+    expect(matchEndpointToRateLimitType('POST', '/api/mobile/register')).toBe('mobile_register')
+    expect(matchEndpointToRateLimitType('POST', '/api/mobile/token/generate')).toBe('mobile_register')
+    expect(matchEndpointToRateLimitType('POST', '/api/mobile/sync')).toBe('mobile_sync')
+    expect(matchEndpointToRateLimitType('GET', '/api/mobile/upload-queue')).toBe('mobile_sync')
+    expect(matchEndpointToRateLimitType('POST', '/api/desktop-pairing/device-code')).toBe('desktop_pairing_request')
+    expect(matchEndpointToRateLimitType('POST', '/api/desktop-pairing/token')).toBe('desktop_pairing_poll')
+    expect(matchEndpointToRateLimitType('POST', '/api/desktop-pairing/verify')).toBe('desktop_pairing_verify')
+    expect(matchEndpointToRateLimitType('POST', '/api/desktop-pairing/approve')).toBe('desktop_pairing_approve')
+  })
+
+  it('matches vpn/backup/sync operation groups', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/vpn')).toBe('vpn_operations')
+    expect(matchEndpointToRateLimitType('POST', '/api/vpn/clients')).toBe('vpn_operations')
+    expect(matchEndpointToRateLimitType('GET', '/api/backup')).toBe('backup_operations')
+    expect(matchEndpointToRateLimitType('POST', '/api/sync/start')).toBe('sync_operations')
+  })
+
+  it('matches POST benchmark/run before the admin catch-all', () => {
+    expect(matchEndpointToRateLimitType('POST', '/api/benchmark/run')).toBe('admin_benchmark')
+    // non-run benchmark falls to admin catch-all
+    expect(matchEndpointToRateLimitType('GET', '/api/benchmark/history')).toBe('admin_operations')
+  })
+
+  it('matches api-keys and users groups', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/api-keys')).toBe('api_key_operations')
+    expect(matchEndpointToRateLimitType('GET', '/api/users')).toBe('user_operations')
+  })
+
+  it('splits system/monitoring/energy by GET vs write', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/system/info')).toBe('system_monitor')
+    expect(matchEndpointToRateLimitType('POST', '/api/system/reboot')).toBe('admin_operations')
+    expect(matchEndpointToRateLimitType('GET', '/api/monitoring/cpu')).toBe('system_monitor')
+    expect(matchEndpointToRateLimitType('GET', '/api/energy/stats')).toBe('system_monitor')
+  })
+
+  it('splits vcl and ssd-cache by GET vs write', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/vcl/versions')).toBe('file_list')
+    expect(matchEndpointToRateLimitType('POST', '/api/vcl/restore')).toBe('file_write')
+    expect(matchEndpointToRateLimitType('GET', '/api/ssd-cache/status')).toBe('file_list')
+    expect(matchEndpointToRateLimitType('POST', '/api/ssd-cache/clear')).toBe('admin_operations')
+  })
+
+  it('matches admin-prefix catch-all', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/pihole/status')).toBe('admin_operations')
+    expect(matchEndpointToRateLimitType('POST', '/api/fans/config')).toBe('admin_operations')
+    expect(matchEndpointToRateLimitType('GET', '/api/updates/check')).toBe('admin_operations')
+  })
+
+  it('returns null for unmatched paths', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/unknown/x')).toBeNull()
+    expect(matchEndpointToRateLimitType('GET', '/healthz')).toBeNull()
+  })
+})

--- a/client/src/components/CLAUDE.md
+++ b/client/src/components/CLAUDE.md
@@ -47,7 +47,7 @@ Reusable, generic building blocks. No business logic, no API calls.
 | `fan-control/` | Fan curves, schedules, profiles — `FanDetails` composes `fan-details/*` (`FanPresetProfileButtons`, `FanCurveGraphControls`, `FanCurveTableEditor`, `FanStatsGrid`) + pure `fanCurveValidation`; state/handlers in `hooks/useFanCurveEditor`. `FanCurveChart` composes `fan-curve-chart/*` (`FanCurveTooltip`, `FanChartLegend`, `FanChartHint`) + pure `fanCurveGeometry`; drag/click/touch interaction in `hooks/useFanCurveInteraction` (extracted F2/#301) |
 | `file-manager/` | File browser, context menus, preview |
 | `firebase/` | Firebase push notification config |
-| `manual/` | User manual article viewer |
+| `manual/` | User manual article viewer — `ApiReferenceTab` composes `api-reference/*` (`EndpointCard`, `ApiViewToggle`, `ApiBaseUrlCard`, `ApiSearchBar`, `ApiCategoryTabs`, `ApiSchemaError`, `ApiLoadingSkeleton`, `ApiSectionList`) + pure `lib/apiRateLimitMatch`; state/fetch in `hooks/useApiReference` (extracted F2/#301) |
 | `mobile-devices/` | Mobile device registration — `MobileDevicesPage` composes `mobile-devices/*`: `RegisterDeviceCard`, `MobileDevicesList`/`MobileDeviceCard`, `NotificationStatus`, `QrCodeDialog` (→ `NewTokenQrView` / `ExistingDeviceInfoView`) + `mobileDeviceDates` helper; state/handlers in `hooks/useMobileRegistration` (extracted F2/#301) |
 | `monitoring/` | System monitoring charts and cards |
 | `pihole/` | Pi-hole DNS dashboard, `ad-discovery/` |

--- a/client/src/components/manual/ApiReferenceTab.tsx
+++ b/client/src/components/manual/ApiReferenceTab.tsx
@@ -1,240 +1,11 @@
-import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  Code,
-  ChevronDown,
-  ChevronRight,
-  Copy,
-  Check,
-  Zap,
-  Search,
-  RefreshCw,
-  AlertTriangle,
-  Gauge,
-  Shield,
-} from 'lucide-react';
-import toast from 'react-hot-toast';
-import { buildApiUrl } from '../../lib/api';
-import { methodColors } from '../../data/api-endpoints';
-import type { ApiEndpoint } from '../../data/api-endpoints';
-import { useOpenApiSchema } from '../../hooks/useOpenApiSchema';
+import { RefreshCw } from 'lucide-react';
 import { RateLimitsTab } from '../rate-limits';
-
-// ==================== Types ====================
-
-interface RateLimitConfig {
-  id: number;
-  endpoint_type: string;
-  limit_string: string;
-  description: string | null;
-  enabled: boolean;
-  created_at: string;
-  updated_at: string | null;
-  updated_by: number | null;
-}
-
-// ==================== Dynamic Rate Limit Matching ====================
-
-/**
- * Dynamically match an API endpoint to its rate limit endpoint_type
- * based on HTTP method and path patterns (mirrors backend decorator usage).
- */
-function matchEndpointToRateLimitType(method: string, path: string): string | null {
-  const p = path.toLowerCase();
-  const m = method.toUpperCase();
-
-  // Auth endpoints (most specific first)
-  if (m === 'POST' && p === '/api/auth/login') return 'auth_login';
-  if (m === 'POST' && p === '/api/auth/register') return 'auth_register';
-  if (m === 'POST' && p === '/api/auth/change-password') return 'auth_password_change';
-  if (m === 'POST' && p === '/api/auth/refresh') return 'auth_refresh';
-  if (m === 'POST' && p === '/api/auth/verify-2fa') return 'auth_2fa_verify';
-  if (m === 'POST' && p.startsWith('/api/auth/2fa/')) return 'auth_2fa_setup';
-  if (p.startsWith('/api/auth/')) return 'user_operations';
-
-  // Files (specific before generic)
-  if (p.startsWith('/api/files/upload/chunked')) return 'file_chunked';
-  if (m === 'POST' && p.startsWith('/api/files/upload')) return 'file_upload';
-  if (m === 'GET' && p.startsWith('/api/files/download')) return 'file_download';
-  if (m === 'GET' && p.startsWith('/api/files/list')) return 'file_list';
-  if (m === 'DELETE' && p.startsWith('/api/files/')) return 'file_delete';
-  if (p.startsWith('/api/files/')) return 'file_write';
-
-  // Activity
-  if (p.startsWith('/api/activity/')) return 'file_list';
-
-  // Shares
-  if (['POST', 'PATCH', 'DELETE'].includes(m) && p.startsWith('/api/shares')) return 'share_create';
-  if (p.startsWith('/api/shares')) return 'share_list';
-
-  // Mobile
-  if (m === 'POST' && (p === '/api/mobile/register' || p === '/api/mobile/token/generate')) return 'mobile_register';
-  if (p.includes('/mobile/sync') || p.includes('/mobile/upload-queue')) return 'mobile_sync';
-
-  // Desktop pairing
-  if (p.includes('/desktop-pairing/device-code')) return 'desktop_pairing_request';
-  if (p.includes('/desktop-pairing/token')) return 'desktop_pairing_poll';
-  if (p.includes('/desktop-pairing/verify')) return 'desktop_pairing_verify';
-  if (p.includes('/desktop-pairing/approve')) return 'desktop_pairing_approve';
-
-  // VPN, Backup, Sync
-  if (p.startsWith('/api/vpn/') || p === '/api/vpn') return 'vpn_operations';
-  if (p.startsWith('/api/backup/') || p === '/api/backup') return 'backup_operations';
-  if (p.startsWith('/api/sync/')) return 'sync_operations';
-
-  // Benchmark (POST run before admin catch-all)
-  if (m === 'POST' && p.includes('/benchmark/run')) return 'admin_benchmark';
-
-  // API Keys
-  if (p.startsWith('/api/api-keys')) return 'api_key_operations';
-
-  // Users
-  if (p.startsWith('/api/users')) return 'user_operations';
-
-  // System / Monitoring / Energy (GET = monitor, else admin)
-  if (p.startsWith('/api/system/') || p.startsWith('/api/monitoring/') || p.startsWith('/api/energy/')) {
-    return m === 'GET' ? 'system_monitor' : 'admin_operations';
-  }
-
-  // VCL
-  if (p.startsWith('/api/vcl/')) return m === 'GET' ? 'file_list' : 'file_write';
-
-  // SSD Cache
-  if (p.startsWith('/api/ssd-cache/')) return m === 'GET' ? 'file_list' : 'admin_operations';
-
-  // Admin catch-all
-  const adminPrefixes = [
-    '/api/admin/', '/api/admin-db/', '/api/schedulers/', '/api/fans/',
-    '/api/power/', '/api/pihole/', '/api/sleep/', '/api/cloud/',
-    '/api/updates/', '/api/samba/', '/api/webdav/', '/api/plugins/',
-    '/api/notifications/', '/api/benchmark/', '/api/smart-devices/',
-  ];
-  if (adminPrefixes.some(prefix => p.startsWith(prefix))) return 'admin_operations';
-
-  return null;
-}
-
-// ==================== Endpoint Card Component ====================
-
-interface EndpointCardProps {
-  endpoint: ApiEndpoint;
-  rateLimits: Record<string, RateLimitConfig>;
-  t: (key: string) => string;
-}
-
-function EndpointCard({ endpoint, rateLimits, t }: EndpointCardProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
-
-  const rateLimitKey = matchEndpointToRateLimitType(endpoint.method, endpoint.path);
-  const rateLimit = rateLimitKey ? rateLimits[rateLimitKey] : null;
-
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  return (
-    <div className="bg-slate-800/40 backdrop-blur-sm rounded-xl border border-slate-700/50 p-3 sm:p-4 hover:border-slate-600/50 transition-all">
-      <div
-        className="flex items-center justify-between cursor-pointer touch-manipulation"
-        onClick={() => setIsOpen(!isOpen)}
-      >
-        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3 flex-1 min-w-0">
-          <span className={`px-2 sm:px-3 py-1 rounded-lg text-[10px] sm:text-xs font-bold border flex-shrink-0 ${methodColors[endpoint.method]}`}>
-            {endpoint.method}
-          </span>
-          <code className="text-cyan-400 font-mono text-xs sm:text-sm truncate">{endpoint.path}</code>
-          <span className="text-slate-400 text-xs sm:text-sm hidden lg:inline truncate">{endpoint.description}</span>
-          {endpoint.requiresAuth && (
-            <span title={t('system:apiCenter.authRequired')} className="flex-shrink-0"><Shield className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-amber-400" /></span>
-          )}
-          {rateLimit && (
-            <span
-              className={`px-1.5 sm:px-2 py-0.5 rounded text-[10px] sm:text-xs font-mono flex-shrink-0 ${
-                rateLimit.enabled
-                  ? 'bg-emerald-500/20 text-emerald-400'
-                  : 'bg-slate-500/20 text-slate-500'
-              }`}
-              title={`Rate limit: ${rateLimit.limit_string}`}
-            >
-              <Zap className="w-2.5 h-2.5 sm:w-3 sm:h-3 inline mr-0.5 sm:mr-1" />
-              <span className="hidden sm:inline">{rateLimit.limit_string}</span>
-            </span>
-          )}
-        </div>
-        <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0 ml-2">
-          {isOpen ? (
-            <ChevronDown className="w-5 h-5 text-slate-400" />
-          ) : (
-            <ChevronRight className="w-5 h-5 text-slate-400" />
-          )}
-        </div>
-      </div>
-
-      {isOpen && (
-        <div className="mt-3 sm:mt-4 space-y-3 sm:space-y-4 border-t border-slate-700/50 pt-3 sm:pt-4">
-          <p className="text-slate-300 text-xs sm:text-sm lg:hidden">{endpoint.description}</p>
-
-          {endpoint.params && endpoint.params.length > 0 && (
-            <div>
-              <h4 className="text-xs sm:text-sm font-semibold text-slate-300 mb-2">{t('system:apiCenter.parameters')}</h4>
-              <div className="space-y-1.5 sm:space-y-2">
-                {endpoint.params.map((param, idx) => (
-                  <div key={idx} className="flex items-start gap-2 sm:gap-3 text-xs sm:text-sm flex-wrap">
-                    <code className="text-cyan-400 font-mono">{param.name}</code>
-                    <span className="text-slate-500">({param.type})</span>
-                    {param.required && <span className="text-red-400 text-[10px] sm:text-xs">{t('system:apiCenter.required')}</span>}
-                    <span className="text-slate-400 w-full sm:w-auto">{param.description}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {endpoint.body && endpoint.body.length > 0 && (
-            <div>
-              <h4 className="text-xs sm:text-sm font-semibold text-slate-300 mb-2">{t('system:apiCenter.requestBody')}</h4>
-              <div className="space-y-1.5 sm:space-y-2">
-                {endpoint.body.map((field, idx) => (
-                  <div key={idx} className="flex items-start gap-2 sm:gap-3 text-xs sm:text-sm flex-wrap">
-                    <code className="text-violet-400 font-mono">{field.field}</code>
-                    <span className="text-slate-500">({field.type})</span>
-                    {field.required && <span className="text-red-400 text-[10px] sm:text-xs">{t('system:apiCenter.required')}</span>}
-                    <span className="text-slate-400 w-full sm:w-auto">{field.description}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {endpoint.response && (
-            <div>
-              <div className="flex items-center justify-between mb-2">
-                <h4 className="text-xs sm:text-sm font-semibold text-slate-300">{t('system:apiCenter.response')}</h4>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copyToClipboard(endpoint.response!);
-                  }}
-                  className="text-slate-400 hover:text-cyan-400 transition-colors p-2 -mr-2 touch-manipulation active:scale-95 min-w-[36px] min-h-[36px] flex items-center justify-center"
-                >
-                  {copied ? <Check className="w-4 h-4 text-emerald-400" /> : <Copy className="w-4 h-4" />}
-                </button>
-              </div>
-              <pre className="bg-slate-900/60 border border-slate-700/50 rounded-lg p-2 sm:p-3 text-[10px] sm:text-xs overflow-x-auto max-w-full">
-                <code className="text-slate-300">{endpoint.response}</code>
-              </pre>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ==================== ApiReferenceTab Component ====================
+import { useApiReference } from '../../hooks/useApiReference';
+import {
+  ApiViewToggle, ApiBaseUrlCard, ApiSearchBar, ApiCategoryTabs,
+  ApiSchemaError, ApiLoadingSkeleton, ApiSectionList,
+} from './api-reference';
 
 export interface ApiReferenceTabProps {
   isAdmin: boolean;
@@ -243,321 +14,52 @@ export interface ApiReferenceTabProps {
 
 export function ApiReferenceTab({ isAdmin, token }: ApiReferenceTabProps) {
   const { t } = useTranslation(['system', 'common']);
-  const [activeView, setActiveView] = useState<'docs' | 'limits'>('docs');
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const [selectedSection, setSelectedSection] = useState<string | null>(null);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [rateLimits, setRateLimits] = useState<Record<string, RateLimitConfig>>({});
-  const [loading, setLoading] = useState(true);
-
-  const { sections: apiSections, categories: apiCategories, loading: schemaLoading, error: schemaError, refetch: refetchSchema } = useOpenApiSchema();
-
-  // Dynamically determine API base URL based on current location
-  const getApiBaseUrl = (): string => {
-    const hostname = window.location.hostname;
-    const isDev = import.meta.env.DEV;
-
-    // In development, backend runs on port 3001
-    // In production, backend typically runs on port 8000
-    const port = isDev ? 3001 : 8000;
-    const protocol = window.location.protocol; // http: or https:
-
-    return `${protocol}//${hostname}:${port}`;
-  };
-
-  const apiBaseUrl = getApiBaseUrl();
-
-  // Load rate limits for displaying badges (admin only)
-  useEffect(() => {
-    if (isAdmin) {
-      loadRateLimits();
-    } else {
-      setLoading(false);
-    }
-  }, [isAdmin]);
-
-  const loadRateLimits = async () => {
-    if (!token) {
-      setLoading(false);
-      return;
-    }
-
-    try {
-      const response = await fetch(buildApiUrl('/api/admin/rate-limits'), {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        const map: Record<string, RateLimitConfig> = {};
-        data.configs.forEach((c: RateLimitConfig) => {
-          map[c.endpoint_type] = c;
-        });
-        setRateLimits(map);
-      }
-    } catch {
-      // Rate limits not available
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const visibleSections = useMemo(() => {
-    if (searchQuery.trim()) {
-      const q = searchQuery.toLowerCase();
-      return apiSections
-        .map(s => ({
-          ...s,
-          endpoints: s.endpoints.filter(e =>
-            e.path.toLowerCase().includes(q) ||
-            e.description.toLowerCase().includes(q)
-          ),
-        }))
-        .filter(s => s.endpoints.length > 0);
-    }
-
-    const categorySections = selectedCategory
-      ? apiCategories.find(c => c.id === selectedCategory)?.sections ?? []
-      : apiSections;
-
-    return selectedSection
-      ? categorySections.filter(s => s.title === selectedSection)
-      : categorySections;
-  }, [searchQuery, selectedCategory, selectedSection, apiSections, apiCategories]);
-
-  const currentCategorySections = selectedCategory
-    ? apiCategories.find(c => c.id === selectedCategory)?.sections ?? []
-    : [];
+  const api = useApiReference({ isAdmin, token });
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      {/* View Toggle (admin: API Docs | Rate Limits) */}
       {isAdmin && (
-        <div className="flex gap-2">
-          <button
-            onClick={() => setActiveView('docs')}
-            className={`flex items-center gap-2 rounded-xl px-4 py-2 sm:py-2.5 text-sm sm:text-base font-semibold transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
-              activeView === 'docs'
-                ? 'bg-cyan-500/20 text-cyan-400 border border-cyan-500/40 shadow-lg shadow-cyan-500/10'
-                : 'bg-slate-800/40 text-slate-400 hover:bg-slate-800/60 hover:text-slate-300 border border-slate-700/40'
-            }`}
-          >
-            <Code className="w-4 h-4" />
-            <span>{t('system:apiCenter.tabs.apiDocs')}</span>
-          </button>
-          <button
-            onClick={() => setActiveView('limits')}
-            className={`flex items-center gap-2 rounded-xl px-4 py-2 sm:py-2.5 text-sm sm:text-base font-semibold transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
-              activeView === 'limits'
-                ? 'bg-amber-500/20 text-amber-400 border border-amber-500/40 shadow-lg shadow-amber-500/10'
-                : 'bg-slate-800/40 text-slate-400 hover:bg-slate-800/60 hover:text-slate-300 border border-slate-700/40'
-            }`}
-          >
-            <Gauge className="w-4 h-4" />
-            <span>{t('system:apiCenter.tabs.rateLimits')}</span>
-          </button>
-        </div>
+        <ApiViewToggle activeView={api.activeView} onChange={api.setActiveView} t={t} />
       )}
 
-      {/* ==================== Rate Limits View ==================== */}
-      {activeView === 'limits' && isAdmin && <RateLimitsTab />}
+      {api.activeView === 'limits' && isAdmin && <RateLimitsTab />}
 
-      {/* ==================== API Docs View ==================== */}
-      {activeView === 'docs' && <>
-
-      {/* Refresh Button */}
-      <div className="flex justify-end">
-        <button
-          onClick={refetchSchema}
-          className="p-2 bg-slate-800/40 hover:bg-slate-700/60 border border-slate-700/50 rounded-lg transition-colors touch-manipulation active:scale-95"
-          title="Refresh API schema"
-        >
-          <RefreshCw className={`w-4 h-4 text-slate-400 ${schemaLoading ? 'animate-spin' : ''}`} />
-        </button>
-      </div>
-
-      {/* Schema Error */}
-      {schemaError && (
-        <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-4">
-          <div className="flex items-center gap-3">
-            <AlertTriangle className="w-5 h-5 text-red-400 flex-shrink-0" />
-            <div className="flex-1">
-              <p className="text-sm text-red-300">API schema could not be loaded: {schemaError}</p>
-            </div>
-            <button
-              onClick={refetchSchema}
-              className="px-3 py-1.5 bg-red-600 hover:bg-red-500 text-white rounded-lg transition-colors text-sm font-medium"
-            >
-              Retry
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Base URL Info */}
-      <div className="bg-cyan-500/10 border border-cyan-500/30 rounded-xl p-3 sm:p-4">
-        <div className="flex items-start gap-2 sm:gap-3">
-          <Code className="w-4 h-4 sm:w-5 sm:h-5 text-cyan-400 mt-0.5 flex-shrink-0" />
-          <div className="min-w-0 flex-1">
-            <h3 className="font-semibold text-white text-sm sm:text-base mb-1">{t('system:apiCenter.baseUrl')}</h3>
-            <div className="flex items-center gap-2">
-              <code className="text-xs sm:text-sm text-cyan-400 bg-slate-900/60 px-2 sm:px-3 py-1 rounded block overflow-x-auto flex-1">
-                {apiBaseUrl}
-              </code>
-              <button
-                onClick={() => {
-                  navigator.clipboard.writeText(apiBaseUrl);
-                  toast.success(t('system:apiCenter.baseUrlCopied'));
-                }}
-                className="p-2 bg-slate-700/50 hover:bg-slate-700 rounded-lg transition-colors flex-shrink-0 touch-manipulation active:scale-95"
-                title={t('system:apiCenter.baseUrl')}
-              >
-                <Copy className="w-4 h-4 text-slate-300" />
-              </button>
-            </div>
-            <p className="text-xs sm:text-sm text-slate-400 mt-2">
-              <span className="hidden sm:inline">{t('system:apiCenter.authRequiredNote')} </span>
-              <code className="text-[10px] sm:text-xs text-slate-300 bg-slate-900/60 px-1.5 sm:px-2 py-0.5 rounded sm:ml-2 block sm:inline mt-1 sm:mt-0 overflow-x-auto">
-                Authorization: Bearer {"<token>"}
-              </code>
-            </p>
-          </div>
-        </div>
-      </div>
-
-      {/* Search Field */}
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
-        <input
-          type="text"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          placeholder={t('system:apiCenter.searchPlaceholder', 'Search endpoints...')}
-          className="w-full pl-10 pr-4 py-2.5 bg-slate-800/40 border border-slate-700/50 rounded-xl text-sm text-white placeholder-slate-500 focus:outline-none focus:border-cyan-500/50 focus:ring-1 focus:ring-cyan-500/30 transition-all"
-        />
-        {searchQuery && (
+      {api.activeView === 'docs' && <>
+        {/* Refresh */}
+        <div className="flex justify-end">
           <button
-            onClick={() => setSearchQuery('')}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition-colors text-xs"
+            onClick={api.refetchSchema}
+            className="p-2 bg-slate-800/40 hover:bg-slate-700/60 border border-slate-700/50 rounded-lg transition-colors touch-manipulation active:scale-95"
+            title="Refresh API schema"
           >
-            ✕
+            <RefreshCw className={`w-4 h-4 text-slate-400 ${api.schemaLoading ? 'animate-spin' : ''}`} />
           </button>
+        </div>
+
+        {api.schemaError && <ApiSchemaError error={api.schemaError} onRetry={api.refetchSchema} />}
+
+        <ApiBaseUrlCard apiBaseUrl={api.apiBaseUrl} t={t} />
+
+        <ApiSearchBar value={api.searchQuery} onChange={api.setSearchQuery} t={t} />
+
+        {!api.searchQuery.trim() && (
+          <ApiCategoryTabs
+            apiSections={api.apiSections}
+            apiCategories={api.apiCategories}
+            selectedCategory={api.selectedCategory}
+            selectedSection={api.selectedSection}
+            currentCategorySections={api.currentCategorySections}
+            onSelectCategory={(id) => { api.setSelectedCategory(id); api.setSelectedSection(null); }}
+            onSelectSection={api.setSelectedSection}
+            t={t}
+          />
         )}
-      </div>
 
-      {/* Category Tabs */}
-      {!searchQuery.trim() && (
-        <div className="space-y-3">
-          {/* Category Pills */}
-          <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0 scrollbar-none">
-            <div className="flex gap-2 min-w-max sm:min-w-0 sm:flex-wrap">
-              <button
-                onClick={() => { setSelectedCategory(null); setSelectedSection(null); }}
-                className={`flex items-center gap-2 rounded-xl px-4 py-2 sm:py-2.5 text-sm sm:text-base font-semibold transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
-                  !selectedCategory
-                    ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40 shadow-lg shadow-blue-500/10'
-                    : 'bg-slate-800/40 text-slate-400 hover:bg-slate-800/60 hover:text-slate-300 border border-slate-700/40'
-                }`}
-              >
-                <span>{t('system:apiCenter.all')}</span>
-                <span className="text-[10px] opacity-70">({apiSections.reduce((sum, s) => sum + s.endpoints.length, 0)})</span>
-              </button>
-              {apiCategories.map((cat) => {
-                const endpointCount = cat.sections.reduce((sum, s) => sum + s.endpoints.length, 0);
-                return (
-                  <button
-                    key={cat.id}
-                    onClick={() => { setSelectedCategory(cat.id); setSelectedSection(null); }}
-                    className={`flex items-center gap-2 rounded-xl px-4 py-2 sm:py-2.5 text-sm sm:text-base font-semibold transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
-                      selectedCategory === cat.id
-                        ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40 shadow-lg shadow-blue-500/10'
-                        : 'bg-slate-800/40 text-slate-400 hover:bg-slate-800/60 hover:text-slate-300 border border-slate-700/40'
-                    }`}
-                  >
-                    <span>{cat.label}</span>
-                    <span className="text-[10px] opacity-70">({endpointCount})</span>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
+        {(api.loading || api.schemaLoading) && <ApiLoadingSkeleton />}
 
-          {/* Sub-Tabs (only for active category) */}
-          {selectedCategory && currentCategorySections.length > 0 && (
-            <div className="relative">
-              <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0 scrollbar-none">
-                <div className="flex gap-2 border-b border-slate-800 pb-3 min-w-max sm:min-w-0 sm:flex-wrap">
-                  <button
-                    onClick={() => setSelectedSection(null)}
-                    className={`flex items-center gap-2 rounded-lg px-3 sm:px-4 py-2 sm:py-2.5 text-xs sm:text-sm font-medium transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
-                      !selectedSection
-                        ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40'
-                        : 'text-slate-400 hover:bg-slate-800/50 hover:text-slate-300 border border-transparent'
-                    }`}
-                  >
-                    <span>{t('system:apiCenter.all')}</span>
-                  </button>
-                  {currentCategorySections.map((section) => (
-                    <button
-                      key={section.title}
-                      onClick={() => setSelectedSection(section.title)}
-                      className={`flex items-center gap-2 rounded-lg px-3 sm:px-4 py-2 sm:py-2.5 text-xs sm:text-sm font-medium transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
-                        selectedSection === section.title
-                          ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40'
-                          : 'text-slate-400 hover:bg-slate-800/50 hover:text-slate-300 border border-transparent'
-                      }`}
-                    >
-                      {section.icon}
-                      <span>{section.title}</span>
-                      <span className="text-[10px] opacity-70">({section.endpoints.length})</span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-              {/* Fade gradient right - mobile only */}
-              <div className="pointer-events-none absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-slate-950 to-transparent sm:hidden" />
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Loading State */}
-      {(loading || schemaLoading) && (
-        <div className="space-y-4">
-          {[1, 2, 3].map(i => (
-            <div key={i} className="animate-pulse">
-              <div className="h-6 bg-slate-800/60 rounded w-48 mb-3" />
-              <div className="space-y-2">
-                <div className="h-14 bg-slate-800/40 rounded-xl" />
-                <div className="h-14 bg-slate-800/40 rounded-xl" />
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* API Sections */}
-      {!loading && !schemaLoading && visibleSections.map((section) => (
-        <div key={section.title}>
-          <div className="flex items-center gap-2 sm:gap-3 mb-3 sm:mb-4">
-            <div className="p-1.5 sm:p-2 bg-cyan-500/20 rounded-lg text-cyan-400">
-              {section.icon}
-            </div>
-            <h2 className="text-lg sm:text-xl font-bold text-white">{section.title}</h2>
-          </div>
-          <div className="space-y-2 sm:space-y-3">
-            {section.endpoints.map((endpoint, idx) => (
-              <EndpointCard
-                key={idx}
-                endpoint={endpoint}
-                rateLimits={rateLimits}
-                t={t}
-              />
-            ))}
-          </div>
-        </div>
-      ))}
-
+        {!api.loading && !api.schemaLoading && (
+          <ApiSectionList sections={api.visibleSections} rateLimits={api.rateLimits} t={t} />
+        )}
       </>}
     </div>
   );

--- a/client/src/components/manual/api-reference/ApiBaseUrlCard.tsx
+++ b/client/src/components/manual/api-reference/ApiBaseUrlCard.tsx
@@ -1,0 +1,41 @@
+import { Code, Copy } from 'lucide-react';
+import toast from 'react-hot-toast';
+
+export interface ApiBaseUrlCardProps {
+  apiBaseUrl: string;
+  t: (key: string) => string;
+}
+
+export function ApiBaseUrlCard({ apiBaseUrl, t }: ApiBaseUrlCardProps) {
+  return (
+    <div className="bg-cyan-500/10 border border-cyan-500/30 rounded-xl p-3 sm:p-4">
+      <div className="flex items-start gap-2 sm:gap-3">
+        <Code className="w-4 h-4 sm:w-5 sm:h-5 text-cyan-400 mt-0.5 flex-shrink-0" />
+        <div className="min-w-0 flex-1">
+          <h3 className="font-semibold text-white text-sm sm:text-base mb-1">{t('system:apiCenter.baseUrl')}</h3>
+          <div className="flex items-center gap-2">
+            <code className="text-xs sm:text-sm text-cyan-400 bg-slate-900/60 px-2 sm:px-3 py-1 rounded block overflow-x-auto flex-1">
+              {apiBaseUrl}
+            </code>
+            <button
+              onClick={() => {
+                navigator.clipboard.writeText(apiBaseUrl);
+                toast.success(t('system:apiCenter.baseUrlCopied'));
+              }}
+              className="p-2 bg-slate-700/50 hover:bg-slate-700 rounded-lg transition-colors flex-shrink-0 touch-manipulation active:scale-95"
+              title={t('system:apiCenter.baseUrl')}
+            >
+              <Copy className="w-4 h-4 text-slate-300" />
+            </button>
+          </div>
+          <p className="text-xs sm:text-sm text-slate-400 mt-2">
+            <span className="hidden sm:inline">{t('system:apiCenter.authRequiredNote')} </span>
+            <code className="text-[10px] sm:text-xs text-slate-300 bg-slate-900/60 px-1.5 sm:px-2 py-0.5 rounded sm:ml-2 block sm:inline mt-1 sm:mt-0 overflow-x-auto">
+              Authorization: Bearer {"<token>"}
+            </code>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/manual/api-reference/ApiCategoryTabs.tsx
+++ b/client/src/components/manual/api-reference/ApiCategoryTabs.tsx
@@ -1,0 +1,99 @@
+import type { ApiCategory } from '../../../lib/openapi-transform';
+import type { ApiSection } from '../../../data/api-endpoints/types';
+
+export interface ApiCategoryTabsProps {
+  apiSections: ApiSection[];
+  apiCategories: ApiCategory[];
+  selectedCategory: string | null;
+  selectedSection: string | null;
+  currentCategorySections: ApiSection[];
+  onSelectCategory: (id: string | null) => void;
+  onSelectSection: (title: string | null) => void;
+  t: (key: string) => string;
+}
+
+export function ApiCategoryTabs({
+  apiSections,
+  apiCategories,
+  selectedCategory,
+  selectedSection,
+  currentCategorySections,
+  onSelectCategory,
+  onSelectSection,
+  t,
+}: ApiCategoryTabsProps) {
+  return (
+    <div className="space-y-3">
+      {/* Category Pills */}
+      <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0 scrollbar-none">
+        <div className="flex gap-2 min-w-max sm:min-w-0 sm:flex-wrap">
+          <button
+            onClick={() => onSelectCategory(null)}
+            className={`flex items-center gap-2 rounded-xl px-4 py-2 sm:py-2.5 text-sm sm:text-base font-semibold transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
+              !selectedCategory
+                ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40 shadow-lg shadow-blue-500/10'
+                : 'bg-slate-800/40 text-slate-400 hover:bg-slate-800/60 hover:text-slate-300 border border-slate-700/40'
+            }`}
+          >
+            <span>{t('system:apiCenter.all')}</span>
+            <span className="text-[10px] opacity-70">({apiSections.reduce((sum, s) => sum + s.endpoints.length, 0)})</span>
+          </button>
+          {apiCategories.map((cat) => {
+            const endpointCount = cat.sections.reduce((sum, s) => sum + s.endpoints.length, 0);
+            return (
+              <button
+                key={cat.id}
+                onClick={() => onSelectCategory(cat.id)}
+                className={`flex items-center gap-2 rounded-xl px-4 py-2 sm:py-2.5 text-sm sm:text-base font-semibold transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
+                  selectedCategory === cat.id
+                    ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40 shadow-lg shadow-blue-500/10'
+                    : 'bg-slate-800/40 text-slate-400 hover:bg-slate-800/60 hover:text-slate-300 border border-slate-700/40'
+                }`}
+              >
+                <span>{cat.label}</span>
+                <span className="text-[10px] opacity-70">({endpointCount})</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Sub-Tabs (only for active category) */}
+      {selectedCategory && currentCategorySections.length > 0 && (
+        <div className="relative">
+          <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0 scrollbar-none">
+            <div className="flex gap-2 border-b border-slate-800 pb-3 min-w-max sm:min-w-0 sm:flex-wrap">
+              <button
+                onClick={() => onSelectSection(null)}
+                className={`flex items-center gap-2 rounded-lg px-3 sm:px-4 py-2 sm:py-2.5 text-xs sm:text-sm font-medium transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
+                  !selectedSection
+                    ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40'
+                    : 'text-slate-400 hover:bg-slate-800/50 hover:text-slate-300 border border-transparent'
+                }`}
+              >
+                <span>{t('system:apiCenter.all')}</span>
+              </button>
+              {currentCategorySections.map((section) => (
+                <button
+                  key={section.title}
+                  onClick={() => onSelectSection(section.title)}
+                  className={`flex items-center gap-2 rounded-lg px-3 sm:px-4 py-2 sm:py-2.5 text-xs sm:text-sm font-medium transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
+                    selectedSection === section.title
+                      ? 'bg-blue-500/20 text-blue-400 border border-blue-500/40'
+                      : 'text-slate-400 hover:bg-slate-800/50 hover:text-slate-300 border border-transparent'
+                  }`}
+                >
+                  {section.icon}
+                  <span>{section.title}</span>
+                  <span className="text-[10px] opacity-70">({section.endpoints.length})</span>
+                </button>
+              ))}
+            </div>
+          </div>
+          {/* Fade gradient right - mobile only */}
+          <div className="pointer-events-none absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-slate-950 to-transparent sm:hidden" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/manual/api-reference/ApiLoadingSkeleton.tsx
+++ b/client/src/components/manual/api-reference/ApiLoadingSkeleton.tsx
@@ -1,0 +1,15 @@
+export function ApiLoadingSkeleton() {
+  return (
+    <div className="space-y-4">
+      {[1, 2, 3].map(i => (
+        <div key={i} className="animate-pulse">
+          <div className="h-6 bg-slate-800/60 rounded w-48 mb-3" />
+          <div className="space-y-2">
+            <div className="h-14 bg-slate-800/40 rounded-xl" />
+            <div className="h-14 bg-slate-800/40 rounded-xl" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/manual/api-reference/ApiSchemaError.tsx
+++ b/client/src/components/manual/api-reference/ApiSchemaError.tsx
@@ -1,0 +1,25 @@
+import { AlertTriangle } from 'lucide-react';
+
+export interface ApiSchemaErrorProps {
+  error: string;
+  onRetry: () => void;
+}
+
+export function ApiSchemaError({ error, onRetry }: ApiSchemaErrorProps) {
+  return (
+    <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-4">
+      <div className="flex items-center gap-3">
+        <AlertTriangle className="w-5 h-5 text-red-400 flex-shrink-0" />
+        <div className="flex-1">
+          <p className="text-sm text-red-300">API schema could not be loaded: {error}</p>
+        </div>
+        <button
+          onClick={onRetry}
+          className="px-3 py-1.5 bg-red-600 hover:bg-red-500 text-white rounded-lg transition-colors text-sm font-medium"
+        >
+          Retry
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/manual/api-reference/ApiSearchBar.tsx
+++ b/client/src/components/manual/api-reference/ApiSearchBar.tsx
@@ -1,0 +1,30 @@
+import { Search } from 'lucide-react';
+
+export interface ApiSearchBarProps {
+  value: string;
+  onChange: (q: string) => void;
+  t: (key: string, fallback?: string) => string;
+}
+
+export function ApiSearchBar({ value, onChange, t }: ApiSearchBarProps) {
+  return (
+    <div className="relative">
+      <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={t('system:apiCenter.searchPlaceholder', 'Search endpoints...')}
+        className="w-full pl-10 pr-4 py-2.5 bg-slate-800/40 border border-slate-700/50 rounded-xl text-sm text-white placeholder-slate-500 focus:outline-none focus:border-cyan-500/50 focus:ring-1 focus:ring-cyan-500/30 transition-all"
+      />
+      {value && (
+        <button
+          onClick={() => onChange('')}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition-colors text-xs"
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/manual/api-reference/ApiSearchBar.tsx
+++ b/client/src/components/manual/api-reference/ApiSearchBar.tsx
@@ -1,9 +1,10 @@
 import { Search } from 'lucide-react';
+import type { TFunction } from 'i18next';
 
 export interface ApiSearchBarProps {
   value: string;
   onChange: (q: string) => void;
-  t: (key: string, fallback?: string) => string;
+  t: TFunction;
 }
 
 export function ApiSearchBar({ value, onChange, t }: ApiSearchBarProps) {

--- a/client/src/components/manual/api-reference/ApiSectionList.tsx
+++ b/client/src/components/manual/api-reference/ApiSectionList.tsx
@@ -1,0 +1,36 @@
+import type { ApiSection } from '../../../data/api-endpoints/types';
+import type { RateLimitConfig } from '../../../lib/apiRateLimitMatch';
+import { EndpointCard } from './EndpointCard';
+
+export interface ApiSectionListProps {
+  sections: ApiSection[];
+  rateLimits: Record<string, RateLimitConfig>;
+  t: (key: string) => string;
+}
+
+export function ApiSectionList({ sections, rateLimits, t }: ApiSectionListProps) {
+  return (
+    <>
+      {sections.map((section) => (
+        <div key={section.title}>
+          <div className="flex items-center gap-2 sm:gap-3 mb-3 sm:mb-4">
+            <div className="p-1.5 sm:p-2 bg-cyan-500/20 rounded-lg text-cyan-400">
+              {section.icon}
+            </div>
+            <h2 className="text-lg sm:text-xl font-bold text-white">{section.title}</h2>
+          </div>
+          <div className="space-y-2 sm:space-y-3">
+            {section.endpoints.map((endpoint, idx) => (
+              <EndpointCard
+                key={idx}
+                endpoint={endpoint}
+                rateLimits={rateLimits}
+                t={t}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}

--- a/client/src/components/manual/api-reference/ApiViewToggle.tsx
+++ b/client/src/components/manual/api-reference/ApiViewToggle.tsx
@@ -1,0 +1,36 @@
+import { Code, Gauge } from 'lucide-react';
+
+export interface ApiViewToggleProps {
+  activeView: 'docs' | 'limits';
+  onChange: (v: 'docs' | 'limits') => void;
+  t: (key: string) => string;
+}
+
+export function ApiViewToggle({ activeView, onChange, t }: ApiViewToggleProps) {
+  return (
+    <div className="flex gap-2">
+      <button
+        onClick={() => onChange('docs')}
+        className={`flex items-center gap-2 rounded-xl px-4 py-2 sm:py-2.5 text-sm sm:text-base font-semibold transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
+          activeView === 'docs'
+            ? 'bg-cyan-500/20 text-cyan-400 border border-cyan-500/40 shadow-lg shadow-cyan-500/10'
+            : 'bg-slate-800/40 text-slate-400 hover:bg-slate-800/60 hover:text-slate-300 border border-slate-700/40'
+        }`}
+      >
+        <Code className="w-4 h-4" />
+        <span>{t('system:apiCenter.tabs.apiDocs')}</span>
+      </button>
+      <button
+        onClick={() => onChange('limits')}
+        className={`flex items-center gap-2 rounded-xl px-4 py-2 sm:py-2.5 text-sm sm:text-base font-semibold transition-all whitespace-nowrap touch-manipulation active:scale-95 ${
+          activeView === 'limits'
+            ? 'bg-amber-500/20 text-amber-400 border border-amber-500/40 shadow-lg shadow-amber-500/10'
+            : 'bg-slate-800/40 text-slate-400 hover:bg-slate-800/60 hover:text-slate-300 border border-slate-700/40'
+        }`}
+      >
+        <Gauge className="w-4 h-4" />
+        <span>{t('system:apiCenter.tabs.rateLimits')}</span>
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/manual/api-reference/EndpointCard.tsx
+++ b/client/src/components/manual/api-reference/EndpointCard.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Copy, Check, Zap, Shield } from 'lucide-react';
+import { methodColors } from '../../../data/api-endpoints';
+import type { ApiEndpoint } from '../../../data/api-endpoints';
+import { matchEndpointToRateLimitType, type RateLimitConfig } from '../../../lib/apiRateLimitMatch';
+
+export interface EndpointCardProps {
+  endpoint: ApiEndpoint;
+  rateLimits: Record<string, RateLimitConfig>;
+  t: (key: string) => string;
+}
+
+export function EndpointCard({ endpoint, rateLimits, t }: EndpointCardProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const rateLimitKey = matchEndpointToRateLimitType(endpoint.method, endpoint.path);
+  const rateLimit = rateLimitKey ? rateLimits[rateLimitKey] : null;
+
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="bg-slate-800/40 backdrop-blur-sm rounded-xl border border-slate-700/50 p-3 sm:p-4 hover:border-slate-600/50 transition-all">
+      <div
+        className="flex items-center justify-between cursor-pointer touch-manipulation"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3 flex-1 min-w-0">
+          <span className={`px-2 sm:px-3 py-1 rounded-lg text-[10px] sm:text-xs font-bold border flex-shrink-0 ${methodColors[endpoint.method]}`}>
+            {endpoint.method}
+          </span>
+          <code className="text-cyan-400 font-mono text-xs sm:text-sm truncate">{endpoint.path}</code>
+          <span className="text-slate-400 text-xs sm:text-sm hidden lg:inline truncate">{endpoint.description}</span>
+          {endpoint.requiresAuth && (
+            <span title={t('system:apiCenter.authRequired')} className="flex-shrink-0"><Shield className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-amber-400" /></span>
+          )}
+          {rateLimit && (
+            <span
+              className={`px-1.5 sm:px-2 py-0.5 rounded text-[10px] sm:text-xs font-mono flex-shrink-0 ${
+                rateLimit.enabled
+                  ? 'bg-emerald-500/20 text-emerald-400'
+                  : 'bg-slate-500/20 text-slate-500'
+              }`}
+              title={`Rate limit: ${rateLimit.limit_string}`}
+            >
+              <Zap className="w-2.5 h-2.5 sm:w-3 sm:h-3 inline mr-0.5 sm:mr-1" />
+              <span className="hidden sm:inline">{rateLimit.limit_string}</span>
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0 ml-2">
+          {isOpen ? (
+            <ChevronDown className="w-5 h-5 text-slate-400" />
+          ) : (
+            <ChevronRight className="w-5 h-5 text-slate-400" />
+          )}
+        </div>
+      </div>
+
+      {isOpen && (
+        <div className="mt-3 sm:mt-4 space-y-3 sm:space-y-4 border-t border-slate-700/50 pt-3 sm:pt-4">
+          <p className="text-slate-300 text-xs sm:text-sm lg:hidden">{endpoint.description}</p>
+
+          {endpoint.params && endpoint.params.length > 0 && (
+            <div>
+              <h4 className="text-xs sm:text-sm font-semibold text-slate-300 mb-2">{t('system:apiCenter.parameters')}</h4>
+              <div className="space-y-1.5 sm:space-y-2">
+                {endpoint.params.map((param, idx) => (
+                  <div key={idx} className="flex items-start gap-2 sm:gap-3 text-xs sm:text-sm flex-wrap">
+                    <code className="text-cyan-400 font-mono">{param.name}</code>
+                    <span className="text-slate-500">({param.type})</span>
+                    {param.required && <span className="text-red-400 text-[10px] sm:text-xs">{t('system:apiCenter.required')}</span>}
+                    <span className="text-slate-400 w-full sm:w-auto">{param.description}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {endpoint.body && endpoint.body.length > 0 && (
+            <div>
+              <h4 className="text-xs sm:text-sm font-semibold text-slate-300 mb-2">{t('system:apiCenter.requestBody')}</h4>
+              <div className="space-y-1.5 sm:space-y-2">
+                {endpoint.body.map((field, idx) => (
+                  <div key={idx} className="flex items-start gap-2 sm:gap-3 text-xs sm:text-sm flex-wrap">
+                    <code className="text-violet-400 font-mono">{field.field}</code>
+                    <span className="text-slate-500">({field.type})</span>
+                    {field.required && <span className="text-red-400 text-[10px] sm:text-xs">{t('system:apiCenter.required')}</span>}
+                    <span className="text-slate-400 w-full sm:w-auto">{field.description}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {endpoint.response && (
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <h4 className="text-xs sm:text-sm font-semibold text-slate-300">{t('system:apiCenter.response')}</h4>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    copyToClipboard(endpoint.response!);
+                  }}
+                  className="text-slate-400 hover:text-cyan-400 transition-colors p-2 -mr-2 touch-manipulation active:scale-95 min-w-[36px] min-h-[36px] flex items-center justify-center"
+                >
+                  {copied ? <Check className="w-4 h-4 text-emerald-400" /> : <Copy className="w-4 h-4" />}
+                </button>
+              </div>
+              <pre className="bg-slate-900/60 border border-slate-700/50 rounded-lg p-2 sm:p-3 text-[10px] sm:text-xs overflow-x-auto max-w-full">
+                <code className="text-slate-300">{endpoint.response}</code>
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/manual/api-reference/index.ts
+++ b/client/src/components/manual/api-reference/index.ts
@@ -1,0 +1,8 @@
+export { EndpointCard } from './EndpointCard';
+export { ApiViewToggle } from './ApiViewToggle';
+export { ApiBaseUrlCard } from './ApiBaseUrlCard';
+export { ApiSearchBar } from './ApiSearchBar';
+export { ApiCategoryTabs } from './ApiCategoryTabs';
+export { ApiSchemaError } from './ApiSchemaError';
+export { ApiLoadingSkeleton } from './ApiLoadingSkeleton';
+export { ApiSectionList } from './ApiSectionList';

--- a/client/src/hooks/useApiReference.ts
+++ b/client/src/hooks/useApiReference.ts
@@ -1,0 +1,129 @@
+import { useState, useEffect, useMemo } from 'react';
+import { buildApiUrl } from '../lib/api';
+import type { ApiSection } from '../data/api-endpoints/types';
+import type { ApiCategory } from '../lib/openapi-transform';
+import type { RateLimitConfig } from '../lib/apiRateLimitMatch';
+import { useOpenApiSchema } from './useOpenApiSchema';
+
+export interface UseApiReferenceArgs {
+  isAdmin: boolean;
+  token: string | null;
+}
+
+export interface UseApiReferenceResult {
+  activeView: 'docs' | 'limits';
+  setActiveView: (v: 'docs' | 'limits') => void;
+  selectedCategory: string | null;
+  setSelectedCategory: (c: string | null) => void;
+  selectedSection: string | null;
+  setSelectedSection: (s: string | null) => void;
+  searchQuery: string;
+  setSearchQuery: (q: string) => void;
+  rateLimits: Record<string, RateLimitConfig>;
+  loading: boolean;
+  apiBaseUrl: string;
+  apiSections: ApiSection[];
+  apiCategories: ApiCategory[];
+  schemaLoading: boolean;
+  schemaError: string | null;
+  refetchSchema: () => void;
+  visibleSections: ApiSection[];
+  currentCategorySections: ApiSection[];
+}
+
+export function useApiReference({ isAdmin, token }: UseApiReferenceArgs): UseApiReferenceResult {
+  const [activeView, setActiveView] = useState<'docs' | 'limits'>('docs');
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [selectedSection, setSelectedSection] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [rateLimits, setRateLimits] = useState<Record<string, RateLimitConfig>>({});
+  const [loading, setLoading] = useState(true);
+
+  const { sections: apiSections, categories: apiCategories, loading: schemaLoading, error: schemaError, refetch: refetchSchema } = useOpenApiSchema();
+
+  // Dynamically determine API base URL based on current location
+  const getApiBaseUrl = (): string => {
+    const hostname = window.location.hostname;
+    const isDev = import.meta.env.DEV;
+
+    // In development, backend runs on port 3001
+    // In production, backend typically runs on port 8000
+    const port = isDev ? 3001 : 8000;
+    const protocol = window.location.protocol; // http: or https:
+
+    return `${protocol}//${hostname}:${port}`;
+  };
+
+  const apiBaseUrl = getApiBaseUrl();
+
+  // Load rate limits for displaying badges (admin only)
+  useEffect(() => {
+    if (isAdmin) {
+      loadRateLimits();
+    } else {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAdmin]);
+
+  const loadRateLimits = async () => {
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const response = await fetch(buildApiUrl('/api/admin/rate-limits'), {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        const map: Record<string, RateLimitConfig> = {};
+        data.configs.forEach((c: RateLimitConfig) => {
+          map[c.endpoint_type] = c;
+        });
+        setRateLimits(map);
+      }
+    } catch {
+      // Rate limits not available
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const visibleSections = useMemo(() => {
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      return apiSections
+        .map(s => ({
+          ...s,
+          endpoints: s.endpoints.filter(e =>
+            e.path.toLowerCase().includes(q) ||
+            e.description.toLowerCase().includes(q)
+          ),
+        }))
+        .filter(s => s.endpoints.length > 0);
+    }
+
+    const categorySections = selectedCategory
+      ? apiCategories.find(c => c.id === selectedCategory)?.sections ?? []
+      : apiSections;
+
+    return selectedSection
+      ? categorySections.filter(s => s.title === selectedSection)
+      : categorySections;
+  }, [searchQuery, selectedCategory, selectedSection, apiSections, apiCategories]);
+
+  const currentCategorySections = selectedCategory
+    ? apiCategories.find(c => c.id === selectedCategory)?.sections ?? []
+    : [];
+
+  return {
+    activeView, setActiveView, selectedCategory, setSelectedCategory,
+    selectedSection, setSelectedSection, searchQuery, setSearchQuery,
+    rateLimits, loading, apiBaseUrl,
+    apiSections, apiCategories, schemaLoading, schemaError, refetchSchema,
+    visibleSections, currentCategorySections,
+  };
+}

--- a/client/src/lib/apiRateLimitMatch.ts
+++ b/client/src/lib/apiRateLimitMatch.ts
@@ -1,0 +1,91 @@
+export interface RateLimitConfig {
+  id: number;
+  endpoint_type: string;
+  limit_string: string;
+  description: string | null;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string | null;
+  updated_by: number | null;
+}
+
+// ==================== Dynamic Rate Limit Matching ====================
+
+/**
+ * Dynamically match an API endpoint to its rate limit endpoint_type
+ * based on HTTP method and path patterns (mirrors backend decorator usage).
+ */
+export function matchEndpointToRateLimitType(method: string, path: string): string | null {
+  const p = path.toLowerCase();
+  const m = method.toUpperCase();
+
+  // Auth endpoints (most specific first)
+  if (m === 'POST' && p === '/api/auth/login') return 'auth_login';
+  if (m === 'POST' && p === '/api/auth/register') return 'auth_register';
+  if (m === 'POST' && p === '/api/auth/change-password') return 'auth_password_change';
+  if (m === 'POST' && p === '/api/auth/refresh') return 'auth_refresh';
+  if (m === 'POST' && p === '/api/auth/verify-2fa') return 'auth_2fa_verify';
+  if (m === 'POST' && p.startsWith('/api/auth/2fa/')) return 'auth_2fa_setup';
+  if (p.startsWith('/api/auth/')) return 'user_operations';
+
+  // Files (specific before generic)
+  if (p.startsWith('/api/files/upload/chunked')) return 'file_chunked';
+  if (m === 'POST' && p.startsWith('/api/files/upload')) return 'file_upload';
+  if (m === 'GET' && p.startsWith('/api/files/download')) return 'file_download';
+  if (m === 'GET' && p.startsWith('/api/files/list')) return 'file_list';
+  if (m === 'DELETE' && p.startsWith('/api/files/')) return 'file_delete';
+  if (p.startsWith('/api/files/')) return 'file_write';
+
+  // Activity
+  if (p.startsWith('/api/activity/')) return 'file_list';
+
+  // Shares
+  if (['POST', 'PATCH', 'DELETE'].includes(m) && p.startsWith('/api/shares')) return 'share_create';
+  if (p.startsWith('/api/shares')) return 'share_list';
+
+  // Mobile
+  if (m === 'POST' && (p === '/api/mobile/register' || p === '/api/mobile/token/generate')) return 'mobile_register';
+  if (p.includes('/mobile/sync') || p.includes('/mobile/upload-queue')) return 'mobile_sync';
+
+  // Desktop pairing
+  if (p.includes('/desktop-pairing/device-code')) return 'desktop_pairing_request';
+  if (p.includes('/desktop-pairing/token')) return 'desktop_pairing_poll';
+  if (p.includes('/desktop-pairing/verify')) return 'desktop_pairing_verify';
+  if (p.includes('/desktop-pairing/approve')) return 'desktop_pairing_approve';
+
+  // VPN, Backup, Sync
+  if (p.startsWith('/api/vpn/') || p === '/api/vpn') return 'vpn_operations';
+  if (p.startsWith('/api/backup/') || p === '/api/backup') return 'backup_operations';
+  if (p.startsWith('/api/sync/')) return 'sync_operations';
+
+  // Benchmark (POST run before admin catch-all)
+  if (m === 'POST' && p.includes('/benchmark/run')) return 'admin_benchmark';
+
+  // API Keys
+  if (p.startsWith('/api/api-keys')) return 'api_key_operations';
+
+  // Users
+  if (p.startsWith('/api/users')) return 'user_operations';
+
+  // System / Monitoring / Energy (GET = monitor, else admin)
+  if (p.startsWith('/api/system/') || p.startsWith('/api/monitoring/') || p.startsWith('/api/energy/')) {
+    return m === 'GET' ? 'system_monitor' : 'admin_operations';
+  }
+
+  // VCL
+  if (p.startsWith('/api/vcl/')) return m === 'GET' ? 'file_list' : 'file_write';
+
+  // SSD Cache
+  if (p.startsWith('/api/ssd-cache/')) return m === 'GET' ? 'file_list' : 'admin_operations';
+
+  // Admin catch-all
+  const adminPrefixes = [
+    '/api/admin/', '/api/admin-db/', '/api/schedulers/', '/api/fans/',
+    '/api/power/', '/api/pihole/', '/api/sleep/', '/api/cloud/',
+    '/api/updates/', '/api/samba/', '/api/webdav/', '/api/plugins/',
+    '/api/notifications/', '/api/benchmark/', '/api/smart-devices/',
+  ];
+  if (adminPrefixes.some(prefix => p.startsWith(prefix))) return 'admin_operations';
+
+  return null;
+}

--- a/docs/superpowers/plans/2026-07-13-f2-apireferencetab-decomposition.md
+++ b/docs/superpowers/plans/2026-07-13-f2-apireferencetab-decomposition.md
@@ -60,10 +60,47 @@ The component has **0 existing tests** → this decomposition is a net test gain
 All Tailwind classes, `t()` keys, and icons carried over verbatim. `getApiBaseUrl`
 port heuristic (3001 dev / 8000 prod) ported unchanged — not "cleaned up".
 
+## Test Plan
+
+Component has **0 existing tests** → net gain (~35 new tests, comparable to
+RaidSetupWizard +31 / FanDetails +26). Style mirrors `__tests__/lib/adminOwnerMap.test.ts`.
+
+**1. `lib/apiRateLimitMatch.ts` — the centrepiece (~22 tests).** The matcher has ~40
+*ordered* branches (specific-before-generic); the ordering is behaviour-relevant, so each
+critical priority is pinned:
+
+| Pinned case | expected | why order-sensitive |
+|---|---|---|
+| `POST /api/auth/login` | `auth_login` | before `/api/auth/*` catch (`user_operations`) |
+| `POST /api/auth/2fa/setup` | `auth_2fa_setup` | before generic auth catch |
+| `POST /api/files/upload/chunked` | `file_chunked` | before `/api/files/upload` → `file_upload` |
+| `GET /api/files/download/x` | `file_download` | before `/api/files/` catch (`file_write`) |
+| `DELETE /api/files/x` | `file_delete` | method decides |
+| `PATCH /api/shares/1` | `share_create` | POST/PATCH/DELETE before GET → `share_list` |
+| `POST /api/benchmark/run` | `admin_benchmark` | before admin catch-all (`/api/benchmark/`) |
+| `GET` vs `POST /api/system/x` | `system_monitor` / `admin_operations` | GET split |
+| `GET` vs `POST /api/vcl/x` | `file_list` / `file_write` | GET split |
+| `GET` vs `POST /api/ssd-cache/x` | `file_list` / `admin_operations` | GET split |
+| `/api/pihole/…`, `/api/fans/…` (admin prefixes) | `admin_operations` | catch-all |
+| `/api/unknown/x` | `null` | fallback |
+
+**2. `EndpointCard` (~4):** renders method/path/auth-shield/rate-limit badge; click
+toggles open; copy sets `copied`.
+
+**3. `useApiReference` (renderHook, ~5):** admin loads rate limits + maps by
+`endpoint_type`; non-admin skips fetch → `loading=false`; `visibleSections` filters
+correctly for search / category / section.
+
+**4. Smoke (`ApiCategoryTabs`, `ApiSectionList`, ~4):** click calls the right setter /
+renders the endpoint list.
+
+Purely presentational blocks (`ApiBaseUrlCard`, `ApiSearchBar`, `ApiLoadingSkeleton`,
+`ApiSchemaError`) get tests only if they carry logic — no artificial markup tests (YAGNI,
+matching prior F2 PRs).
+
 ## Verification
 
-- Per-unit Vitest: pure helper (branch coverage), `EndpointCard`, `useApiReference`,
-  plus render-smoke tests for `ApiCategoryTabs` / `ApiSectionList` (click → setter).
+- Per-unit Vitest as above.
 - Gates before PR: `eslint .` (0 errors), `npm run build` (tsc -b), `npx vitest run`.
 - Browser smoke (Manual → API reference): category/sub-tab switch, search filters,
   card open/close + copy, refresh, admin Docs↔Rate-Limits toggle. No full Playwright

--- a/docs/superpowers/plans/2026-07-13-f2-apireferencetab-decomposition.md
+++ b/docs/superpowers/plans/2026-07-13-f2-apireferencetab-decomposition.md
@@ -1,0 +1,76 @@
+# F2 Decomposition — `components/manual/ApiReferenceTab.tsx` (#301)
+
+**Date:** 2026-07-13
+**Branch:** `refactor/f2-decompose-apireferencetab`
+**Goal:** Behaviour-preserving decomposition of `ApiReferenceTab.tsx` (565 → target ~90–130 lines)
+into a thin orchestrator over a pure helper + a state hook + presentation subcomponents.
+Same pattern as the prior 14 F2 decompositions (#396–#414). Full split (Variante A).
+
+## Baseline
+
+`ApiReferenceTab.tsx` (565 lines). A docs/reference tab — mostly presentational, one
+admin-only fetch, no drag/touch interaction subtleties. Current pieces:
+
+- `RateLimitConfig` type (25–34)
+- `matchEndpointToRateLimitType(method, path)` — pure, ~74 lines, ~40 ordered branches
+  mirroring backend rate-limit decorator assignment (36–115)
+- `EndpointCard` — presentational card with local `isOpen`/`copied` state (117–235)
+- `ApiReferenceTab` orchestrator: state (`activeView`, `selectedCategory`, `selectedSection`,
+  `searchQuery`, `rateLimits`, `loading`), `loadRateLimits` fetch, `visibleSections` memo,
+  `getApiBaseUrl`, `currentCategorySections`, and the full JSX (view toggle, refresh,
+  schema error, base-url card, search, category/sub-tabs, loading skeleton, section list)
+  (237–564)
+
+The component has **0 existing tests** → this decomposition is a net test gain.
+
+## Target Units
+
+1. **`lib/apiRateLimitMatch.ts`** (pure — the test centrepiece)
+   - `matchEndpointToRateLimitType(method, path): string | null` — **byte-identical port**.
+     Branch order is behaviour-relevant (specific-before-generic) → copied 1:1.
+   - `RateLimitConfig` interface (shared by hook + `EndpointCard`).
+   - Tested: auth specificity-before-generic, files specific→generic, shares
+     POST/PATCH/DELETE vs GET, system GET vs non-GET, VCL/SSD-cache GET split,
+     admin catch-all prefixes, `null` fallback for unmatched paths.
+
+2. **`hooks/useApiReference.ts`** — `useApiReference({ isAdmin, token })`
+   - State: `activeView`, `selectedCategory`, `selectedSection`, `searchQuery`,
+     `rateLimits`, `loading` (+ setters).
+   - `loadRateLimits` fetch of `/api/admin/rate-limits` (admin-gated; empty catch preserved).
+   - `useEffect([isAdmin])` load/skip logic 1:1; `visibleSections` memo, `currentCategorySections`,
+     `apiBaseUrl` (from `getApiBaseUrl`), and pass-through of `useOpenApiSchema()`
+     (`apiSections`/`apiCategories`/`schemaLoading`/`schemaError`/`refetchSchema`).
+   - Tested via `renderHook`: admin loads + maps by `endpoint_type`; non-admin skips fetch
+     and sets `loading=false`; `visibleSections` filters correctly for search / category / section.
+
+3. **`components/manual/api-reference/`** presentation (pure props, no fetch):
+   - `EndpointCard.tsx` — keeps local `isOpen`/`copied`; uses `matchEndpointToRateLimitType`.
+   - `ApiViewToggle.tsx` — Docs | Rate Limits (admin only).
+   - `ApiBaseUrlCard.tsx` — base-url infobox + copy.
+   - `ApiSearchBar.tsx` — search input + clear.
+   - `ApiCategoryTabs.tsx` — category pills + per-category sub-tabs.
+   - `ApiSchemaError.tsx` — error banner + retry.
+   - `ApiLoadingSkeleton.tsx` — pulse skeleton.
+   - `ApiSectionList.tsx` — section header + `EndpointCard` list.
+   - `index.ts` — barrel re-export.
+
+4. **`ApiReferenceTab.tsx`** — thin: calls `useApiReference`, wires subcomponents, keeps
+   top-level layout (`space-y-*`, Docs/Limits switch, `RateLimitsTab` when `activeView==='limits'`).
+
+All Tailwind classes, `t()` keys, and icons carried over verbatim. `getApiBaseUrl`
+port heuristic (3001 dev / 8000 prod) ported unchanged — not "cleaned up".
+
+## Verification
+
+- Per-unit Vitest: pure helper (branch coverage), `EndpointCard`, `useApiReference`,
+  plus render-smoke tests for `ApiCategoryTabs` / `ApiSectionList` (click → setter).
+- Gates before PR: `eslint .` (0 errors), `npm run build` (tsc -b), `npx vitest run`.
+- Browser smoke (Manual → API reference): category/sub-tab switch, search filters,
+  card open/close + copy, refresh, admin Docs↔Rate-Limits toggle. No full Playwright
+  (no interaction subtlety like FanCurveChart).
+- Whole-branch review (Opus) — byte-for-behaviour fidelity check.
+
+## Non-goals (YAGNI)
+
+- No behaviour change, no re-design, no new deps.
+- Do not refactor the `getApiBaseUrl` heuristic or the rate-limit branch logic — port verbatim.

--- a/docs/superpowers/plans/2026-07-13-f2-apireferencetab-implementation.md
+++ b/docs/superpowers/plans/2026-07-13-f2-apireferencetab-implementation.md
@@ -1,0 +1,800 @@
+# ApiReferenceTab F2 Decomposition — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Behaviour-preserving decomposition of `client/src/components/manual/ApiReferenceTab.tsx` (565 lines) into a pure helper + a state hook + presentation subcomponents, leaving a thin orchestrator (~90–130 lines).
+
+**Architecture:** Extract the pure rate-limit matcher to `lib/`, the view/fetch/derived state to `hooks/useApiReference.ts`, and each JSX block to a presentation component under `components/manual/api-reference/`. Build the new units alongside the still-working original (Tasks 1–4 add files only), then swap the orchestrator to consume them (Task 5). Every extracted unit is a verbatim port — no behaviour change.
+
+**Tech Stack:** React 18 + TypeScript (strict), Tailwind, lucide-react, react-i18next, Vitest + @testing-library/react.
+
+**Spec:** `docs/superpowers/plans/2026-07-13-f2-apireferencetab-decomposition.md`
+**Source of truth for verbatim slices:** the pre-change `ApiReferenceTab.tsx` (line ranges cited per task).
+
+## Global Constraints
+
+- Same F2 pattern as #396–#414: pure helper + `hooks/use…` + `<feature>/*` presentation + thin orchestrator; per-unit Vitest; verbatim/behaviour-preserving.
+- Full split (Variante A): every JSX block becomes its own component.
+- Tailwind classes, `t()` keys, icons, and the `getApiBaseUrl` heuristic (3001 dev / 8000 prod) copied **verbatim** — do NOT "clean up" the matcher branch order or the base-url logic.
+- Pure matcher `lib/apiRateLimitMatch.ts`; presentation under `components/manual/api-reference/` with a barrel `index.ts`.
+- Tests live under `client/src/__tests__/**` mirroring the source path (repo convention).
+- Gates before PR: `npx eslint .` (0 errors — warnings allowed), `npm run build` (tsc -b), `npx vitest run` (all from `client/`).
+- CRLF repo (`core.autocrlf=true`) — let git handle EOL; do not fight it.
+
+---
+
+### Task 1: Pure rate-limit matcher `lib/apiRateLimitMatch.ts`
+
+**Files:**
+- Create: `client/src/lib/apiRateLimitMatch.ts`
+- Test: `client/src/__tests__/lib/apiRateLimitMatch.test.ts`
+- Source: verbatim from `ApiReferenceTab.tsx:25-34` (type) and `:42-115` (function)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `export interface RateLimitConfig { id: number; endpoint_type: string; limit_string: string; description: string | null; enabled: boolean; created_at: string; updated_at: string | null; updated_by: number | null; }`
+  - `export function matchEndpointToRateLimitType(method: string, path: string): string | null`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/lib/apiRateLimitMatch.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { matchEndpointToRateLimitType } from '../../lib/apiRateLimitMatch'
+
+describe('matchEndpointToRateLimitType', () => {
+  it('matches specific auth endpoints before the auth catch-all', () => {
+    expect(matchEndpointToRateLimitType('POST', '/api/auth/login')).toBe('auth_login')
+    expect(matchEndpointToRateLimitType('POST', '/api/auth/register')).toBe('auth_register')
+    expect(matchEndpointToRateLimitType('POST', '/api/auth/change-password')).toBe('auth_password_change')
+    expect(matchEndpointToRateLimitType('POST', '/api/auth/refresh')).toBe('auth_refresh')
+    expect(matchEndpointToRateLimitType('POST', '/api/auth/verify-2fa')).toBe('auth_2fa_verify')
+    expect(matchEndpointToRateLimitType('POST', '/api/auth/2fa/setup')).toBe('auth_2fa_setup')
+    // generic auth path falls through to the catch-all
+    expect(matchEndpointToRateLimitType('GET', '/api/auth/me')).toBe('user_operations')
+  })
+
+  it('is case-insensitive on method and path', () => {
+    expect(matchEndpointToRateLimitType('post', '/API/AUTH/LOGIN')).toBe('auth_login')
+  })
+
+  it('matches files specific-before-generic', () => {
+    expect(matchEndpointToRateLimitType('POST', '/api/files/upload/chunked/init')).toBe('file_chunked')
+    expect(matchEndpointToRateLimitType('POST', '/api/files/upload')).toBe('file_upload')
+    expect(matchEndpointToRateLimitType('GET', '/api/files/download/x')).toBe('file_download')
+    expect(matchEndpointToRateLimitType('GET', '/api/files/list')).toBe('file_list')
+    expect(matchEndpointToRateLimitType('DELETE', '/api/files/x')).toBe('file_delete')
+    expect(matchEndpointToRateLimitType('PUT', '/api/files/x')).toBe('file_write')
+  })
+
+  it('matches activity as file_list', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/activity/feed')).toBe('file_list')
+  })
+
+  it('matches shares by write-method vs read', () => {
+    expect(matchEndpointToRateLimitType('POST', '/api/shares')).toBe('share_create')
+    expect(matchEndpointToRateLimitType('PATCH', '/api/shares/1')).toBe('share_create')
+    expect(matchEndpointToRateLimitType('DELETE', '/api/shares/1')).toBe('share_create')
+    expect(matchEndpointToRateLimitType('GET', '/api/shares')).toBe('share_list')
+  })
+
+  it('matches mobile + desktop-pairing endpoints', () => {
+    expect(matchEndpointToRateLimitType('POST', '/api/mobile/register')).toBe('mobile_register')
+    expect(matchEndpointToRateLimitType('POST', '/api/mobile/token/generate')).toBe('mobile_register')
+    expect(matchEndpointToRateLimitType('POST', '/api/mobile/sync')).toBe('mobile_sync')
+    expect(matchEndpointToRateLimitType('GET', '/api/mobile/upload-queue')).toBe('mobile_sync')
+    expect(matchEndpointToRateLimitType('POST', '/api/desktop-pairing/device-code')).toBe('desktop_pairing_request')
+    expect(matchEndpointToRateLimitType('POST', '/api/desktop-pairing/token')).toBe('desktop_pairing_poll')
+    expect(matchEndpointToRateLimitType('POST', '/api/desktop-pairing/verify')).toBe('desktop_pairing_verify')
+    expect(matchEndpointToRateLimitType('POST', '/api/desktop-pairing/approve')).toBe('desktop_pairing_approve')
+  })
+
+  it('matches vpn/backup/sync operation groups', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/vpn')).toBe('vpn_operations')
+    expect(matchEndpointToRateLimitType('POST', '/api/vpn/clients')).toBe('vpn_operations')
+    expect(matchEndpointToRateLimitType('GET', '/api/backup')).toBe('backup_operations')
+    expect(matchEndpointToRateLimitType('POST', '/api/sync/start')).toBe('sync_operations')
+  })
+
+  it('matches POST benchmark/run before the admin catch-all', () => {
+    expect(matchEndpointToRateLimitType('POST', '/api/benchmark/run')).toBe('admin_benchmark')
+    // non-run benchmark falls to admin catch-all
+    expect(matchEndpointToRateLimitType('GET', '/api/benchmark/history')).toBe('admin_operations')
+  })
+
+  it('matches api-keys and users groups', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/api-keys')).toBe('api_key_operations')
+    expect(matchEndpointToRateLimitType('GET', '/api/users')).toBe('user_operations')
+  })
+
+  it('splits system/monitoring/energy by GET vs write', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/system/info')).toBe('system_monitor')
+    expect(matchEndpointToRateLimitType('POST', '/api/system/reboot')).toBe('admin_operations')
+    expect(matchEndpointToRateLimitType('GET', '/api/monitoring/cpu')).toBe('system_monitor')
+    expect(matchEndpointToRateLimitType('GET', '/api/energy/stats')).toBe('system_monitor')
+  })
+
+  it('splits vcl and ssd-cache by GET vs write', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/vcl/versions')).toBe('file_list')
+    expect(matchEndpointToRateLimitType('POST', '/api/vcl/restore')).toBe('file_write')
+    expect(matchEndpointToRateLimitType('GET', '/api/ssd-cache/status')).toBe('file_list')
+    expect(matchEndpointToRateLimitType('POST', '/api/ssd-cache/clear')).toBe('admin_operations')
+  })
+
+  it('matches admin-prefix catch-all', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/pihole/status')).toBe('admin_operations')
+    expect(matchEndpointToRateLimitType('POST', '/api/fans/config')).toBe('admin_operations')
+    expect(matchEndpointToRateLimitType('GET', '/api/updates/check')).toBe('admin_operations')
+  })
+
+  it('returns null for unmatched paths', () => {
+    expect(matchEndpointToRateLimitType('GET', '/api/unknown/x')).toBeNull()
+    expect(matchEndpointToRateLimitType('GET', '/healthz')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `client/`): `npx vitest run src/__tests__/lib/apiRateLimitMatch.test.ts`
+Expected: FAIL — cannot resolve `../../lib/apiRateLimitMatch`.
+
+- [ ] **Step 3: Create the module (verbatim port)**
+
+Create `client/src/lib/apiRateLimitMatch.ts`. Copy the `RateLimitConfig` interface from `ApiReferenceTab.tsx:25-34` and the function body from `:42-115` **unchanged**, exported:
+
+```ts
+export interface RateLimitConfig {
+  id: number;
+  endpoint_type: string;
+  limit_string: string;
+  description: string | null;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string | null;
+  updated_by: number | null;
+}
+
+/**
+ * Dynamically match an API endpoint to its rate limit endpoint_type
+ * based on HTTP method and path patterns (mirrors backend decorator usage).
+ */
+export function matchEndpointToRateLimitType(method: string, path: string): string | null {
+  // ... copy lines 43-114 of ApiReferenceTab.tsx VERBATIM (the p/m locals through
+  //     the admin catch-all and the final `return null;`). Do not reorder branches.
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run (from `client/`): `npx vitest run src/__tests__/lib/apiRateLimitMatch.test.ts`
+Expected: PASS (all cases green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/lib/apiRateLimitMatch.ts client/src/__tests__/lib/apiRateLimitMatch.test.ts
+git commit -m "feat(api-ref): extract pure apiRateLimitMatch helper + branch tests (#301)"
+```
+
+---
+
+### Task 2: State hook `hooks/useApiReference.ts`
+
+**Files:**
+- Create: `client/src/hooks/useApiReference.ts`
+- Test: `client/src/__tests__/hooks/useApiReference.test.tsx`
+- Source: `ApiReferenceTab.tsx:244-330` (state, `getApiBaseUrl`, effect, `loadRateLimits`, `visibleSections`, `currentCategorySections`)
+
+**Interfaces:**
+- Consumes: `RateLimitConfig` from `lib/apiRateLimitMatch` (Task 1); `useOpenApiSchema` from `hooks/useOpenApiSchema` (returns `{ sections, categories, loading, error, refetch }`); `buildApiUrl` from `lib/api`; `ApiSection` from `data/api-endpoints/types`; `ApiCategory` from `lib/openapi-transform`.
+- Produces:
+
+```ts
+export interface UseApiReferenceArgs { isAdmin: boolean; token: string | null }
+export interface UseApiReferenceResult {
+  activeView: 'docs' | 'limits';
+  setActiveView: (v: 'docs' | 'limits') => void;
+  selectedCategory: string | null;
+  setSelectedCategory: (c: string | null) => void;
+  selectedSection: string | null;
+  setSelectedSection: (s: string | null) => void;
+  searchQuery: string;
+  setSearchQuery: (q: string) => void;
+  rateLimits: Record<string, RateLimitConfig>;
+  loading: boolean;
+  apiBaseUrl: string;
+  apiSections: ApiSection[];
+  apiCategories: ApiCategory[];
+  schemaLoading: boolean;
+  schemaError: string | null;
+  refetchSchema: () => void;
+  visibleSections: ApiSection[];
+  currentCategorySections: ApiSection[];
+}
+export function useApiReference(args: UseApiReferenceArgs): UseApiReferenceResult
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/hooks/useApiReference.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+// Controlled schema so the hook doesn't hit /openapi.json.
+const mkSection = (title: string, paths: string[]) => ({
+  title, icon: null,
+  endpoints: paths.map(p => ({ method: 'GET', path: p, description: `${p} desc`, requiresAuth: false })),
+})
+const SECTIONS = [mkSection('Files', ['/api/files/list']), mkSection('Auth', ['/api/auth/me'])]
+const CATEGORIES = [{ id: 'core', label: 'Core', sections: [SECTIONS[0]] }]
+
+vi.mock('../../hooks/useOpenApiSchema', () => ({
+  useOpenApiSchema: () => ({
+    sections: SECTIONS, categories: CATEGORIES,
+    loading: false, error: null, refetch: vi.fn(),
+  }),
+}))
+
+import { useApiReference } from '../../hooks/useApiReference'
+
+describe('useApiReference', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('non-admin skips the rate-limit fetch and clears loading', async () => {
+    const { result } = renderHook(() => useApiReference({ isAdmin: false, token: 't' }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetch).not.toHaveBeenCalled()
+    expect(result.current.rateLimits).toEqual({})
+  })
+
+  it('admin loads rate limits and maps them by endpoint_type', async () => {
+    const configs = [
+      { id: 1, endpoint_type: 'auth_login', limit_string: '5/min', description: null,
+        enabled: true, created_at: '', updated_at: null, updated_by: null },
+    ]
+    ;(fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true, json: async () => ({ configs }),
+    })
+    const { result } = renderHook(() => useApiReference({ isAdmin: true, token: 'tok' }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(result.current.rateLimits.auth_login.limit_string).toBe('5/min')
+  })
+
+  it('visibleSections: no filter returns all sections', () => {
+    const { result } = renderHook(() => useApiReference({ isAdmin: false, token: null }))
+    expect(result.current.visibleSections.map(s => s.title)).toEqual(['Files', 'Auth'])
+  })
+
+  it('visibleSections: search filters endpoints by path/description', () => {
+    const { result } = renderHook(() => useApiReference({ isAdmin: false, token: null }))
+    result.current.setSearchQuery('files')
+    // re-read after state update
+    const { result: r2 } = renderHook(() => useApiReference({ isAdmin: false, token: null }))
+    r2.current.setSearchQuery('files')
+    // Query in a fresh render:
+    expect(SECTIONS.some(s => s.endpoints.some(e => e.path.includes('files')))).toBe(true)
+  })
+
+  it('visibleSections: selecting a category narrows to its sections', () => {
+    const { result } = renderHook(() => useApiReference({ isAdmin: false, token: null }))
+    result.current.setSelectedCategory('core')
+    // one render tick later the category sections are ['Files']
+    expect(CATEGORIES[0].sections.map(s => s.title)).toEqual(['Files'])
+  })
+})
+```
+
+> Note: React state updates inside `renderHook` need `act`/rerender to observe; keep the search/category assertions focused on the pure filter contract (as above) to avoid flakiness. The core admin/non-admin fetch behaviour is the load-bearing coverage.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `client/`): `npx vitest run src/__tests__/hooks/useApiReference.test.tsx`
+Expected: FAIL — cannot resolve `../../hooks/useApiReference`.
+
+- [ ] **Step 3: Create the hook (verbatim port of the state)**
+
+Create `client/src/hooks/useApiReference.ts`. Move the state, `getApiBaseUrl`, the `useEffect([isAdmin])` + `loadRateLimits`, `visibleSections` memo, and `currentCategorySections` from `ApiReferenceTab.tsx:244-330` **unchanged**; wire the `useOpenApiSchema()` pass-through:
+
+```ts
+import { useState, useEffect, useMemo } from 'react';
+import { buildApiUrl } from '../lib/api';
+import type { ApiSection } from '../data/api-endpoints/types';
+import type { ApiCategory } from '../lib/openapi-transform';
+import type { RateLimitConfig } from '../lib/apiRateLimitMatch';
+import { useOpenApiSchema } from './useOpenApiSchema';
+
+export interface UseApiReferenceArgs { isAdmin: boolean; token: string | null }
+export interface UseApiReferenceResult { /* ...as in Interfaces block... */ }
+
+export function useApiReference({ isAdmin, token }: UseApiReferenceArgs): UseApiReferenceResult {
+  const [activeView, setActiveView] = useState<'docs' | 'limits'>('docs');
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [selectedSection, setSelectedSection] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [rateLimits, setRateLimits] = useState<Record<string, RateLimitConfig>>({});
+  const [loading, setLoading] = useState(true);
+
+  const {
+    sections: apiSections, categories: apiCategories,
+    loading: schemaLoading, error: schemaError, refetch: refetchSchema,
+  } = useOpenApiSchema();
+
+  const getApiBaseUrl = (): string => {
+    const hostname = window.location.hostname;
+    const isDev = import.meta.env.DEV;
+    const port = isDev ? 3001 : 8000;
+    const protocol = window.location.protocol;
+    return `${protocol}//${hostname}:${port}`;
+  };
+  const apiBaseUrl = getApiBaseUrl();
+
+  useEffect(() => {
+    if (isAdmin) {
+      loadRateLimits();
+    } else {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAdmin]);
+
+  const loadRateLimits = async () => {
+    if (!token) { setLoading(false); return; }
+    try {
+      const response = await fetch(buildApiUrl('/api/admin/rate-limits'), {
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+      if (response.ok) {
+        const data = await response.json();
+        const map: Record<string, RateLimitConfig> = {};
+        data.configs.forEach((c: RateLimitConfig) => { map[c.endpoint_type] = c; });
+        setRateLimits(map);
+      }
+    } catch {
+      // Rate limits not available
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const visibleSections = useMemo(() => {
+    // copy lines 306-326 verbatim
+  }, [searchQuery, selectedCategory, selectedSection, apiSections, apiCategories]);
+
+  const currentCategorySections = selectedCategory
+    ? apiCategories.find(c => c.id === selectedCategory)?.sections ?? []
+    : [];
+
+  return {
+    activeView, setActiveView, selectedCategory, setSelectedCategory,
+    selectedSection, setSelectedSection, searchQuery, setSearchQuery,
+    rateLimits, loading, apiBaseUrl,
+    apiSections, apiCategories, schemaLoading, schemaError, refetchSchema,
+    visibleSections, currentCategorySections,
+  };
+}
+```
+
+> Behaviour note: the effect dep array stays `[isAdmin]` (matches the original — it does NOT re-fetch on token change). The `eslint-disable-next-line` keeps the 0-error gate clean without changing behaviour.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run (from `client/`): `npx vitest run src/__tests__/hooks/useApiReference.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/hooks/useApiReference.ts client/src/__tests__/hooks/useApiReference.test.tsx
+git commit -m "feat(api-ref): extract useApiReference state hook + tests (#301)"
+```
+
+---
+
+### Task 3: `EndpointCard` presentation component
+
+**Files:**
+- Create: `client/src/components/manual/api-reference/EndpointCard.tsx`
+- Test: `client/src/__tests__/components/manual/api-reference/EndpointCard.test.tsx`
+- Source: `ApiReferenceTab.tsx:117-235` (the whole `EndpointCard` incl. its local state)
+
+**Interfaces:**
+- Consumes: `matchEndpointToRateLimitType`, `RateLimitConfig` from `lib/apiRateLimitMatch` (Task 1); `methodColors`, `ApiEndpoint` from `data/api-endpoints`.
+- Produces: `export interface EndpointCardProps { endpoint: ApiEndpoint; rateLimits: Record<string, RateLimitConfig>; t: (key: string) => string }` and `export function EndpointCard(props: EndpointCardProps)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/components/manual/api-reference/EndpointCard.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { EndpointCard } from '../../../../components/manual/api-reference/EndpointCard'
+import type { ApiEndpoint } from '../../../../data/api-endpoints'
+
+const t = (k: string) => k
+const endpoint: ApiEndpoint = {
+  method: 'POST', path: '/api/auth/login', description: 'Log in',
+  requiresAuth: true,
+  params: [], body: [], response: '{"token":"x"}',
+} as ApiEndpoint
+
+describe('EndpointCard', () => {
+  beforeEach(() => {
+    Object.assign(navigator, { clipboard: { writeText: vi.fn() } })
+  })
+
+  it('renders method, path and the auth shield', () => {
+    render(<EndpointCard endpoint={endpoint} rateLimits={{}} t={t} />)
+    expect(screen.getByText('POST')).toBeInTheDocument()
+    expect(screen.getByText('/api/auth/login')).toBeInTheDocument()
+    expect(screen.getByTitle('system:apiCenter.authRequired')).toBeInTheDocument()
+  })
+
+  it('shows the rate-limit badge when a matching config exists', () => {
+    const rl = {
+      auth_login: { id: 1, endpoint_type: 'auth_login', limit_string: '5/min',
+        description: null, enabled: true, created_at: '', updated_at: null, updated_by: null },
+    }
+    render(<EndpointCard endpoint={endpoint} rateLimits={rl} t={t} />)
+    expect(screen.getByText('5/min')).toBeInTheDocument()
+  })
+
+  it('expands to show the response and copies it', () => {
+    render(<EndpointCard endpoint={endpoint} rateLimits={{}} t={t} />)
+    // collapsed: response not shown
+    expect(screen.queryByText('{"token":"x"}')).toBeNull()
+    fireEvent.click(screen.getByText('/api/auth/login'))
+    expect(screen.getByText('{"token":"x"}')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '' })) // copy button (icon-only)
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('{"token":"x"}')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `client/`): `npx vitest run src/__tests__/components/manual/api-reference/EndpointCard.test.tsx`
+Expected: FAIL — cannot resolve the component.
+
+- [ ] **Step 3: Create the component (verbatim port)**
+
+Create `client/src/components/manual/api-reference/EndpointCard.tsx`. Move `EndpointCard` from `ApiReferenceTab.tsx:117-235` **verbatim** (incl. `useState` for `isOpen`/`copied`, `copyToClipboard`, all JSX). Change only the imports:
+
+```tsx
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Copy, Check, Zap, Shield } from 'lucide-react';
+import { methodColors } from '../../../data/api-endpoints';
+import type { ApiEndpoint } from '../../../data/api-endpoints';
+import { matchEndpointToRateLimitType, type RateLimitConfig } from '../../../lib/apiRateLimitMatch';
+
+export interface EndpointCardProps {
+  endpoint: ApiEndpoint;
+  rateLimits: Record<string, RateLimitConfig>;
+  t: (key: string) => string;
+}
+
+export function EndpointCard({ endpoint, rateLimits, t }: EndpointCardProps) {
+  // ... body verbatim from lines 126-234 ...
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run (from `client/`): `npx vitest run src/__tests__/components/manual/api-reference/EndpointCard.test.tsx`
+Expected: PASS. If the icon-only copy-button query is ambiguous, select via `getAllByRole('button')` and click the last one.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/manual/api-reference/EndpointCard.tsx client/src/__tests__/components/manual/api-reference/EndpointCard.test.tsx
+git commit -m "feat(api-ref): extract EndpointCard component + tests (#301)"
+```
+
+---
+
+### Task 4: Remaining presentation components + barrel
+
+**Files:**
+- Create: `client/src/components/manual/api-reference/ApiViewToggle.tsx`
+- Create: `client/src/components/manual/api-reference/ApiBaseUrlCard.tsx`
+- Create: `client/src/components/manual/api-reference/ApiSearchBar.tsx`
+- Create: `client/src/components/manual/api-reference/ApiCategoryTabs.tsx`
+- Create: `client/src/components/manual/api-reference/ApiSchemaError.tsx`
+- Create: `client/src/components/manual/api-reference/ApiLoadingSkeleton.tsx`
+- Create: `client/src/components/manual/api-reference/ApiSectionList.tsx`
+- Create: `client/src/components/manual/api-reference/index.ts`
+- Test: `client/src/__tests__/components/manual/api-reference/ApiCategoryTabs.test.tsx`
+- Test: `client/src/__tests__/components/manual/api-reference/ApiSectionList.test.tsx`
+- Source ranges in `ApiReferenceTab.tsx`: view toggle `335-360`, schema error `380-395`, base-url card `398-426`, search `429-446`, category tabs `449-522`, loading skeleton `525-537`, section list `540-559`.
+
+**Interfaces (props each component consumes; all values come from `useApiReference` in Task 5):**
+
+```ts
+// ApiViewToggle.tsx
+export interface ApiViewToggleProps {
+  activeView: 'docs' | 'limits';
+  onChange: (v: 'docs' | 'limits') => void;
+  t: (key: string) => string;
+}
+// ApiBaseUrlCard.tsx
+export interface ApiBaseUrlCardProps { apiBaseUrl: string; t: (key: string) => string }
+// ApiSearchBar.tsx
+export interface ApiSearchBarProps {
+  value: string; onChange: (q: string) => void; t: (key: string, fallback?: string) => string;
+}
+// ApiCategoryTabs.tsx
+import type { ApiCategory } from '../../../lib/openapi-transform';
+import type { ApiSection } from '../../../data/api-endpoints/types';
+export interface ApiCategoryTabsProps {
+  apiSections: ApiSection[];
+  apiCategories: ApiCategory[];
+  selectedCategory: string | null;
+  selectedSection: string | null;
+  currentCategorySections: ApiSection[];
+  onSelectCategory: (id: string | null) => void;
+  onSelectSection: (title: string | null) => void;
+  t: (key: string) => string;
+}
+// ApiSchemaError.tsx
+export interface ApiSchemaErrorProps { error: string; onRetry: () => void }
+// ApiLoadingSkeleton.tsx  — no props
+// ApiSectionList.tsx
+export interface ApiSectionListProps {
+  sections: ApiSection[];
+  rateLimits: Record<string, RateLimitConfig>;
+  t: (key: string) => string;
+}
+```
+
+- [ ] **Step 1: Write the failing smoke tests (the two logic-bearing components)**
+
+Create `client/src/__tests__/components/manual/api-reference/ApiCategoryTabs.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ApiCategoryTabs } from '../../../../components/manual/api-reference/ApiCategoryTabs'
+
+const t = (k: string) => k
+const section = (title: string) => ({ title, icon: null, endpoints: [
+  { method: 'GET', path: `/api/${title}`, description: '', requiresAuth: false },
+] })
+const apiSections = [section('files'), section('auth')]
+const apiCategories = [{ id: 'core', label: 'Core', sections: [section('files')] }]
+
+describe('ApiCategoryTabs', () => {
+  it('renders the "all" pill with the total endpoint count and per-category pills', () => {
+    render(<ApiCategoryTabs apiSections={apiSections} apiCategories={apiCategories}
+      selectedCategory={null} selectedSection={null} currentCategorySections={[]}
+      onSelectCategory={vi.fn()} onSelectSection={vi.fn()} t={t} />)
+    expect(screen.getByText('Core')).toBeInTheDocument()
+    expect(screen.getByText('(2)')).toBeInTheDocument() // total endpoints across all sections
+  })
+
+  it('calls onSelectCategory when a category pill is clicked', () => {
+    const onSelectCategory = vi.fn()
+    render(<ApiCategoryTabs apiSections={apiSections} apiCategories={apiCategories}
+      selectedCategory={null} selectedSection={null} currentCategorySections={[]}
+      onSelectCategory={onSelectCategory} onSelectSection={vi.fn()} t={t} />)
+    fireEvent.click(screen.getByText('Core'))
+    expect(onSelectCategory).toHaveBeenCalledWith('core')
+  })
+})
+```
+
+Create `client/src/__tests__/components/manual/api-reference/ApiSectionList.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ApiSectionList } from '../../../../components/manual/api-reference/ApiSectionList'
+
+const t = (k: string) => k
+const sections = [{
+  title: 'Files', icon: null,
+  endpoints: [{ method: 'GET', path: '/api/files/list', description: 'List', requiresAuth: false }],
+}]
+
+describe('ApiSectionList', () => {
+  it('renders a section header and its endpoint cards', () => {
+    render(<ApiSectionList sections={sections} rateLimits={{}} t={t} />)
+    expect(screen.getByText('Files')).toBeInTheDocument()
+    expect(screen.getByText('/api/files/list')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run the smoke tests to verify they fail**
+
+Run (from `client/`): `npx vitest run src/__tests__/components/manual/api-reference/ApiCategoryTabs.test.tsx src/__tests__/components/manual/api-reference/ApiSectionList.test.tsx`
+Expected: FAIL — components not found.
+
+- [ ] **Step 3: Create the seven components (verbatim JSX slices) + barrel**
+
+For each file, wrap the cited JSX slice from `ApiReferenceTab.tsx` in the component signature from the Interfaces block, substituting the orchestrator locals with props (`activeView`→`props.activeView`, `setActiveView(x)`→`onChange(x)`, `searchQuery`→`value`, `setSearchQuery`→`onChange`, `refetchSchema`→`onRetry`, `schemaError`→`error`, `apiBaseUrl`/`rateLimits`/`t` etc.). Keep all Tailwind classes and `t()` keys verbatim. `toast` stays only in `ApiBaseUrlCard` (base-url copy) — import `toast from 'react-hot-toast'` there. `ApiSectionList` renders `EndpointCard` (Task 3) per endpoint (verbatim map from `:549-556`). Icons per file: `ApiViewToggle` → `Code, Gauge`; `ApiBaseUrlCard` → `Code, Copy`; `ApiSearchBar` → `Search`; `ApiSchemaError` → `AlertTriangle`; `ApiCategoryTabs` → none (uses `section.icon`); `ApiLoadingSkeleton` → none; `ApiSectionList` → none.
+
+Then create the barrel `client/src/components/manual/api-reference/index.ts`:
+
+```ts
+export { EndpointCard } from './EndpointCard';
+export { ApiViewToggle } from './ApiViewToggle';
+export { ApiBaseUrlCard } from './ApiBaseUrlCard';
+export { ApiSearchBar } from './ApiSearchBar';
+export { ApiCategoryTabs } from './ApiCategoryTabs';
+export { ApiSchemaError } from './ApiSchemaError';
+export { ApiLoadingSkeleton } from './ApiLoadingSkeleton';
+export { ApiSectionList } from './ApiSectionList';
+```
+
+> `ApiViewToggle` renders ONLY the two toggle buttons (the `isAdmin` guard stays in the orchestrator). `ApiCategoryTabs` renders the whole `!searchQuery.trim()` block (`:449-522`) INCLUDING the sub-tab section; the orchestrator passes `selectedCategory`/`currentCategorySections` so the component decides internally whether to show sub-tabs (verbatim condition `selectedCategory && currentCategorySections.length > 0`).
+
+- [ ] **Step 4: Run the smoke tests to verify they pass**
+
+Run (from `client/`): `npx vitest run src/__tests__/components/manual/api-reference/`
+Expected: PASS (EndpointCard + ApiCategoryTabs + ApiSectionList).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/manual/api-reference/ client/src/__tests__/components/manual/api-reference/ApiCategoryTabs.test.tsx client/src/__tests__/components/manual/api-reference/ApiSectionList.test.tsx
+git commit -m "feat(api-ref): extract remaining api-reference presentation components + barrel (#301)"
+```
+
+---
+
+### Task 5: Thin orchestrator + docs + full gates
+
+**Files:**
+- Modify: `client/src/components/manual/ApiReferenceTab.tsx` (replace body; keep `export interface ApiReferenceTabProps` + `export function ApiReferenceTab`)
+- Modify: `client/src/components/CLAUDE.md` (add `api-reference/*` note to the `manual/` row)
+
+**Interfaces:**
+- Consumes: `useApiReference` (Task 2); all components via the `api-reference` barrel (Tasks 3–4); `RateLimitsTab` from `../rate-limits`.
+- Produces: unchanged public API — `export interface ApiReferenceTabProps { isAdmin: boolean; token: string | null }`, `export function ApiReferenceTab(props: ApiReferenceTabProps)`.
+
+- [ ] **Step 1: Rewrite the orchestrator**
+
+Replace the entire contents of `client/src/components/manual/ApiReferenceTab.tsx` with the thin version (remove the now-extracted `RateLimitConfig`, `matchEndpointToRateLimitType`, `EndpointCard`, and all inline JSX/state):
+
+```tsx
+import { useTranslation } from 'react-i18next';
+import { RefreshCw } from 'lucide-react';
+import { RateLimitsTab } from '../rate-limits';
+import { useApiReference } from '../../hooks/useApiReference';
+import {
+  ApiViewToggle, ApiBaseUrlCard, ApiSearchBar, ApiCategoryTabs,
+  ApiSchemaError, ApiLoadingSkeleton, ApiSectionList,
+} from './api-reference';
+
+export interface ApiReferenceTabProps {
+  isAdmin: boolean;
+  token: string | null;
+}
+
+export function ApiReferenceTab({ isAdmin, token }: ApiReferenceTabProps) {
+  const { t } = useTranslation(['system', 'common']);
+  const api = useApiReference({ isAdmin, token });
+
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      {isAdmin && (
+        <ApiViewToggle activeView={api.activeView} onChange={api.setActiveView} t={t} />
+      )}
+
+      {api.activeView === 'limits' && isAdmin && <RateLimitsTab />}
+
+      {api.activeView === 'docs' && <>
+        {/* Refresh */}
+        <div className="flex justify-end">
+          <button
+            onClick={api.refetchSchema}
+            className="p-2 bg-slate-800/40 hover:bg-slate-700/60 border border-slate-700/50 rounded-lg transition-colors touch-manipulation active:scale-95"
+            title="Refresh API schema"
+          >
+            <RefreshCw className={`w-4 h-4 text-slate-400 ${api.schemaLoading ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+
+        {api.schemaError && <ApiSchemaError error={api.schemaError} onRetry={api.refetchSchema} />}
+
+        <ApiBaseUrlCard apiBaseUrl={api.apiBaseUrl} t={t} />
+
+        <ApiSearchBar value={api.searchQuery} onChange={api.setSearchQuery} t={t} />
+
+        {!api.searchQuery.trim() && (
+          <ApiCategoryTabs
+            apiSections={api.apiSections}
+            apiCategories={api.apiCategories}
+            selectedCategory={api.selectedCategory}
+            selectedSection={api.selectedSection}
+            currentCategorySections={api.currentCategorySections}
+            onSelectCategory={(id) => { api.setSelectedCategory(id); api.setSelectedSection(null); }}
+            onSelectSection={api.setSelectedSection}
+            t={t}
+          />
+        )}
+
+        {(api.loading || api.schemaLoading) && <ApiLoadingSkeleton />}
+
+        {!api.loading && !api.schemaLoading && (
+          <ApiSectionList sections={api.visibleSections} rateLimits={api.rateLimits} t={t} />
+        )}
+      </>}
+    </div>
+  );
+}
+```
+
+> The refresh button stays inline (12 lines, not worth a component). Note `onSelectCategory` folds the original `setSelectedCategory(x); setSelectedSection(null)` pair (from `:455` and `:470`); the "all" pill inside `ApiCategoryTabs` calls `onSelectCategory(null)` → same reset. Keep `ApiCategoryTabs`' internal "all" and sub-tab buttons calling `onSelectCategory`/`onSelectSection` exactly as the original wired them.
+
+- [ ] **Step 2: Typecheck + build**
+
+Run (from `client/`): `npm run build`
+Expected: PASS (tsc -b clean; no unused imports; `ApiReferenceTab.tsx` now ~95–120 lines).
+
+- [ ] **Step 3: Lint (0-error gate) + full unit suite**
+
+Run (from `client/`): `npx eslint .`
+Expected: 0 errors (warnings allowed).
+
+Run (from `client/`): `npx vitest run`
+Expected: all green, including the four new test files.
+
+- [ ] **Step 4: Update `components/CLAUDE.md`**
+
+In the `manual/` table row, append the decomposition note (mirroring the other F2 rows), e.g.:
+
+```
+| `manual/` | User manual article viewer — `ApiReferenceTab` composes `api-reference/*` (`EndpointCard`, `ApiViewToggle`, `ApiBaseUrlCard`, `ApiSearchBar`, `ApiCategoryTabs`, `ApiSchemaError`, `ApiLoadingSkeleton`, `ApiSectionList`) + pure `lib/apiRateLimitMatch`; state/fetch in `hooks/useApiReference` (extracted F2/#301) |
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/manual/ApiReferenceTab.tsx client/src/components/CLAUDE.md
+git commit -m "refactor(api-ref): ApiReferenceTab thin orchestrator over api-reference/* + useApiReference (#301) [F2]"
+```
+
+---
+
+### Task 6: Browser smoke verification
+
+**Files:** none (manual verification against the running dev app).
+
+- [ ] **Step 1: Start dev + open the API reference**
+
+Run: `python start_dev.py` (backend :8000/:3001, frontend :5173). Log in (admin/DevMode2024). Navigate to the manual → API reference tab.
+
+- [ ] **Step 2: Exercise the flows (verbatim behaviour check)**
+
+Confirm each still works as before the refactor:
+- Admin Docs↔Rate Limits toggle switches views; `RateLimitsTab` renders under "Rate Limits".
+- Category pill + sub-tab selection narrows the list; the "all" pill resets.
+- Search filters endpoints (path/description) and hides the category tabs while active.
+- An endpoint card expands/collapses; the response copy button copies (toast/clipboard).
+- Base-url copy button copies the URL and toasts.
+- Refresh spins and reloads the schema; the rate-limit badges show for admin.
+
+- [ ] **Step 3: Record the result**
+
+Note the outcome in the PR description (what was exercised, all green). No Playwright needed — no drag/touch interaction.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** pure helper (T1), hook (T2), EndpointCard (T3), 7 presentation components + barrel (T4), thin orchestrator + CLAUDE.md (T5), browser smoke (T6), full gates (T5 S2–S3). Test plan table from the spec → covered by T1 (matcher branches), T3 (card), T2 (hook), T4 (category/section smoke). All spec sections map to a task.
+- **Placeholder scan:** verbatim-port steps cite exact source line ranges + show the import/signature deltas; no "TBD"/"add error handling". Acceptable because the moved code already exists and is unambiguous.
+- **Type consistency:** `RateLimitConfig` defined in T1, consumed by T2/T3/T4; `UseApiReferenceResult` field names in T2 match the orchestrator's `api.*` reads in T5; component prop names in T4 match the T5 call sites (`onChange`/`onRetry`/`onSelectCategory`/`onSelectSection`/`value`/`error`/`apiBaseUrl`/`sections`).

--- a/docs/superpowers/plans/2026-07-13-f2-apireferencetab-implementation.md
+++ b/docs/superpowers/plans/2026-07-13-f2-apireferencetab-implementation.md
@@ -223,7 +223,7 @@ Create `client/src/__tests__/hooks/useApiReference.test.tsx`:
 
 ```tsx
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { renderHook, waitFor } from '@testing-library/react'
+import { renderHook, waitFor, act } from '@testing-library/react'
 
 // Controlled schema so the hook doesn't hit /openapi.json.
 const mkSection = (title: string, paths: string[]) => ({
@@ -279,24 +279,20 @@ describe('useApiReference', () => {
 
   it('visibleSections: search filters endpoints by path/description', () => {
     const { result } = renderHook(() => useApiReference({ isAdmin: false, token: null }))
-    result.current.setSearchQuery('files')
-    // re-read after state update
-    const { result: r2 } = renderHook(() => useApiReference({ isAdmin: false, token: null }))
-    r2.current.setSearchQuery('files')
-    // Query in a fresh render:
-    expect(SECTIONS.some(s => s.endpoints.some(e => e.path.includes('files')))).toBe(true)
+    act(() => result.current.setSearchQuery('files'))
+    // only the "Files" section survives the /api/files/list path match
+    expect(result.current.visibleSections.map(s => s.title)).toEqual(['Files'])
   })
 
   it('visibleSections: selecting a category narrows to its sections', () => {
     const { result } = renderHook(() => useApiReference({ isAdmin: false, token: null }))
-    result.current.setSelectedCategory('core')
-    // one render tick later the category sections are ['Files']
-    expect(CATEGORIES[0].sections.map(s => s.title)).toEqual(['Files'])
+    act(() => result.current.setSelectedCategory('core'))
+    expect(result.current.visibleSections.map(s => s.title)).toEqual(['Files'])
   })
 })
 ```
 
-> Note: React state updates inside `renderHook` need `act`/rerender to observe; keep the search/category assertions focused on the pure filter contract (as above) to avoid flakiness. The core admin/non-admin fetch behaviour is the load-bearing coverage.
+> Note: state updates must be wrapped in `act(...)` from `@testing-library/react` (the repo standard — see `useRaidSetupWizard.test.tsx` / `useSleepConfigForm.test.ts`), then assert on `result.current.visibleSections`. Do NOT assert on the raw fixture constants — that would test nothing.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -369,7 +365,9 @@ export function useApiReference({ isAdmin, token }: UseApiReferenceArgs): UseApi
   };
 
   const visibleSections = useMemo(() => {
-    // copy lines 306-326 verbatim
+    // copy the memo BODY, lines 306-325, verbatim (NOT line 326 — that is the
+    // closing `}, [...]);` which this template already provides; copying it too
+    // duplicates the closing and is a syntax error).
   }, [searchQuery, selectedCategory, selectedSection, apiSections, apiCategories]);
 
   const currentCategorySections = selectedCategory
@@ -386,7 +384,7 @@ export function useApiReference({ isAdmin, token }: UseApiReferenceArgs): UseApi
 }
 ```
 
-> Behaviour note: the effect dep array stays `[isAdmin]` (matches the original — it does NOT re-fetch on token change). The `eslint-disable-next-line` keeps the 0-error gate clean without changing behaviour.
+> Behaviour note: the effect dep array stays `[isAdmin]` (matches the original — it does NOT re-fetch on token change). The `eslint-disable-next-line react-hooks/exhaustive-deps` is a benign addition (the original relies on the ungated warning); it changes no behaviour and just silences the one warning this moved code would otherwise emit. `exhaustive-deps` is a warning, not part of the 0-error gate — the disable is cosmetic. `loadRateLimits` is referenced in the effect above its `const` declaration exactly as the original does; the deferred effect callback runs after the `const` is initialised, so there is no TDZ error.
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -457,7 +455,9 @@ describe('EndpointCard', () => {
     expect(screen.queryByText('{"token":"x"}')).toBeNull()
     fireEvent.click(screen.getByText('/api/auth/login'))
     expect(screen.getByText('{"token":"x"}')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: '' })) // copy button (icon-only)
+    // after expansion the copy button is the only <button> in the card
+    // (the header toggle is a <div onClick>, not a button)
+    fireEvent.click(screen.getByRole('button'))
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('{"token":"x"}')
   })
 })
@@ -493,7 +493,7 @@ export function EndpointCard({ endpoint, rateLimits, t }: EndpointCardProps) {
 - [ ] **Step 4: Run test to verify it passes**
 
 Run (from `client/`): `npx vitest run src/__tests__/components/manual/api-reference/EndpointCard.test.tsx`
-Expected: PASS. If the icon-only copy-button query is ambiguous, select via `getAllByRole('button')` and click the last one.
+Expected: PASS. (The expanded card has exactly one `<button>` — the copy button — so `getByRole('button')` is unambiguous.)
 
 - [ ] **Step 5: Commit**
 


### PR DESCRIPTION
## F2-Zerlegung: `ApiReferenceTab.tsx` (#301)

Verhaltenserhaltende Zerlegung von `client/src/components/manual/ApiReferenceTab.tsx` (**565 → 66 Zeilen**) in einen dünnen Orchestrator über einen pure Helper, einen State-Hook und acht Präsentations-Komponenten. Gleiches Muster wie die 14 vorherigen F2-Zerlegungen (#396–#414). Full split (Variante A).

### Neue Einheiten
| Datei | Verantwortung |
|---|---|
| `lib/apiRateLimitMatch.ts` | pure `matchEndpointToRateLimitType` (+ `RateLimitConfig`) — Branch-Reihenfolge 1:1 (spiegelt Backend-Decorator-Zuordnung) |
| `hooks/useApiReference.ts` | View/Fetch/Derived-State (`loadRateLimits` admin-gated, `visibleSections`-Memo, `useOpenApiSchema`-Pass-through) |
| `components/manual/api-reference/*` | `EndpointCard`, `ApiViewToggle`, `ApiBaseUrlCard`, `ApiSearchBar`, `ApiCategoryTabs`, `ApiSchemaError`, `ApiLoadingSkeleton`, `ApiSectionList` + Barrel |

`ApiReferenceTab.tsx` bleibt dünner Orchestrator; Public API (`{ isAdmin, token }`) unverändert.

### Tests
Komponente hatte **0 Tests** → Netto-Zugewinn: pure Matcher-Branch-Tests (alle order-sensitiven Pfade gepinnt: auth specific-before-catch-all, files chunked-before-upload, shares write-vs-read, benchmark/run-before-admin, GET-Splits, `null`-Fallback), `useApiReference` (admin/non-admin Fetch + `visibleSections`-Filter via `act`), `EndpointCard` (expand/copy), Smoke für `ApiCategoryTabs`/`ApiSectionList`.

### Verifikation
- `npm run build` clean (tsc -b) · `eslint .` **0 Errors** · `vitest` **1069/1069 grün**
- Kritisches Plan-Review (adversarisch gegen den Code) + Per-Task-Review (Task 4) + finaler Whole-Branch-Review (Opus) → **Ready to merge**, keine Critical/Important
- Load-bearing verifiziert: Kategorie-Pill **Dual-Reset** (`setSelectedCategory(id); setSelectedSection(null)` für `null` **und** `cat.id`) korrekt im Orchestrator komponiert
- Browser-Smoke: in der Entwicklungsumgebung nicht fahrbar (Playwright-MCP auf `chrome`-Channel gepinnt, kein System-Chrome/Admin) — verhaltenserhaltender Docs-Tab-Refactor, niedrigste F2-Risikoklasse

### Deviation
`ApiSearchBar` nutzt `TFunction` statt `(key, fallback?) => string` (strukturelle Zuweisbarkeit von i18next; Präzedenz `mobileDeviceDates.ts`) — typsicher, im finalen Review als sound bewertet.

### Nebenbefund (out-of-scope, verhaltensgetreu portiert)
`useApiReference`-Effect feuert nur auf `[isAdmin]`, nicht auf `token` → ein nach Mount eintreffender Token ohne `isAdmin`-Wechsel triggert keinen Re-Fetch. Pre-existing, keine Regression. Follow-up-Issue nur, falls das je praktisch auffällt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
