### PR TITLE
ci: E2E-Dispatch reparieren + gemockten Lauf auf ci-sandbox (#330, #348)

### DIFF
--- a/.claude/rules/ci-cd-security.md
+++ b/.claude/rules/ci-cd-security.md
@@ -35,7 +35,8 @@ Owned paths:
 | `ci-check.yml` `backend-tests` | **upstream: `self-hosted, ci-sandbox` (hardcoded repo literal); forks: `vars.BACKEND_TEST_RUNNER`, default `ubuntu-latest`** (rootless Podman everywhere) | `pull_request` (gated by `ci-tests` env), `workflow_call` (ungated) |
 | `create-release.yml` | `ubuntu-latest` | tag push (`v*-pre.*`) |
 | `deploy-pi.yml` | `ubuntu-latest` | `workflow_dispatch` |
-| `playwright-e2e.yml` | `ubuntu-latest` | `pull_request`, `push: main` |
+| `playwright-e2e.yml` `mock-e2e` | **upstream: `self-hosted, ci-sandbox` (hardcoded repo literal); forks: `vars.E2E_RUNNER`, default `ubuntu-latest`** (rootless Podman everywhere) | `pull_request` (gated by `ci-tests` env), `push: main`, `workflow_dispatch` |
+| `playwright-e2e.yml` `live-e2e` | `ubuntu-latest` | `workflow_dispatch` only (never ran — env + secret unprovisioned, #330) |
 | `release-stable.yml` | `ubuntu-latest` | `workflow_dispatch` |
 | `deploy-production.yml` | **`self-hosted, prod`** | `push: main`, `workflow_dispatch` |
 | `deploy-fork.yml` | **fork-configured via `vars.DEPLOY_FORK_RUNNER`** | `push: main`, `workflow_dispatch` — dead upstream (repo guard on every job) |
@@ -58,13 +59,14 @@ A workflow on `ci-sandbox` that runs `pip install` directly on the runner host (
 are driven exclusively by `github.repository == 'Xveyn/BaluHost'` literals and
 server-side Repository Variables (`vars.*`, set via `scripts/configure-ci.sh`).
 Upstream behavior is hardcoded and needs no variables; PR code cannot influence
-runner choice or environment gates through either mechanism. `backend-tests`
-and `frontend-build` follow the identical pattern, gated by `vars.BACKEND_TEST_RUNNER`
-and `vars.FRONTEND_BUILD_RUNNER` respectively. The `ci-tests` gate condition on
+runner choice or environment gates through either mechanism. `backend-tests`,
+`frontend-build`, and `playwright-e2e.yml`'s `mock-e2e` follow the identical pattern,
+gated by `vars.BACKEND_TEST_RUNNER`, `vars.FRONTEND_BUILD_RUNNER`, and `vars.E2E_RUNNER`
+respectively. The `ci-tests` gate condition on
 `pull_request` events is
 `github.repository == 'Xveyn/BaluHost' || contains(vars.BACKEND_TEST_RUNNER, 'self-hosted')`
 for `backend-tests`, and the same shape with `contains(vars.FRONTEND_BUILD_RUNNER, 'self-hosted')`
-for `frontend-build`.
+/ `contains(vars.E2E_RUNNER, 'self-hosted')` for the other two.
 `raid-mdadm-loopback.yml` is deliberately NOT runner-configurable: real mdadm on
 a self-hosted box could destroy disks — only the on/off toggle
 `ENABLE_RAID_LOOPBACK` exists, and `BALUHOST_MDADM_LOOPBACK=1` is never set
@@ -117,7 +119,7 @@ Gates PR-triggered backend/frontend runs on `ci-sandbox`. Configured in GitHub r
 | Deployment branches and tags | All branches | `deployment_branch_policy: null` ✓ |
 | `can_admins_bypass` | `false` | `false` ✓ |
 
-Both `backend-tests` and `frontend-build` declare `environment: ci-tests` conditionally on `github.event_name == 'pull_request'`. PR runs pause for Xveyn approval (one click approves both jobs of the run); `workflow_call` runs (from `deploy-production.yml` after a manual merge to `main`) execute immediately because the code is already trusted at that point.
+`backend-tests`, `frontend-build`, and `playwright-e2e.yml`'s `mock-e2e` declare `environment: ci-tests` conditionally on `github.event_name == 'pull_request'`. PR runs pause for Xveyn approval — one click releases both `ci-check.yml` jobs, and `mock-e2e` raises a **second, separate prompt** because GitHub groups pending deployments per workflow run, not per repo. `workflow_call` runs (from `deploy-production.yml` after a manual merge to `main`) execute immediately because the code is already trusted at that point.
 
 > **Incident 2026-07-19 — this gate was hollow for two months.** The environment
 > was created 2026-05-19 but **no protection rules were ever added**
@@ -184,7 +186,7 @@ When reviewing changes that touch CI/CD, deploy scripts, or these rules:
 - [ ] **Sudoers / systemd**: Changes under `deploy/install/templates/` to sudoers or service units? Verify the new rules are scoped to specific binaries with explicit args (no `ALL`, no globs that match user-controlled paths).
 - [ ] **Deploy script**: Changes to `deploy/scripts/ci-deploy.sh`? Verify no new shell injection surfaces (user-controlled env vars interpolated into commands), no new `sudo` invocations without sudoers entries, rollback path still works.
 - [ ] **Workflow secrets**: New `secrets.*` references? Confirm the secret exists, is scoped correctly, and is not echoed/logged.
-- [ ] **Fork-config gate logic**: Does a change touch the `github.repository == 'Xveyn/BaluHost'` literals or the `contains(vars.BACKEND_TEST_RUNNER, 'self-hosted')` / `contains(vars.FRONTEND_BUILD_RUNNER, 'self-hosted')` environment-gate conditions in `ci-check.yml`/`deploy-fork.yml`? If it weakens the upstream-hardcoded path or derives gates from PR-controlled data — block.
+- [ ] **Fork-config gate logic**: Does a change touch the `github.repository == 'Xveyn/BaluHost'` literals or the `contains(vars.BACKEND_TEST_RUNNER, 'self-hosted')` / `contains(vars.FRONTEND_BUILD_RUNNER, 'self-hosted')` / `contains(vars.E2E_RUNNER, 'self-hosted')` environment-gate conditions in `ci-check.yml`/`playwright-e2e.yml`/`deploy-fork.yml`? If it weakens the upstream-hardcoded path or derives gates from PR-controlled data — block.
 - [ ] **mdadm runner pin**: Does a change make the `raid-mdadm-loopback.yml` runner configurable, or set `BALUHOST_MDADM_LOOPBACK` outside that workflow? If yes — block (mdadm must never run on self-hosted hardware).
 
 ---
@@ -194,7 +196,7 @@ When reviewing changes that touch CI/CD, deploy scripts, or these rules:
 1. **`main` does not require PR approvals** — Solo-dev workflow: Xveyn merges manually after CI passes (no auto-merge bot). The `production` environment reviewer (Layer 4) is the compensating control.
 2. **Two self-hosted runners with different trust levels on one host**:
     - `BaluNode` (`self-hosted, Linux, X64, prod`) — runs production deploys. Full access to `/opt/baluhost`, `.env.production`, sudo entries. Never sees PR code (Layer 2 prohibition + workflows pin to label `ci-sandbox` for PR work). The `prod` label is what `deploy-production.yml` targets — removing it from `BaluNode` would route deploys to the sandbox and break them (caught 2026-05-19).
-    - `BaluNode-ci-sandbox` (`self-hosted, Linux, X64, ci-sandbox`) — runs `backend-tests` for PRs. Runs as `ci-runner` (no sudo, no production read), wraps test execution in rootless Podman. Even if a PR is maliciously approved at the `ci-tests` gate, blast radius is limited to the container workdir and outbound network (see gap #8).
+    - `BaluNode-ci-sandbox` (`self-hosted, Linux, X64, ci-sandbox`) — runs `backend-tests`, `frontend-build`, and `mock-e2e` for PRs. Runs as `ci-runner` (no sudo, no production read), wraps test execution in rootless Podman. Even if a PR is maliciously approved at the `ci-tests` gate, blast radius is limited to the container workdir and outbound network (see gap #8).
     Both runners share the host kernel. A kernel-namespace escape from the Podman container would land as `ci-runner` on the host — still without sudo or production access. The bootstrap script's self-tests must pass for these guarantees to hold.
 3. **`DEPLOY_PAT` is a personal access token, not a fine-grained app token** — Rotation is manual. Track in [[project_baluhost_secrets_todo]].
 4. **CODEOWNERS is advisory on `main`** — See the deliberate gap above.

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -1,21 +1,30 @@
 name: Playwright E2E
 
 # Notes:
-# - To allow live E2E runs, add a repository secret named `RUN_LIVE_E2E` and set it to `true` only
-#   when you want to enable live, production-adjacent tests. Keep this secret off for normal PRs.
-# - Protect the `live-e2e` environment (Repository Settings → Environments) and require
-#   reviews/approvals before allowing jobs to run there — this provides an additional safety
-#   gate beyond the secret.
-# - The `live-e2e` job checks `secrets.RUN_LIVE_E2E` at runtime and will abort if it is not set
-#   to `true`. Use manual `workflow_dispatch` to start the live job and ensure approvers are
-#   available to review the protected environment.
+# - `mock-e2e` runs on every trigger and needs no backend: the specs stub every route and
+#   Playwright starts its own Vite server. Upstream it runs in rootless Podman on the
+#   `ci-sandbox` runner, gated by the `ci-tests` environment on PRs.
+# - `live-e2e` is NOT provisioned yet (checked 2026-07-21): neither the `live-e2e`
+#   environment nor the `RUN_LIVE_E2E` secret exists on the repo, so a dispatch with
+#   live=true reaches the job and then aborts at the secret check. Before enabling it,
+#   create the environment WITH required reviewers (an environment referenced by a job is
+#   auto-created without any protection — existing ≠ protected, cf. the ci-tests incident
+#   2026-07-19) and add the secret. Tracked in #330.
+# - Note what live-e2e does today: it starts a throwaway dev backend on the runner. Running
+#   E2E against the real deployed NAS instance is a different design (prod runner, real
+#   data, dedicated test user) and is deliberately NOT what this job does.
 
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ '*' ]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      live:
+        description: 'Run the gated live E2E job after the mocked run'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -23,33 +32,90 @@ permissions:
 jobs:
   mock-e2e:
     name: Mocked E2E (fast)
+    # Runner selection (#207 pattern, identical to backend-tests/frontend-build):
+    # upstream ALWAYS the hardened ci-sandbox runner (Layer 2, not configurable);
+    # forks choose via the server-side repo variable E2E_RUNNER (JSON array, set
+    # by scripts/configure-ci.sh), falling back to a secret-free ubuntu-latest VM.
+    # PR code cannot influence this: repository literal + vars only.
+    runs-on: ${{ fromJSON(github.repository == 'Xveyn/BaluHost' && '["self-hosted","ci-sandbox"]' || vars.E2E_RUNNER || '"ubuntu-latest"') }}
     # vars.ENABLE_PLAYWRIGHT_E2E: fork toggle (#207), default on; unset upstream.
-    if: vars.ENABLE_PLAYWRIGHT_E2E != 'false' && (github.event_name != 'workflow_dispatch' || github.event.inputs.run == 'mock')
-    runs-on: ubuntu-latest
+    # Runs on every trigger, dispatch included. It used to also require
+    # `github.event.inputs.run == 'mock'` — an input that was never declared, so
+    # on dispatch this job skipped and took live-e2e down with it via needs: (D1/#330).
+    if: vars.ENABLE_PLAYWRIGHT_E2E != 'false'
+    # ci-tests approval gate: always for upstream PRs; in forks only when the
+    # fork opted into a self-hosted runner. Same construct as ci-check.yml.
+    environment: ${{ (github.event_name == 'pull_request' && (github.repository == 'Xveyn/BaluHost' || contains(vars.E2E_RUNNER, 'self-hosted'))) && 'ci-tests' || '' }}
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
 
-      - name: Setup Node
-        uses: actions/setup-node@v5
-        with:
-          node-version: '20'
-
-      - name: Install client deps
+      - name: Assert runner identity (defense-in-depth tripwire)
+        # Upstream-only: identical to the ci-check.yml tripwires.
+        if: github.repository == 'Xveyn/BaluHost'
         run: |
-          cd client
-          npm ci
-          npx playwright install --with-deps
+          set -euo pipefail
+          test "$(whoami)" = "ci-runner" || { echo "::error::Runner not running as ci-runner (got: $(whoami))"; exit 1; }
+          test "$(id -u)" -ne 0 || { echo "::error::Runner running as root"; exit 1; }
+          command -v podman >/dev/null || { echo "::error::podman not installed on runner host"; exit 1; }
+          for grp in docker sudo wheel; do
+            if id -nG "$(whoami)" | tr ' ' '\n' | grep -qx "$grp"; then
+              echo "::error::ci-runner is in group '$grp' — isolation broken"
+              exit 1
+            fi
+          done
+          echo "Identity OK: $(whoami) uid=$(id -u) groups=$(id -nG)"
 
-      - name: Run mocked Playwright tests
+      - name: Mocked Playwright tests in rootless Podman container
+        env:
+          # Pinned to the SAME version as client/package-lock.json's
+          # @playwright/test — the image ships matching browsers in
+          # /ms-playwright, which is why no `playwright install` download is
+          # needed. Bump both together; the guard below catches it if not.
+          PLAYWRIGHT_IMAGE: mcr.microsoft.com/playwright:v1.57.0-noble
         run: |
-          cd client
-          npx playwright test --project=chromium --reporter=list
+          set -euo pipefail
+          # Untrusted PR code never runs on the runner host (Layer B) — same
+          # construct as ci-check.yml. No npm cache (a PR-writable cache is
+          # shared mutable state between PRs). --cpus/--memory: the box is also
+          # the production NAS. --shm-size=1g: Chromium crashes with the 64 MB
+          # podman default. -e CI=true: the runner's CI var does not cross into
+          # the container, and playwright.config.ts branches on it
+          # (reuseExistingServer). --workers=2 for the same reason pytest is
+          # pinned to -n 4: --cpus is a CFS quota, not a cpuset, so os.cpus()
+          # still reports every host thread and Playwright would oversubscribe.
+          # No backend is started: the mocked specs stub every route and
+          # Playwright brings up its own Vite server (webServer in the config).
+          podman run --rm \
+            --network=bridge \
+            --cpus=4 --memory=3g --shm-size=1g \
+            -e CI=true \
+            -e PLAYWRIGHT_IMAGE \
+            -v "${{ github.workspace }}:/work:Z" \
+            -w /work/client \
+            "$PLAYWRIGHT_IMAGE" \
+            bash -c '
+              set -euo pipefail
+              npm ci
+              # Version-drift guard: npm-installed Playwright vs the browsers
+              # baked into the image. A mismatch otherwise surfaces mid-run as a
+              # confusing missing-executable error.
+              have=$(npx playwright --version | cut -d" " -f2)
+              want=${PLAYWRIGHT_IMAGE##*:}
+              case "$want" in
+                "v$have"|"v$have"-*) ;;
+                *) echo "::error::Playwright version drift: package-lock has $have, image is $want — bump PLAYWRIGHT_IMAGE"; exit 1 ;;
+              esac
+              npx playwright test --project=chromium --reporter=list --workers=2
+            '
 
   live-e2e:
     name: Live E2E (gated)
     # Toggle repeated here on purpose: the needs:-skip cascade already covers
     # this today, but an explicit guard survives future needs: refactors.
-    if: vars.ENABLE_PLAYWRIGHT_E2E != 'false' && github.event_name == 'workflow_dispatch'
+    # `needs: mock-e2e` keeps the cheap mocked run as the gate in front of the
+    # live one — a red mock still blocks live, which is why it is not always().
+    if: vars.ENABLE_PLAYWRIGHT_E2E != 'false' && github.event_name == 'workflow_dispatch' && inputs.live
     runs-on: ubuntu-latest
     needs: mock-e2e
     environment: live-e2e

--- a/README.md
+++ b/README.md
@@ -216,12 +216,17 @@ BaluHost/
 │       ├── hooks/           # Custom React hooks
 │       ├── contexts/        # Auth context
 │       └── lib/             # Utilities, formatters
-├── deploy/                  # Deployment configs
+├── deploy/                  # Deployment configs & installer
+│   ├── install/             # Modular installer (modules/, templates/, verify/)
+│   │                        #   systemd units live in install/templates/
+│   ├── scripts/             # ci-deploy.sh, backup & DB restore
 │   ├── nginx/               # Reverse proxy configs
-│   ├── systemd/             # Service files
 │   ├── samba/               # SMB configuration
-│   ├── prometheus/          # Metrics scraping
-│   └── grafana/             # Dashboard templates
+│   ├── nfs/                 # NFS export setup
+│   ├── ssl/                 # Let's Encrypt / self-signed certs
+│   ├── avahi/, wsdd/        # mDNS + WS-Discovery announcements
+│   ├── runner/              # Self-hosted CI runner helpers
+│   └── update/              # Self-update runner
 ├── docs/                    # Documentation
 ├── .github/workflows/       # CI/CD pipelines
 ├── start_dev.py             # Dev launcher

--- a/ci-config.example.conf
+++ b/ci-config.example.conf
@@ -25,6 +25,14 @@ FRONTEND_BUILD_RUNNER=github
 # Only used with FRONTEND_BUILD_RUNNER=self-hosted. 'self-hosted' is always implied.
 #FRONTEND_BUILD_RUNNER_LABELS=my-test-box
 
+# Where the mocked Playwright E2E run happens: 'github' (default, ubuntu-latest VM)
+# or 'self-hosted'. Needs no backend and no secrets.
+E2E_RUNNER=github
+
+# Extra labels of your self-hosted runner (comma-separated).
+# Only used with E2E_RUNNER=self-hosted. 'self-hosted' is always implied.
+#E2E_RUNNER_LABELS=my-test-box
+
 # --- Secret-free workflows (default: enabled) ---
 ENABLE_PLAYWRIGHT_E2E=true
 # RAID mdadm loopback tests. Toggle on/off ONLY — the runner is ALWAYS

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -18,8 +18,8 @@ replace it.
 | `deploy-fork.yml` → `ci-check` / `deploy` | fork-supplied only; dead upstream (`github.repository != 'Xveyn/BaluHost'` guard) | `DEPLOY_FORK_RUNNER` (required once `ENABLE_DEPLOY_FORK=true`) | `environment: fork-production` (protection is opt-in — you must add required reviewers yourself) |
 | `deploy-pi.yml` → `deploy` | `ubuntu-latest` | `ENABLE_DEPLOY_PI` (on/off) | none |
 | `deploy-production.yml` → `deploy` | `[self-hosted, prod]` (hardcoded, not fork-configurable) | — | `environment: production` + actor allowlist (Layer 3 in the security rules) |
-| `playwright-e2e.yml` → `mock-e2e` | `ubuntu-latest` | `ENABLE_PLAYWRIGHT_E2E` (on/off) | none |
-| `playwright-e2e.yml` → `live-e2e` | `ubuntu-latest` | `ENABLE_PLAYWRIGHT_E2E` (on/off) | `environment: live-e2e` + `RUN_LIVE_E2E` secret, `workflow_dispatch` only |
+| `playwright-e2e.yml` → `mock-e2e` | `self-hosted, ci-sandbox` (hardcoded) | `E2E_RUNNER` (default: `ubuntu-latest`), `ENABLE_PLAYWRIGHT_E2E` (on/off) | `ci-tests` on `pull_request` |
+| `playwright-e2e.yml` → `live-e2e` | `ubuntu-latest` | `ENABLE_PLAYWRIGHT_E2E` (on/off) | `environment: live-e2e` + `RUN_LIVE_E2E` secret, `workflow_dispatch` only — **neither exists yet**, see below |
 | `raid-mdadm-loopback.yml` → `mdadm-loopback` | `ubuntu-latest` (hardcoded, **must not** become configurable) | `ENABLE_RAID_LOOPBACK` (on/off only — no runner variable exists) | none |
 | `release-stable.yml` → `release` | `ubuntu-latest` | `ENABLE_RELEASE_STABLE` (needs a `DEPLOY_PAT` secret) | none (`workflow_dispatch` already requires repo write access) |
 | `tauri-build.yml` → `build` | `ubuntu-latest` (hardcoded) | `ENABLE_TAURI_BUILD` (on/off) | none |
@@ -41,17 +41,26 @@ script's self-tests on every run:
   `.env.production`).
 - **Rootless Podman.** `pip install`, `npm ci`, and the rest of the PR's
   build/test commands run inside `podman run --rm` against a pinned image
-  (`python:3.11-slim` / `node:20-slim`), with only the checked-out workspace
-  bind-mounted in. No Docker daemon, no `docker.sock`, no host filesystem
-  access beyond that mount.
+  (`python:3.11-slim` / `node:20-slim` / `mcr.microsoft.com/playwright`), with
+  only the checked-out workspace bind-mounted in. No Docker daemon, no
+  `docker.sock`, no host filesystem access beyond that mount.
 
-Both PR-facing jobs in `ci-check.yml` also run an "assert runner identity"
-tripwire step (upstream only) that fails the job outright if it somehow ends
-up running as `root`, outside `ci-runner`, or in a privileged group.
+All three PR-facing jobs (`backend-tests`, `frontend-build`, `mock-e2e`) also
+run an "assert runner identity" tripwire step (upstream only) that fails the
+job outright if it somehow ends up running as `root`, outside `ci-runner`, or
+in a privileged group.
+
+The Playwright image is pinned to the exact version in
+`client/package-lock.json`, because it ships matching browsers in
+`/ms-playwright` — that is what removes the per-run browser download. A guard
+inside the container compares `npx playwright --version` against the image tag
+and fails loudly on drift, so bumping `@playwright/test` without bumping
+`PLAYWRIGHT_IMAGE` cannot turn into a confusing mid-run error. Chromium also
+needs `--shm-size=1g`; it segfaults on podman's 64 MB default.
 
 ### Why the upstream runner choice is hardcoded
 
-`runs-on` for `backend-tests` and `frontend-build` is
+`runs-on` for `backend-tests`, `frontend-build`, and `mock-e2e` is
 `github.repository == 'Xveyn/BaluHost' && '[...]' || vars.<NAME> || '"ubuntu-latest"'`
 — a repository literal, not anything derived from PR content. A PR cannot
 change which runner its own job lands on: forks steer this exclusively
@@ -67,13 +76,22 @@ that `backend-tests` and `frontend-build` — both gated, both potentially
 triggered by the same PR — run in parallel instead of queuing behind each
 other and roughly doubling PR turnaround time.
 
+Since `mock-e2e` joined the sandbox there are three sandbox jobs and two
+instances, so on any given PR one of them waits for a free slot. That is a
+deliberate trade rather than an oversight: E2E is the slowest and least
+urgent of the three, and a third instance costs RAM on a box that is also the
+production NAS. Register one with `--dir runner-3` if the queueing becomes
+the bottleneck.
+
 ## Approval gates
 
 **`ci-tests` environment.** PR-triggered jobs on self-hosted hardware pause
 for manual approval ("Review pending deployments") before they run at all.
 GitHub groups every job in a run that's waiting on the same environment under
 one prompt, so approving once releases both `backend-tests` and
-`frontend-build` together. `workflow_call` invocations of `ci-check.yml` (from
+`frontend-build` together. `mock-e2e` lives in a *different workflow*, so it
+raises its own separate approval prompt — one extra click per PR, the price of
+running E2E on the sandbox instead of a GitHub VM. `workflow_call` invocations of `ci-check.yml` (from
 `deploy-production.yml`, after a PR has already been merged to `main`) skip
 the gate — that code is already trusted.
 
@@ -130,10 +148,14 @@ than the other way around. Full detail: `.claude/rules/ci-cd-security.md`.
 
 ## Egress expectations
 
-The two sandboxed jobs and the runner agent itself need outbound access to:
-`registry.npmjs.org` (`npm ci` in `frontend-build`), `pypi.org` and
-`files.pythonhosted.org` (`pip install` in `backend-tests`),
+The three sandboxed jobs and the runner agent itself need outbound access to:
+`registry.npmjs.org` (`npm ci` in `frontend-build` and `mock-e2e`), `pypi.org`
+and `files.pythonhosted.org` (`pip install` in `backend-tests`),
 `registry.docker.io` (pulling the pinned `python:3.11-slim` / `node:20-slim`
-images), and `api.github.com` plus `objects.githubusercontent.com` (job
-orchestration, checkout, log/artifact upload). Any future egress firewall on
-the runner host must allow all of these or CI silently breaks.
+images), `mcr.microsoft.com` plus `*.data.mcr.microsoft.com` (pulling the
+pinned Playwright image and its blobs), and `api.github.com` plus
+`objects.githubusercontent.com` (job orchestration, checkout, log/artifact
+upload). Any future egress firewall on the runner host must allow all of these
+or CI silently breaks. Note that the Playwright image needs no
+`playwright.download.prss.microsoft.com` access, because the browsers come
+baked into the pinned image rather than being downloaded per run.

--- a/scripts/configure-ci.sh
+++ b/scripts/configure-ci.sh
@@ -44,7 +44,7 @@ while IFS='=' read -r key value; do
 done < <(grep -E '^[A-Z0-9_]+=' "$CONFIG_FILE")
 
 KNOWN_KEYS="BACKEND_TEST_RUNNER BACKEND_TEST_RUNNER_LABELS FRONTEND_BUILD_RUNNER \
-FRONTEND_BUILD_RUNNER_LABELS ENABLE_PLAYWRIGHT_E2E \
+FRONTEND_BUILD_RUNNER_LABELS E2E_RUNNER E2E_RUNNER_LABELS ENABLE_PLAYWRIGHT_E2E \
 ENABLE_RAID_LOOPBACK ENABLE_TAURI_BUILD ENABLE_TUI_BUILD ENABLE_DEPLOY_PI \
 ENABLE_RELEASE_STABLE ENABLE_DEPLOY_FORK DEPLOY_FORK_RUNNER_LABELS DEPLOY_FORK_INSTALL_DIR"
 for key in "${!CFG[@]}"; do
@@ -120,6 +120,15 @@ case "${CFG[FRONTEND_BUILD_RUNNER]:-github}" in
 esac
 if [[ "${CFG[FRONTEND_BUILD_RUNNER]:-github}" != "self-hosted" && -n "${CFG[FRONTEND_BUILD_RUNNER_LABELS]:-}" ]]; then
     echo "WARNING: FRONTEND_BUILD_RUNNER_LABELS is set but FRONTEND_BUILD_RUNNER is not 'self-hosted' — labels ignored" >&2
+fi
+
+case "${CFG[E2E_RUNNER]:-github}" in
+    github)      del_var E2E_RUNNER ;;
+    self-hosted) set_var E2E_RUNNER "$(labels_to_json "${CFG[E2E_RUNNER_LABELS]:-}")" ;;
+    *) die "E2E_RUNNER must be 'github' or 'self-hosted'" ;;
+esac
+if [[ "${CFG[E2E_RUNNER]:-github}" != "self-hosted" && -n "${CFG[E2E_RUNNER_LABELS]:-}" ]]; then
+    echo "WARNING: E2E_RUNNER_LABELS is set but E2E_RUNNER is not 'self-hosted' — labels ignored" >&2
 fi
 
 bool_var ENABLE_PLAYWRIGHT_E2E true


