### PR TITLE
fix: Dev-Backend-Port :3001 → :8000 (Code + 24 Doku-Stellen)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -111,7 +111,7 @@ All API routes are prefixed with `/api`:
 - `/api/benchmark/*` - System benchmarking
 - `/api/api-keys/*` - API key management
 
-API documentation available at: `http://localhost:3001/docs` (Swagger UI with custom BaluHost styling)
+API documentation available at: `http://localhost:8000/docs` (Swagger UI with custom BaluHost styling)
 
 ## Important Patterns & Conventions
 

--- a/.claude/rules/development.md
+++ b/.claude/rules/development.md
@@ -4,7 +4,7 @@
 
 ### Combined Development Start
 ```bash
-# Starts both backend (port 3001) and frontend (port 5173)
+# Starts both backend (port 8000) and frontend (port 5173)
 python start_dev.py
 ```
 
@@ -16,7 +16,7 @@ cd backend
 pip install -e ".[dev]"
 
 # Run server (dev mode with auto-reload)
-uvicorn app.main:app --reload --port 3001
+uvicorn app.main:app --reload --port 8000
 
 # Run tests
 python -m pytest
@@ -80,14 +80,14 @@ alembic downgrade -1
 
 1. **Always use dev mode** for local development (`python start_dev.py`)
 2. **Check logs** in terminal where `start_dev.py` is running
-3. **API testing**: Use Swagger UI at `http://localhost:3001/docs`
+3. **API testing**: Use Swagger UI at `http://localhost:8000/docs`
 4. **Database inspection**: Use SQLite browser on `backend/baluhost.db`
 5. **Reset dev environment**: `python backend/scripts/debug/reset_dev_storage.py`
 6. **Test a specific feature**: Write pytest test, then implement feature (TDD)
 
 ## Common Issues & Solutions
 
-**Backend won't start**: Check if port 3001 is already in use
+**Backend won't start**: Check if port 8000 is already in use
 **Frontend can't reach API**: Verify proxy config in `client/vite.config.ts`
 **Permission denied on file operation**: Check file ownership in `.metadata.json`
 **RAID commands fail**: Ensure dev mode is active or run on Linux with mdadm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ python start_dev.py
 # This will:
 # - Set up Python virtual environment
 # - Install dependencies
-# - Start FastAPI backend (port 3001)
+# - Start FastAPI backend (port 8000)
 # - Start Vite dev server (port 5173)
 # - Initialize 2x5GB RAID1 sandbox storage
 ```
@@ -51,7 +51,7 @@ cd backend
 python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -e ".[dev]"
-uvicorn app.main:app --reload --port 3001
+uvicorn app.main:app --reload --port 8000
 ```
 
 **Frontend:**

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The same machine doubles as a KDE Plasma desktop and — thanks to the Radeon GP
 ### Development (recommended)
 
 ```bash
-# Start both backend (port 3001) and frontend (port 5173)
+# Start both backend (port 8000) and frontend (port 5173)
 python start_dev.py
 ```
 
@@ -137,7 +137,7 @@ cd backend
 python -m venv .venv
 source .venv/bin/activate   # Windows: .venv\Scripts\activate
 pip install -e ".[dev]"
-uvicorn app.main:app --reload --port 3001
+uvicorn app.main:app --reload --port 8000
 
 # Frontend (separate terminal)
 cd client
@@ -243,7 +243,7 @@ BaluHost/
 
 ## API Overview
 
-Interactive API docs at http://localhost:3001/docs (Swagger UI) or `/redoc`.
+Interactive API docs at http://localhost:8000/docs (Swagger UI) or `/redoc`.
 
 All routes prefixed with `/api`:
 
@@ -289,10 +289,10 @@ TELEMETRY_INTERVAL_SECONDS=3.0
 ### Frontend `.env`
 
 ```env
-VITE_API_BASE_URL=http://localhost:3001
+VITE_API_BASE_URL=http://localhost:8000
 ```
 
-The Vite dev server proxies `/api` requests to port 3001 automatically (see `client/vite.config.ts`).
+The Vite dev server proxies `/api` requests to port 8000 automatically (see `client/vite.config.ts`).
 
 ---
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -162,14 +162,14 @@ python scripts/migrate_sqlite_to_postgresql.py --backup --no-migrate
 ### Start Application
 ```bash
 # Backend alleine starten
-python -m uvicorn app.main:app --reload --port 3001
+python -m uvicorn app.main:app --reload --port 8000
 
 # Kombinierter Start (Frontend + Backend): im Projektstamm
 python start_dev.py
 
 # API Dokumentation öffnen (Custom Styled)
-# http://localhost:3001/docs (Swagger UI - BaluHost Design)
-# http://localhost:3001/redoc (ReDoc)
+# http://localhost:8000/docs (Swagger UI - BaluHost Design)
+# http://localhost:8000/redoc (ReDoc)
 ```
 
 ### Custom API Documentation
