### PR TITLE
ci: Podman-Pause-Rennen zwischen den Sandbox-Jobs schließen (#394)

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -46,6 +46,34 @@ jobs:
           done
           echo "Identity OK: $(whoami) uid=$(id -u) groups=$(id -nG)"
 
+      # Name is quoted: an unquoted '#394)' would start a YAML comment and the
+      # step would silently lose the issue reference from its display name.
+      - name: "Ensure rootless Podman is healthy (serialized, #394)"
+        # Upstream-only: the shared rootless state exists solely on the
+        # ci-sandbox pool. Fork/GitHub-hosted runners get podman per VM.
+        if: github.repository == 'Xveyn/BaluHost'
+        run: |
+          set -euo pipefail
+          # BaluNode-ci-sandbox and BaluNode-ci-sandbox-2 run as the SAME POSIX
+          # user (ci-runner), so all three sandbox jobs share ONE rootless
+          # Podman state — including the pause process that holds the user
+          # namespace. Both recorded failures (#127, #394) hit a job that
+          # started while another job's podman was coming up or running:
+          #   2026-07-13 17:00:01Z  backend-tests and frontend-build started in
+          #                         the same second; backend-tests died after 8s
+          #   2026-07-19 18:29:03Z  backend-tests started inside frontend-build's
+          #                         podman window; died after 21s
+          # both with 'invalid internal status ... could not find any running
+          # process'. Re-running the failed job alone is always green, because
+          # nothing races it then.
+          # `podman info` initialises the runtime and would recreate the pause
+          # process itself, so the probe has to be serialized too — hence flock
+          # around the whole check rather than a bare `||`.
+          # `podman system migrate` runs ONLY when podman is already broken:
+          # resetting the pause process unconditionally would rip it out from
+          # under a container the other runner instance is running right now.
+          flock "$HOME/.podman-health.lock" -c 'podman info >/dev/null 2>&1 || podman system migrate'
+
       - name: Lint + backend tests (with coverage) in rootless Podman container
         env:
           TEST_IMAGE: docker.io/library/python:3.11-slim
@@ -137,6 +165,16 @@ jobs:
             fi
           done
           echo "Identity OK: $(whoami) uid=$(id -u) groups=$(id -nG)"
+
+      - name: "Ensure rootless Podman is healthy (serialized, #394)"
+        # Identical to the backend-tests step; full rationale lives there. This
+        # job is the OTHER half of the race, so it needs the same lock —
+        # whichever job starts first recreates the pause process while the other
+        # waits, instead of both racing to create it.
+        if: github.repository == 'Xveyn/BaluHost'
+        run: |
+          set -euo pipefail
+          flock "$HOME/.podman-health.lock" -c 'podman info >/dev/null 2>&1 || podman system migrate'
 
       - name: Lint + build + unit tests (with coverage) in rootless Podman container
         env:

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -66,6 +66,16 @@ jobs:
           done
           echo "Identity OK: $(whoami) uid=$(id -u) groups=$(id -nG)"
 
+      - name: "Ensure rootless Podman is healthy (serialized, #394)"
+        # Same lock as ci-check.yml's two jobs (full rationale there). mock-e2e
+        # is the third consumer of the one shared rootless Podman state on the
+        # ci-sandbox pool and runs concurrently with them on every PR, so it has
+        # to take part in the serialization rather than race past it.
+        if: github.repository == 'Xveyn/BaluHost'
+        run: |
+          set -euo pipefail
+          flock "$HOME/.podman-health.lock" -c 'podman info >/dev/null 2>&1 || podman system migrate'
+
       - name: Mocked Playwright tests in rootless Podman container
         env:
           # Pinned to the SAME version as client/package-lock.json's


### PR DESCRIPTION
Behebt #394 — aber mit einer anderen Ursache als der, die #394 und #127 vermutet haben.

## Was wirklich passiert

`BaluNode-ci-sandbox` und `BaluNode-ci-sandbox-2` laufen als **derselbe POSIX-User** (`ci-runner`). Damit teilen sich alle drei Sandbox-Jobs — `backend-tests`, `frontend-build`, `mock-e2e` — **einen** rootless-Podman-Zustand samt Pause-Prozess, der den User-Namespace hält.

Beide protokollierten Fehlschläge starteten, während der Podman eines anderen Jobs gerade hochkam oder lief:

| Zeitpunkt (UTC) | backend-tests | parallel |
|---|---|---|
| 2026-07-13 17:00:01 | tot nach **8 s** | `frontend-build` startete in **derselben Sekunde** |
| 2026-07-19 18:29:03 | tot nach **21 s** | `frontend-build` lief seit 18:24:39, mitten im Podman-Fenster |

Beide mit `invalid internal status … could not find any running process`. Der Re-Run mit `--failed` ist **immer** grün — weil dann nur ein Job läuft und nichts mit ihm konkurriert. Genau das hat das Bild „passiert nach einem Reboot" erzeugt.

## Fix

Vor dem Container-Schritt nimmt jeder Job ein gemeinsames Lock und repariert nur, wenn Podman tatsächlich kaputt ist:

```bash
flock "$HOME/.podman-health.lock" -c 'podman info >/dev/null 2>&1 || podman system migrate'
```

Zwei Details sind tragend:

- **Das Lock umschließt die Prüfung, nicht nur die Reparatur.** `podman info` initialisiert die Runtime und legt den Pause-Prozess selbst neu an — zwei gleichzeitige Prüfungen würden also exakt das Rennen reproduzieren, das hier geschlossen werden soll.
- **`podman system migrate` läuft nur im Defektfall.** Ein bedingungsloses Zurücksetzen würde dem Container der *anderen* Runner-Instanz den Pause-Prozess unter den Füßen wegziehen.

Alle drei Jobs nehmen teil, sonst rennt der nicht beteiligte weiter gegen die anderen.

## Was ausgeschlossen wurde

Damit das niemand noch einmal durchläuft — alles auf der Box gemessen:

| Vermutung | Befund |
|---|---|
| Fehlendes `enable-linger` (Diagnose aus #127) | Linger ist aktiv, `loginctl … Linger` = `yes` — trat trotzdem zweimal wieder auf |
| Runner-Service hat andere Umgebung als der Bootstrap-Selbsttest | Beide haben `XDG_RUNTIME_DIR` **ungesetzt**; meine eigene Hypothese, widerlegt |
| `systemd-tmpfiles-clean` räumt Podmans Runtime weg | Cleaner lief 17.07., 18.07., 20.07. — **nie** zwischen Resume (19.07. 13:00) und Fail (20:29). RunRoot ist `/run/user/993/containers` auf der logind-tmpfs, nicht unter `/tmp` |
| Reboot | An beiden Fail-Tagen keiner; letzter Boot vor dem 19.07.-Fail lag 22 h zurück |

## Ehrliche Grenzen

- **Der genaue Mechanismus des Rennens ist nicht bewiesen.** Die Journal-Abfrage, die das Sterben des Pause-Scopes gezeigt hätte, war auf vier Zeilen gekürzt. Belegt ist die Korrelation mit gleichzeitigem Podman-Start in *beiden* Vorfällen. Der Fix ist davon unabhängig korrekt: er deckt auch die Lesart „Zustand ist im Leerlauf stale geworden" ab, weil die Prüfung in beiden Fällen repariert.
- **`flock` konnte lokal nicht ausgeführt werden** (Windows, kein util-linux). Es steckt in util-linux, auf Debian `Priority: required`. Der Nachweis ist der CI-Lauf dieses PRs selbst: der neue Schritt läuft auf dem echten ci-sandbox-Runner in allen drei Jobs, bevor sonst irgendetwas passiert — ein falscher Aufruf färbt also diesen PR rot, statt auf `main` zu landen.
- Geprüft wurde außerdem: kein BOM, kein Mojibake, YAML parst, Step-Namen sind gequotet (ein unquotiertes `#394)` hätte YAML als Kommentar gelesen und die Referenz still verschluckt).

## Bewusst nicht in diesem PR

Der Selbsttest in `scripts/bootstrap-ci-runner.sh` prüft die Podman-Gesundheit **nur einmal bei der Provisionierung**. Über den Zustand Wochen später kann er per Konstruktion nichts sagen — so konnte #127 als verifiziert geschlossen werden und trotzdem zweimal wiederkommen. Das gehört in den Bootstrap (CODEOWNERS-Pfad) und bleibt als Folgearbeit an #394 hängen.

## CI-Security-Checkliste

Kein Runner-Wechsel, kein Trigger-Wechsel, kein Environment entfernt, keine neuen Secrets. Der neue Schritt läuft auf dem Host — wie der bestehende Identity-Tripwire — und führt ausschließlich workflow-definierte podman-Kommandos aus, keinen PR-Code. Layer B bleibt unangetastet: untrusted Code läuft weiterhin ausschließlich im `podman run`. Der Schritt ist mit demselben `github.repository`-Literal auf Upstream begrenzt wie der Tripwire, Forks bleiben unberührt.

Refs #394, #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLKW8YZ71BLogbmsBZ3Yi9
