### PR TITLE
feat(plugins): Menue-Extension-Point fuer Plugin-Aktionen + Gaming-Modus (Teilprojekt 2/4)

### DIFF
--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -1,4 +1,5 @@
 """API routes for plugin management."""
+import asyncio
 import html
 import logging
 
@@ -10,6 +11,7 @@ from app.api.deps import get_current_admin, get_current_user, get_db, require_lo
 from app.core.rate_limiter import user_limiter, get_limit
 from app.models.user import User
 from app.middleware.plugin_gate import invalidate_plugin_cache
+from app.plugins.base import MenuActionResult, PluginBase
 from app.plugins.manifest import load_manifest
 from app.plugins.manager import PluginManager, PluginLoadError
 from app.plugins.permissions import PermissionManager
@@ -26,6 +28,7 @@ from app.schemas.plugin import (
     PluginDetailResponse,
     PluginInfo,
     PluginListResponse,
+    PluginMenuActionResponse,
     PluginNavItemSchema,
     PluginStorageSetRequest,
     PluginToggleRequest,
@@ -40,6 +43,13 @@ from app.schemas.plugin import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/plugins", tags=["plugins"])
+
+# Generous compared to the 2s pill-collector timeout: a menu action may shell
+# out (kscreen-doctor carries a 30s subprocess timeout of its own). Note that
+# wait_for cannot preempt work already running inside asyncio.to_thread - it
+# frees the request, the thread finishes on its own. That is acceptable: it
+# occupies a thread, not the event loop.
+PLUGIN_MENU_ACTION_TIMEOUT_SECONDS = 20.0
 
 
 def get_plugin_manager() -> PluginManager:
@@ -802,3 +812,81 @@ async def uninstall_plugin(
         status_code=status.HTTP_404_NOT_FOUND,
         detail="Plugin not installed",
     )
+
+
+@router.post("/{name}/menu-actions/{action_id}", response_model=PluginMenuActionResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def run_plugin_menu_action(
+    request: Request,
+    response: Response,
+    name: str,
+    action_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_admin),
+    plugin_manager: PluginManager = Depends(get_plugin_manager),
+) -> PluginMenuActionResponse:
+    """Run a menu action a plugin declared in its UI manifest. Admin only.
+
+    Requests for a disabled plugin never reach this handler - PluginGateMiddleware
+    rejects them with 403 based on the DB (see middleware/plugin_gate.py).
+    """
+    plugin = plugin_manager.get_plugin(name)
+    if plugin is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Plugin not found or not enabled",
+        )
+
+    # Only declared actions are dispatchable - never call through on an
+    # arbitrary path segment.
+    declared = {item.id for item in plugin.get_menu_items()}
+    if action_id not in declared:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Unknown menu action",
+        )
+
+    result = await _execute_menu_action(plugin, name, action_id, db)
+
+    get_audit_logger_db().log_event(
+        event_type="PLUGIN",
+        user=current_user.username,
+        action="menu_action",
+        resource=f"{name}:{action_id}",
+        details={"ok": result.ok},
+        success=result.ok,
+        ip_address=request.client.host if request.client else None,
+    )
+    return PluginMenuActionResponse(**result.model_dump())
+
+
+async def _execute_menu_action(
+    plugin: PluginBase, name: str, action_id: str, db: Session
+) -> MenuActionResult:
+    """Run the action under a timeout and an exception guard.
+
+    A plugin fault must never become a 5xx and must never leak internals into
+    the response - the detail goes to the log, the caller gets a generic
+    failure. Mirrors the pill-collector guard in services/status_bar/service.py.
+    """
+    try:
+        result = await asyncio.wait_for(
+            plugin.run_menu_action(action_id, db),
+            timeout=PLUGIN_MENU_ACTION_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("plugin %s menu action %s timed out", name, action_id)
+        return MenuActionResult(ok=False, message_text="Action timed out")
+    except Exception:  # noqa: BLE001 - a plugin fault must not 5xx the endpoint
+        logger.warning(
+            "plugin %s menu action %s failed", name, action_id, exc_info=True
+        )
+        return MenuActionResult(ok=False, message_text="Action failed")
+
+    if result is None:
+        # Declared but not handled - a plugin bug, not a user error.
+        logger.warning(
+            "plugin %s declared menu action %s but returned None", name, action_id
+        )
+        return MenuActionResult(ok=False, message_text="Action failed")
+    return result

--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -827,11 +827,17 @@ async def run_plugin_menu_action(
 ) -> PluginMenuActionResponse:
     """Run a menu action a plugin declared in its UI manifest. Admin only.
 
-    Requests for a disabled plugin never reach this handler - PluginGateMiddleware
-    rejects them with 403 based on the DB (see middleware/plugin_gate.py).
+    Requests for a disabled plugin should never reach this handler -
+    PluginGateMiddleware rejects them with 403 based on the DB (see
+    middleware/plugin_gate.py). This is only the first line of defense
+    though: PluginManager.disable_plugin() drops the name from ``_enabled``
+    but leaves the instance in ``_plugins``, so get_plugin() alone would
+    still return it. Check is_enabled() too, so this endpoint does not rely
+    solely on the middleware (a prefix change or router move must not
+    silently defeat the enabled-check).
     """
     plugin = plugin_manager.get_plugin(name)
-    if plugin is None:
+    if plugin is None or not plugin_manager.is_enabled(name):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Plugin not found or not enabled",
@@ -843,7 +849,7 @@ async def run_plugin_menu_action(
     # log and fail closed (no action is dispatchable).
     try:
         declared = {item.id for item in plugin.get_menu_items()}
-    except Exception:  # noqa: BLE001 - a plugin fault must not 5xx the endpoint
+    except Exception:  # broad on purpose: a plugin fault must not 5xx the endpoint
         logger.warning(
             "plugin %s failed to list menu items", name, exc_info=True
         )
@@ -864,7 +870,7 @@ async def run_plugin_menu_action(
         user=current_user.username,
         action="menu_action",
         resource=f"{name}:{action_id}",
-        details={"ok": result.ok},
+        details={"ok": result.ok, "message_key": result.message_key},
         success=result.ok,
         ip_address=request.client.host if request.client else None,
     )
@@ -888,7 +894,7 @@ async def _execute_menu_action(
     except asyncio.TimeoutError:
         logger.warning("plugin %s menu action %s timed out", name, action_id)
         return MenuActionResult(ok=False, message_text="Action timed out")
-    except Exception:  # noqa: BLE001 - a plugin fault must not 5xx the endpoint
+    except Exception:  # broad on purpose: a plugin fault must not 5xx the endpoint
         logger.warning(
             "plugin %s menu action %s failed", name, action_id, exc_info=True
         )

--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -838,8 +838,19 @@ async def run_plugin_menu_action(
         )
 
     # Only declared actions are dispatchable - never call through on an
-    # arbitrary path segment.
-    declared = {item.id for item in plugin.get_menu_items()}
+    # arbitrary path segment. A plugin that cannot even declare its actions
+    # must not 5xx the request - treat it the same as a failing action:
+    # log and fail closed (no action is dispatchable).
+    try:
+        declared = {item.id for item in plugin.get_menu_items()}
+    except Exception:  # noqa: BLE001 - a plugin fault must not 5xx the endpoint
+        logger.warning(
+            "plugin %s failed to list menu items", name, exc_info=True
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Unknown menu action",
+        )
     if action_id not in declared:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -883,10 +894,15 @@ async def _execute_menu_action(
         )
         return MenuActionResult(ok=False, message_text="Action failed")
 
-    if result is None:
-        # Declared but not handled - a plugin bug, not a user error.
+    if not isinstance(result, MenuActionResult):
+        # Declared but not handled correctly (None, or some other type
+        # entirely) - a plugin bug, not a user error. Guard against any
+        # non-MenuActionResult return, not only None: calling .model_dump()
+        # on a plain dict/str would 500 the request instead of failing closed.
         logger.warning(
-            "plugin %s declared menu action %s but returned None", name, action_id
+            "plugin %s declared menu action %s but returned %r instead of "
+            "MenuActionResult",
+            name, action_id, type(result).__name__,
         )
         return MenuActionResult(ok=False, message_text="Action failed")
     return result

--- a/backend/app/plugins/CLAUDE.md
+++ b/backend/app/plugins/CLAUDE.md
@@ -79,11 +79,35 @@ Two plugin trust tiers with different isolation:
    from `get_translations()`, resolved client-side via `resolvePluginString`,
    with `name_text`/`label_text` as literal fallbacks.
    **Operator note:** `PluginManager._enabled` is process-local, populated at
-   startup. Toggling a pill-contributing plugin on/off through the UI only
-   updates the worker that handled that request — in production (4 Uvicorn
-   workers) the pill then appears on roughly one in four status-strip polls
-   until the backend is restarted. Restart `baluhost-backend` after enabling
-   or disabling a plugin that contributes a status pill so all workers agree.
+   startup. Toggling a pill- or menu-contributing plugin on/off through the UI
+   only updates the worker that handled that request — in production (4 Uvicorn
+   workers) the pill then appears on roughly one in four status-strip polls, and
+   a menu action fails with 404 on the three workers that never loaded it, until
+   the backend is restarted. Restart `baluhost-backend` after enabling or
+   disabling such a plugin so all workers agree (#448).
+7. Override `get_ui_manifest()` with `menu_items` + `run_menu_action()` to
+   contribute an action to the system (power) menu. `get_menu_items()` is not
+   a separate override point: its default implementation derives the list
+   from `get_ui_manifest().menu_items`, so a plugin declares its items in
+   exactly one place. That single declaration is what the manifest endpoint
+   (`GET /api/plugins/ui/manifest`) serves to the frontend *and* what the
+   route validates an incoming `action_id` against — two declaration sites
+   would drift silently, and the drift is invisible: the entry still
+   renders, the click just 404s. The plugin picks only a local `id`
+   (validated against `^[a-z0-9_]+$`); the core enforces the admin gate, the
+   rate limit, the audit entry, the declaration check (an `action_id` not
+   present in `get_menu_items()` is a 404 and never dispatches — a plugin
+   whose `get_menu_items()` itself throws is treated the same way, fail
+   closed, not a 500) and a `PLUGIN_MENU_ACTION_TIMEOUT_SECONDS` (20s)
+   timeout. `PluginMenuItem` deliberately has **no** `admin_only` field —
+   unlike `PluginNavItem`, an action executes something, so its audience is
+   not the plugin's call. Failures and timeouts become `ok=false` with a
+   generic message; details stay in the log. Labels come from
+   `get_translations()`, resolved client-side via `resolvePluginString`.
+   Blocking work belongs in `asyncio.to_thread`, otherwise the timeout
+   cannot take effect. Disabled plugins are rejected by
+   `PluginGateMiddleware` (403, DB-backed) — `menu-actions` is
+   intentionally **not** a management route.
 
 ## SmartDevice Framework (`smart_device/`)
 

--- a/backend/app/plugins/base.py
+++ b/backend/app/plugins/base.py
@@ -57,6 +57,44 @@ class PluginNavItem(BaseModel):
     order: int = Field(default=100, description="Sort order in navigation")
 
 
+class PluginMenuItem(BaseModel):
+    """An action a plugin contributes to the system (power) menu.
+
+    Declaration only: the plugin says what it offers, the core decides who may
+    run it. There is deliberately no ``admin_only`` field (unlike
+    PluginNavItem) - a menu action executes something, so widening its
+    audience must not be the plugin's call.
+    """
+
+    id: str = Field(
+        pattern=r"^[a-z0-9_]+$",
+        description="Plugin-local action id, e.g. 'gaming_mode'",
+    )
+    icon: str = Field(description="lucide icon name, e.g. 'Gamepad2'")
+    label_key: str = Field(description="Key into get_translations() for the label")
+    label_text: str = Field(description="Literal fallback for the label")
+    description_key: Optional[str] = Field(
+        default=None, description="Key into get_translations() for the sub-label"
+    )
+    description_text: Optional[str] = Field(
+        default=None, description="Literal fallback for the sub-label"
+    )
+    tone: Literal["neutral", "info", "success", "warning", "danger"] = "neutral"
+    order: int = Field(default=100, description="Sort order within the plugin block")
+
+
+class MenuActionResult(BaseModel):
+    """Outcome of a menu action, rendered as a toast by the frontend.
+
+    ``message_key`` is resolved client-side against the plugin's translations
+    (same mechanic as pill labels) - the backend never picks a language.
+    """
+
+    ok: bool
+    message_key: Optional[str] = None
+    message_text: str = Field(description="Literal fallback, always set")
+
+
 class PluginUIManifest(BaseModel):
     """UI manifest for plugin frontend integration."""
 
@@ -64,6 +102,10 @@ class PluginUIManifest(BaseModel):
     nav_items: List[PluginNavItem] = Field(
         default_factory=list,
         description="Navigation items to add to sidebar",
+    )
+    menu_items: List["PluginMenuItem"] = Field(
+        default_factory=list,
+        description="Actions to add to the system menu",
     )
     bundle_path: str = Field(
         default="ui/bundle.js",
@@ -240,6 +282,23 @@ class PluginBase(ABC):
         *pill_id* is the plugin-local suffix from the spec, not the namespaced
         public id. The returned dict is passed to PillState — supply at least
         ``kind``, ``tone`` and ``label_key``/``label_text``.
+        """
+        return None
+
+    def get_menu_items(self) -> List["PluginMenuItem"]:
+        """System-menu actions this plugin contributes. Default: none."""
+        return []
+
+    async def run_menu_action(
+        self, action_id: str, db: "Session"
+    ) -> Optional["MenuActionResult"]:
+        """Execute one menu action, or None if this plugin does not know it.
+
+        *action_id* is the plugin-local id from the declared menu item. The
+        core validates it against get_menu_items() before calling, enforces the
+        admin gate, and applies a timeout - implementations only do the work.
+        Blocking work belongs in ``asyncio.to_thread`` so the timeout can
+        actually take effect.
         """
         return None
 

--- a/backend/app/plugins/base.py
+++ b/backend/app/plugins/base.py
@@ -292,9 +292,17 @@ class PluginBase(ABC):
         manifest is what reaches the frontend, and this is what the core
         validates an incoming action_id against. Two declaration sites would
         drift, and the drift is invisible - the entry renders and the click 404s.
+
+        Respects manifest.enabled the same way PluginManager.get_ui_manifest()
+        does: a manifest with enabled=False must not advertise a dispatchable
+        action just because it still lists menu_items - that would be the same
+        two-sites drift in the opposite direction (nothing shown, something
+        runnable).
         """
         manifest = self.get_ui_manifest()
-        return list(manifest.menu_items) if manifest is not None else []
+        if manifest is None or not manifest.enabled:
+            return []
+        return list(manifest.menu_items)
 
     async def run_menu_action(
         self, action_id: str, db: "Session"
@@ -306,6 +314,15 @@ class PluginBase(ABC):
         admin gate, and applies a timeout - implementations only do the work.
         Blocking work belongs in ``asyncio.to_thread`` so the timeout can
         actually take effect.
+
+        ``db`` is the route's request-scoped SQLAlchemy Session - it is not
+        thread-safe. Do not hand it into ``asyncio.to_thread`` (or any other
+        thread): a slow action that outlives the request's timeout continues
+        running in its own thread with a Session that may already be torn
+        down, which is a use-after-close bug waiting to happen, not a
+        performance question. If a menu action needs blocking work AND
+        database access, open a fresh Session inside the thread instead of
+        reusing this one.
         """
         return None
 

--- a/backend/app/plugins/base.py
+++ b/backend/app/plugins/base.py
@@ -286,8 +286,15 @@ class PluginBase(ABC):
         return None
 
     def get_menu_items(self) -> List["PluginMenuItem"]:
-        """System-menu actions this plugin contributes. Default: none."""
-        return []
+        """System-menu actions this plugin contributes. Default: none.
+
+        Derived from get_ui_manifest() so a plugin declares its items once: the
+        manifest is what reaches the frontend, and this is what the core
+        validates an incoming action_id against. Two declaration sites would
+        drift, and the drift is invisible - the entry renders and the click 404s.
+        """
+        manifest = self.get_ui_manifest()
+        return list(manifest.menu_items) if manifest is not None else []
 
     async def run_menu_action(
         self, action_id: str, db: "Session"

--- a/backend/app/plugins/installed/steam_gaming/__init__.py
+++ b/backend/app/plugins/installed/steam_gaming/__init__.py
@@ -15,11 +15,21 @@ from typing import Dict, List, Optional
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
-from app.plugins.base import PluginBase, PluginMetadata, StatusPillSpec
+from app.plugins.base import (
+    MenuActionResult,
+    PluginBase,
+    PluginMenuItem,
+    PluginMetadata,
+    PluginUIManifest,
+    StatusPillSpec,
+)
 from app.plugins.installed.steam_gaming.detector import detect_running_app_id
+from app.plugins.installed.steam_gaming.launcher import open_big_picture
 from app.plugins.installed.steam_gaming.names import resolve_name
+from app.services.power.desktop import get_desktop_service
 
 _PILL_ID = "session"
+_MENU_ACTION_ID = "gaming_mode"
 _CACHE_TTL_SECONDS = 3.0
 _CACHE: Dict[str, object] = {}
 
@@ -94,8 +104,70 @@ class SteamGamingPlugin(PluginBase):
             "icon": "Gamepad2",
         }
 
+    def get_ui_manifest(self) -> PluginUIManifest:
+        return PluginUIManifest(
+            enabled=True,
+            menu_items=[PluginMenuItem(
+                id=_MENU_ACTION_ID,
+                icon="Gamepad2",
+                tone="info",
+                order=10,
+                label_key="menu_gaming_mode",
+                label_text="Gaming Mode",
+                description_key="menu_gaming_mode_desc",
+                description_text="Turn displays on and open Big Picture",
+            )],
+        )
+
+    async def run_menu_action(self, action_id: str, db: Session) -> Optional[MenuActionResult]:
+        if action_id != _MENU_ACTION_ID:
+            return None
+
+        # Displays first: opening Big Picture onto dark screens helps nobody.
+        # LinuxDesktopBackend.enable() runs kscreen-doctor in a thread, so the
+        # core's wait_for stays effective.
+        ok, detail = await get_desktop_service().enable()
+        if not ok:
+            return MenuActionResult(
+                ok=False,
+                message_key="menu_displays_failed",
+                message_text=f"Displays could not be turned on: {detail}",
+            )
+
+        launched, detail = await asyncio.to_thread(open_big_picture)
+        if not launched:
+            return MenuActionResult(
+                ok=False,
+                message_key="menu_steam_failed",
+                message_text=f"Displays are on, but Steam did not start: {detail}",
+            )
+
+        # "started", not "Big Picture is running": the process is detached, so
+        # anything past the spawn is not observable from here.
+        return MenuActionResult(
+            ok=True,
+            message_key="menu_gaming_mode_started",
+            message_text="Gaming mode started",
+        )
+
     def get_translations(self) -> Optional[Dict[str, Dict[str, str]]]:
         return {
-            "en": {"pill_name": "Gaming Session", "pill_label": "Gaming Session"},
-            "de": {"pill_name": "Gaming-Session", "pill_label": "Gaming-Session"},
+            "en": {
+                "pill_name": "Gaming Session",
+                "pill_label": "Gaming Session",
+                "menu_gaming_mode": "Gaming Mode",
+                "menu_gaming_mode_desc": "Displays on + Big Picture",
+                "menu_gaming_mode_started": "Gaming mode started",
+                "menu_displays_failed": "Displays could not be turned on",
+                "menu_steam_failed": "Displays are on, but Steam did not start",
+            },
+            "de": {
+                "pill_name": "Gaming-Session",
+                "pill_label": "Gaming-Session",
+                "menu_gaming_mode": "Gaming-Modus",
+                "menu_gaming_mode_desc": "Displays an + Big Picture",
+                "menu_gaming_mode_started": "Gaming-Modus gestartet",
+                "menu_displays_failed": "Displays konnten nicht eingeschaltet werden",
+                "menu_steam_failed": "Displays sind an, aber Steam startete nicht",
+            },
         }

--- a/backend/app/plugins/installed/steam_gaming/__init__.py
+++ b/backend/app/plugins/installed/steam_gaming/__init__.py
@@ -9,6 +9,7 @@ avoids sharing state between workers entirely.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from typing import Dict, List, Optional
 
@@ -27,6 +28,8 @@ from app.plugins.installed.steam_gaming.detector import detect_running_app_id
 from app.plugins.installed.steam_gaming.launcher import open_big_picture
 from app.plugins.installed.steam_gaming.names import resolve_name
 from app.services.power.desktop import get_desktop_service
+
+logger = logging.getLogger(__name__)
 
 _PILL_ID = "session"
 _MENU_ACTION_ID = "gaming_mode"
@@ -128,6 +131,9 @@ class SteamGamingPlugin(PluginBase):
         # core's wait_for stays effective.
         ok, detail = await get_desktop_service().enable()
         if not ok:
+            # The user only ever sees the translated key, so without this line
+            # the reason kscreen-doctor refused is lost for good.
+            logger.warning("gaming mode: turning the displays on failed: %s", detail)
             return MenuActionResult(
                 ok=False,
                 message_key="menu_displays_failed",
@@ -136,6 +142,7 @@ class SteamGamingPlugin(PluginBase):
 
         launched, detail = await asyncio.to_thread(open_big_picture)
         if not launched:
+            logger.warning("gaming mode: Big Picture did not start: %s", detail)
             return MenuActionResult(
                 ok=False,
                 message_key="menu_steam_failed",

--- a/backend/app/plugins/installed/steam_gaming/launcher.py
+++ b/backend/app/plugins/installed/steam_gaming/launcher.py
@@ -35,7 +35,7 @@ def open_big_picture() -> tuple[bool, str]:
         return True, "big picture requested (dev)"
 
     try:
-        subprocess.Popen(  # noqa: S603 - fixed argv, no shell, no user input
+        subprocess.Popen(  # fixed argv, no shell, no user input
             ["steam", BIG_PICTURE_URL],
             env=wayland_session_env(),
             start_new_session=True,

--- a/backend/app/plugins/installed/steam_gaming/launcher.py
+++ b/backend/app/plugins/installed/steam_gaming/launcher.py
@@ -1,0 +1,52 @@
+"""Open Steam's Big Picture mode in the user's desktop session.
+
+On the production box Steam runs permanently (app-steam@autostart.service), so
+this hands a steam:// URL to the running instance, which then switches to Big
+Picture and the invoked process exits immediately.
+
+The call is deliberately detached: if Steam is NOT running, the very same
+command starts it in the foreground, and an attached child would live for as
+long as the gaming session - hanging off the backend process. start_new_session
+puts it in its own session/process group and nothing is ever waited on.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+
+from app.core.config import settings
+from app.services.power.session_env import wayland_session_env
+
+logger = logging.getLogger(__name__)
+
+BIG_PICTURE_URL = "steam://open/bigpicture"
+
+
+def open_big_picture() -> tuple[bool, str]:
+    """Ask Steam to show Big Picture. Blocking - call via asyncio.to_thread.
+
+    Returns:
+        (ok, detail). ok=True means the request was dispatched, not that Big
+        Picture is on screen - the process is detached, so anything beyond the
+        spawn is unobservable from here.
+    """
+    if settings.is_dev_mode:
+        # No desktop session on a Windows dev box.
+        return True, "big picture requested (dev)"
+
+    try:
+        subprocess.Popen(  # noqa: S603 - fixed argv, no shell, no user input
+            ["steam", BIG_PICTURE_URL],
+            env=wayland_session_env(),
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        return False, "steam binary not found"
+    except OSError as exc:
+        logger.warning("failed to launch Big Picture: %s", exc)
+        return False, "could not start steam"
+
+    return True, "big picture requested"

--- a/backend/app/plugins/manager.py
+++ b/backend/app/plugins/manager.py
@@ -807,6 +807,9 @@ class PluginManager:
                         "nav_items": [
                             item.model_dump() for item in ui_manifest.nav_items
                         ],
+                        "menu_items": [
+                            item.model_dump() for item in ui_manifest.menu_items
+                        ],
                         "bundle_path": ui_manifest.bundle_path,
                         "styles_path": ui_manifest.styles_path,
                         "dashboard_widgets": ui_manifest.dashboard_widgets,

--- a/backend/app/schemas/plugin.py
+++ b/backend/app/schemas/plugin.py
@@ -15,12 +15,26 @@ class PluginNavItemSchema(BaseModel):
     order: int = 100
 
 
+class PluginMenuItemSchema(BaseModel):
+    """System-menu action offered by a plugin (mirror of PluginMenuItem)."""
+
+    id: str
+    icon: str
+    label_key: str
+    label_text: str
+    description_key: Optional[str] = None
+    description_text: Optional[str] = None
+    tone: str = "neutral"
+    order: int = 100
+
+
 class PluginUIInfo(BaseModel):
     """UI information for a plugin."""
 
     name: str
     display_name: str
     nav_items: List[PluginNavItemSchema] = []
+    menu_items: List[PluginMenuItemSchema] = []
     bundle_path: str = "ui/bundle.js"
     styles_path: Optional[str] = None
     dashboard_widgets: List[str] = []

--- a/backend/app/schemas/plugin.py
+++ b/backend/app/schemas/plugin.py
@@ -28,6 +28,14 @@ class PluginMenuItemSchema(BaseModel):
     order: int = 100
 
 
+class PluginMenuActionResponse(BaseModel):
+    """Outcome of a plugin menu action (mirror of MenuActionResult)."""
+
+    ok: bool
+    message_key: Optional[str] = None
+    message_text: str
+
+
 class PluginUIInfo(BaseModel):
     """UI information for a plugin."""
 

--- a/backend/app/services/power/desktop_backend.py
+++ b/backend/app/services/power/desktop_backend.py
@@ -14,12 +14,14 @@ docs/superpowers/plans/2026-05-30-desktop-toggle.md.
 """
 from __future__ import annotations
 
+import asyncio
 import os
 import subprocess
 from typing import Optional, Protocol, Tuple
 
 from app.schemas.desktop import DesktopState, DesktopStatus
 from app.services.power.gpu.display_detector import get_active_display_count
+from app.services.power.session_env import wayland_session_env
 
 
 class DesktopBackend(Protocol):
@@ -65,15 +67,8 @@ class LinuxDesktopBackend:
         self._uid = uid if uid is not None else os.getuid()
 
     def _session_env(self) -> dict:
-        """Env so kscreen-doctor can reach the user's Wayland session.
-
-        The backend runs as the session user (uid match) but outside the
-        graphical session, so XDG_RUNTIME_DIR/WAYLAND_DISPLAY must be set.
-        """
-        env = dict(os.environ)
-        env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{self._uid}")
-        env.setdefault("WAYLAND_DISPLAY", "wayland-0")
-        return env
+        """Env so kscreen-doctor can reach the user's Wayland session."""
+        return wayland_session_env(self._uid)
 
     def _run(self, cmd: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
         return subprocess.run(
@@ -94,10 +89,10 @@ class LinuxDesktopBackend:
         return DesktopStatus(state=DesktopState.STOPPED, display_manager=name, detail="displays off")
 
     async def enable(self) -> Tuple[bool, str]:
-        return self._exec(["kscreen-doctor", "--dpms", "on"])
+        return await asyncio.to_thread(self._exec, ["kscreen-doctor", "--dpms", "on"])
 
     async def disable(self) -> Tuple[bool, str]:
-        return self._exec(["kscreen-doctor", "--dpms", "off"])
+        return await asyncio.to_thread(self._exec, ["kscreen-doctor", "--dpms", "off"])
 
     def _exec(self, cmd: list[str]) -> Tuple[bool, str]:
         try:

--- a/backend/app/services/power/session_env.py
+++ b/backend/app/services/power/session_env.py
@@ -1,0 +1,22 @@
+"""Environment for reaching the logged-in user's Wayland session.
+
+The backend runs as the session user (uid match) but outside the graphical
+session, so XDG_RUNTIME_DIR and WAYLAND_DISPLAY have to be supplied for
+commands like kscreen-doctor or steam to talk to it.
+
+Two callers share this: the desktop (DPMS) backend and the steam_gaming
+plugin's Big Picture launcher.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+
+def wayland_session_env(uid: Optional[int] = None) -> dict:
+    """Return os.environ plus the session variables, without overriding them."""
+    resolved = uid if uid is not None else os.getuid()
+    env = dict(os.environ)
+    env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{resolved}")
+    env.setdefault("WAYLAND_DISPLAY", "wayland-0")
+    return env

--- a/backend/tests/plugins/test_plugin_menu_actions.py
+++ b/backend/tests/plugins/test_plugin_menu_actions.py
@@ -112,3 +112,142 @@ class TestManifestCarriesMenuItems:
     def test_schema_defaults_to_empty(self):
         info = PluginUIInfo(name="demo", display_name="Demo")
         assert info.menu_items == []
+
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from fastapi import HTTPException
+
+from app.api.routes.plugins import (
+    PLUGIN_MENU_ACTION_TIMEOUT_SECONDS,
+    run_plugin_menu_action,
+)
+
+
+@pytest.fixture(autouse=True)
+def _bypass_limiter_request_check():
+    """Allow calling the decorated route function directly with a MagicMock request.
+
+    These tests call ``run_plugin_menu_action`` as a plain coroutine (no
+    TestClient/ASGI stack), matching this repo's established direct-call
+    pattern for route-level unit tests. slowapi's ``@user_limiter.limit(...)``
+    wrapper requires an actual ``starlette.requests.Request`` instance
+    whenever ``Limiter.enabled`` is True - unrelated to the behaviour under
+    test here. Disabling it for the duration of these tests only bypasses
+    that isinstance check, not any assertion in the tests below.
+    """
+    from app.core.rate_limiter import user_limiter
+
+    original = user_limiter.enabled
+    user_limiter.enabled = False
+    try:
+        yield
+    finally:
+        user_limiter.enabled = original
+
+
+def _declaring_plugin(action_id: str = "do_it") -> MagicMock:
+    plugin = MagicMock()
+    plugin.get_menu_items.return_value = [PluginMenuItem(
+        id=action_id, icon="Zap", label_key="k", label_text="Do it",
+    )]
+    return plugin
+
+
+async def _call(plugin, name: str = "demo", action_id: str = "do_it"):
+    manager = MagicMock()
+    manager.get_plugin.return_value = plugin
+    return await run_plugin_menu_action(
+        request=MagicMock(client=MagicMock(host="127.0.0.1")),
+        response=MagicMock(),
+        name=name,
+        action_id=action_id,
+        db=MagicMock(),
+        current_user=MagicMock(username="admin"),
+        plugin_manager=manager,
+    )
+
+
+class TestMenuActionRoute:
+    async def test_unknown_plugin_is_404(self):
+        manager = MagicMock()
+        manager.get_plugin.return_value = None
+        with pytest.raises(HTTPException) as exc:
+            await run_plugin_menu_action(
+                request=MagicMock(), response=MagicMock(),
+                name="nope", action_id="do_it", db=MagicMock(),
+                current_user=MagicMock(username="admin"), plugin_manager=manager,
+            )
+        assert exc.value.status_code == 404
+
+    async def test_undeclared_action_is_404_and_never_dispatches(self):
+        plugin = _declaring_plugin()
+        plugin.run_menu_action = AsyncMock()
+        with pytest.raises(HTTPException) as exc:
+            await _call(plugin, action_id="something_else")
+        assert exc.value.status_code == 404
+        plugin.run_menu_action.assert_not_awaited()
+
+    async def test_happy_path_returns_result_and_audits_success(self):
+        plugin = _declaring_plugin()
+        plugin.run_menu_action = AsyncMock(
+            return_value=MenuActionResult(ok=True, message_key="ok_key", message_text="done")
+        )
+        with patch("app.api.routes.plugins.get_audit_logger_db") as audit:
+            result = await _call(plugin)
+        assert (result.ok, result.message_key, result.message_text) == (True, "ok_key", "done")
+        kwargs = audit.return_value.log_event.call_args.kwargs
+        assert kwargs["event_type"] == "PLUGIN"
+        assert kwargs["action"] == "menu_action"
+        assert kwargs["resource"] == "demo:do_it"
+        assert kwargs["success"] is True
+
+    async def test_raising_action_stays_200_with_generic_message(self):
+        plugin = _declaring_plugin()
+        plugin.run_menu_action = AsyncMock(side_effect=RuntimeError("secret path /opt/baluhost"))
+        with patch("app.api.routes.plugins.get_audit_logger_db") as audit:
+            result = await _call(plugin)
+        assert result.ok is False
+        assert "secret path" not in result.message_text
+        assert audit.return_value.log_event.call_args.kwargs["success"] is False
+
+    async def test_hanging_action_is_cut_off_by_the_timeout(self):
+        async def _hang(action_id, db):
+            await asyncio.sleep(60)
+
+        plugin = _declaring_plugin()
+        plugin.run_menu_action = _hang
+        with patch("app.api.routes.plugins.PLUGIN_MENU_ACTION_TIMEOUT_SECONDS", 0.01), \
+             patch("app.api.routes.plugins.get_audit_logger_db"):
+            result = await _call(plugin)
+        assert result.ok is False
+
+    async def test_plugin_returning_none_despite_declaration_is_not_ok(self):
+        plugin = _declaring_plugin()
+        plugin.run_menu_action = AsyncMock(return_value=None)
+        with patch("app.api.routes.plugins.get_audit_logger_db"):
+            result = await _call(plugin)
+        assert result.ok is False
+
+    def test_timeout_is_generous_enough_for_kscreen_doctor(self):
+        """kscreen-doctor carries a 30s subprocess timeout of its own."""
+        assert PLUGIN_MENU_ACTION_TIMEOUT_SECONDS >= 10.0
+
+
+from app.middleware.plugin_gate import _is_management_route
+
+
+class TestMenuActionIsGatedByMiddleware:
+    def test_menu_action_path_is_not_a_management_route(self):
+        """A disabled plugin must not be able to run actions.
+
+        Management routes (toggle/config/ui) stay reachable while a plugin is
+        disabled - menu actions must NOT, or disabling a plugin would leave its
+        actions live.
+        """
+        assert _is_management_route("/menu-actions/gaming_mode") is False
+
+    def test_management_routes_still_bypass(self):
+        assert _is_management_route("/toggle") is True
+        assert _is_management_route("/config") is True

--- a/backend/tests/plugins/test_plugin_menu_actions.py
+++ b/backend/tests/plugins/test_plugin_menu_actions.py
@@ -1,0 +1,66 @@
+"""Tests for the plugin menu-action extension point."""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.plugins.base import (
+    MenuActionResult,
+    PluginBase,
+    PluginMenuItem,
+    PluginMetadata,
+    PluginUIManifest,
+)
+
+
+class TestPluginMenuItem:
+    def test_minimal_item(self):
+        item = PluginMenuItem(
+            id="gaming_mode", icon="Gamepad2",
+            label_key="menu_gaming_mode", label_text="Gaming Mode",
+        )
+        assert item.tone == "neutral"
+        assert item.order == 100
+        assert item.description_key is None
+
+    @pytest.mark.parametrize("bad_id", ["Gaming", "gaming-mode", "gaming.mode", "../etc", "", "a b"])
+    def test_rejects_ids_outside_the_namespace(self, bad_id):
+        with pytest.raises(ValidationError):
+            PluginMenuItem(
+                id=bad_id, icon="Gamepad2",
+                label_key="k", label_text="t",
+            )
+
+    def test_has_no_admin_only_field(self):
+        """The core decides who may run an action - a plugin must not widen it."""
+        assert "admin_only" not in PluginMenuItem.model_fields
+
+
+class TestMenuActionResult:
+    def test_message_text_is_required(self):
+        with pytest.raises(ValidationError):
+            MenuActionResult(ok=True)
+
+    def test_key_is_optional(self):
+        result = MenuActionResult(ok=False, message_text="boom")
+        assert result.message_key is None
+
+
+class _BarePlugin(PluginBase):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="bare", display_name="Bare", version="1.0.0",
+            description="", author="test",
+        )
+
+
+class TestPluginBaseDefaults:
+    def test_no_menu_items_by_default(self):
+        assert _BarePlugin().get_menu_items() == []
+
+    async def test_run_menu_action_returns_none_by_default(self):
+        assert await _BarePlugin().run_menu_action("anything", db=None) is None
+
+    def test_ui_manifest_menu_items_default_empty(self):
+        assert PluginUIManifest().menu_items == []

--- a/backend/tests/plugins/test_plugin_menu_actions.py
+++ b/backend/tests/plugins/test_plugin_menu_actions.py
@@ -64,3 +64,51 @@ class TestPluginBaseDefaults:
 
     def test_ui_manifest_menu_items_default_empty(self):
         assert PluginUIManifest().menu_items == []
+
+
+from unittest.mock import MagicMock
+
+from app.plugins.manager import PluginManager
+from app.schemas.plugin import PluginUIInfo
+
+
+def _plugin_with_menu(name: str = "demo") -> MagicMock:
+    plugin = MagicMock()
+    plugin.metadata.display_name = "Demo"
+    plugin.get_ui_manifest.return_value = PluginUIManifest(
+        enabled=True,
+        menu_items=[PluginMenuItem(
+            id="do_it", icon="Zap", label_key="menu_do_it", label_text="Do it",
+        )],
+    )
+    plugin.get_translations.return_value = {"en": {"menu_do_it": "Do it"}}
+    return plugin
+
+
+class TestManifestCarriesMenuItems:
+    def test_enabled_plugin_menu_items_reach_the_manifest(self, tmp_path):
+        manager = PluginManager(plugins_dir=tmp_path)
+        manager._plugins = {"demo": _plugin_with_menu()}
+        manager._enabled = {"demo"}
+
+        entry = manager.get_ui_manifest()["plugins"][0]
+
+        assert entry["menu_items"] == [{
+            "id": "do_it", "icon": "Zap",
+            "label_key": "menu_do_it", "label_text": "Do it",
+            "description_key": None, "description_text": None,
+            "tone": "neutral", "order": 100,
+        }]
+
+    def test_plugin_without_menu_items_yields_empty_list(self, tmp_path):
+        plugin = _plugin_with_menu()
+        plugin.get_ui_manifest.return_value = PluginUIManifest(enabled=True)
+        manager = PluginManager(plugins_dir=tmp_path)
+        manager._plugins = {"demo": plugin}
+        manager._enabled = {"demo"}
+
+        assert manager.get_ui_manifest()["plugins"][0]["menu_items"] == []
+
+    def test_schema_defaults_to_empty(self):
+        info = PluginUIInfo(name="demo", display_name="Demo")
+        assert info.menu_items == []

--- a/backend/tests/plugins/test_plugin_menu_actions.py
+++ b/backend/tests/plugins/test_plugin_menu_actions.py
@@ -115,36 +115,17 @@ class TestManifestCarriesMenuItems:
 
 
 import asyncio
+import inspect
+import time
 from unittest.mock import AsyncMock, patch
 
 from fastapi import HTTPException
 
+from app.api.deps import get_current_admin
 from app.api.routes.plugins import (
     PLUGIN_MENU_ACTION_TIMEOUT_SECONDS,
     run_plugin_menu_action,
 )
-
-
-@pytest.fixture(autouse=True)
-def _bypass_limiter_request_check():
-    """Allow calling the decorated route function directly with a MagicMock request.
-
-    These tests call ``run_plugin_menu_action`` as a plain coroutine (no
-    TestClient/ASGI stack), matching this repo's established direct-call
-    pattern for route-level unit tests. slowapi's ``@user_limiter.limit(...)``
-    wrapper requires an actual ``starlette.requests.Request`` instance
-    whenever ``Limiter.enabled`` is True - unrelated to the behaviour under
-    test here. Disabling it for the duration of these tests only bypasses
-    that isinstance check, not any assertion in the tests below.
-    """
-    from app.core.rate_limiter import user_limiter
-
-    original = user_limiter.enabled
-    user_limiter.enabled = False
-    try:
-        yield
-    finally:
-        user_limiter.enabled = original
 
 
 def _declaring_plugin(action_id: str = "do_it") -> MagicMock:
@@ -158,22 +139,42 @@ def _declaring_plugin(action_id: str = "do_it") -> MagicMock:
 async def _call(plugin, name: str = "demo", action_id: str = "do_it"):
     manager = MagicMock()
     manager.get_plugin.return_value = plugin
-    return await run_plugin_menu_action(
-        request=MagicMock(client=MagicMock(host="127.0.0.1")),
-        response=MagicMock(),
-        name=name,
-        action_id=action_id,
-        db=MagicMock(),
-        current_user=MagicMock(username="admin"),
-        plugin_manager=manager,
-    )
+    # Bypass slowapi's isinstance(Request) check for direct (non-ASGI)
+    # coroutine calls - see test_dashboard_panel.py for the established
+    # per-call pattern this mirrors.
+    with patch("app.api.routes.plugins.user_limiter.enabled", False):
+        return await run_plugin_menu_action(
+            request=MagicMock(client=MagicMock(host="127.0.0.1")),
+            response=MagicMock(),
+            name=name,
+            action_id=action_id,
+            db=MagicMock(),
+            current_user=MagicMock(username="admin"),
+            plugin_manager=manager,
+        )
+
+
+class TestMenuActionRouteRequiresAdmin:
+    def test_current_user_dependency_is_get_current_admin(self):
+        """Pin the admin gate on the route signature itself.
+
+        Every other test here calls the route function directly with a
+        fabricated ``current_user``, so FastAPI's dependency injection is
+        never exercised - a downgrade to ``get_current_user`` would leave
+        every other test green. Assert the ``Depends`` object actually
+        wraps ``get_current_admin``.
+        """
+        sig = inspect.signature(run_plugin_menu_action)
+        dependency = sig.parameters["current_user"].default
+        assert dependency.dependency is get_current_admin
 
 
 class TestMenuActionRoute:
     async def test_unknown_plugin_is_404(self):
         manager = MagicMock()
         manager.get_plugin.return_value = None
-        with pytest.raises(HTTPException) as exc:
+        with patch("app.api.routes.plugins.user_limiter.enabled", False), \
+             pytest.raises(HTTPException) as exc:
             await run_plugin_menu_action(
                 request=MagicMock(), response=MagicMock(),
                 name="nope", action_id="do_it", db=MagicMock(),
@@ -186,6 +187,19 @@ class TestMenuActionRoute:
         plugin.run_menu_action = AsyncMock()
         with pytest.raises(HTTPException) as exc:
             await _call(plugin, action_id="something_else")
+        assert exc.value.status_code == 404
+        plugin.run_menu_action.assert_not_awaited()
+
+    async def test_get_menu_items_raising_is_404_and_never_dispatches(self):
+        """A plugin that cannot even declare its actions must not 500.
+
+        Fails closed the same way an unknown action does: 404, no dispatch.
+        """
+        plugin = MagicMock()
+        plugin.get_menu_items.side_effect = RuntimeError("boom")
+        plugin.run_menu_action = AsyncMock()
+        with pytest.raises(HTTPException) as exc:
+            await _call(plugin)
         assert exc.value.status_code == 404
         plugin.run_menu_action.assert_not_awaited()
 
@@ -219,9 +233,19 @@ class TestMenuActionRoute:
         plugin = _declaring_plugin()
         plugin.run_menu_action = _hang
         with patch("app.api.routes.plugins.PLUGIN_MENU_ACTION_TIMEOUT_SECONDS", 0.01), \
-             patch("app.api.routes.plugins.get_audit_logger_db"):
+             patch("app.api.routes.plugins.get_audit_logger_db") as audit:
+            started = time.monotonic()
             result = await _call(plugin)
+            elapsed = time.monotonic() - started
+        # Discriminating against a deleted wait_for(): without it, _hang
+        # would run its full 60s sleep, return None, and fall into the
+        # "returned None" branch - also ok=False, but slow and with a
+        # different message. Pin both the message only the timeout branch
+        # produces and a wall-clock bound well under the 60s sleep.
+        assert result.message_text == "Action timed out"
         assert result.ok is False
+        assert elapsed < 5.0
+        assert audit.return_value.log_event.call_args.kwargs["success"] is False
 
     async def test_plugin_returning_none_despite_declaration_is_not_ok(self):
         plugin = _declaring_plugin()
@@ -230,9 +254,22 @@ class TestMenuActionRoute:
             result = await _call(plugin)
         assert result.ok is False
 
-    def test_timeout_is_generous_enough_for_kscreen_doctor(self):
+    async def test_plugin_returning_non_result_type_is_not_ok_and_no_500(self):
+        """A plugin returning a dict/str instead of MenuActionResult must not 500.
+
+        model_dump() on a plain dict/str would raise inside the route -
+        guard against any non-MenuActionResult return, not only None.
+        """
+        plugin = _declaring_plugin()
+        plugin.run_menu_action = AsyncMock(return_value={"ok": True, "message_text": "not a model"})
+        with patch("app.api.routes.plugins.get_audit_logger_db") as audit:
+            result = await _call(plugin)
+        assert result.ok is False
+        assert audit.return_value.log_event.call_args.kwargs["success"] is False
+
+    def test_timeout_pins_the_spec_value(self):
         """kscreen-doctor carries a 30s subprocess timeout of its own."""
-        assert PLUGIN_MENU_ACTION_TIMEOUT_SECONDS >= 10.0
+        assert PLUGIN_MENU_ACTION_TIMEOUT_SECONDS == 20.0
 
 
 from app.middleware.plugin_gate import _is_management_route

--- a/backend/tests/plugins/test_plugin_menu_actions.py
+++ b/backend/tests/plugins/test_plugin_menu_actions.py
@@ -69,7 +69,7 @@ class TestPluginBaseDefaults:
 from unittest.mock import MagicMock
 
 from app.plugins.manager import PluginManager
-from app.schemas.plugin import PluginUIInfo
+from app.schemas.plugin import PluginUIInfo, PluginUIManifestResponse
 
 
 def _plugin_with_menu(name: str = "demo") -> MagicMock:
@@ -288,3 +288,160 @@ class TestMenuActionIsGatedByMiddleware:
     def test_management_routes_still_bypass(self):
         assert _is_management_route("/toggle") is True
         assert _is_management_route("/config") is True
+
+
+class TestDisabledPluginIsRefusedInTheRouteToo:
+    """The route must not lean on PluginGateMiddleware alone.
+
+    disable_plugin() drops the name from _enabled but leaves the instance in
+    _plugins, so get_plugin() still hands one back. Without a local check the
+    only thing standing between a disabled plugin and execution is a path
+    prefix in middleware plus a 5s DB cache - and a router move or prefix
+    change would defeat it with every test still green.
+    """
+
+    async def test_loaded_but_disabled_plugin_is_refused(self):
+        plugin = _declaring_plugin()
+        plugin.run_menu_action = AsyncMock()
+        manager = MagicMock()
+        manager.get_plugin.return_value = plugin
+        manager.is_enabled.return_value = False
+
+        with patch("app.api.routes.plugins.user_limiter.enabled", False):
+            with pytest.raises(HTTPException) as exc:
+                await run_plugin_menu_action(
+                    request=MagicMock(), response=MagicMock(),
+                    name="demo", action_id="do_it", db=MagicMock(),
+                    current_user=MagicMock(username="admin"), plugin_manager=manager,
+                )
+
+        assert exc.value.status_code == 404
+        plugin.run_menu_action.assert_not_awaited()
+
+    async def test_enabled_plugin_still_runs(self):
+        """Pins that the new check refuses only the disabled case."""
+        plugin = _declaring_plugin()
+        plugin.run_menu_action = AsyncMock(
+            return_value=MenuActionResult(ok=True, message_text="done")
+        )
+        manager = MagicMock()
+        manager.get_plugin.return_value = plugin
+        manager.is_enabled.return_value = True
+
+        with patch("app.api.routes.plugins.user_limiter.enabled", False), \
+             patch("app.api.routes.plugins.get_audit_logger_db"):
+            result = await run_plugin_menu_action(
+                request=MagicMock(client=MagicMock(host="127.0.0.1")),
+                response=MagicMock(), name="demo", action_id="do_it",
+                db=MagicMock(), current_user=MagicMock(username="admin"),
+                plugin_manager=manager,
+            )
+
+        assert result.ok is True
+
+
+class TestManifestEnabledFlagIsRespected:
+    def test_disabled_manifest_declares_no_actions(self):
+        """A manifest with enabled=False advertises nothing to the frontend.
+
+        PluginManager.get_ui_manifest() filters on that flag, so if the
+        derivation ignored it, a plugin could have a dispatchable action that
+        is invisible in the UI - the same two-sites drift in reverse.
+        """
+        class _Plugin(_BarePlugin):
+            def get_ui_manifest(self):
+                return PluginUIManifest(
+                    enabled=False,
+                    menu_items=[PluginMenuItem(
+                        id="hidden", icon="Zap", label_key="k", label_text="Hidden",
+                    )],
+                )
+
+        assert _Plugin().get_menu_items() == []
+
+    def test_enabled_manifest_declares_its_actions(self):
+        class _Plugin(_BarePlugin):
+            def get_ui_manifest(self):
+                return PluginUIManifest(
+                    enabled=True,
+                    menu_items=[PluginMenuItem(
+                        id="shown", icon="Zap", label_key="k", label_text="Shown",
+                    )],
+                )
+
+        assert [item.id for item in _Plugin().get_menu_items()] == ["shown"]
+
+
+class TestManifestResponseModelCarriesMenuItems:
+    def test_menu_items_survive_the_response_model(self, tmp_path):
+        """Nothing else asserts this leg.
+
+        The manager test checks its raw dict and the frontend tests feed
+        hand-written objects - so dropping menu_items from PluginUIInfo would
+        keep every test green while the menu entry vanishes in production.
+        """
+        manager = PluginManager(plugins_dir=tmp_path)
+        manager._plugins = {"demo": _plugin_with_menu()}
+        manager._enabled = {"demo"}
+
+        response = PluginUIManifestResponse(**manager.get_ui_manifest())
+
+        assert [item.id for item in response.plugins[0].menu_items] == ["do_it"]
+
+
+class TestMenuActionThroughTheRealStack:
+    """The one test that goes through the ASGI stack instead of around it.
+
+    Every other route test here calls the endpoint function directly, so the
+    middleware never runs. That is exactly where the "a disabled plugin cannot
+    run actions" invariant lives - and it was asserted only against
+    _is_management_route()'s return value, a helper, not the gate.
+
+    What is stubbed: PluginGateMiddleware reads plugin state through its own
+    SessionLocal(), which points at the app's database, not the in-memory one
+    the test fixtures build - so the DB lookup is replaced. Everything else is
+    real: middleware dispatch, path matching, routing, auth, the route.
+    """
+
+    def _post(self, client, headers):
+        return client.post(
+            "/api/plugins/demo/menu-actions/do_it", headers=headers
+        )
+
+    def test_disabled_plugin_is_refused_by_the_stack(self, client, admin_headers):
+        from app.middleware import plugin_gate
+
+        plugin_gate._plugin_cache.clear()
+        with patch.object(
+            plugin_gate, "_fetch_plugin_status", return_value=(False, [])
+        ):
+            response = self._post(client, admin_headers)
+
+        assert response.status_code == 403
+        assert "disabled" in response.json()["detail"]
+
+    def test_enabled_plugin_reaches_the_route(self, client, admin_headers):
+        """Discriminates the 403 above: with the same request and an enabled
+        plugin the gate lets it through, and the 404 comes from the route
+        itself (no such plugin loaded in this process)."""
+        from app.middleware import plugin_gate
+
+        plugin_gate._plugin_cache.clear()
+        with patch.object(
+            plugin_gate, "_fetch_plugin_status", return_value=(True, [])
+        ):
+            response = self._post(client, admin_headers)
+
+        assert response.status_code == 404
+
+    def test_non_admin_is_refused_on_an_enabled_plugin(self, client, user_headers):
+        from app.middleware import plugin_gate
+
+        plugin_gate._plugin_cache.clear()
+        with patch.object(
+            plugin_gate, "_fetch_plugin_status", return_value=(True, [])
+        ):
+            response = self._post(client, user_headers)
+
+        assert response.status_code == 403
+        assert "disabled" not in response.json()["detail"]

--- a/backend/tests/plugins/test_steam_gaming_launcher.py
+++ b/backend/tests/plugins/test_steam_gaming_launcher.py
@@ -1,0 +1,87 @@
+"""Big Picture launcher for the steam_gaming plugin."""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from app.plugins.installed.steam_gaming.launcher import BIG_PICTURE_URL, open_big_picture
+
+
+class TestOpenBigPicture:
+    def test_launches_steam_with_the_big_picture_url(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen") as popen, \
+             patch("app.plugins.installed.steam_gaming.launcher.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            ok, _detail = open_big_picture()
+
+        assert ok is True
+        args, kwargs = popen.call_args
+        assert args[0] == ["steam", BIG_PICTURE_URL]
+
+    def test_detaches_so_steam_does_not_hang_off_the_backend(self):
+        """steam:// hands off to a running instance and exits - but if Steam is
+        NOT running, the same call starts it in the foreground."""
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen") as popen, \
+             patch("app.plugins.installed.steam_gaming.launcher.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            open_big_picture()
+
+        kwargs = popen.call_args.kwargs
+        assert kwargs["start_new_session"] is True
+        assert kwargs["stdout"] == subprocess.DEVNULL
+        assert kwargs["stderr"] == subprocess.DEVNULL
+        assert kwargs["stdin"] == subprocess.DEVNULL
+        assert "shell" not in kwargs  # never shell=True
+
+    def test_passes_the_wayland_session_env(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen") as popen, \
+             patch(
+                 "app.plugins.installed.steam_gaming.launcher.wayland_session_env",
+                 return_value={"XDG_RUNTIME_DIR": "/run/user/1000"},
+             ):
+            cfg.is_dev_mode = False
+            open_big_picture()
+
+        assert popen.call_args.kwargs["env"] == {"XDG_RUNTIME_DIR": "/run/user/1000"}
+
+    def test_missing_steam_binary_is_reported_not_raised(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen", side_effect=FileNotFoundError()), \
+             patch("app.plugins.installed.steam_gaming.launcher.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            ok, detail = open_big_picture()
+
+        assert ok is False
+        assert "steam" in detail.lower()
+
+    def test_unexpected_os_error_is_reported_not_raised(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen", side_effect=OSError("no display")), \
+             patch("app.plugins.installed.steam_gaming.launcher.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            ok, _detail = open_big_picture()
+
+        assert ok is False
+
+    def test_dev_mode_does_not_spawn_anything(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen") as popen:
+            cfg.is_dev_mode = True
+            ok, _detail = open_big_picture()
+
+        assert ok is True
+        popen.assert_not_called()
+
+    def test_never_waits_for_the_process(self):
+        handle = MagicMock()
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen", return_value=handle), \
+             patch("app.plugins.installed.steam_gaming.launcher.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            open_big_picture()
+
+        handle.wait.assert_not_called()
+        handle.communicate.assert_not_called()

--- a/backend/tests/plugins/test_steam_gaming_plugin.py
+++ b/backend/tests/plugins/test_steam_gaming_plugin.py
@@ -1,5 +1,7 @@
 """The Steam gaming plugin's status pill."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from app.plugins.installed import steam_gaming as plugin_module
@@ -102,3 +104,75 @@ async def test_dev_mode_shows_a_mock_game(plugin, monkeypatch, dev_mode):
 
 async def test_an_unknown_pill_id_is_silent(plugin, dev_mode):
     assert await plugin.collect_status_pill("nope", None) is None
+
+
+_ACTION = "gaming_mode"
+
+
+def _patch_desktop(ok: bool, message: str = ""):
+    service = MagicMock()
+    service.enable = AsyncMock(return_value=(ok, message))
+    return patch(
+        "app.plugins.installed.steam_gaming.get_desktop_service",
+        return_value=service,
+    ), service
+
+
+class TestGamingModeMenuItem:
+    def test_manifest_declares_the_action(self):
+        manifest = SteamGamingPlugin().get_ui_manifest()
+        assert [item.id for item in manifest.menu_items] == [_ACTION]
+
+    def test_item_carries_key_and_literal_fallback(self):
+        item = SteamGamingPlugin().get_ui_manifest().menu_items[0]
+        assert item.label_key == "menu_gaming_mode"
+        assert item.label_text
+        assert item.icon == "Gamepad2"
+
+    def test_translations_cover_every_key_the_item_uses(self):
+        plugin = SteamGamingPlugin()
+        item = plugin.get_ui_manifest().menu_items[0]
+        translations = plugin.get_translations()
+        for lang in ("en", "de"):
+            assert item.label_key in translations[lang]
+            assert item.description_key in translations[lang]
+
+
+class TestGamingModeAction:
+    async def test_unknown_action_returns_none(self):
+        assert await SteamGamingPlugin().run_menu_action("nope", db=None) is None
+
+    async def test_turns_displays_on_then_opens_big_picture(self):
+        desktop_patch, service = _patch_desktop(True, "ok")
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            return_value=(True, "requested"),
+        ) as launcher:
+            result = await SteamGamingPlugin().run_menu_action(_ACTION, db=None)
+
+        service.enable.assert_awaited_once()
+        launcher.assert_called_once()
+        assert result.ok is True
+        assert result.message_key == "menu_gaming_mode_started"
+
+    async def test_does_not_open_big_picture_on_dark_displays(self):
+        desktop_patch, _service = _patch_desktop(False, "kscreen-doctor not found")
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+        ) as launcher:
+            result = await SteamGamingPlugin().run_menu_action(_ACTION, db=None)
+
+        launcher.assert_not_called()
+        assert result.ok is False
+        assert result.message_key == "menu_displays_failed"
+
+    async def test_reports_partial_success_when_steam_is_missing(self):
+        desktop_patch, _service = _patch_desktop(True, "ok")
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            return_value=(False, "steam binary not found"),
+        ):
+            result = await SteamGamingPlugin().run_menu_action(_ACTION, db=None)
+
+        assert result.ok is False
+        assert result.message_key == "menu_steam_failed"

--- a/backend/tests/plugins/test_steam_gaming_plugin.py
+++ b/backend/tests/plugins/test_steam_gaming_plugin.py
@@ -1,9 +1,11 @@
 """The Steam gaming plugin's status pill."""
 
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.api.routes.plugins import run_plugin_menu_action
 from app.plugins.installed import steam_gaming as plugin_module
 from app.plugins.installed.steam_gaming import SteamGamingPlugin
 
@@ -176,3 +178,76 @@ class TestGamingModeAction:
 
         assert result.ok is False
         assert result.message_key == "menu_steam_failed"
+
+
+class TestManifestAndRouteAgreeOnDeclaredActions:
+    """Regression test for the manifest/get_menu_items split.
+
+    The plugin only declares ``gaming_mode`` in get_ui_manifest() - that is
+    what makes the entry render in the frontend menu. get_menu_items() is
+    what the route validates the clicked action_id against. If those two
+    ever disagree again, the entry renders and the click 404s - invisible to
+    every test that drives run_menu_action() directly or mocks
+    get_menu_items(). Use the real plugin and the real route function.
+    """
+
+    def test_every_manifest_menu_item_id_is_declared(self):
+        plugin = SteamGamingPlugin()
+        manifest_ids = {item.id for item in plugin.get_ui_manifest().menu_items}
+        declared_ids = {item.id for item in plugin.get_menu_items()}
+
+        assert manifest_ids, "the manifest must actually declare something for this test to mean anything"
+        assert manifest_ids == declared_ids
+
+    async def test_route_does_not_404_the_action_the_manifest_advertises(self):
+        plugin = SteamGamingPlugin()
+        manager = MagicMock()
+        manager.get_plugin.return_value = plugin
+
+        desktop_patch, _service = _patch_desktop(True, "ok")
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            return_value=(True, "requested"),
+        ), patch("app.api.routes.plugins.user_limiter.enabled", False), patch(
+            "app.api.routes.plugins.get_audit_logger_db"
+        ):
+            result = await run_plugin_menu_action(
+                request=MagicMock(client=MagicMock(host="127.0.0.1")),
+                response=MagicMock(),
+                name="steam_gaming",
+                action_id=_ACTION,
+                db=MagicMock(),
+                current_user=MagicMock(username="admin"),
+                plugin_manager=manager,
+            )
+
+        assert result.ok is True
+
+
+class TestGamingModeRunsLauncherOffTheEventLoop:
+    """asyncio.wait_for() in the route can only interrupt awaits, not a
+    blocking call made directly on the event loop thread - the launcher must
+    run via asyncio.to_thread() or the route's timeout is decorative.
+    """
+
+    async def test_open_big_picture_runs_on_a_worker_thread(self):
+        caller_thread_idents: list[int] = []
+
+        def _record_ident_and_launch():
+            caller_thread_idents.append(threading.get_ident())
+            return True, "requested"
+
+        desktop_patch, _service = _patch_desktop(True, "ok")
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            side_effect=_record_ident_and_launch,
+        ):
+            result = await SteamGamingPlugin().run_menu_action(_ACTION, db=None)
+
+        assert result.ok is True
+        assert caller_thread_idents, "open_big_picture was never called"
+        assert caller_thread_idents[0] != threading.get_ident(), (
+            "open_big_picture ran on the event loop's own thread - "
+            "asyncio.to_thread() is missing, so the route's wait_for timeout "
+            "cannot interrupt it"
+        )

--- a/backend/tests/test_session_env.py
+++ b/backend/tests/test_session_env.py
@@ -1,0 +1,27 @@
+"""Wayland session environment helper."""
+from __future__ import annotations
+
+from app.services.power.session_env import wayland_session_env
+
+
+class TestWaylandSessionEnv:
+    def test_sets_runtime_dir_and_display_for_the_uid(self):
+        env = wayland_session_env(uid=1000)
+        assert env["XDG_RUNTIME_DIR"] == "/run/user/1000"
+        assert env["WAYLAND_DISPLAY"] == "wayland-0"
+
+    def test_keeps_existing_environment(self, monkeypatch):
+        monkeypatch.setenv("PATH", "/custom/bin")
+        assert wayland_session_env(uid=1000)["PATH"] == "/custom/bin"
+
+    def test_does_not_override_an_explicit_session(self, monkeypatch):
+        monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-7")
+        assert wayland_session_env(uid=1000)["WAYLAND_DISPLAY"] == "wayland-7"
+
+
+class TestDesktopBackendUsesTheHelper:
+    def test_linux_backend_env_matches_the_helper(self):
+        from app.services.power.desktop_backend import LinuxDesktopBackend
+
+        backend = LinuxDesktopBackend(uid=1000)
+        assert backend._session_env() == wayland_session_env(uid=1000)

--- a/backend/tests/test_session_env.py
+++ b/backend/tests/test_session_env.py
@@ -5,7 +5,13 @@ from app.services.power.session_env import wayland_session_env
 
 
 class TestWaylandSessionEnv:
-    def test_sets_runtime_dir_and_display_for_the_uid(self):
+    def test_sets_runtime_dir_and_display_for_the_uid(self, monkeypatch):
+        # The helper uses setdefault, so this asserts the *supplied* values only
+        # when the runner's own environment carries neither. CI runs as a
+        # session user whose XDG_RUNTIME_DIR may well be set - clear both first
+        # or the assertion silently depends on the host.
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
         env = wayland_session_env(uid=1000)
         assert env["XDG_RUNTIME_DIR"] == "/run/user/1000"
         assert env["WAYLAND_DISPLAY"] == "wayland-0"

--- a/client/src/__tests__/api/plugins.menuActions.test.ts
+++ b/client/src/__tests__/api/plugins.menuActions.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/api', () => ({
+  apiClient: { post: vi.fn() },
+}));
+
+import { apiClient } from '../../lib/api';
+import { runPluginMenuAction } from '../../api/plugins';
+
+describe('runPluginMenuAction', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('posts to the namespaced menu-action endpoint', async () => {
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: true, message_key: 'menu_gaming_mode_started', message_text: 'Gaming mode started' },
+    });
+
+    const result = await runPluginMenuAction('steam_gaming', 'gaming_mode');
+
+    expect(apiClient.post).toHaveBeenCalledWith('/api/plugins/steam_gaming/menu-actions/gaming_mode');
+    expect(result.ok).toBe(true);
+    expect(result.message_key).toBe('menu_gaming_mode_started');
+  });
+
+  it('returns the failure result unchanged', async () => {
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: false, message_key: 'menu_steam_failed', message_text: 'Steam did not start' },
+    });
+
+    expect((await runPluginMenuAction('steam_gaming', 'gaming_mode')).ok).toBe(false);
+  });
+});

