### PR TITLE
docs: Rules-Drift korrigieren — Token-Typen, JWT-TTL, Testzahlen (#338)

### DIFF
--- a/.claude/rules/backend/coding-style.md
+++ b/.claude/rules/backend/coding-style.md
@@ -42,5 +42,5 @@ async def get_file_list(
 - **Integration tests**: Test API endpoints with test database
 - **Fixtures**: Use pytest fixtures for database, auth tokens
 - **Test database**: Separate SQLite database for tests
-- **Coverage**: 82 test files, 1465 test functions
+- **Suite size**: see the Testing row in `README.md` — those counts are machine-maintained (`scripts/generate_readme_stats.py`, spliced on stable release). Deliberately not repeated here: this line said "82 test files, 1465 test functions" for long enough that it was off by a factor of four
 - Run with: `python -m pytest -v`

--- a/.claude/rules/security-agent.md
+++ b/.claude/rules/security-agent.md
@@ -40,6 +40,9 @@ Active security enforcement rule for BaluHost. Applies to all changes in `backen
 | Access | 15 min (`ACCESS_TOKEN_EXPIRE_MINUTES`) | `"access"` | Contains `sub`, `username`, `role` |
 | Refresh | 7 days (`REFRESH_TOKEN_EXPIRE_DAYS`) | `"refresh"` | Contains `jti` for revocation |
 | SSE | 60 sec | `"sse"` | Scoped to single `upload_id`, safe for query params |
+| WS | 60 sec | `"ws"` | WebSocket handshake, contains `sub` + `username` |
+| 2FA pending | 5 min | `"2fa_pending"` | Issued between password check and TOTP verify; carries `sub` only |
+| Setup | 30 min | `"setup"` | Setup wizard; `role: admin` but only accepted by setup endpoints |
 
 ### Dependency Chain
 ```

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -7,7 +7,7 @@
 ## Security Patterns
 - All file operations check ownership or admin role
 - Path traversal prevention via `is_within_sandbox()`
-- JWT tokens expire after 12 hours (configurable)
+- JWT access tokens expire after 15 minutes, refresh tokens after 7 days (`ACCESS_TOKEN_EXPIRE_MINUTES` / `REFRESH_TOKEN_EXPIRE_DAYS` in `core/config.py`). Short-lived special-purpose tokens (`sse`, `ws`, `2fa_pending`, `setup`) are listed in `.claude/rules/security-agent.md` and `backend/app/core/CLAUDE.md` — keep those two in sync rather than restating TTLs here
 - Audit logging for sensitive operations
 - Rate limiting implemented via slowapi
 

--- a/backend/app/core/CLAUDE.md
+++ b/backend/app/core/CLAUDE.md
@@ -8,7 +8,7 @@ Application foundation: configuration, database, security, and cross-cutting inf
 |---|---|
 | `config.py` | `Settings` (pydantic-settings) — all config via env vars. Access via `settings` singleton or `get_settings()`. Production validators reject weak secrets |
 | `database.py` | SQLAlchemy engine + `SessionLocal` factory. SQLite (dev, WAL mode) or PostgreSQL (prod, QueuePool). `get_db()` is the FastAPI dependency. `init_db()` creates tables (SQLite only; Postgres uses Alembic) |
-| `security.py` | JWT token creation/verification (HS256). Token types: `access` (15min), `refresh` (7d, has JTI), `sse` (60s), `ws` (60s), `2fa_pending` (5min). Always validates `type` claim |
+| `security.py` | JWT token creation/verification (HS256). Token types: `access` (15min), `refresh` (7d, has JTI), `sse` (60s), `ws` (60s), `2fa_pending` (5min), `setup` (30min, admin-equivalent but only accepted by setup endpoints). Always validates `type` claim |
 | `crypto.py` | Shared at-rest encryption (MultiFernet, TOTP→VPN key); totp_service delegates here |
 | `rate_limiter.py` | slowapi-based rate limiting. `limiter` instance + `get_limit(endpoint_type)` lookup. DB-backed config with in-memory cache. Dev/test mode relaxes non-auth limits. `user_limiter` for per-user limits |
 | `lifespan.py` | FastAPI lifespan: startup/shutdown orchestration. Primary-worker election via file lock. Starts hardware services, plugins, mDNS, heartbeat writer. `IS_PRIMARY_WORKER` flag controls which process runs hardware tasks |


### PR DESCRIPTION
Schließt **#338** (K11 🟡). Reine Doku-Änderung, vier Zeilen — aber jede Behauptung am Code nachgeprüft statt aus dem Issue-Text übernommen.

Der vierte Punkt des Issues („80%+ coverage target") war bereits durch #426 erledigt; das ist [dort kommentiert](https://github.com/Xveyn/BaluHost/issues/338#issuecomment-5033468625).

## Die drei Korrekturen

**1. Token-Typen — `backend/app/core/CLAUDE.md`**
Listete fünf, `security.py` erzeugt sechs. Ergänzt: `setup` (30 min, `role: admin` im Payload, aber ausschließlich von `deps.py:249` akzeptiert, das mit `token_type="setup"` dekodiert). Verifiziert: erzeugt nur in `setup.py:114`.

**2. JWT-TTL — `.claude/rules/security.md`**
Sagte „JWT tokens expire after 12 hours (configurable)". Real: **15 Minuten** Access, **7 Tage** Refresh (`config.py:67-68`).

Das war schlimmer als eine veraltete Zeile: `security-agent.md` führte die *richtigen* Werte, zwei Rules-Dateien widersprachen sich also, und wer sie liest, hat keine Möglichkeit zu erkennen, welche gilt. Die Zeile nennt jetzt die Settings-Namen und verweist auf die Token-Tabelle, statt TTLs ein zweites Mal zu behaupten — eine Stelle zum Pflegen statt zwei.

**3. Testzahlen — `.claude/rules/backend/coding-style.md`**
Sagte „82 test files, 1465 test functions"; real sind es über 300 Dateien. Statt die heutige Zahl einzutragen und dieselbe Drift neu zu starten, verweist die Zeile jetzt auf die Testing-Zeile der README — die wird von `scripts/generate_readme_stats.py` beim Stable-Release automatisch gespliced (`release-stable.yml:77`), ist also maschinengepflegt.

## Zusätzlich gefunden

Beim Ergänzen der `setup`-Zeile stellte sich heraus, dass **`security-agent.md`s Token-Tabelle denselben Defekt hatte** wie die im Issue genannte Datei: drei von sechs Typen. `ws`, `2fa_pending` und `setup` ergänzt — meinen Verweis aus Punkt 2 auf eine unvollständige Tabelle zu richten hätte eine Ungenauigkeit nur durch eine andere ersetzt.

Alle vier Tabellenzeilen gegen `security.py` geprüft: `ws` trägt `sub` + `username` (Z. 163-169), `2fa_pending` nur `sub` (Z. 185-190), `setup` zusätzlich `role: admin` (Z. 210-217).

## Nicht angefasst

`python scripts/generate_readme_stats.py --check` meldet aktuell Drift (Exit 1) — die README steht auf „3677 tests / 345 test files". Das ist **kein Fehler**: der Splice läuft bewusst nur bei `release-stable`, die Zahlen werden beim nächsten Stable-Release korrigiert. Nichts in diesem PR hängt davon ab.

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)
