### PR TITLE
ci: move frontend-build into rootless podman on the ci-sandbox runner

### DIFF
--- a/.claude/rules/ci-cd-security.md
+++ b/.claude/rules/ci-cd-security.md
@@ -31,7 +31,7 @@ Owned paths:
 
 | Workflow | Runner | Triggers |
 |---|---|---|
-| `ci-check.yml` `frontend-build` | `ubuntu-latest` | `pull_request`, `workflow_call` |
+| `ci-check.yml` `frontend-build` | **upstream: `self-hosted, ci-sandbox` (hardcoded repo literal); forks: `vars.FRONTEND_BUILD_RUNNER`, default `ubuntu-latest`** (rootless Podman everywhere) | `pull_request` (gated by `ci-tests` env), `workflow_call` (ungated) |
 | `ci-check.yml` `backend-tests` | **upstream: `self-hosted, ci-sandbox` (hardcoded repo literal); forks: `vars.BACKEND_TEST_RUNNER`, default `ubuntu-latest`** (rootless Podman everywhere) | `pull_request` (gated by `ci-tests` env), `workflow_call` (ungated) |
 | `create-release.yml` | `ubuntu-latest` | tag push (`v*-pre.*`) |
 | `deploy-pi.yml` | `ubuntu-latest` | `workflow_dispatch` |
