### PR TITLE
ci: Coverage-Floors auf beiden Test-Jobs erzwingen (#315, #340)

### DIFF
--- a/.claude/rules/backend/coding-style.md
+++ b/.claude/rules/backend/coding-style.md
@@ -10,7 +10,7 @@ paths:
 - **Pydantic models** for request/response validation
 - **Docstrings** for all services
 - **Services pattern**: Business logic in `services/`, not in routes
-- **Testing**: Pytest with async support, 80%+ coverage target
+- **Testing**: Pytest with async support; CI enforces a coverage **floor** of 65% on `app/` (`--cov-fail-under`), measured at 67% on 2026-07-21 — not an 80% target
 - **Formatting**: Follow existing patterns (4 spaces, snake_case)
 
 ## Example Service Function

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -51,9 +51,11 @@ jobs:
           TEST_IMAGE: docker.io/library/python:3.11-slim
         run: |
           set -euo pipefail
-          # Coverage is measured and printed only — no threshold enforced yet
-          # (matches the frontend job; a low number does not fail CI). The tests
-          # themselves still gate. `-o addopts=` drops the pyproject addopts
+          # Coverage is gated by a floor, not a target (BT1/#340): 65% is the
+          # 2026-07-21 measurement (67%) rounded down for churn headroom. It
+          # catches a regression; raise it when the job summary sits comfortably
+          # above. The frontend job carries the same construct in vite.config.ts.
+          # `-o addopts=` drops the pyproject addopts
           # (term-missing + html) so CI prints the concise skip-covered table;
           # `term:skip-covered` hides 100%-covered files to keep the log short.
           # `--cov-report=json` writes backend/coverage.json (bind-mounted, so it
@@ -68,7 +70,7 @@ jobs:
             -w /work/backend \
             -e NAS_MODE=dev \
             "$TEST_IMAGE" \
-            bash -c "set -euo pipefail; pip install --no-cache-dir -e '.[dev]' && python -m ruff check . && python -m pytest -q --timeout=120 -n 4 -o addopts= --cov=app --cov-report=term:skip-covered --cov-report=json"
+            bash -c "set -euo pipefail; pip install --no-cache-dir -e '.[dev]' && python -m ruff check . && python -m pytest -q --timeout=120 -n 4 -o addopts= --cov=app --cov-fail-under=65 --cov-report=term:skip-covered --cov-report=json"
 
       - name: Backend coverage → job summary
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ npm run test
 
 ### Test Requirements
 - **All new features must have tests**
-- Maintain **80%+ code coverage**
+- Don't drop below the CI coverage floor: **65%** on `backend/app/`, **23%** lines on `client/src/` (`--cov-fail-under` / Vitest `thresholds`). These are regression guards frozen just under the current measurement, not quality targets — raise them when the numbers climb.
 - Tests should be deterministic (no random failures)
 - Use dev-mode fixtures for reproducibility
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -94,7 +94,8 @@ extend-exclude = ["dev-storage", "storage", "tmp"]
 # Ruff's default rule set, made explicit: pyflakes (F) + a curated pycodestyle
 # subset (E4 imports, E7 statements, E9 syntax). Line-length (E501) and the
 # pycodestyle W warnings are intentionally NOT enabled yet — see issue #184 for
-# the staged rollout (ruff -> eslint -> mypy -> coverage threshold).
+# the staged rollout (ruff -> eslint -> mypy -> coverage threshold; the coverage
+# stage landed 2026-07-21 as --cov-fail-under=65 in ci-check.yml, #340).
 select = ["E4", "E7", "E9", "F"]
 ignore = [
     # SQLAlchemy: `Column == True/False/None` is the INTENDED way to build SQL

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -63,9 +63,6 @@ export default defineConfig(({ mode }) => {
     setupFiles: ['./src/__tests__/setup.ts'],
     include: ['src/__tests__/**/*.test.{ts,tsx}'],
     coverage: {
-      // Measurement only — no thresholds yet (coverage is intentionally low
-      // while the untested surface is being decomposed under #301). Enforced
-      // targets can be added later via `thresholds`.
       provider: 'v8',
       reporter: ['text-summary', 'json-summary'],
       reportsDirectory: './coverage',
@@ -77,6 +74,19 @@ export default defineConfig(({ mode }) => {
         'src/main.tsx',
         'src/vite-env.d.ts',
       ],
+      // Floor, not a target (T1/#315). Measured on CI 2026-07-21:
+      // lines 23.91 / statements 23.67 / functions 23.34 / branches 21.37 —
+      // each rounded DOWN to leave room for churn. This catches a regression,
+      // it does not reward standing still: when the frontend-build job summary
+      // sits comfortably above a number below, raise that number and note the
+      // new measurement here. A floor without its measurement date decays into
+      // a hollow control (cf. the ci-tests gate, 2026-07-19).
+      thresholds: {
+        lines: 23,
+        statements: 23,
+        functions: 23,
+        branches: 21,
+      },
     },
   },
   server: {

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -109,6 +109,17 @@ than the other way around. Full detail: `.claude/rules/ci-cd-security.md`.
   (`ENABLE_RAID_LOOPBACK`) exists. Real `mdadm` commands against real disks
   could destroy an array; the loop-device tests only ever run on disposable
   GitHub-hosted VMs.
+- **Coverage floors, not coverage targets.** Both test jobs measure coverage,
+  print it to the job summary, and fail below a floor frozen just under the
+  last measurement (`--cov-fail-under=65` for `backend/app`; Vitest
+  `thresholds` of 23/23/23/21 for `client/src`). The floor exists to catch a
+  regression, not to certify quality — the numbers are low and honest about
+  it. Deliberately absent: per-diff coverage ("new code ≥ X%") and any
+  third-party coverage service. Diff-coverage would need a second container
+  image just to run `diff-cover`, and an external service would mean an
+  unpinned action plus egress to a host that isn't on the allowlist below.
+  Both become worth revisiting once the frontend test surface grows
+  (issues #316, #317).
 - **Resource limits on CI containers.** Both sandbox jobs run their container
   with `--cpus=4 --memory=3g`. The runner host also runs production BaluHost
   workloads, so CI must not be free to saturate it. Because `--cpus` is a CFS


### PR DESCRIPTION
Schließt die letzte offene Stufe von #315 (T1, Frontend) **und** #340 (BT1, Backend) — beide hatten denselben Rest, deshalb ein PR.

## Ausgangslage

Beide Test-Jobs **messen** Coverage längst und schreiben sie ins Job-Summary (23,91 % lines Frontend / 67 % lines Backend, Stand 2026-07-21). Nur: **nichts schlug an, wenn die Zahl fiel.** Eine Regression war ausschließlich sichtbar, wenn jemand zwei Summaries im Kopf verglich.

Nebenbefund beim Nachschauen: die Titel beider Issues waren überholt. #315 sagt „kein `@vitest/coverage-v8`" (ist seit #402 installiert), #340 sagt „CI läuft mit `--no-cov`" (läuft seit derselben PR mit `--cov=app`). Übrig war in beiden Fällen nur das Gate.

## Änderung

Ist-Stand einfrieren — ein Floor, kein Target:

| | Wert | Herkunft |
|---|---|---|
| `client/vite.config.ts` → `thresholds` | lines 23 / statements 23 / functions 23 / branches 21 | Messung 2026-07-21: 23.91 / 23.67 / 23.34 / 21.37, je abgerundet |
| `ci-check.yml` → `--cov-fail-under` | 65 | Messung 2026-07-21: 67 % |

Beide Zahlen stehen **mit Messdatum im Kommentar** daneben. Das ist bewusst: ein Floor ohne Herkunft verkommt still zur hohlen Kontrolle — genau das Muster des `ci-tests`-Vorfalls vom 19.07., wo eine „Verified state"-Spalte zwei Monate lang eine Prüfung behauptete, die nie stattgefunden hatte.

## Verifikation

Nicht nur „ist konfiguriert", sondern **greift auch**:

```
$ npx vitest run --coverage --coverage.thresholds.lines=99
ERROR: Coverage for lines (23.91%) does not meet global threshold (99%)   → exit 1

$ pytest tests/auth/test_permissions.py -o addopts= --cov=app --cov-fail-under=99
FAIL Required test coverage of 99% not reached. Total coverage: 32.09%    → exit 1
```

Mit den echten Werten:

- `npm run test:coverage` → **256 Files / 1136 Tests grün**, 23.91 / 23.67 / 23.34 / 21.37 — deckt sich exakt mit der CI-Messung, Exit 0
- `npm run build` → grün (`vite.config.ts` angefasst)

Die volle Backend-Suite ist auf Windows nicht lauffähig (bekannt); der 65er-Floor stützt sich auf die CI-Messung von 67 % aus dem letzten `backend-tests`-Lauf und wird von diesem PR-Lauf selbst gegengeprüft.

## Bewusst nicht gebaut

**Diff-Coverage** („neuer Code ≥ X %", die ursprüngliche Empfehlung in #315) und **externe Coverage-Services**. Ersteres bräuchte ein zweites Container-Image nur für `diff-cover` (das Node-Image hat kein Python), Letzteres eine ungepinnte Third-Party-Action (#333) plus Egress zu einem Host außerhalb der Allowlist (Gap #8). Beides lohnt erst, wenn #316/#317 die Testfläche vergrößert haben — als Entscheidung in `docs/CI.md` festgehalten, nicht nur hier im PR.

## Doku-Drift mitgezogen (2. Commit)

`CONTRIBUTING.md` und `.claude/rules/backend/coding-style.md` forderten beide „80 %+ coverage". Das hat nie jemand durchgesetzt und die Realität ist 67 % / 24 % — Wunsch als Anforderung verkleidet. Beide Stellen nennen jetzt die tatsächlich erzwungenen Floors und sagen dazu, dass es Regressionswächter und keine Qualitätsziele sind.

## CI-Security

Die `ci-check.yml`-Änderung ist ein einzelnes Flag innerhalb des bestehenden `podman run … bash -c`-Strings. **Nicht angefasst:** Runner-Auswahl, `environment:`-Gates, Trigger, Fork-Variablen, Layer-B-Isolation.

Closes #315
Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