--- a/client/src/__tests__/components/PowerMenu.pluginActions.test.tsx
+++ b/client/src/__tests__/components/PowerMenu.pluginActions.test.tsx
@@ -96,7 +96,34 @@ describe('PowerMenu — plugin menu actions', () => {
     openMenu();
     fireEvent.click(await screen.findByText('Gaming Mode'));
 
-    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    // Assert the text, not just that a toast happened: without it the test
+    // passes on an empty string or a raw axios message leaking to the user.
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Action failed'));
+  });
+
+  it('colours the entry by its declared tone', async () => {
+    setItems([{ ...gamingItem, tone: 'danger' }]);
+    const { unmount } = render(<PowerMenu {...baseProps} />);
+    openMenu();
+    const dangerClasses = (await screen.findByText('Gaming Mode')).closest('button')!.className;
+    unmount();
+
+    setItems([{ ...gamingItem, tone: 'success' }]);
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    const successClasses = (await screen.findByText('Gaming Mode')).closest('button')!.className;
+
+    expect(dangerClasses).not.toBe(successClasses);
+    expect(dangerClasses).toContain('rose');
+    expect(successClasses).toContain('emerald');
+  });
+
+  it('falls back to the neutral tone for an unknown one', async () => {
+    setItems([{ ...gamingItem, tone: 'chartreuse' }]);
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    const classes = (await screen.findByText('Gaming Mode')).closest('button')!.className;
+    expect(classes).toContain('slate');
   });
 
   it('renders an item whose icon is unknown instead of crashing', async () => {

--- a/client/src/__tests__/components/PowerMenu.pluginActions.test.tsx
+++ b/client/src/__tests__/components/PowerMenu.pluginActions.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, def?: string) => def ?? _key }),
+}));
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('../../api/sleep', () => ({
+  getSleepStatus: vi.fn(), enterSoftSleep: vi.fn(), enterSuspend: vi.fn(),
+}));
+vi.mock('../../api/desktop', () => ({
+  getDesktopStatus: vi.fn(), disableDesktop: vi.fn(), enableDesktop: vi.fn(),
+}));
+vi.mock('../../api/plugins', () => ({ runPluginMenuAction: vi.fn() }));
+
+// vi.mock factories are hoisted above this file's const declarations — a plain
+// top-level array would hit the temporal dead zone. vi.hoisted lifts the state
+// alongside the mock.
+const menuItems = vi.hoisted(() => [] as unknown[]);
+vi.mock('../../contexts/PluginContext', () => ({
+  usePlugins: () => ({ pluginMenuItems: menuItems }),
+}));
+
+import PowerMenu from '../../components/PowerMenu';
+import { getSleepStatus } from '../../api/sleep';
+import { getDesktopStatus } from '../../api/desktop';
+import { runPluginMenuAction } from '../../api/plugins';
+import toast from 'react-hot-toast';
+
+const baseProps = {
+  isAdmin: true,
+  onShutdown: vi.fn().mockResolvedValue(undefined),
+  onRestart: vi.fn().mockResolvedValue(undefined),
+  onLogout: vi.fn(),
+};
+
+const gamingItem = {
+  id: 'gaming_mode', icon: 'Gamepad2', tone: 'info', order: 10,
+  label_key: 'menu_gaming_mode', label_text: 'Gaming Mode',
+  description_key: 'menu_gaming_mode_desc', description_text: 'Displays on + Big Picture',
+  _pluginName: 'steam_gaming',
+  _translations: { en: { menu_gaming_mode: 'Gaming Mode' } },
+};
+
+function setItems(items: unknown[]) {
+  menuItems.length = 0;
+  menuItems.push(...items);
+}
+
+const openMenu = () => fireEvent.click(screen.getByTitle('Power'));
+
+describe('PowerMenu — plugin menu actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getSleepStatus as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (getDesktopStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'stopped', display_manager: 'sddm', detail: null,
+    });
+    setItems([gamingItem]);
+  });
+
+  it('renders a plugin action with its resolved label', async () => {
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    expect(await screen.findByText('Gaming Mode')).toBeInTheDocument();
+  });
+
+  it('posts to the right plugin and action on click', async () => {
+    (runPluginMenuAction as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true, message_key: null, message_text: 'Gaming mode started',
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByText('Gaming Mode'));
+
+    await waitFor(() =>
+      expect(runPluginMenuAction).toHaveBeenCalledWith('steam_gaming', 'gaming_mode'));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Gaming mode started'));
+  });
+
+  it('shows an error toast when the action reports ok:false', async () => {
+    (runPluginMenuAction as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false, message_key: null, message_text: 'Steam did not start',
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByText('Gaming Mode'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Steam did not start'));
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('shows an error toast when the request itself fails', async () => {
+    (runPluginMenuAction as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network'));
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByText('Gaming Mode'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+  });
+
+  it('renders an item whose icon is unknown instead of crashing', async () => {
+    setItems([{ ...gamingItem, icon: 'NotARealIcon' }]);
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    expect(await screen.findByText('Gaming Mode')).toBeInTheDocument();
+  });
+
+  it('renders no plugin actions for a non-admin', async () => {
+    render(<PowerMenu {...baseProps} isAdmin={false} />);
+    openMenu();
+    expect(screen.queryByText('Gaming Mode')).not.toBeInTheDocument();
+  });
+
+  it('locks the plugin actions while one is running', async () => {
+    let resolveAction!: (value: unknown) => void;
+    (runPluginMenuAction as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise((resolve) => { resolveAction = resolve; }),
+    );
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    const button = (await screen.findByText('Gaming Mode')).closest('button')!;
+    fireEvent.click(button);
+
+    await waitFor(() => expect(button).toBeDisabled());
+
+    resolveAction({ ok: true, message_key: null, message_text: 'done' });
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('done'));
+  });
+});

--- a/client/src/__tests__/components/PowerMenu.test.tsx
+++ b/client/src/__tests__/components/PowerMenu.test.tsx
@@ -22,6 +22,10 @@ vi.mock('../../api/desktop', () => ({
   enableDesktop: vi.fn(),
 }));
 
+vi.mock('../../contexts/PluginContext', () => ({
+  usePlugins: () => ({ pluginMenuItems: [] }),
+}));
+
 import PowerMenu from '../../components/PowerMenu';
 import { getSleepStatus } from '../../api/sleep';
 import { getDesktopStatus, disableDesktop, enableDesktop } from '../../api/desktop';

--- a/client/src/__tests__/contexts/PluginContext.menuItems.test.tsx
+++ b/client/src/__tests__/contexts/PluginContext.menuItems.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('../../lib/features', () => ({ isPi: false }));
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: () => ({ token: 'tok' }) }));
+vi.mock('../../api/plugins', () => ({
+  listPlugins: vi.fn(),
+  getUIManifest: vi.fn(),
+}));
+
+import { PluginProvider, usePlugins } from '../../contexts/PluginContext';
+import { listPlugins, getUIManifest } from '../../api/plugins';
+
+function Probe() {
+  const { pluginMenuItems } = usePlugins();
+  return <div data-testid="items">{pluginMenuItems.map((i) => `${i._pluginName}:${i.id}`).join(',')}</div>;
+}
+
+const uiPlugin = (name: string, items: unknown[]) => ({
+  name, display_name: name, nav_items: [], menu_items: items,
+  bundle_path: 'ui/bundle.js', dashboard_widgets: [], granted_api_scopes: [],
+  translations: { en: { k: 'v' } },
+});
+
+const item = (id: string, order: number) => ({
+  id, icon: 'Zap', label_key: 'k', label_text: id, tone: 'neutral', order,
+});
+
+describe('PluginContext.pluginMenuItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (listPlugins as ReturnType<typeof vi.fn>).mockResolvedValue({ plugins: [] });
+  });
+
+  it('flattens items across plugins and sorts by order', async () => {
+    (getUIManifest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      plugins: [uiPlugin('a', [item('late', 50)]), uiPlugin('b', [item('early', 10)])],
+    });
+
+    render(<PluginProvider><Probe /></PluginProvider>);
+
+    await waitFor(() => expect(screen.getByTestId('items')).toHaveTextContent('b:early,a:late'));
+  });
+
+  it('carries the plugin translations for client-side label resolution', async () => {
+    (getUIManifest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      plugins: [uiPlugin('a', [item('one', 10)])],
+    });
+
+    function TranslationProbe() {
+      const { pluginMenuItems } = usePlugins();
+      return <div data-testid="tr">{JSON.stringify(pluginMenuItems[0]?._translations ?? null)}</div>;
+    }
+
+    render(<PluginProvider><TranslationProbe /></PluginProvider>);
+
+    await waitFor(() => expect(screen.getByTestId('tr')).toHaveTextContent('"k":"v"'));
+  });
+
+  it('tolerates a manifest without menu_items', async () => {
+    (getUIManifest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      plugins: [{ name: 'legacy', display_name: 'Legacy', nav_items: [] }],
+    });
+
+    render(<PluginProvider><Probe /></PluginProvider>);
+
+    await waitFor(() => expect(screen.getByTestId('items')).toBeEmptyDOMElement());
+  });
+});