### PR DESCRIPTION
Schließt **#330** (D1 🔴) und **#348** (R1 🔴) — plus die Verlagerung des gemockten E2E-Laufs auf eigene Hardware, die sich aus #330 ergeben hat.

## #330 — der Live-Job war nie erreichbar

`workflow_dispatch: {}` deklarierte **keine** Inputs, aber `mock-e2e` verlangte `github.event.inputs.run == 'mock'`. Bei einem Dispatch war der Ausdruck immer falsch → mock-e2e skippt → `live-e2e` skippt über `needs:` mit. Der Job war durch **keinen** Trigger erreichbar und ist folglich noch nie gelaufen.

Fix: echten `live`-Boolean-Input deklarieren, die Phantom-Bedingung entfernen, live-e2e am deklarierten Input hängen. `needs: mock-e2e` bleibt bewusst ohne `always()` — der billige Mock-Lauf *soll* das Tor vor dem teuren sein.

### Dabei aufgefallen: der Job würde auch jetzt noch nicht funktionieren

```
gh api .../environments      → ci-tests, production        (kein live-e2e)
gh api .../actions/secrets   → BALUPI_DEPLOY_KEY, DEPLOY_PAT  (kein RUN_LIVE_E2E)
```

Der Kopfkommentar der Datei verlangte bisher, „das `live-e2e`-Environment zu schützen" — es existiert gar nicht. Ein Dispatch mit `live=true` erreicht den Job jetzt und bricht am Secret-Check ab, statt still zu skippen. **Das ist Absicht: sichtbar kaputt schlägt still tot.** Der Header dokumentiert, was zu provisionieren ist — inklusive des Punkts, dass ein von einem Job referenziertes Environment **ohne Schutzregeln automatisch angelegt** wird, „existiert" also nichts beweist (vgl. `ci-tests`-Vorfall 19.07.).