@@ -560,7 +560,7 @@ CREATE TABLE file_metadata (
 ### Health
 - `GET /api/health` - Health check
 
-**Vollständige API-Referenz**: `http://localhost:3001/docs`
+**Vollständige API-Referenz**: `http://localhost:8000/docs`
 
 ## RAID Settings (CI and Production Safety)
 
@@ -658,8 +658,8 @@ CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
 
 ## Documentation
 
-- **API Docs**: http://localhost:3001/docs (Swagger UI)
-- **ReDoc**: http://localhost:3001/redoc
+- **API Docs**: http://localhost:8000/docs (Swagger UI)
+- **ReDoc**: http://localhost:8000/redoc
 - **Deployment**: `docs/DEPLOYMENT.md`
 
 ## Nächste Schritte

--- a/backend/app/services/pihole/ad_discovery/custom_lists.py
+++ b/backend/app/services/pihole/ad_discovery/custom_lists.py
@@ -355,7 +355,7 @@ class CustomListsService:
         Args:
             db: Database session.
             list_id: ID of the list to deploy.
-            base_url: Public base URL of the BaluHost API (e.g. ``http://nas.local:3001``).
+            base_url: Public base URL of the BaluHost API (e.g. ``http://nas.local:8000``).
             pihole_backend: Pi-hole protocol backend instance.
 
         Returns:

--- a/backend/scripts/debug/dev_check.py
+++ b/backend/scripts/debug/dev_check.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 import httpx
 
-DEFAULT_BASE_URL = "http://127.0.0.1:3001/api"
+DEFAULT_BASE_URL = "http://127.0.0.1:8000/api"
 
 
 def _print_section(title: str, payload: Dict[str, Any]) -> None:

--- a/backend/scripts/migration/simulate_migration.py
+++ b/backend/scripts/migration/simulate_migration.py
@@ -332,7 +332,7 @@ def generate_test_commands(sqlite_path: Path):
 
     print("# 5. Start backend")
     print("cd backend")
-    print("uvicorn app.main:app --reload --port 3001")
+    print("uvicorn app.main:app --reload --port 8000")
 
 
 def main():

--- a/client/README.md
+++ b/client/README.md
@@ -284,7 +284,7 @@ npm install
 ### Configuration
 Create `.env` file (optional):
 ```env
-VITE_API_BASE_URL=http://localhost:3001
+VITE_API_BASE_URL=http://localhost:8000
 ```
 
 ### Start Development Server

--- a/client/src/hooks/useApiReference.ts
+++ b/client/src/hooks/useApiReference.ts
@@ -44,11 +44,13 @@ export function useApiReference({ isAdmin, token }: UseApiReferenceArgs): UseApi
   // Dynamically determine API base URL based on current location
   const getApiBaseUrl = (): string => {
     const hostname = window.location.hostname;
-    const isDev = import.meta.env.DEV;
 
-    // In development, backend runs on port 3001
-    // In production, backend typically runs on port 8000
-    const port = isDev ? 3001 : 8000;
+    // 8000 in both modes: start_dev.py starts uvicorn on 8000 (which is also
+    // what client/vite.config.ts proxies to), and in production
+    // baluhost-backend.service binds 8000 behind nginx. The dev branch used to
+    // say 3001 — a port nothing has listened on, so the API reference showed a
+    // base URL that did not work.
+    const port = 8000;
     const protocol = window.location.protocol; // http: or https:
 
     return `${protocol}//${hostname}:${port}`;

--- a/docs/TECHNICAL_DOCUMENTATION.md
+++ b/docs/TECHNICAL_DOCUMENTATION.md
@@ -136,7 +136,7 @@ Dev-Mode & Testing
 
 Deployment (Kurz)
 -
-- Production Backend: `uvicorn app.main:app --host 0.0.0.0 --port 3001`
+- Production Backend: `uvicorn app.main:app --host 0.0.0.0 --port 8000`
 - Frontend: `npm run build` → `client/dist/` → Serve via Nginx / static host
 - DB: Verwende PostgreSQL in Produktion, setze `DATABASE_URL`
 
@@ -1965,7 +1965,7 @@ python start_dev.py
 
 **URLs:**
 - Frontend: http://localhost:5173
-- Backend API: http://localhost:3001/api
+- Backend API: http://localhost:8000/api
 
 ### Production (Recommended)
 
@@ -1973,7 +1973,7 @@ python start_dev.py
 # Backend
 cd backend
 pip install .
-uvicorn app.main:app --host 0.0.0.0 --port 3001
+uvicorn app.main:app --host 0.0.0.0 --port 8000
 
 # Frontend (Build)
 cd client
@@ -2046,8 +2046,8 @@ npm run test:e2e    # E2E tests (Placeholder)
 Complete API reference: See `docs/API_REFERENCE.md`.
 
 **FastAPI Docs (automatically generated with custom styling):**
-- Swagger UI: http://localhost:3001/docs (Custom BaluHost design)
-- ReDoc: http://localhost:3001/redoc
+- Swagger UI: http://localhost:8000/docs (Custom BaluHost design)
+- ReDoc: http://localhost:8000/redoc
 
 **Custom Swagger Features:**
 - Dark theme matching frontend design


### PR DESCRIPTION
Das Dev-Backend läuft auf **:8000** — `start_dev.py:416` startet uvicorn dort, `client/vite.config.ts:109` proxyt dorthin, und in Produktion bindet `baluhost-backend.service` ebenfalls 8000. Die Doku sagte durchgängig **:3001**.

Die README behauptete sogar wörtlich, Vite proxye „`/api` requests to port 3001 (see `client/vite.config.ts`)" — also mit Verweis auf genau die Datei, die 8000 sagt. Wer der README folgte, startete das Backend auf einem Port und ließ das Frontend auf einen anderen proxyen.

## Der echte Bug (Commit 1)

Nicht nur Doku — drei Stellen im Code:

| Stelle | Wirkung |
|---|---|
| `client/src/hooks/useApiReference.ts` | `isDev ? 3001 : 8000` — die **API-Referenz im User-Manual zeigte im Dev-Modus eine Base-URL an, unter der nichts lauscht**. Beide Modi sind 8000, der Branch (und das damit unbenutzte `isDev`) ist weg |
| `backend/scripts/debug/dev_check.py` | `DEFAULT_BASE_URL` auf :3001 → die Debug-Probe konnte ein laufendes Dev-Backend nie erreichen |
| `backend/scripts/migration/simulate_migration.py` | druckte eine Copy-Paste-uvicorn-Zeile mit falschem Port |

## Die Doku (Commit 2)

24 Stellen in `README.md`, `backend/README.md`, `client/README.md`, `CONTRIBUTING.md`, `docs/TECHNICAL_DOCUMENTATION.md`, `.claude/rules/development.md`, `.claude/rules/architecture.md` + das `base_url`-Docstring-Beispiel in `custom_lists.py`.

## Bewusst NICHT angefasst

Der wichtigste Teil dieses PRs, weil ein pauschales Repo-weites Replace hier Schaden angerichtet hätte:

- **`docs/monitoring/*.md` — 28 Treffer, das ist Grafanas Port** (`GRAFANA_PORT=3001`), nicht das Backend. Deshalb wurde jede Datei einzeln geprüft, bevor sie editiert wurde; die Monitoring-Doku steht unverändert bei 28 Treffern.
- **`docs/superpowers/plans|specs/*` und `CHANGELOG.md`** — Zeitdokumente. Was dort steht, war zum Zeitpunkt des Schreibens wahr; Historie umzuschreiben ist kein Fix.
- **Test-Fixtures** mit `base_url="http://localhost:3001"` (Desktop-Pairing, TUI-Client, Ad-Discovery) — beliebige Eingabewerte, keine Aussage über einen realen Port; keine Assertion hängt daran.

## Verifikation

- `npx vitest run src/__tests__/hooks/useApiReference.test.tsx` → 5/5 grün
- `npx eslint .` → **0 Errors** (das entfernte `isDev` hätte den Gate sonst gerissen)
- `npm run build` → grün
- `pytest tests/test_ad_discovery_custom_lists.py` → 21 passed
- Nachkontrolle: in den 11 geänderten Dateien ist genau **ein** `3001` übrig — mein eigener Erklärkommentar in `useApiReference.ts`
- Diff-Umfang pro Datei gegen die Vorab-Zählung geprüft (1/4/2/5/6/1/5 Doku-Zeilen) — nur Port-Zeilen, keine Kollateraländerungen

🤖 Generated with [Claude Code](https://claude.com/claude-code)
