### PR TITLE
docs: Versions-Drift beheben — Doku-Header streichen, SECURITY.md automatisieren (#349)

### DIFF
--- a/.claude/rules/security-agent.md
+++ b/.claude/rules/security-agent.md
@@ -197,4 +197,8 @@ Do NOT attempt to fix these without explicit discussion — they are documented 
 7. **Token in localStorage** — XSS risk mitigated by CSP headers; HttpOnly cookies would require significant auth refactor
 8. **`change-password` uses raw `dict`** — `api/routes/auth.py:121` accepts `payload: dict` instead of Pydantic model, meaning new passwords bypass the `RegisterRequest` password strength validator
 9. **VPN encryption key empty default** — Validated at use-time in `VPNEncryption` methods, not at startup; fails loudly if missing
-10. **SECURITY.md "Supported Versions" table is stale** — The file was rewritten and no longer documents fixed limitations; reporting channels, response timeline, disclosure policy and scope are current. What remains stale is the version table (still `1.30.x`, the project is past 1.38). `scripts/bump_version.py` propagates the version from its source of truth (`backend/pyproject.toml`) into `client/package.json` and `CLAUDE.md`, but not into `SECURITY.md` — wiring it in (or dropping the concrete numbers) is tracked in #349. Not a gap in the security posture, only in the version metadata
+
+Entry 10 ("SECURITY.md outdated") was removed on 2026-07-21: the file had already
+been rewritten, and its one remaining stale item — the supported-versions table —
+is now maintained by `scripts/bump_version.py` (#349). It was never a gap in the
+security posture, only in version metadata.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,12 @@
 
 ## Supported Versions
 
-Only the latest minor release line receives security updates. BaluHost follows semantic versioning — patch releases (`1.30.x`) carry security fixes for the current minor.
+Only the latest minor release line receives security updates. BaluHost follows semantic versioning — patch releases (`1.38.x`) carry security fixes for the current minor.
 
 | Version | Supported |
 | ------- | --------- |
-| 1.30.x  | ✅        |
-| < 1.30  | ❌        |
+| 1.38.x  | ✅        |
+| < 1.38  | ❌        |
 
 ## Reporting a Vulnerability
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,13 @@
 # BaluHost NAS Manager - TODO List
 
-## 🚀 Production Deployment Status (deployed 25. Januar 2026, current v1.36.0 / Juni 2026)
+## 🚀 Production Deployment Status (deployed 25. Januar 2026)
 
 BaluHost ist **LIVE IN PRODUCTION**:
 - ✅ Debian 13 Server (Ryzen 5 5600GT, 16GB RAM, 250GB NVMe SSD)
 - ✅ PostgreSQL 17.7 Datenbank
 - ✅ Nginx Reverse Proxy (Port 80, HTTP)
 - ✅ Systemd Services (4 Uvicorn Workers)
-- ✅ 82 Test Files, 1465 Test Functions
+- ✅ Pytest-Suite (Umfang: Testing-Zeile in `README.md`, maschinell gepflegt)
 - ✅ Prometheus/Grafana Ready Monitoring
 - ✅ Structured JSON Logging
 
@@ -106,7 +106,7 @@ BaluHost ist **LIVE IN PRODUCTION**:
 | 📝 Docs | Documentation | Code-Kommentare standardisieren | ⏳ Pending | Docstrings, JSDoc |
 | 📝 Docs | Documentation | Changelog.md für Versionshistorie | ✅ Done | CHANGELOG.md complete through v1.4.x |
 | 📝 Docs | Documentation | Badges aktualisieren | ⏳ Pending | Test-Coverage, Build |
-| 🧪 Test | Backend Testing | Integration Tests für alle API-Endpunkte | ✅ Done | 82 test files, 1465 test functions including integration, security, RAID, upload progress, sync tests |
+| 🧪 Test | Backend Testing | Integration Tests für alle API-Endpunkte | ✅ Done | Integration, security, RAID, upload progress, sync tests; Suite-Umfang siehe Testing-Zeile in `README.md` |
 | 🧪 Test | Backend Testing | Unit Tests für alle Services erweitern | ✅ Done | Excellent test coverage across all services |
 | 🧪 Test | Backend Testing | Load Testing (Performance unter Last) | ⏳ Pending | Performance |
 | 🧪 Test | Backend Testing | Security Testing (Penetration Tests) | ⏳ Pending | Security |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # BaluHost - Architecture Documentation
 
-**Version:** 1.16.4
-**Last Updated:** 19. März 2026
 **Status:** ✅ DEPLOYED IN PRODUCTION (seit 25. Januar 2026)
+**Version:** see `backend/pyproject.toml` (single source of truth) or the top of `CHANGELOG.md` — deliberately not repeated here, because the hand-maintained copy sat at 1.16.4 until July 2026 while the project was at 1.38.0 (#349)
+**Last content change:** `git log -1 --format=%ad -- docs/ARCHITECTURE.md`
 
 ## 📐 System Overview
 
@@ -148,7 +148,7 @@ baluhost/
 │   │   ├── core/              # Config, security, database, rate limiter
 │   │   └── middleware/        # Security headers, rate limiting, device tracking
 │   ├── baluhost_tui/          # Terminal UI (Textual)
-│   ├── tests/                 # 82 test files, 1465 test functions
+│   ├── tests/                 # Pytest suite (size: Testing row in README.md)
 │   ├── alembic/               # 74 database migrations
 │   └── pyproject.toml         # Python dependencies
 │
@@ -434,7 +434,7 @@ class TelemetrySnapshot:
 ```
 
 ### Test Coverage
-- 82 test files, 1465 test functions
+- Suite size: see the Testing row in `README.md`, kept current by `scripts/generate_readme_stats.py`. Not restated here — this line claimed "82 test files, 1465 test functions" long after the suite had grown past four times that (#349)
 - Services: Comprehensive coverage
 - API routes: Integration tests
 - Frontend: Vitest unit tests configured
@@ -685,7 +685,6 @@ For detailed documentation see [`backend/app/plugins/README.md`](../backend/app/
 
 ---
 
-**Last Updated:** 19. März 2026
-**Version:** 1.16.4
 **Maintainer:** Xveyn
+**Version & last change:** see the header of this document
 **Status:** ✅ DEPLOYED IN PRODUCTION

--- a/docs/TECHNICAL_DOCUMENTATION.md
+++ b/docs/TECHNICAL_DOCUMENTATION.md
@@ -4,12 +4,12 @@ Kurzfassung
 -
 BaluHost ist eine Full‑Stack NAS-Management-Anwendung. Das Backend ist in Python (FastAPI) implementiert, das Frontend ist ein React + TypeScript Single-Page-Application (Vite). Diese Dokumentation beschreibt Architektur, Komponenten, Deployment- und Entwicklungs-Workflows und zeigt ein ASCII-Diagramm, wie Frontend und Backend miteinander zusammenspielen.
 
-Version & Datum
+Stand
 -
-- **Version:** 1.16.4
-- **Last Updated:** 19. März 2026
 - **Maintainer:** Xveyn
 - **Status:** ✅ DEPLOYED IN PRODUCTION (seit 25. Januar 2026)
+- **Version:** siehe `backend/pyproject.toml` (Single Source of Truth) bzw. den Kopf von `CHANGELOG.md`. Hier bewusst nicht wiederholt: die handgepflegte Kopie stand bis Juli 2026 auf 1.16.4, während das Projekt bei 1.38.0 war (#349)
+- **Letzte inhaltliche Änderung:** `git log -1 --format=%ad -- docs/TECHNICAL_DOCUMENTATION.md` — git weiß das genauer als eine Zeile, die beim Bearbeiten mitgepflegt werden müsste
 
 Technologie-Überblick
 -
@@ -18,7 +18,7 @@ Technologie-Überblick
 - Runtime: Uvicorn (ASGI)
 - System & Monitoring: psutil, smartctl (optional, Linux)
 - Auth: JWT (Access + Refresh flows)
-- DB (dev): SQLite; Production: PostgreSQL empfohlen
+- DB (dev): SQLite; Production: PostgreSQL 17.7 (seit Januar 2026 im Einsatz, nicht bloß empfohlen)
 
 Projektstruktur (Wichtigste Ordner)
 -
@@ -164,7 +164,8 @@ Was ist neu / Highlights (Kurz)
 
 Änderungs- und Releasehinweis
 -
-- Version: 1.16.4 — Plugin-System mit Pluggy-Hooks, async Events, Permission-System, Dashboard-Panels. Smart-Device-Framework mit Capability-Protocols und SHM-basiertem Polling. Mitgelieferte Plugins: Optical Drive, Storage Analytics, Tapo Smart Plug. Security: Rate Limiting, Security Headers, TOTP 2FA, Fernet-Verschlüsselung. PostgreSQL 17.7 in Produktion.
+- Die Release-Historie steht vollständig in `CHANGELOG.md` und wird dort gepflegt; dieser Abschnitt fasst nur zusammen, was das System heute kann.
+- Plugin-System mit Pluggy-Hooks, async Events, Permission-System, Dashboard-Panels. Smart-Device-Framework mit Capability-Protocols und SHM-basiertem Polling. Mitgelieferte Plugins: Optical Drive, Storage Analytics, Tapo Smart Plug. Security: Rate Limiting, Security Headers, TOTP 2FA, Fernet-Verschlüsselung. PostgreSQL 17.7 in Produktion.
 
 Kontakt & Mitwirkung
 -
@@ -2143,7 +2144,6 @@ Comprehensive user settings interface with multiple tabs:
 
 ---
 
-**Last Updated:** 19. März 2026
-**Version:** 1.16.4
 **Maintainer:** Xveyn
 **Status:** ✅ DEPLOYED IN PRODUCTION
+**Version & Änderungsdatum:** siehe „Stand" am Anfang dieses Dokuments

--- a/docs/deployment/PRODUCTION_READINESS.de.md
+++ b/docs/deployment/PRODUCTION_READINESS.de.md
@@ -4,7 +4,7 @@
 
 **Produktiv seit:** 25. Januar 2026  
 **Server:** Debian 13, Ryzen 5 5600GT, 16 GB RAM, 250 GB NVMe SSD  
-**Version:** 1.23.0
+**Version:** siehe `backend/pyproject.toml` bzw. den Kopf von `CHANGELOG.md` — hier nicht wiederholt, diese Zeile stand auf 1.23.0, während das Projekt bei 1.38.0 war (#349)
 
 ## Infrastruktur
 
@@ -33,7 +33,7 @@
 
 ## Tests
 
-- **82 Testdateien**, 1465 Testfunktionen
+- Pytest-Suite — Umfang in der Testing-Zeile von `README.md` (maschinell gepflegt)
 - CI/CD-Pipeline via GitHub Actions
 - Automatische Tests bei Push/PR
 

--- a/docs/deployment/PRODUCTION_READINESS.en.md
+++ b/docs/deployment/PRODUCTION_READINESS.en.md
@@ -4,7 +4,7 @@
 
 **In production since:** January 25, 2026  
 **Server:** Debian 13, Ryzen 5 5600GT, 16 GB RAM, 250 GB NVMe SSD  
-**Version:** 1.23.0
+**Version:** see `backend/pyproject.toml` or the top of `CHANGELOG.md` — not repeated here, this line sat at 1.23.0 while the project was at 1.38.0 (#349)
 
 ## Infrastructure
 
@@ -33,7 +33,7 @@
 
 ## Tests
 
-- **82 test files**, 1465 test functions
+- Pytest suite — size in the Testing row of `README.md` (machine-maintained)
 - CI/CD pipeline via GitHub Actions
 - Automatic tests on push/PR
 
@@ -79,4 +79,4 @@ rsync -av /opt/baluhost/storage/ /backup/storage/
 
 ---
 
-**Last updated:** April 2026
+**Last content change:** `git log -1 --format=%ad -- docs/deployment/PRODUCTION_READINESS.en.md`

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -2,7 +2,7 @@
 """Bump the project version in all relevant files.
 
 Single source of truth: backend/pyproject.toml
-Synced targets: client/package.json, CLAUDE.md
+Synced targets: client/package.json, CLAUDE.md, SECURITY.md (supported-version table)
 
 Usage:
     python scripts/bump_version.py 1.21.0
@@ -22,6 +22,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = ROOT / "backend" / "pyproject.toml"
 PACKAGE_JSON = ROOT / "client" / "package.json"
 CLAUDE_MD = ROOT / "CLAUDE.md"
+SECURITY_MD = ROOT / "SECURITY.md"
 
 
 def read_current_version() -> str:
@@ -78,6 +79,25 @@ def update_claude_md(version: str) -> None:
     CLAUDE_MD.write_text(text, encoding="utf-8")
 
 
+def update_security_md(version: str) -> None:
+    """Point SECURITY.md's supported-version table at the current minor line.
+
+    Unlike the version headers that #349 removed from the docs, this number is a
+    policy statement — it tells a reporter which release line still receives
+    security fixes — so it has to stay accurate rather than be deleted. It sat
+    at 1.30.x while the project was at 1.38.0.
+
+    Only the minor line is written (1.38.x / < 1.38); the patch level is
+    irrelevant to the statement being made.
+    """
+    major_minor = ".".join(version.split(".")[:2])
+    text = SECURITY_MD.read_text(encoding="utf-8")
+    # Prose mention and the two table rows all carry the same two shapes.
+    text = re.sub(r"\d+\.\d+\.x", f"{major_minor}.x", text)
+    text = re.sub(r"< \d+\.\d+(?!\.)", f"< {major_minor}", text)
+    SECURITY_MD.write_text(text, encoding="utf-8")
+
+
 def main() -> None:
     args = sys.argv[1:]
     dry_run = False
@@ -113,11 +133,14 @@ def main() -> None:
 
     update_package_json(new_version)
     update_claude_md(new_version)
+    update_security_md(new_version)
 
+    major_minor = ".".join(new_version.split(".")[:2])
     print(f"Updated files:")
     print(f"  backend/pyproject.toml  -> {new_version}")
     print(f"  client/package.json     -> {new_version}")
     print(f"  CLAUDE.md               -> {new_version}")
+    print(f"  SECURITY.md             -> {major_minor}.x")
     print()
     print("Note: Run 'cd client && npm install' to sync package-lock.json")
 


### PR DESCRIPTION
Behebt #349. Das Issue stellte die Wahl „in `bump_version.py` aufnehmen **oder** Versionszeilen streichen" — die Antwort fällt pro Zeile unterschiedlich aus, weil es nicht dieselbe Art von Aussage ist.

## Gestrichen: Dokument-Kopfzeilen

`docs/TECHNICAL_DOCUMENTATION.md`, `docs/ARCHITECTURE.md`, `docs/deployment/PRODUCTION_READINESS.{de,en}.md`, `TODO.md`

Diese trugen Header wie `**Version:** 1.16.4` und `**Last Updated:** 19. März 2026`. Sie sagen nichts, was ein Leser braucht: die Version steht in `backend/pyproject.toml` und im Kopf von `CHANGELOG.md`, das Änderungsdatum weiß git.

**Warum hier bewusst nicht automatisiert wurde:** Ein `bump_version.py`, das diese Zeilen mitstempelt, wäre *schlechter* als die Drift. Ein Release-Bump würde das heutige Datum auf ein Dokument schreiben, das seit März niemand gelesen hat — aus sichtbarer Veraltung würde unsichtbare. Die Header verweisen jetzt auf die echten Quellen und benennen den Wert, auf dem sie steckengeblieben waren, damit die Korrektur nachvollziehbar bleibt.

## Automatisiert: SECURITY.md

Dort ist die Nummer eine **Policy-Aussage** — sie sagt einem Melder, welche Release-Linie noch Sicherheitsfixes bekommt. Die muss stimmen, nicht verschwinden.

Neu in `bump_version.py`: `update_security_md()` schreibt die Prosa-Erwähnung und beide Tabellenzeilen auf die aktuelle Minor-Linie. Sie stand auf `1.30.x`, während das Projekt bei 1.38.0 war.

## Nebenher korrigiert

- **Stale Testzahlen** („82 test files, 1465 test functions") in ARCHITECTURE.md (2×), TODO.md (2×) und PRODUCTION_READINESS.{de,en}.md verweisen jetzt auf die Testing-Zeile der README, die `generate_readme_stats.py` pflegt — dieselbe Behandlung wie in #432 und #433. Reale Zahlen: 3677 Tests in 345 Dateien, die Angabe lag also um Faktor vier daneben.
- **TECHNICAL_DOCUMENTATION.md** sagte „Production: PostgreSQL empfohlen", während Zeile 167 derselben Datei und ARCHITECTURE.md beide „deployed seit Januar 2026" sagen. Jetzt konsistent.
- **`security-agent.md` Gap #10 entfernt** statt erneut umformuliert: #433 hatte ihn auf „nur die Versions-Tabelle ist stale, tracked in #349" eingekürzt — und genau das behebt dieser PR. Ein erledigter Gap, der in der Liste stehenbleibt, hätte denselben Defekt wie der Eintrag ursprünglich selbst.

## Scope-Abweichungen (bewusst)

- **`PRODUCTION_READINESS.{de,en}.md` waren im Issue nicht genannt.** Sie trugen denselben Defekt (`**Version:** 1.23.0`, dieselben Testzahlen, „Last updated: April 2026") und sind je zwei Zeilen. Bekannt falsche Zahlen stehenzulassen, während vier Dateien weiter dieselbe Aussage korrigiert wird, wäre seltsam gewesen.
- **`TODO.md` Zeile 214 bleibt unverändert.** Dort steht „Roadmap-Abgleich gegen den aktuellen Code-Stand (v1.36.0 …)" unter der Überschrift „Review Notes (6. Juni 2026)". Die Version, gegen die geprüft wurde, zu nennen, ist dort korrekt — das ist ein Protokoll, keine Statuszeile.

## Verifikation

- `python scripts/bump_version.py` ohne Argumente (Sync-Modus) fasst **nur** SECURITY.md an. `pyproject.toml`, `package.json` und `CLAUDE.md` standen bereits auf 1.38.0 und blieben byte-identisch — genau das belegt, dass die beiden Regexe auf die gemeinten Zeilen begrenzt sind.
- Ein erneuter Lauf lässt den SHA-256 von SECURITY.md unverändert → die Transformation ist idempotent.
- `--dry-run` gibt weiterhin nur die Version aus, wie `ci-deploy.sh` es erwartet.
- Kein BOM eingeschleppt. (`docs/TECHNICAL_DOCUMENTATION.md` hat eins — das steckte bereits in HEAD und wurde nicht angefasst, um den Diff nicht zu verrauschen.)

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLKW8YZ71BLogbmsBZ3Yi9
