### PR TITLE
fix(plugins): Plugin-Aktivierung ueber alle vier Worker konsistent (#448)

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -480,6 +480,19 @@ async def require_local_or_setup_secret(
     )
 
 
+async def reconciled_plugin_state() -> None:
+    """Align this worker's loaded plugins with the database before answering.
+
+    Plugin enablement lives in the database; a runtime toggle only reaches the
+    worker that handled it. Routes whose answer depends on which plugins are
+    enabled declare this so their view does not depend on which of the four
+    workers replied (#448). Best-effort: it never raises.
+    """
+    from app.services.plugin_enablement import reconcile_worker
+
+    await reconcile_worker()
+
+
 async def require_sync_allowed(request: Request) -> None:
     """Dependency that blocks automatic sync requests during sleep mode.
 

--- a/backend/app/api/routes/dashboard.py
+++ b/backend/app/api/routes/dashboard.py
@@ -6,7 +6,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, Request, Response
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_user, get_db
+from app.api.deps import get_current_user, get_db, reconciled_plugin_state
 from app.core.rate_limiter import user_limiter, get_limit
 from app.models.user import User
 from app.plugins.manager import PluginManager
@@ -25,6 +25,7 @@ async def get_plugin_panel(
     response: Response,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
+    _reconciled: None = Depends(reconciled_plugin_state),
 ) -> Optional[DashboardPanelResponse]:
     """Get the active Dashboard plugin panel with current data.
 

--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -265,6 +265,7 @@ async def get_plugin_details(
         has_dashboard_panel=plugin.get_dashboard_panel() is not None,
         dashboard_panel_enabled=db_record.dashboard_panel_enabled if db_record else False,
         is_external=False,
+        restart_required=plugin_manager.router_restart_required(name),
         requested_api_scopes=[],
         nav_items=[
             PluginNavItemSchema(**item.model_dump())
@@ -841,12 +842,19 @@ async def run_plugin_menu_action(
     middleware/plugin_gate.py). This is only the first line of defense
     though: PluginManager.disable_plugin() drops the name from ``_enabled``
     but leaves the instance in ``_plugins``, so get_plugin() alone would
-    still return it. Check is_enabled() too, so this endpoint does not rely
+    still return it. Check is_loaded() too, so this endpoint does not rely
     solely on the middleware (a prefix change or router move must not
     silently defeat the enabled-check).
+
+    is_loaded() rather than is_enabled(): is_enabled() answers "the database
+    says this plugin is on", which is true even when this worker's
+    enable_plugin() call itself failed (e.g. on_startup() raised) - the
+    instance sits in _plugins but never entered _enabled. Dispatching into
+    such a plugin would run a menu action against something that never
+    finished starting up.
     """
     plugin = plugin_manager.get_plugin(name)
-    if plugin is None or not plugin_manager.is_enabled(name):
+    if plugin is None or not plugin_manager.is_loaded(name):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Plugin not found or not enabled",

--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -7,7 +7,13 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_admin, get_current_user, get_db, require_local_admin
+from app.api.deps import (
+    get_current_admin,
+    get_current_user,
+    get_db,
+    reconciled_plugin_state as deps_reconciled_plugin_state,
+    require_local_admin,
+)
 from app.core.rate_limiter import user_limiter, get_limit
 from app.models.user import User
 from app.middleware.plugin_gate import invalidate_plugin_cache
@@ -63,6 +69,7 @@ async def list_plugins(
     request: Request, response: Response,
     current_user: User = Depends(get_current_user),
     plugin_manager: PluginManager = Depends(get_plugin_manager),
+    _reconciled: None = Depends(deps_reconciled_plugin_state),
 ) -> PluginListResponse:
     """List all available plugins.
 
@@ -138,6 +145,7 @@ async def get_ui_manifest(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
     plugin_manager: PluginManager = Depends(get_plugin_manager),
+    _reconciled: None = Depends(deps_reconciled_plugin_state),
 ) -> PluginUIManifestResponse:
     """Get UI manifest for frontend integration.
 
@@ -824,6 +832,7 @@ async def run_plugin_menu_action(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_admin),
     plugin_manager: PluginManager = Depends(get_plugin_manager),
+    _reconciled: None = Depends(deps_reconciled_plugin_state),
 ) -> PluginMenuActionResponse:
     """Run a menu action a plugin declared in its UI manifest. Admin only.
 

--- a/backend/app/api/routes/status_bar.py
+++ b/backend/app/api/routes/status_bar.py
@@ -34,6 +34,7 @@ async def get_statusbar_config(
     response: Response,
     db: Session = Depends(deps.get_db),
     current_user: UserPublic = Depends(deps.get_current_admin),
+    _reconciled: None = Depends(deps.reconciled_plugin_state),
 ) -> StatusBarConfigResponse:
     """Full catalog + persisted config (admin only)."""
     return StatusBarService(db).get_config()
@@ -83,6 +84,7 @@ async def get_statusbar_state(
     response: Response,
     db: Session = Depends(deps.get_db),
     current_user: UserPublic = Depends(deps.get_current_user),
+    _reconciled: None = Depends(deps.reconciled_plugin_state),
 ) -> StatusBarStateResponse:
     """Aggregated pill payload, filtered by the caller's role."""
     return await StatusBarService(db).collect_state(role=current_user.role)

--- a/backend/app/middleware/CLAUDE.md
+++ b/backend/app/middleware/CLAUDE.md
@@ -12,7 +12,7 @@ Starlette `BaseHTTPMiddleware` classes applied to all requests. Registered in `m
 | `device_tracking.py` | Updates `MobileDevice.last_seen` timestamp when `X-Device-ID` header is present. DB write runs in worker thread via `asyncio.to_thread()`, debounced to at most one write per device per `_WRITE_TTL_SECONDS` (60s) via a bounded LRU cache — the timestamps are coarse activity indicators, the dashboard's "recently active" threshold is 5 min (#322) | Requests with X-Device-ID |
 | `local_only.py` | Blocks non-local-network requests to protected prefixes when `ENFORCE_LOCAL_ONLY=true`. Protected: `/api/server-profiles`, `/api/auth/login`, `/api/auth/register` | Configurable endpoints |
 | `api_version.py` | Adds `X-API-Version` and `X-API-Min-Version` headers to all `/api/` responses | API responses |
-| `plugin_gate.py` | Enforces plugin enabled-status and permissions at runtime. Checks DB with 5s TTL cache. Management routes (toggle, config, UI assets) bypass the gate | `/api/plugins/{name}/...` |
+| `plugin_gate.py` | Enforces plugin enabled-status and permissions at runtime. Reads the shared TTL cache in `services/plugin_enablement.py` (5s `CACHE_TTL_SECONDS`) rather than keeping a cache of its own. Management routes (toggle, config, UI assets) bypass the gate | `/api/plugins/{name}/...` |
 | `sleep_auto_wake.py` | Counts HTTP requests for idle detection. Auto-wakes from soft sleep on non-whitelisted requests. Whitelisted: monitoring, health, docs, sleep status endpoints | All requests |
 
 ## Adding Middleware

--- a/backend/app/middleware/plugin_gate.py
+++ b/backend/app/middleware/plugin_gate.py
@@ -9,20 +9,16 @@ Management routes (toggle, config, details, ui assets) are excluded so
 admins can still manage plugins that are currently disabled.
 """
 
-import asyncio
 import logging
-import time
-from typing import Dict, List, Tuple
 
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 
-logger = logging.getLogger(__name__)
+from app.plugins.manager import PluginManager
+from app.services import plugin_enablement
 
-# TTL-based in-memory cache: {plugin_name: (is_enabled, granted_perms, timestamp)}
-_plugin_cache: Dict[str, Tuple[bool, List[str], float]] = {}
-CACHE_TTL_SECONDS = 5.0
+logger = logging.getLogger(__name__)
 
 # Path suffixes for management routes that should NOT be gated.
 # These are the admin endpoints defined in api/routes/plugins.py.
@@ -46,33 +42,13 @@ def _is_management_route(sub_path: str) -> bool:
     return False
 
 
-def _fetch_plugin_status(name: str) -> Tuple[bool, List[str]]:
-    """Synchronous DB lookup -- designed to run in a worker thread via
-    ``asyncio.to_thread()``.
-
-    Returns ``(is_enabled, granted_permissions)``."""
-    from app.core.database import SessionLocal
-    from app.models.plugin import InstalledPlugin
-
-    db = SessionLocal()
-    try:
-        record = (
-            db.query(InstalledPlugin)
-            .filter(InstalledPlugin.name == name)
-            .first()
-        )
-        if record and record.is_enabled:
-            return (True, record.granted_permissions or [])
-        return (False, [])
-    finally:
-        db.close()
-
-
 def invalidate_plugin_cache(name: str) -> None:
-    """Drop the cached entry for *name* so the next request triggers a
-    fresh DB lookup.  Call this from the local worker after toggling a
-    plugin."""
-    _plugin_cache.pop(name, None)
+    """Drop the cached enablement state after a local toggle.
+
+    Kept as a named function because routes/plugins.py calls it; the state now
+    lives in services/plugin_enablement, shared with the manager's readers.
+    """
+    plugin_enablement.invalidate()
 
 
 class PluginGateMiddleware(BaseHTTPMiddleware):
@@ -120,39 +96,25 @@ class PluginGateMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         # --- Gate: check plugin status ---
-        now = time.monotonic()
-        cached = _plugin_cache.get(name)
+        try:
+            await plugin_enablement.refresh()
+        except Exception:
+            logger.exception("Failed to fetch plugin status for %s", name)
+            return JSONResponse(
+                status_code=500,
+                content={"detail": "Internal error checking plugin status"},
+            )
 
-        if cached is not None:
-            is_enabled, granted_perms, ts = cached
-            if (now - ts) >= CACHE_TTL_SECONDS:
-                cached = None  # expired
-
-        if cached is None:
-            try:
-                is_enabled, granted_perms = await asyncio.to_thread(
-                    _fetch_plugin_status, name
-                )
-            except Exception:
-                logger.exception("Failed to fetch plugin status for %s", name)
-                return JSONResponse(
-                    status_code=500,
-                    content={"detail": "Internal error checking plugin status"},
-                )
-            _plugin_cache[name] = (is_enabled, granted_perms, now)
-        else:
-            is_enabled, granted_perms, _ = cached
-
-        if not is_enabled:
+        enabled = plugin_enablement.enabled_plugins() or {}
+        if name not in enabled:
             return JSONResponse(
                 status_code=403,
                 content={"detail": f"Plugin '{name}' is disabled"},
             )
+        granted_perms = enabled[name]
 
         # Check permissions: granted must be a superset of required
         try:
-            from app.plugins.manager import PluginManager
-
             manager = PluginManager.get_instance()
             required = manager.get_required_permissions(name)
         except Exception:

--- a/backend/app/plugins/CLAUDE.md
+++ b/backend/app/plugins/CLAUDE.md
@@ -78,13 +78,21 @@ Two plugin trust tiers with different isolation:
    or hangs silences only its own pill, never the whole strip. Labels come
    from `get_translations()`, resolved client-side via `resolvePluginString`,
    with `name_text`/`label_text` as literal fallbacks.
-   **Operator note:** `PluginManager._enabled` is process-local, populated at
-   startup. Toggling a pill- or menu-contributing plugin on/off through the UI
-   only updates the worker that handled that request — in production (4 Uvicorn
-   workers) the pill then appears on roughly one in four status-strip polls, and
-   a menu action fails with 404 on the three workers that never loaded it, until
-   the backend is restarted. Restart `baluhost-backend` after enabling or
-   disabling such a plugin so all workers agree (#448).
+   **Operator note:** plugin enablement lives in the database and every worker
+   reconciles itself against it on the next request that needs the state
+   (`services/plugin_enablement.py`), so a toggle now takes effect within a few
+   seconds across all four production workers — no restart needed for status
+   pills, menu actions or the plugin list itself (#448). The reconcile is
+   wired to five routes via `Depends(deps.reconciled_plugin_state)`:
+   `list_plugins`, `get_ui_manifest`, `run_plugin_menu_action`,
+   `get_statusbar_config` and `get_statusbar_state`. The Dashboard plugin
+   panel (`GET /api/dashboard/plugin-panel`) is **not** one of them — it reads
+   `PluginManager.get_plugin()` directly with no DB fallback, so it only
+   catches up once some other reconciled route has run on the same worker.
+   **One exception:** plugin HTTP routes are mounted once at startup
+   (`core/lifespan.py`), so a plugin that ships its own router still needs a
+   `baluhost-backend` restart before its endpoints exist. Its
+   method-based contributions work immediately.
 7. Override `get_ui_manifest()` with `menu_items` + `run_menu_action()` to
    contribute an action to the system (power) menu. `get_menu_items()` is not
    a separate override point: its default implementation derives the list

--- a/backend/app/plugins/CLAUDE.md
+++ b/backend/app/plugins/CLAUDE.md
@@ -92,7 +92,13 @@ Two plugin trust tiers with different isolation:
    **One exception:** plugin HTTP routes are mounted once at startup
    (`core/lifespan.py`), so a plugin that ships its own router still needs a
    `baluhost-backend` restart before its endpoints exist. Its
-   method-based contributions work immediately.
+   method-based contributions work immediately. `GET /api/plugins/{name}`
+   surfaces this as `PluginDetailResponse.restart_required` — true when the
+   plugin contributes a router that was not part of the set
+   `PluginManager.get_router()` mounted at startup
+   (`PluginManager.router_restart_required()`); always false for plugins
+   without a router and for external (sandboxed) plugins, whose requests are
+   routed dynamically through the catch-all proxy with no restart needed.
 7. Override `get_ui_manifest()` with `menu_items` + `run_menu_action()` to
    contribute an action to the system (power) menu. `get_menu_items()` is not
    a separate override point: its default implementation derives the list

--- a/backend/app/plugins/manager.py
+++ b/backend/app/plugins/manager.py
@@ -135,6 +135,13 @@ class PluginManager:
         self._sandboxes: Dict[str, Any] = {}
         self._routers_mounted = False
         self._discovered: Optional[Dict[str, DiscoveredPlugin]] = None
+        # Names whose plugin.get_router() contributed a sub-router the one
+        # time get_router() was called (lifespan startup). Bundled plugin
+        # HTTP routes are mounted onto the app exactly once at startup - a
+        # plugin enabled later never gets its endpoints wired in until a
+        # restart, and this set is how a later request can tell which
+        # plugins are in that boat (#448 restart_required).
+        self._routes_mounted_at_startup: Set[str] = set()
 
     @classmethod
     def get_instance(
@@ -751,7 +758,17 @@ class PluginManager:
             return []
 
     def get_router(self) -> APIRouter:
-        """Combined router: bundled plugin routes + a catch-all for sandboxed ones."""
+        """Combined router: bundled plugin routes + a catch-all for sandboxed ones.
+
+        Called exactly once in practice, from ``lifespan.py`` right after
+        startup loads the enabled plugins, and the result is mounted onto the
+        app with ``include_router()`` - there is no later re-mount. That makes
+        this the natural place to snapshot which plugin names actually got a
+        router wired in: ``_routes_mounted_at_startup`` records them here
+        rather than lifespan calling a separate ``mark_routers_mounted()``
+        afterwards, which would require lifespan to duplicate the same
+        "does this plugin have a router" check to build the argument.
+        """
         from fastapi import Request  # noqa: PLC0415
         from app.api.deps import get_current_user  # noqa: PLC0415
         from app.plugins.sandbox.proxy import proxy_request  # noqa: PLC0415
@@ -767,6 +784,7 @@ class PluginManager:
                     router.include_router(
                         plugin_router, prefix=f"/{name}", tags=[f"plugin:{name}"]
                     )
+                    self._routes_mounted_at_startup.add(name)
 
         # Catch-all for external/sandboxed plugins, registered LAST.
         manager = self
@@ -861,7 +879,7 @@ class PluginManager:
             if plugin is not None:
                 yield name, plugin
 
-    def _effective_enabled(self) -> set:
+    def _effective_enabled(self) -> Set[str]:
         """Names the database says are enabled, falling back to local state.
 
         The database is the only state shared across the production workers;
@@ -887,6 +905,37 @@ class PluginManager:
             True if plugin is enabled
         """
         return name in self._effective_enabled()
+
+    def is_loaded(self, name: str) -> bool:
+        """Whether THIS worker has the plugin loaded and started.
+
+        Distinct from is_enabled(), which answers the database's question.
+        A plugin whose on_startup() threw stays in _plugins but never enters
+        _enabled - executing endpoints must require this, not enablement.
+        """
+        return name in self._enabled
+
+    def router_restart_required(self, name: str) -> bool:
+        """True if ``name`` ships an HTTP router that was NOT mounted at startup.
+
+        Plugin routers are wired onto the app once, in ``get_router()``
+        (called from lifespan). A plugin enabled after that moment - even
+        though ``enable_plugin()`` ran its startup hook successfully in this
+        worker - never gets its endpoints registered until the process
+        restarts. Plugins without a router are unaffected: their method-based
+        contributions (menu items, status pills, dashboard panels, ...) work
+        immediately, so this only ever returns True for the router case.
+        """
+        plugin = self._plugins.get(name)
+        if plugin is None:
+            return False
+        try:
+            has_router = plugin.get_router() is not None
+        except Exception:
+            return False
+        if not has_router:
+            return False
+        return name not in self._routes_mounted_at_startup
 
     def get_required_permissions(self, name: str) -> List[str]:
         """Get required permissions for a loaded plugin.

--- a/backend/app/plugins/manager.py
+++ b/backend/app/plugins/manager.py
@@ -861,8 +861,24 @@ class PluginManager:
             if plugin is not None:
                 yield name, plugin
 
+    def _effective_enabled(self) -> set:
+        """Names the database says are enabled, falling back to local state.
+
+        The database is the only state shared across the production workers;
+        ``_enabled`` only says what THIS worker loaded. Falling back to it when
+        the cache has no data keeps a DB outage from blanking the plugin list -
+        the gate fails closed instead, which is the opposite direction on
+        purpose (see services/plugin_enablement).
+        """
+        from app.services import plugin_enablement
+
+        cached = plugin_enablement.enabled_plugins()
+        if cached is None:
+            return set(self._enabled)
+        return set(cached)
+
     def is_enabled(self, name: str) -> bool:
-        """Check if a plugin is enabled.
+        """Check if a plugin is enabled per the database (not per this worker).
 
         Args:
             name: Plugin name
@@ -870,7 +886,7 @@ class PluginManager:
         Returns:
             True if plugin is enabled
         """
-        return name in self._enabled
+        return name in self._effective_enabled()
 
     def get_required_permissions(self, name: str) -> List[str]:
         """Get required permissions for a loaded plugin.
@@ -894,6 +910,7 @@ class PluginManager:
         """
         discovered = self.discover_plugins()
         result = {}
+        effective = self._effective_enabled()
 
         for name in discovered:
             info = self.get_discovered(name)
@@ -907,7 +924,7 @@ class PluginManager:
                     "author": m.author,
                     "category": m.category,
                     "required_permissions": list(m.required_permissions),
-                    "is_enabled": name in self._enabled,
+                    "is_enabled": name in effective,
                     "has_ui": m.ui is not None,
                     "has_routes": True,
                     "is_external": True,
@@ -931,7 +948,7 @@ class PluginManager:
                     "author": meta.author,
                     "category": meta.category,
                     "required_permissions": meta.required_permissions,
-                    "is_enabled": name in self._enabled,
+                    "is_enabled": name in effective,
                     "has_ui": plugin.get_ui_manifest() is not None,
                     "has_routes": plugin.get_router() is not None,
                     "is_external": False,

--- a/backend/app/plugins/manager.py
+++ b/backend/app/plugins/manager.py
@@ -932,7 +932,15 @@ class PluginManager:
         try:
             has_router = plugin.get_router() is not None
         except Exception:
-            return False
+            # Fail toward "tell the admin to restart". This flag exists so the
+            # UI does not feign readiness; a plugin whose get_router() throws
+            # is exactly the case where we cannot claim its endpoints are up.
+            logger.warning(
+                "plugin %s: get_router() raised while computing restart_required",
+                name,
+                exc_info=True,
+            )
+            return True
         if not has_router:
             return False
         return name not in self._routes_mounted_at_startup

--- a/backend/app/schemas/plugin.py
+++ b/backend/app/schemas/plugin.py
@@ -133,6 +133,7 @@ class PluginDetailResponse(BaseModel):
     dashboard_panel_enabled: bool = False
     is_external: bool = False
     requested_api_scopes: List[str] = []
+    restart_required: bool = False
 
     # UI info
     nav_items: List[PluginNavItemSchema] = []

--- a/backend/app/services/CLAUDE.md
+++ b/backend/app/services/CLAUDE.md
@@ -25,6 +25,7 @@ Business logic layer. Routes delegate to services — services contain the actua
 | `recovery_code_service.py` | Password recovery codes — generate/verify/consume single-use codes (hash+encrypt at rest), timing-equalized username verify |
 | `token_service.py` | Refresh token management, rotation |
 | `plugin_service.py` | Plugin install/uninstall/toggle operations |
+| `plugin_enablement.py` | Single source of truth for "which plugins are enabled" across the four Uvicorn workers (#448) — TTL-cached DB read (`refresh()`/`enabled_plugins()`/`is_enabled()`) plus `reconcile_worker()`, which aligns THIS worker's loaded plugins (`PluginManager._enabled`) with the DB on the next request via `Depends(deps.reconciled_plugin_state)`. Single-flight per worker; a plugin whose `enable_plugin()` fails is backed off `FAILED_RETRY_SECONDS` (60s) until `invalidate()` (called after a local toggle) clears the backoff early |
 | `power_permissions.py` | Per-user power action permissions (get, update, check), incl. `can_toggle_desktop`. UI name: "System Permissions / Systemberechtigungen"; backend identifiers stay `power_permissions` (deliberate — no rename/migration). |
 | `samba_service.py` | Samba/SMB share management |
 | `webdav_service.py` | WebDAV server lifecycle control |

--- a/backend/app/services/plugin_enablement.py
+++ b/backend/app/services/plugin_enablement.py
@@ -101,10 +101,17 @@ def is_enabled(name: str) -> Optional[bool]:
 
 
 def invalidate() -> None:
-    """Drop the cache so the next refresh reloads (called after a local toggle)."""
+    """Drop the cache so the next refresh reloads (called after a local toggle).
+
+    Also clears the reconcile backoff: an invalidation is exactly the signal
+    that the DB state changed, so an admin who fixes and re-enables a plugin
+    should not have to wait out the full FAILED_RETRY_SECONDS backoff on the
+    other workers.
+    """
     global _cache, _cached_at
     _cache = None
     _cached_at = 0.0
+    _failed_until.clear()
 
 
 FAILED_RETRY_SECONDS: float = 60.0
@@ -158,15 +165,25 @@ async def reconcile_worker() -> None:
 
         now = _monotonic()
 
-        for name, grant in desired.items():
-            if name in loaded:
-                continue
-            if _failed_until.get(name, 0.0) > now:
-                continue
-            try:
-                from app.core.database import SessionLocal
+        # One session for the whole reconcile, not one per missing plugin:
+        # enable_plugin() never uses `db` itself, so holding a pool connection
+        # across its (possibly slow) on_startup() call - once per plugin that
+        # needs enabling - only ties up a connection for no reason.
+        try:
+            from app.core.database import SessionLocal
 
-                with SessionLocal() as db:
+            db = SessionLocal()
+        except Exception:  # broad on purpose: never raises - best-effort maintenance
+            logger.warning("plugin enablement reconcile session setup failed", exc_info=True)
+            return
+
+        try:
+            for name, grant in desired.items():
+                if name in loaded:
+                    continue
+                if _failed_until.get(name, 0.0) > now:
+                    continue
+                try:
                     ok = await manager.enable_plugin(
                         name,
                         grant["granted_permissions"],
@@ -174,11 +191,13 @@ async def reconcile_worker() -> None:
                         start_background_tasks=lifespan.IS_PRIMARY_WORKER,
                         granted_api_scopes=grant["granted_api_scopes"],
                     )
-            except Exception:  # broad on purpose: one bad plugin must not stop the rest
-                logger.warning("lazy enable of plugin %s failed", name, exc_info=True)
-                ok = False
-            if not ok:
-                _failed_until[name] = now + FAILED_RETRY_SECONDS
+                except Exception:  # broad on purpose: one bad plugin must not stop the rest
+                    logger.warning("lazy enable of plugin %s failed", name, exc_info=True)
+                    ok = False
+                if not ok:
+                    _failed_until[name] = now + FAILED_RETRY_SECONDS
+        finally:
+            db.close()
 
         for name in loaded - set(desired):
             try:

--- a/backend/app/services/plugin_enablement.py
+++ b/backend/app/services/plugin_enablement.py
@@ -1,0 +1,89 @@
+"""Single source of truth for "which plugins are enabled" (#448).
+
+The database is the only state shared by the four production workers.
+``PluginManager._enabled`` is process-local and populated at startup, so a
+runtime toggle reaches exactly one worker - which made the plugin list report
+whatever the answering worker happened to know.
+
+This module caches the database answer for a short window. The read itself
+lives in the async ``refresh()`` and runs off the event loop; synchronous
+readers consume the warm cache and never open a session of their own, because
+the callers that need them (``PluginManager.get_all_plugins()``) have no
+session to give.
+
+The cache maps ``name -> granted_permissions`` rather than holding a bare set
+of names: ``PluginGateMiddleware`` needs both out of the same read, and a
+name-only cache would have forced it to keep a second query.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+CACHE_TTL_SECONDS: float = 5.0
+
+_cache: Optional[Dict[str, List[str]]] = None
+_cached_at: float = 0.0
+
+
+def _monotonic() -> float:
+    """Indirection so tests can control the clock."""
+    return time.monotonic()
+
+
+def _fetch() -> Dict[str, List[str]]:
+    """Blocking DB read - always called through asyncio.to_thread."""
+    from app.core.database import SessionLocal
+    from app.models.plugin import InstalledPlugin
+
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(InstalledPlugin)
+            .filter(InstalledPlugin.is_enabled == True)  # SQL boolean filter - `is True` would break the query (E712 is globally ignored for this reason)
+            .all()
+        )
+        return {row.name: list(row.granted_permissions or []) for row in rows}
+    finally:
+        db.close()
+
+
+async def refresh(force: bool = False) -> None:
+    """Reload the cache if the TTL expired. Raises whatever the DB raises.
+
+    Deliberately not swallowing: the display path wants to fall back to the
+    last known state, the security gate wants to fail closed. Only the callers
+    know which.
+    """
+    global _cache, _cached_at
+
+    now = _monotonic()
+    if not force and _cache is not None and (now - _cached_at) < CACHE_TTL_SECONDS:
+        return
+
+    fetched = await asyncio.to_thread(_fetch)
+    _cache = fetched
+    _cached_at = now
+
+
+def enabled_plugins() -> Optional[Dict[str, List[str]]]:
+    """Warm cache as ``name -> granted_permissions``; None if never loaded."""
+    return dict(_cache) if _cache is not None else None
+
+
+def is_enabled(name: str) -> Optional[bool]:
+    """True/False from the cache, or None when there is no data yet."""
+    if _cache is None:
+        return None
+    return name in _cache
+
+
+def invalidate() -> None:
+    """Drop the cache so the next refresh reloads (called after a local toggle)."""
+    global _cache, _cached_at
+    _cache = None
+    _cached_at = 0.0

--- a/backend/app/services/plugin_enablement.py
+++ b/backend/app/services/plugin_enablement.py
@@ -11,22 +11,32 @@ readers consume the warm cache and never open a session of their own, because
 the callers that need them (``PluginManager.get_all_plugins()``) have no
 session to give.
 
-The cache maps ``name -> granted_permissions`` rather than holding a bare set
-of names: ``PluginGateMiddleware`` needs both out of the same read, and a
-name-only cache would have forced it to keep a second query.
+Internally the cache keeps both ``granted_permissions`` (bundled-plugin
+permission model) and ``granted_api_scopes`` (external-plugin capability
+model) per plugin, because ``reconcile_worker()`` needs both out of the same
+read to call ``PluginManager.enable_plugin()`` correctly. ``enabled_plugins()``
+only ever hands out ``name -> granted_permissions`` - that is its contract and
+other modules (``PluginManager._effective_enabled()``, ``PluginGateMiddleware``)
+depend on the shape staying exactly that.
 """
 from __future__ import annotations
 
 import asyncio
 import logging
 import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TypedDict
 
 logger = logging.getLogger(__name__)
 
 CACHE_TTL_SECONDS: float = 5.0
 
-_cache: Optional[Dict[str, List[str]]] = None
+
+class _PluginGrant(TypedDict):
+    granted_permissions: List[str]
+    granted_api_scopes: List[str]
+
+
+_cache: Optional[Dict[str, _PluginGrant]] = None
 _cached_at: float = 0.0
 
 
@@ -35,7 +45,7 @@ def _monotonic() -> float:
     return time.monotonic()
 
 
-def _fetch() -> Dict[str, List[str]]:
+def _fetch() -> Dict[str, _PluginGrant]:
     """Blocking DB read - always called through asyncio.to_thread."""
     from app.core.database import SessionLocal
     from app.models.plugin import InstalledPlugin
@@ -47,7 +57,13 @@ def _fetch() -> Dict[str, List[str]]:
             .filter(InstalledPlugin.is_enabled == True)  # SQL boolean filter - `is True` would break the query (E712 is globally ignored for this reason)
             .all()
         )
-        return {row.name: list(row.granted_permissions or []) for row in rows}
+        return {
+            row.name: {
+                "granted_permissions": list(row.granted_permissions or []),
+                "granted_api_scopes": list(row.granted_api_scopes or []),
+            }
+            for row in rows
+        }
     finally:
         db.close()
 
@@ -72,7 +88,9 @@ async def refresh(force: bool = False) -> None:
 
 def enabled_plugins() -> Optional[Dict[str, List[str]]]:
     """Warm cache as ``name -> granted_permissions``; None if never loaded."""
-    return dict(_cache) if _cache is not None else None
+    if _cache is None:
+        return None
+    return {name: list(entry["granted_permissions"]) for name, entry in _cache.items()}
 
 
 def is_enabled(name: str) -> Optional[bool]:
@@ -123,19 +141,24 @@ async def reconcile_worker() -> None:
             logger.warning("plugin enablement refresh failed", exc_info=True)
             return
 
-        desired = enabled_plugins()
+        desired = _cache
         if desired is None:
             return
 
-        # Read as a module attribute: lifespan sets this after the fork, so a
-        # from-import would freeze the pre-fork False forever.
-        from app.core import lifespan
+        try:
+            # Read as a module attribute: lifespan sets this after the fork, so
+            # a from-import would freeze the pre-fork False forever.
+            from app.core import lifespan
 
-        manager = _get_manager()
-        loaded = set(manager._enabled)
+            manager = _get_manager()
+            loaded = set(manager._enabled)
+        except Exception:  # broad on purpose: never raises - best-effort maintenance on a request path
+            logger.warning("plugin enablement reconcile setup failed", exc_info=True)
+            return
+
         now = _monotonic()
 
-        for name, permissions in desired.items():
+        for name, grant in desired.items():
             if name in loaded:
                 continue
             if _failed_until.get(name, 0.0) > now:
@@ -146,9 +169,10 @@ async def reconcile_worker() -> None:
                 with SessionLocal() as db:
                     ok = await manager.enable_plugin(
                         name,
-                        permissions,
+                        grant["granted_permissions"],
                         db,
                         start_background_tasks=lifespan.IS_PRIMARY_WORKER,
+                        granted_api_scopes=grant["granted_api_scopes"],
                     )
             except Exception:  # broad on purpose: one bad plugin must not stop the rest
                 logger.warning("lazy enable of plugin %s failed", name, exc_info=True)

--- a/backend/app/services/plugin_enablement.py
+++ b/backend/app/services/plugin_enablement.py
@@ -87,3 +87,77 @@ def invalidate() -> None:
     global _cache, _cached_at
     _cache = None
     _cached_at = 0.0
+
+
+FAILED_RETRY_SECONDS: float = 60.0
+
+_reconcile_lock = asyncio.Lock()
+_failed_until: Dict[str, float] = {}
+
+
+def _get_manager():
+    """Indirection so tests can inject a manager double."""
+    from app.plugins.manager import PluginManager
+
+    return PluginManager.get_instance()
+
+
+async def reconcile_worker() -> None:
+    """Align this worker's loaded plugins with the database.
+
+    Single-flight: a second caller returns immediately rather than queueing.
+    Two requests arriving together (status-strip poll plus plugin list is the
+    realistic pair) would otherwise both see the same diff and run the same
+    plugin's on_startup() twice, in parallel. The loser proceeds on the current
+    state - the winner's reconcile is a moment away.
+
+    Never raises: a reconcile is best-effort maintenance on a request path.
+    """
+    if _reconcile_lock.locked():
+        return
+
+    async with _reconcile_lock:
+        try:
+            await refresh()
+        except Exception:  # broad on purpose: a DB blip must not fail the request
+            logger.warning("plugin enablement refresh failed", exc_info=True)
+            return
+
+        desired = enabled_plugins()
+        if desired is None:
+            return
+
+        # Read as a module attribute: lifespan sets this after the fork, so a
+        # from-import would freeze the pre-fork False forever.
+        from app.core import lifespan
+
+        manager = _get_manager()
+        loaded = set(manager._enabled)
+        now = _monotonic()
+
+        for name, permissions in desired.items():
+            if name in loaded:
+                continue
+            if _failed_until.get(name, 0.0) > now:
+                continue
+            try:
+                from app.core.database import SessionLocal
+
+                with SessionLocal() as db:
+                    ok = await manager.enable_plugin(
+                        name,
+                        permissions,
+                        db,
+                        start_background_tasks=lifespan.IS_PRIMARY_WORKER,
+                    )
+            except Exception:  # broad on purpose: one bad plugin must not stop the rest
+                logger.warning("lazy enable of plugin %s failed", name, exc_info=True)
+                ok = False
+            if not ok:
+                _failed_until[name] = now + FAILED_RETRY_SECONDS
+
+        for name in loaded - set(desired):
+            try:
+                await manager.disable_plugin(name)
+            except Exception:  # broad on purpose: same reasoning as above
+                logger.warning("lazy disable of plugin %s failed", name, exc_info=True)

--- a/backend/tests/middleware/test_plugin_gate.py
+++ b/backend/tests/middleware/test_plugin_gate.py
@@ -1,6 +1,5 @@
 """Tests for the PluginGateMiddleware."""
 
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,12 +7,22 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.middleware.plugin_gate import (
-    CACHE_TTL_SECONDS,
     PluginGateMiddleware,
     _is_management_route,
-    _plugin_cache,
     invalidate_plugin_cache,
 )
+from app.services import plugin_enablement
+from app.services.plugin_enablement import CACHE_TTL_SECONDS
+
+
+def _grant(permissions=None) -> dict:
+    """Build a ``_fetch()``-shaped cache entry for one plugin.
+
+    The cache also carries ``granted_api_scopes`` (Task 3); the gate only
+    ever consumes ``granted_permissions`` via ``enabled_plugins()``, so tests
+    here only need to populate that half.
+    """
+    return {"granted_permissions": list(permissions or []), "granted_api_scopes": []}
 
 
 # ---------------------------------------------------------------------------
@@ -73,9 +82,9 @@ def _make_app() -> FastAPI:
 @pytest.fixture(autouse=True)
 def _clear_cache():
     """Ensure the module-level cache is empty before each test."""
-    _plugin_cache.clear()
+    plugin_enablement.invalidate()
     yield
-    _plugin_cache.clear()
+    plugin_enablement.invalidate()
 
 
 # ---------------------------------------------------------------------------
@@ -95,7 +104,7 @@ def test_non_plugin_path_passes_through():
 # ---------------------------------------------------------------------------
 
 
-@patch("app.middleware.plugin_gate._fetch_plugin_status")
+@patch("app.services.plugin_enablement._fetch")
 def test_plugin_list_not_gated(mock_fetch):
     """GET /api/plugins (list) should never be gated."""
     client = TestClient(_make_app())
@@ -104,7 +113,7 @@ def test_plugin_list_not_gated(mock_fetch):
     mock_fetch.assert_not_called()
 
 
-@patch("app.middleware.plugin_gate._fetch_plugin_status")
+@patch("app.services.plugin_enablement._fetch")
 def test_permissions_endpoint_not_gated(mock_fetch):
     """GET /api/plugins/permissions should never be gated."""
     client = TestClient(_make_app())
@@ -128,7 +137,7 @@ def test_permissions_endpoint_not_gated(mock_fetch):
         ("GET", "/api/plugins/my_plugin/ui/bundle.js"),  # ui asset
     ],
 )
-@patch("app.middleware.plugin_gate._fetch_plugin_status")
+@patch("app.services.plugin_enablement._fetch")
 def test_management_routes_not_gated(mock_fetch, method, path):
     """Management routes must pass through even if plugin is disabled."""
     client = TestClient(_make_app())
@@ -143,7 +152,10 @@ def test_management_routes_not_gated(mock_fetch, method, path):
 
 
 @patch("app.plugins.manager.PluginManager.get_instance")
-@patch("app.middleware.plugin_gate._fetch_plugin_status", return_value=(True, ["files:read"]))
+@patch(
+    "app.services.plugin_enablement._fetch",
+    return_value={"my_plugin": _grant(["files:read"])},
+)
 def test_enabled_plugin_passes(mock_fetch, mock_get_instance):
     """An enabled plugin with sufficient permissions -> 200."""
     mock_manager = MagicMock()
@@ -161,7 +173,7 @@ def test_enabled_plugin_passes(mock_fetch, mock_get_instance):
 # ---------------------------------------------------------------------------
 
 
-@patch("app.middleware.plugin_gate._fetch_plugin_status", return_value=(False, []))
+@patch("app.services.plugin_enablement._fetch", return_value={})
 def test_disabled_plugin_blocked(mock_fetch):
     """A disabled plugin -> 403."""
     client = TestClient(_make_app())
@@ -177,8 +189,8 @@ def test_disabled_plugin_blocked(mock_fetch):
 
 @patch("app.plugins.manager.PluginManager.get_instance")
 @patch(
-    "app.middleware.plugin_gate._fetch_plugin_status",
-    return_value=(True, ["files:read"]),
+    "app.services.plugin_enablement._fetch",
+    return_value={"my_plugin": _grant(["files:read"])},
 )
 def test_missing_permissions_blocked(mock_fetch, mock_get_instance):
     """Plugin is enabled but granted permissions don't cover required -> 403."""
@@ -202,7 +214,10 @@ def test_missing_permissions_blocked(mock_fetch, mock_get_instance):
 
 
 @patch("app.plugins.manager.PluginManager.get_instance")
-@patch("app.middleware.plugin_gate._fetch_plugin_status", return_value=(True, []))
+@patch(
+    "app.services.plugin_enablement._fetch",
+    return_value={"my_plugin": _grant()},
+)
 def test_cache_hit_no_repeat_db_query(mock_fetch, mock_get_instance):
     """Second request within TTL should use cache, not call DB again."""
     mock_manager = MagicMock()
@@ -227,7 +242,10 @@ def test_cache_hit_no_repeat_db_query(mock_fetch, mock_get_instance):
 
 
 @patch("app.plugins.manager.PluginManager.get_instance")
-@patch("app.middleware.plugin_gate._fetch_plugin_status", return_value=(True, []))
+@patch(
+    "app.services.plugin_enablement._fetch",
+    return_value={"my_plugin": _grant()},
+)
 def test_invalidate_cache_forces_db_query(mock_fetch, mock_get_instance):
     """After invalidate_plugin_cache(), the next request must hit the DB."""
     mock_manager = MagicMock()
@@ -251,22 +269,30 @@ def test_invalidate_cache_forces_db_query(mock_fetch, mock_get_instance):
 
 
 @patch("app.plugins.manager.PluginManager.get_instance")
-@patch("app.middleware.plugin_gate._fetch_plugin_status", return_value=(True, []))
-def test_cache_expires_after_ttl(mock_fetch, mock_get_instance):
-    """After TTL seconds the cached entry is considered stale."""
+@patch(
+    "app.services.plugin_enablement._fetch",
+    return_value={"my_plugin": _grant()},
+)
+def test_cache_expires_after_ttl(mock_fetch, mock_get_instance, monkeypatch):
+    """After TTL seconds the cached entry is considered stale.
+
+    The new cache is global (not per-name): advance the shared clock past
+    the TTL, the same way test_plugin_enablement.py's own TTL test does,
+    rather than reaching into a per-name timestamp that no longer exists.
+    """
     mock_manager = MagicMock()
     mock_manager.get_required_permissions.return_value = []
     mock_get_instance.return_value = mock_manager
+
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(plugin_enablement, "_monotonic", lambda: clock["now"])
 
     client = TestClient(_make_app())
 
     client.get("/api/plugins/my_plugin/data")
     assert mock_fetch.call_count == 1
 
-    # Manually expire the cache entry
-    name = "my_plugin"
-    is_enabled, perms, _ts = _plugin_cache[name]
-    _plugin_cache[name] = (is_enabled, perms, time.monotonic() - CACHE_TTL_SECONDS - 1)
+    clock["now"] += CACHE_TTL_SECONDS + 0.1
 
     client.get("/api/plugins/my_plugin/data")
     assert mock_fetch.call_count == 2
@@ -277,7 +303,7 @@ def test_cache_expires_after_ttl(mock_fetch, mock_get_instance):
 # ---------------------------------------------------------------------------
 
 
-@patch("app.middleware.plugin_gate._fetch_plugin_status", return_value=(False, []))
+@patch("app.services.plugin_enablement._fetch", return_value={})
 def test_unknown_plugin_returns_403(mock_fetch):
     """A plugin name that doesn't exist in the DB -> disabled -> 403."""
     client = TestClient(_make_app())
@@ -291,7 +317,7 @@ def test_unknown_plugin_returns_403(mock_fetch):
 
 
 @patch(
-    "app.middleware.plugin_gate._fetch_plugin_status",
+    "app.services.plugin_enablement._fetch",
     side_effect=Exception("DB connection failed"),
 )
 def test_db_error_returns_500(mock_fetch):
@@ -308,7 +334,10 @@ def test_db_error_returns_500(mock_fetch):
 
 
 @patch("app.plugins.manager.PluginManager.get_instance")
-@patch("app.middleware.plugin_gate._fetch_plugin_status", return_value=(True, []))
+@patch(
+    "app.services.plugin_enablement._fetch",
+    return_value={"my_plugin": _grant()},
+)
 def test_no_required_permissions_passes(mock_fetch, mock_get_instance):
     """If a plugin has no required permissions, just being enabled is enough."""
     mock_manager = MagicMock()

--- a/backend/tests/middleware/test_plugin_gate_enablement.py
+++ b/backend/tests/middleware/test_plugin_gate_enablement.py
@@ -1,0 +1,79 @@
+"""PluginGateMiddleware reads the shared enablement cache (#448)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.middleware import plugin_gate
+from app.services import plugin_enablement as pe
+
+
+def _grant(permissions=None, scopes=None) -> dict:
+    """Build a ``_fetch()``-shaped cache entry for one plugin.
+
+    NOTE: the brief's Step 1 code block shows ``{"demo": []}`` /
+    ``{"demo": ["files.read"]}`` for these patches - that shape predates the
+    Task 3 extension that added ``granted_api_scopes`` to ``_fetch()``'s
+    return value. Using the stale shape here would make ``enabled_plugins()``
+    raise (``entry["granted_permissions"]`` on a plain list), which the task
+    brief's own correction note calls out explicitly.
+    """
+    return {
+        "granted_permissions": list(permissions or []),
+        "granted_api_scopes": list(scopes or []),
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    pe.invalidate()
+    yield
+    pe.invalidate()
+
+
+def _request(path: str) -> MagicMock:
+    request = MagicMock()
+    request.url.path = path
+    return request
+
+
+async def _dispatch(path: str):
+    middleware = plugin_gate.PluginGateMiddleware(app=MagicMock())
+
+    async def _call_next(_request):
+        return "PASSED"
+
+    return await middleware.dispatch(_request(path), _call_next)
+
+
+class TestGateUsesTheSharedCache:
+    async def test_enabled_plugin_passes(self):
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}), \
+             patch.object(plugin_gate.PluginManager, "get_instance") as manager:
+            manager.return_value.get_required_permissions.return_value = []
+            result = await _dispatch("/api/plugins/demo/menu-actions/go")
+        assert result == "PASSED"
+
+    async def test_disabled_plugin_is_403(self):
+        with patch.object(pe, "_fetch", return_value={}):
+            result = await _dispatch("/api/plugins/demo/menu-actions/go")
+        assert result.status_code == 403
+
+    async def test_missing_permission_is_403(self):
+        with patch.object(pe, "_fetch", return_value={"demo": _grant(["files.read"])}), \
+             patch.object(plugin_gate.PluginManager, "get_instance") as manager:
+            manager.return_value.get_required_permissions.return_value = ["files.write"]
+            result = await _dispatch("/api/plugins/demo/menu-actions/go")
+        assert result.status_code == 403
+
+    async def test_db_failure_fails_closed(self):
+        """Opposite direction to the display path: no state, no entry."""
+        with patch.object(pe, "_fetch", side_effect=RuntimeError("db down")):
+            result = await _dispatch("/api/plugins/demo/menu-actions/go")
+        assert result.status_code == 500
+
+    async def test_management_routes_still_bypass_the_gate(self):
+        with patch.object(pe, "_fetch", side_effect=AssertionError("should not be consulted")):
+            assert await _dispatch("/api/plugins/demo/toggle") == "PASSED"
+            assert await _dispatch("/api/plugins/ui/manifest") == "PASSED"

--- a/backend/tests/plugins/test_manager_enabled_readers.py
+++ b/backend/tests/plugins/test_manager_enabled_readers.py
@@ -20,6 +20,14 @@ def _manager(tmp_path) -> PluginManager:
     return PluginManager(plugins_dir=tmp_path)
 
 
+def _grant(permissions=None, scopes=None) -> dict:
+    """Build a ``_fetch()``-shaped cache entry for one plugin."""
+    return {
+        "granted_permissions": list(permissions or []),
+        "granted_api_scopes": list(scopes or []),
+    }
+
+
 class TestIsEnabled:
     async def test_reports_enabled_although_this_worker_never_loaded_it(self, tmp_path):
         """The bug, in one assertion.
@@ -30,7 +38,7 @@ class TestIsEnabled:
         worker_b = _manager(tmp_path)
         assert worker_b._enabled == set()
 
-        with patch.object(pe, "_fetch", return_value={"demo": []}):
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}):
             await pe.refresh()
 
         assert worker_b.is_enabled("demo") is True
@@ -72,7 +80,7 @@ class TestGetAllPlugins:
 
         with patch.object(manager, "discover_plugins", return_value=["demo"]), \
              patch.object(manager, "get_discovered", return_value=None), \
-             patch.object(pe, "_fetch", return_value={"demo": []}):
+             patch.object(pe, "_fetch", return_value={"demo": _grant()}):
             await pe.refresh()
             info = manager.get_all_plugins()
 

--- a/backend/tests/plugins/test_manager_enabled_readers.py
+++ b/backend/tests/plugins/test_manager_enabled_readers.py
@@ -1,0 +1,79 @@
+"""The manager's status readers answer from the DB cache, not from _enabled (#448)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.plugins.manager import PluginManager
+from app.services import plugin_enablement as pe
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    pe.invalidate()
+    yield
+    pe.invalidate()
+
+
+def _manager(tmp_path) -> PluginManager:
+    return PluginManager(plugins_dir=tmp_path)
+
+
+class TestIsEnabled:
+    async def test_reports_enabled_although_this_worker_never_loaded_it(self, tmp_path):
+        """The bug, in one assertion.
+
+        Worker B never handled the toggle, so its _enabled is empty - but the
+        database says the plugin is on, and that is what a client must see.
+        """
+        worker_b = _manager(tmp_path)
+        assert worker_b._enabled == set()
+
+        with patch.object(pe, "_fetch", return_value={"demo": []}):
+            await pe.refresh()
+
+        assert worker_b.is_enabled("demo") is True
+
+    async def test_reports_disabled_although_this_worker_still_has_it_loaded(self, tmp_path):
+        """The reverse direction: disabling used to survive on other workers."""
+        worker_b = _manager(tmp_path)
+        worker_b._enabled = {"demo"}
+
+        with patch.object(pe, "_fetch", return_value={}):
+            await pe.refresh()
+
+        assert worker_b.is_enabled("demo") is False
+
+    def test_falls_back_to_local_state_when_the_cache_has_no_data(self, tmp_path):
+        """A DB outage must not blank the plugin list."""
+        worker = _manager(tmp_path)
+        worker._enabled = {"demo"}
+
+        assert pe.enabled_plugins() is None
+        assert worker.is_enabled("demo") is True
+
+
+class TestGetAllPlugins:
+    async def test_status_flag_comes_from_the_cache(self, tmp_path):
+        manager = _manager(tmp_path)
+        plugin = MagicMock()
+        plugin.metadata.name = "demo"
+        plugin.metadata.version = "1.0.0"
+        plugin.metadata.display_name = "Demo"
+        plugin.metadata.description = ""
+        plugin.metadata.author = "test"
+        plugin.metadata.category = "general"
+        plugin.metadata.required_permissions = []
+        plugin.get_ui_manifest.return_value = None
+        plugin.get_router.return_value = None
+        manager._plugins = {"demo": plugin}
+        manager._enabled = set()
+
+        with patch.object(manager, "discover_plugins", return_value=["demo"]), \
+             patch.object(manager, "get_discovered", return_value=None), \
+             patch.object(pe, "_fetch", return_value={"demo": []}):
+            await pe.refresh()
+            info = manager.get_all_plugins()
+
+        assert info["demo"]["is_enabled"] is True

--- a/backend/tests/plugins/test_plugin_manager.py
+++ b/backend/tests/plugins/test_plugin_manager.py
@@ -300,6 +300,22 @@ class TestRouterRestartRequired:
         mgr = PluginManager(plugins_dir=empty_plugins_dir)
         assert mgr.router_restart_required("nope") is False
 
+    def test_true_when_get_router_raises(self, empty_plugins_dir: Path):
+        """Fail toward telling the admin to restart.
+
+        The flag exists so the UI does not feign readiness. A plugin whose
+        get_router() throws is precisely the case where we cannot claim its
+        endpoints are up - answering False there would be the one wrong
+        direction this field must never take.
+        """
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        plugin = MagicMock()
+        plugin.get_router.side_effect = RuntimeError("boom")
+        mgr._plugins["broken"] = plugin
+        mgr._enabled.add("broken")
+
+        assert mgr.router_restart_required("broken") is True
+
     def test_true_when_enabled_after_the_startup_router_snapshot(self, empty_plugins_dir: Path):
         """The startup mount (get_router()) ran before this plugin existed -
         it has a router, but it is not in the mounted-at-startup set."""

--- a/backend/tests/plugins/test_plugin_manager.py
+++ b/backend/tests/plugins/test_plugin_manager.py
@@ -251,3 +251,81 @@ class TestIterEnabledPlugins:
     def test_empty_when_nothing_enabled(self, empty_plugins_dir: Path):
         mgr = PluginManager(plugins_dir=empty_plugins_dir)
         assert list(mgr.iter_enabled_plugins()) == []
+
+
+class TestIsLoaded:
+    """is_loaded() answers "did THIS worker start it", distinct from
+    is_enabled() (the DB's answer). #448 review finding 1."""
+
+    @pytest.mark.asyncio
+    async def test_true_once_enable_plugin_succeeds(
+        self, plugins_dir_with_plugin: Path, db_session: Session
+    ):
+        mgr = PluginManager(plugins_dir=plugins_dir_with_plugin)
+        await mgr.enable_plugin("test_plugin", [], db_session)
+        assert mgr.is_loaded("test_plugin") is True
+
+    def test_false_for_a_name_never_enabled(self, empty_plugins_dir: Path):
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        assert mgr.is_loaded("nope") is False
+
+    def test_false_when_the_instance_is_loaded_but_on_startup_never_finished(
+        self, empty_plugins_dir: Path
+    ):
+        """The exact #448 scenario: enable_plugin() put the instance in
+        _plugins before calling on_startup(), which then raised - so the
+        name never reached _enabled. is_loaded() must say False even though
+        get_plugin() still returns the instance."""
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        mgr._plugins["broken"] = MagicMock()
+
+        assert mgr.get_plugin("broken") is not None
+        assert mgr.is_loaded("broken") is False
+
+
+class TestRouterRestartRequired:
+    """router_restart_required(): a plugin whose router was not mounted at
+    startup needs a process restart before its endpoints exist (#448)."""
+
+    def test_false_for_a_plugin_without_a_router(self, empty_plugins_dir: Path):
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        plugin = MagicMock()
+        plugin.get_router.return_value = None
+        mgr._plugins["demo"] = plugin
+        mgr._enabled.add("demo")
+
+        assert mgr.router_restart_required("demo") is False
+
+    def test_false_for_an_unknown_plugin(self, empty_plugins_dir: Path):
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        assert mgr.router_restart_required("nope") is False
+
+    def test_true_when_enabled_after_the_startup_router_snapshot(self, empty_plugins_dir: Path):
+        """The startup mount (get_router()) ran before this plugin existed -
+        it has a router, but it is not in the mounted-at-startup set."""
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+
+        # Simulate the startup mount with nothing enabled yet.
+        mgr.get_router()
+        assert mgr._routes_mounted_at_startup == set()
+
+        # A plugin is enabled afterwards, at runtime, and it ships a router.
+        plugin = MagicMock()
+        plugin.get_router.return_value = MagicMock()
+        mgr._plugins["late"] = plugin
+        mgr._enabled.add("late")
+
+        assert mgr.router_restart_required("late") is True
+
+    def test_false_when_the_router_was_part_of_the_startup_mount(self, empty_plugins_dir: Path):
+        mgr = PluginManager(plugins_dir=empty_plugins_dir)
+        plugin = MagicMock()
+        plugin.get_router.return_value = MagicMock()
+        mgr._plugins["early"] = plugin
+        mgr._enabled.add("early")
+
+        # Startup mount runs with the plugin already enabled - it is captured.
+        mgr.get_router()
+        assert "early" in mgr._routes_mounted_at_startup
+
+        assert mgr.router_restart_required("early") is False

--- a/backend/tests/plugins/test_plugin_manager.py
+++ b/backend/tests/plugins/test_plugin_manager.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import APIRouter
 from sqlalchemy.orm import Session
 
 from app.plugins.manager import PluginLoadError, PluginManager
@@ -326,8 +327,11 @@ class TestRouterRestartRequired:
         assert mgr._routes_mounted_at_startup == set()
 
         # A plugin is enabled afterwards, at runtime, and it ships a router.
+        # A real APIRouter, not a MagicMock: get_router() (the combined one)
+        # feeds it into router.include_router(), whose circularity check
+        # (FastAPI >=0.115.x) rejects a mock.
         plugin = MagicMock()
-        plugin.get_router.return_value = MagicMock()
+        plugin.get_router.return_value = APIRouter()
         mgr._plugins["late"] = plugin
         mgr._enabled.add("late")
 
@@ -336,7 +340,7 @@ class TestRouterRestartRequired:
     def test_false_when_the_router_was_part_of_the_startup_mount(self, empty_plugins_dir: Path):
         mgr = PluginManager(plugins_dir=empty_plugins_dir)
         plugin = MagicMock()
-        plugin.get_router.return_value = MagicMock()
+        plugin.get_router.return_value = APIRouter()
         mgr._plugins["early"] = plugin
         mgr._enabled.add("early")
 

--- a/backend/tests/plugins/test_plugin_menu_actions.py
+++ b/backend/tests/plugins/test_plugin_menu_actions.py
@@ -403,18 +403,31 @@ class TestMenuActionThroughTheRealStack:
     real: middleware dispatch, path matching, routing, auth, the route.
     """
 
+    @pytest.fixture(autouse=True)
+    def _reset_enablement_state(self):
+        """The enablement cache is module state that survives file boundaries
+        in the same pytest process. These tests warm the cache (``{"demo": ...}``);
+        without cleanup, any alphabetically later file that consults
+        ``manager.is_enabled()`` would read this stale state instead of its own.
+        """
+        from app.services import plugin_enablement as pe
+
+        pe.invalidate()
+        pe._failed_until.clear()
+        yield
+        pe.invalidate()
+        pe._failed_until.clear()
+
     def _post(self, client, headers):
         return client.post(
             "/api/plugins/demo/menu-actions/do_it", headers=headers
         )
 
     def test_disabled_plugin_is_refused_by_the_stack(self, client, admin_headers):
-        from app.middleware import plugin_gate
+        from app.services import plugin_enablement
 
-        plugin_gate._plugin_cache.clear()
-        with patch.object(
-            plugin_gate, "_fetch_plugin_status", return_value=(False, [])
-        ):
+        plugin_enablement.invalidate()
+        with patch.object(plugin_enablement, "_fetch", return_value={}):
             response = self._post(client, admin_headers)
 
         assert response.status_code == 403
@@ -424,22 +437,26 @@ class TestMenuActionThroughTheRealStack:
         """Discriminates the 403 above: with the same request and an enabled
         plugin the gate lets it through, and the 404 comes from the route
         itself (no such plugin loaded in this process)."""
-        from app.middleware import plugin_gate
+        from app.services import plugin_enablement
 
-        plugin_gate._plugin_cache.clear()
+        plugin_enablement.invalidate()
         with patch.object(
-            plugin_gate, "_fetch_plugin_status", return_value=(True, [])
+            plugin_enablement,
+            "_fetch",
+            return_value={"demo": {"granted_permissions": [], "granted_api_scopes": []}},
         ):
             response = self._post(client, admin_headers)
 
         assert response.status_code == 404
 
     def test_non_admin_is_refused_on_an_enabled_plugin(self, client, user_headers):
-        from app.middleware import plugin_gate
+        from app.services import plugin_enablement
 
-        plugin_gate._plugin_cache.clear()
+        plugin_enablement.invalidate()
         with patch.object(
-            plugin_gate, "_fetch_plugin_status", return_value=(True, [])
+            plugin_enablement,
+            "_fetch",
+            return_value={"demo": {"granted_permissions": [], "granted_api_scopes": []}},
         ):
             response = self._post(client, user_headers)
 

--- a/backend/tests/plugins/test_plugin_menu_actions.py
+++ b/backend/tests/plugins/test_plugin_menu_actions.py
@@ -305,7 +305,7 @@ class TestDisabledPluginIsRefusedInTheRouteToo:
         plugin.run_menu_action = AsyncMock()
         manager = MagicMock()
         manager.get_plugin.return_value = plugin
-        manager.is_enabled.return_value = False
+        manager.is_loaded.return_value = False
 
         with patch("app.api.routes.plugins.user_limiter.enabled", False):
             with pytest.raises(HTTPException) as exc:
@@ -326,7 +326,7 @@ class TestDisabledPluginIsRefusedInTheRouteToo:
         )
         manager = MagicMock()
         manager.get_plugin.return_value = plugin
-        manager.is_enabled.return_value = True
+        manager.is_loaded.return_value = True
 
         with patch("app.api.routes.plugins.user_limiter.enabled", False), \
              patch("app.api.routes.plugins.get_audit_logger_db"):
@@ -462,3 +462,60 @@ class TestMenuActionThroughTheRealStack:
 
         assert response.status_code == 403
         assert "disabled" not in response.json()["detail"]
+
+
+class TestRunPluginMenuActionRequiresLoadedNotJustEnabled:
+    """#448 review finding 1: a failed-to-start plugin must not be dispatchable.
+
+    is_enabled() answers the database's question ("is this plugin on"), which
+    stays True even when THIS worker's enable_plugin() call itself failed
+    (on_startup() raised) - the instance sits in _plugins but never entered
+    _enabled. The route must key its guard off is_loaded(), not is_enabled().
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_enablement_state(self):
+        from app.services import plugin_enablement as pe
+
+        pe.invalidate()
+        pe._failed_until.clear()
+        yield
+        pe.invalidate()
+        pe._failed_until.clear()
+
+    async def test_a_plugin_whose_on_startup_raised_is_refused(self, tmp_path):
+        from app.plugins.manager import PluginManager
+        from app.services import plugin_enablement as pe
+
+        manager = PluginManager(plugins_dir=tmp_path)
+
+        plugin = _declaring_plugin()
+        plugin.metadata = MagicMock(required_permissions=[])
+        plugin.on_startup = AsyncMock(side_effect=RuntimeError("boom"))
+        plugin.run_menu_action = AsyncMock()
+        manager._plugins["demo"] = plugin
+
+        with patch.object(
+            pe,
+            "_fetch",
+            return_value={"demo": {"granted_permissions": [], "granted_api_scopes": []}},
+        ), patch.object(pe, "_get_manager", return_value=manager):
+            await pe.reconcile_worker()
+
+        # on_startup() blew up: the instance is loaded but never entered
+        # _enabled, while the DB (and therefore is_enabled()) still says "on".
+        assert manager.get_plugin("demo") is plugin
+        assert manager.is_loaded("demo") is False
+        assert manager.is_enabled("demo") is True
+
+        with patch("app.api.routes.plugins.user_limiter.enabled", False):
+            with pytest.raises(HTTPException) as exc:
+                await run_plugin_menu_action(
+                    request=MagicMock(), response=MagicMock(),
+                    name="demo", action_id="do_it", db=MagicMock(),
+                    current_user=MagicMock(username="admin"),
+                    plugin_manager=manager,
+                )
+
+        assert exc.value.status_code == 404
+        plugin.run_menu_action.assert_not_awaited()

--- a/backend/tests/plugins/test_restart_required_route.py
+++ b/backend/tests/plugins/test_restart_required_route.py
@@ -1,0 +1,83 @@
+"""GET /api/plugins/{name} surfaces restart_required (#448 review finding 3).
+
+The manager-level logic (PluginManager.router_restart_required()) is pinned
+in test_plugin_manager.py::TestRouterRestartRequired. These tests go one
+layer up and prove the route actually wires that value into the response.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.api.routes.plugins import get_plugin_details
+from app.plugins.base import PluginMetadata
+from app.plugins.manager import PluginManager
+
+
+def _plugin(has_router: bool) -> MagicMock:
+    plugin = MagicMock()
+    plugin.metadata = PluginMetadata(
+        name="demo", version="1.0.0", display_name="Demo",
+        description="", author="test",
+    )
+    plugin.get_ui_manifest.return_value = None
+    plugin.get_router.return_value = MagicMock() if has_router else None
+    plugin.get_background_tasks.return_value = []
+    plugin.get_dashboard_panel.return_value = None
+    plugin.get_translations.return_value = None
+    plugin.get_config_schema.return_value = None
+    plugin.get_default_config.return_value = {}
+    return plugin
+
+
+@pytest.mark.asyncio
+class TestGetPluginDetailsRestartRequiredField:
+    @pytest.fixture(autouse=True)
+    def _reset_enablement_cache(self):
+        from app.services import plugin_enablement as pe
+
+        pe.invalidate()
+        yield
+        pe.invalidate()
+
+    async def _call(self, mgr: PluginManager):
+        with patch(
+            "app.api.routes.plugins.plugin_service.get_installed_plugin", return_value=None
+        ), patch("app.api.routes.plugins.user_limiter.enabled", False):
+            return await get_plugin_details(
+                request=MagicMock(), response=MagicMock(),
+                name="demo", db=MagicMock(),
+                current_user=MagicMock(), plugin_manager=mgr,
+            )
+
+    async def test_true_for_a_router_carrying_plugin_enabled_after_startup(self, tmp_path):
+        mgr = PluginManager(plugins_dir=tmp_path)
+        mgr.get_router()  # simulate the startup mount, before this plugin exists
+
+        plugin = _plugin(has_router=True)
+        mgr._plugins["demo"] = plugin
+        mgr._enabled.add("demo")
+
+        result = await self._call(mgr)
+        assert result.restart_required is True
+
+    async def test_false_for_a_router_carrying_plugin_mounted_at_startup(self, tmp_path):
+        mgr = PluginManager(plugins_dir=tmp_path)
+        plugin = _plugin(has_router=True)
+        mgr._plugins["demo"] = plugin
+        mgr._enabled.add("demo")
+        mgr.get_router()  # startup mount runs with the plugin already enabled
+
+        result = await self._call(mgr)
+        assert result.restart_required is False
+
+    async def test_false_for_a_plugin_without_a_router(self, tmp_path):
+        mgr = PluginManager(plugins_dir=tmp_path)
+        plugin = _plugin(has_router=False)
+        mgr._plugins["demo"] = plugin
+        mgr._enabled.add("demo")
+        mgr.get_router()
+
+        result = await self._call(mgr)
+        assert result.restart_required is False

--- a/backend/tests/plugins/test_restart_required_route.py
+++ b/backend/tests/plugins/test_restart_required_route.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import APIRouter
 
 from app.api.routes.plugins import get_plugin_details
 from app.plugins.base import PluginMetadata
@@ -22,7 +23,11 @@ def _plugin(has_router: bool) -> MagicMock:
         description="", author="test",
     )
     plugin.get_ui_manifest.return_value = None
-    plugin.get_router.return_value = MagicMock() if has_router else None
+    # A real APIRouter, not a MagicMock: get_router() feeds the value straight
+    # into router.include_router(), whose circularity check (FastAPI >=0.115.x)
+    # rejects a mock. The mock only passed on the older local FastAPI that
+    # lacked that check - exactly the local-green / CI-red gap here.
+    plugin.get_router.return_value = APIRouter() if has_router else None
     plugin.get_background_tasks.return_value = []
     plugin.get_dashboard_panel.return_value = None
     plugin.get_translations.return_value = None

--- a/backend/tests/services/test_plugin_enablement.py
+++ b/backend/tests/services/test_plugin_enablement.py
@@ -281,3 +281,40 @@ class TestReconcile:
         with patch.object(pe, "_fetch", return_value={"demo": _grant()}), \
              patch.object(pe, "_get_manager", side_effect=RuntimeError("boom")):
             await pe.reconcile_worker()  # must not raise
+
+
+class TestReconcileDependency:
+    async def test_dependency_runs_the_reconcile(self):
+        from app.api.deps import reconciled_plugin_state
+
+        with patch.object(pe, "reconcile_worker", new=AsyncMock()) as reconcile:
+            await reconciled_plugin_state()
+
+        reconcile.assert_awaited_once()
+
+    def test_every_entry_point_declares_the_dependency(self):
+        """The routes that must not report stale state.
+
+        A route added later without the dependency would silently reintroduce
+        the bug for its own view, so the list is asserted rather than trusted.
+        """
+        import inspect
+
+        from app.api.deps import reconciled_plugin_state
+        from app.api.routes import plugins as plugins_routes
+        from app.api.routes import status_bar as status_bar_routes
+
+        expected = [
+            (plugins_routes.list_plugins, "list_plugins"),
+            (plugins_routes.get_ui_manifest, "get_ui_manifest"),
+            (plugins_routes.run_plugin_menu_action, "run_plugin_menu_action"),
+            (status_bar_routes.get_statusbar_config, "get_statusbar_config"),
+            (status_bar_routes.get_statusbar_state, "get_statusbar_state"),
+        ]
+        for func, label in expected:
+            deps = [
+                param.default.dependency
+                for param in inspect.signature(func).parameters.values()
+                if hasattr(param.default, "dependency")
+            ]
+            assert reconciled_plugin_state in deps, f"{label} misses the reconcile dependency"

--- a/backend/tests/services/test_plugin_enablement.py
+++ b/backend/tests/services/test_plugin_enablement.py
@@ -9,25 +9,35 @@ import pytest
 from app.services import plugin_enablement as pe
 
 
+def _grant(permissions=None, scopes=None) -> dict:
+    """Build a ``_fetch()``-shaped cache entry for one plugin."""
+    return {
+        "granted_permissions": list(permissions or []),
+        "granted_api_scopes": list(scopes or []),
+    }
+
+
 @pytest.fixture(autouse=True)
 def _clean_cache():
     pe.invalidate()
     pe._failed_until.clear()
+    pe._reconcile_lock = asyncio.Lock()
     yield
     pe.invalidate()
     pe._failed_until.clear()
+    pe._reconcile_lock = asyncio.Lock()
 
 
 class TestCache:
     async def test_refresh_loads_names_and_permissions(self):
-        with patch.object(pe, "_fetch", return_value={"demo": ["files.read"]}):
+        with patch.object(pe, "_fetch", return_value={"demo": _grant(["files.read"])}):
             await pe.refresh()
         assert pe.enabled_plugins() == {"demo": ["files.read"]}
         assert pe.is_enabled("demo") is True
         assert pe.is_enabled("other") is False
 
     async def test_second_refresh_inside_the_ttl_does_not_hit_the_db(self):
-        with patch.object(pe, "_fetch", return_value={"demo": []}) as fetch:
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}) as fetch:
             await pe.refresh()
             await pe.refresh()
         assert fetch.call_count == 1
@@ -35,14 +45,14 @@ class TestCache:
     async def test_refresh_after_the_ttl_hits_the_db_again(self, monkeypatch):
         clock = {"now": 1000.0}
         monkeypatch.setattr(pe, "_monotonic", lambda: clock["now"])
-        with patch.object(pe, "_fetch", return_value={"demo": []}) as fetch:
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}) as fetch:
             await pe.refresh()
             clock["now"] += pe.CACHE_TTL_SECONDS + 0.1
             await pe.refresh()
         assert fetch.call_count == 2
 
     async def test_force_bypasses_the_ttl(self):
-        with patch.object(pe, "_fetch", return_value={"demo": []}) as fetch:
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}) as fetch:
             await pe.refresh()
             await pe.refresh(force=True)
         assert fetch.call_count == 2
@@ -55,7 +65,7 @@ class TestCache:
                 await pe.refresh()
 
     async def test_stale_cache_survives_a_failed_refresh(self):
-        with patch.object(pe, "_fetch", return_value={"demo": []}):
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}):
             await pe.refresh()
         with patch.object(pe, "_fetch", side_effect=RuntimeError("db down")):
             with pytest.raises(RuntimeError):
@@ -68,18 +78,29 @@ class TestCache:
 
     async def test_sync_readers_never_touch_the_db(self):
         """Pinned because get_all_plugins() has no session to give them."""
-        with patch.object(pe, "_fetch", return_value={"demo": []}):
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}):
             await pe.refresh()
         with patch.object(pe, "_fetch", side_effect=AssertionError("sync read hit the DB")):
             assert pe.is_enabled("demo") is True
             assert pe.enabled_plugins() == {"demo": []}
 
     async def test_invalidate_forces_the_next_refresh(self):
-        with patch.object(pe, "_fetch", return_value={"demo": []}) as fetch:
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}) as fetch:
             await pe.refresh()
             pe.invalidate()
             await pe.refresh()
         assert fetch.call_count == 2
+
+    async def test_enabled_plugins_carries_only_permissions_not_scopes(self):
+        """enabled_plugins() must keep its documented ``name -> granted_permissions``
+        contract even though the internal cache now also carries API scopes."""
+        with patch.object(
+            pe,
+            "_fetch",
+            return_value={"demo": _grant(["files.read"], ["read:storage"])},
+        ):
+            await pe.refresh()
+        assert pe.enabled_plugins() == {"demo": ["files.read"]}
 
 
 def _fake_manager(loaded: set) -> MagicMock:
@@ -102,7 +123,7 @@ def _fake_manager(loaded: set) -> MagicMock:
 class TestReconcile:
     async def test_loads_what_the_database_says_is_missing(self):
         manager = _fake_manager(set())
-        with patch.object(pe, "_fetch", return_value={"demo": ["files.read"]}), \
+        with patch.object(pe, "_fetch", return_value={"demo": _grant(["files.read"])}), \
              patch.object(pe, "_get_manager", return_value=manager):
             await pe.reconcile_worker()
 
@@ -110,6 +131,23 @@ class TestReconcile:
         args, kwargs = manager.enable_plugin.await_args
         assert args[0] == "demo"
         assert args[1] == ["files.read"]
+
+    async def test_grants_the_api_scopes_to_the_manager(self):
+        """External plugins are routed through granted_api_scopes (manager.py:463-465);
+        dropping it leaves a lazily-reconciled external plugin with zero
+        capabilities even though it is now counted as enabled."""
+        manager = _fake_manager(set())
+        with patch.object(
+            pe,
+            "_fetch",
+            return_value={"demo": _grant(["files.read"], ["read:storage", "read:network"])},
+        ), patch.object(pe, "_get_manager", return_value=manager):
+            await pe.reconcile_worker()
+
+        manager.enable_plugin.assert_awaited_once()
+        args, kwargs = manager.enable_plugin.await_args
+        assert args[0] == "demo"
+        assert sorted(kwargs["granted_api_scopes"]) == ["read:network", "read:storage"]
 
     async def test_drops_what_the_database_no_longer_lists(self):
         manager = _fake_manager({"demo"})
@@ -125,7 +163,7 @@ class TestReconcile:
         from app.core import lifespan
 
         manager = _fake_manager(set())
-        with patch.object(pe, "_fetch", return_value={"demo": []}), \
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}), \
              patch.object(pe, "_get_manager", return_value=manager), \
              patch.object(lifespan, "IS_PRIMARY_WORKER", False):
             await pe.reconcile_worker()
@@ -134,7 +172,7 @@ class TestReconcile:
 
         manager = _fake_manager(set())
         pe.invalidate()
-        with patch.object(pe, "_fetch", return_value={"demo": []}), \
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}), \
              patch.object(pe, "_get_manager", return_value=manager), \
              patch.object(lifespan, "IS_PRIMARY_WORKER", True):
             await pe.reconcile_worker()
@@ -152,8 +190,9 @@ class TestReconcile:
 
         manager.enable_plugin = AsyncMock(side_effect=_enable)
 
-        with patch.object(pe, "_fetch", return_value={"bad": [], "good": []}), \
-             patch.object(pe, "_get_manager", return_value=manager):
+        with patch.object(
+            pe, "_fetch", return_value={"bad": _grant(), "good": _grant()}
+        ), patch.object(pe, "_get_manager", return_value=manager):
             await pe.reconcile_worker()
 
         assert "good" in manager._enabled
@@ -162,12 +201,32 @@ class TestReconcile:
         manager = _fake_manager(set())
         manager.enable_plugin = AsyncMock(return_value=False)
 
-        with patch.object(pe, "_fetch", return_value={"demo": []}), \
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}), \
              patch.object(pe, "_get_manager", return_value=manager):
             await pe.reconcile_worker()
             await pe.reconcile_worker()
 
         assert manager.enable_plugin.await_count == 1
+
+    async def test_a_failed_plugin_is_retried_once_the_backoff_expires(self, monkeypatch):
+        """Proves the release half of the backoff, not just the block: removing
+        ``+ FAILED_RETRY_SECONDS`` (turning the pause permanent) leaves this red."""
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(pe, "_monotonic", lambda: clock["now"])
+
+        manager = _fake_manager(set())
+        manager.enable_plugin = AsyncMock(return_value=False)
+
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}), \
+             patch.object(pe, "_get_manager", return_value=manager):
+            await pe.reconcile_worker()
+            assert manager.enable_plugin.await_count == 1
+
+            clock["now"] += pe.FAILED_RETRY_SECONDS + 0.1
+            pe.invalidate()
+            await pe.reconcile_worker()
+
+        assert manager.enable_plugin.await_count == 2
 
     async def test_concurrent_reconciles_enable_only_once(self):
         """Status-strip poll and plugin list arrive together in practice; both
@@ -184,18 +243,25 @@ class TestReconcile:
 
         manager.enable_plugin = AsyncMock(side_effect=_slow_enable)
 
-        with patch.object(pe, "_fetch", return_value={"demo": []}), \
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}), \
              patch.object(pe, "_get_manager", return_value=manager):
             first = asyncio.create_task(pe.reconcile_worker())
-            await started.wait()
-            # wait_for is what makes this test fail CLEANLY under mutation:
-            # without the single-flight guard the second call queues on the
-            # lock, release.set() is never reached, and the test would hang
-            # forever instead of going red (no pytest timeout is configured).
-            # With the guard it returns immediately; without it, TimeoutError.
-            await asyncio.wait_for(pe.reconcile_worker(), timeout=1.0)
-            release.set()
-            await first
+            try:
+                await started.wait()
+                # wait_for is what makes this test fail CLEANLY under mutation:
+                # without the single-flight guard the second call queues on the
+                # lock, release.set() is never reached, and the test would hang
+                # forever instead of going red (no pytest timeout is configured).
+                # With the guard it returns immediately; without it, TimeoutError.
+                await asyncio.wait_for(pe.reconcile_worker(), timeout=1.0)
+            finally:
+                # If the assertion/wait_for above raises, `first` must still be
+                # released and awaited - otherwise it stays pending forever
+                # holding _reconcile_lock, and every later test in the process
+                # single-flights out immediately (poisoned suite, see #448
+                # review finding 3).
+                release.set()
+                await first
 
         assert manager.enable_plugin.await_count == 1
 
@@ -207,3 +273,11 @@ class TestReconcile:
 
         manager.enable_plugin.assert_not_awaited()
         manager.disable_plugin.assert_not_awaited()
+
+    async def test_get_manager_failure_does_not_propagate(self):
+        """The docstring promises reconcile_worker() never raises. _get_manager()
+        constructs the PluginManager singleton and can touch settings; a failure
+        there must not fail the caller's request."""
+        with patch.object(pe, "_fetch", return_value={"demo": _grant()}), \
+             patch.object(pe, "_get_manager", side_effect=RuntimeError("boom")):
+            await pe.reconcile_worker()  # must not raise

--- a/backend/tests/services/test_plugin_enablement.py
+++ b/backend/tests/services/test_plugin_enablement.py
@@ -1,0 +1,79 @@
+"""Cross-worker plugin enablement: the DB-backed cache (#448)."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.services import plugin_enablement as pe
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    pe.invalidate()
+    yield
+    pe.invalidate()
+
+
+class TestCache:
+    async def test_refresh_loads_names_and_permissions(self):
+        with patch.object(pe, "_fetch", return_value={"demo": ["files.read"]}):
+            await pe.refresh()
+        assert pe.enabled_plugins() == {"demo": ["files.read"]}
+        assert pe.is_enabled("demo") is True
+        assert pe.is_enabled("other") is False
+
+    async def test_second_refresh_inside_the_ttl_does_not_hit_the_db(self):
+        with patch.object(pe, "_fetch", return_value={"demo": []}) as fetch:
+            await pe.refresh()
+            await pe.refresh()
+        assert fetch.call_count == 1
+
+    async def test_refresh_after_the_ttl_hits_the_db_again(self, monkeypatch):
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(pe, "_monotonic", lambda: clock["now"])
+        with patch.object(pe, "_fetch", return_value={"demo": []}) as fetch:
+            await pe.refresh()
+            clock["now"] += pe.CACHE_TTL_SECONDS + 0.1
+            await pe.refresh()
+        assert fetch.call_count == 2
+
+    async def test_force_bypasses_the_ttl(self):
+        with patch.object(pe, "_fetch", return_value={"demo": []}) as fetch:
+            await pe.refresh()
+            await pe.refresh(force=True)
+        assert fetch.call_count == 2
+
+    async def test_db_error_propagates_instead_of_being_swallowed(self):
+        """The two callers must fail in opposite directions, so the helper
+        does not get to decide - it hands the failure up."""
+        with patch.object(pe, "_fetch", side_effect=RuntimeError("db down")):
+            with pytest.raises(RuntimeError):
+                await pe.refresh()
+
+    async def test_stale_cache_survives_a_failed_refresh(self):
+        with patch.object(pe, "_fetch", return_value={"demo": []}):
+            await pe.refresh()
+        with patch.object(pe, "_fetch", side_effect=RuntimeError("db down")):
+            with pytest.raises(RuntimeError):
+                await pe.refresh(force=True)
+        assert pe.enabled_plugins() == {"demo": []}
+
+    def test_no_data_before_the_first_refresh(self):
+        assert pe.enabled_plugins() is None
+        assert pe.is_enabled("demo") is None
+
+    async def test_sync_readers_never_touch_the_db(self):
+        """Pinned because get_all_plugins() has no session to give them."""
+        with patch.object(pe, "_fetch", return_value={"demo": []}):
+            await pe.refresh()
+        with patch.object(pe, "_fetch", side_effect=AssertionError("sync read hit the DB")):
+            assert pe.is_enabled("demo") is True
+            assert pe.enabled_plugins() == {"demo": []}
+
+    async def test_invalidate_forces_the_next_refresh(self):
+        with patch.object(pe, "_fetch", return_value={"demo": []}) as fetch:
+            await pe.refresh()
+            pe.invalidate()
+            await pe.refresh()
+        assert fetch.call_count == 2

--- a/backend/tests/services/test_plugin_enablement.py
+++ b/backend/tests/services/test_plugin_enablement.py
@@ -1,7 +1,8 @@
 """Cross-worker plugin enablement: the DB-backed cache (#448)."""
 from __future__ import annotations
 
-from unittest.mock import patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -11,8 +12,10 @@ from app.services import plugin_enablement as pe
 @pytest.fixture(autouse=True)
 def _clean_cache():
     pe.invalidate()
+    pe._failed_until.clear()
     yield
     pe.invalidate()
+    pe._failed_until.clear()
 
 
 class TestCache:
@@ -77,3 +80,130 @@ class TestCache:
             pe.invalidate()
             await pe.refresh()
         assert fetch.call_count == 2
+
+
+def _fake_manager(loaded: set) -> MagicMock:
+    manager = MagicMock()
+    manager._enabled = set(loaded)
+
+    async def _enable(name, perms, db, start_background_tasks=True, **kw):
+        manager._enabled.add(name)
+        return True
+
+    async def _disable(name):
+        manager._enabled.discard(name)
+        return True
+
+    manager.enable_plugin = AsyncMock(side_effect=_enable)
+    manager.disable_plugin = AsyncMock(side_effect=_disable)
+    return manager
+
+
+class TestReconcile:
+    async def test_loads_what_the_database_says_is_missing(self):
+        manager = _fake_manager(set())
+        with patch.object(pe, "_fetch", return_value={"demo": ["files.read"]}), \
+             patch.object(pe, "_get_manager", return_value=manager):
+            await pe.reconcile_worker()
+
+        manager.enable_plugin.assert_awaited_once()
+        args, kwargs = manager.enable_plugin.await_args
+        assert args[0] == "demo"
+        assert args[1] == ["files.read"]
+
+    async def test_drops_what_the_database_no_longer_lists(self):
+        manager = _fake_manager({"demo"})
+        with patch.object(pe, "_fetch", return_value={}), \
+             patch.object(pe, "_get_manager", return_value=manager):
+            await pe.reconcile_worker()
+
+        manager.disable_plugin.assert_awaited_once_with("demo")
+
+    async def test_background_tasks_only_on_the_primary_worker(self):
+        """Four workers each starting a plugin's background tasks would turn a
+        display bug into real damage."""
+        from app.core import lifespan
+
+        manager = _fake_manager(set())
+        with patch.object(pe, "_fetch", return_value={"demo": []}), \
+             patch.object(pe, "_get_manager", return_value=manager), \
+             patch.object(lifespan, "IS_PRIMARY_WORKER", False):
+            await pe.reconcile_worker()
+
+        assert manager.enable_plugin.await_args.kwargs["start_background_tasks"] is False
+
+        manager = _fake_manager(set())
+        pe.invalidate()
+        with patch.object(pe, "_fetch", return_value={"demo": []}), \
+             patch.object(pe, "_get_manager", return_value=manager), \
+             patch.object(lifespan, "IS_PRIMARY_WORKER", True):
+            await pe.reconcile_worker()
+
+        assert manager.enable_plugin.await_args.kwargs["start_background_tasks"] is True
+
+    async def test_a_throwing_plugin_does_not_block_the_others(self):
+        manager = _fake_manager(set())
+
+        async def _enable(name, perms, db, start_background_tasks=True, **kw):
+            if name == "bad":
+                raise RuntimeError("on_startup blew up")
+            manager._enabled.add(name)
+            return True
+
+        manager.enable_plugin = AsyncMock(side_effect=_enable)
+
+        with patch.object(pe, "_fetch", return_value={"bad": [], "good": []}), \
+             patch.object(pe, "_get_manager", return_value=manager):
+            await pe.reconcile_worker()
+
+        assert "good" in manager._enabled
+
+    async def test_a_failed_plugin_is_not_retried_immediately(self):
+        manager = _fake_manager(set())
+        manager.enable_plugin = AsyncMock(return_value=False)
+
+        with patch.object(pe, "_fetch", return_value={"demo": []}), \
+             patch.object(pe, "_get_manager", return_value=manager):
+            await pe.reconcile_worker()
+            await pe.reconcile_worker()
+
+        assert manager.enable_plugin.await_count == 1
+
+    async def test_concurrent_reconciles_enable_only_once(self):
+        """Status-strip poll and plugin list arrive together in practice; both
+        would see the same diff and run on_startup() twice in parallel."""
+        manager = _fake_manager(set())
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _slow_enable(name, perms, db, start_background_tasks=True, **kw):
+            started.set()
+            await release.wait()
+            manager._enabled.add(name)
+            return True
+
+        manager.enable_plugin = AsyncMock(side_effect=_slow_enable)
+
+        with patch.object(pe, "_fetch", return_value={"demo": []}), \
+             patch.object(pe, "_get_manager", return_value=manager):
+            first = asyncio.create_task(pe.reconcile_worker())
+            await started.wait()
+            # wait_for is what makes this test fail CLEANLY under mutation:
+            # without the single-flight guard the second call queues on the
+            # lock, release.set() is never reached, and the test would hang
+            # forever instead of going red (no pytest timeout is configured).
+            # With the guard it returns immediately; without it, TimeoutError.
+            await asyncio.wait_for(pe.reconcile_worker(), timeout=1.0)
+            release.set()
+            await first
+
+        assert manager.enable_plugin.await_count == 1
+
+    async def test_db_failure_leaves_the_worker_untouched(self):
+        manager = _fake_manager({"demo"})
+        with patch.object(pe, "_fetch", side_effect=RuntimeError("db down")), \
+             patch.object(pe, "_get_manager", return_value=manager):
+            await pe.reconcile_worker()
+
+        manager.enable_plugin.assert_not_awaited()
+        manager.disable_plugin.assert_not_awaited()

--- a/backend/tests/services/test_plugin_enablement.py
+++ b/backend/tests/services/test_plugin_enablement.py
@@ -91,6 +91,14 @@ class TestCache:
             await pe.refresh()
         assert fetch.call_count == 2
 
+    async def test_invalidate_clears_the_failed_backoff(self):
+        """An admin who fixes and re-enables a plugin must not have to wait
+        out the full backoff on other workers - invalidate() is exactly the
+        signal that the DB state changed."""
+        pe._failed_until["demo"] = pe._monotonic() + pe.FAILED_RETRY_SECONDS
+        pe.invalidate()
+        assert pe._failed_until == {}
+
     async def test_enabled_plugins_carries_only_permissions_not_scopes(self):
         """enabled_plugins() must keep its documented ``name -> granted_permissions``
         contract even though the internal cache now also carries API scopes."""
@@ -101,6 +109,71 @@ class TestCache:
         ):
             await pe.refresh()
         assert pe.enabled_plugins() == {"demo": ["files.read"]}
+
+
+class TestFetchAgainstARealDatabase:
+    """``_fetch()`` itself, against a real DB session (#448 review finding 4).
+
+    Every other test in this file patches ``_fetch`` away, so the column
+    names, the ``is_enabled == True`` filter, and the row -> dict shape were
+    only eyeballed. A typo there raises inside ``asyncio.to_thread`` ->
+    ``refresh()`` raises -> every gated plugin request 500s while the display
+    silently falls back forever - and none of the mocked tests would notice.
+
+    ``_fetch()`` opens its own ``SessionLocal()`` rather than taking a
+    session. Rather than monkeypatching ``app.core.database.SessionLocal``
+    itself (module-global, riskier to leave patched across tests sharing the
+    same process), this rebinds a fresh sessionmaker to the ``db_session``
+    fixture's own engine and hands that to ``_fetch`` via ``pe._fetch`` calling
+    ``SessionLocal()`` -> the same underlying (StaticPool, single-connection)
+    SQLite database the fixture already wrote to, so the rows are visible
+    without needing the two sessions to share a transaction.
+    """
+
+    def test_fetch_returns_only_enabled_plugins_with_normalized_columns(
+        self, db_session, monkeypatch
+    ):
+        from sqlalchemy.orm import sessionmaker
+
+        import app.core.database as database_module
+        from app.models.plugin import InstalledPlugin
+
+        monkeypatch.setattr(
+            database_module, "SessionLocal", sessionmaker(bind=db_session.get_bind())
+        )
+
+        db_session.add_all([
+            InstalledPlugin(
+                name="alpha", version="1.0.0", display_name="Alpha",
+                is_enabled=True,
+                granted_permissions=["files.read"],
+                granted_api_scopes=["read:storage"],
+            ),
+            InstalledPlugin(
+                name="beta", version="1.0.0", display_name="Beta",
+                is_enabled=True,
+                granted_permissions=None,
+                granted_api_scopes=None,
+            ),
+            InstalledPlugin(
+                name="gamma", version="1.0.0", display_name="Gamma",
+                is_enabled=False,
+                granted_permissions=["files.read"],
+                granted_api_scopes=["read:storage"],
+            ),
+        ])
+        db_session.commit()
+
+        result = pe._fetch()
+
+        assert result == {
+            "alpha": {
+                "granted_permissions": ["files.read"],
+                "granted_api_scopes": ["read:storage"],
+            },
+            "beta": {"granted_permissions": [], "granted_api_scopes": []},
+        }
+        assert "gamma" not in result
 
 
 def _fake_manager(loaded: set) -> MagicMock:
@@ -301,6 +374,7 @@ class TestReconcileDependency:
         import inspect
 
         from app.api.deps import reconciled_plugin_state
+        from app.api.routes import dashboard as dashboard_routes
         from app.api.routes import plugins as plugins_routes
         from app.api.routes import status_bar as status_bar_routes
 
@@ -310,6 +384,7 @@ class TestReconcileDependency:
             (plugins_routes.run_plugin_menu_action, "run_plugin_menu_action"),
             (status_bar_routes.get_statusbar_config, "get_statusbar_config"),
             (status_bar_routes.get_statusbar_state, "get_statusbar_state"),
+            (dashboard_routes.get_plugin_panel, "get_plugin_panel"),
         ]
         for func, label in expected:
             deps = [
@@ -318,3 +393,20 @@ class TestReconcileDependency:
                 if hasattr(param.default, "dependency")
             ]
             assert reconciled_plugin_state in deps, f"{label} misses the reconcile dependency"
+
+    def test_toggle_plugin_does_not_declare_the_dependency(self):
+        """toggle_plugin must NOT reconcile - it would race the toggle's own
+        local enable/disable call with a reconcile reading the pre-toggle DB
+        state.
+        """
+        import inspect
+
+        from app.api.deps import reconciled_plugin_state
+        from app.api.routes import plugins as plugins_routes
+
+        deps = [
+            param.default.dependency
+            for param in inspect.signature(plugins_routes.toggle_plugin).parameters.values()
+            if hasattr(param.default, "dependency")
+        ]
+        assert reconciled_plugin_state not in deps

--- a/docs/superpowers/plans/2026-07-23-plugin-enablement-cross-worker.md
+++ b/docs/superpowers/plans/2026-07-23-plugin-enablement-cross-worker.md
@@ -209,7 +209,7 @@ def _fetch() -> Dict[str, List[str]]:
     try:
         rows = (
             db.query(InstalledPlugin)
-            .filter(InstalledPlugin.is_enabled == True)  # noqa: E712 - SQL boolean
+            .filter(InstalledPlugin.is_enabled == True)  # SQL boolean filter - `is True` would break the query (E712 is globally ignored for this reason)
             .all()
         )
         return {row.name: list(row.granted_permissions or []) for row in rows}
@@ -564,7 +564,12 @@ class TestReconcile:
              patch.object(pe, "_get_manager", return_value=manager):
             first = asyncio.create_task(pe.reconcile_worker())
             await started.wait()
-            await pe.reconcile_worker()      # must return immediately, not enable again
+            # wait_for is what makes this test fail CLEANLY under mutation:
+            # without the single-flight guard the second call queues on the
+            # lock, release.set() is never reached, and the test would hang
+            # forever instead of going red (no pytest timeout is configured).
+            # With the guard it returns immediately; without it, TimeoutError.
+            await asyncio.wait_for(pe.reconcile_worker(), timeout=1.0)
             release.set()
             await first
 
@@ -622,7 +627,7 @@ async def reconcile_worker() -> None:
     async with _reconcile_lock:
         try:
             await refresh()
-        except Exception:  # noqa: BLE001 - a DB blip must not fail the request
+        except Exception:  # broad on purpose: a DB blip must not fail the request
             logger.warning("plugin enablement refresh failed", exc_info=True)
             return
 
@@ -653,7 +658,7 @@ async def reconcile_worker() -> None:
                         db,
                         start_background_tasks=lifespan.IS_PRIMARY_WORKER,
                     )
-            except Exception:  # noqa: BLE001 - one bad plugin must not stop the rest
+            except Exception:  # broad on purpose: one bad plugin must not stop the rest
                 logger.warning("lazy enable of plugin %s failed", name, exc_info=True)
                 ok = False
             if not ok:
@@ -662,7 +667,7 @@ async def reconcile_worker() -> None:
         for name in loaded - set(desired):
             try:
                 await manager.disable_plugin(name)
-            except Exception:  # noqa: BLE001 - same reasoning as above
+            except Exception:  # broad on purpose: same reasoning as above
                 logger.warning("lazy disable of plugin %s failed", name, exc_info=True)
 ```
 
@@ -673,7 +678,7 @@ Expected: PASS (16 Tests)
 
 - [ ] **Step 5: Prove the single-flight test discriminates**
 
-Entferne testweise die beiden Zeilen `if _reconcile_lock.locked(): return`, führe `python -m pytest tests/services/test_plugin_enablement.py -q --no-cov -k concurrent` aus — der Test **muss** fehlschlagen (`await_count == 2`). Danach zurückbauen und erneut laufen lassen.
+Entferne testweise die beiden Zeilen `if _reconcile_lock.locked(): return`, führe `python -m pytest tests/services/test_plugin_enablement.py -q --no-cov -k concurrent` aus — der Test **muss** nach ~1 s mit `asyncio.TimeoutError` fehlschlagen (der zweite Aufruf hängt am Lock, das `wait_for` schneidet ihn ab). Danach zurückbauen und erneut laufen lassen.
 
 - [ ] **Step 6: Lint + commit**
 
@@ -842,6 +847,22 @@ Mechanische Übersetzung, Assertions bleiben unangetastet:
 Achtung beim Plugin-Namen: die alten Patches lieferten den Zustand **für jeden** Namen zurück; der neue Cache ist ein Mapping, also muss der im Test verwendete Name (`my_plugin`) als Schlüssel auftauchen, sonst gilt das Plugin als deaktiviert.
 
 Ebenso in `backend/tests/plugins/test_plugin_menu_actions.py`: `TestMenuActionThroughTheRealStack` patcht `plugin_gate._fetch_plugin_status` → auf `plugin_enablement._fetch` umstellen (`{"demo": []}` für aktiviert, `{}` für deaktiviert) und `plugin_gate._plugin_cache.clear()` → `plugin_enablement.invalidate()`.
+
+**Zusätzlich in dieser Datei eine Autouse-Reset-Fixture ergänzen** (auf `TestMenuActionThroughTheRealStack` scoped oder modulweit):
+
+```python
+@pytest.fixture(autouse=True)
+def _reset_enablement_state():
+    from app.services import plugin_enablement as pe
+
+    pe.invalidate()
+    pe._failed_until.clear()
+    yield
+    pe.invalidate()
+    pe._failed_until.clear()
+```
+
+Grund: Der Helper-Zustand ist Modulzustand und überlebt Dateigrenzen im selben pytest-Prozess. Die Stack-Tests wärmen den Cache (`{"demo": []}`); ohne Abräumen liest jede alphabetisch spätere Datei, die `manager.is_enabled()` konsultiert, fremden Cache statt lokalen Zustand. Heute überlebt `test_plugins.py:356` das nur, weil es zufällig `is False` assertiert — das ist Glück, keine Isolation.
 
 - [ ] **Step 6: Run the ported suites**
 

--- a/docs/superpowers/plans/2026-07-23-plugin-enablement-cross-worker.md
+++ b/docs/superpowers/plans/2026-07-23-plugin-enablement-cross-worker.md
@@ -1,0 +1,1059 @@
+# Plugin-Aktivierung über Worker hinweg — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** „Ist dieses Plugin aktiviert?" wird aus der Datenbank beantwortet statt aus prozess-lokalem Zustand, und jeder Worker gleicht sich beim nächsten Request selbst an — damit ein Toggle ohne Neustart auf allen vier Prod-Workern wirkt (#448).
+
+**Architecture:** Ein neuer Helper `services/plugin_enablement.py` hält `name -> granted_permissions` aus `installed_plugins` in einem TTL-Cache; der DB-Zugriff passiert ausschließlich in einer async `refresh()` über `asyncio.to_thread`. Synchrone Leser (`PluginManager.is_enabled()`, `get_all_plugins()`) konsumieren nur den warmen Cache. Eine async `reconcile_worker()` gleicht `PluginManager._enabled` an die DB an (single-flight), und `PluginGateMiddleware` wird zweiter Nutzer desselben Caches statt zweiter Implementierung.
+
+**Tech Stack:** Python 3.11+ / FastAPI / SQLAlchemy 2.0 / Pydantic v2, pytest (`asyncio_mode = "auto"`).
+
+**Spec:** `docs/superpowers/specs/2026-07-23-plugin-enablement-cross-worker-design.md`
+
+## Global Constraints
+
+- Backend-Tests laufen aus `backend/`: `python -m pytest <pfad> -q --no-cov` (`--no-cov` nötig, der Repo-Default schaltet Coverage an).
+- Lint: `python -m ruff check <geänderte dateien>` muss sauber sein (ein blankes `ruff` liegt nicht im PATH). Regelsatz `["E4","E7","E9","F"]`, `line-length = 100`.
+- Keine neuen Dependencies, keine DB-Migration. Die Tabelle `installed_plugins` bleibt unverändert.
+- Kommentare und Docstrings auf Englisch (Repo-Konvention); Commit-Betreff Englisch.
+- **Kein synchroner DB-Zugriff in einem synchronen Getter.** Der einzige DB-Read liegt in `refresh()` und läuft über `asyncio.to_thread`.
+- **Hintergrund-Tasks bleiben primary-only.** Der Reconcile übergibt `start_background_tasks=lifespan.IS_PRIMARY_WORKER`.
+- **`IS_PRIMARY_WORKER` nur als Modulattribut lesen** (`from app.core import lifespan` … `lifespan.IS_PRIMARY_WORKER`). Es wird erst nach dem Fork gesetzt (`lifespan.py:478`); ein `from app.core.lifespan import IS_PRIMARY_WORKER` friert dauerhaft `False` ein.
+- **Gegenläufige Fehlersemantik:** Anzeigepfade fallen bei DB-Fehler auf den letzten bekannten Zustand zurück; `PluginGateMiddleware` bleibt fail-closed.
+- Plugin-Router werden nicht nachgerüstet (Mounting nur beim Start, `lifespan.py:630-633`).
+
+---
+
+## File Structure
+
+**Neu:**
+
+| Datei | Verantwortung |
+|---|---|
+| `backend/app/services/plugin_enablement.py` | TTL-Cache `name -> granted_permissions`, `refresh()`, synchrone Accessoren, `reconcile_worker()` |
+| `backend/tests/services/test_plugin_enablement.py` | Cache, TTL, Fehlerweitergabe, Reconcile, Single-Flight, Primary-Gating |
+| `backend/tests/plugins/test_manager_enabled_readers.py` | Manager-Statusleser gegen den Cache, inkl. „zweiter Worker"-Test |
+| `backend/tests/middleware/test_plugin_gate_enablement.py` | Middleware nutzt den Helper und bleibt fail-closed |
+
+**Geändert:**
+
+| Datei | Änderung |
+|---|---|
+| `backend/app/plugins/manager.py` | `is_enabled()` und `get_all_plugins()` beantworten aus dem Cache (Fallback `_enabled`) |
+| `backend/app/middleware/plugin_gate.py` | eigener Cache/Fetch entfällt; `invalidate_plugin_cache()` delegiert an den Helper |
+| `backend/app/api/deps.py` | neue Dependency `reconciled_plugin_state` |
+| `backend/app/api/routes/plugins.py` | Dependency an `list_plugins`, `get_ui_manifest`, `run_plugin_menu_action` |
+| `backend/app/api/routes/status_bar.py` | Dependency an `get_statusbar_config`, `get_statusbar_state` |
+| `backend/app/plugins/CLAUDE.md` | Operator-Note: aus „Restart nötig" wird „binnen weniger Sekunden, außer bei Router-Plugins" |
+
+**Unverändert (und warum):** `iter_enabled_plugins()` und `PluginManager.get_ui_manifest()` lesen weiter `self._enabled`. Ihre Semantik ist **DB ∩ lokal geladen** — sie liefern Instanzen, und eine Instanz kann nur lokal existieren. Der Reconcile sorgt dafür, dass `_enabled` der DB entspricht; damit werden sie automatisch richtig, ohne Änderung.
+
+---
+
+## Task 1: Helper mit TTL-Cache
+
+**Files:**
+- Create: `backend/app/services/plugin_enablement.py`
+- Test: `backend/tests/services/test_plugin_enablement.py`
+
+**Interfaces:**
+- Consumes: `app.core.database.SessionLocal`, `app.models.plugin.InstalledPlugin`.
+- Produces:
+```python
+CACHE_TTL_SECONDS: float = 5.0
+async def refresh(force: bool = False) -> None      # raises on DB error
+def enabled_plugins() -> Optional[Dict[str, List[str]]]   # None = nie erfolgreich geladen
+def is_enabled(name: str) -> Optional[bool]               # None = keine Daten
+def invalidate() -> None
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/services/test_plugin_enablement.py`:
+
+```python
+"""Cross-worker plugin enablement: the DB-backed cache (#448)."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.services import plugin_enablement as pe
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    pe.invalidate()
+    yield
+    pe.invalidate()
+
+
+class TestCache:
+    async def test_refresh_loads_names_and_permissions(self):
+        with patch.object(pe, "_fetch", return_value={"demo": ["files.read"]}):
+            await pe.refresh()
+        assert pe.enabled_plugins() == {"demo": ["files.read"]}
+        assert pe.is_enabled("demo") is True
+        assert pe.is_enabled("other") is False
+
+    async def test_second_refresh_inside_the_ttl_does_not_hit_the_db(self):
+        with patch.object(pe, "_fetch", return_value={"demo": []}) as fetch:
+            await pe.refresh()
+            await pe.refresh()
+        assert fetch.call_count == 1
+
+    async def test_refresh_after_the_ttl_hits_the_db_again(self, monkeypatch):
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(pe, "_monotonic", lambda: clock["now"])
+        with patch.object(pe, "_fetch", return_value={"demo": []}) as fetch:
+            await pe.refresh()
+            clock["now"] += pe.CACHE_TTL_SECONDS + 0.1
+            await pe.refresh()
+        assert fetch.call_count == 2
+
+    async def test_force_bypasses_the_ttl(self):
+        with patch.object(pe, "_fetch", return_value={"demo": []}) as fetch:
+            await pe.refresh()
+            await pe.refresh(force=True)
+        assert fetch.call_count == 2
+
+    async def test_db_error_propagates_instead_of_being_swallowed(self):
+        """The two callers must fail in opposite directions, so the helper
+        does not get to decide - it hands the failure up."""
+        with patch.object(pe, "_fetch", side_effect=RuntimeError("db down")):
+            with pytest.raises(RuntimeError):
+                await pe.refresh()
+
+    async def test_stale_cache_survives_a_failed_refresh(self):
+        with patch.object(pe, "_fetch", return_value={"demo": []}):
+            await pe.refresh()
+        with patch.object(pe, "_fetch", side_effect=RuntimeError("db down")):
+            with pytest.raises(RuntimeError):
+                await pe.refresh(force=True)
+        assert pe.enabled_plugins() == {"demo": []}
+
+    def test_no_data_before_the_first_refresh(self):
+        assert pe.enabled_plugins() is None
+        assert pe.is_enabled("demo") is None
+
+    async def test_sync_readers_never_touch_the_db(self):
+        """Pinned because get_all_plugins() has no session to give them."""
+        with patch.object(pe, "_fetch", return_value={"demo": []}):
+            await pe.refresh()
+        with patch.object(pe, "_fetch", side_effect=AssertionError("sync read hit the DB")):
+            assert pe.is_enabled("demo") is True
+            assert pe.enabled_plugins() == {"demo": []}
+
+    async def test_invalidate_forces_the_next_refresh(self):
+        with patch.object(pe, "_fetch", return_value={"demo": []}) as fetch:
+            await pe.refresh()
+            pe.invalidate()
+            await pe.refresh()
+        assert fetch.call_count == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend ; python -m pytest tests/services/test_plugin_enablement.py -q --no-cov`
+Expected: FAIL — `ModuleNotFoundError: app.services.plugin_enablement`
+
+- [ ] **Step 3: Implement the helper**
+
+Create `backend/app/services/plugin_enablement.py`:
+
+```python
+"""Single source of truth for "which plugins are enabled" (#448).
+
+The database is the only state shared by the four production workers.
+``PluginManager._enabled`` is process-local and populated at startup, so a
+runtime toggle reaches exactly one worker - which made the plugin list report
+whatever the answering worker happened to know.
+
+This module caches the database answer for a short window. The read itself
+lives in the async ``refresh()`` and runs off the event loop; synchronous
+readers consume the warm cache and never open a session of their own, because
+the callers that need them (``PluginManager.get_all_plugins()``) have no
+session to give.
+
+The cache maps ``name -> granted_permissions`` rather than holding a bare set
+of names: ``PluginGateMiddleware`` needs both out of the same read, and a
+name-only cache would have forced it to keep a second query.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+CACHE_TTL_SECONDS: float = 5.0
+
+_cache: Optional[Dict[str, List[str]]] = None
+_cached_at: float = 0.0
+
+
+def _monotonic() -> float:
+    """Indirection so tests can control the clock."""
+    return time.monotonic()
+
+
+def _fetch() -> Dict[str, List[str]]:
+    """Blocking DB read - always called through asyncio.to_thread."""
+    from app.core.database import SessionLocal
+    from app.models.plugin import InstalledPlugin
+
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(InstalledPlugin)
+            .filter(InstalledPlugin.is_enabled == True)  # noqa: E712 - SQL boolean
+            .all()
+        )
+        return {row.name: list(row.granted_permissions or []) for row in rows}
+    finally:
+        db.close()
+
+
+async def refresh(force: bool = False) -> None:
+    """Reload the cache if the TTL expired. Raises whatever the DB raises.
+
+    Deliberately not swallowing: the display path wants to fall back to the
+    last known state, the security gate wants to fail closed. Only the callers
+    know which.
+    """
+    global _cache, _cached_at
+
+    now = _monotonic()
+    if not force and _cache is not None and (now - _cached_at) < CACHE_TTL_SECONDS:
+        return
+
+    fetched = await asyncio.to_thread(_fetch)
+    _cache = fetched
+    _cached_at = now
+
+
+def enabled_plugins() -> Optional[Dict[str, List[str]]]:
+    """Warm cache as ``name -> granted_permissions``; None if never loaded."""
+    return dict(_cache) if _cache is not None else None
+
+
+def is_enabled(name: str) -> Optional[bool]:
+    """True/False from the cache, or None when there is no data yet."""
+    if _cache is None:
+        return None
+    return name in _cache
+
+
+def invalidate() -> None:
+    """Drop the cache so the next refresh reloads (called after a local toggle)."""
+    global _cache, _cached_at
+    _cache = None
+    _cached_at = 0.0
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend ; python -m pytest tests/services/test_plugin_enablement.py -q --no-cov`
+Expected: PASS (9 Tests)
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd backend ; python -m ruff check app/services/plugin_enablement.py tests/services/test_plugin_enablement.py
+git add backend/app/services/plugin_enablement.py backend/tests/services/test_plugin_enablement.py
+git commit -m "feat(plugins): add the DB-backed plugin enablement cache"
+```
+
+---
+
+## Task 2: Manager-Statusleser aus dem Cache
+
+**Files:**
+- Modify: `backend/app/plugins/manager.py` (`is_enabled()` bei Z. 864-873, `get_all_plugins()` — die beiden `"is_enabled": name in self._enabled` bei Z. 910 und Z. 934)
+- Test: `backend/tests/plugins/test_manager_enabled_readers.py` (neu)
+
+**Interfaces:**
+- Consumes: `plugin_enablement.is_enabled()`, `plugin_enablement.enabled_plugins()` (Task 1).
+- Produces: `PluginManager.is_enabled(name)` und der `is_enabled`-Schlüssel aus `get_all_plugins()` beantworten aus der DB-Wahrheit; `_enabled` bleibt Fallback.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/plugins/test_manager_enabled_readers.py`:
+
+```python
+"""The manager's status readers answer from the DB cache, not from _enabled (#448)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.plugins.manager import PluginManager
+from app.services import plugin_enablement as pe
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    pe.invalidate()
+    yield
+    pe.invalidate()
+
+
+def _manager(tmp_path) -> PluginManager:
+    return PluginManager(plugins_dir=tmp_path)
+
+
+class TestIsEnabled:
+    async def test_reports_enabled_although_this_worker_never_loaded_it(self, tmp_path):
+        """The bug, in one assertion.
+
+        Worker B never handled the toggle, so its _enabled is empty - but the
+        database says the plugin is on, and that is what a client must see.
+        """
+        worker_b = _manager(tmp_path)
+        assert worker_b._enabled == set()
+
+        with patch.object(pe, "_fetch", return_value={"demo": []}):
+            await pe.refresh()
+
+        assert worker_b.is_enabled("demo") is True
+
+    async def test_reports_disabled_although_this_worker_still_has_it_loaded(self, tmp_path):
+        """The reverse direction: disabling used to survive on other workers."""
+        worker_b = _manager(tmp_path)
+        worker_b._enabled = {"demo"}
+
+        with patch.object(pe, "_fetch", return_value={}):
+            await pe.refresh()
+
+        assert worker_b.is_enabled("demo") is False
+
+    def test_falls_back_to_local_state_when_the_cache_has_no_data(self, tmp_path):
+        """A DB outage must not blank the plugin list."""
+        worker = _manager(tmp_path)
+        worker._enabled = {"demo"}
+
+        assert pe.enabled_plugins() is None
+        assert worker.is_enabled("demo") is True
+
+
+class TestGetAllPlugins:
+    async def test_status_flag_comes_from_the_cache(self, tmp_path):
+        manager = _manager(tmp_path)
+        plugin = MagicMock()
+        plugin.metadata.name = "demo"
+        plugin.metadata.version = "1.0.0"
+        plugin.metadata.display_name = "Demo"
+        plugin.metadata.description = ""
+        plugin.metadata.author = "test"
+        plugin.metadata.category = "general"
+        plugin.metadata.required_permissions = []
+        plugin.get_ui_manifest.return_value = None
+        plugin.get_router.return_value = None
+        manager._plugins = {"demo": plugin}
+        manager._enabled = set()
+
+        with patch.object(manager, "discover_plugins", return_value=["demo"]), \
+             patch.object(manager, "get_discovered", return_value=None), \
+             patch.object(pe, "_fetch", return_value={"demo": []}):
+            await pe.refresh()
+            info = manager.get_all_plugins()
+
+        assert info["demo"]["is_enabled"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend ; python -m pytest tests/plugins/test_manager_enabled_readers.py -q --no-cov`
+Expected: FAIL — `assert False is True` (die Leser antworten noch aus `_enabled`)
+
+- [ ] **Step 3: Add the effective-state helper to the manager**
+
+In `backend/app/plugins/manager.py`, direkt **vor** `def is_enabled` (Z. 864) einfügen:
+
+```python
+    def _effective_enabled(self) -> set:
+        """Names the database says are enabled, falling back to local state.
+
+        The database is the only state shared across the production workers;
+        ``_enabled`` only says what THIS worker loaded. Falling back to it when
+        the cache has no data keeps a DB outage from blanking the plugin list -
+        the gate fails closed instead, which is the opposite direction on
+        purpose (see services/plugin_enablement).
+        """
+        from app.services import plugin_enablement
+
+        cached = plugin_enablement.enabled_plugins()
+        if cached is None:
+            return set(self._enabled)
+        return set(cached)
+```
+
+- [ ] **Step 4: Rewrite the two readers**
+
+`is_enabled()` (Z. 864-873) ersetzen durch:
+
+```python
+    def is_enabled(self, name: str) -> bool:
+        """Check if a plugin is enabled per the database (not per this worker).
+
+        Args:
+            name: Plugin name
+
+        Returns:
+            True if plugin is enabled
+        """
+        return name in self._effective_enabled()
+```
+
+In `get_all_plugins()` beide Vorkommen von `"is_enabled": name in self._enabled,` (Z. 910 und Z. 934) ersetzen durch `"is_enabled": name in effective,` und am Anfang der Methode, direkt nach `result = {}`, ergänzen:
+
+```python
+        effective = self._effective_enabled()
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend ; python -m pytest tests/plugins/test_manager_enabled_readers.py -q --no-cov`
+Expected: PASS (4 Tests)
+
+- [ ] **Step 6: Run the plugin suite for regressions**
+
+Run: `cd backend ; python -m pytest tests/plugins -q --no-cov`
+Expected: PASS, keine neuen Fehler (die vorhandenen Suites laufen mit leerem Cache und damit über den Fallback).
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+cd backend ; python -m ruff check app/plugins/manager.py tests/plugins/test_manager_enabled_readers.py
+git add backend/app/plugins/manager.py backend/tests/plugins/test_manager_enabled_readers.py
+git commit -m "fix(plugins): answer enabled-state from the database, not per-worker memory"
+```
+
+---
+
+## Task 3: Reconcile mit Single-Flight
+
+**Files:**
+- Modify: `backend/app/services/plugin_enablement.py` (anfügen)
+- Test: `backend/tests/services/test_plugin_enablement.py` (anfügen)
+
+**Interfaces:**
+- Consumes: `refresh()`, `enabled_plugins()` (Task 1); `PluginManager.enable_plugin(name, granted_permissions, db, start_background_tasks=...)`, `PluginManager.disable_plugin(name)`.
+- Produces:
+```python
+FAILED_RETRY_SECONDS: float = 60.0
+async def reconcile_worker() -> None
+```
+
+- [ ] **Step 1: Write the failing test**
+
+An `backend/tests/services/test_plugin_enablement.py` anhängen:
+
+```python
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+
+def _fake_manager(loaded: set) -> MagicMock:
+    manager = MagicMock()
+    manager._enabled = set(loaded)
+
+    async def _enable(name, perms, db, start_background_tasks=True, **kw):
+        manager._enabled.add(name)
+        return True
+
+    async def _disable(name):
+        manager._enabled.discard(name)
+        return True
+
+    manager.enable_plugin = AsyncMock(side_effect=_enable)
+    manager.disable_plugin = AsyncMock(side_effect=_disable)
+    return manager
+
+
+class TestReconcile:
+    async def test_loads_what_the_database_says_is_missing(self):
+        manager = _fake_manager(set())
+        with patch.object(pe, "_fetch", return_value={"demo": ["files.read"]}), \
+             patch.object(pe, "_get_manager", return_value=manager):
+            await pe.reconcile_worker()
+
+        manager.enable_plugin.assert_awaited_once()
+        args, kwargs = manager.enable_plugin.await_args
+        assert args[0] == "demo"
+        assert args[1] == ["files.read"]
+
+    async def test_drops_what_the_database_no_longer_lists(self):
+        manager = _fake_manager({"demo"})
+        with patch.object(pe, "_fetch", return_value={}), \
+             patch.object(pe, "_get_manager", return_value=manager):
+            await pe.reconcile_worker()
+
+        manager.disable_plugin.assert_awaited_once_with("demo")
+
+    async def test_background_tasks_only_on_the_primary_worker(self):
+        """Four workers each starting a plugin's background tasks would turn a
+        display bug into real damage."""
+        from app.core import lifespan
+
+        manager = _fake_manager(set())
+        with patch.object(pe, "_fetch", return_value={"demo": []}), \
+             patch.object(pe, "_get_manager", return_value=manager), \
+             patch.object(lifespan, "IS_PRIMARY_WORKER", False):
+            await pe.reconcile_worker()
+
+        assert manager.enable_plugin.await_args.kwargs["start_background_tasks"] is False
+
+        manager = _fake_manager(set())
+        pe.invalidate()
+        with patch.object(pe, "_fetch", return_value={"demo": []}), \
+             patch.object(pe, "_get_manager", return_value=manager), \
+             patch.object(lifespan, "IS_PRIMARY_WORKER", True):
+            await pe.reconcile_worker()
+
+        assert manager.enable_plugin.await_args.kwargs["start_background_tasks"] is True
+
+    async def test_a_throwing_plugin_does_not_block_the_others(self):
+        manager = _fake_manager(set())
+
+        async def _enable(name, perms, db, start_background_tasks=True, **kw):
+            if name == "bad":
+                raise RuntimeError("on_startup blew up")
+            manager._enabled.add(name)
+            return True
+
+        manager.enable_plugin = AsyncMock(side_effect=_enable)
+
+        with patch.object(pe, "_fetch", return_value={"bad": [], "good": []}), \
+             patch.object(pe, "_get_manager", return_value=manager):
+            await pe.reconcile_worker()
+
+        assert "good" in manager._enabled
+
+    async def test_a_failed_plugin_is_not_retried_immediately(self):
+        manager = _fake_manager(set())
+        manager.enable_plugin = AsyncMock(return_value=False)
+
+        with patch.object(pe, "_fetch", return_value={"demo": []}), \
+             patch.object(pe, "_get_manager", return_value=manager):
+            await pe.reconcile_worker()
+            await pe.reconcile_worker()
+
+        assert manager.enable_plugin.await_count == 1
+
+    async def test_concurrent_reconciles_enable_only_once(self):
+        """Status-strip poll and plugin list arrive together in practice; both
+        would see the same diff and run on_startup() twice in parallel."""
+        manager = _fake_manager(set())
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _slow_enable(name, perms, db, start_background_tasks=True, **kw):
+            started.set()
+            await release.wait()
+            manager._enabled.add(name)
+            return True
+
+        manager.enable_plugin = AsyncMock(side_effect=_slow_enable)
+
+        with patch.object(pe, "_fetch", return_value={"demo": []}), \
+             patch.object(pe, "_get_manager", return_value=manager):
+            first = asyncio.create_task(pe.reconcile_worker())
+            await started.wait()
+            await pe.reconcile_worker()      # must return immediately, not enable again
+            release.set()
+            await first
+
+        assert manager.enable_plugin.await_count == 1
+
+    async def test_db_failure_leaves_the_worker_untouched(self):
+        manager = _fake_manager({"demo"})
+        with patch.object(pe, "_fetch", side_effect=RuntimeError("db down")), \
+             patch.object(pe, "_get_manager", return_value=manager):
+            await pe.reconcile_worker()
+
+        manager.enable_plugin.assert_not_awaited()
+        manager.disable_plugin.assert_not_awaited()
+```
+
+Ergänze die `_clean_cache`-Fixture in dieser Datei um `pe._failed_until.clear()` vor und nach dem `yield`, damit die Backoff-Sperre nicht zwischen Tests leckt.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend ; python -m pytest tests/services/test_plugin_enablement.py -q --no-cov -k Reconcile`
+Expected: FAIL — `AttributeError: module ... has no attribute 'reconcile_worker'`
+
+- [ ] **Step 3: Implement the reconcile**
+
+An `backend/app/services/plugin_enablement.py` anhängen:
+
+```python
+FAILED_RETRY_SECONDS: float = 60.0
+
+_reconcile_lock = asyncio.Lock()
+_failed_until: Dict[str, float] = {}
+
+
+def _get_manager():
+    """Indirection so tests can inject a manager double."""
+    from app.plugins.manager import PluginManager
+
+    return PluginManager.get_instance()
+
+
+async def reconcile_worker() -> None:
+    """Align this worker's loaded plugins with the database.
+
+    Single-flight: a second caller returns immediately rather than queueing.
+    Two requests arriving together (status-strip poll plus plugin list is the
+    realistic pair) would otherwise both see the same diff and run the same
+    plugin's on_startup() twice, in parallel. The loser proceeds on the current
+    state - the winner's reconcile is a moment away.
+
+    Never raises: a reconcile is best-effort maintenance on a request path.
+    """
+    if _reconcile_lock.locked():
+        return
+
+    async with _reconcile_lock:
+        try:
+            await refresh()
+        except Exception:  # noqa: BLE001 - a DB blip must not fail the request
+            logger.warning("plugin enablement refresh failed", exc_info=True)
+            return
+
+        desired = enabled_plugins()
+        if desired is None:
+            return
+
+        # Read as a module attribute: lifespan sets this after the fork, so a
+        # from-import would freeze the pre-fork False forever.
+        from app.core import lifespan
+
+        manager = _get_manager()
+        loaded = set(manager._enabled)
+        now = _monotonic()
+
+        for name, permissions in desired.items():
+            if name in loaded:
+                continue
+            if _failed_until.get(name, 0.0) > now:
+                continue
+            try:
+                from app.core.database import SessionLocal
+
+                with SessionLocal() as db:
+                    ok = await manager.enable_plugin(
+                        name,
+                        permissions,
+                        db,
+                        start_background_tasks=lifespan.IS_PRIMARY_WORKER,
+                    )
+            except Exception:  # noqa: BLE001 - one bad plugin must not stop the rest
+                logger.warning("lazy enable of plugin %s failed", name, exc_info=True)
+                ok = False
+            if not ok:
+                _failed_until[name] = now + FAILED_RETRY_SECONDS
+
+        for name in loaded - set(desired):
+            try:
+                await manager.disable_plugin(name)
+            except Exception:  # noqa: BLE001 - same reasoning as above
+                logger.warning("lazy disable of plugin %s failed", name, exc_info=True)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend ; python -m pytest tests/services/test_plugin_enablement.py -q --no-cov`
+Expected: PASS (16 Tests)
+
+- [ ] **Step 5: Prove the single-flight test discriminates**
+
+Entferne testweise die beiden Zeilen `if _reconcile_lock.locked(): return`, führe `python -m pytest tests/services/test_plugin_enablement.py -q --no-cov -k concurrent` aus — der Test **muss** fehlschlagen (`await_count == 2`). Danach zurückbauen und erneut laufen lassen.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd backend ; python -m ruff check app/services/plugin_enablement.py tests/services/test_plugin_enablement.py
+git add backend/app/services/plugin_enablement.py backend/tests/services/test_plugin_enablement.py
+git commit -m "feat(plugins): reconcile a worker's loaded plugins against the database"
+```
+
+---
+
+## Task 4: Middleware auf denselben Cache
+
+**Files:**
+- Modify: `backend/app/middleware/plugin_gate.py:23-46` (Cache + `_fetch_plugin_status`), `:122-151` (Gate-Block)
+- Test: `backend/tests/middleware/test_plugin_gate_enablement.py` (neu)
+
+**Interfaces:**
+- Consumes: `plugin_enablement.refresh()`, `enabled_plugins()`, `invalidate()` (Task 1).
+- Produces: `invalidate_plugin_cache(name)` bleibt als öffentliche Funktion erhalten (Aufrufer: `routes/plugins.py`), delegiert aber an den Helper.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/middleware/test_plugin_gate_enablement.py`:
+
+```python
+"""PluginGateMiddleware reads the shared enablement cache (#448)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.middleware import plugin_gate
+from app.services import plugin_enablement as pe
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    pe.invalidate()
+    yield
+    pe.invalidate()
+
+
+def _request(path: str) -> MagicMock:
+    request = MagicMock()
+    request.url.path = path
+    return request
+
+
+async def _dispatch(path: str):
+    middleware = plugin_gate.PluginGateMiddleware(app=MagicMock())
+
+    async def _call_next(_request):
+        return "PASSED"
+
+    return await middleware.dispatch(_request(path), _call_next)
+
+
+class TestGateUsesTheSharedCache:
+    async def test_enabled_plugin_passes(self):
+        with patch.object(pe, "_fetch", return_value={"demo": []}), \
+             patch.object(plugin_gate.PluginManager, "get_instance") as manager:
+            manager.return_value.get_required_permissions.return_value = []
+            result = await _dispatch("/api/plugins/demo/menu-actions/go")
+        assert result == "PASSED"
+
+    async def test_disabled_plugin_is_403(self):
+        with patch.object(pe, "_fetch", return_value={}):
+            result = await _dispatch("/api/plugins/demo/menu-actions/go")
+        assert result.status_code == 403
+
+    async def test_missing_permission_is_403(self):
+        with patch.object(pe, "_fetch", return_value={"demo": ["files.read"]}), \
+             patch.object(plugin_gate.PluginManager, "get_instance") as manager:
+            manager.return_value.get_required_permissions.return_value = ["files.write"]
+            result = await _dispatch("/api/plugins/demo/menu-actions/go")
+        assert result.status_code == 403
+
+    async def test_db_failure_fails_closed(self):
+        """Opposite direction to the display path: no state, no entry."""
+        with patch.object(pe, "_fetch", side_effect=RuntimeError("db down")):
+            result = await _dispatch("/api/plugins/demo/menu-actions/go")
+        assert result.status_code == 500
+
+    async def test_management_routes_still_bypass_the_gate(self):
+        with patch.object(pe, "_fetch", side_effect=AssertionError("should not be consulted")):
+            assert await _dispatch("/api/plugins/demo/toggle") == "PASSED"
+            assert await _dispatch("/api/plugins/ui/manifest") == "PASSED"
+```
+
+Hinweis: `PluginManager` muss in `plugin_gate` als Modulname importierbar sein, damit `patch.object(plugin_gate.PluginManager, ...)` greift — der bisherige lokale Import innerhalb von `dispatch()` wandert dafür an den Dateikopf.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend ; python -m pytest tests/middleware/test_plugin_gate_enablement.py -q --no-cov`
+Expected: FAIL — `AttributeError: module 'app.middleware.plugin_gate' has no attribute 'PluginManager'`
+
+- [ ] **Step 3: Replace the private cache with the shared one**
+
+In `backend/app/middleware/plugin_gate.py`:
+
+Den Block `_plugin_cache`, `CACHE_TTL_SECONDS` und `_fetch_plugin_status` (Z. 23-25 und Z. 49-68) **löschen**. Am Dateikopf ergänzen:
+
+```python
+from app.plugins.manager import PluginManager
+from app.services import plugin_enablement
+```
+
+`invalidate_plugin_cache` ersetzen durch:
+
+```python
+def invalidate_plugin_cache(name: str) -> None:
+    """Drop the cached enablement state after a local toggle.
+
+    Kept as a named function because routes/plugins.py calls it; the state now
+    lives in services/plugin_enablement, shared with the manager's readers.
+    """
+    plugin_enablement.invalidate()
+```
+
+Im `dispatch()` den Gate-Block (Z. 122-151) ersetzen durch:
+
+```python
+        # --- Gate: check plugin status ---
+        try:
+            await plugin_enablement.refresh()
+        except Exception:
+            logger.exception("Failed to fetch plugin status for %s", name)
+            return JSONResponse(
+                status_code=500,
+                content={"detail": "Internal error checking plugin status"},
+            )
+
+        enabled = plugin_enablement.enabled_plugins() or {}
+        if name not in enabled:
+            return JSONResponse(
+                status_code=403,
+                content={"detail": f"Plugin '{name}' is disabled"},
+            )
+        granted_perms = enabled[name]
+```
+
+Der darauffolgende Permission-Block (`required = manager.get_required_permissions(name)` …) bleibt unverändert, nutzt aber den nun am Dateikopf importierten `PluginManager` statt des lokalen Imports.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend ; python -m pytest tests/middleware/test_plugin_gate_enablement.py -q --no-cov`
+Expected: PASS (5 Tests)
+
+- [ ] **Step 5: Port the existing gate suite — es hängt am entfernten Symbol**
+
+`backend/tests/middleware/test_plugin_gate.py` importiert `CACHE_TTL_SECONDS`, `_plugin_cache` und patcht an **14 Stellen** `plugin_gate._fetch_plugin_status`. Alle drei Symbole verschwinden in Step 3 — die Datei bricht also beim Import, nicht erst in einer Assertion. Sie ist zu portieren, **nicht** zu löschen: sie deckt Pfad-Matching, Management-Bypässe und die `_storage`-Backdoor-Fälle ab, die dieser Umbau nicht ersetzt.
+
+Mechanische Übersetzung, Assertions bleiben unangetastet:
+
+| alt | neu |
+|---|---|
+| `from ... import CACHE_TTL_SECONDS, _plugin_cache` | `from app.services.plugin_enablement import CACHE_TTL_SECONDS` |
+| `_plugin_cache.clear()` (Z. 76, 78) | `plugin_enablement.invalidate()` |
+| `@patch("...plugin_gate._fetch_plugin_status", return_value=(True, ["files:read"]))` | `@patch("app.services.plugin_enablement._fetch", return_value={"my_plugin": ["files:read"]})` |
+| `return_value=(False, [])` | `return_value={}` |
+| `side_effect=Exception(...)` (Z. 294-297) | unverändert, nur am neuen Patch-Punkt |
+| Cache-Ablauf über `_plugin_cache[name] = (..., time.monotonic() - TTL - 1)` (Z. 268-269) | `plugin_enablement.invalidate()` — der neue Cache ist global, nicht pro Name; der Test prüft weiterhin, dass danach erneut gelesen wird |
+
+Achtung beim Plugin-Namen: die alten Patches lieferten den Zustand **für jeden** Namen zurück; der neue Cache ist ein Mapping, also muss der im Test verwendete Name (`my_plugin`) als Schlüssel auftauchen, sonst gilt das Plugin als deaktiviert.
+
+Ebenso in `backend/tests/plugins/test_plugin_menu_actions.py`: `TestMenuActionThroughTheRealStack` patcht `plugin_gate._fetch_plugin_status` → auf `plugin_enablement._fetch` umstellen (`{"demo": []}` für aktiviert, `{}` für deaktiviert) und `plugin_gate._plugin_cache.clear()` → `plugin_enablement.invalidate()`.
+
+- [ ] **Step 6: Run the ported suites**
+
+Run: `cd backend ; python -m pytest tests/middleware tests/plugins/test_plugin_menu_actions.py -q --no-cov`
+Expected: PASS — die portierte Datei mit **derselben Testanzahl** wie vorher (nichts gestrichen).
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+cd backend ; python -m ruff check app/middleware/plugin_gate.py tests/middleware tests/plugins/test_plugin_menu_actions.py
+git add backend/app/middleware/plugin_gate.py backend/tests/middleware backend/tests/plugins/test_plugin_menu_actions.py
+git commit -m "refactor(plugins): let the gate share the enablement cache"
+```
+
+---
+
+## Task 5: Reconcile an den Einstiegspunkten
+
+**Files:**
+- Modify: `backend/app/api/deps.py` (neue Dependency)
+- Modify: `backend/app/api/routes/plugins.py` (`list_plugins` Z. 62, `get_ui_manifest` Z. 136, `run_plugin_menu_action` Z. 819)
+- Modify: `backend/app/api/routes/status_bar.py` (`get_statusbar_config` Z. 32, `get_statusbar_state` Z. 81)
+- Test: `backend/tests/services/test_plugin_enablement.py` (anfügen)
+
+**Interfaces:**
+- Consumes: `plugin_enablement.reconcile_worker()` (Task 3).
+- Produces: `app.api.deps.reconciled_plugin_state` — async FastAPI-Dependency ohne Rückgabewert.
+
+- [ ] **Step 1: Write the failing test**
+
+An `backend/tests/services/test_plugin_enablement.py` anhängen:
+
+```python
+class TestReconcileDependency:
+    async def test_dependency_runs_the_reconcile(self):
+        from app.api.deps import reconciled_plugin_state
+
+        with patch.object(pe, "reconcile_worker", new=AsyncMock()) as reconcile:
+            await reconciled_plugin_state()
+
+        reconcile.assert_awaited_once()
+
+    def test_every_entry_point_declares_the_dependency(self):
+        """The routes that must not report stale state.
+
+        A route added later without the dependency would silently reintroduce
+        the bug for its own view, so the list is asserted rather than trusted.
+        """
+        import inspect
+
+        from app.api.deps import reconciled_plugin_state
+        from app.api.routes import plugins as plugins_routes
+        from app.api.routes import status_bar as status_bar_routes
+
+        expected = [
+            (plugins_routes.list_plugins, "list_plugins"),
+            (plugins_routes.get_ui_manifest, "get_ui_manifest"),
+            (plugins_routes.run_plugin_menu_action, "run_plugin_menu_action"),
+            (status_bar_routes.get_statusbar_config, "get_statusbar_config"),
+            (status_bar_routes.get_statusbar_state, "get_statusbar_state"),
+        ]
+        for func, label in expected:
+            deps = [
+                param.default.dependency
+                for param in inspect.signature(func).parameters.values()
+                if hasattr(param.default, "dependency")
+            ]
+            assert reconciled_plugin_state in deps, f"{label} misses the reconcile dependency"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend ; python -m pytest tests/services/test_plugin_enablement.py -q --no-cov -k Dependency`
+Expected: FAIL — `ImportError: cannot import name 'reconciled_plugin_state'`
+
+- [ ] **Step 3: Add the dependency**
+
+An `backend/app/api/deps.py` anhängen:
+
+```python
+async def reconciled_plugin_state() -> None:
+    """Align this worker's loaded plugins with the database before answering.
+
+    Plugin enablement lives in the database; a runtime toggle only reaches the
+    worker that handled it. Routes whose answer depends on which plugins are
+    enabled declare this so their view does not depend on which of the four
+    workers replied (#448). Best-effort: it never raises.
+    """
+    from app.services.plugin_enablement import reconcile_worker
+
+    await reconcile_worker()
+```
+
+- [ ] **Step 4: Declare it on the five routes**
+
+In `backend/app/api/routes/plugins.py` bei `list_plugins`, `get_ui_manifest` und `run_plugin_menu_action` jeweils als letzten Parameter ergänzen:
+
+```python
+    _reconciled: None = Depends(deps_reconciled_plugin_state),
+```
+
+und am Dateikopf importieren:
+
+```python
+from app.api.deps import reconciled_plugin_state as deps_reconciled_plugin_state
+```
+
+In `backend/app/api/routes/status_bar.py` dasselbe bei `get_statusbar_config` und `get_statusbar_state` — Import analog ergänzen.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend ; python -m pytest tests/services/test_plugin_enablement.py -q --no-cov`
+Expected: PASS (18 Tests)
+
+- [ ] **Step 6: Run the affected route suites**
+
+Run: `cd backend ; python -m pytest tests/plugins tests/api/test_status_bar_routes.py -q --no-cov`
+Expected: PASS. Direkt aufgerufene Routenfunktionen (das etablierte Testmuster hier) müssen den neuen Parameter nicht übergeben — er hat einen Default.
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+cd backend ; python -m ruff check app/api/deps.py app/api/routes/plugins.py app/api/routes/status_bar.py
+git add backend/app/api/deps.py backend/app/api/routes/plugins.py backend/app/api/routes/status_bar.py backend/tests/services/test_plugin_enablement.py
+git commit -m "feat(plugins): reconcile worker state on the routes that report it"
+```
+
+---
+
+## Task 6: Doku und Gesamt-Gates
+
+**Files:**
+- Modify: `backend/app/plugins/CLAUDE.md` (Operator-Note im Abschnitt „Creating a Plugin")
+
+**Interfaces:**
+- Consumes: alles Vorige. Produces: nichts.
+
+- [ ] **Step 1: Rewrite the operator note**
+
+Die bestehende **Operator note** (sie sagt heute, ein Toggle wirke erst nach `baluhost-backend`-Restart auf allen Workern) ersetzen durch:
+
+```markdown
+   **Operator note:** plugin enablement lives in the database and every worker
+   reconciles itself against it on the next request that needs the state
+   (`services/plugin_enablement.py`), so a toggle now takes effect within a few
+   seconds across all four production workers — no restart needed for status
+   pills, menu actions or dashboard panels (#448).
+   **One exception:** plugin HTTP routes are mounted once at startup
+   (`core/lifespan.py`), so a plugin that ships its own router still needs a
+   `baluhost-backend` restart before its endpoints exist. Its
+   method-based contributions work immediately.
+```
+
+- [ ] **Step 2: Run the full backend gates**
+
+```bash
+cd backend
+python -m pytest tests/plugins tests/services/test_plugin_enablement.py tests/middleware tests/api/test_status_bar_routes.py -q --no-cov
+python -m ruff check app tests
+```
+Expected: alles grün. (Bekannt und **nicht** von dieser Arbeit verursacht: `tests/test_desktop_backend.py` hat 3 Windows-only-Fehlschläge wegen `os.getuid()` im Konstruktor.)
+
+- [ ] **Step 3: Frontend unberührt — nur gegenprüfen**
+
+```bash
+cd client ; npx vitest run src/__tests__/api/plugins.menuActions.test.ts src/__tests__/contexts
+```
+Expected: PASS. Diese Arbeit ändert kein Frontend; der Lauf belegt nur, dass die API-Form unverändert ist.
+
+- [ ] **Step 4: Manueller Smoketest (durch den Maintainer, nicht dispatchen)**
+
+Auf BaluNode nach dem Deploy:
+
+1. `steam_gaming` unter *Plugins* deaktivieren, Seite 5–6× hart neu laden → bleibt **jedes Mal** deaktiviert.
+2. Aktivieren, Seite 5–6× hart neu laden → bleibt **jedes Mal** aktiviert (vorher: etwa drei von vier Reloads falsch).
+3. Ohne Neustart ins Power-Menü: „Gaming-Modus" ist da und der Klick liefert kein 404.
+4. `sudo journalctl -u baluhost-backend -n 50 | grep -i "enabled plugin"` → das Nachladen taucht auf den anderen Workern auf, nicht nur einmal.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/plugins/CLAUDE.md
+git commit -m "docs(plugins): the enablement note now matches how it behaves"
+```
+
+---
+
+## Self-Review
+
+**Spec-Abdeckung:**
+
+| Spec-Anforderung | Task |
+|---|---|
+| Helper mit `name -> granted_permissions`, TTL-Cache | 1 |
+| DB-Read nur async über `to_thread`; sync Leser nur Cache | 1 (Test „sync readers never touch the DB") |
+| DB-Fehler wird nach oben gereicht statt verschluckt | 1 |
+| Statusleser antworten aus der DB-Wahrheit | 2 |
+| Fallback auf lokalen Zustand bei fehlenden Daten | 2 |
+| `iter_enabled_plugins`/`get_ui_manifest` = DB ∩ geladen, unverändert | 2 (File-Structure-Begründung) |
+| Reconcile lädt nach / räumt ab | 3 |
+| Single-Flight | 3 (+ Mutationsnachweis in Step 5) |
+| Hintergrund-Tasks primary-only | 3 |
+| `IS_PRIMARY_WORKER` als Modulattribut | 3 (Global Constraints + Code-Kommentar) |
+| Backoff nach Fehlschlag | 3 |
+| Middleware nutzt denselben Cache, bleibt fail-closed | 4 |
+| `invalidate_plugin_cache` bleibt für die Aufrufer bestehen | 4 |
+| Reconcile an den async Einstiegspunkten | 5 |
+| Operator-Note korrigiert, Router-Ausnahme benannt | 6 |
+| „Zwei Worker, eine DB"-Test | 2 (`test_reports_enabled_although_this_worker_never_loaded_it`) |
+
+**Platzhalter-Scan:** keine TBD/TODO; jeder Code-Schritt enthält den vollständigen Code, jeder Test-Schritt den vollständigen Test.
+
+**Typ-Konsistenz:** `enabled_plugins() -> Optional[Dict[str, List[str]]]` wird in Task 2 (`_effective_enabled`), Task 3 (`desired`) und Task 4 (`enabled[name]`) identisch behandelt — überall `None`-geprüft. `is_enabled()` heißt im Helper wie in `PluginManager`, hat aber unterschiedliche Rückgaben (`Optional[bool]` vs. `bool`); der Manager wandelt bewusst um, indem er `enabled_plugins()` statt `pe.is_enabled()` benutzt. `_fetch`, `_monotonic`, `_get_manager` sind in allen Tests dieselben Patch-Punkte.
+
+**Nicht enthalten (bewusst):** kein Broadcast/SHM zwischen Workern, kein Hot-Mounting von Routern, keine Änderung am Toggle-Endpunkt, keine Migration, keine Frontend-Änderung.

--- a/docs/superpowers/specs/2026-07-23-plugin-enablement-cross-worker-design.md
+++ b/docs/superpowers/specs/2026-07-23-plugin-enablement-cross-worker-design.md
@@ -45,7 +45,7 @@ Solange beide immer gleich waren (Zustand nur beim Start gesetzt), fiel das nich
 
 ## Ziel
 
-- Die UI zeigt den Zustand, der in der DB steht — unabhängig davon, welcher Worker antwortet.
+- Die UI zeigt den Zustand, der in der DB steht — unabhängig davon, welcher Worker antwortet (verbleibende Staleness TTL-begrenzt auf wenige Sekunden, statt wie heute unbegrenzt bis zum Restart).
 - Ein Toggle wirkt **ohne Neustart** für methodenbasierte Extension-Points (Status-Pills, Menü-Aktionen, Dashboard-Panels).
 - Wo ein Neustart technisch unvermeidbar bleibt, sagt das System es, statt Bereitschaft vorzutäuschen.
 
@@ -64,29 +64,43 @@ Konsequenz für den Entwurf: nachaktiviert wird trotzdem (halbe Funktion ist bes
 ## Architektur
 
 ```
-services/plugin_enablement.py     NEU: enabled_names(db) -> set[str], DB + TTL-Cache
-                                       reconcile_worker(db) -> None  (async)
-plugins/manager.py                 Lesepfade beantworten aus der DB-Menge;
+services/plugin_enablement.py     NEU: enabled_plugins() -> Mapping[name, granted_permissions]
+                                       (DB + TTL-Cache, Refresh off-loop)
+                                       refresh(force=False) -> None      (async, to_thread)
+                                       reconcile_worker() -> None        (async, single-flight)
+plugins/manager.py                 Status-Lesepfade konsumieren den Cache;
                                    _enabled bedeutet nur noch "lokal geladen"
 middleware/plugin_gate.py          nutzt denselben Helper statt eigener Kopie
-api/routes/plugins.py              reconcile an den async-Einstiegspunkten
+api/routes/plugins.py              refresh + reconcile an den async-Einstiegspunkten
 services/status_bar/service.py     dito vor dem Pill-Collect
 ```
 
 ### Eine Wahrheitsquelle
 
-`enabled_names(db) -> set[str]` liest `installed_plugins.is_enabled` und cacht das Ergebnis für ein kurzes TTL-Fenster. Das Muster existiert bereits in `PluginGateMiddleware._fetch_plugin_status` (5 s TTL, `plugin_gate.py:25`); dieser Entwurf zieht es an **eine** Stelle, und die Middleware wird sein zweiter Nutzer statt einer zweiten Implementierung.
+Der Helper liest `installed_plugins` und cacht **`name -> granted_permissions`** für ein kurzes TTL-Fenster; die Menge der aktivierten Namen ist davon abgeleitet.
+
+**Warum ein Mapping und kein Set:** `PluginGateMiddleware` braucht aus demselben DB-Read zwei Dinge — den Aktivierungszustand *und* die granted permissions, die sie gegen `get_required_permissions()` prüft (`plugin_gate.py:49-68`, Rückgabe heute `(bool, List[str])`). Ein reines Namens-Set würde die Middleware zwingen, ihre eigene Abfrage zu behalten — und das „eine Stelle"-Versprechen wäre von Anfang an gebrochen. Mit dem Mapping wird sie tatsächlich zweiter Nutzer statt zweiter Implementierung; ihr Fail-Closed-Verhalten (DB-Fehler → 500) bleibt unverändert.
+
+**Wer liest wie:** Der DB-Zugriff passiert ausschließlich im async `refresh()` und läuft per `asyncio.to_thread` — dieselbe Konvention, mit der die Middleware heute ihren Read vom Event-Loop fernhält. **Synchrone Leser (`get_all_plugins()`, `is_enabled()`) konsumieren nur den warmen Cache und fassen die DB nie selbst an.** Das ist keine Nebensächlichkeit: `get_all_plugins()` hat keine Session (auch die Route `list_plugins` hat heute kein `db`-Dependency), und ein synchroner DB-Read im Getter würde den Event-Loop blockieren — genau die Fehlerklasse, die beim `kscreen-doctor`-Fix gerade erst beseitigt wurde. Die async Einstiegspunkte rufen `refresh()` vor dem Getter auf.
 
 `_enabled` bleibt bestehen, verliert aber seine Doppelrolle: es beantwortet ausschließlich „dieser Worker hat die Instanz geladen und gestartet" und wird nie wieder als Aktivierungszustand nach außen gegeben.
+
+**Zwei Sorten Lesepfade, zwei Semantiken.** Reine Statusanzeigen (`get_all_plugins()`-`is_enabled`-Flag, `is_enabled()`) beantworten aus dem Cache — der DB-Wahrheit. `iter_enabled_plugins()` und `get_ui_manifest()` dagegen brauchen **Instanzen** (`manager.py:859-862` yieldet `self.get_plugin(name)`), und eine Instanz kann nur aus dem lokalen Zustand kommen: ihre Semantik ist **DB ∩ lokal geladen**. Nach dem Reconcile konvergieren beide Mengen; die Formulierung steht hier, damit niemand versucht, aus einer DB-Zeile eine Instanz zu yielden.
+
+**Verbleibende Staleness ist begrenzt, nicht null.** Nach einem Toggle ist der behandelnde Worker sofort frisch (`invalidate_plugin_cache` bleibt prozess-lokal und wird um die Invalidierung des neuen Caches ergänzt); die übrigen Worker sind bis zum TTL-Ablauf stale. Aus „falsch bis zum Restart" wird „maximal ~5 s" — das ist das ehrliche Versprechen dieses Entwurfs, kein absolutes.
 
 ### Selbstheilung statt Signalisierung
 
 ```python
-async def reconcile_worker(db: Session) -> None:
-    """Gleicht die lokal geladenen Plugins an die DB an."""
+async def reconcile_worker() -> None:
+    """Gleicht die lokal geladenen Plugins an die DB an. Single-flight."""
 ```
 
-Die Funktion bildet die Differenz zwischen `enabled_names(db)` und `manager._enabled` und gleicht sie lokal an: fehlende werden über `enable_plugin()` nachgeladen, überzählige über `disable_plugin()` abgeräumt. Aufgerufen wird sie an den **async** Einstiegspunkten, die den Zustand brauchen:
+Die Funktion refresht den Cache, bildet die Differenz zwischen der DB-Menge und `manager._enabled` und gleicht sie lokal an: fehlende werden über `enable_plugin()` nachgeladen (mit den `granted_permissions` aus dem Cache-Mapping), überzählige über `disable_plugin()` abgeräumt.
+
+**Single-flight pro Worker.** Zwei gleichzeitige Requests (Statusleisten-Poll und Plugin-Liste treffen realistisch zusammen) sehen sonst beide dieselbe Differenz und rufen beide `enable_plugin()` für dasselbe Plugin — `on_startup()` liefe doppelt und parallel. Ein `asyncio.Lock` um den Reconcile genügt; wer den Lock nicht bekommt, wartet nicht, sondern läuft mit dem aktuellen Zustand weiter (der Reconcile des anderen ist gleich fertig).
+
+Aufgerufen wird sie an den **async** Einstiegspunkten, die den Zustand brauchen:
 
 - `GET /api/plugins` (Liste)
 - `GET /api/plugins/ui/manifest`
@@ -133,9 +147,10 @@ Weitere Fälle:
 
 Dazu:
 
-- **Helper:** liefert die DB-Menge; cacht innerhalb des TTL-Fensters (zweiter Aufruf liest nicht erneut); nach Ablauf wieder; DB-Fehler wird nach oben gereicht statt verschluckt.
-- **Lesepfade:** `get_all_plugins()`, `ui/manifest` und `is_enabled()` melden „aktiviert", obwohl `_enabled` des Workers leer ist.
-- **Reconcile:** lädt Fehlendes nach; räumt Überzähliges ab; startet Hintergrund-Tasks **nur** wenn Primary; ein werfendes Plugin blockiert die übrigen nicht; ein gescheitertes wird nicht sofort erneut versucht.
+- **Helper:** liefert das Mapping `name -> granted_permissions`; cacht innerhalb des TTL-Fensters (zweiter Aufruf liest nicht erneut); nach Ablauf wieder; DB-Fehler wird nach oben gereicht statt verschluckt; synchrone Leser lösen **keinen** DB-Read aus (nachweisbar: Cache warm, DB-Fixture entfernt, Leser funktioniert weiter).
+- **Lesepfade:** `get_all_plugins()` und `is_enabled()` melden „aktiviert", obwohl `_enabled` des Workers leer ist; `iter_enabled_plugins()`/`get_ui_manifest()` liefern das Plugin erst **nach** dem Reconcile (DB ∩ geladen).
+- **Reconcile:** lädt Fehlendes nach (mit den Permissions aus dem Mapping); räumt Überzähliges ab; startet Hintergrund-Tasks **nur** wenn Primary; ein werfendes Plugin blockiert die übrigen nicht; ein gescheitertes wird nicht sofort erneut versucht; **zwei gleichzeitige Reconciles aktivieren nur einmal** (Single-Flight — `on_startup()`-Zählung unter parallelem Aufruf).
+- **Middleware:** bezieht Zustand und Permissions aus dem Helper und verhält sich unverändert (aktiviert+Permissions → durch, deaktiviert → 403, fehlende Permission → 403).
 - **Regression Gate:** `PluginGateMiddleware` antwortet bei DB-Fehler weiterhin fehlschlagend, nicht durchlassend.
 - **Router-Fall:** ein lazy aktiviertes Plugin mit Router wird als „Neustart erforderlich" gemeldet.
 

--- a/docs/superpowers/specs/2026-07-23-plugin-enablement-cross-worker-design.md
+++ b/docs/superpowers/specs/2026-07-23-plugin-enablement-cross-worker-design.md
@@ -1,0 +1,146 @@
+# Plugin-Aktivierung über Worker hinweg — Design
+
+**Datum:** 2026-07-23
+**Status:** entworfen, abgenommen
+**Issue:** #448
+**Anlass:** In Produktion beobachtet, nachdem Teilprojekt 2 (#457) ausgeliefert war.
+
+## Das Symptom
+
+Ein Admin aktiviert `steam_gaming` unter *Plugins*, lädt die Seite hart neu — und das Plugin steht wieder auf **deaktiviert**. Beim nächsten Reload womöglich wieder auf aktiviert. Der Zustand scheint zu springen.
+
+## Root Cause (gemessen, nicht vermutet)
+
+Der Schreibpfad ist in Ordnung. `POST /api/plugins/{name}/toggle` schreibt `is_enabled=True` in die Tabelle `installed_plugins` (`routes/plugins.py:329`, `plugin_service.enable_plugin`). Das ist der einzige worker-übergreifende Zustand, und er stimmt.
+
+Der **Lesepfad** ist der Fehler. Jede „ist aktiviert?"-Frage wird aus `PluginManager._enabled` beantwortet — einer **prozess-lokalen** Menge:
+
+| Fundort | Zeile |
+|---|---|
+| `get_all_plugins()` (speist `GET /api/plugins`) | `manager.py:910`, `:934` |
+| `get_ui_manifest()` (speist `GET /api/plugins/ui/manifest`) | `manager.py:799` |
+| `is_enabled()` | `manager.py:873` |
+| `iter_enabled_plugins()` (Status-Bar-Pills, Menü-Aktionen) | `manager.py:859` |
+
+`_enabled` wird beim Start jedes Workers aus der DB befüllt (`load_enabled_plugins`, `manager.py:696`) — deshalb heilt ein Neustart das Problem. Ein Toggle zur Laufzeit erreicht dagegen nur **den einen** Worker, der die Anfrage bearbeitet hat (`manager.py:341` im Toggle-Handler); `invalidate_plugin_cache(name)` ebenso.
+
+**Auf der Prod-Box gemessen** (`ps -eo pid,ppid,cmd`):
+
+```
+792957  1  /opt/baluhost/backend/.venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 4 ...
+```
+
+Vier Worker. Der Toggle landet auf einem davon, der Reload auf einem zufälligen — **etwa drei von vier Aufrufen zeigen den falschen Zustand**. Genau das beobachtete Bild.
+
+*Messhinweis für später:* `pgrep -fa uvicorn | wc -l` liefert hier `2` und ist irreführend — Uvicorns Kindprozesse tragen „uvicorn" nicht in der Kommandozeile (sie entstehen über `multiprocessing`). Nur Master und ein fremder `open_webui`-Prozess matchen. Die Worker-Zahl kommt aus dem `--workers`-Argument, nicht aus einer Prozesszählung.
+
+## Der eigentliche Konstruktionsfehler
+
+`_enabled` beantwortet heute **zwei verschiedene Fragen** mit einem Feld:
+
+1. *Ist dieses Plugin laut Konfiguration aktiviert?* — eine globale Tatsache, die in der DB steht.
+2. *Hat dieser Worker die Plugin-Instanz geladen und gestartet?* — eine lokale Tatsache.
+
+Solange beide immer gleich waren (Zustand nur beim Start gesetzt), fiel das nicht auf. Ein Laufzeit-Toggle trennt sie, und die Antwort auf Frage 2 wird als Antwort auf Frage 1 ausgegeben.
+
+## Ziel
+
+- Die UI zeigt den Zustand, der in der DB steht — unabhängig davon, welcher Worker antwortet.
+- Ein Toggle wirkt **ohne Neustart** für methodenbasierte Extension-Points (Status-Pills, Menü-Aktionen, Dashboard-Panels).
+- Wo ein Neustart technisch unvermeidbar bleibt, sagt das System es, statt Bereitschaft vorzutäuschen.
+
+## Nicht-Ziele
+
+- **Kein Broadcast/SHM/Message-Bus zwischen Workern.** Die DB ist bereits der geteilte Zustand; ein zweiter Kanal wäre eine zweite Wahrheit.
+- **Kein Hot-Mounting von Plugin-Routern.** Siehe Randbedingung unten.
+- **Keine Änderung am Toggle-Endpunkt selbst** — der schreibt bereits korrekt.
+
+## Randbedingung: Router lassen sich nicht nachrüsten
+
+Plugin-Router werden **einmalig beim Start** eingehängt (`lifespan.py:630-633`, `app.include_router(...)`). Ein zur Laufzeit nachaktiviertes Plugin kann seine HTTP-Endpunkte deshalb nicht bekommen. Methodenbasierte Beiträge — `collect_status_pill()`, `run_menu_action()`, `get_dashboard_data()` — funktionieren dagegen sofort, weil sie über die Instanz laufen, nicht über die Routing-Tabelle.
+
+Konsequenz für den Entwurf: nachaktiviert wird trotzdem (halbe Funktion ist besser als keine), aber ein Plugin mit eigenem Router meldet in der Detailansicht **„Neustart erforderlich"**. `steam_gaming` hat keinen Router und ist vollständig abgedeckt.
+
+## Architektur
+
+```
+services/plugin_enablement.py     NEU: enabled_names(db) -> set[str], DB + TTL-Cache
+                                       reconcile_worker(db) -> None  (async)
+plugins/manager.py                 Lesepfade beantworten aus der DB-Menge;
+                                   _enabled bedeutet nur noch "lokal geladen"
+middleware/plugin_gate.py          nutzt denselben Helper statt eigener Kopie
+api/routes/plugins.py              reconcile an den async-Einstiegspunkten
+services/status_bar/service.py     dito vor dem Pill-Collect
+```
+
+### Eine Wahrheitsquelle
+
+`enabled_names(db) -> set[str]` liest `installed_plugins.is_enabled` und cacht das Ergebnis für ein kurzes TTL-Fenster. Das Muster existiert bereits in `PluginGateMiddleware._fetch_plugin_status` (5 s TTL, `plugin_gate.py:25`); dieser Entwurf zieht es an **eine** Stelle, und die Middleware wird sein zweiter Nutzer statt einer zweiten Implementierung.
+
+`_enabled` bleibt bestehen, verliert aber seine Doppelrolle: es beantwortet ausschließlich „dieser Worker hat die Instanz geladen und gestartet" und wird nie wieder als Aktivierungszustand nach außen gegeben.
+
+### Selbstheilung statt Signalisierung
+
+```python
+async def reconcile_worker(db: Session) -> None:
+    """Gleicht die lokal geladenen Plugins an die DB an."""
+```
+
+Die Funktion bildet die Differenz zwischen `enabled_names(db)` und `manager._enabled` und gleicht sie lokal an: fehlende werden über `enable_plugin()` nachgeladen, überzählige über `disable_plugin()` abgeräumt. Aufgerufen wird sie an den **async** Einstiegspunkten, die den Zustand brauchen:
+
+- `GET /api/plugins` (Liste)
+- `GET /api/plugins/ui/manifest`
+- `POST /api/plugins/{name}/menu-actions/{action_id}`
+- Status-Bar-`collect_state()`
+
+Damit heilt sich jeder Worker beim nächsten Request selbst; im eingeschwungenen Zustand ist die Differenz leer und der Aufruf kostet nichts außer einem gecachten DB-Blick.
+
+**Warum nicht im Getter?** `get_all_plugins()` ist synchron, `enable_plugin()` async. Ein Reconcile im Getter bräuchte `asyncio.run()` mitten im Request — die Sorte Abkürzung, die später als Deadlock zurückkommt. Der Reconcile gehört deshalb vor den Getter, in den async Aufrufer.
+
+### Hintergrund-Tasks bleiben primary-only
+
+`load_enabled_plugins()` übergibt heute `start_background_tasks=IS_PRIMARY_WORKER` (`lifespan.py:628`). Der Reconcile **muss** dasselbe tun. Täte er es nicht, würden nach dem ersten Reconcile alle vier Worker die Hintergrund-Tasks eines Plugins starten — aus einem Anzeigefehler würde vierfache Arbeit, vierfache Schreibzugriffe und ein echter Schaden.
+
+## Fehlerbehandlung
+
+Der interessante Fall ist die nicht lesbare DB — und derselbe Fakt muss dort in **zwei Richtungen** scheitern:
+
+| Aufrufer | Verhalten bei DB-Fehler | Begründung |
+|---|---|---|
+| Anzeige, Manifest, Pills | Rückfall auf den letzten bekannten lokalen Zustand + Warnung | Ein DB-Aussetzer darf die Plugin-Liste nicht leeren und Pills nicht verschwinden lassen |
+| `PluginGateMiddleware` | **fail closed** (wie heute: 500) | Eine Sicherheitsentscheidung darf nicht auf veraltetem Zustand fußen |
+
+Der Helper reicht den Fehler deshalb nach oben durch, statt ihn selbst zu behandeln; die beiden Aufrufer entscheiden gegenläufig. Ein Helper, der „etwas Sinnvolles" täte, hätte zwangsläufig einen der beiden Fälle falsch.
+
+Weitere Fälle:
+
+| Fall | Verhalten |
+|---|---|
+| `on_startup()` des nachzuladenden Plugins wirft | Warnung im Log, Plugin **nicht** in `_enabled`; die übrigen laufen unberührt weiter |
+| Wiederholt scheiterndes Nachladen | Kurze Sperre pro Plugin, damit nicht jeder Request es erneut versucht |
+| Plugin in der DB aktiviert, aber im Verzeichnis nicht vorhanden | Übersprungen mit Warnung (wie `load_enabled_plugins` es heute tut) |
+| Plugin mit eigenem Router lazy aktiviert | Methodenbasierte Beiträge funktionieren; Detailansicht meldet „Neustart erforderlich" |
+
+## Sicherheit
+
+- Der Reconcile ändert **nichts** an der Berechtigungsprüfung: `enable_plugin()` validiert weiterhin die in der DB hinterlegten `granted_permissions`.
+- Das Gate wird nicht aufgeweicht, sondern nutzt künftig dieselbe Quelle mit unverändertem Fail-Closed-Verhalten.
+- Ein deaktiviertes Plugin wird beim Reconcile **aktiv abgeräumt** — bisher blieb es auf einem Worker geladen, bis dieser neu startete. Der Fix schließt also nebenbei die Gegenrichtung: „deaktiviert" wirkt jetzt ebenfalls ohne Neustart.
+
+## Tests
+
+**Der Test, den es bisher nicht gab und der genau diesen Bug gefangen hätte:** zwei `PluginManager`-Instanzen auf **einer** DB — Toggle über Instanz A, Abfrage über Instanz B meldet „aktiviert". Das ist die Mehr-Worker-Situation im Kleinen, ohne echte Prozesse, und es ist der einzige Test, der die Trennung von globaler und lokaler Tatsache tatsächlich prüft.
+
+Dazu:
+
+- **Helper:** liefert die DB-Menge; cacht innerhalb des TTL-Fensters (zweiter Aufruf liest nicht erneut); nach Ablauf wieder; DB-Fehler wird nach oben gereicht statt verschluckt.
+- **Lesepfade:** `get_all_plugins()`, `ui/manifest` und `is_enabled()` melden „aktiviert", obwohl `_enabled` des Workers leer ist.
+- **Reconcile:** lädt Fehlendes nach; räumt Überzähliges ab; startet Hintergrund-Tasks **nur** wenn Primary; ein werfendes Plugin blockiert die übrigen nicht; ein gescheitertes wird nicht sofort erneut versucht.
+- **Regression Gate:** `PluginGateMiddleware` antwortet bei DB-Fehler weiterhin fehlschlagend, nicht durchlassend.
+- **Router-Fall:** ein lazy aktiviertes Plugin mit Router wird als „Neustart erforderlich" gemeldet.
+
+## Risiken
+
+- **Reconcile auf dem heißen Pfad.** Er läuft bei jedem Request an den genannten Endpunkten. Im Normalfall ist die Differenz leer und die DB-Antwort gecacht; die Kosten liegen bei einem Mengenvergleich. Wird das je spürbar, ist das TTL die Stellschraube.
+- **Nachladen ist nicht kostenlos.** Ein `on_startup()` kann langsam sein; der erste Request nach einem Toggle zahlt das auf einem Worker einmalig.
+- **Halbe Aktivierung bei Router-Plugins** bleibt bestehen und ist nur durch Neustart auflösbar. Bewusst dokumentiert statt kaschiert.


### PR DESCRIPTION
Fixt #448 · Spec: `docs/superpowers/specs/2026-07-23-plugin-enablement-cross-worker-design.md` · Plan: `docs/superpowers/plans/2026-07-23-plugin-enablement-cross-worker.md`

## Das Symptom

Ein Admin aktiviert `steam_gaming` unter *Plugins*, lädt hart neu — und es steht wieder auf **deaktiviert**. Beim nächsten Reload womöglich wieder aktiviert. Der Zustand springt.

## Root Cause — auf der Prod-Box gemessen

Der **Schreibpfad** ist korrekt: `POST /toggle` schreibt `is_enabled=True` in die DB, den einzigen worker-übergreifenden Zustand. Der **Lesepfad** war der Fehler: jede „ist aktiviert?"-Frage wurde aus `PluginManager._enabled` beantwortet — einer **prozess-lokalen** Menge, beim Worker-Start aus der DB befüllt. Der Toggle erreicht einen Worker, der Reload landet auf einem zufälligen der vier (`--workers 4`, auf der Box verifiziert). **Etwa drei von vier Reloads zeigen den falschen Zustand.**

Der eigentliche Konstruktionsfehler: `_enabled` beantwortete **zwei** Fragen mit einem Feld — „laut Konfiguration aktiviert?" (global, in der DB) und „von diesem Worker geladen und gestartet?" (lokal). Solange der Zustand nur beim Start gesetzt wurde, waren beide gleich; ein Laufzeit-Toggle trennt sie.

## Der Fix

Die DB ist die Wahrheit, jeder Worker gleicht sich beim nächsten Request selbst an — kein Broadcast, kein SHM, kein zweiter Prozess.

- **`services/plugin_enablement.py`** (neu): TTL-Cache `name -> {granted_permissions, granted_api_scopes}`, DB-Read ausschließlich im async `refresh()` über `asyncio.to_thread`. Synchrone Leser konsumieren nur den warmen Cache — der Aufrufer, der sie braucht (`get_all_plugins()`), hat keine Session zu geben.
- **`reconcile_worker()`**: gleicht `_enabled` an die DB an (beide Richtungen), single-flight, Hintergrund-Tasks primary-only, wirft nie. Läuft über eine FastAPI-Dependency auf den sechs Routen, deren Antwort vom Plugin-Zustand abhängt.
- **`PluginManager.is_enabled()` / `get_all_plugins()`** beantworten aus dem Cache, mit Fallback auf den lokalen Zustand bei fehlenden Daten.
- **`PluginGateMiddleware`** wird zweiter Nutzer desselben Caches statt zweiter Implementierung — bei DB-Fehler weiterhin **fail-closed** (500).

`_enabled` behält genau eine Bedeutung: „dieser Worker hat die Instanz geladen".

## Die harte Zusage: derselbe Fakt scheitert in zwei Richtungen

Bei nicht lesbarer DB fällt der **Anzeigepfad** auf den letzten bekannten Zustand zurück (eine Plugin-Liste darf nicht leerlaufen), das **Security-Gate** schlägt fehl-geschlossen (eine Zugriffsentscheidung darf nicht auf veraltetem Zustand laufen). Der Helper reicht den Fehler nach oben durch; die Aufrufer entscheiden gegenläufig. Beide Richtungen sind getestet.

## Was der Whole-Branch-Review gefangen hat

Drei Important, die die Task-Reviews strukturell nicht sehen konnten:

- **Eine echte Regression dieses Branches:** `is_enabled()` wechselte die Bedeutung, `run_plugin_menu_action` nutzte es weiter als Lebendigkeitsprüfung. Ein Plugin, dessen `on_startup()` wirft, liegt trotzdem in `_plugins` (Instanz wird **vor** dem Start-Hook abgelegt) — DB sagt „aktiviert", Guard passiert, Ausführung. Vorher ein 404. Gefixt mit einem eigenen `is_loaded()` (DB ∩ geladen); `is_enabled()` bleibt der DB-Leser.
- **Die Dashboard-Panel-Route** hatte keinen Reconcile, obwohl die Spec Dashboard-Panels namentlich zusagt — Dependency ergänzt.
- **Die Spec-Zusage `restart_required`** war zwischen Spec und Plan still verschwunden. Plugin-Router werden nur beim Start gemountet; ein zur Laufzeit aktiviertes Plugin mit Router bekommt seine Endpunkte nicht. Betrifft `optical_drive` und `storage_analytics` heute. Jetzt implementiert: die Detailansicht meldet `restart_required=true`, statt Bereitschaft vorzutäuschen — und fällt im Zweifel (`get_router()` wirft) auf `true`, nie auf ein falsches `false`.

## Grenzen, ehrlich benannt

- **Staleness ist TTL-begrenzt, nicht null.** Der toggelnde Worker ist sofort frisch; die übrigen bis zum TTL-Ablauf (~5 s). Aus „falsch bis zum Restart" wird „maximal wenige Sekunden".
- **Router-Plugins brauchen weiter einen Restart** (Mounting nur beim Start) — genau das meldet `restart_required` jetzt. Methodenbasierte Beiträge (Pills, Menü-Aktionen, Dashboard-Panels) wirken sofort.

## Tests & Gates

Backend **736 passed / 7 skipped**, `ruff check app tests` sauber. Keine Migration. Frontend unberührt (nur gegengeprüft, API-Form unverändert). Neu u. a.: der erste **Integrationstest für `_fetch()` gegen eine echte DB** (die Query war vorher nur begutachtet — ein Tippfehler dort hätte jeden Plugin-Request 500en lassen, bei grünem CI), und ein „Zwei Manager, eine DB"-Test, der die Trennung von globaler und lokaler Tatsache prüft — der Test, den es bisher nicht gab und der genau diesen Bug gefangen hätte.

## Vor dem Merge — Smoketest auf BaluNode

Plugin deaktivieren und aktivieren, je 5–6× hart neu laden → muss **jedes Mal** konsistent sein (vorher: ~3 von 4 falsch). Ohne Restart ins Power-Menü: „Gaming-Modus" darf kein 404 liefern. `journalctl -u baluhost-backend` zeigt das Nachladen auf den anderen Workern.

## Follow-up-Issues

Aus dem Whole-Branch-Review, außerhalb dieses PRs: #458 (Reconcile lädt nach Worker-Start installierte Plugins nicht — Discovery-Cache), #459 (SmartDeviceManager hält eine eigene Cross-Worker-Sync mit sync DB-Read und un-registriert nie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
