### PR TITLE
fix(metrics): Prometheus-Collector-Fehler ins Logging statt nach stdout (#308)

### DIFF
--- a/backend/app/api/routes/metrics.py
+++ b/backend/app/api/routes/metrics.py
@@ -22,6 +22,7 @@ from prometheus_client import (
     generate_latest,
     CONTENT_TYPE_LATEST,
 )
+import logging
 import psutil
 import time
 
@@ -29,6 +30,8 @@ from app.api import deps
 from app.core.config import settings
 from app.services.hardware.sensors import get_cpu_sensor_data
 from app.core.rate_limiter import limiter, get_limit
+
+logger = logging.getLogger(__name__)
 
 # Create router
 router = APIRouter()
@@ -374,7 +377,7 @@ def collect_system_metrics():
 
     except Exception as e:
         # Log error but don't fail metrics endpoint
-        print(f"Error collecting system metrics: {e}")
+        logger.warning("Error collecting system metrics: %s", e)
 
 
 def collect_raid_metrics():
@@ -404,7 +407,7 @@ def collect_raid_metrics():
             raid_sync_progress_percent.labels(device=device).set(sync_progress)
 
     except Exception as e:
-        print(f"Error collecting RAID metrics: {e}")
+        logger.warning("Error collecting RAID metrics: %s", e)
 
 
 def collect_smart_metrics():
@@ -441,7 +444,7 @@ def collect_smart_metrics():
                     pass
 
     except Exception as e:
-        print(f"Error collecting SMART metrics: {e}")
+        logger.warning("Error collecting SMART metrics: %s", e)
 
 
 def collect_database_metrics(db: Session):
@@ -457,7 +460,7 @@ def collect_database_metrics(db: Session):
         users_total.labels(role='user').set(user_count)
 
     except Exception as e:
-        print(f"Error collecting database metrics: {e}")
+        logger.warning("Error collecting database metrics: %s", e)
 
 
 def collect_app_metrics():
@@ -478,7 +481,7 @@ def collect_app_metrics():
         app_uptime_seconds.set(uptime)
 
     except Exception as e:
-        print(f"Error collecting app metrics: {e}")
+        logger.warning("Error collecting app metrics: %s", e)
 
 
 # ===================================

--- a/backend/tests/api/test_metrics_collection_logging.py
+++ b/backend/tests/api/test_metrics_collection_logging.py
@@ -1,0 +1,79 @@
+"""Prometheus collectors must report failures through the logger (#308).
+
+Each collector swallows its exception so `/api/metrics` keeps serving even
+when one data source is broken. That part is deliberate — but the swallowed
+error still has to reach the structured production log. Written to `print()`
+it lands nowhere a NAS operator looks: a box whose RAID or SMART collection
+has been failing for weeks looks perfectly healthy in the logs.
+"""
+
+import logging
+
+import pytest
+
+from app.api.routes import metrics
+
+
+def _explode(*args, **kwargs):
+    raise RuntimeError("collector exploded")
+
+
+def _break_system(monkeypatch):
+    monkeypatch.setattr(metrics.psutil, "cpu_percent", _explode)
+    return metrics.collect_system_metrics
+
+
+def _break_raid(monkeypatch):
+    from app.services.hardware.raid import api as raid_api
+
+    monkeypatch.setattr(raid_api, "get_status", _explode)
+    return metrics.collect_raid_metrics
+
+
+def _break_smart(monkeypatch):
+    from app.services.hardware.smart import api as smart_api
+
+    monkeypatch.setattr(smart_api, "get_smart_status", _explode)
+    return metrics.collect_smart_metrics
+
+
+def _break_database(monkeypatch):
+    class _BrokenSession:
+        def query(self, *args, **kwargs):
+            _explode()
+
+    return lambda: metrics.collect_database_metrics(_BrokenSession())
+
+
+def _break_app(monkeypatch):
+    monkeypatch.setattr(metrics.app_info, "labels", _explode)
+    return metrics.collect_app_metrics
+
+
+@pytest.mark.parametrize(
+    "break_collector,subject",
+    [
+        (_break_system, "system"),
+        (_break_raid, "RAID"),
+        (_break_smart, "SMART"),
+        (_break_database, "database"),
+        (_break_app, "app"),
+    ],
+)
+def test_collector_failure_is_logged(break_collector, subject, monkeypatch, caplog):
+    """A failing collector logs the error instead of printing it, and never raises."""
+    collect = break_collector(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger=metrics.logger.name):
+        collect()  # must not propagate — the endpoint keeps serving
+
+    records = [r for r in caplog.records if r.name == metrics.logger.name]
+    assert records, f"{subject} collection failure never reached the logger"
+
+    messages = [r.getMessage() for r in records]
+    assert any("collector exploded" in m for m in messages), (
+        f"{subject} log line drops the underlying error: {messages}"
+    )
+    assert any(subject.lower() in m.lower() for m in messages), (
+        f"{subject} log line does not say which collector failed: {messages}"
+    )


### PR DESCRIPTION
Closes #308 ([S5] aus dem Code-Assessment #298).

## Problem

Alle fünf Prometheus-Collectoren in `backend/app/api/routes/metrics.py` — System, RAID, SMART, Datenbank, App — fingen ihre Exception ab und meldeten sie per `print()`:

```python
except Exception as e:
    print(f"Error collecting RAID metrics: {e}")
```

Das Schlucken selbst ist richtig: eine kaputte Datenquelle darf `/api/metrics` nicht abschießen. Aber `print()` läuft am strukturierten Prod-Logging vorbei (systemd-JSON-Format, `journalctl -u baluhost-backend`). Ausgerechnet die Fehler, die man auf einem NAS sehen will — RAID- oder SMART-Collection seit Wochen defekt — landen nirgends, wo jemand hinschaut. Der Endpunkt liefert weiter brav seine übrigen Metriken, das Log bleibt still.

## Fix

Modul-Logger plus `logger.warning(...)` in allen fünf Handlern, im repo-dominanten Lazy-`%`-Stil (`logger.warning("...: %s", e)`, wie in `backup.py`, `admin_db.py`, `cloud.py`).

`WARNING` statt `ERROR`, weil der Endpunkt weiter funktioniert; ohne Traceback, weil Prometheus alle 15 s scrapt und ein Dauerfehler sonst das Log flutet.

## Tests

Neu: `backend/tests/api/test_metrics_collection_logging.py` — parametrisiert über alle fünf Collectoren (TDD, zuerst rot gesehen: `AttributeError: module 'app.api.routes.metrics' has no attribute 'logger'`).

Pro Collector wird die jeweilige Datenquelle zum Werfen gebracht (`psutil.cpu_percent`, `raid.api.get_status`, `smart.api.get_smart_status`, eine kaputte Session, `app_info.labels`) und geprüft:

- der Aufruf propagiert die Exception **nicht** — der Endpunkt bedient weiter
- der Fehler erreicht den Modul-Logger (nicht stdout)
- die Logzeile trägt die Ursache **und** sagt, welcher Collector gescheitert ist

Lokal: `tests/api` + `tests/monitoring` → 523 passed. `ruff check` sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
