### PR TITLE
fix(services): restliche zwei print()-Fehlerpfade ins Logging (Nachzug zu #308)

### DIFF
--- a/backend/app/services/audit/admin_db.py
+++ b/backend/app/services/audit/admin_db.py
@@ -1,4 +1,5 @@
 from typing import List, Optional, Dict, Any
+import logging
 import re
 import os
 
@@ -7,6 +8,8 @@ from sqlalchemy.orm import Session
 
 from app.core import database
 from app.schemas.admin_db import AdminTableSchemaField, AdminTableRowsResponse
+
+logger = logging.getLogger(__name__)
 
 
 REDACT_PATTERN = re.compile(
@@ -232,7 +235,7 @@ class AdminDBService:
         try:
             total = db.execute(count_stmt).scalar()
         except Exception as e:
-            print(f"[ADMIN_DB] Failed to count rows: {e}")
+            logger.warning("Failed to count rows in %s: %s", table_name, e)
             total = None
 
         # Sorting

--- a/backend/app/services/versioning/priority.py
+++ b/backend/app/services/versioning/priority.py
@@ -6,6 +6,8 @@ preserving high-priority and recent versions.
 """
 from typing import List, Tuple, Optional, TYPE_CHECKING
 from datetime import datetime, timedelta, timezone
+import logging
+
 from sqlalchemy import and_, or_, func
 from sqlalchemy.orm import Session
 
@@ -15,6 +17,8 @@ if TYPE_CHECKING:
 else:
     from app.models.vcl import FileVersion, VersionBlob, VCLSettings, VCLStats
     from app.services.versioning.vcl import VCLService
+
+logger = logging.getLogger(__name__)
 
 
 class VCLPriorityMode:
@@ -278,7 +282,7 @@ class VCLPriorityMode:
                     })
                     freed_bytes += blob_size
                 except Exception as e:
-                    print(f"⚠️ Failed to delete blob {blob.id}: {e}")
+                    logger.warning("Failed to delete blob %s: %s", blob.id, e)
             else:
                 deleted_blobs.append({
                     'id': blob.id,

--- a/backend/tests/services/test_vcl_priority_logging.py
+++ b/backend/tests/services/test_vcl_priority_logging.py
@@ -1,0 +1,48 @@
+"""A blob that refuses to be deleted must not fail silently.
+
+`cleanup_orphaned_blobs` swallows per-blob delete errors so one stuck blob
+cannot abort the whole cleanup run. Reported via `print()` that was invisible
+in the structured production log — and a silently failing blob delete means
+storage that is never actually reclaimed. Follow-up to #308.
+"""
+
+import logging
+
+from app.models.vcl import VersionBlob
+from app.services.versioning import priority as priority_module
+from app.services.versioning.priority import VCLPriorityMode
+
+
+def test_failed_blob_delete_is_logged(db_session, monkeypatch, caplog):
+    blob = VersionBlob(
+        checksum="a" * 64,
+        storage_path="/tmp/baluhost-test-blob",
+        original_size=1024,
+        compressed_size=512,
+        reference_count=0,
+    )
+    db_session.add(blob)
+    db_session.commit()
+
+    mode = VCLPriorityMode(db_session)
+
+    def _refuse_delete(_blob):
+        raise RuntimeError("blob unlink failed")
+
+    monkeypatch.setattr(mode.vcl_service, "delete_blob", _refuse_delete)
+
+    with caplog.at_level(logging.WARNING, logger=priority_module.logger.name):
+        result = mode.cleanup_orphaned_blobs(dry_run=False)
+
+    # The run completes and honestly reports that nothing was freed.
+    assert result["deleted_blobs"] == 0
+    assert result["freed_bytes"] == 0
+
+    messages = [
+        r.getMessage() for r in caplog.records if r.name == priority_module.logger.name
+    ]
+    assert messages, "failed blob delete never reached the logger"
+    assert any("blob unlink failed" in m for m in messages), messages
+    assert any(str(blob.id) in m for m in messages), (
+        f"log line does not identify which blob got stuck: {messages}"
+    )

--- a/backend/tests/test_admin_db.py
+++ b/backend/tests/test_admin_db.py
@@ -1,6 +1,10 @@
+import logging
+
 import pytest
 
 from app.core.config import settings
+from app.services.audit import admin_db as admin_db_module
+from app.services.audit.admin_db import AdminDBService
 
 
 def test_admin_tables_requires_admin(client, user_headers):
@@ -29,3 +33,30 @@ def test_admin_tables_and_schema_and_rows(client, admin_headers, db_session):
         rows_payload = res3.json()
         assert rows_payload.get("table") == "users"
         assert isinstance(rows_payload.get("rows"), list)
+
+
+def test_row_count_failure_is_logged(db_session, monkeypatch, caplog):
+    """A failed COUNT degrades to total=None — but must say so in the log (#308 follow-up)."""
+    real_execute = db_session.execute
+    calls = {"n": 0}
+
+    def _flaky_execute(stmt, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:  # the COUNT query runs before the row query
+            raise RuntimeError("count query blew up")
+        return real_execute(stmt, *args, **kwargs)
+
+    monkeypatch.setattr(db_session, "execute", _flaky_execute)
+
+    with caplog.at_level(logging.WARNING, logger=admin_db_module.logger.name):
+        result = AdminDBService.get_table_rows(db_session, "users", page=1, page_size=5)
+
+    # Rows still come back; only the total is unknown.
+    assert result.total is None
+    assert isinstance(result.rows, list)
+
+    messages = [
+        r.getMessage() for r in caplog.records if r.name == admin_db_module.logger.name
+    ]
+    assert messages, "failed row count never reached the logger"
+    assert any("count query blew up" in m for m in messages), messages


### PR DESCRIPTION
Direkter Nachzug zu #308 (PR #441). Das Issue listete die fünf Prometheus-Collectoren; beim Aufräumen fanden sich zwei weitere Stellen derselben Klasse, die im Assessment nicht erfasst waren.

## Die beiden Fundstellen

**`app/services/audit/admin_db.py:235`** — `AdminDBService.get_table_rows()`

```python
except Exception as e:
    print(f"[ADMIN_DB] Failed to count rows: {e}")
    total = None
```

Der Fallback ist in Ordnung: Zeilen werden weiter geliefert, nur `total` bleibt unbekannt. Aber im Admin-DB-Browser steht dann einfach keine Gesamtzahl, und im Log erklärt nichts, warum. Die Logzeile nennt jetzt zusätzlich die betroffene Tabelle.

**`app/services/versioning/priority.py:281`** — `VCLPriorityMode.cleanup_orphaned_blobs()`

```python
except Exception as e:
    print(f"⚠️ Failed to delete blob {blob.id}: {e}")
```

Das war der unangenehmere von beiden. Ein einzelner klemmender Blob soll den ganzen Cleanup-Lauf nicht abbrechen — richtig so. Nur: Wenn das Löschen dauerhaft scheitert, wird Speicher nie zurückgewonnen, der Lauf meldet trotzdem Erfolg, und der Grund landet auf stdout statt im Journal. Genau der Fall, den man auf einem vollaufenden NAS erst merkt, wenn es zu spät ist.

## Fix

Modul-Logger in beiden Dateien, `logger.warning(...)` im Lazy-`%`-Stil, mit Tabellenname bzw. Blob-ID in der Meldung.

**Bewusst nicht angefasst** — die drei verbleibenden `print()` in `app/` sind legitim:
- `plugins/sandbox/worker.py:63` schreibt nach `stderr`, das der Elternprozess einsammelt
- `plugins/verify_index_signature.py:59,61` ist ein CLI-Smoke-Check, dessen Ausgabe der Zweck ist

## Tests

TDD, beide zuerst rot gesehen (`AttributeError: module ... has no attribute 'logger'`):

- `tests/test_admin_db.py::test_row_count_failure_is_logged` — die COUNT-Query wird gezielt zum Werfen gebracht (die Row-Query läuft normal weiter). Geprüft: `total is None`, Zeilen kommen trotzdem, Ursache steht im Log.
- `tests/services/test_vcl_priority_logging.py::test_failed_blob_delete_is_logged` — echter `VersionBlob` mit `reference_count=0` in der DB, `delete_blob` wirft. Geprüft: der Lauf meldet ehrlich `deleted_blobs == 0` und `freed_bytes == 0`, und die Logzeile trägt sowohl die Ursache als auch die Blob-ID.

Lokal: `tests/services` + `tests/test_admin_db.py` → 1128 passed. `ruff check` sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
