### PR TITLE
perf(device-tracking): last_seen-Writes pro Gerät debouncen (#322)

### DIFF
--- a/backend/app/middleware/CLAUDE.md
+++ b/backend/app/middleware/CLAUDE.md
@@ -1,6 +1,6 @@
 # Middleware
 
-Starlette `BaseHTTPMiddleware` classes applied to all requests. Registered in `main.py` — order matters (first added = outermost).
+Starlette `BaseHTTPMiddleware` classes applied to all requests. Registered in `main.py` — order matters. `add_middleware()` does `user_middleware.insert(0, ...)`, so **the last one registered is the outermost** and sees every request first (verified against starlette 0.41.3).
 
 ## Files
 
@@ -9,7 +9,7 @@ Starlette `BaseHTTPMiddleware` classes applied to all requests. Registered in `m
 | `security_headers.py` | CSP, X-Frame-Options, HSTS, Referrer-Policy, Permissions-Policy. Dev mode allows `unsafe-inline`/`unsafe-eval` for Vite HMR; prod restricts `script-src` to `'self'`. HSTS only sent over HTTPS | All responses |
 | `channel_marker.py` | Sets `request.state.channel` from `settings.channel` (provider-callable injection for test monkeypatch). The TCP-bound backend process gets `remote`; the UDS-bound process gets `local`. Used by `require_local_admin` (Task 5) to gate destructive admin endpoints behind physical presence. **The `request.state.channel` attribute is reserved for this purpose — other middleware/routes must not overwrite it.** | All requests |
 | `error_counter.py` | Thread-safe counters for 4xx/5xx responses. Read via `ErrorCounterMiddleware.get_counts()` or `get_error_counts()`. Used by admin metrics dashboard | All responses |
-| `device_tracking.py` | Updates `MobileDevice.last_seen` timestamp when `X-Device-ID` header is present. DB write runs in worker thread via `asyncio.to_thread()` | Requests with X-Device-ID |
+| `device_tracking.py` | Updates `MobileDevice.last_seen` timestamp when `X-Device-ID` header is present. DB write runs in worker thread via `asyncio.to_thread()`, debounced to at most one write per device per `_WRITE_TTL_SECONDS` (60s) via a bounded LRU cache — the timestamps are coarse activity indicators, the dashboard's "recently active" threshold is 5 min (#322) | Requests with X-Device-ID |
 | `local_only.py` | Blocks non-local-network requests to protected prefixes when `ENFORCE_LOCAL_ONLY=true`. Protected: `/api/server-profiles`, `/api/auth/login`, `/api/auth/register` | Configurable endpoints |
 | `api_version.py` | Adds `X-API-Version` and `X-API-Min-Version` headers to all `/api/` responses | API responses |
 | `plugin_gate.py` | Enforces plugin enabled-status and permissions at runtime. Checks DB with 5s TTL cache. Management routes (toggle, config, UI assets) bypass the gate | `/api/plugins/{name}/...` |

--- a/backend/app/middleware/device_tracking.py
+++ b/backend/app/middleware/device_tracking.py
@@ -1,6 +1,8 @@
 """Middleware to track mobile device activity and update last_seen timestamps."""
 
 import asyncio
+import time
+from collections import OrderedDict
 from datetime import datetime, timezone
 from fastapi import Request
 from sqlalchemy.orm import Session
@@ -15,6 +17,55 @@ _SYNC_PATH_PREFIXES = (
     "/api/files/download",
     "/api/mobile/sync",
 )
+
+# How long a device's timestamps may go stale before we write again. The only
+# consumer that compares against a threshold is the dashboard's "recently
+# active" badge at 5 minutes, so a minute of staleness is invisible there —
+# while a syncing device drops from up to 300 commits/min to at most one.
+_WRITE_TTL_SECONDS = 60.0
+
+# `X-Device-ID` is unauthenticated input, so the cache must not be a lever for
+# unbounded memory growth. A NAS tracks a handful of devices; anything past
+# this is flooding and gets evicted least-recently-used first.
+_MAX_TRACKED_DEVICES = 512
+
+# device_id -> (last_seen written at, last_sync written at), monotonic seconds.
+# Only ever touched from the event loop (see `dispatch`), so it needs no lock.
+_WRITE_CACHE: "OrderedDict[str, tuple[float, float | None]]" = OrderedDict()
+
+
+def _monotonic() -> float:
+    """Indirection so tests can control the clock."""
+    return time.monotonic()
+
+
+def _claim_write(device_id: str, is_sync: bool) -> bool:
+    """Decide whether this request must hit the DB, and record that it will.
+
+    Returns True at most once per `_WRITE_TTL_SECONDS` per device — except that
+    a sync request also forces a write when `last_sync` itself is stale, so
+    sync freshness never rides on unrelated traffic.
+    """
+    now = _monotonic()
+    entry = _WRITE_CACHE.get(device_id)
+
+    if entry is None:
+        seen_due = True
+        sync_due = is_sync
+        prev_sync: float | None = None
+    else:
+        seen_at, prev_sync = entry
+        seen_due = now - seen_at >= _WRITE_TTL_SECONDS
+        sync_due = is_sync and (prev_sync is None or now - prev_sync >= _WRITE_TTL_SECONDS)
+
+    if not (seen_due or sync_due):
+        return False
+
+    _WRITE_CACHE[device_id] = (now, now if is_sync else prev_sync)
+    _WRITE_CACHE.move_to_end(device_id)
+    while len(_WRITE_CACHE) > _MAX_TRACKED_DEVICES:
+        _WRITE_CACHE.popitem(last=False)
+    return True
 
 
 def _update_device_last_seen(device_id: str, update_last_sync: bool = False) -> None:
@@ -49,6 +100,10 @@ class DeviceTrackingMiddleware(BaseHTTPMiddleware):
     For file upload/download/sync requests, it also updates last_sync.
 
     This allows the web UI to show which devices are currently active/connected.
+
+    Writes are debounced per device (`_WRITE_TTL_SECONDS`): the timestamps are
+    coarse activity indicators, not an audit trail, so paying a round-trip on
+    every single request buys nothing the UI can show.
     """
 
     async def dispatch(self, request: Request, call_next):
@@ -56,11 +111,14 @@ class DeviceTrackingMiddleware(BaseHTTPMiddleware):
         device_id = request.headers.get("X-Device-ID")
 
         # Update last_seen in a thread so the sync DB call doesn't block the event loop
-        # Also update last_sync for file operation paths
+        # Also update last_sync for file operation paths.
+        # The claim runs in the event loop, so concurrent requests from one
+        # device cannot both decide to write.
         if device_id:
             path = request.url.path
             is_sync = any(path.startswith(p) for p in _SYNC_PATH_PREFIXES)
-            await asyncio.to_thread(_update_device_last_seen, device_id, is_sync)
+            if _claim_write(device_id, is_sync):
+                await asyncio.to_thread(_update_device_last_seen, device_id, is_sync)
 
         # Continue with the request
         response = await call_next(request)

--- a/backend/tests/middleware/test_device_tracking.py
+++ b/backend/tests/middleware/test_device_tracking.py
@@ -1,0 +1,118 @@
+"""Tests for DeviceTrackingMiddleware's write debouncing (#322).
+
+Every request carrying `X-Device-ID` used to trigger SELECT + UPDATE + COMMIT
+before the handler even ran. With `mobile_sync` allowing 300 requests/min that
+is 300 commits per minute per device, purely to move a `last_seen` timestamp
+the UI only reads with a 5-minute "recently active" threshold.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.middleware import device_tracking
+from app.middleware.device_tracking import DeviceTrackingMiddleware
+
+DEVICE = "device-abc"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """The debounce cache is module state — never leak it between tests."""
+    device_tracking._WRITE_CACHE.clear()
+    yield
+    device_tracking._WRITE_CACHE.clear()
+
+
+@pytest.fixture
+def writes(monkeypatch):
+    """Record calls to the DB writer instead of touching a database."""
+    recorded = []
+
+    def _record(device_id, update_last_sync=False):
+        recorded.append((device_id, update_last_sync))
+
+    monkeypatch.setattr(device_tracking, "_update_device_last_seen", _record)
+    return recorded
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Controllable monotonic clock."""
+
+    class _Clock:
+        now = 1000.0
+
+        def advance(self, seconds):
+            self.now += seconds
+
+    c = _Clock()
+    monkeypatch.setattr(device_tracking, "_monotonic", lambda: c.now)
+    return c
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.add_middleware(DeviceTrackingMiddleware)
+
+    @app.get("/ping")
+    async def ping():
+        return {"ok": True}
+
+    @app.get("/api/mobile/sync/items")
+    async def sync_items():
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def test_first_request_from_a_device_is_written(client, writes, clock):
+    client.get("/ping", headers={"X-Device-ID": DEVICE})
+
+    assert writes == [(DEVICE, False)]
+
+
+def test_repeated_requests_within_the_ttl_are_debounced(client, writes, clock):
+    for _ in range(50):
+        clock.advance(1)
+        client.get("/ping", headers={"X-Device-ID": DEVICE})
+
+    assert len(writes) == 1, f"50 requests inside the TTL caused {len(writes)} writes"
+
+
+def test_the_device_is_written_again_after_the_ttl(client, writes, clock):
+    client.get("/ping", headers={"X-Device-ID": DEVICE})
+    clock.advance(device_tracking._WRITE_TTL_SECONDS + 1)
+    client.get("/ping", headers={"X-Device-ID": DEVICE})
+
+    assert len(writes) == 2
+
+
+def test_a_sync_request_still_refreshes_last_sync_within_the_ttl(client, writes, clock):
+    """last_seen was just written, but last_sync has its own freshness."""
+    client.get("/ping", headers={"X-Device-ID": DEVICE})
+    clock.advance(1)
+    client.get("/api/mobile/sync/items", headers={"X-Device-ID": DEVICE})
+
+    assert writes == [(DEVICE, False), (DEVICE, True)]
+
+    # ...but a second sync inside the TTL is debounced like everything else.
+    clock.advance(1)
+    client.get("/api/mobile/sync/items", headers={"X-Device-ID": DEVICE})
+    assert len(writes) == 2
+
+
+def test_requests_without_the_header_never_write(client, writes, clock):
+    client.get("/ping")
+    client.get("/api/mobile/sync/items")
+
+    assert writes == []
+
+
+def test_unknown_device_ids_cannot_grow_the_cache_without_bound(client, writes, clock):
+    """The header is unauthenticated input — it must not be a memory lever."""
+    for i in range(device_tracking._MAX_TRACKED_DEVICES * 2):
+        client.get("/ping", headers={"X-Device-ID": f"flood-{i}"})
+
+    assert len(device_tracking._WRITE_CACHE) <= device_tracking._MAX_TRACKED_DEVICES


### PR DESCRIPTION
Closes #322 ([K3] aus dem Code-Assessment #298).

## Was das Issue beschrieb — und was beim Nachschauen dazukam

Bekannt war: DB-Roundtrip pro Request mit `X-Device-ID`, ohne Debounce.

Beim Lesen der Middleware fiel auf, dass der `await` **vor** `call_next` steht:

```python
if device_id:
    await asyncio.to_thread(_update_device_last_seen, device_id, is_sync)
response = await call_next(request)
```

Der Roundtrip lag also nicht nur als Last auf der DB, sondern **auf dem kritischen Pfad jedes einzelnen Mobile-Requests** — der Handler startete erst, nachdem SELECT + UPDATE + COMMIT durch waren. Bei `mobile_sync` (300/min) sind das bis zu 300 Commits/min pro Gerät, plus 300× serialisierte Wartezeit.

## Wie viel Genauigkeit man dafür kauft

Praktisch keine. Ich habe die Konsumenten von `last_seen`/`last_sync` durchgesehen:

- `ConnectedDevicesWidget.tsx:57` — der einzige Ort mit einer **Schwelle**: `recentThreshold = 5 * 60 * 1000`, also 5 Minuten
- `DeviceCard.tsx:82`, `MobileDeviceCard.tsx:77` — reine Anzeige („vor 3 Minuten")
- `sync_compat.py:67` — Listenausgabe, ohne Auswertung

Kein Auth-, Expiry- oder Sync-Entscheidungspfad hängt an diesen Feldern (Device-Ablauf läuft über `expires_at`). Ein TTL von 60 s ist gegenüber einer 5-Minuten-Schwelle unsichtbar.

## Fix

`_claim_write(device_id, is_sync)` entscheidet **im Event-Loop**, ob dieser Request in die DB darf, und vermerkt das gleich. Ergebnis: höchstens ein Write pro Gerät und Minute; alle anderen Requests sehen die DB gar nicht mehr.

Drei Details, die nicht offensichtlich sind:

- **`last_sync` hat eigene Frische.** Ein Sync-Request erzwingt einen Write, wenn `last_sync` alt ist — auch wenn `last_seen` gerade geschrieben wurde. Sonst würde die Sync-Aktualität davon abhängen, ob das Gerät zufällig anderen Traffic erzeugt hat.
- **Der Cache ist beschränkt (LRU, 512 Geräte).** `X-Device-ID` ist unauthentifizierter Input — ein unbegrenztes Dict darüber wäre ein Speicherhebel. Ein NAS verwaltet eine Handvoll Geräte; alles darüber ist Flooding und fliegt raus.
- **Kein Lock nötig.** Das Claiming passiert im Event-Loop, der DB-Write in einem Thread. Zwei gleichzeitige Requests desselben Geräts können daher nicht beide „schreiben" entscheiden.

Den `await` habe ich bewusst **gelassen**. Fire-and-forget würde die letzte Latenz auch noch entfernen, aber ein nicht referenziertes `create_task` ist genau das, was #320 [K2] anprangert — und bei einem Write pro Minute lohnt der Tausch nicht.

## Tests

`backend/tests/middleware/test_device_tracking.py`, TDD, zuerst rot gesehen (`no attribute '_WRITE_CACHE'`). Sechs Fälle über eine Mini-App mit kontrollierter Uhr:

- erster Request schreibt
- 50 Requests innerhalb des TTL → **ein** Write
- nach Ablauf des TTL wieder ein Write
- Sync-Request innerhalb des TTL schreibt trotzdem (`update_last_sync=True`), ein zweiter Sync danach nicht mehr
- ohne Header nie ein Write
- 1024 verschiedene Device-IDs lassen den Cache nicht über die Grenze wachsen

Lokal: `tests/middleware` + `tests/api` + `tests/integration` → 480 passed. `ruff check` sauber.

## Nebenbefund, mitkorrigiert

`middleware/CLAUDE.md` behauptete „order matters (first added = outermost)". Starlettes `add_middleware()` macht `user_middleware.insert(0, ...)` — es ist also die **zuletzt** registrierte Middleware, die außen liegt (gegen starlette 0.41.3 geprüft). Die Zeile stand direkt über der Tabelle, in der ich den `device_tracking`-Eintrag aktualisiert habe; eine nachweislich falsche Aussage dort stehen zu lassen, während man sie liest, wäre die schlechtere Wahl gewesen. Falls du das lieber getrennt hättest, nehme ich es wieder raus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