--- a/client/src/api/plugins.ts
+++ b/client/src/api/plugins.ts
@@ -257,7 +257,7 @@ export async function runPluginMenuAction(
   actionId: string,
 ): Promise<PluginMenuActionResult> {
   const res = await apiClient.post<PluginMenuActionResult>(
-    `/api/plugins/${pluginName}/menu-actions/${actionId}`,
+    `/api/plugins/${encodeURIComponent(pluginName)}/menu-actions/${encodeURIComponent(actionId)}`,
   );
   return res.data;
 }

--- a/client/src/api/plugins.ts
+++ b/client/src/api/plugins.ts
@@ -12,6 +12,23 @@ export interface PluginNavItem {
   order: number;
 }
 
+export interface PluginMenuItem {
+  id: string;
+  icon: string;
+  label_key: string;
+  label_text: string;
+  description_key?: string | null;
+  description_text?: string | null;
+  tone: 'neutral' | 'info' | 'success' | 'warning' | 'danger';
+  order: number;
+}
+
+export interface PluginMenuActionResult {
+  ok: boolean;
+  message_key?: string | null;
+  message_text: string;
+}
+
 export interface ScopeInfo {
   key: string;
   tier: 'frontend' | 'backend';
@@ -50,6 +67,7 @@ export interface PluginUIInfo {
   name: string;
   display_name: string;
   nav_items: PluginNavItem[];
+  menu_items: PluginMenuItem[];
   bundle_path: string;
   styles_path?: string;
   dashboard_widgets: string[];
@@ -226,4 +244,20 @@ export async function uninstallPlugin(name: string): Promise<{ message: string }
  */
 export function getPluginBundleUrl(pluginName: string, bundlePath: string): string {
   return `/api/plugins/${pluginName}/ui/${bundlePath}`;
+}
+
+/**
+ * Run a plugin-contributed system-menu action. Admin only (server-enforced).
+ *
+ * Resolves with the plugin's own outcome — a failed action is a normal `ok:
+ * false` response, not an HTTP error.
+ */
+export async function runPluginMenuAction(
+  pluginName: string,
+  actionId: string,
+): Promise<PluginMenuActionResult> {
+  const res = await apiClient.post<PluginMenuActionResult>(
+    `/api/plugins/${pluginName}/menu-actions/${actionId}`,
+  );
+  return res.data;
 }

--- a/client/src/components/PowerMenu.tsx
+++ b/client/src/components/PowerMenu.tsx
@@ -17,6 +17,23 @@ interface PowerMenuProps {
   onLogout: () => void;
 }
 
+/**
+ * Colour vocabulary for a plugin action's declared tone, reusing the palette
+ * the core entries already use (amber = restart, rose = shutdown, …).
+ *
+ * Written out as literal class names on purpose: Tailwind scans the source for
+ * complete strings, so a composed `bg-${tone}-500/10` would be dropped from the
+ * build. A plugin-supplied tone therefore picks from this map or gets neutral —
+ * it never reaches the class list itself.
+ */
+const PLUGIN_ACTION_TONES = {
+  neutral: { hover: 'hover:bg-slate-500/10', square: 'border-slate-700 bg-slate-800/50', icon: 'text-slate-300' },
+  info: { hover: 'hover:bg-sky-500/10', square: 'border-sky-500/30 bg-sky-500/10', icon: 'text-sky-400' },
+  success: { hover: 'hover:bg-emerald-500/10', square: 'border-emerald-500/30 bg-emerald-500/10', icon: 'text-emerald-400' },
+  warning: { hover: 'hover:bg-amber-500/10', square: 'border-amber-500/30 bg-amber-500/10', icon: 'text-amber-400' },
+  danger: { hover: 'hover:bg-rose-500/10', square: 'border-rose-500/30 bg-rose-500/10', icon: 'text-rose-400' },
+} as const;
+
 export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: PowerMenuProps) {
   const { t } = useTranslation('common');
   const [isOpen, setIsOpen] = useState(false);
@@ -242,6 +259,7 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
                   {pluginMenuItems.map((item) => {
                     const Icon = resolveIcon(item.icon) ?? Plug;
                     const key = `${item._pluginName}:${item.id}`;
+                    const tone = PLUGIN_ACTION_TONES[item.tone] ?? PLUGIN_ACTION_TONES.neutral;
                     const label = resolvePluginString(item._translations, item.label_key, item.label_text);
                     const description = item.description_key
                       ? resolvePluginString(item._translations, item.description_key, item.description_text ?? '')
@@ -251,10 +269,10 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
                         key={key}
                         onClick={() => { void handlePluginAction(item); }}
                         disabled={runningAction !== null}
-                        className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-sky-500/10 disabled:opacity-50"
+                        className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition disabled:opacity-50 ${tone.hover}`}
                       >
-                        <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-sky-500/30 bg-sky-500/10">
-                          <Icon className="h-4 w-4 text-sky-400" />
+                        <div className={`flex h-9 w-9 items-center justify-center rounded-lg border ${tone.square}`}>
+                          <Icon className={`h-4 w-4 ${tone.icon}`} />
                         </div>
                         <div>
                           <p className="text-sm font-medium text-slate-100">{label}</p>

--- a/client/src/components/PowerMenu.tsx
+++ b/client/src/components/PowerMenu.tsx
@@ -1,9 +1,13 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Power, PowerOff, RotateCcw, LogOut, Moon, Pause, MonitorOff, Monitor } from 'lucide-react';
+import { Power, PowerOff, RotateCcw, LogOut, Moon, Pause, MonitorOff, Monitor, Plug } from 'lucide-react';
 import { ConfirmDialog } from './ui/ConfirmDialog';
 import { getSleepStatus, enterSoftSleep, enterSuspend } from '../api/sleep';
 import { getDesktopStatus, disableDesktop, enableDesktop, type DesktopState } from '../api/desktop';
+import { usePlugins } from '../contexts/PluginContext';
+import { runPluginMenuAction } from '../api/plugins';
+import { resolvePluginString } from '../lib/pluginI18n';
+import { resolveIcon } from './topbar/iconMap';
 import toast from 'react-hot-toast';
 
 interface PowerMenuProps {
@@ -19,6 +23,8 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
   const [confirmAction, setConfirmAction] = useState<'shutdown' | 'restart' | 'sleep' | 'suspend' | null>(null);
   const [sleepAvailable, setSleepAvailable] = useState(false);
   const [desktopState, setDesktopState] = useState<DesktopState | null>(null);
+  const { pluginMenuItems } = usePlugins();
+  const [runningAction, setRunningAction] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Check sleep + desktop availability when dropdown opens. Both states are
@@ -102,6 +108,29 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
       }
     } catch {
       toast.error(t('powerMenu.desktopEnableFailed', 'Failed to enable desktop'));
+    }
+  };
+
+  const handlePluginAction = async (item: (typeof pluginMenuItems)[number]) => {
+    const key = `${item._pluginName}:${item.id}`;
+    setRunningAction(key);
+    try {
+      const result = await runPluginMenuAction(item._pluginName, item.id);
+      const message = resolvePluginString(
+        item._translations,
+        result.message_key ?? '',
+        result.message_text,
+      );
+      if (result.ok) {
+        toast.success(message);
+        setIsOpen(false);
+      } else {
+        toast.error(message);
+      }
+    } catch {
+      toast.error(t('powerMenu.pluginActionFailed', 'Action failed'));
+    } finally {
+      setRunningAction(null);
     }
   };
 
@@ -209,6 +238,31 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
                       </div>
                     </button>
                   )}
+
+                  {pluginMenuItems.map((item) => {
+                    const Icon = resolveIcon(item.icon) ?? Plug;
+                    const key = `${item._pluginName}:${item.id}`;
+                    const label = resolvePluginString(item._translations, item.label_key, item.label_text);
+                    const description = item.description_key
+                      ? resolvePluginString(item._translations, item.description_key, item.description_text ?? '')
+                      : item.description_text;
+                    return (
+                      <button
+                        key={key}
+                        onClick={() => { void handlePluginAction(item); }}
+                        disabled={runningAction !== null}
+                        className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-sky-500/10 disabled:opacity-50"
+                      >
+                        <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-sky-500/30 bg-sky-500/10">
+                          <Icon className="h-4 w-4 text-sky-400" />
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium text-slate-100">{label}</p>
+                          {description && <p className="text-xs text-slate-400">{description}</p>}
+                        </div>
+                      </button>
+                    );
+                  })}
                 </div>
 
                 <div className="mx-3 border-t border-slate-800" />

--- a/client/src/contexts/PluginContext.tsx
+++ b/client/src/contexts/PluginContext.tsx
@@ -6,6 +6,8 @@ import type {
   PluginInfo,
   PluginUIInfo,
   PluginNavItem,
+  PluginMenuItem,
+  PluginTranslations,
 } from '../api/plugins';
 import {
   listPlugins,
@@ -14,10 +16,16 @@ import {
 import { useAuth } from './AuthContext';
 import { isPi } from '../lib/features';
 
+export interface PluginMenuItemWithSource extends PluginMenuItem {
+  _pluginName: string;
+  _translations?: PluginTranslations;
+}
+
 interface PluginContextType {
   plugins: PluginInfo[];
   enabledPlugins: PluginUIInfo[];
   pluginNavItems: PluginNavItem[];
+  pluginMenuItems: PluginMenuItemWithSource[];
   isLoading: boolean;
   error: string | null;
   refreshPlugins: () => Promise<void>;
@@ -84,10 +92,23 @@ export function PluginProvider({ children }: PluginProviderProps) {
     )
     .sort((a, b) => a.order - b.order);
 
+  // Flatten menu items from all enabled plugins, sorted by order.
+  // menu_items may be absent when talking to an older backend.
+  const pluginMenuItems: PluginMenuItemWithSource[] = (enabledPlugins ?? [])
+    .flatMap((plugin) =>
+      (plugin.menu_items ?? []).map((item) => ({
+        ...item,
+        _pluginName: plugin.name,
+        _translations: plugin.translations ?? undefined,
+      }))
+    )
+    .sort((a, b) => a.order - b.order);
+
   const value: PluginContextType = {
     plugins,
     enabledPlugins,
     pluginNavItems,
+    pluginMenuItems,
     isLoading,
     error,
     refreshPlugins: loadPlugins,

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -263,7 +263,8 @@
     "desktopEnable": "Desktop aktivieren",
     "desktopEnableDesc": "Bildschirme wieder einschalten",
     "desktopEnabled": "Desktop aktiviert",
-    "desktopEnableFailed": "Desktop konnte nicht aktiviert werden"
+    "desktopEnableFailed": "Desktop konnte nicht aktiviert werden",
+    "pluginActionFailed": "Aktion fehlgeschlagen"
   },
   "adminOnly": "Nur für Admins",
   "local_only_action_hint": "Nur über die BaluHost-Companion-App am Server selbst möglich.",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -263,7 +263,8 @@
     "desktopEnable": "Enable desktop",
     "desktopEnableDesc": "Turn displays back on",
     "desktopEnabled": "Desktop enabled",
-    "desktopEnableFailed": "Failed to enable desktop"
+    "desktopEnableFailed": "Failed to enable desktop",
+    "pluginActionFailed": "Action failed"
   },
   "adminOnly": "Admin only",
   "local_only_action_hint": "Only available via the BaluHost Companion app running on the server itself.",

--- a/docs/superpowers/plans/2026-07-23-plugin-menu-contribution-gaming-mode.md
+++ b/docs/superpowers/plans/2026-07-23-plugin-menu-contribution-gaming-mode.md
@@ -245,7 +245,7 @@ Import-Zeile am Dateikopf prüfen: `Literal` muss aus `typing` importiert sein (
 - [ ] **Step 5: Run tests to verify they pass**
 
 Run: `cd backend && python -m pytest tests/plugins/test_plugin_menu_actions.py -q --no-cov`
-Expected: PASS (8 Tests)
+Expected: PASS (13 Tests — die 6 Parametrize-Fälle zählen einzeln)
 
 - [ ] **Step 6: Lint + commit**
 
@@ -303,8 +303,8 @@ def _plugin_with_menu(name: str = "demo") -> MagicMock:
 
 
 class TestManifestCarriesMenuItems:
-    def test_enabled_plugin_menu_items_reach_the_manifest(self):
-        manager = PluginManager()
+    def test_enabled_plugin_menu_items_reach_the_manifest(self, tmp_path):
+        manager = PluginManager(plugins_dir=tmp_path)
         manager._plugins = {"demo": _plugin_with_menu()}
         manager._enabled = {"demo"}
 
@@ -317,10 +317,10 @@ class TestManifestCarriesMenuItems:
             "tone": "neutral", "order": 100,
         }]
 
-    def test_plugin_without_menu_items_yields_empty_list(self):
+    def test_plugin_without_menu_items_yields_empty_list(self, tmp_path):
         plugin = _plugin_with_menu()
         plugin.get_ui_manifest.return_value = PluginUIManifest(enabled=True)
-        manager = PluginManager()
+        manager = PluginManager(plugins_dir=tmp_path)
         manager._plugins = {"demo": plugin}
         manager._enabled = {"demo"}
 
@@ -331,7 +331,7 @@ class TestManifestCarriesMenuItems:
         assert info.menu_items == []
 ```
 
-Hinweis für die Umsetzung: `PluginManager()` direkt zu instanziieren umgeht das Singleton bewusst — die vorhandenen Tests in `tests/plugins/test_plugin_manager.py` machen das genauso. Falls der Konstruktor Argumente verlangt, dort abschauen.
+Hinweis für die Umsetzung: `PluginManager(plugins_dir=tmp_path)` umgeht das Singleton und zeigt auf ein leeres Verzeichnis statt auf das echte `installed/` — dasselbe Muster wie `tests/plugins/test_plugin_manager.py:78`. Das direkte Setzen von `_plugins`/`_enabled` entspricht den internen Typen (`Dict[str, PluginBase]` / `Set[str]`, `manager.py:130-131`); auch die Sandbox-Tests legen Einträge direkt in `_enabled` ab.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -377,7 +377,7 @@ Der externe (sandboxed) Zweig weiter unten bleibt **unverändert**: externe Plug
 - [ ] **Step 5: Run tests to verify they pass**
 
 Run: `cd backend && python -m pytest tests/plugins/test_plugin_menu_actions.py -q --no-cov`
-Expected: PASS (11 Tests)
+Expected: PASS (16 Tests)
 
 - [ ] **Step 6: Run the neighbouring suites for regressions**
 
@@ -544,7 +544,7 @@ In `backend/app/api/routes/plugins.py`:
 Imports ergänzen — `import asyncio` oben bei `import html`, und im Schema-Import-Block (Zeile 20-37) alphabetisch `PluginMenuActionResponse` einfügen. Zusätzlich am Kopf:
 
 ```python
-from app.plugins.base import MenuActionResult
+from app.plugins.base import MenuActionResult, PluginBase
 ```
 
 Konstante direkt unter `router = APIRouter(...)` (Zeile 42):
@@ -608,7 +608,7 @@ async def run_plugin_menu_action(
 
 
 async def _execute_menu_action(
-    plugin, name: str, action_id: str, db: Session
+    plugin: PluginBase, name: str, action_id: str, db: Session
 ) -> MenuActionResult:
     """Run the action under a timeout and an exception guard.
 
@@ -642,7 +642,7 @@ async def _execute_menu_action(
 - [ ] **Step 5: Run tests to verify they pass**
 
 Run: `cd backend && python -m pytest tests/plugins/test_plugin_menu_actions.py -q --no-cov`
-Expected: PASS (18 Tests)
+Expected: PASS (23 Tests)
 
 - [ ] **Step 6: Pin the middleware gate (no production code changes)**
 
@@ -1131,7 +1131,7 @@ Methoden in der Klasse ergänzen (nach `collect_status_pill`):
             )],
         )
 
-    async def run_menu_action(self, action_id: str, db) -> Optional[MenuActionResult]:
+    async def run_menu_action(self, action_id: str, db: Session) -> Optional[MenuActionResult]:
         if action_id != _MENU_ACTION_ID:
             return None
 
@@ -1536,7 +1536,10 @@ vi.mock('../../api/desktop', () => ({
 }));
 vi.mock('../../api/plugins', () => ({ runPluginMenuAction: vi.fn() }));
 
-const menuItems: unknown[] = [];
+// vi.mock factories are hoisted above this file's const declarations — a plain
+// top-level array would hit the temporal dead zone. vi.hoisted lifts the state
+// alongside the mock.
+const menuItems = vi.hoisted(() => [] as unknown[]);
 vi.mock('../../contexts/PluginContext', () => ({
   usePlugins: () => ({ pluginMenuItems: menuItems }),
 }));
@@ -1631,6 +1634,22 @@ describe('PowerMenu — plugin menu actions', () => {
     openMenu();
     expect(screen.queryByText('Gaming Mode')).not.toBeInTheDocument();
   });
+
+  it('locks the plugin actions while one is running', async () => {
+    let resolveAction!: (value: unknown) => void;
+    (runPluginMenuAction as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise((resolve) => { resolveAction = resolve; }),
+    );
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    const button = (await screen.findByText('Gaming Mode')).closest('button')!;
+    fireEvent.click(button);
+
+    await waitFor(() => expect(button).toBeDisabled());
+
+    resolveAction({ ok: true, message_key: null, message_text: 'done' });
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('done'));
+  });
 });
 ```
 
@@ -1664,8 +1683,9 @@ import { usePlugins } from '../contexts/PluginContext';
 import { runPluginMenuAction } from '../api/plugins';
 import { resolvePluginString } from '../lib/pluginI18n';
 import { resolveIcon } from './topbar/iconMap';
-import { Plug } from 'lucide-react';
 ```
+
+und `Plug` in den **vorhandenen** `lucide-react`-Import (Zeile 3) aufnehmen — keinen zweiten Import derselben Quelle anlegen.
 
 State und Handler in der Komponente (nach `const [desktopState, ...]`):
 
@@ -1728,14 +1748,22 @@ Rendering im Admin-Block, direkt **nach** dem `desktopState === 'stopped'`-Butto
 
 Der Block steht innerhalb von `{isAdmin && (...)}` — Nicht-Admins sehen ihn dadurch gar nicht, und die Route lehnt sie ohnehin ab.
 
-- [ ] **Step 5: Run tests to verify they pass**
+- [ ] **Step 5: Fix the existing PowerMenu suite — it WILL break**
+
+`PowerMenu` ruft nach diesem Task `usePlugins()` unconditional auf; die bestehende Suite `src/__tests__/components/PowerMenu.test.tsx` rendert ohne Provider und wirft „usePlugins must be used within a PluginProvider". In dieser Datei nach den vorhandenen `vi.mock`-Blöcken (Zeile 19-23) ergänzen:
+
+```tsx
+vi.mock('../../contexts/PluginContext', () => ({
+  usePlugins: () => ({ pluginMenuItems: [] }),
+}));
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
 
 Run: `cd client && npx vitest run src/__tests__/components/PowerMenu.pluginActions.test.tsx src/__tests__/components/PowerMenu.test.tsx`
-Expected: PASS (6 neue Tests + die bestehende PowerMenu-Suite).
+Expected: PASS (7 neue Tests + die bestehende PowerMenu-Suite unverändert grün).
 
-Falls die bestehende Suite mit „usePlugins must be used within a PluginProvider" bricht: dort denselben `vi.mock('../../contexts/PluginContext', ...)`-Block ergänzen wie in der neuen Datei — der Test rendert `PowerMenu` ohne Provider.
-
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add client/src/components/PowerMenu.tsx client/src/i18n/locales/de/common.json client/src/i18n/locales/en/common.json client/src/__tests__/components/PowerMenu.pluginActions.test.tsx client/src/__tests__/components/PowerMenu.test.tsx

--- a/docs/superpowers/plans/2026-07-23-plugin-menu-contribution-gaming-mode.md
+++ b/docs/superpowers/plans/2026-07-23-plugin-menu-contribution-gaming-mode.md
@@ -1,0 +1,1884 @@
+# Plugin-Menü-Contribution + Gaming-Modus — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Plugins können Aktionen ins System-Menü (`PowerMenu`) hängen; das `steam_gaming`-Plugin nutzt das als erster Konsument für „Gaming-Modus" — Displays an, dann Steams Big Picture öffnen.
+
+**Architecture:** `PluginUIManifest` bekommt `menu_items` (reine Deklaration: id, Icon, Label-Key + Literal-Fallback), `PluginBase` bekommt `run_menu_action()`. Eine neue Core-Route `POST /api/plugins/{name}/menu-actions/{action_id}` besitzt Admin-Gate, Ratelimit, Audit, Deklarationsprüfung und Timeout — das Plugin liefert nur *was* passiert, nie *wer* es darf. Der Lesepfad läuft über das vorhandene `GET /api/plugins/ui/manifest` und den `PluginContext`, es kommt kein zweiter Fetch dazu.
+
+**Tech Stack:** Python 3.11 / FastAPI / Pydantic v2 / SQLAlchemy 2.0, pytest (`asyncio_mode = "auto"`), React 18 + TypeScript + Vitest, lucide-react.
+
+**Spec:** `docs/superpowers/specs/2026-07-23-plugin-menu-contribution-gaming-mode-design.md`
+
+## Global Constraints
+
+- Backend-Tests laufen aus `backend/`: `python -m pytest <pfad> -q --no-cov`. Der Repo-Default in `pyproject.toml` schaltet Coverage an; für Einzelläufe `--no-cov` verwenden.
+- `ruff check <geänderte dateien>` muss sauber sein (CI-Gate).
+- Frontend: `npx vitest run <pfad>` aus `client/`; vor dem Abschluss zusätzlich `npx eslint .` und `npm run build`.
+- Keine neuen Dependencies. Alles mit Stdlib + vorhandenen Paketen.
+- Keine neuen Sudoers-Regeln. Kein `shell=True`; Subprozesse ausschließlich mit Listen-Argumenten.
+- Eine Plugin-Aktion darf **niemals** einen 5xx erzeugen und niemals Server-Interna in die Antwort schreiben: Exception und Timeout werden zu `ok=false` mit generischer Meldung, Details nur ins Log.
+- `PluginMenuItem` hat bewusst **kein** `admin_only`-Feld — der Core erzwingt Admin, das Plugin kann das nicht aufweichen.
+- Kommentare und Docstrings auf Englisch (Repo-Konvention); Commit-Betreff Englisch. Nutzersichtbare Strings de/en.
+- Keine DB-Migration in diesem Teilprojekt. `menu_items` sind Laufzeit-Deklaration, kein persistenter Zustand.
+
+---
+
+## File Structure
+
+**Neu:**
+
+| Datei | Verantwortung |
+|---|---|
+| `backend/app/services/power/session_env.py` | Wayland-Session-Env (`XDG_RUNTIME_DIR`, `WAYLAND_DISPLAY`) — ein Helper für zwei Aufrufer |
+| `backend/app/plugins/installed/steam_gaming/launcher.py` | Big Picture abgekoppelt starten |
+| `backend/tests/plugins/test_plugin_menu_actions.py` | Extension-Point: Schemas, Manifest, Route, Middleware-Gate |
+| `backend/tests/plugins/test_steam_gaming_launcher.py` | Launcher: argv, Detach-Flags, Fehlerpfade |
+| `backend/tests/test_session_env.py` | Session-Env-Helper + Nutzung im Desktop-Backend |
+| `client/src/__tests__/contexts/PluginContext.menuItems.test.tsx` | Flatten + Sortierung der Menü-Items |
+| `client/src/__tests__/components/PowerMenu.pluginActions.test.tsx` | Rendern, Auslösen, Toast, Sperre, Icon-Fallback |
+
+**Geändert:**
+
+| Datei | Änderung |
+|---|---|
+| `backend/app/plugins/base.py` | `PluginMenuItem`, `MenuActionResult`; `PluginUIManifest.menu_items`; `get_menu_items()`, `run_menu_action()` |
+| `backend/app/schemas/plugin.py` | `PluginMenuItemSchema`, `PluginMenuActionResponse`; `PluginUIInfo.menu_items` |
+| `backend/app/plugins/manager.py` | `menu_items` in `get_ui_manifest()` aufnehmen |
+| `backend/app/api/routes/plugins.py` | Route `POST /{name}/menu-actions/{action_id}` + Timeout-Konstante + Guard-Helper |
+| `backend/app/services/power/desktop_backend.py` | `_session_env()` → gemeinsamer Helper; `_exec` in `asyncio.to_thread` |
+| `backend/app/plugins/installed/steam_gaming/__init__.py` | `get_ui_manifest()` mit Menü-Item, `run_menu_action()`, neue Übersetzungen |
+| `backend/tests/plugins/test_steam_gaming_plugin.py` | Tests für Menü-Item und Aktion |
+| `client/src/api/plugins.ts` | Typen `PluginMenuItem`/`PluginMenuActionResult`, `PluginUIInfo.menu_items`, `runPluginMenuAction()` |
+| `client/src/contexts/PluginContext.tsx` | `pluginMenuItems` (flach, sortiert, mit Plugin-Name + Translations) |
+| `client/src/components/PowerMenu.tsx` | Plugin-Aktionen im Admin-Block rendern und auslösen |
+| `client/src/i18n/locales/{de,en}/common.json` | `powerMenu.pluginActionFailed` |
+| `backend/app/plugins/CLAUDE.md` | Extension-Point dokumentieren + Operator-Note erweitern |
+
+---
+
+## Task 1: `PluginMenuItem`, `MenuActionResult`, PluginBase-Hooks
+
+**Files:**
+- Modify: `backend/app/plugins/base.py:50-79` (Schemas neben `PluginNavItem`/`PluginUIManifest`), `:233-244` (Hooks neben den Pill-Hooks)
+- Test: `backend/tests/plugins/test_plugin_menu_actions.py` (neu)
+
+**Interfaces:**
+- Consumes: nichts.
+- Produces:
+```python
+class PluginMenuItem(BaseModel):
+    id: str            # pattern ^[a-z0-9_]+$
+    icon: str
+    label_key: str
+    label_text: str
+    description_key: Optional[str] = None
+    description_text: Optional[str] = None
+    tone: Literal["neutral", "info", "success", "warning", "danger"] = "neutral"
+    order: int = 100
+
+class MenuActionResult(BaseModel):
+    ok: bool
+    message_key: Optional[str] = None
+    message_text: str
+
+PluginUIManifest.menu_items: List[PluginMenuItem]           # default []
+PluginBase.get_menu_items() -> List[PluginMenuItem]          # default []
+PluginBase.run_menu_action(action_id: str, db: Session) -> Optional[MenuActionResult]   # default None
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/plugins/test_plugin_menu_actions.py`:
+
+```python
+"""Tests for the plugin menu-action extension point."""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.plugins.base import (
+    MenuActionResult,
+    PluginBase,
+    PluginMenuItem,
+    PluginMetadata,
+    PluginUIManifest,
+)
+
+
+class TestPluginMenuItem:
+    def test_minimal_item(self):
+        item = PluginMenuItem(
+            id="gaming_mode", icon="Gamepad2",
+            label_key="menu_gaming_mode", label_text="Gaming Mode",
+        )
+        assert item.tone == "neutral"
+        assert item.order == 100
+        assert item.description_key is None
+
+    @pytest.mark.parametrize("bad_id", ["Gaming", "gaming-mode", "gaming.mode", "../etc", "", "a b"])
+    def test_rejects_ids_outside_the_namespace(self, bad_id):
+        with pytest.raises(ValidationError):
+            PluginMenuItem(
+                id=bad_id, icon="Gamepad2",
+                label_key="k", label_text="t",
+            )
+
+    def test_has_no_admin_only_field(self):
+        """The core decides who may run an action - a plugin must not widen it."""
+        assert "admin_only" not in PluginMenuItem.model_fields
+
+
+class TestMenuActionResult:
+    def test_message_text_is_required(self):
+        with pytest.raises(ValidationError):
+            MenuActionResult(ok=True)
+
+    def test_key_is_optional(self):
+        result = MenuActionResult(ok=False, message_text="boom")
+        assert result.message_key is None
+
+
+class _BarePlugin(PluginBase):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="bare", display_name="Bare", version="1.0.0",
+            description="", author="test",
+        )
+
+
+class TestPluginBaseDefaults:
+    def test_no_menu_items_by_default(self):
+        assert _BarePlugin().get_menu_items() == []
+
+    async def test_run_menu_action_returns_none_by_default(self):
+        assert await _BarePlugin().run_menu_action("anything", db=None) is None
+
+    def test_ui_manifest_menu_items_default_empty(self):
+        assert PluginUIManifest().menu_items == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/test_plugin_menu_actions.py -q --no-cov`
+Expected: FAIL — `ImportError: cannot import name 'MenuActionResult'`
+
+- [ ] **Step 3: Add the schemas**
+
+In `backend/app/plugins/base.py`, direkt **nach** `class PluginNavItem` (endet Zeile 57) und **vor** `class PluginUIManifest`:
+
+```python
+class PluginMenuItem(BaseModel):
+    """An action a plugin contributes to the system (power) menu.
+
+    Declaration only: the plugin says what it offers, the core decides who may
+    run it. There is deliberately no ``admin_only`` field (unlike
+    PluginNavItem) - a menu action executes something, so widening its
+    audience must not be the plugin's call.
+    """
+
+    id: str = Field(
+        pattern=r"^[a-z0-9_]+$",
+        description="Plugin-local action id, e.g. 'gaming_mode'",
+    )
+    icon: str = Field(description="lucide icon name, e.g. 'Gamepad2'")
+    label_key: str = Field(description="Key into get_translations() for the label")
+    label_text: str = Field(description="Literal fallback for the label")
+    description_key: Optional[str] = Field(
+        default=None, description="Key into get_translations() for the sub-label"
+    )
+    description_text: Optional[str] = Field(
+        default=None, description="Literal fallback for the sub-label"
+    )
+    tone: Literal["neutral", "info", "success", "warning", "danger"] = "neutral"
+    order: int = Field(default=100, description="Sort order within the plugin block")
+
+
+class MenuActionResult(BaseModel):
+    """Outcome of a menu action, rendered as a toast by the frontend.
+
+    ``message_key`` is resolved client-side against the plugin's translations
+    (same mechanic as pill labels) - the backend never picks a language.
+    """
+
+    ok: bool
+    message_key: Optional[str] = None
+    message_text: str = Field(description="Literal fallback, always set")
+```
+
+Im `class PluginUIManifest` (Zeile 60-79) nach dem Feld `nav_items` ergänzen:
+
+```python
+    menu_items: List[PluginMenuItem] = Field(
+        default_factory=list,
+        description="Actions to add to the system menu",
+    )
+```
+
+- [ ] **Step 4: Add the PluginBase hooks**
+
+In `backend/app/plugins/base.py`, direkt nach `collect_status_pill` (endet Zeile 244):
+
+```python
+    def get_menu_items(self) -> List["PluginMenuItem"]:
+        """System-menu actions this plugin contributes. Default: none."""
+        return []
+
+    async def run_menu_action(
+        self, action_id: str, db: "Session"
+    ) -> Optional["MenuActionResult"]:
+        """Execute one menu action, or None if this plugin does not know it.
+
+        *action_id* is the plugin-local id from the declared menu item. The
+        core validates it against get_menu_items() before calling, enforces the
+        admin gate, and applies a timeout - implementations only do the work.
+        Blocking work belongs in ``asyncio.to_thread`` so the timeout can
+        actually take effect.
+        """
+        return None
+```
+
+Import-Zeile am Dateikopf prüfen: `Literal` muss aus `typing` importiert sein (ist es bereits für `PanelType`).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/plugins/test_plugin_menu_actions.py -q --no-cov`
+Expected: PASS (8 Tests)
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd backend && ruff check app/plugins/base.py tests/plugins/test_plugin_menu_actions.py
+git add backend/app/plugins/base.py backend/tests/plugins/test_plugin_menu_actions.py
+git commit -m "feat(plugins): declare menu items and menu actions on PluginBase"
+```
+
+---
+
+## Task 2: Manifest-Durchleitung (Schema + Manager)
+
+**Files:**
+- Modify: `backend/app/schemas/plugin.py:8-30`
+- Modify: `backend/app/plugins/manager.py` (in `get_ui_manifest()`, im `nav_items`-Block)
+- Test: `backend/tests/plugins/test_plugin_menu_actions.py` (anhängen)
+
+**Interfaces:**
+- Consumes: `PluginMenuItem` (Task 1).
+- Produces:
+```python
+class PluginMenuItemSchema(BaseModel):
+    id: str; icon: str
+    label_key: str; label_text: str
+    description_key: Optional[str] = None; description_text: Optional[str] = None
+    tone: str = "neutral"; order: int = 100
+
+PluginUIInfo.menu_items: List[PluginMenuItemSchema] = []
+# manager.get_ui_manifest()["plugins"][i]["menu_items"] -> list[dict]
+```
+
+- [ ] **Step 1: Write the failing test**
+
+An `backend/tests/plugins/test_plugin_menu_actions.py` anhängen:
+
+```python
+from unittest.mock import MagicMock
+
+from app.plugins.manager import PluginManager
+from app.schemas.plugin import PluginUIInfo
+
+
+def _plugin_with_menu(name: str = "demo") -> MagicMock:
+    plugin = MagicMock()
+    plugin.metadata.display_name = "Demo"
+    plugin.get_ui_manifest.return_value = PluginUIManifest(
+        enabled=True,
+        menu_items=[PluginMenuItem(
+            id="do_it", icon="Zap", label_key="menu_do_it", label_text="Do it",
+        )],
+    )
+    plugin.get_translations.return_value = {"en": {"menu_do_it": "Do it"}}
+    return plugin
+
+
+class TestManifestCarriesMenuItems:
+    def test_enabled_plugin_menu_items_reach_the_manifest(self):
+        manager = PluginManager()
+        manager._plugins = {"demo": _plugin_with_menu()}
+        manager._enabled = {"demo"}
+
+        entry = manager.get_ui_manifest()["plugins"][0]
+
+        assert entry["menu_items"] == [{
+            "id": "do_it", "icon": "Zap",
+            "label_key": "menu_do_it", "label_text": "Do it",
+            "description_key": None, "description_text": None,
+            "tone": "neutral", "order": 100,
+        }]
+
+    def test_plugin_without_menu_items_yields_empty_list(self):
+        plugin = _plugin_with_menu()
+        plugin.get_ui_manifest.return_value = PluginUIManifest(enabled=True)
+        manager = PluginManager()
+        manager._plugins = {"demo": plugin}
+        manager._enabled = {"demo"}
+
+        assert manager.get_ui_manifest()["plugins"][0]["menu_items"] == []
+
+    def test_schema_defaults_to_empty(self):
+        info = PluginUIInfo(name="demo", display_name="Demo")
+        assert info.menu_items == []
+```
+
+Hinweis für die Umsetzung: `PluginManager()` direkt zu instanziieren umgeht das Singleton bewusst — die vorhandenen Tests in `tests/plugins/test_plugin_manager.py` machen das genauso. Falls der Konstruktor Argumente verlangt, dort abschauen.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/test_plugin_menu_actions.py -q --no-cov -k Manifest`
+Expected: FAIL — `KeyError: 'menu_items'`
+
+- [ ] **Step 3: Add the mirror schema**
+
+In `backend/app/schemas/plugin.py` nach `class PluginNavItemSchema` (endet Zeile 15):
+
+```python
+class PluginMenuItemSchema(BaseModel):
+    """System-menu action offered by a plugin (mirror of PluginMenuItem)."""
+
+    id: str
+    icon: str
+    label_key: str
+    label_text: str
+    description_key: Optional[str] = None
+    description_text: Optional[str] = None
+    tone: str = "neutral"
+    order: int = 100
+```
+
+In `class PluginUIInfo` nach `nav_items` (Zeile 23):
+
+```python
+    menu_items: List[PluginMenuItemSchema] = []
+```
+
+- [ ] **Step 4: Emit menu_items from the manager**
+
+In `backend/app/plugins/manager.py`, in `get_ui_manifest()` im Dict für in-process Plugins, direkt nach dem `"nav_items"`-Eintrag:
+
+```python
+                        "menu_items": [
+                            item.model_dump() for item in ui_manifest.menu_items
+                        ],
+```
+
+Der externe (sandboxed) Zweig weiter unten bleibt **unverändert**: externe Plugins beschreiben ihre UI über `PluginManifestUI` (Bundle/Styles) und können keine Menü-Aktionen deklarieren. Das ist gewollt — ausführende Extension-Points für sandboxed Plugins sind eigener Scope.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/plugins/test_plugin_menu_actions.py -q --no-cov`
+Expected: PASS (11 Tests)
+
+- [ ] **Step 6: Run the neighbouring suites for regressions**
+
+Run: `cd backend && python -m pytest tests/plugins/test_plugin_manager.py tests/plugins/test_external_ui_manifest.py tests/plugins/test_plugins.py -q --no-cov`
+Expected: PASS, keine neuen Fehler.
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+cd backend && ruff check app/schemas/plugin.py app/plugins/manager.py tests/plugins/test_plugin_menu_actions.py
+git add backend/app/schemas/plugin.py backend/app/plugins/manager.py backend/tests/plugins/test_plugin_menu_actions.py
+git commit -m "feat(plugins): carry menu_items through the UI manifest"
+```
+
+---
+
+## Task 3: Ausführungs-Route mit Gate, Timeout und Audit
+
+**Files:**
+- Modify: `backend/app/schemas/plugin.py` (Response-Schema)
+- Modify: `backend/app/api/routes/plugins.py` (Route + Helper + Import-Block Zeile 20-37)
+- Test: `backend/tests/plugins/test_plugin_menu_actions.py` (anhängen)
+
+**Interfaces:**
+- Consumes: `PluginMenuItem`, `MenuActionResult` (Task 1); `PluginMenuItemSchema` (Task 2).
+- Produces:
+```python
+PLUGIN_MENU_ACTION_TIMEOUT_SECONDS = 20.0
+class PluginMenuActionResponse(BaseModel):
+    ok: bool; message_key: Optional[str] = None; message_text: str
+
+async def run_plugin_menu_action(request, response, name: str, action_id: str,
+                                 db: Session, current_user: User,
+                                 plugin_manager: PluginManager) -> PluginMenuActionResponse
+# route: POST /api/plugins/{name}/menu-actions/{action_id}
+```
+
+- [ ] **Step 1: Write the failing test**
+
+An `backend/tests/plugins/test_plugin_menu_actions.py` anhängen:
+
+```python
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from fastapi import HTTPException
+
+from app.api.routes.plugins import (
+    PLUGIN_MENU_ACTION_TIMEOUT_SECONDS,
+    run_plugin_menu_action,
+)
+
+
+def _declaring_plugin(action_id: str = "do_it") -> MagicMock:
+    plugin = MagicMock()
+    plugin.get_menu_items.return_value = [PluginMenuItem(
+        id=action_id, icon="Zap", label_key="k", label_text="Do it",
+    )]
+    return plugin
+
+
+async def _call(plugin, name: str = "demo", action_id: str = "do_it"):
+    manager = MagicMock()
+    manager.get_plugin.return_value = plugin
+    return await run_plugin_menu_action(
+        request=MagicMock(client=MagicMock(host="127.0.0.1")),
+        response=MagicMock(),
+        name=name,
+        action_id=action_id,
+        db=MagicMock(),
+        current_user=MagicMock(username="admin"),
+        plugin_manager=manager,
+    )
+
+
+class TestMenuActionRoute:
+    async def test_unknown_plugin_is_404(self):
+        manager = MagicMock()
+        manager.get_plugin.return_value = None
+        with pytest.raises(HTTPException) as exc:
+            await run_plugin_menu_action(
+                request=MagicMock(), response=MagicMock(),
+                name="nope", action_id="do_it", db=MagicMock(),
+                current_user=MagicMock(username="admin"), plugin_manager=manager,
+            )
+        assert exc.value.status_code == 404
+
+    async def test_undeclared_action_is_404_and_never_dispatches(self):
+        plugin = _declaring_plugin()
+        plugin.run_menu_action = AsyncMock()
+        with pytest.raises(HTTPException) as exc:
+            await _call(plugin, action_id="something_else")
+        assert exc.value.status_code == 404
+        plugin.run_menu_action.assert_not_awaited()
+
+    async def test_happy_path_returns_result_and_audits_success(self):
+        plugin = _declaring_plugin()
+        plugin.run_menu_action = AsyncMock(
+            return_value=MenuActionResult(ok=True, message_key="ok_key", message_text="done")
+        )
+        with patch("app.api.routes.plugins.get_audit_logger_db") as audit:
+            result = await _call(plugin)
+        assert (result.ok, result.message_key, result.message_text) == (True, "ok_key", "done")
+        kwargs = audit.return_value.log_event.call_args.kwargs
+        assert kwargs["event_type"] == "PLUGIN"
+        assert kwargs["action"] == "menu_action"
+        assert kwargs["resource"] == "demo:do_it"
+        assert kwargs["success"] is True
+
+    async def test_raising_action_stays_200_with_generic_message(self):
+        plugin = _declaring_plugin()
+        plugin.run_menu_action = AsyncMock(side_effect=RuntimeError("secret path /opt/baluhost"))
+        with patch("app.api.routes.plugins.get_audit_logger_db") as audit:
+            result = await _call(plugin)
+        assert result.ok is False
+        assert "secret path" not in result.message_text
+        assert audit.return_value.log_event.call_args.kwargs["success"] is False
+
+    async def test_hanging_action_is_cut_off_by_the_timeout(self):
+        async def _hang(action_id, db):
+            await asyncio.sleep(60)
+
+        plugin = _declaring_plugin()
+        plugin.run_menu_action = _hang
+        with patch("app.api.routes.plugins.PLUGIN_MENU_ACTION_TIMEOUT_SECONDS", 0.01), \
+             patch("app.api.routes.plugins.get_audit_logger_db"):
+            result = await _call(plugin)
+        assert result.ok is False
+
+    async def test_plugin_returning_none_despite_declaration_is_not_ok(self):
+        plugin = _declaring_plugin()
+        plugin.run_menu_action = AsyncMock(return_value=None)
+        with patch("app.api.routes.plugins.get_audit_logger_db"):
+            result = await _call(plugin)
+        assert result.ok is False
+
+    def test_timeout_is_generous_enough_for_kscreen_doctor(self):
+        """kscreen-doctor carries a 30s subprocess timeout of its own."""
+        assert PLUGIN_MENU_ACTION_TIMEOUT_SECONDS >= 10.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/test_plugin_menu_actions.py -q --no-cov -k MenuActionRoute`
+Expected: FAIL — `ImportError: cannot import name 'run_plugin_menu_action'`
+
+- [ ] **Step 3: Add the response schema**
+
+In `backend/app/schemas/plugin.py` nach `PluginMenuItemSchema`:
+
+```python
+class PluginMenuActionResponse(BaseModel):
+    """Outcome of a plugin menu action (mirror of MenuActionResult)."""
+
+    ok: bool
+    message_key: Optional[str] = None
+    message_text: str
+```
+
+- [ ] **Step 4: Add the route**
+
+In `backend/app/api/routes/plugins.py`:
+
+Imports ergänzen — `import asyncio` oben bei `import html`, und im Schema-Import-Block (Zeile 20-37) alphabetisch `PluginMenuActionResponse` einfügen. Zusätzlich am Kopf:
+
+```python
+from app.plugins.base import MenuActionResult
+```
+
+Konstante direkt unter `router = APIRouter(...)` (Zeile 42):
+
+```python
+# Generous compared to the 2s pill-collector timeout: a menu action may shell
+# out (kscreen-doctor carries a 30s subprocess timeout of its own). Note that
+# wait_for cannot preempt work already running inside asyncio.to_thread - it
+# frees the request, the thread finishes on its own. That is acceptable: it
+# occupies a thread, not the event loop.
+PLUGIN_MENU_ACTION_TIMEOUT_SECONDS = 20.0
+```
+
+Route ans Dateiende:
+
+```python
+@router.post("/{name}/menu-actions/{action_id}", response_model=PluginMenuActionResponse)
+@user_limiter.limit(get_limit("admin_operations"))
+async def run_plugin_menu_action(
+    request: Request,
+    response: Response,
+    name: str,
+    action_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_admin),
+    plugin_manager: PluginManager = Depends(get_plugin_manager),
+) -> PluginMenuActionResponse:
+    """Run a menu action a plugin declared in its UI manifest. Admin only.
+
+    Requests for a disabled plugin never reach this handler - PluginGateMiddleware
+    rejects them with 403 based on the DB (see middleware/plugin_gate.py).
+    """
+    plugin = plugin_manager.get_plugin(name)
+    if plugin is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Plugin not found or not enabled",
+        )
+
+    # Only declared actions are dispatchable - never call through on an
+    # arbitrary path segment.
+    declared = {item.id for item in plugin.get_menu_items()}
+    if action_id not in declared:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Unknown menu action",
+        )
+
+    result = await _execute_menu_action(plugin, name, action_id, db)
+
+    get_audit_logger_db().log_event(
+        event_type="PLUGIN",
+        user=current_user.username,
+        action="menu_action",
+        resource=f"{name}:{action_id}",
+        details={"ok": result.ok},
+        success=result.ok,
+        ip_address=request.client.host if request.client else None,
+    )
+    return PluginMenuActionResponse(**result.model_dump())
+
+
+async def _execute_menu_action(
+    plugin, name: str, action_id: str, db: Session
+) -> MenuActionResult:
+    """Run the action under a timeout and an exception guard.
+
+    A plugin fault must never become a 5xx and must never leak internals into
+    the response - the detail goes to the log, the caller gets a generic
+    failure. Mirrors the pill-collector guard in services/status_bar/service.py.
+    """
+    try:
+        result = await asyncio.wait_for(
+            plugin.run_menu_action(action_id, db),
+            timeout=PLUGIN_MENU_ACTION_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("plugin %s menu action %s timed out", name, action_id)
+        return MenuActionResult(ok=False, message_text="Action timed out")
+    except Exception:  # noqa: BLE001 - a plugin fault must not 5xx the endpoint
+        logger.warning(
+            "plugin %s menu action %s failed", name, action_id, exc_info=True
+        )
+        return MenuActionResult(ok=False, message_text="Action failed")
+
+    if result is None:
+        # Declared but not handled - a plugin bug, not a user error.
+        logger.warning(
+            "plugin %s declared menu action %s but returned None", name, action_id
+        )
+        return MenuActionResult(ok=False, message_text="Action failed")
+    return result
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/plugins/test_plugin_menu_actions.py -q --no-cov`
+Expected: PASS (18 Tests)
+
+- [ ] **Step 6: Pin the middleware gate (no production code changes)**
+
+An dieselbe Testdatei anhängen:
+
+```python
+from app.middleware.plugin_gate import _is_management_route
+
+
+class TestMenuActionIsGatedByMiddleware:
+    def test_menu_action_path_is_not_a_management_route(self):
+        """A disabled plugin must not be able to run actions.
+
+        Management routes (toggle/config/ui) stay reachable while a plugin is
+        disabled - menu actions must NOT, or disabling a plugin would leave its
+        actions live.
+        """
+        assert _is_management_route("/menu-actions/gaming_mode") is False
+
+    def test_management_routes_still_bypass(self):
+        assert _is_management_route("/toggle") is True
+        assert _is_management_route("/config") is True
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/plugins/test_plugin_menu_actions.py -q --no-cov -k Middleware`
+Expected: PASS (2 Tests) — ohne Produktionsänderung; falls es fehlschlägt, wäre die Spec-Annahme falsch und der Fund muss gemeldet werden, **nicht** durch Aufweichen der Middleware „gefixt".
+
+- [ ] **Step 8: Lint + commit**
+
+```bash
+cd backend && ruff check app/api/routes/plugins.py app/schemas/plugin.py tests/plugins/test_plugin_menu_actions.py
+git add backend/app/api/routes/plugins.py backend/app/schemas/plugin.py backend/tests/plugins/test_plugin_menu_actions.py
+git commit -m "feat(plugins): add the admin-gated menu-action endpoint"
+```
+
+---
+
+## Task 4: Session-Env-Helper + nicht-blockierendes Desktop-Backend
+
+**Files:**
+- Create: `backend/app/services/power/session_env.py`
+- Modify: `backend/app/services/power/desktop_backend.py:63-111`
+- Test: `backend/tests/test_session_env.py` (neu)
+
+**Interfaces:**
+- Consumes: nichts.
+- Produces:
+```python
+# app/services/power/session_env.py
+def wayland_session_env(uid: Optional[int] = None) -> dict
+```
+
+**Warum die zweite Änderung mit hier hineingehört:** `LinuxDesktopBackend.enable()` ruft heute `subprocess.run` synchron aus einer `async def` heraus — das blockiert den Event-Loop, und ein `asyncio.wait_for` aus Task 3 könnte es nicht abbrechen. Beide Änderungen betreffen dieselbe Datei und denselben Aufrufpfad.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_session_env.py`:
+
+```python
+"""Wayland session environment helper."""
+from __future__ import annotations
+
+from app.services.power.session_env import wayland_session_env
+
+
+class TestWaylandSessionEnv:
+    def test_sets_runtime_dir_and_display_for_the_uid(self):
+        env = wayland_session_env(uid=1000)
+        assert env["XDG_RUNTIME_DIR"] == "/run/user/1000"
+        assert env["WAYLAND_DISPLAY"] == "wayland-0"
+
+    def test_keeps_existing_environment(self, monkeypatch):
+        monkeypatch.setenv("PATH", "/custom/bin")
+        assert wayland_session_env(uid=1000)["PATH"] == "/custom/bin"
+
+    def test_does_not_override_an_explicit_session(self, monkeypatch):
+        monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-7")
+        assert wayland_session_env(uid=1000)["WAYLAND_DISPLAY"] == "wayland-7"
+
+
+class TestDesktopBackendUsesTheHelper:
+    def test_linux_backend_env_matches_the_helper(self):
+        from app.services.power.desktop_backend import LinuxDesktopBackend
+
+        backend = LinuxDesktopBackend(uid=1000)
+        assert backend._session_env() == wayland_session_env(uid=1000)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_session_env.py -q --no-cov`
+Expected: FAIL — `ModuleNotFoundError: app.services.power.session_env`
+
+- [ ] **Step 3: Create the helper**
+
+```python
+# backend/app/services/power/session_env.py
+"""Environment for reaching the logged-in user's Wayland session.
+
+The backend runs as the session user (uid match) but outside the graphical
+session, so XDG_RUNTIME_DIR and WAYLAND_DISPLAY have to be supplied for
+commands like kscreen-doctor or steam to talk to it.
+
+Two callers share this: the desktop (DPMS) backend and the steam_gaming
+plugin's Big Picture launcher.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+
+def wayland_session_env(uid: Optional[int] = None) -> dict:
+    """Return os.environ plus the session variables, without overriding them."""
+    resolved = uid if uid is not None else os.getuid()
+    env = dict(os.environ)
+    env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{resolved}")
+    env.setdefault("WAYLAND_DISPLAY", "wayland-0")
+    return env
+```
+
+Hinweis: `os.getuid()` existiert auf Windows nicht. Der Default-Zweig wird nur auf Linux erreicht (dev-Mode nutzt `DevDesktopBackend`); Tests übergeben `uid` immer explizit.
+
+- [ ] **Step 4: Use it in the desktop backend**
+
+In `backend/app/services/power/desktop_backend.py` den Import ergänzen:
+
+```python
+from app.services.power.session_env import wayland_session_env
+```
+
+`_session_env()` (Zeile 67-76) ersetzen durch:
+
+```python
+    def _session_env(self) -> dict:
+        """Env so kscreen-doctor can reach the user's Wayland session."""
+        return wayland_session_env(self._uid)
+```
+
+- [ ] **Step 5: Stop blocking the event loop**
+
+In derselben Datei `enable()`/`disable()` (Zeile 96-100) so ändern, dass der Subprozess in einem Thread läuft:
+
+```python
+    async def enable(self) -> Tuple[bool, str]:
+        return await asyncio.to_thread(self._exec, ["kscreen-doctor", "--dpms", "on"])
+
+    async def disable(self) -> Tuple[bool, str]:
+        return await asyncio.to_thread(self._exec, ["kscreen-doctor", "--dpms", "off"])
+```
+
+und `import asyncio` am Dateikopf ergänzen. `_exec` selbst bleibt unverändert synchron.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/test_session_env.py tests/test_desktop_backend.py tests/test_desktop_routes.py -q --no-cov`
+Expected: PASS. Die vorhandenen Desktop-Tests müssen **unverändert** grün bleiben — schlagen sie fehl, ist die `to_thread`-Umstellung schuld und nicht der Test.
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+cd backend && ruff check app/services/power/session_env.py app/services/power/desktop_backend.py tests/test_session_env.py
+git add backend/app/services/power/session_env.py backend/app/services/power/desktop_backend.py backend/tests/test_session_env.py
+git commit -m "refactor(power): share the Wayland session env and run kscreen-doctor off-loop"
+```
+
+---
+
+## Task 5: Big-Picture-Launcher
+
+**Files:**
+- Create: `backend/app/plugins/installed/steam_gaming/launcher.py`
+- Test: `backend/tests/plugins/test_steam_gaming_launcher.py` (neu)
+
+**Interfaces:**
+- Consumes: `wayland_session_env` (Task 4).
+- Produces:
+```python
+BIG_PICTURE_URL = "steam://open/bigpicture"
+def open_big_picture() -> tuple[bool, str]     # blocking; call via asyncio.to_thread
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/plugins/test_steam_gaming_launcher.py`:
+
+```python
+"""Big Picture launcher for the steam_gaming plugin."""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from app.plugins.installed.steam_gaming.launcher import BIG_PICTURE_URL, open_big_picture
+
+
+class TestOpenBigPicture:
+    def test_launches_steam_with_the_big_picture_url(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen") as popen:
+            cfg.is_dev_mode = False
+            ok, _detail = open_big_picture()
+
+        assert ok is True
+        args, kwargs = popen.call_args
+        assert args[0] == ["steam", BIG_PICTURE_URL]
+
+    def test_detaches_so_steam_does_not_hang_off_the_backend(self):
+        """steam:// hands off to a running instance and exits - but if Steam is
+        NOT running, the same call starts it in the foreground."""
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen") as popen:
+            cfg.is_dev_mode = False
+            open_big_picture()
+
+        kwargs = popen.call_args.kwargs
+        assert kwargs["start_new_session"] is True
+        assert kwargs["stdout"] == subprocess.DEVNULL
+        assert kwargs["stderr"] == subprocess.DEVNULL
+        assert kwargs["stdin"] == subprocess.DEVNULL
+        assert "shell" not in kwargs  # never shell=True
+
+    def test_passes_the_wayland_session_env(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen") as popen, \
+             patch(
+                 "app.plugins.installed.steam_gaming.launcher.wayland_session_env",
+                 return_value={"XDG_RUNTIME_DIR": "/run/user/1000"},
+             ):
+            cfg.is_dev_mode = False
+            open_big_picture()
+
+        assert popen.call_args.kwargs["env"] == {"XDG_RUNTIME_DIR": "/run/user/1000"}
+
+    def test_missing_steam_binary_is_reported_not_raised(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen", side_effect=FileNotFoundError()):
+            cfg.is_dev_mode = False
+            ok, detail = open_big_picture()
+
+        assert ok is False
+        assert "steam" in detail.lower()
+
+    def test_unexpected_os_error_is_reported_not_raised(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen", side_effect=OSError("no display")):
+            cfg.is_dev_mode = False
+            ok, _detail = open_big_picture()
+
+        assert ok is False
+
+    def test_dev_mode_does_not_spawn_anything(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen") as popen:
+            cfg.is_dev_mode = True
+            ok, _detail = open_big_picture()
+
+        assert ok is True
+        popen.assert_not_called()
+
+    def test_never_waits_for_the_process(self):
+        handle = MagicMock()
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen", return_value=handle):
+            cfg.is_dev_mode = False
+            open_big_picture()
+
+        handle.wait.assert_not_called()
+        handle.communicate.assert_not_called()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/test_steam_gaming_launcher.py -q --no-cov`
+Expected: FAIL — `ModuleNotFoundError: ...steam_gaming.launcher`
+
+- [ ] **Step 3: Implement the launcher**
+
+```python
+# backend/app/plugins/installed/steam_gaming/launcher.py
+"""Open Steam's Big Picture mode in the user's desktop session.
+
+On the production box Steam runs permanently (app-steam@autostart.service), so
+this hands a steam:// URL to the running instance, which then switches to Big
+Picture and the invoked process exits immediately.
+
+The call is deliberately detached: if Steam is NOT running, the very same
+command starts it in the foreground, and an attached child would live for as
+long as the gaming session - hanging off the backend process. start_new_session
+puts it in its own session/process group and nothing is ever waited on.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+
+from app.core.config import settings
+from app.services.power.session_env import wayland_session_env
+
+logger = logging.getLogger(__name__)
+
+BIG_PICTURE_URL = "steam://open/bigpicture"
+
+
+def open_big_picture() -> tuple[bool, str]:
+    """Ask Steam to show Big Picture. Blocking - call via asyncio.to_thread.
+
+    Returns:
+        (ok, detail). ok=True means the request was dispatched, not that Big
+        Picture is on screen - the process is detached, so anything beyond the
+        spawn is unobservable from here.
+    """
+    if settings.is_dev_mode:
+        # No desktop session on a Windows dev box.
+        return True, "big picture requested (dev)"
+
+    try:
+        subprocess.Popen(  # noqa: S603 - fixed argv, no shell, no user input
+            ["steam", BIG_PICTURE_URL],
+            env=wayland_session_env(),
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        return False, "steam binary not found"
+    except OSError as exc:
+        logger.warning("failed to launch Big Picture: %s", exc)
+        return False, "could not start steam"
+
+    return True, "big picture requested"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/plugins/test_steam_gaming_launcher.py -q --no-cov`
+Expected: PASS (7 Tests)
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd backend && ruff check app/plugins/installed/steam_gaming/launcher.py tests/plugins/test_steam_gaming_launcher.py
+git add backend/app/plugins/installed/steam_gaming/launcher.py backend/tests/plugins/test_steam_gaming_launcher.py
+git commit -m "feat(steam-gaming): launch Big Picture detached from the backend"
+```
+
+---
+
+## Task 6: Gaming-Modus im Steam-Plugin
+
+**Files:**
+- Modify: `backend/app/plugins/installed/steam_gaming/__init__.py`
+- Test: `backend/tests/plugins/test_steam_gaming_plugin.py` (anhängen)
+
+**Interfaces:**
+- Consumes: `PluginMenuItem`, `MenuActionResult`, `PluginUIManifest` (Task 1); `open_big_picture` (Task 5); `get_desktop_service` (vorhanden).
+- Produces: `SteamGamingPlugin.get_ui_manifest()`, `.run_menu_action()`; Übersetzungsschlüssel `menu_gaming_mode`, `menu_gaming_mode_desc`, `menu_gaming_mode_started`, `menu_displays_failed`, `menu_steam_failed`.
+
+- [ ] **Step 1: Write the failing test**
+
+An `backend/tests/plugins/test_steam_gaming_plugin.py` anhängen (Imports oben ergänzen: `from unittest.mock import AsyncMock, MagicMock, patch`):
+
+```python
+from app.plugins.installed.steam_gaming import SteamGamingPlugin
+
+_ACTION = "gaming_mode"
+
+
+def _patch_desktop(ok: bool, message: str = ""):
+    service = MagicMock()
+    service.enable = AsyncMock(return_value=(ok, message))
+    return patch(
+        "app.plugins.installed.steam_gaming.get_desktop_service",
+        return_value=service,
+    ), service
+
+
+class TestGamingModeMenuItem:
+    def test_manifest_declares_the_action(self):
+        manifest = SteamGamingPlugin().get_ui_manifest()
+        assert [item.id for item in manifest.menu_items] == [_ACTION]
+
+    def test_item_carries_key_and_literal_fallback(self):
+        item = SteamGamingPlugin().get_ui_manifest().menu_items[0]
+        assert item.label_key == "menu_gaming_mode"
+        assert item.label_text
+        assert item.icon == "Gamepad2"
+
+    def test_translations_cover_every_key_the_item_uses(self):
+        plugin = SteamGamingPlugin()
+        item = plugin.get_ui_manifest().menu_items[0]
+        translations = plugin.get_translations()
+        for lang in ("en", "de"):
+            assert item.label_key in translations[lang]
+            assert item.description_key in translations[lang]
+
+
+class TestGamingModeAction:
+    async def test_unknown_action_returns_none(self):
+        assert await SteamGamingPlugin().run_menu_action("nope", db=None) is None
+
+    async def test_turns_displays_on_then_opens_big_picture(self):
+        desktop_patch, service = _patch_desktop(True, "ok")
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            return_value=(True, "requested"),
+        ) as launcher:
+            result = await SteamGamingPlugin().run_menu_action(_ACTION, db=None)
+
+        service.enable.assert_awaited_once()
+        launcher.assert_called_once()
+        assert result.ok is True
+        assert result.message_key == "menu_gaming_mode_started"
+
+    async def test_does_not_open_big_picture_on_dark_displays(self):
+        desktop_patch, _service = _patch_desktop(False, "kscreen-doctor not found")
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+        ) as launcher:
+            result = await SteamGamingPlugin().run_menu_action(_ACTION, db=None)
+
+        launcher.assert_not_called()
+        assert result.ok is False
+        assert result.message_key == "menu_displays_failed"
+
+    async def test_reports_partial_success_when_steam_is_missing(self):
+        desktop_patch, _service = _patch_desktop(True, "ok")
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            return_value=(False, "steam binary not found"),
+        ):
+            result = await SteamGamingPlugin().run_menu_action(_ACTION, db=None)
+
+        assert result.ok is False
+        assert result.message_key == "menu_steam_failed"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/plugins/test_steam_gaming_plugin.py -q --no-cov -k GamingMode`
+Expected: FAIL — `get_ui_manifest()` liefert `None`
+
+- [ ] **Step 3: Implement the menu item and the action**
+
+In `backend/app/plugins/installed/steam_gaming/__init__.py`:
+
+Imports ergänzen:
+
+```python
+from app.plugins.base import (
+    MenuActionResult,
+    PluginBase,
+    PluginMenuItem,
+    PluginMetadata,
+    PluginUIManifest,
+    StatusPillSpec,
+)
+from app.plugins.installed.steam_gaming.launcher import open_big_picture
+from app.services.power.desktop import get_desktop_service
+```
+
+Konstante neben `_PILL_ID` (Zeile 22):
+
+```python
+_MENU_ACTION_ID = "gaming_mode"
+```
+
+Methoden in der Klasse ergänzen (nach `collect_status_pill`):
+
+```python
+    def get_ui_manifest(self) -> PluginUIManifest:
+        return PluginUIManifest(
+            enabled=True,
+            menu_items=[PluginMenuItem(
+                id=_MENU_ACTION_ID,
+                icon="Gamepad2",
+                tone="info",
+                order=10,
+                label_key="menu_gaming_mode",
+                label_text="Gaming Mode",
+                description_key="menu_gaming_mode_desc",
+                description_text="Turn displays on and open Big Picture",
+            )],
+        )
+
+    async def run_menu_action(self, action_id: str, db) -> Optional[MenuActionResult]:
+        if action_id != _MENU_ACTION_ID:
+            return None
+
+        # Displays first: opening Big Picture onto dark screens helps nobody.
+        # LinuxDesktopBackend.enable() runs kscreen-doctor in a thread, so the
+        # core's wait_for stays effective.
+        ok, detail = await get_desktop_service().enable()
+        if not ok:
+            return MenuActionResult(
+                ok=False,
+                message_key="menu_displays_failed",
+                message_text=f"Displays could not be turned on: {detail}",
+            )
+
+        launched, detail = await asyncio.to_thread(open_big_picture)
+        if not launched:
+            return MenuActionResult(
+                ok=False,
+                message_key="menu_steam_failed",
+                message_text=f"Displays are on, but Steam did not start: {detail}",
+            )
+
+        # "started", not "Big Picture is running": the process is detached, so
+        # anything past the spawn is not observable from here.
+        return MenuActionResult(
+            ok=True,
+            message_key="menu_gaming_mode_started",
+            message_text="Gaming mode started",
+        )
+```
+
+`get_translations()` (Zeile 97-101) erweitern:
+
+```python
+    def get_translations(self) -> Optional[Dict[str, Dict[str, str]]]:
+        return {
+            "en": {
+                "pill_name": "Gaming Session",
+                "pill_label": "Gaming Session",
+                "menu_gaming_mode": "Gaming Mode",
+                "menu_gaming_mode_desc": "Displays on + Big Picture",
+                "menu_gaming_mode_started": "Gaming mode started",
+                "menu_displays_failed": "Displays could not be turned on",
+                "menu_steam_failed": "Displays are on, but Steam did not start",
+            },
+            "de": {
+                "pill_name": "Gaming-Session",
+                "pill_label": "Gaming-Session",
+                "menu_gaming_mode": "Gaming-Modus",
+                "menu_gaming_mode_desc": "Displays an + Big Picture",
+                "menu_gaming_mode_started": "Gaming-Modus gestartet",
+                "menu_displays_failed": "Displays konnten nicht eingeschaltet werden",
+                "menu_steam_failed": "Displays sind an, aber Steam startete nicht",
+            },
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/plugins/test_steam_gaming_plugin.py -q --no-cov`
+Expected: PASS (bestehende Pill-Tests + 7 neue)
+
+- [ ] **Step 5: Run the plugin suite for regressions**
+
+Run: `cd backend && python -m pytest tests/plugins -q --no-cov`
+Expected: PASS, keine neuen Fehler.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd backend && ruff check app/plugins/installed/steam_gaming/__init__.py tests/plugins/test_steam_gaming_plugin.py
+git add backend/app/plugins/installed/steam_gaming/__init__.py backend/tests/plugins/test_steam_gaming_plugin.py
+git commit -m "feat(steam-gaming): contribute the Gaming Mode menu action"
+```
+
+---
+
+## Task 7: Frontend-Typen und API-Funktion
+
+**Files:**
+- Modify: `client/src/api/plugins.ts:7-63` (Typen), Dateiende (Funktion)
+- Test: `client/src/__tests__/api/plugins.menuActions.test.ts` (neu)
+
+**Interfaces:**
+- Consumes: Route aus Task 3.
+- Produces:
+```ts
+export interface PluginMenuItem {
+  id: string; icon: string;
+  label_key: string; label_text: string;
+  description_key?: string | null; description_text?: string | null;
+  tone: 'neutral' | 'info' | 'success' | 'warning' | 'danger';
+  order: number;
+}
+export interface PluginMenuActionResult { ok: boolean; message_key?: string | null; message_text: string }
+PluginUIInfo.menu_items: PluginMenuItem[]
+export async function runPluginMenuAction(pluginName: string, actionId: string): Promise<PluginMenuActionResult>
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/api/plugins.menuActions.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/api', () => ({
+  apiClient: { post: vi.fn() },
+}));
+
+import { apiClient } from '../../lib/api';
+import { runPluginMenuAction } from '../../api/plugins';
+
+describe('runPluginMenuAction', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('posts to the namespaced menu-action endpoint', async () => {
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: true, message_key: 'menu_gaming_mode_started', message_text: 'Gaming mode started' },
+    });
+
+    const result = await runPluginMenuAction('steam_gaming', 'gaming_mode');
+
+    expect(apiClient.post).toHaveBeenCalledWith('/api/plugins/steam_gaming/menu-actions/gaming_mode');
+    expect(result.ok).toBe(true);
+    expect(result.message_key).toBe('menu_gaming_mode_started');
+  });
+
+  it('returns the failure result unchanged', async () => {
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { ok: false, message_key: 'menu_steam_failed', message_text: 'Steam did not start' },
+    });
+
+    expect((await runPluginMenuAction('steam_gaming', 'gaming_mode')).ok).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && npx vitest run src/__tests__/api/plugins.menuActions.test.ts`
+Expected: FAIL — `runPluginMenuAction is not a function`
+
+- [ ] **Step 3: Add types and the client function**
+
+In `client/src/api/plugins.ts` nach `interface PluginNavItem` (Zeile 13):
+
+```ts
+export interface PluginMenuItem {
+  id: string;
+  icon: string;
+  label_key: string;
+  label_text: string;
+  description_key?: string | null;
+  description_text?: string | null;
+  tone: 'neutral' | 'info' | 'success' | 'warning' | 'danger';
+  order: number;
+}
+
+export interface PluginMenuActionResult {
+  ok: boolean;
+  message_key?: string | null;
+  message_text: string;
+}
+```
+
+In `interface PluginUIInfo` nach `nav_items` (Zeile 52):
+
+```ts
+  menu_items: PluginMenuItem[];
+```
+
+Ans Dateiende:
+
+```ts
+/**
+ * Run a plugin-contributed system-menu action. Admin only (server-enforced).
+ *
+ * Resolves with the plugin's own outcome — a failed action is a normal `ok:
+ * false` response, not an HTTP error.
+ */
+export async function runPluginMenuAction(
+  pluginName: string,
+  actionId: string,
+): Promise<PluginMenuActionResult> {
+  const res = await apiClient.post<PluginMenuActionResult>(
+    `/api/plugins/${pluginName}/menu-actions/${actionId}`,
+  );
+  return res.data;
+}
+```
+
+Hinweis: `menu_items` ist im Typ **nicht** optional; ältere Backends liefern das Feld nicht. Der Kontext in Task 8 greift deshalb defensiv über `?? []` zu — genau wie er es heute für `nav_items` tut.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client && npx vitest run src/__tests__/api/plugins.menuActions.test.ts`
+Expected: PASS (2 Tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/api/plugins.ts client/src/__tests__/api/plugins.menuActions.test.ts
+git commit -m "feat(plugins): add the menu-action API client"
+```
+
+---
+
+## Task 8: `pluginMenuItems` im PluginContext
+
+**Files:**
+- Modify: `client/src/contexts/PluginContext.tsx:17-95`
+- Test: `client/src/__tests__/contexts/PluginContext.menuItems.test.tsx` (neu)
+
+**Interfaces:**
+- Consumes: `PluginMenuItem`, `PluginUIInfo` (Task 7).
+- Produces:
+```ts
+export interface PluginMenuItemWithSource extends PluginMenuItem {
+  _pluginName: string;
+  _translations?: PluginTranslations;
+}
+// PluginContextType.pluginMenuItems: PluginMenuItemWithSource[]
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/contexts/PluginContext.menuItems.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('../../lib/features', () => ({ isPi: false }));
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: () => ({ token: 'tok' }) }));
+vi.mock('../../api/plugins', () => ({
+  listPlugins: vi.fn(),
+  getUIManifest: vi.fn(),
+}));
+
+import { PluginProvider, usePlugins } from '../../contexts/PluginContext';
+import { listPlugins, getUIManifest } from '../../api/plugins';
+
+function Probe() {
+  const { pluginMenuItems } = usePlugins();
+  return <div data-testid="items">{pluginMenuItems.map((i) => `${i._pluginName}:${i.id}`).join(',')}</div>;
+}
+
+const uiPlugin = (name: string, items: unknown[]) => ({
+  name, display_name: name, nav_items: [], menu_items: items,
+  bundle_path: 'ui/bundle.js', dashboard_widgets: [], granted_api_scopes: [],
+  translations: { en: { k: 'v' } },
+});
+
+const item = (id: string, order: number) => ({
+  id, icon: 'Zap', label_key: 'k', label_text: id, tone: 'neutral', order,
+});
+
+describe('PluginContext.pluginMenuItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (listPlugins as ReturnType<typeof vi.fn>).mockResolvedValue({ plugins: [] });
+  });
+
+  it('flattens items across plugins and sorts by order', async () => {
+    (getUIManifest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      plugins: [uiPlugin('a', [item('late', 50)]), uiPlugin('b', [item('early', 10)])],
+    });
+
+    render(<PluginProvider><Probe /></PluginProvider>);
+
+    await waitFor(() => expect(screen.getByTestId('items')).toHaveTextContent('b:early,a:late'));
+  });
+
+  it('carries the plugin translations for client-side label resolution', async () => {
+    (getUIManifest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      plugins: [uiPlugin('a', [item('one', 10)])],
+    });
+
+    function TranslationProbe() {
+      const { pluginMenuItems } = usePlugins();
+      return <div data-testid="tr">{JSON.stringify(pluginMenuItems[0]?._translations ?? null)}</div>;
+    }
+
+    render(<PluginProvider><TranslationProbe /></PluginProvider>);
+
+    await waitFor(() => expect(screen.getByTestId('tr')).toHaveTextContent('"k":"v"'));
+  });
+
+  it('tolerates a manifest without menu_items', async () => {
+    (getUIManifest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      plugins: [{ name: 'legacy', display_name: 'Legacy', nav_items: [] }],
+    });
+
+    render(<PluginProvider><Probe /></PluginProvider>);
+
+    await waitFor(() => expect(screen.getByTestId('items')).toBeEmptyDOMElement());
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && npx vitest run src/__tests__/contexts/PluginContext.menuItems.test.tsx`
+Expected: FAIL — `pluginMenuItems` ist `undefined`
+
+- [ ] **Step 3: Extend the context**
+
+In `client/src/contexts/PluginContext.tsx`:
+
+Import-Block (Zeile 5-9) erweitern:
+
+```tsx
+import type {
+  PluginInfo,
+  PluginUIInfo,
+  PluginNavItem,
+  PluginMenuItem,
+  PluginTranslations,
+} from '../api/plugins';
+```
+
+Typ und Kontext-Interface ergänzen (vor `const PluginContext = createContext...`):
+
+```tsx
+export interface PluginMenuItemWithSource extends PluginMenuItem {
+  _pluginName: string;
+  _translations?: PluginTranslations;
+}
+```
+
+In `interface PluginContextType` nach `pluginNavItems`:
+
+```tsx
+  pluginMenuItems: PluginMenuItemWithSource[];
+```
+
+Nach der `pluginNavItems`-Ableitung (Zeile 72-85):
+
+```tsx
+  // Flatten menu items from all enabled plugins, sorted by order.
+  // menu_items may be absent when talking to an older backend.
+  const pluginMenuItems: PluginMenuItemWithSource[] = (enabledPlugins ?? [])
+    .flatMap((plugin) =>
+      (plugin.menu_items ?? []).map((item) => ({
+        ...item,
+        _pluginName: plugin.name,
+        _translations: plugin.translations ?? undefined,
+      }))
+    )
+    .sort((a, b) => a.order - b.order);
+```
+
+und in das `value`-Objekt aufnehmen:
+
+```tsx
+    pluginMenuItems,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd client && npx vitest run src/__tests__/contexts/PluginContext.menuItems.test.tsx src/__tests__/contexts/PluginContext.externalNav.test.tsx`
+Expected: PASS (3 neue + der bestehende Test)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/contexts/PluginContext.tsx client/src/__tests__/contexts/PluginContext.menuItems.test.tsx
+git commit -m "feat(plugins): expose plugin menu items through PluginContext"
+```
+
+---
+
+## Task 9: Plugin-Aktionen im PowerMenu
+
+**Files:**
+- Modify: `client/src/components/PowerMenu.tsx:1-16` (Imports/State), `:196-216` (Rendering im Admin-Block)
+- Modify: `client/src/i18n/locales/de/common.json`, `client/src/i18n/locales/en/common.json` (`powerMenu.pluginActionFailed`)
+- Test: `client/src/__tests__/components/PowerMenu.pluginActions.test.tsx` (neu)
+
+**Interfaces:**
+- Consumes: `usePlugins().pluginMenuItems` (Task 8), `runPluginMenuAction` (Task 7), `resolveIcon` aus `components/topbar/iconMap` (vorhanden, enthält `Gamepad2` seit Teilprojekt 1), `resolvePluginString` aus `lib/pluginI18n`.
+- Produces: nichts.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/components/PowerMenu.pluginActions.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, def?: string) => def ?? _key }),
+}));
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('../../api/sleep', () => ({
+  getSleepStatus: vi.fn(), enterSoftSleep: vi.fn(), enterSuspend: vi.fn(),
+}));
+vi.mock('../../api/desktop', () => ({
+  getDesktopStatus: vi.fn(), disableDesktop: vi.fn(), enableDesktop: vi.fn(),
+}));
+vi.mock('../../api/plugins', () => ({ runPluginMenuAction: vi.fn() }));
+
+const menuItems: unknown[] = [];
+vi.mock('../../contexts/PluginContext', () => ({
+  usePlugins: () => ({ pluginMenuItems: menuItems }),
+}));
+
+import PowerMenu from '../../components/PowerMenu';
+import { getSleepStatus } from '../../api/sleep';
+import { getDesktopStatus } from '../../api/desktop';
+import { runPluginMenuAction } from '../../api/plugins';
+import toast from 'react-hot-toast';
+
+const baseProps = {
+  isAdmin: true,
+  onShutdown: vi.fn().mockResolvedValue(undefined),
+  onRestart: vi.fn().mockResolvedValue(undefined),
+  onLogout: vi.fn(),
+};
+
+const gamingItem = {
+  id: 'gaming_mode', icon: 'Gamepad2', tone: 'info', order: 10,
+  label_key: 'menu_gaming_mode', label_text: 'Gaming Mode',
+  description_key: 'menu_gaming_mode_desc', description_text: 'Displays on + Big Picture',
+  _pluginName: 'steam_gaming',
+  _translations: { en: { menu_gaming_mode: 'Gaming Mode' } },
+};
+
+function setItems(items: unknown[]) {
+  menuItems.length = 0;
+  menuItems.push(...items);
+}
+
+const openMenu = () => fireEvent.click(screen.getByTitle('Power'));
+
+describe('PowerMenu — plugin menu actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getSleepStatus as ReturnType<typeof vi.fn>).mockResolvedValue({});
+    (getDesktopStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'stopped', display_manager: 'sddm', detail: null,
+    });
+    setItems([gamingItem]);
+  });
+
+  it('renders a plugin action with its resolved label', async () => {
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    expect(await screen.findByText('Gaming Mode')).toBeInTheDocument();
+  });
+
+  it('posts to the right plugin and action on click', async () => {
+    (runPluginMenuAction as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true, message_key: null, message_text: 'Gaming mode started',
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByText('Gaming Mode'));
+
+    await waitFor(() =>
+      expect(runPluginMenuAction).toHaveBeenCalledWith('steam_gaming', 'gaming_mode'));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Gaming mode started'));
+  });
+
+  it('shows an error toast when the action reports ok:false', async () => {
+    (runPluginMenuAction as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false, message_key: null, message_text: 'Steam did not start',
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByText('Gaming Mode'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Steam did not start'));
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('shows an error toast when the request itself fails', async () => {
+    (runPluginMenuAction as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network'));
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByText('Gaming Mode'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+  });
+
+  it('renders an item whose icon is unknown instead of crashing', async () => {
+    setItems([{ ...gamingItem, icon: 'NotARealIcon' }]);
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    expect(await screen.findByText('Gaming Mode')).toBeInTheDocument();
+  });
+
+  it('renders no plugin actions for a non-admin', async () => {
+    render(<PowerMenu {...baseProps} isAdmin={false} />);
+    openMenu();
+    expect(screen.queryByText('Gaming Mode')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client && npx vitest run src/__tests__/components/PowerMenu.pluginActions.test.tsx`
+Expected: FAIL — „Gaming Mode" wird nicht gerendert
+
+- [ ] **Step 3: Add the i18n fallback key**
+
+In `client/src/i18n/locales/de/common.json` im Block `"powerMenu"`:
+
+```json
+    "pluginActionFailed": "Aktion fehlgeschlagen",
+```
+
+In `client/src/i18n/locales/en/common.json` im selben Block:
+
+```json
+    "pluginActionFailed": "Action failed",
+```
+
+- [ ] **Step 4: Render and wire the actions**
+
+In `client/src/components/PowerMenu.tsx`:
+
+Imports ergänzen:
+
+```tsx
+import { usePlugins } from '../contexts/PluginContext';
+import { runPluginMenuAction } from '../api/plugins';
+import { resolvePluginString } from '../lib/pluginI18n';
+import { resolveIcon } from './topbar/iconMap';
+import { Plug } from 'lucide-react';
+```
+
+State und Handler in der Komponente (nach `const [desktopState, ...]`):
+
+```tsx
+  const { pluginMenuItems } = usePlugins();
+  const [runningAction, setRunningAction] = useState<string | null>(null);
+
+  const handlePluginAction = async (item: (typeof pluginMenuItems)[number]) => {
+    const key = `${item._pluginName}:${item.id}`;
+    setRunningAction(key);
+    try {
+      const result = await runPluginMenuAction(item._pluginName, item.id);
+      const message = resolvePluginString(
+        item._translations,
+        result.message_key ?? '',
+        result.message_text,
+      );
+      if (result.ok) {
+        toast.success(message);
+        setIsOpen(false);
+      } else {
+        toast.error(message);
+      }
+    } catch {
+      toast.error(t('powerMenu.pluginActionFailed', 'Action failed'));
+    } finally {
+      setRunningAction(null);
+    }
+  };
+```
+
+Rendering im Admin-Block, direkt **nach** dem `desktopState === 'stopped'`-Button (Zeile 198-211) und **vor** dem schließenden `</div>` des `p-1.5`-Containers:
+
+```tsx
+                  {pluginMenuItems.map((item) => {
+                    const Icon = resolveIcon(item.icon) ?? Plug;
+                    const key = `${item._pluginName}:${item.id}`;
+                    const label = resolvePluginString(item._translations, item.label_key, item.label_text);
+                    const description = item.description_key
+                      ? resolvePluginString(item._translations, item.description_key, item.description_text ?? '')
+                      : item.description_text;
+                    return (
+                      <button
+                        key={key}
+                        onClick={() => { void handlePluginAction(item); }}
+                        disabled={runningAction !== null}
+                        className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-sky-500/10 disabled:opacity-50"
+                      >
+                        <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-sky-500/30 bg-sky-500/10">
+                          <Icon className="h-4 w-4 text-sky-400" />
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium text-slate-100">{label}</p>
+                          {description && <p className="text-xs text-slate-400">{description}</p>}
+                        </div>
+                      </button>
+                    );
+                  })}
+```
+
+Der Block steht innerhalb von `{isAdmin && (...)}` — Nicht-Admins sehen ihn dadurch gar nicht, und die Route lehnt sie ohnehin ab.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd client && npx vitest run src/__tests__/components/PowerMenu.pluginActions.test.tsx src/__tests__/components/PowerMenu.test.tsx`
+Expected: PASS (6 neue Tests + die bestehende PowerMenu-Suite).
+
+Falls die bestehende Suite mit „usePlugins must be used within a PluginProvider" bricht: dort denselben `vi.mock('../../contexts/PluginContext', ...)`-Block ergänzen wie in der neuen Datei — der Test rendert `PowerMenu` ohne Provider.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/components/PowerMenu.tsx client/src/i18n/locales/de/common.json client/src/i18n/locales/en/common.json client/src/__tests__/components/PowerMenu.pluginActions.test.tsx client/src/__tests__/components/PowerMenu.test.tsx
+git commit -m "feat(power-menu): render plugin-contributed menu actions"
+```
+
+---
+
+## Task 10: Doku, Gates und Smoketest
+
+**Files:**
+- Modify: `backend/app/plugins/CLAUDE.md` (Extension-Point + Operator-Note)
+
+**Interfaces:**
+- Consumes: alles Vorige.
+- Produces: nichts.
+
+- [ ] **Step 1: Document the extension point**
+
+In `backend/app/plugins/CLAUDE.md`, in „Creating a Plugin" nach Punkt 6 (den Status-Pills) als Punkt 7:
+
+```markdown
+7. Override `get_ui_manifest()` with `menu_items` + `run_menu_action()` to
+   contribute an action to the system (power) menu. The plugin picks only a
+   local `id` (validated against `^[a-z0-9_]+$`); the core enforces the admin
+   gate, the rate limit, the audit entry, a declaration check (an `action_id`
+   not present in `get_menu_items()` is a 404 and never dispatches) and a
+   `PLUGIN_MENU_ACTION_TIMEOUT_SECONDS` (20s) timeout. `PluginMenuItem`
+   deliberately has **no** `admin_only` field — unlike `PluginNavItem`, an
+   action executes something, so its audience is not the plugin's call.
+   Failures and timeouts become `ok=false` with a generic message; details
+   stay in the log. Labels come from `get_translations()`, resolved
+   client-side via `resolvePluginString`. Blocking work belongs in
+   `asyncio.to_thread`, otherwise the timeout cannot take effect.
+   Disabled plugins are rejected by `PluginGateMiddleware` (403, DB-backed) —
+   `menu-actions` is intentionally **not** a management route.
+```
+
+Die vorhandene **Operator note** im selben Abschnitt so erweitern, dass sie Menü-Aktionen einschließt:
+
+```markdown
+   **Operator note:** `PluginManager._enabled` is process-local, populated at
+   startup. Toggling a pill- or menu-contributing plugin on/off through the UI
+   only updates the worker that handled that request — in production (4 Uvicorn
+   workers) the pill then appears on roughly one in four status-strip polls, and
+   a menu action fails with 404 on the three workers that never loaded it, until
+   the backend is restarted. Restart `baluhost-backend` after enabling or
+   disabling such a plugin so all workers agree (#448).
+```
+
+- [ ] **Step 2: Run the full backend gates**
+
+```bash
+cd backend
+python -m pytest tests/plugins tests/test_session_env.py tests/test_desktop_backend.py tests/test_desktop_routes.py -q --no-cov
+ruff check app tests
+```
+Expected: alles grün.
+
+- [ ] **Step 3: Run the full frontend gates**
+
+```bash
+cd client
+npx vitest run
+npx eslint .
+npm run build
+```
+Expected: Tests grün, ESLint 0 Fehler, Build erfolgreich.
+
+- [ ] **Step 4: Dev-mode smoketest (Windows)**
+
+1. `python start_dev.py`, als Admin anmelden (`admin` / `DevMode2024`).
+2. Plugin-Verwaltung öffnen, `steam_gaming` aktivieren (falls nicht aktiv).
+3. Power-Menü öffnen → Eintrag **„Gaming-Modus"** mit Gamepad-Icon erscheint
+   unter den Desktop-Einträgen.
+4. Klicken → Erfolgs-Toast „Gaming-Modus gestartet"; das Menü schließt.
+   (Dev-Modus: `DevDesktopBackend` und Launcher sind no-ops.)
+5. Sprache auf Englisch stellen, Menü erneut öffnen → „Gaming Mode".
+6. Als Nicht-Admin anmelden → das Power-Menü zeigt nur „Logout", kein
+   Plugin-Eintrag.
+7. `steam_gaming` deaktivieren, Backend neu starten, Menü öffnen → Eintrag weg.
+
+- [ ] **Step 5: Production smoketest on BaluNode — the open measurement**
+
+**Das ist der Schritt, der die Annahme prüft, auf der die ganze Aktionswahl
+steht.** Vor dem Merge auf der Box ausführen:
+
+1. Displays per Power-Menü ausschalten („Desktop deaktivieren").
+2. Prüfen, dass Steam läuft: `systemctl --user status app-steam@autostart.service`
+3. Den Aufruf **von Hand** gegen die laufende Instanz testen:
+   `XDG_RUNTIME_DIR=/run/user/1000 WAYLAND_DISPLAY=wayland-0 steam steam://open/bigpicture`
+   Erwartet: Steam wechselt in den Big-Picture-Modus, das Kommando kehrt sofort zurück.
+4. Hält das **nicht**: Fund melden und `BIG_PICTURE_URL`/argv in
+   `launcher.py` auf die Variante ändern, die auf der Box wirkt (Kandidaten:
+   `steam -bigpicture`, oder `steam` ohne Argument, das nur das Fenster nach
+   vorn holt). Nur diese eine Stelle ändert sich — Extension-Point, Route und
+   Frontend bleiben unberührt. Testerwartung in
+   `test_steam_gaming_launcher.py` mitziehen.
+5. Displays wieder aus, dann im Web-UI „Gaming-Modus" klicken → Displays gehen
+   an **und** Big Picture erscheint; Toast meldet Erfolg.
+6. Audit-Log prüfen (Admin → Logging): Eintrag `menu_action` mit Ressource
+   `steam_gaming:gaming_mode` und `success=true`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/plugins/CLAUDE.md
+git commit -m "docs(plugins): document the menu-action extension point"
+```
+
+---
+
+## Self-Review
+
+**Spec-Abdeckung:**
+
+| Spec-Anforderung | Task |
+|---|---|
+| `PluginMenuItem` mit id/icon/label_key/label_text/description/tone/order | 1 |
+| Kein `admin_only` am Menü-Item (Core erzwingt Admin) | 1 (Test), 3 (Route) |
+| `MenuActionResult` mit key + Literal-Fallback | 1 |
+| `get_menu_items()` / `run_menu_action()` auf `PluginBase` | 1 |
+| `menu_items` reisen im vorhandenen `/ui/manifest` mit | 2 |
+| Route `POST /{name}/menu-actions/{action_id}`, Admin, Ratelimit, Audit | 3 |
+| Deklarationsprüfung (404, kein Dispatch) | 3 |
+| Exception/Timeout → `ok=false`, keine Interna, nie 5xx | 3 |
+| `PluginGateMiddleware` blockt deaktivierte Plugins (403) | 3 (Regressionstest) |
+| Audit nach Ausführung mit `success=ok` | 3 |
+| Gemeinsamer Session-Env-Helper | 4 |
+| Displays-an vor Big Picture, Abbruch bei Fehlschlag | 6 |
+| Abgekoppelter Start, kein `wait()` | 5 |
+| Teilerfolg als Teilerfolg melden | 6 |
+| Dev-Modus klickbar ohne Linux | 5 (Launcher), 9 (Smoketest) |
+| Frontend: Flatten + Sortierung, Translations mitführen | 8 |
+| Frontend: Icon-Allowlist mit Fallback | 9 |
+| Frontend: Sperre während des Laufs | 9 |
+| Frontend: Toast bei beiden Ausgängen | 9 |
+| Kein zusätzlicher Desktop-Status-Refetch | 9 (bewusst nicht implementiert) |
+| Offener Messpunkt `steam://open/bigpicture` | 10, Step 5 |
+| Operator-Note #448 auf Menü-Aktionen erweitert | 10 |
+
+**Platzhalter-Scan:** keine TBD/TODO; jeder Code-Schritt enthält den vollständigen Code, jeder Test-Schritt den vollständigen Test.
+
+**Typ-Konsistenz:** `PluginMenuItem` (Python) ↔ `PluginMenuItemSchema` (Schema) ↔ `PluginMenuItem` (TS) tragen dieselben Feldnamen; `MenuActionResult` ↔ `PluginMenuActionResponse` ↔ `PluginMenuActionResult` ebenfalls (`ok`, `message_key`, `message_text`). `_MENU_ACTION_ID = "gaming_mode"` wird in Task 6 gesetzt und in den Tests von Task 6 und 9 identisch verwendet. `run_menu_action(action_id, db)` hat in Base (Task 1), Route (Task 3) und Plugin (Task 6) dieselbe Signatur. `_pluginName`/`_translations` sind in Task 8 definiert und in Task 9 identisch benutzt.
+
+**Bewusste Nicht-Ziele, die kein Task ist:** kein „Gaming-Modus beenden", kein feineres Berechtigungsmodell, keine Zustandsanzeige im Menüpunkt, kein Bestätigungsdialog, keine Migration, keine Menü-Aktionen für externe (sandboxed) Plugins.

--- a/docs/superpowers/specs/2026-07-23-plugin-menu-contribution-gaming-mode-design.md
+++ b/docs/superpowers/specs/2026-07-23-plugin-menu-contribution-gaming-mode-design.md
@@ -1,0 +1,289 @@
+# Plugin-Menü-Contribution + Gaming-Modus — Design
+
+**Datum:** 2026-07-23
+**Status:** entworfen, abgenommen
+**Teilprojekt 2 von 4** — Gesamtschnitt siehe
+`docs/superpowers/specs/2026-07-22-status-bar-plugin-pills-steam-gaming-design.md`
+
+## Ziel
+
+Das System-Menü (`PowerMenu`) soll einen Eintrag **„Gaming-Modus"** bekommen:
+Displays einschalten und Steams Big Picture öffnen — ein Klick, statt Displays
+an, hinsetzen, Steam suchen.
+
+Wie Teilprojekt 1 wird das **nicht** als Core-Feature gebaut, sondern als
+Beitrag des `steam_gaming`-Plugins über einen **neuen Extension-Point**:
+Plugins können Aktionen ins System-Menü hängen. Der Extension-Point entsteht
+wieder zusammen mit seinem ersten Konsumenten — eine API ohne echten Nutzer
+bekommt fast immer den falschen Schnitt.
+
+## Ausgangslage
+
+Vorhanden und wiederverwendet, nicht neu gebaut:
+
+- **Displays an/aus** — `DesktopService.enable()/disable()`
+  (`services/power/desktop.py`) über `kscreen-doctor --dpms on|off`
+  (`services/power/desktop_backend.py:96-100`). Bewusst DPMS statt `systemctl
+  stop sddm`: das Stoppen des Display-Managers lässt den Framebuffer alle
+  Ausgänge zünden und nagelt die dGPU bei ~78 W fest (gemessen), DPMS lässt sie
+  auf ~18 W idlen.
+- **Session-Umgebung** — `LinuxDesktopBackend._session_env()`
+  (`desktop_backend.py:67-76`) setzt `XDG_RUNTIME_DIR=/run/user/<uid>` und
+  `WAYLAND_DISPLAY`, damit ein Kommando die Wayland-Session des angemeldeten
+  Users erreicht. Das Backend läuft als derselbe User (`sven`, UID 1000), dem
+  die KDE-Session gehört — kein sudo nötig.
+- **UI-Manifest** — `GET /api/plugins/ui/manifest` (`routes/plugins.py:124`)
+  liefert je aktiviertem Plugin `nav_items` und `translations`; der
+  `PluginContext` konsumiert das bereits beim Login.
+- **Plugin-Texte im Frontend** — `resolvePluginString(translations, key,
+  fallback)` (`lib/pluginI18n.ts`), etabliert für Dashboard-Panels und seit
+  Teilprojekt 1 auch für Pills.
+- **Berechtigungen** — Displays an/aus ist heute über
+  `require_power_toggle_desktop` gegated (Admin **oder** delegierter Nutzer mit
+  `can_toggle_desktop`), mit Audit-Eintrag und Notification-Emit
+  (`routes/desktop.py:73-109`). Das umgebende `PowerMenu` ist admin-only.
+
+Steam läuft auf der Box dauerhaft über die User-Unit
+`app-steam@autostart.service`. „Steam starten" heißt deshalb **nicht** einen
+Prozess starten, sondern die laufende Instanz in den Big-Picture-Modus holen.
+
+## Nicht-Ziele
+
+- **Kein „Gaming-Modus beenden".** Zum Ausschalten existiert direkt darüber im
+  selben Menü „Desktop deaktivieren". Ein Gegenstück müsste Steam-Prozesse
+  beenden dürfen — deutlich größere Angriffsfläche, und die Frage „was passiert
+  bei laufendem Spiel" wäre zu beantworten. Automatisches Displays-aus nach
+  Session-Ende ist ohnehin Teilprojekt 4.
+- **Kein feineres Berechtigungsmodell.** Die Aktion ist admin-only; ein Gate
+  analog `can_toggle_desktop` ist später additiv nachrüstbar.
+- **Keine Zustandsanzeige im Menüpunkt** (ausgegraut, wenn Displays schon an).
+  Ein Einmal-Auslöser, immer sichtbar.
+- **Kein Bestätigungsdialog.** Displays einschalten und ein Fenster öffnen ist
+  nicht destruktiv; ein Dialog wäre Zeremonie ohne Schutzwirkung.
+
+## Architektur
+
+```
+backend/app/plugins/base.py            + PluginMenuItem, MenuActionResult,
+                                         get_menu_items(), run_menu_action()
+backend/app/schemas/plugin.py          + PluginMenuItemSchema; PluginUIInfo.menu_items
+backend/app/plugins/manager.py           menu_items in das UI-Manifest aufnehmen
+backend/app/api/routes/plugins.py      + POST /{name}/menu-actions/{action_id}
+backend/app/services/power/session_env.py   gemeinsamer Wayland-Session-Env-Helper
+
+backend/app/plugins/installed/steam_gaming/
+  __init__.py                          + get_menu_items(), run_menu_action()
+  launcher.py                            Big Picture abgekoppelt starten
+
+client/src/api/plugins.ts               Typ PluginMenuItem
+client/src/contexts/PluginContext.tsx   pluginMenuItems (flach, sortiert)
+client/src/components/PowerMenu.tsx     generisches Rendern + Auslösen
+```
+
+### Extension-Point
+
+**Deklaration.** `PluginUIManifest` bekommt `menu_items`:
+
+```python
+class PluginMenuItem(BaseModel):
+    id: str = Field(pattern=r"^[a-z0-9_]+$")   # plugin-lokal, z. B. "gaming_mode"
+    icon: str                                   # lucide-Name
+    label_key: str                              # Schlüssel in get_translations()
+    label_text: str                             # Literal-Fallback
+    description_key: str | None = None
+    description_text: str | None = None
+    tone: Literal["neutral", "info", "success", "warning", "danger"] = "neutral"
+    order: int = 100
+```
+
+**Ausführung.** `PluginBase` bekommt zwei Methoden, spiegelbildlich zu
+`get_status_pills()` / `collect_status_pill()`:
+
+```python
+def get_menu_items(self) -> List[PluginMenuItem]:
+    """Aktionen dieses Plugins im System-Menü. Default: keine."""
+    return []
+
+async def run_menu_action(self, action_id: str, db: Session) -> Optional[MenuActionResult]:
+    """Aktion ausführen. None = Plugin kennt diese Aktion nicht."""
+    return None
+```
+
+```python
+class MenuActionResult(BaseModel):
+    ok: bool
+    message_key: str | None = None   # Schlüssel in get_translations()
+    message_text: str                # Literal-Fallback, immer gesetzt
+```
+
+**Route.** `POST /api/plugins/{name}/menu-actions/{action_id}`,
+`get_current_admin`, Ratelimit `admin_operations`, Audit mit
+`event_type="PLUGIN"`, Ressource `{plugin}:{action_id}`.
+
+Der Antwortkörper ist das `MenuActionResult` des Plugins
+(`{ok, message_key, message_text}`), unverändert durchgereicht. Der
+`message_key` wird **nicht** serverseitig aufgelöst: das Frontend hat die
+`translations` des Plugins bereits aus dem UI-Manifest und löst über
+`resolvePluginString` auf — dieselbe Mechanik wie bei Pill-Labels, und keine
+Sprachwahl im Backend.
+
+Sie dispatcht **nicht frei**: die `action_id` muss in den vom Plugin
+deklarierten `menu_items` vorkommen, sonst 404 — `run_menu_action()` wird dann
+gar nicht erst aufgerufen. Die Ausführung läuft unter Exception-Guard **und**
+`asyncio.wait_for(..., PLUGIN_MENU_ACTION_TIMEOUT_SECONDS)`.
+
+`PLUGIN_MENU_ACTION_TIMEOUT_SECONDS = 20.0` — großzügiger als die 2 s der
+Pill-Collectoren, weil `kscreen-doctor` selbst ein 30-s-Subprocess-Timeout
+mitbringt. **Ehrliche Einschränkung:** blockierende Arbeit läuft im Plugin über
+`asyncio.to_thread`, und ein `wait_for` kann einen laufenden Thread nicht
+abbrechen — es gibt nur die Anfrage frei. Der Thread läuft bis zu seinem
+eigenen Subprocess-Timeout weiter. Das ist vertretbar, weil er einen Thread
+belegt und nicht den Event-Loop; blockierende Arbeit im Loop wäre der Fehler,
+den Teilprojekt 1 beim Collector gefangen hat.
+
+**Wer darf auslösen, entscheidet der Core.** `PluginNavItem` trägt ein
+`admin_only`, das das Plugin selbst setzt — für einen Link vertretbar, für eine
+Aktion nicht. `PluginMenuItem` hat bewusst **kein** solches Feld: der Core
+erzwingt Admin, das Plugin kann das nicht aufweichen. Damit bleibt die
+Rollenteilung des Pill-Extension-Points erhalten — das Plugin liefert *was*
+passieren soll, nie *wer* es darf.
+
+**Lesepfad ohne neuen Endpunkt.** `menu_items` reisen im vorhandenen
+`GET /api/plugins/ui/manifest` mit (`PluginUIInfo.menu_items`, gespiegelt als
+`PluginMenuItemSchema` in `schemas/plugin.py`, wie `PluginNavItemSchema` es für
+Nav-Items tut). Kein zweiter Fetch, keine zweite Cache-Schicht. Ein
+deaktiviertes Plugin fällt aus dem Manifest — der Menüpunkt verschwindet ohne
+Aufräumjob.
+
+### Steam-Plugin
+
+```python
+PluginMenuItem(
+    id="gaming_mode", icon="Gamepad2", tone="info", order=10,
+    label_key="menu_gaming_mode", label_text="Gaming Mode",
+    description_key="menu_gaming_mode_desc",
+    description_text="Turn displays on and open Big Picture",
+)
+```
+
+`run_menu_action("gaming_mode")` in dieser Reihenfolge:
+
+1. **Displays an** über `get_desktop_service().enable()` — derselbe Pfad wie
+   „Desktop aktivieren", kein eigener Displays-Code. Schlägt das fehl, wird
+   **abgebrochen**: Big Picture auf schwarzen Schirmen zu öffnen hilft niemandem.
+2. **Big Picture** über `steam steam://open/bigpicture`, **abgekoppelt**
+   gestartet (`subprocess.Popen`, `start_new_session=True`, kein `wait()`,
+   Streams nach `DEVNULL`, Session-Env). Läuft Steam bereits, reicht der Aufruf
+   die URL an die Instanz weiter und endet sofort; läuft es nicht, startet er
+   Steam — und hängt dann *nicht* als Kindprozess am Backend.
+
+Beide Schritte sind blockierend und laufen deshalb in `asyncio.to_thread`.
+
+**Rückmeldung sagt nur, was belegbar ist.** Erfolg heißt „Gaming-Modus
+gestartet", nicht „Big Picture läuft" — der Prozess wird abgekoppelt gestartet,
+was er danach tut, wissen wir nicht. Teilerfolg wird als Teilerfolg gemeldet:
+Displays an, aber Steam nicht auffindbar → `ok=False` mit genau dieser Aussage.
+
+**Gemeinsamer Session-Env-Helper.** `XDG_RUNTIME_DIR`/`WAYLAND_DISPLAY` haben
+jetzt zwei Aufrufer. `_session_env()` wandert aus `LinuxDesktopBackend` in
+`services/power/session_env.py`; beide nutzen ihn. Das ist die einzige Änderung
+an bestehendem Code.
+
+### Frontend
+
+`PluginContext` flacht `menu_items` aller aktivierten Plugins zu
+`pluginMenuItems` auf — mit Plugin-Name und `translations`, sortiert nach
+`order`, exakt wie `pluginNavItems` es für Nav-Items tut. `PowerMenu` liest sie
+aus `usePlugins()` und rendert sie im Admin-Block **unter** den
+Desktop-Einträgen, vor dem Trenner zum Logout — dort, wo „Displays an" schon
+heute steht.
+
+- **Label/Beschreibung** über `resolvePluginString(translations, key, text)`.
+- **Icon über Allowlist.** Der Icon-Name kommt vom Plugin; ein
+  `LucideIcons[name]`-Zugriff wäre ein Komponenten-Lookup aus
+  plugin-kontrolliertem String. Stattdessen dieselbe feste Map wie bei den
+  Pills, mit generischem Fallback statt Absturz.
+- **Sperre während des Laufs.** `kscreen-doctor` braucht einen Moment; ohne
+  deaktivierten Button feuert ein Doppelklick die Aktion zweimal.
+- **Nach Erfolg** wird der Desktop-Status neu geholt, damit „Desktop
+  aktivieren" auf „deaktivieren" umspringt statt eine Zeile lang zu lügen.
+- Toast bei beiden Ausgängen, Text aus `MenuActionResult`.
+
+Im Pi-Build lädt der `PluginContext` gar nicht erst Plugins — es erscheinen
+dort automatisch keine Einträge.
+
+## Fehlerbehandlung
+
+| Fall | Verhalten |
+|---|---|
+| Plugin deaktiviert/deinstalliert | Fällt aus dem Manifest → Menüpunkt weg; Route 404 |
+| `action_id` nicht deklariert | 404, `run_menu_action()` wird nicht aufgerufen |
+| Aktion wirft | HTTP 200 mit `ok=false` + generischer Meldung; Details nur ins Log |
+| Aktion überschreitet das Timeout | Abgeschnitten, `ok=false` |
+| `steam`-Binary fehlt | `ok=false`, „Steam nicht gefunden" |
+| Displays-an schlägt fehl | Abbruch vor Schritt 2, `ok=false` |
+| Dev-Modus (Windows) | `DevDesktopBackend` no-op, Launcher no-op → Ablauf klickbar ohne Linux |
+
+Ein Fehler im Plugin führt nie zu einem 5xx und nie zu einer Fehlermeldung mit
+Server-Interna — dieselbe Regel wie bei den Pill-Collectoren.
+
+## Sicherheit
+
+- Keine neuen Sudoers-Regeln, kein `shell=True`, ausschließlich
+  Listen-Argumente. Die einzige URL im Aufruf ist eine Konstante — kein
+  Benutzereingabewert erreicht die Kommandozeile.
+- Plugin-gelieferte Strings werden nie zu Codepfaden: `action_id` ist
+  regexbeschränkt **und** gegen die deklarierte Liste geprüft, das Icon geht
+  durch eine Allowlist.
+- Admin-Gate, Ratelimit und Audit-Eintrag liegen im Core, nicht im Plugin.
+- Der Extension-Point erlaubt Plugins, eine Aktion *anzubieten* — nicht, ihre
+  Sichtbarkeit oder Berechtigung zu bestimmen.
+
+## Tests
+
+**Extension-Point (Core).** `PluginMenuItem.id` weist Großbuchstaben, Punkte
+und Pfadanteile ab. `menu_items` erscheinen im UI-Manifest nur für aktivierte
+Plugins. Route: Nicht-Admin → 403; unbekanntes Plugin → 404; nicht deklarierte
+`action_id` → 404 **und** `run_menu_action()` ungerufen; Happy Path → `ok=true`
+plus Audit-Eintrag; werfende Aktion → 200 mit `ok=false`, keine Interna in der
+Antwort; hängende Aktion wird vom Timeout abgeschnitten.
+
+**Steam-Plugin.** Reihenfolge Displays-vor-Steam; scheiterndes `enable()` →
+Launcher **nicht** aufgerufen, `ok=false`; fehlendes `steam`-Binary
+(`FileNotFoundError`) → `ok=false` mit der passenden Meldung; unbekannte
+`action_id` → `None`.
+
+**Launcher.** Exakt `["steam", "steam://open/bigpicture"]`,
+`start_new_session=True`, Streams auf `DEVNULL`, Session-Env gesetzt, keine
+Shell, kein `wait()`.
+
+**Session-Env-Helper.** Beide Aufrufer erhalten dieselbe Umgebung — pinnt die
+Extraktion gegen ein späteres Auseinanderlaufen.
+
+**Frontend.** Kontext flacht und sortiert `menu_items`; `PowerMenu` rendert
+einen Plugin-Eintrag mit aufgelöstem Label, postet beim Klick auf die richtige
+URL, zeigt Toast bei Erfolg **und** bei `ok=false`, sperrt den Button während
+des Laufs, fällt bei unbekanntem Icon zurück statt zu brechen.
+
+## Offener Messpunkt
+
+Dass `steam steam://open/bigpicture` an der **laufenden** Instanz tatsächlich
+Big Picture öffnet, ist Annahme, nicht Messung. Sie gehört als expliziter
+Smoketest-Schritt auf die Box, bevor der PR als fertig gilt. Hält sie nicht,
+ändert sich eine Zeile im Launcher (etwa `steam -bigpicture` oder ein
+`steam`-Aufruf ohne Argument, der nur das Fenster nach vorn holt) — der
+Extension-Point bleibt unberührt.
+
+## Risiken
+
+- **Steam ändert das URL-Schema.** Dann bliebe der Menüpunkt wirkungslos,
+  ohne Fehler. Der Aufruf ist eine einzelne, benannte Funktion mit Tests; der
+  Bruch wäre lokal.
+- **`to_thread` ist nicht abbrechbar** (siehe Timeout-Abschnitt). Bei einem
+  hängenden `kscreen-doctor` bleibt bis zu 30 s ein Thread belegt. Kein
+  Event-Loop-Stillstand, keine Auswirkung auf andere Requests.
+- **Erster ausführender Extension-Point.** Bisher durften Plugins Daten
+  liefern; hier lösen sie eine Aktion aus. Kompensiert durch Admin-Gate,
+  Deklarationszwang für die `action_id`, Timeout, Audit — und dadurch, dass die
+  Aktion selbst nur bereits vorhandene, ebenfalls admin-gegatete Funktionalität
+  aufruft.

--- a/docs/superpowers/specs/2026-07-23-plugin-menu-contribution-gaming-mode-design.md
+++ b/docs/superpowers/specs/2026-07-23-plugin-menu-contribution-gaming-mode-design.md
@@ -132,6 +132,23 @@ deklarierten `menu_items` vorkommen, sonst 404 — `run_menu_action()` wird dann
 gar nicht erst aufgerufen. Die Ausführung läuft unter Exception-Guard **und**
 `asyncio.wait_for(..., PLUGIN_MENU_ACTION_TIMEOUT_SECONDS)`.
 
+**Deaktivierte Plugins blockt die vorhandene `PluginGateMiddleware`, nicht die
+Route.** `menu-actions` steht bewusst **nicht** in deren
+`_MANAGEMENT_SUFFIXES` — anders als `/toggle` oder `/config` ist eine Aktion
+kein Verwaltungszugriff, der auch bei deaktiviertem Plugin funktionieren muss.
+Die Middleware prüft die **DB** (den einzigen worker-übergreifenden Zustand)
+mit 5-s-TTL-Cache und antwortet 403; ein Deaktivieren wirkt damit binnen
+weniger Sekunden auf allen vier Prod-Workern.
+
+**Bekannte Einschränkung in der Gegenrichtung** (Erbstück aus Teilprojekt 1,
+Issue #448): `PluginManager._enabled` ist prozess-lokal. Nach einem
+*Aktivieren* über die UI kennt nur der behandelnde Worker die Plugin-Instanz;
+auf den übrigen liefert `get_plugin()` `None` → 404 auf einen expliziten
+Nutzerklick, bis das Backend neu gestartet wird. Die Operator-Note aus
+`plugins/CLAUDE.md` (Restart nach Toggle eines beitragenden Plugins) gilt hier
+unverändert und wird um Menü-Aktionen ergänzt. Der strukturelle Fix ist
+#448-Scope, nicht dieses Teilprojekt.
+
 `PLUGIN_MENU_ACTION_TIMEOUT_SECONDS = 20.0` — großzügiger als die 2 s der
 Pill-Collectoren, weil `kscreen-doctor` selbst ein 30-s-Subprocess-Timeout
 mitbringt. **Ehrliche Einschränkung:** blockierende Arbeit läuft im Plugin über
@@ -205,8 +222,10 @@ heute steht.
   Pills, mit generischem Fallback statt Absturz.
 - **Sperre während des Laufs.** `kscreen-doctor` braucht einen Moment; ohne
   deaktivierten Button feuert ein Doppelklick die Aktion zweimal.
-- **Nach Erfolg** wird der Desktop-Status neu geholt, damit „Desktop
-  aktivieren" auf „deaktivieren" umspringt statt eine Zeile lang zu lügen.
+- **Kein zusätzlicher Status-Refetch nötig.** Das Menü schließt beim Klick,
+  und `PowerMenu` lädt den Desktop-Status ohnehin bei jedem Öffnen neu
+  (`PowerMenu.tsx:27-36`) — beim nächsten Öffnen steht „Desktop deaktivieren"
+  also bereits korrekt da. Bestehendes Verhalten, keine neue Arbeit.
 - Toast bei beiden Ausgängen, Text aus `MenuActionResult`.
 
 Im Pi-Build lädt der `PluginContext` gar nicht erst Plugins — es erscheinen
@@ -216,7 +235,8 @@ dort automatisch keine Einträge.
 
 | Fall | Verhalten |
 |---|---|
-| Plugin deaktiviert/deinstalliert | Fällt aus dem Manifest → Menüpunkt weg; Route 404 |
+| Plugin deaktiviert/deinstalliert | Fällt aus dem Manifest → Menüpunkt weg; POST → **403 durch `PluginGateMiddleware`** (DB-basiert, wirkt binnen ~5 s auf allen Workern) |
+| Plugin aktiviert, aber Worker kennt es noch nicht | 404 bis zum Backend-Restart (prozess-lokales `_enabled`, #448 — siehe Extension-Point-Abschnitt) |
 | `action_id` nicht deklariert | 404, `run_menu_action()` wird nicht aufgerufen |
 | Aktion wirft | HTTP 200 mit `ok=false` + generischer Meldung; Details nur ins Log |
 | Aktion überschreitet das Timeout | Abgeschnitten, `ok=false` |
@@ -236,8 +256,16 @@ Server-Interna — dieselbe Regel wie bei den Pill-Collectoren.
   regexbeschränkt **und** gegen die deklarierte Liste geprüft, das Icon geht
   durch eine Allowlist.
 - Admin-Gate, Ratelimit und Audit-Eintrag liegen im Core, nicht im Plugin.
+  Der Audit-Eintrag wird **nach** der Ausführung geschrieben, mit
+  `success=ok` — auch Timeout und Fehlschlag landen im Trail.
 - Der Extension-Point erlaubt Plugins, eine Aktion *anzubieten* — nicht, ihre
   Sichtbarkeit oder Berechtigung zu bestimmen.
+- **Bewusst akzeptiert:** `GET /ui/manifest` ist `get_current_user` — auch
+  Nicht-Admins erhalten die `menu_items` (statische Labels/Icons) im Payload;
+  nur das Rendern ist clientseitig auf den Admin-Block beschränkt. Das ist
+  reine Metadaten-Sichtbarkeit ohne dynamische Daten (anders als der
+  Spielname in Teilprojekt 1, der serverseitig gefiltert wird); die
+  Ausführung selbst ist serverseitig admin-gegated.
 
 ## Tests
 
@@ -245,8 +273,11 @@ Server-Interna — dieselbe Regel wie bei den Pill-Collectoren.
 und Pfadanteile ab. `menu_items` erscheinen im UI-Manifest nur für aktivierte
 Plugins. Route: Nicht-Admin → 403; unbekanntes Plugin → 404; nicht deklarierte
 `action_id` → 404 **und** `run_menu_action()` ungerufen; Happy Path → `ok=true`
-plus Audit-Eintrag; werfende Aktion → 200 mit `ok=false`, keine Interna in der
-Antwort; hängende Aktion wird vom Timeout abgeschnitten.
+plus Audit-Eintrag mit `success=true`; werfende Aktion → 200 mit `ok=false`,
+keine Interna in der Antwort, Audit mit `success=false`; hängende Aktion wird
+vom Timeout abgeschnitten. Middleware: deaktiviertes Plugin → 403 durch
+`PluginGateMiddleware` (Test auf Pfad-Matching des neuen Sub-Pfads — er darf
+**nicht** als Management-Route durchrutschen).
 
 **Steam-Plugin.** Reihenfolge Displays-vor-Steam; scheiterndes `enable()` →
 Launcher **nicht** aufgerufen, `ok=false`; fehlendes `steam`-Binary


### PR DESCRIPTION
**Teilprojekt 2 von 4.** Spec: `docs/superpowers/specs/2026-07-23-plugin-menu-contribution-gaming-mode-design.md` · Plan: `docs/superpowers/plans/2026-07-23-plugin-menu-contribution-gaming-mode.md` · Vorgänger: #452

Das System-Menü bekommt einen Eintrag **„Gaming-Modus"**: Displays an, dann Steams Big Picture. Wie in Teilprojekt 1 ist das **kein** Core-Feature, sondern der Beitrag eines Plugins über einen **neuen Extension-Point** — und der entsteht wieder zusammen mit seinem ersten Konsumenten, weil eine API ohne echten Nutzer fast immer den falschen Schnitt bekommt.

## Die Rollenteilung, um die es geht

Bisher durften Plugins **Daten liefern** (Dashboard-Panels, Status-Pills). Hier lösen sie erstmals etwas **aus**. Der Schnitt dafür:

> Das Plugin sagt, **was** passieren soll — nie, **wer** es darf.

Der Core besitzt Admin-Gate, Ratelimit, Audit-Eintrag, Deklarationsprüfung und Timeout. `PluginMenuItem` hat deshalb bewusst **kein** `admin_only`-Feld, obwohl das benachbarte `PluginNavItem` eines hat: Für einen Link ist das vertretbar, für eine Aktion nicht. Ein Test pinnt die Abwesenheit des Feldes.

## Aufbau

| Schicht | Datei |
|---|---|
| Deklaration + Hooks | `plugins/base.py` (`PluginMenuItem`, `MenuActionResult`, `get_menu_items()`, `run_menu_action()`) |
| Manifest-Durchleitung | `schemas/plugin.py`, `plugins/manager.py` |
| Ausführung | `api/routes/plugins.py` (`POST /{name}/menu-actions/{action_id}`) |
| Session-Umgebung | `services/power/session_env.py` (neu, zwei Aufrufer) |
| Big Picture | `plugins/installed/steam_gaming/launcher.py` |
| Die Aktion | `plugins/installed/steam_gaming/__init__.py` |
| Frontend | `api/plugins.ts`, `contexts/PluginContext.tsx`, `components/PowerMenu.tsx` |

Der Lesepfad kommt **ohne neuen Endpunkt** aus: `menu_items` reisen im vorhandenen `GET /api/plugins/ui/manifest` mit, den der `PluginContext` ohnehin beim Login zieht.

## Zwei Integrationsbrüche, die die Tests nicht sehen konnten

Beide wären mit **100 % grüner Suite** in Produktion gegangen:

**1. Die Deklaration hatte zwei Fundstellen.** Der Manager baute die Frontend-Nutzlast aus `get_ui_manifest().menu_items`, die Route validierte gegen `get_menu_items()` — das vom Plugin nie überschrieben wurde und `[]` lieferte. Der Menüpunkt hätte gerendert und **jeder Klick 404** ergeben. Unsichtbar, weil die Plugin-Tests `run_menu_action()` direkt aufriefen und die Route-Tests ein Mock-Plugin mit gestubbtem `get_menu_items()` benutzten. Gefixt an der Wurzel: `get_menu_items()` leitet per Default aus dem UI-Manifest ab — eine Deklarationsstelle, beide Konsumenten stimmen konstruktionsbedingt überein.

**2. Die „niemals 5xx"-Zusage endete eine Zeile zu früh** — auf **beiden** Seiten des Guards. `plugin.get_menu_items()` lief ungeschützt, und `result.model_dump()` lief auf allem, was das Plugin zurückgab: ein `dict` statt eines `MenuActionResult` ergab 500 **und keinen Audit-Eintrag**, weil `result.ok` zuerst gelesen wird. Beide Ränder sind jetzt abgesichert, mit Test.

## Sicherheit

Die zentrale Zusage — ein deaktiviertes Plugin kann seine Aktionen nicht ausführen — hing bis zum Whole-Branch-Review an **einem** Mechanismus: `PluginGateMiddleware` und ihrem Pfad-Präfix. `disable_plugin()` nimmt den Namen aus `_enabled`, lässt die Instanz aber in `_plugins`, also hätte `get_plugin()` sie weiter geliefert. Zwischen deaktiviertem Plugin und Ausführung standen ein Präfix-String und ein 5-Sekunden-DB-Cache; im ausführenden Code war die Zusage nirgends verankert. Der Endpoint prüft jetzt zusätzlich selbst.

Weiter: keine neuen Sudoers-Regeln, kein `shell=True`, feste Argumentliste, die einzige URL ist eine Konstante. Die `action_id` ist regexbeschränkt **und** gegen die deklarierte Liste geprüft; das plugin-gelieferte Icon geht durch eine Allowlist statt durch einen Komponenten-Lookup. Der Big-Picture-Prozess startet abgekoppelt (`start_new_session=True`, kein `wait()`), damit ein nicht laufendes Steam nicht als Kindprozess am Backend hängt.

## Nebenbei gefixt, weil es die Zusage trägt

`LinuxDesktopBackend.enable()/disable()` riefen `subprocess.run` synchron aus einer `async def` — das blockierte den Event-Loop, und ein `asyncio.wait_for` kann synchrone Arbeit nicht abbrechen. Ohne diese Umstellung wäre das neue Timeout für genau die Aktion dekorativ gewesen, um die dieses Feature gebaut ist. Ein Test pinnt jetzt über `threading.get_ident()`, dass der Launcher wirklich auf einem Worker-Thread läuft.

## Tests & Gates

Backend 658 passed / 7 skipped, `ruff check app tests` sauber. Frontend 259 Dateien / 1154 Tests, `eslint .` 0 Fehler, `npm run build` erfolgreich. Keine Migration.

Neu sind unter anderem die **ersten Tests durch den echten ASGI-Stack** in diesem Bereich: deaktiviertes Plugin → 403 von der Middleware, aktiviertes → erreicht die Route, Nicht-Admin → 403. Vorher war die zentrale Sicherheitszusage nur gegen den Rückgabewert einer Hilfsfunktion assertiert. Vier Verhalten sind mutationsgeprüft — Backstop, `manifest.enabled`, das Response-Feld und die Middleware-Einstufung wurden gezielt gebrochen, jeweils fiel genau der zugehörige Test.

## Offener Messpunkt — vor dem Merge zu prüfen

Dass `steam steam://open/bigpicture` an der **laufenden** Instanz tatsächlich Big Picture öffnet, ist die einzige Annahme des Entwurfs, die nicht gemessen ist. Sie steht als eigener Smoketest-Schritt im Plan (Task 10, Step 5) und gehört auf die Box, bevor das hier gemergt wird. Hält sie nicht, ändert sich **eine Zeile** in `launcher.py` plus ihr Test — Extension-Point, Route und Frontend bleiben unberührt.

Ebenfalls offen: `PluginManager._enabled` ist prozess-lokal (#448). Nach dem Aktivieren des Plugins über die UI kennt es nur der behandelnde Worker; auf den übrigen drei ergibt ein Klick 404, bis das Backend neu startet. Als Operator-Note in `plugins/CLAUDE.md` dokumentiert.

## Bewusst nicht enthalten

Kein „Gaming-Modus beenden" (zum Ausschalten steht „Desktop deaktivieren" direkt darüber im selben Menü), kein feineres Berechtigungsmodell, keine Zustandsanzeige im Menüpunkt, kein Bestätigungsdialog. Automatisches Displays-aus nach Session-Ende ist Teilprojekt 4.

## Follow-up-Issues

Aus dem Whole-Branch-Review, außerhalb dieses PRs: #454 (PluginPage rendert Plugins ohne eigene UI gegen ein nicht existierendes Bundle), #455 (Gaming-Modus schreibt kein POWER-Audit-Event und keine desktop_enabled-Notification), #456 (generische Menü-Aktions-Fehler sind nicht übersetzbar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