@@ -58,9 +58,13 @@ A workflow on `ci-sandbox` that runs `pip install` directly on the runner host (
 are driven exclusively by `github.repository == 'Xveyn/BaluHost'` literals and
 server-side Repository Variables (`vars.*`, set via `scripts/configure-ci.sh`).
 Upstream behavior is hardcoded and needs no variables; PR code cannot influence
-runner choice or environment gates through either mechanism. The `ci-tests`
-gate condition on `pull_request` events is
-`github.repository == 'Xveyn/BaluHost' || contains(vars.BACKEND_TEST_RUNNER, 'self-hosted')`.
+runner choice or environment gates through either mechanism. `backend-tests`
+and `frontend-build` follow the identical pattern, gated by `vars.BACKEND_TEST_RUNNER`
+and `vars.FRONTEND_BUILD_RUNNER` respectively. The `ci-tests` gate condition on
+`pull_request` events is
+`github.repository == 'Xveyn/BaluHost' || contains(vars.BACKEND_TEST_RUNNER, 'self-hosted')`
+for `backend-tests`, and the same shape with `contains(vars.FRONTEND_BUILD_RUNNER, 'self-hosted')`
+for `frontend-build`.
 `raid-mdadm-loopback.yml` is deliberately NOT runner-configurable: real mdadm on
 a self-hosted box could destroy disks — only the on/off toggle
 `ENABLE_RAID_LOOPBACK` exists, and `BALUHOST_MDADM_LOOPBACK=1` is never set
@@ -69,6 +73,8 @@ be invalid: ENABLE_*" on the toggle vars are expected — the variables are
 intentionally unset upstream (unset → `''` → defaults apply).
 
 **Resolved (2026-06-09)**: the dead `raid-mdadm-selfhosted.yml` (which required a non-existent `mdadm` runner label and only ran mock tests anyway) was retired and replaced by `raid-mdadm-loopback.yml` on `ubuntu-latest`. Real mdadm coverage now runs on ephemeral GitHub-hosted VMs against loop-device arrays — no self-hosted runner, no production-disk risk (issue #185).
+
+Fork-/dev-facing summary of the design decisions: `docs/CI.md`.
 
 ### Layer 3 — `github.actor == 'Xveyn'` Allowlist
 
@@ -101,7 +107,7 @@ The deploy job declares `environment: production`, so any run pauses for reviewe
 
 #### `ci-tests` Environment
 
-Gates PR-triggered backend test runs on `ci-sandbox`. Configured in GitHub repo settings.
+Gates PR-triggered backend/frontend runs on `ci-sandbox`. Configured in GitHub repo settings.
 
 | Setting | Required value | Verified state |
 |---|---|---|
@@ -124,7 +130,7 @@ These live as GitHub server-state and cannot be read from the repo. Verify perio
 | Branch protection on `main` | `gh api repos/Xveyn/BaluHost/branches/main/protection` | Required status checks: `backend-tests`, `frontend-build` (jobs from `ci-check.yml`); `allow_force_pushes: false`; `allow_deletions: false`; `enforce_admins: false` (admin bypass — see Known Gaps) |
 | Production environment | `gh api repos/Xveyn/BaluHost/environments/production` | `protection_rules` includes `required_reviewers` (Xveyn), `deployment_branch_policy.protected_branches: true`, `can_admins_bypass: false` |
 | `ci-tests` environment | `gh api repos/Xveyn/BaluHost/environments/ci-tests` | `protection_rules` includes `required_reviewers` (Xveyn), `can_admins_bypass: false` |
-| Self-hosted runners | `gh api repos/Xveyn/BaluHost/actions/runners` | `BaluNode` online (`self-hosted, Linux, X64, prod`) and `BaluNode-ci-sandbox` online (`self-hosted, Linux, X64, ci-sandbox`). The `prod` label is what `deploy-production.yml` targets; without it on `BaluNode` the deploy could land on the sandbox runner. |
+| Self-hosted runners | `gh api repos/Xveyn/BaluHost/actions/runners` | `BaluNode` online (`self-hosted, Linux, X64, prod`); `BaluNode-ci-sandbox` online (`self-hosted, Linux, X64, ci-sandbox`); expected: also `BaluNode-ci-sandbox-2` online (provisioned via `bootstrap-ci-runner.sh --dir runner-2`, see `docs/CI.md`), so `backend-tests` and `frontend-build` run in parallel instead of queuing on one instance. The `prod` label is what `deploy-production.yml` targets; without it on `BaluNode` the deploy could land on the sandbox runner. |
 | Default workflow permissions | `gh api repos/Xveyn/BaluHost/actions/permissions/workflow` | `default_workflow_permissions: read`, `can_approve_pull_request_reviews: false` |
 | `DEPLOY_PAT` secret | repo Settings → Secrets → Actions | Present, owned by Xveyn, has `repo` + `workflow` scopes only |
 
@@ -162,6 +168,6 @@ When reviewing changes that touch CI/CD, deploy scripts, or these rules:
 5. **In-repo CODEOWNERS for paths outside the repo (e.g., GitHub environment settings) is impossible** — Layer 4 protections must be re-verified manually after any account/plan change (see Repo Settings table).
 6. **`enforce_admins: false` on main branch protection** — Xveyn (owner/admin) can bypass branch protection (force-push, skip status checks). Intentional for solo-dev emergency hotfix capability; the production environment reviewer (Layer 4) still gates the actual deploy.
 7. **`raid-mdadm-selfhosted.yml` runner label mismatch — resolved (2026-06-09)** — The dead workflow was retired and replaced by `raid-mdadm-loopback.yml` on `ubuntu-latest` (loop-device mdadm tests). No self-hosted runner is involved, so the label-mismatch gap no longer exists (issue #185).
-8. **`ci-runner` and its containers have unrestricted egress** — A maliciously approved PR can exfiltrate the workdir contents and make outbound calls to arbitrary hosts. Mitigations: the `ci-tests` environment gate (manual approval), the limited blast radius (workdir contains only PR code), no production secrets reachable. Future tightening: egress firewall allowing only `pypi.org`, `files.pythonhosted.org`, `api.github.com`, `objects.githubusercontent.com`, `registry.docker.io`.
+8. **`ci-runner` and its containers have unrestricted egress** — A maliciously approved PR can exfiltrate the workdir contents and make outbound calls to arbitrary hosts. Mitigations: the `ci-tests` environment gate (manual approval), the limited blast radius (workdir contains only PR code), no production secrets reachable. Future tightening: egress firewall allowing only `pypi.org`, `files.pythonhosted.org`, `registry.npmjs.org`, `api.github.com`, `objects.githubusercontent.com`, `registry.docker.io`.
 9. **`baluhost` user may stop/start/mask/unmask `power-profiles-daemon`** — Added in `deploy/install/templates/sudoers-baluhost-power` for the CPU power authority feature (`backend/app/services/power/ppd_authority.py`). Intentional and tightly scoped: four explicit `systemctl <verb> power-profiles-daemon` invocations, no `ALL`, no wildcards, single target unit. Blast radius is limited to that one systemd unit; it grants no general service control. The verbs are exercised only behind the local-channel + admin gate (`require_local_admin`) on `PUT /api/power/authority`.
 10. **`baluhost` user may invoke the plugin spawn wrapper as root** — Added in `deploy/install/templates/baluhost-plugin-sudoers` (Track B Phase 5a). Intentional and tightly scoped: exactly one binary at `/usr/local/sbin/baluhost-spawn-plugin-worker.sh` (root:root 0755, outside `/opt/baluhost` so `baluhost` cannot swap it). The wrapper validates every caller-influenced argument, always drops privilege to the unprivileged `baluhost-plugin` user, and runs the worker in a dedicated network namespace (only loopback). It grants no general command execution — blast radius is one isolated subprocess under `baluhost-plugin` with no NAS-storage or secret access.

--- a/.claude/rules/ci-cd-security.md
+++ b/.claude/rules/ci-cd-security.md
@@ -151,7 +151,7 @@ When reviewing changes that touch CI/CD, deploy scripts, or these rules:
 - [ ] **Sudoers / systemd**: Changes under `deploy/install/templates/` to sudoers or service units? Verify the new rules are scoped to specific binaries with explicit args (no `ALL`, no globs that match user-controlled paths).
 - [ ] **Deploy script**: Changes to `deploy/scripts/ci-deploy.sh`? Verify no new shell injection surfaces (user-controlled env vars interpolated into commands), no new `sudo` invocations without sudoers entries, rollback path still works.
 - [ ] **Workflow secrets**: New `secrets.*` references? Confirm the secret exists, is scoped correctly, and is not echoed/logged.
-- [ ] **Fork-config gate logic**: Does a change touch the `github.repository == 'Xveyn/BaluHost'` literals or the `contains(vars.BACKEND_TEST_RUNNER, 'self-hosted')` environment-gate condition in `ci-check.yml`/`deploy-fork.yml`? If it weakens the upstream-hardcoded path or derives gates from PR-controlled data — block.
+- [ ] **Fork-config gate logic**: Does a change touch the `github.repository == 'Xveyn/BaluHost'` literals or the `contains(vars.BACKEND_TEST_RUNNER, 'self-hosted')` / `contains(vars.FRONTEND_BUILD_RUNNER, 'self-hosted')` environment-gate conditions in `ci-check.yml`/`deploy-fork.yml`? If it weakens the upstream-hardcoded path or derives gates from PR-controlled data — block.
 - [ ] **mdadm runner pin**: Does a change make the `raid-mdadm-loopback.yml` runner configurable, or set `BALUHOST_MDADM_LOOPBACK` outside that workflow? If yes — block (mdadm must never run on self-hosted hardware).
 
 ---

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -58,13 +58,17 @@ jobs:
           # `term:skip-covered` hides 100%-covered files to keep the log short.
           # `--cov-report=json` writes backend/coverage.json (bind-mounted, so it
           # survives the container) for the job-summary step below.
+          # -n 4 (not -n auto): --cpus is a CFS quota, not a cpuset — os.cpu_count()
+          # in the container still reports all 12 host threads, so -n auto would
+          # oversubscribe the 3g-capped container.
           podman run --rm \
             --network=bridge \
+            --cpus=4 --memory=3g \
             -v "${{ github.workspace }}:/work:Z" \
             -w /work/backend \
             -e NAS_MODE=dev \
             "$TEST_IMAGE" \
-            bash -c "set -euo pipefail; pip install --no-cache-dir -e '.[dev]' && python -m ruff check . && python -m pytest -q --timeout=120 -n auto -o addopts= --cov=app --cov-report=term:skip-covered --cov-report=json"
+            bash -c "set -euo pipefail; pip install --no-cache-dir -e '.[dev]' && python -m ruff check . && python -m pytest -q --timeout=120 -n 4 -o addopts= --cov=app --cov-report=term:skip-covered --cov-report=json"
 
       - name: Backend coverage → job summary
         if: always()
@@ -88,49 +92,82 @@ jobs:
             >> "$GITHUB_STEP_SUMMARY"
 
   frontend-build:
-    runs-on: ubuntu-latest
+    # Runner selection (#207-Muster, wie backend-tests): upstream IMMER der
+    # gehärtete ci-sandbox-Runner (nicht konfigurierbar); Forks wählen über
+    # die Repo-Variable FRONTEND_BUILD_RUNNER (JSON-Array, gesetzt von
+    # scripts/configure-ci.sh), Fallback secret-freie ubuntu-latest-VM.
+    # PR-Code kann das nicht beeinflussen: Repository-Literal + vars only.
+    runs-on: ${{ fromJSON(github.repository == 'Xveyn/BaluHost' && '["self-hosted","ci-sandbox"]' || vars.FRONTEND_BUILD_RUNNER || '"ubuntu-latest"') }}
+    # ci-tests-Freigabe-Gate: immer für Upstream-PRs; in Forks nur, wenn der
+    # Fork einen self-hosted Runner gewählt hat. workflow_call (aus
+    # deploy-production nach Merge) läuft ungegated — Code ist dann vertraut.
+    environment: ${{ (github.event_name == 'pull_request' && (github.repository == 'Xveyn/BaluHost' || contains(vars.FRONTEND_BUILD_RUNNER, 'self-hosted'))) && 'ci-tests' || '' }}
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v5
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: client/package-lock.json
+      - name: Assert runner identity (defense-in-depth tripwire)
+        # Upstream-only: identisch zum backend-tests-Tripwire.
+        if: github.repository == 'Xveyn/BaluHost'
+        run: |
+          set -euo pipefail
+          test "$(whoami)" = "ci-runner" || { echo "::error::Runner not running as ci-runner (got: $(whoami))"; exit 1; }
+          test "$(id -u)" -ne 0 || { echo "::error::Runner running as root"; exit 1; }
+          command -v podman >/dev/null || { echo "::error::podman not installed on runner host"; exit 1; }
+          for grp in docker sudo wheel; do
+            if id -nG "$(whoami)" | tr ' ' '\n' | grep -qx "$grp"; then
+              echo "::error::ci-runner is in group '$grp' — isolation broken"
+              exit 1
+            fi
+          done
+          echo "Identity OK: $(whoami) uid=$(id -u) groups=$(id -nG)"
 
-      - name: Install dependencies
-        working-directory: client
-        run: npm ci
-
-      - name: Lint (ESLint)
-        working-directory: client
-        run: npx eslint .
-
-      - name: Build
-        working-directory: client
-        run: npm run build
-
-      - name: Run unit tests (with coverage)
-        working-directory: client
-        # Coverage is measured and printed only — no thresholds enforced yet
-        # (see vite.config.ts `test.coverage`). The unit tests themselves still
-        # gate the build; a low coverage number does not fail CI.
-        run: npm run test:coverage
+      - name: Lint + build + unit tests (with coverage) in rootless Podman container
+        env:
+          NODE_IMAGE: docker.io/library/node:20-slim
+        run: |
+          set -euo pipefail
+          # Kein npm-Cache: ein PR-beschreibbarer Cache wäre geteilter Zustand
+          # zwischen PRs (Poisoning). npm ci läuft frisch, wie pip install im
+          # backend-tests-Job. --cpus/--memory: die Box ist zugleich Prod-NAS;
+          # CI darf sie nicht sättigen. Kein git im Image: vite.config.ts
+          # fällt auf __GIT_COMMIT__='unknown'/buildType 'release' zurück —
+          # akzeptiert, der Gate-Build wird verworfen (Deploy baut auf
+          # BaluNode mit git). Details: docs/CI.md.
+          # --maxWorkers=4: --cpus ist eine CFS-Quote, KEIN cpuset — os.cpus()
+          # im Container meldet weiterhin alle 12 Host-Threads, Vitest würde
+          # also ~11 jsdom-Worker in die 3-GB-Grenze spawnen (OOM-Kill).
+          podman run --rm \
+            --network=bridge \
+            --cpus=4 --memory=3g \
+            -v "${{ github.workspace }}:/work:Z" \
+            -w /work/client \
+            "$NODE_IMAGE" \
+            bash -c "set -euo pipefail; npm ci && npx eslint . && npm run build && npm run test:coverage -- --maxWorkers=4"
 
       - name: Frontend coverage → job summary
         if: always()
-        working-directory: client
-        # Reads the json-summary written by the coverage run and appends a
-        # markdown block to the run summary. Best-effort: no-op if the file is
-        # missing (e.g. tests failed before coverage was written).
+        env:
+          NODE_IMAGE: docker.io/library/node:20-slim
         run: |
-          node -e '
-            const fs = require("fs");
-            const p = "coverage/coverage-summary.json";
-            if (!fs.existsSync(p)) process.exit(0);
-            const t = JSON.parse(fs.readFileSync(p, "utf8")).total;
-            const row = (k) => `| ${k} | ${t[k].pct}% (${t[k].covered}/${t[k].total}) |`;
-            const md = ["## Frontend coverage (client)", "", "| Metric | Coverage |", "|---|---|", row("lines"), row("statements"), row("functions"), row("branches"), ""].join("\n");
-            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, md + "\n");
-          '
+          set -euo pipefail
+          if [ ! -f client/coverage/coverage-summary.json ]; then
+            echo "no client/coverage/coverage-summary.json — skipping coverage summary"
+            exit 0
+          fi
+          # Parsen im selben gepinnten Image (nur stdlib, kein npm install).
+          # Der Container schreibt nach stdout; die Umleitung in
+          # $GITHUB_STEP_SUMMARY passiert auf dem HOST — die Variable ist ein
+          # Host-Pfad und existiert im Container nicht.
+          podman run --rm \
+            -v "${{ github.workspace }}:/work:Z" \
+            -w /work/client \
+            "$NODE_IMAGE" \
+            node -e '
+              const fs = require("fs");
+              const t = JSON.parse(fs.readFileSync("coverage/coverage-summary.json", "utf8")).total;
+              const row = (k) => `| ${k} | ${t[k].pct}% (${t[k].covered}/${t[k].total}) |`;
+              process.stdout.write(["## Frontend coverage (client)", "", "| Metric | Coverage |", "|---|---|", row("lines"), row("statements"), row("functions"), row("branches"), ""].join("\n") + "\n");
+            ' \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/ci-config.example.conf
+++ b/ci-config.example.conf
@@ -7,6 +7,7 @@
 # so your variable set stays minimal.
 #
 # Full guide: docs/deployment/SELF_HOSTING.en.md
+# CI design decisions (runners, gates, caching): docs/CI.md
 # NOTE: This config has no effect on the canonical repo (Xveyn/BaluHost) —
 # its pipeline behavior is hardcoded in the workflows.
 
@@ -16,6 +17,13 @@ BACKEND_TEST_RUNNER=github
 # Extra labels of your self-hosted runner (comma-separated).
 # Only used with BACKEND_TEST_RUNNER=self-hosted. 'self-hosted' is always implied.
 #BACKEND_TEST_RUNNER_LABELS=my-test-box
+
+# Where the frontend build+tests run: 'github' (default, ubuntu-latest VM) or 'self-hosted'
+FRONTEND_BUILD_RUNNER=github
+
+# Extra labels of your self-hosted runner (comma-separated).
+# Only used with FRONTEND_BUILD_RUNNER=self-hosted. 'self-hosted' is always implied.
+#FRONTEND_BUILD_RUNNER_LABELS=my-test-box
 
 # --- Secret-free workflows (default: enabled) ---
 ENABLE_PLAYWRIGHT_E2E=true

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,128 @@
+# CI Design Decisions
+
+Why the BaluHost pipeline is built the way it is. This is a reference for
+fork maintainers and contributors — it explains intent so you don't "fix" a
+deliberate non-feature. For fork setup, see `ci-config.example.conf` +
+`scripts/configure-ci.sh` (walkthrough: `docs/deployment/SELF_HOSTING.en.md`).
+The internal threat model and full layer-by-layer security rationale live in
+`.claude/rules/ci-cd-security.md` — this document summarizes, it does not
+replace it.
+
+## Runner model
+
+| Job (workflow) | Upstream runner | Fork variable | PR approval gate |
+|---|---|---|---|
+| `ci-check.yml` → `backend-tests` | `self-hosted, ci-sandbox` (hardcoded) | `BACKEND_TEST_RUNNER` (default: `ubuntu-latest`) | `ci-tests` on `pull_request`; ungated on `workflow_call` |
+| `ci-check.yml` → `frontend-build` | `self-hosted, ci-sandbox` (hardcoded) | `FRONTEND_BUILD_RUNNER` (default: `ubuntu-latest`) | `ci-tests` on `pull_request`; ungated on `workflow_call` |
+| `create-release.yml` → `release` | `ubuntu-latest` | — | none (tag-push only, never sees PR code) |
+| `deploy-fork.yml` → `ci-check` / `deploy` | fork-supplied only; dead upstream (`github.repository != 'Xveyn/BaluHost'` guard) | `DEPLOY_FORK_RUNNER` (required once `ENABLE_DEPLOY_FORK=true`) | `environment: fork-production` (protection is opt-in — you must add required reviewers yourself) |
+| `deploy-pi.yml` → `deploy` | `ubuntu-latest` | `ENABLE_DEPLOY_PI` (on/off) | none |
+| `deploy-production.yml` → `deploy` | `[self-hosted, prod]` (hardcoded, not fork-configurable) | — | `environment: production` + actor allowlist (Layer 3 in the security rules) |
+| `playwright-e2e.yml` → `mock-e2e` | `ubuntu-latest` | `ENABLE_PLAYWRIGHT_E2E` (on/off) | none |
+| `playwright-e2e.yml` → `live-e2e` | `ubuntu-latest` | `ENABLE_PLAYWRIGHT_E2E` (on/off) | `environment: live-e2e` + `RUN_LIVE_E2E` secret, `workflow_dispatch` only |
+| `raid-mdadm-loopback.yml` → `mdadm-loopback` | `ubuntu-latest` (hardcoded, **must not** become configurable) | `ENABLE_RAID_LOOPBACK` (on/off only — no runner variable exists) | none |
+| `release-stable.yml` → `release` | `ubuntu-latest` | `ENABLE_RELEASE_STABLE` (needs a `DEPLOY_PAT` secret) | none (`workflow_dispatch` already requires repo write access) |
+| `tauri-build.yml` → `build` | `ubuntu-latest` (hardcoded) | `ENABLE_TAURI_BUILD` (on/off) | none |
+| `tui-build.yml` → `build` | `ubuntu-latest` (hardcoded) | `ENABLE_TUI_BUILD` (on/off) | none |
+
+`raid-mdadm-loopback` is deliberately **not** runner-configurable — see
+"Deliberate non-features" below.
+
+### Two-layer isolation of `ci-sandbox`
+
+PR-triggered jobs that land on the self-hosted `ci-sandbox` runner never
+execute untrusted code directly on the runner host. Two independent layers,
+both set up by `scripts/bootstrap-ci-runner.sh` and re-checked by that
+script's self-tests on every run:
+
+- **POSIX user isolation.** The runner agent runs as `ci-runner`, an
+  unprivileged Linux user with no sudo, no membership in `docker`/`sudo`/`wheel`,
+  and no read access to the production install (`/opt/baluhost`,
+  `.env.production`).
+- **Rootless Podman.** `pip install`, `npm ci`, and the rest of the PR's
+  build/test commands run inside `podman run --rm` against a pinned image
+  (`python:3.11-slim` / `node:20-slim`), with only the checked-out workspace
+  bind-mounted in. No Docker daemon, no `docker.sock`, no host filesystem
+  access beyond that mount.
+
+Both PR-facing jobs in `ci-check.yml` also run an "assert runner identity"
+tripwire step (upstream only) that fails the job outright if it somehow ends
+up running as `root`, outside `ci-runner`, or in a privileged group.
+
+### Why the upstream runner choice is hardcoded
+
+`runs-on` for `backend-tests` and `frontend-build` is
+`github.repository == 'Xveyn/BaluHost' && '[...]' || vars.<NAME> || '"ubuntu-latest"'`
+— a repository literal, not anything derived from PR content. A PR cannot
+change which runner its own job lands on: forks steer this exclusively
+through server-side Repository Variables set via `scripts/configure-ci.sh`,
+which PR code cannot write to either.
+
+### Why there are two `ci-sandbox` instances
+
+A single GitHub Actions runner processes one job at a time. `bootstrap-ci-runner.sh`
+supports registering a second `ci-sandbox` instance on the same box (`--name`
+/ `--dir`, sharing the same `ci-runner` user and rootless Podman store) so
+that `backend-tests` and `frontend-build` — both gated, both potentially
+triggered by the same PR — run in parallel instead of queuing behind each
+other and roughly doubling PR turnaround time.
+
+## Approval gates
+
+**`ci-tests` environment.** PR-triggered jobs on self-hosted hardware pause
+for manual approval ("Review pending deployments") before they run at all.
+GitHub groups every job in a run that's waiting on the same environment under
+one prompt, so approving once releases both `backend-tests` and
+`frontend-build` together. `workflow_call` invocations of `ci-check.yml` (from
+`deploy-production.yml`, after a PR has already been merged to `main`) skip
+the gate — that code is already trusted.
+
+**Fork PR approval is the load-bearing control, not the environment.** A pull
+request from an outside contributor runs its own copy of the workflow file —
+including any edits it makes to that file — so it could in principle delete
+the `environment: ci-tests` line before it ever reaches the sandbox runner.
+It cannot, however, edit repository settings. The repo's fork-PR-workflow
+approval policy ("require approval for all external contributors") blocks
+the run itself before a single step executes, regardless of what the
+workflow YAML says. For same-repo branches (no fork involved), that policy
+does not apply — the `ci-tests` environment is what gates those, making the
+environment protection defense-in-depth relative to the fork policy rather
+than the other way around. Full detail: `.claude/rules/ci-cd-security.md`.
+
+## Deliberate non-features
+
+- **No dependency caches on self-hosted runners.** A cache a PR can write to
+  is shared mutable state between PRs — one PR could poison a package that a
+  later, unrelated run then trusts. `npm ci` and `pip install` run fresh,
+  inside the container, on every job.
+- **No git in the CI node image.** `frontend-build` uses `node:20-slim`,
+  which has no `git` binary. `client/vite.config.ts` shells out to `git` for
+  the build's commit hash and branch name and falls back to `'unknown'` /
+  release build type on failure — so the CI gate build silently gets
+  `__GIT_COMMIT__ = 'unknown'`. That's fine: this build is a pass/fail gate
+  whose artifact is discarded; the frontend that's actually deployed is built
+  separately on the production host during deploy, where git is present.
+  Don't "fix" this by installing git in the image.
+- **`raid-mdadm-loopback` never runs on self-hosted hardware.** It's pinned
+  to `ubuntu-latest` and the workflow explicitly forbids making the runner
+  configurable, even for forks — only an on/off toggle
+  (`ENABLE_RAID_LOOPBACK`) exists. Real `mdadm` commands against real disks
+  could destroy an array; the loop-device tests only ever run on disposable
+  GitHub-hosted VMs.
+- **Resource limits on CI containers.** Both sandbox jobs run their container
+  with `--cpus=4 --memory=3g`. The runner host also runs production BaluHost
+  workloads, so CI must not be free to saturate it. Because `--cpus` is a CFS
+  quota rather than a `cpuset`, tools that size their own worker pool from
+  `os.cpu_count()` still see every host thread — `pytest` is pinned to
+  `-n 4` and Vitest to `--maxWorkers=4` so neither oversubscribes the
+  3 GB container and gets OOM-killed.
+
+## Egress expectations
+
+The two sandboxed jobs and the runner agent itself need outbound access to:
+`registry.npmjs.org` (`npm ci` in `frontend-build`), `pypi.org` and
+`files.pythonhosted.org` (`pip install` in `backend-tests`),
+`registry.docker.io` (pulling the pinned `python:3.11-slim` / `node:20-slim`
+images), and `api.github.com` plus `objects.githubusercontent.com` (job
+orchestration, checkout, log/artifact upload). Any future egress firewall on
+the runner host must allow all of these or CI silently breaks.

--- a/docs/deployment/SELF_HOSTING.en.md
+++ b/docs/deployment/SELF_HOSTING.en.md
@@ -64,6 +64,23 @@ The RAID mdadm loopback tests are the deliberate exception: their runner is
 destroy disks on a physical machine; the tests only ever run on ephemeral
 GitHub VMs against loop devices.
 
+## Running the frontend build on your own machine
+
+1. Register a [self-hosted runner](https://docs.github.com/en/actions/hosting-your-own-runners)
+   on your fork and give it a label, e.g. `my-frontend-box`. Podman must be
+   installed on the runner host (build+tests run in a rootless container).
+2. In `ci-config.conf`: `FRONTEND_BUILD_RUNNER=self-hosted` and
+   `FRONTEND_BUILD_RUNNER_LABELS=my-frontend-box`, then re-run `scripts/configure-ci.sh`.
+3. **Security:** with a self-hosted build runner configured, PR-triggered
+   `frontend-build` runs in your fork request the same `ci-tests` environment
+   as `backend-tests`. GitHub auto-creates it unprotected on first use — if
+   you ever accept PRs from strangers into your fork, add yourself as a
+   required reviewer for `ci-tests` in your fork's Settings → Environments.
+   Never run PR code from people you don't trust on hardware you care about.
+   The gate detection relies on the JSON-array format `configure-ci.sh`
+   writes — if you set `FRONTEND_BUILD_RUNNER` by hand, keep the literal
+   `self-hosted` in the value.
+
 ## Deploying your fork to your own box (`deploy-fork`)
 
 Prerequisites (one-time, on a Debian box):
@@ -97,6 +114,8 @@ NOT part of fork deploys — that stays exclusive to the canonical pipeline.
   secret-dependent workflow (`ENABLE_DEPLOY_PI`, `ENABLE_RELEASE_STABLE`)
   without adding the secret to your fork. Disable it or add the secret.
 - **`backend-tests` hangs forever** — your `BACKEND_TEST_RUNNER` points at
+  labels no online runner has. Check `gh api repos/<you>/<fork>/actions/runners`.
+- **`frontend-build` hangs forever** — your `FRONTEND_BUILD_RUNNER` points at
   labels no online runner has. Check `gh api repos/<you>/<fork>/actions/runners`.
 - **`deploy-fork` fails** — `configure-ci.sh` refuses `ENABLE_DEPLOY_FORK=true`
   without `DEPLOY_FORK_RUNNER_LABELS` (stored as the `DEPLOY_FORK_RUNNER`

--- a/docs/superpowers/plans/2026-07-19-frontend-build-sandbox-runner.md
+++ b/docs/superpowers/plans/2026-07-19-frontend-build-sandbox-runner.md
@@ -81,13 +81,16 @@ Den bestehenden `frontend-build:`-Block vollständig ersetzen durch:
           # fällt auf __GIT_COMMIT__='unknown'/buildType 'release' zurück —
           # akzeptiert, der Gate-Build wird verworfen (Deploy baut auf
           # BaluNode mit git). Details: docs/CI.md.
+          # --maxWorkers=4: --cpus ist eine CFS-Quote, KEIN cpuset — os.cpus()
+          # im Container meldet weiterhin alle 12 Host-Threads, Vitest würde
+          # also ~11 jsdom-Worker in die 3-GB-Grenze spawnen (OOM-Kill).
           podman run --rm \
             --network=bridge \
             --cpus=4 --memory=3g \
             -v "${{ github.workspace }}:/work:Z" \
             -w /work/client \
             "$NODE_IMAGE" \
-            bash -c "set -euo pipefail; npm ci && npx eslint . && npm run build && npm run test:coverage"
+            bash -c "set -euo pipefail; npm ci && npx eslint . && npm run build && npm run test:coverage -- --maxWorkers=4"
 
       - name: Frontend coverage → job summary
         if: always()
@@ -118,18 +121,22 @@ Den bestehenden `frontend-build:`-Block vollständig ersetzen durch:
 
 Wichtige Deltas zum Original, die NICHT verloren gehen dürfen: `actions/setup-node` entfällt ersatzlos; das alte `node -e` nutzte `fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, …)` — im Container ist diese Env leer, deshalb stdout + Host-Redirect; der `if (!fs.existsSync(p)) process.exit(0)`-Guard wandert als `[ ! -f … ]` auf den Host (spart den Container-Start komplett).
 
-- [ ] **Step 2: Verifizieren**
+- [ ] **Step 2: backend-tests dieselbe Kappung geben (Spec, Abschnitt A)**
+
+Im `backend-tests`-Job desselben Files, am bestehenden `podman run` (Zeile ~64): `--cpus=4 --memory=3g` ergänzen **und** im inneren pytest-Aufruf `-n auto` durch `-n 4` ersetzen — aus demselben Grund wie oben: `-n auto` zählt die 12 Host-Threads, nicht die CFS-Quote. Sonst NICHTS an dem Job ändern (kein Umbau des Tripwires, der Env-Zeilen oder der Coverage-Schritte).
+
+- [ ] **Step 3: Verifizieren**
 
 Run: `bash -n` ist für YAML nutzlos — stattdessen: `npx --yes actionlint@latest .github/workflows/ci-check.yml 2>&1 | head -30` (falls Netz/npx verfügbar; sonst `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci-check.yml'))"` als Minimal-Syntaxcheck).
 Expected: keine neuen Fehler; Warnungen „Context access might be invalid: FRONTEND_BUILD_RUNNER" sind erwartet und OK.
 
-- [ ] **Step 3: Diff-Selbstkontrolle** — `git diff .github/workflows/ci-check.yml`: `backend-tests`-Job unangetastet, Job-ID `frontend-build` unverändert, keine anderen Jobs berührt.
+- [ ] **Step 4: Diff-Selbstkontrolle** — `git diff .github/workflows/ci-check.yml`: am `backend-tests`-Job NUR die zwei Kappungs-Änderungen (podman-Flags + `-n 4`), Job-ID `frontend-build` unverändert, keine anderen Jobs berührt.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add .github/workflows/ci-check.yml
-git commit -m "ci(frontend): run frontend-build in rootless podman on ci-sandbox (#gate: ci-tests)"
+git commit -m "ci(frontend): run frontend-build in rootless podman on ci-sandbox; cap CI container resources"
 ```
 
 ---
@@ -187,6 +194,8 @@ bash "/d/Programme (x86)/Baluhost/scripts/configure-ci.sh" --repo someone/BaluHo
 ```
 
 Expected: `[dry-run] gh variable set FRONTEND_BUILD_RUNNER … '["self-hosted","my-box"]'` — und mit `FRONTEND_BUILD_RUNNER=github` stattdessen die delete-Zeile. (Der `--repo`-Guard gegen Xveyn/BaluHost greift vor jedem echten API-Call; dry-run macht ohnehin keine.)
+
+**Achtung, ungeprüfte Annahme:** Der Test unterstellt, dass das Skript `ci-config.conf` im CWD sucht. Prüfe zuerst die `CONFIG_FILE`-Auflösung am Skriptanfang (Zeilen 1–40); sucht es im Repo-Root oder relativ zum Skript, den Test dort mit einer temporären `ci-config.conf` fahren (Datei ist gitignored) und sie danach löschen — sie darf unter keinen Umständen committet werden.
 
 - [ ] **Step 4: `SELF_HOSTING.en.md` prüfen** — per `Select-String -Path docs/deployment/SELF_HOSTING.en.md -Pattern "BACKEND_TEST_RUNNER"`. Bei Treffern den Frontend-Pendant-Absatz im selben Stil ergänzen; keine Treffer → nichts tun, im Report vermerken.
 
@@ -361,19 +370,18 @@ sudo cp -r /tmp/balu-ci-branch /var/lib/ci-runner/smoke && sudo chown -R ci-runn
 sudo -u ci-runner -H podman run --rm --network=bridge --cpus=4 --memory=3g \
   -v /var/lib/ci-runner/smoke:/work:Z -w /work/client \
   docker.io/library/node:20-slim \
-  bash -c "set -euo pipefail; npm ci && npx eslint . && npm run build && npm run test:coverage"
+  bash -c "set -euo pipefail; npm ci && npx eslint . && npm run build && npm run test:coverage -- --maxWorkers=4"
 # Erwartung: eslint 0 Errors, build OK, Vitest-Suite grün (~1134 Tests).
 # Laufzeit notieren (Vergleichswert: 4m46s auf ubuntu-latest).
-sudo rm -rf /var/lib/ci-runner/smoke /tmp/balu-ci-branch
+sudo rm -rf /var/lib/ci-runner/smoke
 ```
 
 - [ ] **Step 3: Registrierungs-Token holen** (am Dev-Rechner oder auf der Box, gh als Xveyn): `gh api -X POST repos/Xveyn/BaluHost/actions/runners/registration-token -q .token` — Token ist single-use, ~1 h gültig.
 
-- [ ] **Step 4: Zweite Instanz registrieren** (mit dem Skript AUS DEM BRANCH):
+- [ ] **Step 4: Zweite Instanz registrieren** (mit dem Skript aus dem Clone von Step 1):
 
 ```bash
-cd /tmp && git clone --depth 1 --branch feat/frontend-build-sandbox-runner https://github.com/Xveyn/BaluHost balu-ci-branch
-sudo ./balu-ci-branch/scripts/bootstrap-ci-runner.sh --token <TOKEN> --name BaluNode-ci-sandbox-2 --dir runner-2
+sudo /tmp/balu-ci-branch/scripts/bootstrap-ci-runner.sh --token <TOKEN> --name BaluNode-ci-sandbox-2 --dir runner-2
 # Das Skript ist idempotent und läuft seine Self-Tests selbst; es MUSS mit
 # "All self-tests passed" enden. Bricht es ab: Output an den Controller.
 rm -rf /tmp/balu-ci-branch
@@ -393,7 +401,7 @@ Expected: `BaluNode` (prod, online), `BaluNode-ci-sandbox` (online) **und** `Bal
 
 **Voraussetzungen:** Task 6 bestätigt (drei Runner online), PR #420 gemergt (sonst zuerst darauf hinweisen).
 
-- [ ] **Step 1: Push + PR.** PR-Body (via Write-Tool + `--body-file`, Memory: keine Here-Strings) muss enthalten: Zusammenfassung der Umstellung; die drei Spec-Entscheidungen (kein Cache / eigene Fork-Variable / zweite Instanz) mit je einem Satz Begründung; Hinweis auf `docs/CI.md`; **explizit**: „PRs pausieren ab jetzt sichtbar auf ‚Review pending deployments' — das ist das ci-tests-Gate, kein Hänger; ein Klick gibt beide Jobs frei"; Verweis auf Spec + PR #420.
+- [ ] **Step 1: Push + PR.** PR-Body (via Write-Tool + `--body-file`, Memory: keine Here-Strings) muss enthalten: Zusammenfassung der Umstellung; die drei Spec-Entscheidungen (kein Cache / eigene Fork-Variable / zweite Instanz) mit je einem Satz Begründung; Hinweis auf `docs/CI.md`; **explizit**: „PRs pausieren ab jetzt sichtbar auf ‚Review pending deployments' — das ist das ci-tests-Gate, kein Hänger; ein Klick gibt beide Jobs frei"; **und die DX-Änderung**: bisher lief `frontend-build` sofort und lieferte Lint-Feedback ohne Klick, während nur `backend-tests` wartete — künftig läuft vor der Freigabe gar nichts; Verweis auf Spec + PR #420.
 
 - [ ] **Step 2: Den eigenen PR-Lauf beobachten** — er führt bereits die neue Workflow-Datei aus:
   1. Beide Jobs warten auf ci-tests-Freigabe → Xveyn klickt „Approve and deploy".

--- a/docs/superpowers/plans/2026-07-19-frontend-build-sandbox-runner.md
+++ b/docs/superpowers/plans/2026-07-19-frontend-build-sandbox-runner.md
@@ -232,13 +232,7 @@ RUNNER_DIR="${RUNNER_HOME}/${RUNNER_DIR_NAME}"
 RUNNER_WORK="${RUNNER_HOME}/_work-${RUNNER_DIR_NAME}"
 ```
 
-**Kritisch — `RUNNER_WORK` muss pro Instanz getrennt sein:** zwei Runner, die dasselbe `_work` teilen, checken denselben Workspace-Pfad (`_work/BaluHost/BaluHost`) aus und zerstören sich bei parallelen Jobs gegenseitig den Checkout. Rückwärtskompatibilität für die bereits registrierte Erst-Instanz: prüfen, wo `RUNNER_WORK` verwendet wird (config.sh `--work`?) — falls die Erst-Instanz mit `${RUNNER_HOME}/_work` registriert ist, für `RUNNER_DIR_NAME=runner` den Alt-Pfad beibehalten:
-
-```bash
-if [[ "$RUNNER_DIR_NAME" == "runner" ]]; then
-  RUNNER_WORK="${RUNNER_HOME}/_work"   # Bestands-Instanz nicht umziehen
-fi
-```
+**KORREKTUR (Task 3, verifiziert):** Die ursprüngliche Sorge, zwei Instanzen teilten sich `_work` und zerschössen sich den Checkout, war unbegründet — `config.sh` erhält `--work "_work"` **relativ zu `RUNNER_DIR`**, der effektive Work-Dir ist also `$RUNNER_DIR/_work` und die Instanz-Trennung kommt mit `--dir` automatisch. `RUNNER_WORK` ist vorbestehender toter Code (einziger Effekt: ein `mkdir`-Pre-Create eines nie benutzten Verzeichnisses). Konsequenz: `RUNNER_WORK` bleibt unverändert auf `${RUNNER_HOME}/_work` für alle Instanzen (kein per-Instanz-Suffix — das würde nur ein weiteres unbenutztes Verzeichnis erzeugen), plus ein Kommentar, der den realen Work-Dir dokumentiert. Der tote Code selbst ist ein Nebenbefund (Maintainer-Entscheidung, ggf. Issue).
 
 - [ ] **Step 2: Node-Image vorab pullen** — bei den Konstanten `NODE_IMAGE="docker.io/library/node:20-slim"` ergänzen und neben dem bestehenden `as_runner podman pull "$TEST_IMAGE"` (Zeile ~169): `as_runner podman pull "$NODE_IMAGE"`. (Verhindert einen Pull-Race, wenn beide Instanzen gleichzeitig ihren ersten Job bekommen.)
 

--- a/docs/superpowers/plans/2026-07-19-frontend-build-sandbox-runner.md
+++ b/docs/superpowers/plans/2026-07-19-frontend-build-sandbox-runner.md
@@ -1,0 +1,406 @@
+# frontend-build → ci-sandbox Runner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `frontend-build` läuft PR-getriggert auf dem gehärteten `ci-sandbox`-Runner (BaluNode) hinter dem `ci-tests`-Freigabe-Gate, in rootless Podman — plus eine zweite Runner-Instanz gegen Serialisierung und eine neue `docs/CI.md` mit den Design-Entscheidungen.
+
+**Architecture:** Spiegelt exakt das `backend-tests`-Muster in `ci-check.yml`: hartkodierte Upstream-Runner-Wahl, `vars.FRONTEND_BUILD_RUNNER` für Forks, Identity-Tripwire, aller untrusted Code in **einem** `podman run` gegen `docker.io/library/node:20-slim`. Spec: `docs/superpowers/specs/2026-07-19-frontend-build-sandbox-runner-design.md`.
+
+**Tech Stack:** GitHub Actions, bash, rootless Podman, node:20-slim.
+
+## Global Constraints
+
+- **Reihenfolge ist Teil der Korrektheit:** Tasks 1–5 sind Branch-Arbeit. Task 6 (Operator, BaluNode) MUSS abgeschlossen sein, **bevor** der PR in Task 7 geöffnet wird — der PR-eigene CI-Lauf führt bereits die neue Workflow-Datei aus (`pull_request` nimmt die Workflow-Definition aus dem PR-Merge-Ref) und braucht daher schon den zweiten Runner und das gepullte Node-Image.
+- PR #420 (ci-tests-Gate-Doku) muss vor dem Merge dieses PRs gemergt sein.
+- Job-ID bleibt exakt `frontend-build` (Required-Status-Check auf `main`).
+- Podman-Aufruf mit `--cpus=4 --memory=3g` (Box ist Prod-NAS + Gaming-PC).
+- Kein npm-Cache, kein `actions/setup-node`, kein git im Container (Spec-Entscheidungen 1–3; `__GIT_COMMIT__`='unknown' ist akzeptiert und dokumentiert).
+- `$GITHUB_STEP_SUMMARY`-Umleitung passiert auf dem HOST (Backend-Muster) — der Container schreibt nur stdout.
+- Upstream-Verhalten hartkodiert über `github.repository == 'Xveyn/BaluHost'`; Fork-Wahl NUR über `vars.*`. actionlint-Warnungen „Context access might be invalid: FRONTEND_BUILD_RUNNER" sind erwartet (Variable upstream ungesetzt), analog zu den `ENABLE_*`-Warnungen.
+- Shell auf der Dev-Maschine ist PowerShell 5.1 (kein `&&`); Bash-Tool für POSIX. Skript-Syntaxprüfung: `bash -n <script>`.
+- Commit-Trailer: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- Branch: `feat/frontend-build-sandbox-runner` (existiert, enthält den Spec).
+
+---
+
+### Task 1: `ci-check.yml` — frontend-build auf Sandbox-Muster umstellen
+
+**Files:**
+- Modify: `.github/workflows/ci-check.yml` (der komplette `frontend-build:`-Job)
+- Referenz (nur lesen): derselbe File, `backend-tests:`-Job — Tripwire-Step und Podman-Muster von dort spiegeln
+
+**Interfaces:**
+- Produces: Job `frontend-build` mit identischer Job-ID; für Task 2 die Variablennamen `FRONTEND_BUILD_RUNNER` (JSON-Array-String, z. B. `["self-hosted","my-box"]`).
+
+- [ ] **Step 1: Job ersetzen**
+
+Den bestehenden `frontend-build:`-Block vollständig ersetzen durch:
+
+```yaml
+  frontend-build:
+    # Runner selection (#207-Muster, wie backend-tests): upstream IMMER der
+    # gehärtete ci-sandbox-Runner (nicht konfigurierbar); Forks wählen über
+    # die Repo-Variable FRONTEND_BUILD_RUNNER (JSON-Array, gesetzt von
+    # scripts/configure-ci.sh), Fallback secret-freie ubuntu-latest-VM.
+    # PR-Code kann das nicht beeinflussen: Repository-Literal + vars only.
+    runs-on: ${{ fromJSON(github.repository == 'Xveyn/BaluHost' && '["self-hosted","ci-sandbox"]' || vars.FRONTEND_BUILD_RUNNER || '"ubuntu-latest"') }}
+    # ci-tests-Freigabe-Gate: immer für Upstream-PRs; in Forks nur, wenn der
+    # Fork einen self-hosted Runner gewählt hat. workflow_call (aus
+    # deploy-production nach Merge) läuft ungegated — Code ist dann vertraut.
+    environment: ${{ (github.event_name == 'pull_request' && (github.repository == 'Xveyn/BaluHost' || contains(vars.FRONTEND_BUILD_RUNNER, 'self-hosted'))) && 'ci-tests' || '' }}
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Assert runner identity (defense-in-depth tripwire)
+        # Upstream-only: identisch zum backend-tests-Tripwire.
+        if: github.repository == 'Xveyn/BaluHost'
+        run: |
+          set -euo pipefail
+          test "$(whoami)" = "ci-runner" || { echo "::error::Runner not running as ci-runner (got: $(whoami))"; exit 1; }
+          test "$(id -u)" -ne 0 || { echo "::error::Runner running as root"; exit 1; }
+          command -v podman >/dev/null || { echo "::error::podman not installed on runner host"; exit 1; }
+          for grp in docker sudo wheel; do
+            if id -nG "$(whoami)" | tr ' ' '\n' | grep -qx "$grp"; then
+              echo "::error::ci-runner is in group '$grp' — isolation broken"
+              exit 1
+            fi
+          done
+          echo "Identity OK: $(whoami) uid=$(id -u) groups=$(id -nG)"
+
+      - name: Lint + build + unit tests (with coverage) in rootless Podman container
+        env:
+          NODE_IMAGE: docker.io/library/node:20-slim
+        run: |
+          set -euo pipefail
+          # Kein npm-Cache: ein PR-beschreibbarer Cache wäre geteilter Zustand
+          # zwischen PRs (Poisoning). npm ci läuft frisch, wie pip install im
+          # backend-tests-Job. --cpus/--memory: die Box ist zugleich Prod-NAS;
+          # CI darf sie nicht sättigen. Kein git im Image: vite.config.ts
+          # fällt auf __GIT_COMMIT__='unknown'/buildType 'release' zurück —
+          # akzeptiert, der Gate-Build wird verworfen (Deploy baut auf
+          # BaluNode mit git). Details: docs/CI.md.
+          podman run --rm \
+            --network=bridge \
+            --cpus=4 --memory=3g \
+            -v "${{ github.workspace }}:/work:Z" \
+            -w /work/client \
+            "$NODE_IMAGE" \
+            bash -c "set -euo pipefail; npm ci && npx eslint . && npm run build && npm run test:coverage"
+
+      - name: Frontend coverage → job summary
+        if: always()
+        env:
+          NODE_IMAGE: docker.io/library/node:20-slim
+        run: |
+          set -euo pipefail
+          if [ ! -f client/coverage/coverage-summary.json ]; then
+            echo "no client/coverage/coverage-summary.json — skipping coverage summary"
+            exit 0
+          fi
+          # Parsen im selben gepinnten Image (nur stdlib, kein npm install).
+          # Der Container schreibt nach stdout; die Umleitung in
+          # $GITHUB_STEP_SUMMARY passiert auf dem HOST — die Variable ist ein
+          # Host-Pfad und existiert im Container nicht.
+          podman run --rm \
+            -v "${{ github.workspace }}:/work:Z" \
+            -w /work/client \
+            "$NODE_IMAGE" \
+            node -e '
+              const fs = require("fs");
+              const t = JSON.parse(fs.readFileSync("coverage/coverage-summary.json", "utf8")).total;
+              const row = (k) => `| ${k} | ${t[k].pct}% (${t[k].covered}/${t[k].total}) |`;
+              process.stdout.write(["## Frontend coverage (client)", "", "| Metric | Coverage |", "|---|---|", row("lines"), row("statements"), row("functions"), row("branches"), ""].join("\n") + "\n");
+            ' \
+            >> "$GITHUB_STEP_SUMMARY"
+```
+
+Wichtige Deltas zum Original, die NICHT verloren gehen dürfen: `actions/setup-node` entfällt ersatzlos; das alte `node -e` nutzte `fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, …)` — im Container ist diese Env leer, deshalb stdout + Host-Redirect; der `if (!fs.existsSync(p)) process.exit(0)`-Guard wandert als `[ ! -f … ]` auf den Host (spart den Container-Start komplett).
+
+- [ ] **Step 2: Verifizieren**
+
+Run: `bash -n` ist für YAML nutzlos — stattdessen: `npx --yes actionlint@latest .github/workflows/ci-check.yml 2>&1 | head -30` (falls Netz/npx verfügbar; sonst `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci-check.yml'))"` als Minimal-Syntaxcheck).
+Expected: keine neuen Fehler; Warnungen „Context access might be invalid: FRONTEND_BUILD_RUNNER" sind erwartet und OK.
+
+- [ ] **Step 3: Diff-Selbstkontrolle** — `git diff .github/workflows/ci-check.yml`: `backend-tests`-Job unangetastet, Job-ID `frontend-build` unverändert, keine anderen Jobs berührt.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci-check.yml
+git commit -m "ci(frontend): run frontend-build in rootless podman on ci-sandbox (#gate: ci-tests)"
+```
+
+---
+
+### Task 2: Fork-Konfiguration (`ci-config.example.conf` + `configure-ci.sh`)
+
+**Files:**
+- Modify: `ci-config.example.conf` (nach dem `BACKEND_TEST_RUNNER_LABELS`-Block)
+- Modify: `scripts/configure-ci.sh:46-48` (`KNOWN_KEYS`) und nach `:113` (neuer case-Block)
+- Prüfen/ggf. Modify: `docs/deployment/SELF_HOSTING.en.md` (falls dort `BACKEND_TEST_RUNNER` dokumentiert ist, `FRONTEND_BUILD_RUNNER` analog ergänzen)
+
+**Interfaces:**
+- Consumes: Variablennamen aus Task 1.
+- Produces: Config-Keys `FRONTEND_BUILD_RUNNER` (`github`|`self-hosted`, Default `github`) und `FRONTEND_BUILD_RUNNER_LABELS` (CSV).
+
+- [ ] **Step 1: `ci-config.example.conf` ergänzen** — direkt unter dem `#BACKEND_TEST_RUNNER_LABELS=…`-Block:
+
+```
+# Where the frontend build+tests run: 'github' (default, ubuntu-latest VM) or 'self-hosted'
+FRONTEND_BUILD_RUNNER=github
+
+# Extra labels of your self-hosted runner (comma-separated).
+# Only used with FRONTEND_BUILD_RUNNER=self-hosted. 'self-hosted' is always implied.
+#FRONTEND_BUILD_RUNNER_LABELS=my-test-box
+```
+
+Zusätzlich im Kopfkommentar der Datei (nach der Zeile mit `docs/deployment/SELF_HOSTING.en.md`) den Verweis ergänzen: `# CI design decisions (runners, gates, caching): docs/CI.md`
+
+- [ ] **Step 2: `configure-ci.sh` erweitern**
+
+`KNOWN_KEYS` (Zeile 46–48): `FRONTEND_BUILD_RUNNER FRONTEND_BUILD_RUNNER_LABELS` in die Liste aufnehmen.
+
+Nach dem `BACKEND_TEST_RUNNER`-Block (nach Zeile 113) einfügen:
+
+```bash
+case "${CFG[FRONTEND_BUILD_RUNNER]:-github}" in
+    github)      del_var FRONTEND_BUILD_RUNNER ;;
+    self-hosted) set_var FRONTEND_BUILD_RUNNER "$(labels_to_json "${CFG[FRONTEND_BUILD_RUNNER_LABELS]:-}")" ;;
+    *) die "FRONTEND_BUILD_RUNNER must be 'github' or 'self-hosted'" ;;
+esac
+if [[ "${CFG[FRONTEND_BUILD_RUNNER]:-github}" != "self-hosted" && -n "${CFG[FRONTEND_BUILD_RUNNER_LABELS]:-}" ]]; then
+    echo "WARNING: FRONTEND_BUILD_RUNNER_LABELS is set but FRONTEND_BUILD_RUNNER is not 'self-hosted' — labels ignored" >&2
+fi
+```
+
+- [ ] **Step 3: Verifizieren**
+
+Run: `bash -n scripts/configure-ci.sh` — Expected: kein Output.
+Run (Dry-Run-Funktionstest im Scratchpad, NICHT im Repo):
+
+```bash
+cd "$(mktemp -d)" || exit 1
+printf 'FRONTEND_BUILD_RUNNER=self-hosted\nFRONTEND_BUILD_RUNNER_LABELS=my-box\n' > ci-config.conf
+bash "/d/Programme (x86)/Baluhost/scripts/configure-ci.sh" --repo someone/BaluHost --dry-run
+```
+
+Expected: `[dry-run] gh variable set FRONTEND_BUILD_RUNNER … '["self-hosted","my-box"]'` — und mit `FRONTEND_BUILD_RUNNER=github` stattdessen die delete-Zeile. (Der `--repo`-Guard gegen Xveyn/BaluHost greift vor jedem echten API-Call; dry-run macht ohnehin keine.)
+
+- [ ] **Step 4: `SELF_HOSTING.en.md` prüfen** — per `Select-String -Path docs/deployment/SELF_HOSTING.en.md -Pattern "BACKEND_TEST_RUNNER"`. Bei Treffern den Frontend-Pendant-Absatz im selben Stil ergänzen; keine Treffer → nichts tun, im Report vermerken.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ci-config.example.conf scripts/configure-ci.sh docs/deployment/SELF_HOSTING.en.md
+git commit -m "ci(fork-config): FRONTEND_BUILD_RUNNER variable + apply-script support"
+```
+
+---
+
+### Task 3: `bootstrap-ci-runner.sh` — Mehrfachinstanzen + Node-Image
+
+**Files:**
+- Modify: `scripts/bootstrap-ci-runner.sh`
+
+**Interfaces:**
+- Produces: neuer Flag `--dir <name>` (Instanzverzeichnis-Name unter `$RUNNER_HOME`, Default `runner`); daraus abgeleitet `RUNNER_DIR` **und** `RUNNER_WORK`; Konstante `NODE_IMAGE`. Task 6 (Operator) verwendet exakt die im Header dokumentierten Kommandos.
+
+- [ ] **Step 1: Instanz-Parametrisierung**
+
+Die Zeilen 30–31 setzen `RUNNER_WORK`/`RUNNER_DIR` fest, **bevor** die Args geparst sind — beides muss NACH das Arg-Parsing wandern und vom neuen `--dir` abhängen:
+
+```bash
+# ---------- Configuration ---------- (Zeilen 30-31 ERSETZEN durch:)
+RUNNER_DIR_NAME="runner"   # pro Instanz eindeutig; zweite Instanz: --dir runner-2
+
+# ---------- Arg parsing ---------- (im case ergänzen:)
+    --dir)   RUNNER_DIR_NAME="$2"; shift 2 ;;
+
+# direkt NACH der while-Schleife (nach Zeile 51):
+RUNNER_DIR="${RUNNER_HOME}/${RUNNER_DIR_NAME}"
+RUNNER_WORK="${RUNNER_HOME}/_work-${RUNNER_DIR_NAME}"
+```
+
+**Kritisch — `RUNNER_WORK` muss pro Instanz getrennt sein:** zwei Runner, die dasselbe `_work` teilen, checken denselben Workspace-Pfad (`_work/BaluHost/BaluHost`) aus und zerstören sich bei parallelen Jobs gegenseitig den Checkout. Rückwärtskompatibilität für die bereits registrierte Erst-Instanz: prüfen, wo `RUNNER_WORK` verwendet wird (config.sh `--work`?) — falls die Erst-Instanz mit `${RUNNER_HOME}/_work` registriert ist, für `RUNNER_DIR_NAME=runner` den Alt-Pfad beibehalten:
+
+```bash
+if [[ "$RUNNER_DIR_NAME" == "runner" ]]; then
+  RUNNER_WORK="${RUNNER_HOME}/_work"   # Bestands-Instanz nicht umziehen
+fi
+```
+
+- [ ] **Step 2: Node-Image vorab pullen** — bei den Konstanten `NODE_IMAGE="docker.io/library/node:20-slim"` ergänzen und neben dem bestehenden `as_runner podman pull "$TEST_IMAGE"` (Zeile ~169): `as_runner podman pull "$NODE_IMAGE"`. (Verhindert einen Pull-Race, wenn beide Instanzen gleichzeitig ihren ersten Job bekommen.)
+
+- [ ] **Step 3: Header-Usage aktualisieren** — im Kopfkommentar dokumentieren:
+
+```
+# Usage:
+#   sudo ./bootstrap-ci-runner.sh --token <RUNNER_REGISTRATION_TOKEN>
+#   # zweite Instanz (parallele CI-Jobs; frontend-build + backend-tests):
+#   sudo ./bootstrap-ci-runner.sh --token <TOKEN> --name BaluNode-ci-sandbox-2 --dir runner-2
+```
+
+und die Pre-Pull-Zeile im Beschreibungsblock um das Node-Image ergänzen.
+
+- [ ] **Step 4: Verifizieren** — `bash -n scripts/bootstrap-ci-runner.sh` → kein Output. Zusätzlich per Read prüfen: keine verbliebene Verwendung von `RUNNER_DIR`/`RUNNER_WORK` VOR dem Arg-Parsing (sonst greift `--dir` nicht überall).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/bootstrap-ci-runner.sh
+git commit -m "ci(bootstrap): multi-instance sandbox runners (--dir) + pre-pull node image"
+```
+
+---
+
+### Task 4: `docs/CI.md` — Design-Entscheidungen (fork-/dev-facing)
+
+**Files:**
+- Create: `docs/CI.md`
+
+**Interfaces:** referenziert von `ci-config.example.conf` (Task 2) und `ci-cd-security.md` (Task 5).
+
+- [ ] **Step 1: Datei anlegen.** Zielgruppe: Forks und künftige Entwickler — **nicht** das interne Threat-Model (das bleibt in `.claude/rules/ci-cd-security.md`; `docs/CI.md` verlinkt darauf). Englisch (wie SELF_HOSTING.en.md). Gliederung mit verbindlichem Inhalt:
+
+```markdown
+# CI Design Decisions
+
+Why the BaluHost pipeline is built the way it is. Fork setup: see
+`ci-config.example.conf` + `scripts/configure-ci.sh`; the security threat
+model lives in `.claude/rules/ci-cd-security.md`.
+
+## Runner model
+- Which jobs run where (table: job → upstream runner → fork variable → gate).
+- Two-layer isolation of the ci-sandbox runner (unprivileged `ci-runner`
+  user + rootless Podman; untrusted code NEVER runs on the runner host).
+- Why upstream runner choice is hardcoded (`github.repository` literal):
+  PR content must not be able to influence runner selection.
+- Why there are two sandbox instances (one self-hosted runner = one job at
+  a time; backend-tests + frontend-build would serialize).
+
+## Approval gates
+- `ci-tests` environment: PR-triggered jobs on self-hosted hardware pause
+  for manual approval ("Review pending deployments"); one click approves
+  all gated jobs of that run. `workflow_call` from the deploy pipeline is
+  ungated (code already merged = trusted).
+- Fork PR approval policy `all_external_contributors` and WHY it outranks
+  the environment gate for forks (PRs execute the PR's own workflow file
+  and can delete their `environment:` line; repo settings they cannot touch).
+
+## Deliberate non-features
+- **No dependency caches on self-hosted runners.** A PR-writable cache is
+  shared mutable state between PRs (poisoning). `npm ci` / `pip install`
+  run fresh per job inside the container.
+- **No git in the node image.** `__GIT_COMMIT__` becomes 'unknown' in the
+  CI gate build; the deployed frontend is built during deploy where git
+  exists. Don't "fix" this by installing git.
+- **mdadm tests never on self-hosted hardware** (loop-device tests on
+  GitHub VMs only) — real mdadm can destroy disks.
+- **Resource limits** (`--cpus`/`--memory`) on CI containers: the runner
+  host is also the production NAS.
+
+## Egress expectations
+Containers need: registry.npmjs.org (npm), pypi.org +
+files.pythonhosted.org (pip), docker.io (images), api.github.com.
+Any future egress firewall must include all of these.
+```
+
+Jede Zeile inhaltlich gegen den realen Stand verifizieren (nicht abschreiben, nachsehen) — insbesondere die Job→Runner-Tabelle gegen die Workflow-Dateien.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/CI.md
+git commit -m "docs(ci): add CI.md — runner model, gates, and deliberate non-features"
+```
+
+---
+
+### Task 5: `.claude/rules/ci-cd-security.md` aktualisieren
+
+**Files:**
+- Modify: `.claude/rules/ci-cd-security.md`
+
+- [ ] **Step 1: Vier Änderungen**
+
+1. Layer-2-Tabelle, Zeile `ci-check.yml frontend-build`: von `ubuntu-latest` auf `**upstream: self-hosted, ci-sandbox (hardcoded); Forks: vars.FRONTEND_BUILD_RUNNER, Default ubuntu-latest** (rootless Podman everywhere)` und Trigger-Spalte um den `ci-tests`-Gate-Hinweis ergänzen — Formulierung exakt parallel zur `backend-tests`-Zeile.
+2. „Repo Settings to Verify" → Runner-Zeile: zwei Sandbox-Instanzen (`BaluNode-ci-sandbox`, `BaluNode-ci-sandbox-2`) erwarten.
+3. Fork-Configurability-Absatz (#207): `FRONTEND_BUILD_RUNNER` neben `BACKEND_TEST_RUNNER` nennen; die Gate-Bedingung zitiert dann beide `contains(vars.…)`-Ausdrücke.
+4. Known Gap #8: in der künftigen Egress-Allowlist `registry.npmjs.org` ergänzen.
+
+Zusätzlich am Ende des Layer-2-Abschnitts ein Verweis: „Fork-/Dev-facing Zusammenfassung der Design-Entscheidungen: `docs/CI.md`."
+
+- [ ] **Step 2: Selbstkontrolle** — der `ci-tests`-Abschnitt (inkl. Incident-Notiz aus PR #420) sagt bisher „Gates PR-triggered **backend test** runs": auf „backend/frontend runs" erweitern. Danach `Select-String -Path .claude/rules/ci-cd-security.md -Pattern "ubuntu-latest.*frontend|frontend.*ubuntu-latest"` → keine widersprüchliche Restaussage.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/rules/ci-cd-security.md
+git commit -m "docs(ci-security): frontend-build on ci-sandbox — layer table, runners, egress list"
+```
+
+---
+
+### Task 6: OPERATOR-SCHRITT (Xveyn, auf BaluNode) — Smoke-Test + zweite Instanz
+
+**KEIN Agent-Task.** Diese Kommandos führt Xveyn per SSH auf BaluNode aus, NACHDEM Tasks 1–5 auf dem Branch committet und gepusht sind. Der Controller wartet auf Bestätigung + Verifikation, bevor Task 7 startet.
+
+- [ ] **Step 1: Branch auf die Box holen** (beliebiger Checkout-Pfad, NICHT /opt/baluhost):
+
+```bash
+git clone --depth 1 --branch feat/frontend-build-sandbox-runner https://github.com/Xveyn/BaluHost /tmp/balu-ci-branch
+```
+
+- [ ] **Step 2: Einmaliger Container-Smoke-Test als ci-runner** (belegt: keine nativen Deps fehlen, Build+Tests laufen im Image):
+
+```bash
+sudo -u ci-runner -H podman pull docker.io/library/node:20-slim
+sudo cp -r /tmp/balu-ci-branch /var/lib/ci-runner/smoke && sudo chown -R ci-runner:ci-runner /var/lib/ci-runner/smoke
+sudo -u ci-runner -H podman run --rm --network=bridge --cpus=4 --memory=3g \
+  -v /var/lib/ci-runner/smoke:/work:Z -w /work/client \
+  docker.io/library/node:20-slim \
+  bash -c "set -euo pipefail; npm ci && npx eslint . && npm run build && npm run test:coverage"
+# Erwartung: eslint 0 Errors, build OK, Vitest-Suite grün (~1134 Tests).
+# Laufzeit notieren (Vergleichswert: 4m46s auf ubuntu-latest).
+sudo rm -rf /var/lib/ci-runner/smoke /tmp/balu-ci-branch
+```
+
+- [ ] **Step 3: Registrierungs-Token holen** (am Dev-Rechner oder auf der Box, gh als Xveyn): `gh api -X POST repos/Xveyn/BaluHost/actions/runners/registration-token -q .token` — Token ist single-use, ~1 h gültig.
+
+- [ ] **Step 4: Zweite Instanz registrieren** (mit dem Skript AUS DEM BRANCH):
+
+```bash
+cd /tmp && git clone --depth 1 --branch feat/frontend-build-sandbox-runner https://github.com/Xveyn/BaluHost balu-ci-branch
+sudo ./balu-ci-branch/scripts/bootstrap-ci-runner.sh --token <TOKEN> --name BaluNode-ci-sandbox-2 --dir runner-2
+# Das Skript ist idempotent und läuft seine Self-Tests selbst; es MUSS mit
+# "All self-tests passed" enden. Bricht es ab: Output an den Controller.
+rm -rf /tmp/balu-ci-branch
+```
+
+- [ ] **Step 5: Verifikation (Dev-Rechner):**
+
+```
+gh api repos/Xveyn/BaluHost/actions/runners --jq '.runners[] | "\(.name)  \(.status)  [\([.labels[].name] | join(","))]"'
+```
+
+Expected: `BaluNode` (prod, online), `BaluNode-ci-sandbox` (online) **und** `BaluNode-ci-sandbox-2` (online), beide Sandbox-Instanzen mit Label `ci-sandbox`.
+
+---
+
+### Task 7: PR öffnen — der PR-Lauf ist der Live-Test
+
+**Voraussetzungen:** Task 6 bestätigt (drei Runner online), PR #420 gemergt (sonst zuerst darauf hinweisen).
+
+- [ ] **Step 1: Push + PR.** PR-Body (via Write-Tool + `--body-file`, Memory: keine Here-Strings) muss enthalten: Zusammenfassung der Umstellung; die drei Spec-Entscheidungen (kein Cache / eigene Fork-Variable / zweite Instanz) mit je einem Satz Begründung; Hinweis auf `docs/CI.md`; **explizit**: „PRs pausieren ab jetzt sichtbar auf ‚Review pending deployments' — das ist das ci-tests-Gate, kein Hänger; ein Klick gibt beide Jobs frei"; Verweis auf Spec + PR #420.
+
+- [ ] **Step 2: Den eigenen PR-Lauf beobachten** — er führt bereits die neue Workflow-Datei aus:
+  1. Beide Jobs warten auf ci-tests-Freigabe → Xveyn klickt „Approve and deploy".
+  2. `frontend-build` läuft auf `BaluNode-ci-sandbox`/`-2` (im Job-Log: „Runner name"), Tripwire grün, Podman-Step grün, Coverage-Summary erscheint im Run-Summary.
+  3. `backend-tests` und `frontend-build` laufen **parallel** (Start-Zeitstempel vergleichen).
+  4. Laufzeit `frontend-build` notieren und gegen 4m46s (ubuntu-latest) stellen.
+
+- [ ] **Step 3: Branch-Protection-Gegenprobe:** `gh api repos/Xveyn/BaluHost/branches/main/protection --jq .required_status_checks.contexts` — `frontend-build` muss weiterhin matchen (Job-ID unverändert; der Check-Name bleibt gleich).
+
+- [ ] **Step 4: Nach Merge:** ein `push: main` triggert `deploy-production` → `ci-check` via `workflow_call` läuft **ungegated** auf den Sandbox-Runnern durch (kein Approval-Stopp) und der Deploy wartet wie immer am `production`-Gate. Einmal beobachten und im Ledger festhalten.

--- a/docs/superpowers/specs/2026-07-19-frontend-build-sandbox-runner-design.md
+++ b/docs/superpowers/specs/2026-07-19-frontend-build-sandbox-runner-design.md
@@ -93,6 +93,7 @@ frontend-build:
       run: |
         podman run --rm \
           --network=bridge \
+          --cpus=4 --memory=3g \
           -v "${{ github.workspace }}:/work:Z" \
           -w /work/client \
           "$NODE_IMAGE" \
@@ -100,8 +101,31 @@ frontend-build:
 
     - name: Frontend coverage → job summary
       if: always()
-      # node -e läuft im selben gepinnten Image, nicht auf dem Host
+      # node -e läuft im selben gepinnten Image, nicht auf dem Host.
+      # WICHTIG (Backend-Muster): der Container schreibt nach stdout, die
+      # Umleitung `>> "$GITHUB_STEP_SUMMARY"` passiert auf dem HOST —
+      # $GITHUB_STEP_SUMMARY ist ein Host-Pfad und existiert im Container nicht.
 ```
+
+**Ressourcen-Limits sind Pflicht, nicht Politur.** BaluNode ist zugleich
+Produktions-NAS und Gaming-PC (Ryzen 5 5600GT, 16 GB RAM, 4 Uvicorn-Worker,
+KDE). Mit der zweiten Instanz laufen künftig zwei CI-Container **parallel**,
+und `backend-tests` startet mit `pytest -n auto` bereits ~12 Worker. Ohne
+Limits kann ein PR-Push die Box spürbar ausbremsen. Deshalb `--cpus=4
+--memory=3g` am neuen Job (Werte nach erster Messung justieren) — und im
+selben PR prüfen, ob `backend-tests` dieselbe Kappung bekommt (bisher
+unlimitiert; auf `ubuntu-latest` war das egal, auf der eigenen Box nicht).
+
+**`node:20-slim` enthält kein `git` — bewusst akzeptiert.** `vite.config.ts:9-27`
+liest Branch/Commit per `execSync('git …')` mit try/catch-Fallback: im Container
+wird `__GIT_COMMIT__` zu `'unknown'` und `buildType` zu `'release'`. Das ist
+für diesen Job in Ordnung, weil (a) heute auf dem PR-Detached-HEAD
+`git branch --show-current` ohnehin leer liefert und (b) der CI-Build ein
+reiner Gate-Build ist, dessen Artefakt verworfen wird — das ausgelieferte
+Frontend entsteht beim Deploy auf BaluNode (`ci-deploy.sh`), wo git vorhanden
+ist. **Kein git ins Image installieren** (Zeit + Angriffsfläche); stattdessen
+diese Erwartung hier festhalten, damit „unknown" im CI-Log niemanden auf eine
+falsche Fährte schickt.
 
 Die Job-ID bleibt `frontend-build` — der Required-Status-Check auf `main`
 bricht dadurch nicht.
@@ -142,6 +166,10 @@ userweit und bereits abgedeckt.
 - „Repo Settings to Verify": Runner-Zeile auf **zwei** Sandbox-Instanzen
   erweitern.
 - Fork-Abschnitt um `FRONTEND_BUILD_RUNNER` ergänzen.
+- **Known Gap #8 (Egress-Allowlist) um `registry.npmjs.org` erweitern.** Die
+  dort notierte künftige Firewall-Liste kennt nur PyPI/GitHub/Docker — wer sie
+  später umsetzt und abschreibt, sperrt `npm ci` aus und legt die Frontend-CI
+  still lahm.
 
 Die Reviewer-Checkliste braucht keine neue Zeile — „Does a workflow on
 `ci-sandbox` run `pip install`, `npm install`, or any untrusted code directly
@@ -152,12 +180,17 @@ on the runner host (not inside `podman run`)?" deckt den Fall bereits ab.
 1. **PR #420 muss zuerst gemergt sein.** Er dokumentiert das scharfgeschaltete
    `ci-tests`-Gate. Die Settings selbst sind bereits live, aber ohne #420
    widerspricht die Doku dem Zustand.
-2. Bootstrap-Änderung + zweite Instanz auf BaluNode einrichten und
+2. **Einmaliger Container-Smoke-Test** (auf BaluNode oder lokal):
+   `podman run --rm -v <repo>:/work -w /work/client docker.io/library/node:20-slim bash -c "npm ci && npx eslint . && npm run build && npm run test:coverage"`.
+   `client/package.json` enthält nach Prüfung keine nativen/postinstall-Deps
+   (esbuild/swc nutzen vorgebaute Binaries), aber diese Annahme gehört einmal
+   real belegt, bevor der Gate-Job darauf steht.
+3. Bootstrap-Änderung + zweite Instanz auf BaluNode einrichten und
    `gh api repos/Xveyn/BaluHost/actions/runners` prüfen: zwei Runner mit Label
    `ci-sandbox`, beide `online`.
-3. Erst dann `ci-check.yml` umstellen.
+4. Erst dann `ci-check.yml` umstellen.
 
-Reihenfolge 3-vor-2 würde die CI ausbremsen, ohne dass jemand merkt warum.
+Reihenfolge 4-vor-3 würde die CI ausbremsen, ohne dass jemand merkt warum.
 
 ## Risiken
 
@@ -170,6 +203,8 @@ Reihenfolge 3-vor-2 würde die CI ausbremsen, ohne dass jemand merkt warum.
 | Bösartiger Fork-PR löscht seine eigene `environment:`-Zeile | Fork-Policy `all_external_contributors` greift vorher — sie ist Repo-State, nicht PR-editierbar |
 | Zweite Instanz erbt Isolationsfehler | die Bootstrap-Self-Tests müssen für **beide** Instanzen grün sein |
 | Plattenverbrauch durch zwei `node_modules` + Images | `--rm` räumt Container ab; Workspaces liegen pro Instanz getrennt. Bei Bedarf `podman system prune` per Timer |
+| CI-Last drückt Produktions-NAS/Gaming auf derselben Box | `--cpus`/`--memory` am Frontend-Container (s. o.); Kappung für `backend-tests` im selben PR prüfen; reale Last nach dem ersten parallelen Doppel-Lauf beobachten |
+| `__GIT_COMMIT__`='unknown' im CI-Build irritiert beim Debuggen | bewusst akzeptiert und in Abschnitt A dokumentiert; Deploy-Artefakt entsteht auf BaluNode mit git |
 
 ## Offen (bewusst nicht entschieden)
 

--- a/docs/superpowers/specs/2026-07-19-frontend-build-sandbox-runner-design.md
+++ b/docs/superpowers/specs/2026-07-19-frontend-build-sandbox-runner-design.md
@@ -1,0 +1,178 @@
+# `frontend-build` auf den ci-sandbox-Runner verlagern
+
+**Datum:** 2026-07-19
+**Betroffen:** `.github/workflows/ci-check.yml`, `scripts/configure-ci.sh`,
+`ci-config.example.conf`, `scripts/bootstrap-ci-runner.sh`,
+`.claude/rules/ci-cd-security.md`
+**Baut auf:** PR #420 (`ci-tests`-Environment-Gate scharfgeschaltet). Ohne #420
+ist dieser Umzug **nicht** sicher — siehe „Reihenfolge".
+
+## Ziel
+
+`frontend-build` läuft heute auf `ubuntu-latest`. Es soll auf den gehärteten
+`ci-sandbox`-Runner auf BaluNode wandern, unter derselben zweischichtigen
+Isolation und derselben Freigabepflicht wie `backend-tests`.
+
+Damit gilt die Regel, die Xveyn gesetzt hat: **alles, was PR-getriggert auf
+BaluNode läuft, braucht einen manuellen Freigabe-Klick.**
+
+Nicht-Ziel: Playwright, `raid-mdadm-loopback`, `tauri-build`, `tui-build`,
+`deploy-pi` und die Release-Workflows bleiben, wo sie sind.
+`raid-mdadm-loopback` ist ausdrücklich gesperrt — echtes `mdadm` auf eigener
+Hardware kann Platten zerstören.
+
+## Ist-Zustand
+
+`frontend-build` (`ci-check.yml`): `ubuntu-latest`, `actions/setup-node@v5` mit
+`cache: 'npm'`, dann `npm ci`, `npx eslint .`, `npm run build`,
+`npm run test:coverage`, plus ein Coverage-Summary-Schritt, der auf dem Host
+`node -e` ausführt. Laufzeit zuletzt 4m46s.
+
+`backend-tests` liefert das Muster, das gespiegelt wird: Runner-Auswahl per
+`fromJSON`-Ausdruck, `environment: ci-tests` bedingt auf `pull_request`,
+Runner-Identity-Tripwire, und **ein** `podman run` gegen ein gepinntes Image,
+in dem der gesamte untrusted Code läuft.
+
+Der Bootstrap installiert **kein** Node auf dem Host (nur podman, uidmap,
+passt, slirp4netns, fuse-overlayfs, dbus-user-session) und zieht das
+Python-Testimage vorab.
+
+## Entscheidungen (mit Xveyn abgestimmt)
+
+### 1. Kein npm-Cache — `npm ci` frisch pro Lauf
+
+Ein Cache, in den PR-Code schreiben darf, ist geteilter veränderlicher Zustand
+zwischen PRs: ein bösartiger PR könnte ein Paket vergiften, das ein späterer
+Lauf arglos verwendet. `backend-tests` macht `pip install` aus demselben Grund
+frisch. Kosten: ~30–60 s pro Lauf, die die schnellere Hardware weitgehend
+kompensiert.
+
+Konsequenz: `actions/setup-node` entfällt ersatzlos.
+
+### 2. Eigene Fork-Variable `FRONTEND_BUILD_RUNNER`
+
+Nicht `BACKEND_TEST_RUNNER` mitbenutzen — der Name würde dann nicht mehr
+beschreiben, was er steuert. Eine eigene Variable hält beide Jobs unabhängig
+wählbar und ist keine Breaking Change für Forks, die `BACKEND_TEST_RUNNER`
+bereits gesetzt haben.
+
+Upstream bleibt hartkodiert (`github.repository == 'Xveyn/BaluHost'`); PR-Code
+kann die Runner-Wahl über keinen der beiden Wege beeinflussen.
+
+### 3. Zweite Runner-Instanz gegen Serialisierung
+
+**Ein Self-Hosted-Runner führt immer nur einen Job gleichzeitig aus.** Heute
+laufen `backend-tests` (9m43s, Sandbox) und `frontend-build` (4m46s,
+GitHub-VM) parallel → PR-CI nach ~10 min durch. Auf einem einzigen Runner
+würden sie serialisieren → ~14–15 min.
+
+Deshalb: eine zweite Runner-Instanz auf derselben Box, gleicher `ci-runner`-User,
+gleiches Label `ci-sandbox`, eigener systemd-Service. Beide Jobs laufen wieder
+parallel.
+
+## Änderungen
+
+### A. `ci-check.yml` — `frontend-build`
+
+```yaml
+frontend-build:
+  runs-on: ${{ fromJSON(github.repository == 'Xveyn/BaluHost' && '["self-hosted","ci-sandbox"]' || vars.FRONTEND_BUILD_RUNNER || '"ubuntu-latest"') }}
+  environment: ${{ (github.event_name == 'pull_request' && (github.repository == 'Xveyn/BaluHost' || contains(vars.FRONTEND_BUILD_RUNNER, 'self-hosted'))) && 'ci-tests' || '' }}
+  timeout-minutes: 15
+
+  steps:
+    - uses: actions/checkout@v5
+
+    - name: Assert runner identity (defense-in-depth tripwire)
+      if: github.repository == 'Xveyn/BaluHost'
+      # identisch zum backend-tests-Tripwire
+
+    - name: Lint + build + unit tests (with coverage) in rootless Podman container
+      env:
+        NODE_IMAGE: docker.io/library/node:20-slim
+      run: |
+        podman run --rm \
+          --network=bridge \
+          -v "${{ github.workspace }}:/work:Z" \
+          -w /work/client \
+          "$NODE_IMAGE" \
+          bash -c "set -euo pipefail; npm ci && npx eslint . && npm run build && npm run test:coverage"
+
+    - name: Frontend coverage → job summary
+      if: always()
+      # node -e läuft im selben gepinnten Image, nicht auf dem Host
+```
+
+Die Job-ID bleibt `frontend-build` — der Required-Status-Check auf `main`
+bricht dadurch nicht.
+
+`node:20-slim` spiegelt die bisherige `node-version: '20'`.
+
+### B. Fork-Konfiguration
+
+`ci-config.example.conf`: `FRONTEND_BUILD_RUNNER=github` plus
+auskommentiertes `FRONTEND_BUILD_RUNNER_LABELS`, mit demselben Kommentarstil
+wie der Backend-Block.
+
+`scripts/configure-ci.sh`: beide Schlüssel in `KNOWN_KEYS`, ein `case`-Block
+analog zu `BACKEND_TEST_RUNNER` (`github` → `del_var`, `self-hosted` →
+`set_var` mit `labels_to_json`, sonst `die`), plus dieselbe
+Labels-ohne-self-hosted-Warnung.
+
+### C. `bootstrap-ci-runner.sh`
+
+1. **Node-Image vorab pullen**, analog zum bestehenden `TEST_IMAGE`-Pull —
+   vermeidet ein Pull-Race, wenn beide Instanzen gleichzeitig starten.
+2. **Mehrfachinstanzen ermöglichen.** `RUNNER_NAME` ist bereits über `--name`
+   parametrisiert, aber `RUNNER_DIR="${RUNNER_HOME}/runner"` ist festverdrahtet
+   — jede Instanz braucht ein eigenes Verzeichnis. `RUNNER_DIR` aus dem
+   Instanznamen ableiten (oder `--dir` ergänzen). `svc.sh install` erzeugt den
+   Unit-Namen bereits aus `RUNNER_NAME`, ist also schon eindeutig.
+3. Die Self-Tests laufen pro Instanz unverändert.
+
+Beide Instanzen teilen sich `ci-runner` und damit denselben rootless-Podman-Store.
+Nebenläufige Container sind unproblematisch; das Vorab-Pullen entschärft den
+einzigen Race beim ersten Lauf. Linger und `podman system migrate` sind
+userweit und bereits abgedeckt.
+
+### D. `.claude/rules/ci-cd-security.md`
+
+- Layer-2-Tabelle: `frontend-build` von `ubuntu-latest` auf dieselbe
+  Runner-/Gate-Beschreibung wie `backend-tests` umstellen.
+- „Repo Settings to Verify": Runner-Zeile auf **zwei** Sandbox-Instanzen
+  erweitern.
+- Fork-Abschnitt um `FRONTEND_BUILD_RUNNER` ergänzen.
+
+Die Reviewer-Checkliste braucht keine neue Zeile — „Does a workflow on
+`ci-sandbox` run `pip install`, `npm install`, or any untrusted code directly
+on the runner host (not inside `podman run`)?" deckt den Fall bereits ab.
+
+## Reihenfolge (wichtig)
+
+1. **PR #420 muss zuerst gemergt sein.** Er dokumentiert das scharfgeschaltete
+   `ci-tests`-Gate. Die Settings selbst sind bereits live, aber ohne #420
+   widerspricht die Doku dem Zustand.
+2. Bootstrap-Änderung + zweite Instanz auf BaluNode einrichten und
+   `gh api repos/Xveyn/BaluHost/actions/runners` prüfen: zwei Runner mit Label
+   `ci-sandbox`, beide `online`.
+3. Erst dann `ci-check.yml` umstellen.
+
+Reihenfolge 3-vor-2 würde die CI ausbremsen, ohne dass jemand merkt warum.
+
+## Risiken
+
+| Risiko | Gegenmaßnahme |
+|---|---|
+| Serialisierung halbiert den Durchsatz | zweite Instanz **vor** der Workflow-Änderung |
+| `npm ci` ohne Cache spürbar langsamer | bewusst akzeptiert; reale Laufzeit nach dem ersten Lauf gegen 4m46s prüfen |
+| Job-Umbenennung bricht Branch Protection | Job-ID bleibt `frontend-build`; nach dem Merge `gh api …/branches/main/protection` gegenprüfen |
+| Freigabepflicht wird als CI-Hänger fehlgedeutet | im PR-Body benennen: PRs pausieren jetzt sichtbar auf „Review pending deployments" |
+| Bösartiger Fork-PR löscht seine eigene `environment:`-Zeile | Fork-Policy `all_external_contributors` greift vorher — sie ist Repo-State, nicht PR-editierbar |
+| Zweite Instanz erbt Isolationsfehler | die Bootstrap-Self-Tests müssen für **beide** Instanzen grün sein |
+| Plattenverbrauch durch zwei `node_modules` + Images | `--rm` räumt Container ab; Workspaces liegen pro Instanz getrennt. Bei Bedarf `podman system prune` per Timer |
+
+## Offen (bewusst nicht entschieden)
+
+Ob Playwright später nachzieht, bleibt offen — der Job bräuchte Browser-Deps im
+Image und ist deutlich schwerer. Erst nach Messung der realen Laufzeiten
+sinnvoll zu beurteilen.

--- a/scripts/bootstrap-ci-runner.sh
+++ b/scripts/bootstrap-ci-runner.sh
@@ -8,13 +8,16 @@
 # - Configures subuid/subgid + systemd lingering for rootless containers.
 # - Installs and registers a GitHub Actions self-hosted runner instance as 'ci-runner'
 #   with labels: self-hosted,Linux,X64,ci-sandbox.
-# - Pre-pulls docker.io/library/python:3.11-slim into ci-runner's storage.
+# - Pre-pulls docker.io/library/python:3.11-slim and docker.io/library/node:20-slim
+#   into ci-runner's storage.
 # - Runs self-tests; aborts with a clear error if any isolation guarantee is violated.
 #
 # Idempotent: safe to re-run.
 #
 # Usage:
 #   sudo ./bootstrap-ci-runner.sh --token <RUNNER_REGISTRATION_TOKEN>
+#   # second instance (parallel CI jobs; frontend-build + backend-tests):
+#   sudo ./bootstrap-ci-runner.sh --token <TOKEN> --name BaluNode-ci-sandbox-2 --dir runner-2
 #
 # Get the token from: https://github.com/Xveyn/BaluHost/settings/actions/runners/new
 # (Click "New self-hosted runner", copy the value passed to --token in the displayed
@@ -27,12 +30,12 @@ set -euo pipefail
 # ---------- Configuration ----------
 RUNNER_USER="ci-runner"
 RUNNER_HOME="/var/lib/ci-runner"
-RUNNER_WORK="${RUNNER_HOME}/_work"
-RUNNER_DIR="${RUNNER_HOME}/runner"
+RUNNER_DIR_NAME="runner"   # unique per instance; second instance: --dir runner-2
 REPO_URL="https://github.com/Xveyn/BaluHost"
 RUNNER_LABELS="self-hosted,Linux,X64,ci-sandbox"
 RUNNER_NAME="${RUNNER_NAME:-BaluNode-ci-sandbox}"
 TEST_IMAGE="docker.io/library/python:3.11-slim"
+NODE_IMAGE="docker.io/library/node:20-slim"
 SUBUID_RANGE="100000-165535"
 SUBGID_RANGE="100000-165535"
 
@@ -42,6 +45,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --token) RUNNER_TOKEN="$2"; shift 2 ;;
     --name)  RUNNER_NAME="$2";  shift 2 ;;
+    --dir)   RUNNER_DIR_NAME="$2"; shift 2 ;;
     -h|--help)
       sed -n '1,/^set -euo/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
       exit 0
@@ -49,6 +53,19 @@ while [[ $# -gt 0 ]]; do
     *) echo "ERROR: unknown arg: $1" >&2; exit 2 ;;
   esac
 done
+
+# RUNNER_DIR is per-instance via --dir. RUNNER_WORK is derived the same way for
+# consistency (it seeds an upfront `mkdir -p` below); the GitHub Actions runner's
+# own work directory is actually config.sh's `--work "_work"` arg, which is
+# relative to $RUNNER_DIR at registration time (see Step 5) — so it is already
+# per-instance for free once RUNNER_DIR is. The legacy path is kept for the
+# default instance so a re-run does not change anything for the already
+# registered first runner.
+RUNNER_DIR="${RUNNER_HOME}/${RUNNER_DIR_NAME}"
+RUNNER_WORK="${RUNNER_HOME}/_work-${RUNNER_DIR_NAME}"
+if [[ "$RUNNER_DIR_NAME" == "runner" ]]; then
+  RUNNER_WORK="${RUNNER_HOME}/_work"   # don't relocate the existing instance
+fi
 
 if [[ "$EUID" -ne 0 ]]; then
   echo "ERROR: must be run as root (sudo)." >&2
@@ -167,6 +184,8 @@ log "Starting runner service (idempotent)..."
 # ---------- Step 6: pre-pull test image ----------
 log "Pre-pulling $TEST_IMAGE as $RUNNER_USER (first pull, ~50 MB)..."
 as_runner podman pull "$TEST_IMAGE"
+log "Pre-pulling $NODE_IMAGE as $RUNNER_USER..."
+as_runner podman pull "$NODE_IMAGE"
 
 # ---------- Step 7: self-tests ----------
 log "Running isolation self-tests..."

--- a/scripts/bootstrap-ci-runner.sh
+++ b/scripts/bootstrap-ci-runner.sh
@@ -54,18 +54,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# RUNNER_DIR is per-instance via --dir. RUNNER_WORK is derived the same way for
-# consistency (it seeds an upfront `mkdir -p` below); the GitHub Actions runner's
-# own work directory is actually config.sh's `--work "_work"` arg, which is
-# relative to $RUNNER_DIR at registration time (see Step 5) — so it is already
-# per-instance for free once RUNNER_DIR is. The legacy path is kept for the
-# default instance so a re-run does not change anything for the already
-# registered first runner.
+# RUNNER_DIR is per-instance via --dir.
 RUNNER_DIR="${RUNNER_HOME}/${RUNNER_DIR_NAME}"
-RUNNER_WORK="${RUNNER_HOME}/_work-${RUNNER_DIR_NAME}"
-if [[ "$RUNNER_DIR_NAME" == "runner" ]]; then
-  RUNNER_WORK="${RUNNER_HOME}/_work"   # don't relocate the existing instance
-fi
+
+# RUNNER_WORK is NOT what config.sh actually uses for the runner's work directory
+# (that's `--work "_work"` in Step 5, relative to $RUNNER_DIR — already per-instance
+# for free once RUNNER_DIR is). This variable only seeds the legacy `mkdir -p` below;
+# kept at its single pre-existing value for all instances.
+RUNNER_WORK="${RUNNER_HOME}/_work"
 
 if [[ "$EUID" -ne 0 ]]; then
   echo "ERROR: must be run as root (sudo)." >&2

--- a/scripts/configure-ci.sh
+++ b/scripts/configure-ci.sh
@@ -43,7 +43,8 @@ while IFS='=' read -r key value; do
     CFG[$key]="$value"
 done < <(grep -E '^[A-Z0-9_]+=' "$CONFIG_FILE")
 
-KNOWN_KEYS="BACKEND_TEST_RUNNER BACKEND_TEST_RUNNER_LABELS ENABLE_PLAYWRIGHT_E2E \
+KNOWN_KEYS="BACKEND_TEST_RUNNER BACKEND_TEST_RUNNER_LABELS FRONTEND_BUILD_RUNNER \
+FRONTEND_BUILD_RUNNER_LABELS ENABLE_PLAYWRIGHT_E2E \
 ENABLE_RAID_LOOPBACK ENABLE_TAURI_BUILD ENABLE_TUI_BUILD ENABLE_DEPLOY_PI \
 ENABLE_RELEASE_STABLE ENABLE_DEPLOY_FORK DEPLOY_FORK_RUNNER_LABELS DEPLOY_FORK_INSTALL_DIR"
 for key in "${!CFG[@]}"; do
@@ -110,6 +111,15 @@ case "${CFG[BACKEND_TEST_RUNNER]:-github}" in
 esac
 if [[ "${CFG[BACKEND_TEST_RUNNER]:-github}" != "self-hosted" && -n "${CFG[BACKEND_TEST_RUNNER_LABELS]:-}" ]]; then
     echo "WARNING: BACKEND_TEST_RUNNER_LABELS is set but BACKEND_TEST_RUNNER is not 'self-hosted' — labels ignored" >&2
+fi
+
+case "${CFG[FRONTEND_BUILD_RUNNER]:-github}" in
+    github)      del_var FRONTEND_BUILD_RUNNER ;;
+    self-hosted) set_var FRONTEND_BUILD_RUNNER "$(labels_to_json "${CFG[FRONTEND_BUILD_RUNNER_LABELS]:-}")" ;;
+    *) die "FRONTEND_BUILD_RUNNER must be 'github' or 'self-hosted'" ;;
+esac
+if [[ "${CFG[FRONTEND_BUILD_RUNNER]:-github}" != "self-hosted" && -n "${CFG[FRONTEND_BUILD_RUNNER_LABELS]:-}" ]]; then
+    echo "WARNING: FRONTEND_BUILD_RUNNER_LABELS is set but FRONTEND_BUILD_RUNNER is not 'self-hosted' — labels ignored" >&2
 fi
 
 bool_var ENABLE_PLAYWRIGHT_E2E true


### PR DESCRIPTION
## Summary

Moves `frontend-build` from GitHub-hosted `ubuntu-latest` onto the hardened self-hosted `ci-sandbox` runner, mirroring the `backend-tests` pattern exactly: hardcoded upstream runner selection, `ci-tests` approval gate on `pull_request`, runner-identity tripwire, and all untrusted code inside one rootless podman run against pinned `node:20-slim`.

With this, the rule is complete: **everything PR-triggered that executes on BaluNode requires a manual approval click.**

Design: `docs/superpowers/specs/2026-07-19-frontend-build-sandbox-runner-design.md` · Builds on #420 (ci-tests gate armed).

## The three design decisions (details in the new `docs/CI.md`)

- **No npm cache.** A PR-writable cache is shared mutable state between PRs (poisoning vector). `npm ci` runs fresh per job — same rationale as the existing fresh `pip install`. Measured cost on the box: ~5 s.
- **Own fork variable `FRONTEND_BUILD_RUNNER`** instead of reusing `BACKEND_TEST_RUNNER`, whose name would then lie about its scope. Non-breaking for existing forks; wired through `ci-config.example.conf` + `scripts/configure-ci.sh` + `SELF_HOSTING.en.md`.
- **Second sandbox runner instance** (`BaluNode-ci-sandbox-2`, provisioned via the new `bootstrap-ci-runner.sh --dir` flag). One self-hosted runner executes one job at a time — without the second instance, backend and frontend would serialize (~10 → ~14-15 min). Already registered and online.

## Resource caps (the box is also the production NAS)

Both CI containers now run with `--cpus=4 --memory=3g`. Worker counts are capped explicitly (`--maxWorkers=4` for vitest, pytest `-n auto` → `-n 4`) because CFS quotas are not cpusets: `os.cpus()` inside the container still reports all 12 host threads, and uncapped runners would oversubscribe the limit (vitest would OOM).

## Verified on the box before this PR (operator smoke test as `ci-runner`)

- `npm ci` ~5 s, eslint 0 errors, build OK, vitest 256 files / 1134 tests green in 99 s inside the capped container
- Full chain ~2 min vs. 4m46s on `ubuntu-latest` — the move is a speedup, not a cost
- The expected `git: not found` → `__GIT_COMMIT__='unknown'` fallback occurred exactly as documented in `docs/CI.md` (gate build only; the deployed frontend is built during deploy on BaluNode, where git exists — do not "fix" by installing git in the image)

## What reviewers/future-you should know

- **PR checks now pause on "Review pending deployments" — that is the `ci-tests` gate, not a hang.** One click approves both jobs of the run.
- **DX change:** previously `frontend-build` started immediately and gave lint feedback while only `backend-tests` waited for approval. Now nothing runs before the click. That is the intended consequence of the everything-on-BaluNode-needs-approval rule.
- `workflow_call` from `deploy-production.yml` stays ungated (code already on `main` = trusted), unchanged.
- Job IDs are unchanged, so the required status checks on `main` keep matching.
- `docs/CI.md` is new: fork-/dev-facing record of the runner model, gates, and deliberate non-features. `.claude/rules/ci-cd-security.md` updated (Layer-2 table, two sandbox instances, egress list + `registry.npmjs.org`).
- Found along the way: `RUNNER_WORK` in the bootstrap script is pre-existing dead code → #421.

**This PR's own CI run is the live test** — it already executes the new workflow definition. Expected: both jobs wait at the gate, then run in parallel on the two sandbox instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