## mock-e2e läuft jetzt auf `ci-sandbox`

Dritter PR-Job auf eigener Hardware, exakt nach dem Muster von `backend-tests`/`frontend-build`: Runner upstream hinter Repository-Literal hartkodiert, Forks über `vars.E2E_RUNNER` (in `configure-ci.sh` + `ci-config.example.conf` verdrahtet), Identity-Tripwire, PR-Code ausschließlich in `podman run` — nie auf dem Runner-Host.

Was hier anders ist als bei den zwei bestehenden Jobs:

| Detail | Grund |
|---|---|
| Image `mcr.microsoft.com/playwright:v1.57.0-noble` | Exakt die Version aus `package-lock.json`; Browser liegen in `/ms-playwright` → **`playwright install --with-deps` entfällt komplett** |
| Versions-Drift-Guard im Container | `npx playwright --version` gegen den Image-Tag; ein einseitiger Bump würde sonst mitten im Lauf als „Executable doesn't exist" auflaufen |
| `--shm-size=1g` | Chromium segfaultet mit podmans 64-MB-Default |
| `-e CI=true` | Die CI-Variable des Runners überquert die Container-Grenze nicht, `playwright.config.ts` verzweigt darauf (`reuseExistingServer`) |
| `--workers=2` | Derselbe Grund, aus dem pytest auf `-n 4` gepinnt ist: `--cpus` ist eine CFS-Quote, kein cpuset — `os.cpus()` meldet weiter alle 12 Host-Threads |

