### PR TITLE
ci: pip-Socket-Timeout in backend-tests anheben — ein hängender Read killt nicht mehr den ganzen Job

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -63,6 +63,19 @@ jobs:
           # -n 4 (not -n auto): --cpus is a CFS quota, not a cpuset — os.cpu_count()
           # in the container still reports all 12 host threads, so -n auto would
           # oversubscribe the 3g-capped container.
+          # pip --timeout 60 (default: 15): the job pulls ~150 packages fresh on
+          # every run (--no-cache-dir) over the box's home uplink. On 2026-07-21 a
+          # single stalled read of exactly 15.00s killed the whole install twice —
+          # ReadTimeoutError from files.pythonhosted.org, job dead after ~48s, the
+          # re-run green both times. --retries does NOT cover this: pip defines it
+          # as "maximum attempts to establish a new HTTP connection", not body
+          # reads, and pip 24.0 (pinned in python:3.11-slim) predates the
+          # --resume-retries flag added in pip 25.1. Raising the socket timeout is
+          # the only lever here. A shared pip cache would also mask it but is
+          # deliberately not used — same PR-poisoning argument as the missing npm
+          # cache in frontend-build.
+          # Note the two unrelated timeouts on the line below: pip's --timeout is
+          # a per-read socket timeout, pytest's --timeout=120 is a per-test limit.
           podman run --rm \
             --network=bridge \
             --cpus=4 --memory=3g \
@@ -70,7 +83,7 @@ jobs:
             -w /work/backend \
             -e NAS_MODE=dev \
             "$TEST_IMAGE" \
-            bash -c "set -euo pipefail; pip install --no-cache-dir -e '.[dev]' && python -m ruff check . && python -m pytest -q --timeout=120 -n 4 -o addopts= --cov=app --cov-fail-under=65 --cov-report=term:skip-covered --cov-report=json"
+            bash -c "set -euo pipefail; pip install --no-cache-dir --timeout 60 -e '.[dev]' && python -m ruff check . && python -m pytest -q --timeout=120 -n 4 -o addopts= --cov=app --cov-fail-under=65 --cov-report=term:skip-covered --cov-report=json"
 
       - name: Backend coverage → job summary
         if: always()


### PR DESCRIPTION
Der erste Versuch von `backend-tests` ist bei **beiden** heutigen Merges gefailt, jeweils nach ~48 s, jeweils mit derselben Meldung — der Re-Run war beide Male grün. Genau das ließ es wie Flakiness aussehen.

```
pip._vendor.urllib3.exceptions.ReadTimeoutError:
HTTPSConnectionPool(host='files.pythonhosted.org', port=443): Read timed out.
```

Betroffen: Runs `29828334113` (12:00) und `29859343911` (18:56), jeweils Versuch 1.

## Root Cause

pips Default-Socket-Timeout ist **15 Sekunden**, und der Abstand zwischen dem letzten erfolgreichen Download und dem Traceback beträgt in beiden Runs exakt **15,00 s**:

```
12:00:50.9726  Downloading pyasn1_modules-0.4.2-py3-none-any.whl (181 kB)
12:01:05.9986  ERROR: Exception:
```

Der Job installiert bei jedem Lauf ~150 Pakete frisch (`--no-cache-dir`) über die Uplink-Leitung der Box, die sie sich mit dem Prod-NAS und dem zeitgleich startenden `npm ci` aus `frontend-build` teilt. Ein einziger hängender Read irgendwo in dieser Kette killt die komplette Installation — und damit einen Job, der sonst vier Minuten braucht.

## Fix

`pip install --no-cache-dir --timeout 60 …` (statt Default 15).

**`--retries` wurde bewusst nicht ergänzt.** pips eigene Hilfe definiert es als *„maximum attempts to establish a new HTTP **connection**"* — die Verbindung stand hier aber bereits, der Body-Read ist gestallt. Genau deshalb hat pip auch von sich aus nicht wiederholt. `--resume-retries`, das Teil-Downloads tatsächlich abdeckt, kam erst in pip 25.1; das gepinnte Image `python:3.11-slim` liefert **pip 24.0**. Das Socket-Timeout anzuheben ist ohne Image-Wechsel der einzige greifende Hebel.

Ein geteilter pip-Cache würde das ebenfalls kaschieren und ist bewusst **nicht** gewählt: ein PR-beschreibbarer Cache wäre geteilter Zustand zwischen PRs — dasselbe Argument, das `frontend-build` schon vom npm-Cache abhält (Layer B).

## Abgrenzung zu #394

Das ist **nicht** der Fehlermodus aus #394 (`invalid internal status, try resetting the pause process`). Beide zeigen sich als „erster Lauf failed, Re-Run grün", sind aber verschieden:

| | #394 (offen) | dieser PR |
|---|---|---|
| Meldung | `invalid internal status … pause process` | `ReadTimeoutError … files.pythonhosted.org` |
| Job-Laufzeit bis Fail | 8–21 s, vor jedem Download | ~48 s, mitten in `pip install` |
| Zuletzt aufgetreten | 2026-07-19 (davor 07-13) | 2026-07-21, zweimal |
| Ursache | rootless-Podman-Pause-Prozess nach Reboot stale | pip-Socket-Timeout zu knapp |

#394 bleibt offen — der dauerhafte Boot-Fix (systemd-User-Service mit `podman system migrate`) ist weiterhin nicht implementiert; `bootstrap-ci-runner.sh` macht `migrate` nur einmalig bei der Provisionierung.

## Verifikation

- Flag-Syntax und -Semantik gegen pips eigene `--help` geprüft: *„Set the socket timeout (default 15 seconds)"*.
- Workflow parst weiterhin (`yaml.safe_load`): beide Jobs vorhanden, `timeout-minutes: 15` unverändert, Step-Body abgesehen vom Flag identisch.
- **Ehrliche Einschränkung**: Der Fix selbst ist nicht unit-testbar — er verändert die Toleranz gegenüber einem transienten Netz-Stall. Der echte Nachweis ist, dass der *erste* Versuch der nächsten Merges grün bleibt. Falls es auch bei 60 s wieder auftritt, ist der nächste Schritt ein pip-Upgrade im Container, um `--resume-retries` zu bekommen.

## CI-Security-Checkliste

Kein Runner-Wechsel, kein Trigger-Wechsel, kein Environment entfernt, keine neuen Secrets. Die Ausführung bleibt vollständig im `podman run` (Layer B unangetastet) — geändert ist ausschließlich ein Flag innerhalb des Container-Kommandos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLKW8YZ71BLogbmsBZ3Yi9