Kein Backend nötig: die gemockten Specs stubben jede Route, Playwright startet seinen Vite-Server selbst (`webServer`).

### Kosten, nicht schöngeredet

- `mock-e2e` liegt in einem **anderen Workflow** als `ci-check.yml`. GitHub gruppiert Freigaben pro Workflow-Run → **ein zusätzlicher Approval-Klick pro PR.**
- **Drei** Sandbox-Jobs auf **zwei** Runner-Instanzen → einer wartet auf einen freien Slot. Bewusster Trade (E2E ist der langsamste und am wenigsten dringende); eine dritte Instanz via `bootstrap-ci-runner.sh --dir runner-3` wäre der Ausweg, kostet aber RAM auf der Prod-Box.

Beides steht in `docs/CI.md`, nicht nur hier.

## #348 — README-Baum

Gelistet waren `deploy/systemd/`, `deploy/prometheus/`, `deploy/grafana/` — **keines existiert.** Umgekehrt fehlte `deploy/install/`, also ausgerechnet der echte Installer. Jetzt steht die reale Struktur da (install, scripts, nginx, samba, nfs, ssl, avahi, wsdd, runner, update), mit dem Hinweis, wo die systemd-Units tatsächlich liegen.

## Verifikation

Was lokal überhaupt prüfbar ist, ist geprüft:

- **Image-Tag existiert und matcht**: `mcr.microsoft.com/v2/playwright/tags/list` enthält `v1.57.0-noble`; `package-lock.json` hat `@playwright/test` 1.57.0
- **YAML parst**, Job-Conditions/Inputs stimmen (`workflow_dispatch.inputs.live` als `boolean`, Default `true`)
- **Eingebettetes Container-Skript**: `bash -n` sauber
- **Drift-Guard-Logik** gegen beide Fälle durchgespielt: gleiche Version → ok, `1.58.0` gegen `v1.57.0-noble` → Abbruch
- **`configure-ci.sh`**: `bash -n` sauber; Dry-Run mit `E2E_RUNNER=self-hosted` setzt `["self-hosted","my-box"]`, mit Default `github` löscht er die Variable; Tippfehler-Key wird weiterhin abgewiesen

Was lokal **nicht** prüfbar war und dieser PR-Lauf selbst beweisen muss: dass der Podman-Lauf auf `ci-sandbox` durchgeht (Image-Pull, shm, Worker-Zahl). Der Job in diesem PR läuft bereits gegen die neue Definition.

## CI-Security

Die Reviewer-Checkliste aus `.claude/rules/ci-cd-security.md`, Punkt für Punkt:

- Neuer `self-hosted`-Job auf `pull_request` → **hat `environment: ci-tests`** (Bedingung in derselben Form wie `ci-check.yml`)
- Kein `pip install`/`npm ci` host-direkt — alles in `podman run` (Layer B)
- Kein `pull_request_target`, kein Prod-Runner, kein Secret berührt
- Gate-Bedingung aus Repository-Literal + `vars.*`, nicht aus PR-steuerbaren Daten
- Rules-Tabelle, Fork-Absatz, Checkliste und Known-Gap #2 in derselben Änderung nachgezogen

Closes #330
Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)
