### PR TITLE
feat(steam-gaming): Session-Historie + Dashboard-Panel (Teilprojekt 4/4)

### DIFF
--- a/backend/alembic/versions/b661786568c1_add_steam_sessions_table.py
+++ b/backend/alembic/versions/b661786568c1_add_steam_sessions_table.py
@@ -1,0 +1,44 @@
+"""add steam_sessions table
+
+Revision ID: b661786568c1
+Revises: 71fe791d28d6
+Create Date: 2026-07-24 09:29:49.593379
+
+Teilprojekt 4/4 — siehe docs/superpowers/specs/2026-07-24-steam-session-history-dashboard-panel-design.md
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b661786568c1'
+down_revision: Union[str, Sequence[str], None] = '71fe791d28d6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create steam_sessions (play history for the steam_gaming plugin)."""
+    op.create_table(
+        'steam_sessions',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('app_id', sa.String(length=32), nullable=False),
+        sa.Column('game_name', sa.String(length=200), nullable=True),
+        sa.Column('started_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('last_seen_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('ended_at', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_steam_sessions_id', 'steam_sessions', ['id'])
+    op.create_index('ix_steam_sessions_app_id', 'steam_sessions', ['app_id'])
+    op.create_index('ix_steam_sessions_started_at', 'steam_sessions', ['started_at'])
+
+
+def downgrade() -> None:
+    """Drop steam_sessions. Loses the play history — dev/rollback path only."""
+    op.drop_index('ix_steam_sessions_started_at', table_name='steam_sessions')
+    op.drop_index('ix_steam_sessions_app_id', table_name='steam_sessions')
+    op.drop_index('ix_steam_sessions_id', table_name='steam_sessions')
+    op.drop_table('steam_sessions')

--- a/backend/app/api/routes/dashboard.py
+++ b/backend/app/api/routes/dashboard.py
@@ -11,6 +11,7 @@ from app.core.rate_limiter import user_limiter, get_limit
 from app.models.user import User
 from app.plugins.manager import PluginManager
 from app.schemas.plugin import DashboardPanelResponse
+from app.services.permissions import is_privileged
 from app.services.plugin_service import get_dashboard_panel_plugin
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,12 @@ async def get_plugin_panel(
 
     spec = plugin.get_dashboard_panel()
     if spec is None:
+        return None
+
+    if spec.admin_only and not is_privileged(current_user):
+        # The game name in the Steam panel is information about the box owner -
+        # same privacy call as the status pill. Enforced here so no plugin has
+        # to implement its own gate.
         return None
 
     # Get current data

--- a/backend/app/models/CLAUDE.md
+++ b/backend/app/models/CLAUDE.md
@@ -26,7 +26,7 @@ SQLAlchemy 2.0 ORM models. All models inherit from `Base` (declarative base in `
 
 **Versioning**: `vcl.py` (FileVersion, VersionBlob, VCLSettings, VCLStats)
 
-**Plugins & Integrations**: `plugin.py`, `plugin_storage.py`, `pihole.py`, `dns_queries.py`, `ad_discovery.py`, `cloud.py`, `cloud_export.py`, `benchmark.py`, `energy_price_config.py`
+**Plugins & Integrations**: `plugin.py`, `plugin_storage.py`, `steam_session.py`, `pihole.py`, `dns_queries.py`, `ad_discovery.py`, `cloud.py`, `cloud_export.py`, `benchmark.py`, `energy_price_config.py`
 
 **Desktop Sync**: `desktop_sync_folder.py`, `sync_progress.py`, `sync_state.py`
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -102,6 +102,7 @@ from app.models.notification_routing import UserNotificationRouting
 from app.models.sync_progress import ChunkedUpload, SyncBandwidthLimit, SyncSchedule, SelectiveSync
 from app.models.sync_state import SyncState, SyncMetadata, SyncFileVersion
 from app.models.status_bar import StatusBarPillConfig, StatusBarSettings
+from app.models.steam_session import SteamSession
 from app.models.auth_policy import AuthPolicy
 
 __all__ = [
@@ -217,4 +218,5 @@ __all__ = [
     "SyncFileVersion",
     "StatusBarPillConfig",
     "StatusBarSettings",
+    "SteamSession",
 ]

--- a/backend/app/models/steam_session.py
+++ b/backend/app/models/steam_session.py
@@ -1,0 +1,38 @@
+"""Steam play sessions recorded by the steam_gaming plugin (Teilprojekt 4/4).
+
+The table lives in app/models/ rather than in the plugin because Alembic's
+autogenerate only sees what is attached to Base.metadata — same reason
+smart_device.py sits here for the Tapo plugin.
+"""
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class SteamSession(Base):
+    """One play session. ``ended_at IS NULL`` means it is still running.
+
+    The duration is deliberately NOT stored: it is derived from
+    ``ended_at - started_at``. A stored value would be a second truth that can
+    drift when a session is adopted across a backend restart.
+    """
+
+    __tablename__ = "steam_sessions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    app_id: Mapped[str] = mapped_column(String(32), index=True, nullable=False)
+    game_name: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), index=True, nullable=False
+    )
+    last_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    ended_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    def __repr__(self) -> str:
+        return f"<SteamSession(app_id='{self.app_id}', started_at={self.started_at})>"

--- a/backend/app/plugins/CLAUDE.md
+++ b/backend/app/plugins/CLAUDE.md
@@ -65,7 +65,16 @@ Two plugin trust tiers with different isolation:
 2. Create `__init__.py` exporting a class that extends `PluginBase`
 3. Implement `metadata` property returning `PluginMetadata`
 4. Override `get_router()` for API routes, `get_background_tasks()` for periodic work
-5. Override `get_dashboard_panel()` + `get_dashboard_data()` for dashboard integration
+5. Override `get_dashboard_panel()` + `get_dashboard_data()` for dashboard integration.
+   `DashboardPanelSpec.admin_only=True` beschränkt ein Panel auf privilegierte
+   Nutzer. Durchgesetzt wird das **im Core** an zwei Stellen, nicht im Plugin:
+   in `api/routes/dashboard.py` (`is_privileged`) und in
+   `services/dashboard_panel_bridge.py`, das seinen WebSocket-Broadcast dann
+   mit `broadcast_typed(..., admins_only=True)` fährt. Beides ist nötig — der
+   Bridge schiebt dieselben Daten unabhängig von der Route an verbundene
+   Clients. Panel-Icons werden im Frontend dynamisch aus lucide aufgelöst
+   (kebab-case → PascalCase, Fallback `Plug`), ein neues Icon braucht also
+   keine Core-Änderung.
 6. Override `get_status_pills()` + `collect_status_pill()` to contribute a
    topbar status-strip pill. Only pick the plugin-local suffix (validated
    against `^[a-z0-9_]+$` on `StatusPillSpec.id`) — the core composes the
@@ -85,10 +94,10 @@ Two plugin trust tiers with different isolation:
    pills, menu actions or the plugin list itself (#448). The reconcile is
    wired to five routes via `Depends(deps.reconciled_plugin_state)`:
    `list_plugins`, `get_ui_manifest`, `run_plugin_menu_action`,
-   `get_statusbar_config` and `get_statusbar_state`. The Dashboard plugin
-   panel (`GET /api/dashboard/plugin-panel`) is **not** one of them — it reads
-   `PluginManager.get_plugin()` directly with no DB fallback, so it only
-   catches up once some other reconciled route has run on the same worker.
+   `get_statusbar_config` and `get_statusbar_state`. The Dashboard plugin panel
+   (`GET /api/dashboard/plugin-panel`) is one of them as well
+   (`api/routes/dashboard.py`), so it catches up on the same request like the
+   other five.
    **One exception:** plugin HTTP routes are mounted once at startup
    (`core/lifespan.py`), so a plugin that ships its own router still needs a
    `baluhost-backend` restart before its endpoints exist. Its

--- a/backend/app/plugins/base.py
+++ b/backend/app/plugins/base.py
@@ -125,7 +125,14 @@ PanelType = Literal["gauge", "stat", "status", "chart"]
 
 
 class DashboardPanelSpec(BaseModel):
-    """Specification for a plugin's Dashboard panel."""
+    """Specification for a plugin's Dashboard panel.
+
+    ``admin_only`` is enforced by the core - in the REST route and in the
+    WebSocket bridge - not by the plugin, so no plugin can get its own gate
+    wrong. Same pattern as PluginNavItem.admin_only. (PluginMenuItem
+    deliberately has no such field: an action executes something, a panel
+    displays something.)
+    """
 
     panel_type: PanelType = Field(
         ...,
@@ -136,6 +143,10 @@ class DashboardPanelSpec(BaseModel):
     accent: str = Field(
         default="from-sky-500 to-indigo-500",
         description="Tailwind gradient classes for icon background",
+    )
+    admin_only: bool = Field(
+        default=False,
+        description="Only serve this panel to privileged users",
     )
 
 

--- a/backend/app/plugins/installed/steam_gaming/__init__.py
+++ b/backend/app/plugins/installed/steam_gaming/__init__.py
@@ -11,13 +11,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
-from app.core.config import settings
 from app.plugins.base import (
     BackgroundTaskSpec,
+    DashboardPanelSpec,
     MenuActionResult,
     PluginBase,
     PluginEventSpec,
@@ -26,9 +27,11 @@ from app.plugins.base import (
     PluginUIManifest,
     StatusPillSpec,
 )
-from app.plugins.installed.steam_gaming.detector import detect_running_app_id
+from app.models.steam_session import SteamSession
+from app.plugins.dashboard_panel import StatusItem, StatusPanelData
+from app.plugins.installed.steam_gaming import ledger
+from app.plugins.installed.steam_gaming.detection import current_app_id, resolve_game_name
 from app.plugins.installed.steam_gaming.launcher import open_big_picture
-from app.plugins.installed.steam_gaming.names import resolve_name
 from app.plugins.installed.steam_gaming.poller import SteamSessionPoller
 from app.services.power.desktop import get_desktop_service
 
@@ -36,11 +39,12 @@ logger = logging.getLogger(__name__)
 
 _PILL_ID = "session"
 _MENU_ACTION_ID = "gaming_mode"
-_EVENT_STARTED = "session_started"
-_EVENT_ENDED = "session_ended"
+_EVENT_STARTED = ledger.EVENT_STARTED
+_EVENT_ENDED = ledger.EVENT_ENDED
 _POLL_INTERVAL_SECONDS = 30.0
 _CACHE_TTL_SECONDS = 3.0
 _CACHE: Dict[str, object] = {}
+_PANEL_ROWS = 5
 
 
 def _monotonic() -> float:
@@ -55,11 +59,29 @@ def _current_game() -> Optional[tuple[str, Optional[str]]]:
     if isinstance(checked_at, float) and now - checked_at < _CACHE_TTL_SECONDS:
         return _CACHE.get("game")  # type: ignore[return-value]
 
-    app_id = detect_running_app_id()
-    game = (app_id, resolve_name(app_id)) if app_id else None
+    app_id = current_app_id()
+    game = (app_id, resolve_game_name(app_id)) if app_id else None
     _CACHE["checked_at"] = now
     _CACHE["game"] = game
     return game
+
+
+def _format_duration(seconds: float) -> str:
+    """``3h 04m`` / ``12m`` - digits only, so no string needs translating."""
+    total = int(seconds)
+    hours, remainder = divmod(total, 3600)
+    minutes = remainder // 60
+    if hours:
+        return f"{hours}h {minutes:02d}m"
+    return f"{minutes}m"
+
+
+def _panel_value(row: SteamSession, now: datetime) -> str:
+    """Running sessions show the bare duration; finished ones prepend the date."""
+    duration = _format_duration(ledger.duration_seconds(row, now))
+    if row.ended_at is None:
+        return duration
+    return f"{ledger.as_utc(row.started_at):%d.%m.} · {duration}"
 
 
 class SteamGamingPlugin(PluginBase):
@@ -95,13 +117,11 @@ class SteamGamingPlugin(PluginBase):
         # code, so a slow/spun-down Steam library mount would otherwise stall
         # the whole worker's event loop instead of being cut off by the
         # PLUGIN_COLLECTOR_TIMEOUT_SECONDS timeout in the status bar service.
+        # The dev-mode stand-in now lives in detection.py, so pill, ledger and
+        # panel agree on what is running.
         game = await asyncio.to_thread(_current_game)
         if game is None:
-            if settings.is_dev_mode:
-                # No /proc on a Windows dev box — render something anyway.
-                game = ("0", "Dev Mode Game")
-            else:
-                return None
+            return None
 
         _app_id, name = game
         return {
@@ -162,6 +182,43 @@ class SteamGamingPlugin(PluginBase):
             message_key="menu_gaming_mode_started",
             message_text="Gaming mode started",
         )
+
+    def get_dashboard_panel(self) -> Optional[DashboardPanelSpec]:
+        return DashboardPanelSpec(
+            panel_type="status",
+            title="Steam Gaming",
+            icon="gamepad-2",
+            accent="from-indigo-500 to-purple-500",
+            # The game name is information about the box owner - same call as
+            # the pill's default visibility in Teilprojekt 1.
+            admin_only=True,
+        )
+
+    async def get_dashboard_data(self, db: Session) -> Optional[dict]:
+        """The five newest sessions; the running one sorts to the top.
+
+        Returns None when nothing was ever recorded - a placeholder line would
+        be a translatable string, and StatusItem has no key fields.
+        """
+        rows = (
+            db.query(SteamSession)
+            .order_by(SteamSession.started_at.desc())
+            .limit(_PANEL_ROWS)
+            .all()
+        )
+        if not rows:
+            return None
+
+        now = datetime.now(timezone.utc)
+        items = [
+            StatusItem(
+                label=row.game_name or f"AppID {row.app_id}",
+                value=_panel_value(row, now),
+                tone="ok" if row.ended_at is None else "neutral",
+            )
+            for row in rows
+        ]
+        return StatusPanelData(items=items).model_dump()
 
     def get_notification_events(self) -> List[PluginEventSpec]:
         return [

--- a/backend/app/plugins/installed/steam_gaming/__init__.py
+++ b/backend/app/plugins/installed/steam_gaming/__init__.py
@@ -52,6 +52,11 @@ def _monotonic() -> float:
     return time.monotonic()
 
 
+def _utc_now() -> datetime:
+    """Indirection so tests can control the clock, like the poller's."""
+    return datetime.now(timezone.utc)
+
+
 def _current_game() -> Optional[tuple[str, Optional[str]]]:
     """``(app_id, name)`` of the running game, or None. Cached for a few seconds."""
     now = _monotonic()
@@ -209,7 +214,7 @@ class SteamGamingPlugin(PluginBase):
         if not rows:
             return None
 
-        now = datetime.now(timezone.utc)
+        now = _utc_now()
         items = [
             StatusItem(
                 label=row.game_name or f"AppID {row.app_id}",

--- a/backend/app/plugins/installed/steam_gaming/detection.py
+++ b/backend/app/plugins/installed/steam_gaming/detection.py
@@ -7,21 +7,45 @@ instead of the real behaviour.
 """
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 from app.core.config import settings
 from app.plugins.installed.steam_gaming.detector import detect_running_app_id
 from app.plugins.installed.steam_gaming.names import resolve_name
 
+logger = logging.getLogger(__name__)
+
 # There is no /proc on a Windows dev box, so nothing would ever be detected and
 # neither the pill nor the panel would have anything to show locally.
 DEV_APP_ID = "0"
 DEV_GAME_NAME = "Dev Mode Game"
 
+# Matches SteamSession.app_id: String(32) in app/models/steam_session.py.
+# Real Steam AppIDs are at most 10 digits today; anything longer than the
+# column width is not a game, it is a process that merely looks like one -
+# passing it through would make every booking tick fail with a PostgreSQL
+# DataError (SQLite does not enforce VARCHAR length, so this only bites in
+# production).
+_MAX_APP_ID_LENGTH = 32
+
+# Matches SteamSession.game_name: String(200) in app/models/steam_session.py.
+# A truncated name is a cosmetic issue in the panel; an unbounded one is a
+# permanently failing booking on PostgreSQL.
+_MAX_GAME_NAME_LENGTH = 200
+
 
 def current_app_id() -> Optional[str]:
     """AppID of the running game, or None. Blocking - call via asyncio.to_thread."""
     app_id = detect_running_app_id()
+    if app_id is not None and len(app_id) > _MAX_APP_ID_LENGTH:
+        logger.warning(
+            "Ignoring detected app_id longer than %d chars (got %d): %r",
+            _MAX_APP_ID_LENGTH,
+            len(app_id),
+            app_id,
+        )
+        app_id = None
     if app_id is None and settings.is_dev_mode:
         return DEV_APP_ID
     return app_id
@@ -31,4 +55,7 @@ def resolve_game_name(app_id: str) -> Optional[str]:
     """Display name for *app_id*, or None. Blocking - call via asyncio.to_thread."""
     if settings.is_dev_mode and app_id == DEV_APP_ID:
         return DEV_GAME_NAME
-    return resolve_name(app_id)
+    name = resolve_name(app_id)
+    if name is not None and len(name) > _MAX_GAME_NAME_LENGTH:
+        name = name[:_MAX_GAME_NAME_LENGTH]
+    return name

--- a/backend/app/plugins/installed/steam_gaming/detection.py
+++ b/backend/app/plugins/installed/steam_gaming/detection.py
@@ -1,0 +1,34 @@
+"""One source of truth for "is a game running" - pill, ledger and panel share it.
+
+The dev-mode stand-in lives HERE and not in detector.py/names.py on purpose:
+the test suite runs with NAS_MODE=dev (tests/conftest.py), so a dev branch
+inside the pure /proc scan would make the detector tests assert the mock
+instead of the real behaviour.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from app.core.config import settings
+from app.plugins.installed.steam_gaming.detector import detect_running_app_id
+from app.plugins.installed.steam_gaming.names import resolve_name
+
+# There is no /proc on a Windows dev box, so nothing would ever be detected and
+# neither the pill nor the panel would have anything to show locally.
+DEV_APP_ID = "0"
+DEV_GAME_NAME = "Dev Mode Game"
+
+
+def current_app_id() -> Optional[str]:
+    """AppID of the running game, or None. Blocking - call via asyncio.to_thread."""
+    app_id = detect_running_app_id()
+    if app_id is None and settings.is_dev_mode:
+        return DEV_APP_ID
+    return app_id
+
+
+def resolve_game_name(app_id: str) -> Optional[str]:
+    """Display name for *app_id*, or None. Blocking - call via asyncio.to_thread."""
+    if settings.is_dev_mode and app_id == DEV_APP_ID:
+        return DEV_GAME_NAME
+    return resolve_name(app_id)

--- a/backend/app/plugins/installed/steam_gaming/ledger.py
+++ b/backend/app/plugins/installed/steam_gaming/ledger.py
@@ -78,6 +78,11 @@ def _current_session(db: Session) -> Optional[SteamSession]:
     )
 
 
+def _gap_seconds(session: SteamSession, now: datetime) -> float:
+    """How long the poller was away, measured from the session's last heartbeat."""
+    return (now - as_utc(session.last_seen_at)).total_seconds()
+
+
 def record(
     db: Session,
     app_id: Optional[str],
@@ -105,16 +110,33 @@ def record(
 
         if current is None:
             if app_id is not None:
+                # Nothing open: either nothing was running, or this is the very
+                # first tick after deploying the ledger. Both look identical
+                # here - see the accepted deviation in the design doc.
                 opened = _open(db, app_id, now, resolve_name)
                 events.append(LedgerEvent(EVENT_STARTED, opened.app_id, _label(opened)))
-        elif app_id == current.app_id:
-            current.last_seen_at = now
         else:
-            current.ended_at = now
-            events.append(LedgerEvent(EVENT_ENDED, current.app_id, _label(current)))
-            if app_id is not None:
-                opened = _open(db, app_id, now, resolve_name)
-                events.append(LedgerEvent(EVENT_STARTED, opened.app_id, _label(opened)))
+            gap = _gap_seconds(current, now)
+            live = gap <= STALE_AFTER_SECONDS
+
+            if app_id == current.app_id:
+                if gap <= ADOPT_WINDOW_SECONDS:
+                    current.last_seen_at = now
+                else:
+                    # Same game, but far too long ago to be one session.
+                    current.ended_at = as_utc(current.last_seen_at)
+                    _open(db, app_id, now, resolve_name)  # after a gap: book, never announce
+            else:
+                # `now` is only a truthful end time while the poller was there.
+                current.ended_at = now if live else as_utc(current.last_seen_at)
+                if live:
+                    events.append(LedgerEvent(EVENT_ENDED, current.app_id, _label(current)))
+                if app_id is not None:
+                    opened = _open(db, app_id, now, resolve_name)
+                    if live:
+                        events.append(
+                            LedgerEvent(EVENT_STARTED, opened.app_id, _label(opened))
+                        )
 
         db.commit()
     except Exception:  # broad on purpose: a booking failure must not kill the poller

--- a/backend/app/plugins/installed/steam_gaming/ledger.py
+++ b/backend/app/plugins/installed/steam_gaming/ledger.py
@@ -69,14 +69,22 @@ def _open(
     return session
 
 
-def _current_session(db: Session) -> Optional[SteamSession]:
-    """The newest open session, if any."""
-    return (
+def _claim_current_session(db: Session) -> Optional[SteamSession]:
+    """The newest open session; any older open one is an orphan and gets closed.
+
+    The invariant is "at most one open session". A crash at the wrong moment can
+    still leave more behind, so every tick cleans up instead of trusting it.
+    """
+    open_sessions = (
         db.query(SteamSession)
         .filter(SteamSession.ended_at.is_(None))
         .order_by(SteamSession.started_at.desc())
-        .first()
+        .all()
     )
+    for orphan in open_sessions[1:]:
+        orphan.ended_at = as_utc(orphan.last_seen_at)
+        logger.warning("steam ledger: closed orphaned session id=%s", orphan.id)
+    return open_sessions[0] if open_sessions else None
 
 
 def _gap_seconds(session: SteamSession, now: datetime) -> float:
@@ -115,7 +123,7 @@ def record(
     """
     events: List[LedgerEvent] = []
     try:
-        current = _current_session(db)
+        current = _claim_current_session(db)
 
         if current is None:
             if app_id is not None:
@@ -131,6 +139,10 @@ def record(
             if app_id == current.app_id:
                 if gap <= ADOPT_WINDOW_SECONDS:
                     current.last_seen_at = now
+                    if current.game_name is None:
+                        # A game started during its own install has no manifest
+                        # yet; resolve_name() retries misses after 60s anyway.
+                        current.game_name = resolve_name(app_id)
                 else:
                     # Same game, but far too long ago to be one session.
                     current.ended_at = as_utc(current.last_seen_at)
@@ -164,3 +176,13 @@ def record(
         return []
 
     return events
+
+
+def duration_seconds(session: SteamSession, now: datetime) -> float:
+    """Seconds played. An open session counts up to *now*.
+
+    Clamped at 0: an NTP step backwards would otherwise produce a negative
+    duration, which is worse in the panel than a flattering zero.
+    """
+    end = as_utc(session.ended_at) if session.ended_at is not None else now
+    return max(0.0, (end - as_utc(session.started_at)).total_seconds())

--- a/backend/app/plugins/installed/steam_gaming/ledger.py
+++ b/backend/app/plugins/installed/steam_gaming/ledger.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Callable, List, Optional
 
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.models.steam_session import SteamSession
@@ -83,6 +84,14 @@ def _gap_seconds(session: SteamSession, now: datetime) -> float:
     return (now - as_utc(session.last_seen_at)).total_seconds()
 
 
+def _safe_rollback(db: Session) -> None:
+    """A rollback on a dead connection must not defeat the no-raise contract."""
+    try:
+        db.rollback()
+    except Exception:
+        logger.warning("steam ledger: rollback failed", exc_info=True)
+
+
 def record(
     db: Session,
     app_id: Optional[str],
@@ -139,9 +148,19 @@ def record(
                         )
 
         db.commit()
-    except Exception:  # broad on purpose: a booking failure must not kill the poller
-        db.rollback()
+    except SQLAlchemyError:
+        _safe_rollback(db)
         logger.warning("steam ledger: booking failed", exc_info=True)
+        return []
+    except Exception:
+        # Not a database problem: a programming error, or an injected
+        # resolve_name() that threw. The poller must survive it, but this must
+        # not look like a briefly unreachable database in the log - otherwise a
+        # permanently silent ledger is indistinguishable from a hiccup.
+        _safe_rollback(db)
+        logger.exception(
+            "steam ledger: unexpected failure (app_id=%s, now=%s)", app_id, now
+        )
         return []
 
     return events

--- a/backend/app/plugins/installed/steam_gaming/ledger.py
+++ b/backend/app/plugins/installed/steam_gaming/ledger.py
@@ -1,0 +1,125 @@
+"""Steam session ledger: turn detector observations into persisted sessions.
+
+The open session in the database IS the poller's state - there is no in-process
+last_app_id and no initialization flag. That is what makes a restart mid-session
+harmless: the gap between `now` and the open session's last_seen_at says what
+happened while the process was away (see the gap rules in Task 3).
+
+This module knows the database and nothing about notifications: it returns what
+is worth announcing and lets the caller deliver it, after the booking is
+committed.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.steam_session import SteamSession
+
+logger = logging.getLogger(__name__)
+
+EVENT_STARTED = "session_started"
+EVENT_ENDED = "session_ended"
+
+# Two poll intervals: within this, the poller was there continuously, so `now`
+# is a truthful end time and the edge is live news worth announcing.
+STALE_AFTER_SECONDS = 60.0
+# The same game across a gap this short is one session (a deploy mid-game).
+ADOPT_WINDOW_SECONDS = 600.0
+
+
+@dataclass(frozen=True)
+class LedgerEvent:
+    """A notification the caller should fire once the booking is committed."""
+
+    event_id: str
+    app_id: str
+    game: str
+
+
+def as_utc(value: datetime) -> datetime:
+    """SQLite hands back naive datetimes even for DateTime(timezone=True)."""
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
+def _label(session: SteamSession) -> str:
+    """Name for a notification; the AppID is the honest fallback."""
+    return session.game_name or session.app_id
+
+
+def _open(
+    db: Session,
+    app_id: str,
+    now: datetime,
+    resolve_name: Callable[[str], Optional[str]],
+) -> SteamSession:
+    """Start a new session. Announcing it is the caller's decision."""
+    session = SteamSession(
+        app_id=app_id,
+        game_name=resolve_name(app_id),
+        started_at=now,
+        last_seen_at=now,
+    )
+    db.add(session)
+    return session
+
+
+def _current_session(db: Session) -> Optional[SteamSession]:
+    """The newest open session, if any."""
+    return (
+        db.query(SteamSession)
+        .filter(SteamSession.ended_at.is_(None))
+        .order_by(SteamSession.started_at.desc())
+        .first()
+    )
+
+
+def record(
+    db: Session,
+    app_id: Optional[str],
+    *,
+    now: datetime,
+    resolve_name: Callable[[str], Optional[str]],
+) -> List[LedgerEvent]:
+    """Book one detector observation; return the events worth announcing.
+
+    Commits on success. Never raises: a database failure rolls back, logs and
+    yields no events, so the next tick simply tries again.
+
+    Args:
+        db: SQLAlchemy session, owned by the caller.
+        app_id: AppID of the running game, or None when nothing is running.
+        now: Current time (injected so tests control the clock).
+        resolve_name: AppID -> display name, or None when unresolvable.
+
+    Returns:
+        Events to deliver, in order.
+    """
+    events: List[LedgerEvent] = []
+    try:
+        current = _current_session(db)
+
+        if current is None:
+            if app_id is not None:
+                opened = _open(db, app_id, now, resolve_name)
+                events.append(LedgerEvent(EVENT_STARTED, opened.app_id, _label(opened)))
+        elif app_id == current.app_id:
+            current.last_seen_at = now
+        else:
+            current.ended_at = now
+            events.append(LedgerEvent(EVENT_ENDED, current.app_id, _label(current)))
+            if app_id is not None:
+                opened = _open(db, app_id, now, resolve_name)
+                events.append(LedgerEvent(EVENT_STARTED, opened.app_id, _label(opened)))
+
+        db.commit()
+    except Exception:  # broad on purpose: a booking failure must not kill the poller
+        db.rollback()
+        logger.warning("steam ledger: booking failed", exc_info=True)
+        return []
+
+    return events

--- a/backend/app/plugins/installed/steam_gaming/ledger.py
+++ b/backend/app/plugins/installed/steam_gaming/ledger.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Callable, List, Optional
 
 from sqlalchemy.exc import SQLAlchemyError
@@ -31,6 +31,8 @@ EVENT_ENDED = "session_ended"
 STALE_AFTER_SECONDS = 60.0
 # The same game across a gap this short is one session (a deploy mid-game).
 ADOPT_WINDOW_SECONDS = 600.0
+# Hard-wired on purpose; configurability is tracked in #464.
+RETENTION_DAYS = 365
 
 
 @dataclass(frozen=True)
@@ -186,3 +188,39 @@ def duration_seconds(session: SteamSession, now: datetime) -> float:
     """
     end = as_utc(session.ended_at) if session.ended_at is not None else now
     return max(0.0, (end - as_utc(session.started_at)).total_seconds())
+
+
+def cleanup_old_sessions(db: Session, *, now: datetime) -> int:
+    """Delete ended sessions older than RETENTION_DAYS.
+
+    Deliberately not wired into monitoring/retention_manager.py: that one hangs
+    off the MetricType enum and monitoring_config rows, so putting a plugin
+    table there would couple the core to a plugin.
+
+    An open session (ended_at IS NULL) is never touched, however old - it is
+    the current one.
+
+    Returns:
+        Number of rows deleted; 0 if the delete failed.
+    """
+    cutoff = now - timedelta(days=RETENTION_DAYS)
+    try:
+        deleted = (
+            db.query(SteamSession)
+            .filter(SteamSession.ended_at.isnot(None), SteamSession.ended_at < cutoff)
+            .delete(synchronize_session=False)
+        )
+        db.commit()
+    except SQLAlchemyError:
+        _safe_rollback(db)
+        logger.warning("steam ledger: retention cleanup failed", exc_info=True)
+        return 0
+    except Exception:
+        # Not a database problem: a programming error. The poller must survive
+        # it, but this must not look like a briefly unreachable database in the
+        # log.
+        _safe_rollback(db)
+        logger.exception("steam ledger: unexpected retention cleanup failure (now=%s)", now)
+        return 0
+
+    return deleted

--- a/backend/app/plugins/installed/steam_gaming/poller.py
+++ b/backend/app/plugins/installed/steam_gaming/poller.py
@@ -18,8 +18,7 @@ from sqlalchemy.orm import Session
 
 from app.core.database import SessionLocal
 from app.plugins.installed.steam_gaming import ledger
-from app.plugins.installed.steam_gaming.detector import detect_running_app_id
-from app.plugins.installed.steam_gaming.names import resolve_name
+from app.plugins.installed.steam_gaming.detection import current_app_id, resolve_game_name
 from app.services.notifications.plugin_events import emit_plugin_event
 
 _PLUGIN = "steam_gaming"
@@ -36,8 +35,8 @@ class SteamSessionPoller:
 
     def __init__(
         self,
-        detect: Callable[[], Optional[str]] = detect_running_app_id,
-        resolve: Callable[[str], Optional[str]] = resolve_name,
+        detect: Callable[[], Optional[str]] = current_app_id,
+        resolve: Callable[[str], Optional[str]] = resolve_game_name,
         emit: Callable[..., Awaitable[None]] = emit_plugin_event,
         session_factory: Callable[[], Session] = SessionLocal,
         clock: Callable[[], datetime] = _utc_now,

--- a/backend/app/plugins/installed/steam_gaming/poller.py
+++ b/backend/app/plugins/installed/steam_gaming/poller.py
@@ -1,55 +1,84 @@
-"""Steam session poller: detect play/not-play edges and emit notifications.
+"""Steam session poller: detect, book, announce (Teilprojekt 3+4/4).
 
 Runs as a plugin background task, which thanks to #448 executes primary-only -
-so exactly one instance polls, and its last-seen state can live in the object
-(no cross-worker sharing). The first tick only establishes a baseline: a game
-already running when the backend starts must not be reported as 'started', or
-every restart would false-alarm mid-session.
+so exactly one instance polls. It keeps no state of its own: the open session
+in the database is the state (see ledger.py), which is what makes a restart
+mid-session harmless.
+
+Order matters: book and commit first, announce afterwards. A failed push must
+never roll back a booking.
 """
 from __future__ import annotations
 
 import asyncio
-from typing import Callable, Optional
+import logging
+from datetime import datetime, timezone
+from typing import Callable, List, Optional
 
+from sqlalchemy.orm import Session
+
+from app.core.database import SessionLocal
+from app.plugins.installed.steam_gaming import ledger
 from app.plugins.installed.steam_gaming.detector import detect_running_app_id
 from app.plugins.installed.steam_gaming.names import resolve_name
 from app.services.notifications.plugin_events import emit_plugin_event
 
+logger = logging.getLogger(__name__)
+
 _PLUGIN = "steam_gaming"
+_CLEANUP_INTERVAL_SECONDS = 24 * 60 * 60.0
+
+
+def _utc_now() -> datetime:
+    """Indirection so tests can control the clock."""
+    return datetime.now(timezone.utc)
 
 
 class SteamSessionPoller:
+    """Books what the detector sees and announces the edges worth announcing."""
+
     def __init__(
         self,
         detect: Callable[[], Optional[str]] = detect_running_app_id,
         resolve: Callable[[str], Optional[str]] = resolve_name,
         emit=emit_plugin_event,
+        session_factory: Callable[[], Session] = SessionLocal,
+        clock: Callable[[], datetime] = _utc_now,
     ) -> None:
         self._detect = detect
         self._resolve = resolve
         self._emit = emit
-        self._initialized = False
-        self._last_app_id: Optional[str] = None
+        self._session_factory = session_factory
+        self._clock = clock
+        self._last_cleanup: Optional[datetime] = None
 
     async def tick(self) -> None:
-        # Blocking /proc + manifest reads off the event loop, same convention
-        # as the menu action and the pill collector.
+        """One poll: detect, book, then deliver whatever the ledger returned."""
+        # Blocking /proc + manifest + DB work stays off the event loop.
         app_id = await asyncio.to_thread(self._detect)
+        now = self._clock()
+        events = await asyncio.to_thread(self._book, app_id, now)
 
-        if not self._initialized:
-            self._last_app_id = app_id
-            self._initialized = True
-            return
+        for event in events:
+            await self._emit(
+                _PLUGIN, event.event_id, entity_id=event.app_id, game=event.game
+            )
 
-        prev = self._last_app_id
-        self._last_app_id = app_id
+    def _book(self, app_id: Optional[str], now: datetime) -> List[ledger.LedgerEvent]:
+        """Blocking: owns the database session for this tick."""
+        db = self._session_factory()
+        try:
+            events = ledger.record(db, app_id, now=now, resolve_name=self._resolve)
+            if self._due_for_cleanup(now):
+                ledger.cleanup_old_sessions(db, now=now)
+                self._last_cleanup = now
+            return events
+        finally:
+            db.close()
 
-        if prev is None and app_id is not None:
-            await self._fire("session_started", app_id)
-        elif prev is not None and app_id is None:
-            await self._fire("session_ended", prev)
-        # prev == app_id, or a direct X->Y switch: no event; state already moved.
-
-    async def _fire(self, event_id: str, app_id: str) -> None:
-        name = await asyncio.to_thread(self._resolve, app_id) or app_id
-        await self._emit(_PLUGIN, event_id, entity_id=app_id, game=name)
+    def _due_for_cleanup(self, now: datetime) -> bool:
+        """Once a day. The marker lives in the process - a restart costs at most
+        one extra DELETE that finds nothing."""
+        if self._last_cleanup is None:
+            return True
+        return (now - self._last_cleanup).total_seconds() >= _CLEANUP_INTERVAL_SECONDS

--- a/backend/app/plugins/installed/steam_gaming/poller.py
+++ b/backend/app/plugins/installed/steam_gaming/poller.py
@@ -11,9 +11,8 @@ never roll back a booking.
 from __future__ import annotations
 
 import asyncio
-import logging
 from datetime import datetime, timezone
-from typing import Callable, List, Optional
+from typing import Awaitable, Callable, List, Optional
 
 from sqlalchemy.orm import Session
 
@@ -22,8 +21,6 @@ from app.plugins.installed.steam_gaming import ledger
 from app.plugins.installed.steam_gaming.detector import detect_running_app_id
 from app.plugins.installed.steam_gaming.names import resolve_name
 from app.services.notifications.plugin_events import emit_plugin_event
-
-logger = logging.getLogger(__name__)
 
 _PLUGIN = "steam_gaming"
 _CLEANUP_INTERVAL_SECONDS = 24 * 60 * 60.0
@@ -41,7 +38,7 @@ class SteamSessionPoller:
         self,
         detect: Callable[[], Optional[str]] = detect_running_app_id,
         resolve: Callable[[str], Optional[str]] = resolve_name,
-        emit=emit_plugin_event,
+        emit: Callable[..., Awaitable[None]] = emit_plugin_event,
         session_factory: Callable[[], Session] = SessionLocal,
         clock: Callable[[], datetime] = _utc_now,
     ) -> None:

--- a/backend/app/services/dashboard_panel_bridge.py
+++ b/backend/app/services/dashboard_panel_bridge.py
@@ -51,6 +51,7 @@ async def _build_panel_update(db: Session) -> Optional[Dict[str, Any]]:
     return {
         "panel_type": spec.panel_type,
         "plugin_name": record.name,
+        "admin_only": spec.admin_only,
         "data": data,
     }
 
@@ -96,7 +97,13 @@ async def dashboard_panel_ws_bridge() -> None:
 
             ws = get_websocket_manager()
             if ws:
-                await ws.broadcast_typed("dashboard_panel_update", payload)
+                # An admin_only panel must not reach every socket - the REST
+                # gate would be decorative otherwise.
+                await ws.broadcast_typed(
+                    "dashboard_panel_update",
+                    payload,
+                    admins_only=bool(payload.get("admin_only")),
+                )
 
         except Exception as exc:
             logger.debug("Dashboard panel WS bridge error: %s", exc)

--- a/backend/app/services/websocket_manager.py
+++ b/backend/app/services/websocket_manager.py
@@ -223,8 +223,10 @@ class WebSocketManager:
 
         return sent_count
 
-    async def broadcast_typed(self, msg_type: str, payload: dict[str, Any]) -> int:
-        """Broadcast a typed message to all connected users.
+    async def broadcast_typed(
+        self, msg_type: str, payload: dict[str, Any], admins_only: bool = False
+    ) -> int:
+        """Broadcast a typed message to connected users.
 
         Unlike broadcast_to_all() which wraps in {"type": "notification"},
         this method sends {"type": msg_type, "payload": payload} directly.
@@ -232,6 +234,9 @@ class WebSocketManager:
         Args:
             msg_type: Message type string (e.g. "dashboard_panel_update").
             payload: Message payload dict.
+            admins_only: Skip non-admin connections. Needed for payloads that a
+                REST route would gate behind is_privileged() - without it the
+                gate would be decorative.
 
         Returns:
             Number of connections the message was sent to.
@@ -242,6 +247,8 @@ class WebSocketManager:
                 disconnected = []
 
                 for conn in connections:
+                    if admins_only and not conn.is_admin:
+                        continue
                     try:
                         await conn.websocket.send_json({
                             "type": msg_type,

--- a/backend/app/services/websocket_manager.py
+++ b/backend/app/services/websocket_manager.py
@@ -236,7 +236,14 @@ class WebSocketManager:
             payload: Message payload dict.
             admins_only: Skip non-admin connections. Needed for payloads that a
                 REST route would gate behind is_privileged() - without it the
-                gate would be decorative.
+                gate would be decorative. "Admin" here means conn.is_admin,
+                set at connect time from `role == "admin"` in
+                api/routes/notifications.py - NOT is_privileged(). A
+                PRIVILEGED_ROLES config extended beyond "admin" (e.g. adding
+                "operator") widens REST visibility for admin_only panels
+                without widening this broadcast, so the two enforcement
+                points drift apart. That's fail-closed (no leak), just a trap
+                for the next reader.
 
         Returns:
             Number of connections the message was sent to.

--- a/backend/tests/plugins/test_dashboard_panel.py
+++ b/backend/tests/plugins/test_dashboard_panel.py
@@ -659,8 +659,6 @@ class TestAdminOnlyBroadcast:
         `admins_only=` into `broadcast_typed()`, or the REST gate is
         decorative (the whole reason this extension point exists).
         """
-        import asyncio
-
         from app.services.dashboard_panel_bridge import dashboard_panel_ws_bridge
 
         mock_record = MagicMock()

--- a/backend/tests/plugins/test_dashboard_panel.py
+++ b/backend/tests/plugins/test_dashboard_panel.py
@@ -543,3 +543,169 @@ class TestPluginDetailResponsePanelFields:
         )
         assert resp.has_dashboard_panel is False
         assert resp.dashboard_panel_enabled is False
+
+
+class TestAdminOnlyPanels:
+    def test_spec_defaults_to_public(self):
+        spec = DashboardPanelSpec(panel_type="status", title="Any")
+        assert spec.admin_only is False
+
+    def test_spec_can_be_admin_only(self):
+        spec = DashboardPanelSpec(panel_type="status", title="Any", admin_only=True)
+        assert spec.admin_only is True
+
+    @pytest.mark.asyncio
+    async def test_route_hides_an_admin_only_panel_from_a_normal_user(self):
+        mock_record = MagicMock()
+        mock_record.name = "steam_gaming"
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_record
+
+        mock_plugin = MagicMock()
+        mock_plugin.get_dashboard_panel.return_value = DashboardPanelSpec(
+            panel_type="status", title="Steam Gaming", admin_only=True,
+        )
+        mock_plugin.get_dashboard_data = AsyncMock(return_value={"items": []})
+        mock_pm = MagicMock()
+        mock_pm.get_plugin.return_value = mock_plugin
+
+        with patch("app.api.routes.dashboard.user_limiter.enabled", False), patch(
+            "app.api.routes.dashboard.PluginManager.get_instance", return_value=mock_pm
+        ):
+            result = await get_plugin_panel(
+                request=MagicMock(),
+                response=MagicMock(),
+                db=mock_db,
+                current_user=MagicMock(role="user"),
+            )
+
+        assert result is None
+        mock_plugin.get_dashboard_data.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_route_serves_an_admin_only_panel_to_an_admin(self):
+        mock_record = MagicMock()
+        mock_record.name = "steam_gaming"
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_record
+
+        mock_plugin = MagicMock()
+        mock_plugin.get_dashboard_panel.return_value = DashboardPanelSpec(
+            panel_type="status", title="Steam Gaming", admin_only=True,
+        )
+        mock_plugin.get_dashboard_data = AsyncMock(return_value={"items": []})
+        mock_plugin.get_translations.return_value = None
+        mock_pm = MagicMock()
+        mock_pm.get_plugin.return_value = mock_plugin
+
+        with patch("app.api.routes.dashboard.user_limiter.enabled", False), patch(
+            "app.api.routes.dashboard.PluginManager.get_instance", return_value=mock_pm
+        ):
+            result = await get_plugin_panel(
+                request=MagicMock(),
+                response=MagicMock(),
+                db=mock_db,
+                current_user=MagicMock(role="admin"),
+            )
+
+        assert result is not None
+        assert result.plugin_name == "steam_gaming"
+
+
+class TestAdminOnlyBroadcast:
+    @pytest.mark.asyncio
+    async def test_broadcast_typed_can_skip_non_admins(self):
+        manager = WebSocketManager()
+        admin_ws, user_ws = AsyncMock(), AsyncMock()
+        await manager.connect(admin_ws, user_id=1, is_admin=True)
+        await manager.connect(user_ws, user_id=2, is_admin=False)
+
+        count = await manager.broadcast_typed(
+            "dashboard_panel_update", {"data": {}}, admins_only=True
+        )
+
+        assert count == 1
+        admin_ws.send_json.assert_called_once()
+        user_ws.send_json.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bridge_payload_carries_the_admin_only_flag(self):
+        mock_record = MagicMock()
+        mock_record.name = "steam_gaming"
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_record
+
+        mock_plugin = MagicMock()
+        mock_plugin.get_dashboard_panel.return_value = DashboardPanelSpec(
+            panel_type="status", title="Steam Gaming", admin_only=True,
+        )
+        mock_plugin.get_dashboard_data = AsyncMock(return_value={"items": []})
+        mock_pm = MagicMock()
+        mock_pm.get_plugin.return_value = mock_plugin
+
+        with patch(
+            "app.services.dashboard_panel_bridge.PluginManager.get_instance",
+            return_value=mock_pm,
+        ):
+            payload = await _build_panel_update(mock_db)
+
+        assert payload is not None
+        assert payload["admin_only"] is True
+
+    @pytest.mark.asyncio
+    async def test_bridge_forwards_admin_only_into_the_broadcast_call(self):
+        """`_build_panel_update` carrying admin_only is necessary but not
+        sufficient: `dashboard_panel_ws_bridge()` must actually forward it as
+        `admins_only=` into `broadcast_typed()`, or the REST gate is
+        decorative (the whole reason this extension point exists).
+        """
+        import asyncio
+
+        from app.services.dashboard_panel_bridge import dashboard_panel_ws_bridge
+
+        mock_record = MagicMock()
+        mock_record.name = "steam_gaming"
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_record
+
+        mock_plugin = MagicMock()
+        mock_plugin.get_dashboard_panel.return_value = DashboardPanelSpec(
+            panel_type="status", title="Steam Gaming", admin_only=True,
+        )
+        mock_plugin.get_dashboard_data = AsyncMock(return_value={"items": []})
+        mock_pm = MagicMock()
+        mock_pm.get_plugin.return_value = mock_plugin
+
+        mock_ws = MagicMock()
+        mock_ws.broadcast_typed = AsyncMock(return_value=1)
+
+        sleep_calls = {"n": 0}
+
+        async def fake_sleep(_seconds):
+            sleep_calls["n"] += 1
+            if sleep_calls["n"] > 1:
+                raise asyncio.CancelledError()
+
+        with patch(
+            "app.services.dashboard_panel_bridge.PluginManager.get_instance",
+            return_value=mock_pm,
+        ), patch("app.core.database.SessionLocal", return_value=mock_db), patch(
+            "app.services.monitoring.shm.read_shm",
+            return_value={"timestamp": 1.0},
+        ), patch(
+            "app.services.websocket_manager.get_websocket_manager",
+            return_value=mock_ws,
+        ), patch("asyncio.sleep", side_effect=fake_sleep):
+            with pytest.raises(asyncio.CancelledError):
+                await dashboard_panel_ws_bridge()
+
+        mock_ws.broadcast_typed.assert_awaited_once_with(
+            "dashboard_panel_update",
+            {
+                "panel_type": "status",
+                "plugin_name": "steam_gaming",
+                "admin_only": True,
+                "data": {"items": []},
+            },
+            admins_only=True,
+        )

--- a/backend/tests/plugins/test_steam_gaming_detection.py
+++ b/backend/tests/plugins/test_steam_gaming_detection.py
@@ -1,0 +1,46 @@
+"""detection.py guards the column widths the ledger writes into (TP 4/4)."""
+from __future__ import annotations
+
+import pytest
+
+from app.plugins.installed.steam_gaming import detection
+
+
+@pytest.fixture
+def prod_mode(monkeypatch):
+    """The dev-mode stand-in would mask what these tests check."""
+    monkeypatch.setattr(detection.settings, "is_dev_mode", False)
+
+
+class TestAppIdGuard:
+    def test_a_normal_app_id_passes_through(self, monkeypatch, prod_mode):
+        monkeypatch.setattr(detection, "detect_running_app_id", lambda: "1449560")
+
+        assert detection.current_app_id() == "1449560"
+
+    def test_an_over_long_app_id_is_treated_as_no_game(self, monkeypatch, prod_mode):
+        """SQLite ignores VARCHAR(32), PostgreSQL raises DataError on every
+        tick - a booking that can never succeed is worse than no booking."""
+        monkeypatch.setattr(detection, "detect_running_app_id", lambda: "9" * 40)
+
+        assert detection.current_app_id() is None
+
+
+class TestGameNameGuard:
+    def test_a_normal_name_passes_through(self, monkeypatch, prod_mode):
+        monkeypatch.setattr(detection, "resolve_name", lambda _app_id: "Metro Exodus")
+
+        assert detection.resolve_game_name("1449560") == "Metro Exodus"
+
+    def test_an_over_long_name_is_truncated_to_the_column_width(self, monkeypatch, prod_mode):
+        monkeypatch.setattr(detection, "resolve_name", lambda _app_id: "A" * 500)
+
+        resolved = detection.resolve_game_name("1449560")
+
+        assert len(resolved) == detection._MAX_GAME_NAME_LENGTH
+        assert resolved == "A" * detection._MAX_GAME_NAME_LENGTH
+
+    def test_an_unresolvable_name_stays_none(self, monkeypatch, prod_mode):
+        monkeypatch.setattr(detection, "resolve_name", lambda _app_id: None)
+
+        assert detection.resolve_game_name("999") is None

--- a/backend/tests/plugins/test_steam_gaming_ledger.py
+++ b/backend/tests/plugins/test_steam_gaming_ledger.py
@@ -247,3 +247,66 @@ class TestFailureContract:
 
         assert events == []
         broken.rollback.assert_called_once()
+
+
+class TestHousekeeping:
+    def test_orphaned_open_sessions_are_closed_silently(self, db_session):
+        """The invariant says one open session; a crash can still leave more."""
+        db_session.add_all([
+            SteamSession(app_id="111", started_at=T0, last_seen_at=T0),
+            SteamSession(
+                app_id="222",
+                started_at=T0 + timedelta(hours=1),
+                last_seen_at=T0 + timedelta(hours=1),
+            ),
+        ])
+        db_session.commit()
+
+        events = _record(db_session, "222", T0 + timedelta(hours=1, seconds=30))
+
+        older = db_session.query(SteamSession).filter_by(app_id="111").one()
+        newer = db_session.query(SteamSession).filter_by(app_id="222").one()
+        assert ledger.as_utc(older.ended_at) == T0
+        assert newer.ended_at is None
+        assert events == []
+
+    def test_missing_game_name_is_resolved_on_a_later_heartbeat(self, db_session):
+        """A game started during its own install has no appmanifest yet."""
+        ledger.record(db_session, "111", now=T0, resolve_name=lambda _app_id: None)
+        assert db_session.query(SteamSession).one().game_name is None
+
+        _record(db_session, "111", T0 + timedelta(seconds=30))
+
+        assert db_session.query(SteamSession).one().game_name == "Metro"
+
+    def test_a_resolved_name_is_not_overwritten(self, db_session):
+        _record(db_session, "111", T0)
+
+        ledger.record(
+            db_session, "111", now=T0 + timedelta(seconds=30), resolve_name=lambda _a: None
+        )
+
+        assert db_session.query(SteamSession).one().game_name == "Metro"
+
+
+class TestDuration:
+    def test_closed_session_duration(self, db_session):
+        session = SteamSession(
+            app_id="111",
+            started_at=T0,
+            last_seen_at=T0 + timedelta(minutes=90),
+            ended_at=T0 + timedelta(minutes=90),
+        )
+
+        assert ledger.duration_seconds(session, T0 + timedelta(hours=5)) == 5400.0
+
+    def test_open_session_counts_up_to_now(self, db_session):
+        session = SteamSession(app_id="111", started_at=T0, last_seen_at=T0)
+
+        assert ledger.duration_seconds(session, T0 + timedelta(minutes=12)) == 720.0
+
+    def test_clock_stepping_backwards_clamps_at_zero(self, db_session):
+        """An NTP step backwards must not produce a negative duration."""
+        session = SteamSession(app_id="111", started_at=T0, last_seen_at=T0)
+
+        assert ledger.duration_seconds(session, T0 - timedelta(minutes=5)) == 0.0

--- a/backend/tests/plugins/test_steam_gaming_ledger.py
+++ b/backend/tests/plugins/test_steam_gaming_ledger.py
@@ -112,3 +112,68 @@ class TestLiveEdges:
 
         assert db_session.query(SteamSession).one().game_name is None
         assert events[0].game == "999"
+
+
+class TestGapRules:
+    def test_stale_end_is_booked_at_the_last_heartbeat(self, db_session):
+        """The process was away: `now` would book the outage as playtime."""
+        _record(db_session, "111", T0)
+        _record(db_session, "111", T0 + timedelta(seconds=30))  # last heartbeat
+
+        _record(db_session, None, T0 + timedelta(hours=2))
+
+        row = db_session.query(SteamSession).one()
+        assert ledger.as_utc(row.ended_at) == T0 + timedelta(seconds=30)
+
+    def test_stale_end_is_not_announced(self, db_session):
+        """A deploy must not push 'session ended' for a game that ended hours ago."""
+        _record(db_session, "111", T0)
+
+        events = _record(db_session, None, T0 + timedelta(hours=2))
+
+        assert events == []
+
+    def test_stale_switch_books_both_but_announces_nothing(self, db_session):
+        _record(db_session, "111", T0)
+
+        events = _record(db_session, "222", T0 + timedelta(hours=2))
+
+        rows = db_session.query(SteamSession).order_by(SteamSession.started_at).all()
+        assert len(rows) == 2
+        assert ledger.as_utc(rows[0].ended_at) == T0
+        assert rows[1].app_id == "222" and rows[1].ended_at is None
+        assert events == []
+
+    def test_same_game_across_a_short_gap_continues_the_session(self, db_session):
+        """A deploy mid-game is the normal case on this box."""
+        _record(db_session, "111", T0)
+        resumed = T0 + timedelta(minutes=5)
+
+        events = _record(db_session, "111", resumed)
+
+        row = db_session.query(SteamSession).one()
+        assert ledger.as_utc(row.started_at) == T0
+        assert ledger.as_utc(row.last_seen_at) == resumed
+        assert row.ended_at is None
+        assert events == []
+
+    def test_same_game_across_a_long_gap_splits_into_two_sessions(self, db_session):
+        """Off overnight and restarted in the morning is not a 14h session."""
+        _record(db_session, "111", T0)
+        next_day = T0 + timedelta(hours=14)
+
+        events = _record(db_session, "111", next_day)
+
+        rows = db_session.query(SteamSession).order_by(SteamSession.started_at).all()
+        assert len(rows) == 2
+        assert ledger.as_utc(rows[0].ended_at) == T0
+        assert ledger.as_utc(rows[1].started_at) == next_day
+        assert rows[1].ended_at is None
+        assert events == []
+
+    def test_the_adopt_window_boundary_still_continues(self, db_session):
+        _record(db_session, "111", T0)
+
+        _record(db_session, "111", T0 + timedelta(seconds=ledger.ADOPT_WINDOW_SECONDS))
+
+        assert db_session.query(SteamSession).count() == 1

--- a/backend/tests/plugins/test_steam_gaming_ledger.py
+++ b/backend/tests/plugins/test_steam_gaming_ledger.py
@@ -39,3 +39,76 @@ class TestModel:
         db_session.commit()
 
         assert db_session.query(SteamSession).one().ended_at is not None
+
+
+from app.plugins.installed.steam_gaming import ledger
+
+
+def _names(app_id: str):
+    """Stand-in for names.resolve_name()."""
+    return {"111": "Metro", "222": "Cyberpunk"}.get(app_id)
+
+
+def _record(db, app_id, now):
+    return ledger.record(db, app_id, now=now, resolve_name=_names)
+
+
+class TestLiveEdges:
+    def test_nothing_open_and_nothing_running_books_nothing(self, db_session):
+        events = _record(db_session, None, T0)
+
+        assert events == []
+        assert db_session.query(SteamSession).count() == 0
+
+    def test_game_appears_opens_a_session_and_announces_it(self, db_session):
+        events = _record(db_session, "111", T0)
+
+        row = db_session.query(SteamSession).one()
+        assert row.app_id == "111"
+        assert row.game_name == "Metro"
+        assert row.started_at is not None
+        assert row.ended_at is None
+        assert [(e.event_id, e.app_id, e.game) for e in events] == [
+            (ledger.EVENT_STARTED, "111", "Metro")
+        ]
+
+    def test_same_game_next_tick_only_moves_the_heartbeat(self, db_session):
+        _record(db_session, "111", T0)
+        events = _record(db_session, "111", T0 + timedelta(seconds=30))
+
+        row = db_session.query(SteamSession).one()
+        assert events == []
+        assert ledger.as_utc(row.last_seen_at) == T0 + timedelta(seconds=30)
+        assert row.ended_at is None
+
+    def test_game_disappears_closes_at_now_and_announces_the_end(self, db_session):
+        _record(db_session, "111", T0)
+        end = T0 + timedelta(seconds=30)
+        events = _record(db_session, None, end)
+
+        row = db_session.query(SteamSession).one()
+        assert ledger.as_utc(row.ended_at) == end
+        assert [(e.event_id, e.app_id, e.game) for e in events] == [
+            (ledger.EVENT_ENDED, "111", "Metro")
+        ]
+
+    def test_direct_switch_closes_x_opens_y_and_announces_both(self, db_session):
+        """#462: X->Y without a pause was swallowed in TP3."""
+        _record(db_session, "111", T0)
+        switch = T0 + timedelta(seconds=30)
+        events = _record(db_session, "222", switch)
+
+        rows = db_session.query(SteamSession).order_by(SteamSession.started_at).all()
+        assert len(rows) == 2
+        assert ledger.as_utc(rows[0].ended_at) == switch
+        assert rows[1].app_id == "222" and rows[1].ended_at is None
+        assert [(e.event_id, e.app_id, e.game) for e in events] == [
+            (ledger.EVENT_ENDED, "111", "Metro"),
+            (ledger.EVENT_STARTED, "222", "Cyberpunk"),
+        ]
+
+    def test_unresolved_name_falls_back_to_the_app_id_in_the_event(self, db_session):
+        events = _record(db_session, "999", T0)
+
+        assert db_session.query(SteamSession).one().game_name is None
+        assert events[0].game == "999"

--- a/backend/tests/plugins/test_steam_gaming_ledger.py
+++ b/backend/tests/plugins/test_steam_gaming_ledger.py
@@ -310,3 +310,43 @@ class TestDuration:
         session = SteamSession(app_id="111", started_at=T0, last_seen_at=T0)
 
         assert ledger.duration_seconds(session, T0 - timedelta(minutes=5)) == 0.0
+
+
+class TestRetention:
+    def test_deletes_sessions_older_than_the_retention_window(self, db_session):
+        old_start = T0 - timedelta(days=400)
+        db_session.add(SteamSession(
+            app_id="111",
+            started_at=old_start,
+            last_seen_at=old_start + timedelta(hours=1),
+            ended_at=old_start + timedelta(hours=1),
+        ))
+        db_session.commit()
+
+        deleted = ledger.cleanup_old_sessions(db_session, now=T0)
+
+        assert deleted == 1
+        assert db_session.query(SteamSession).count() == 0
+
+    def test_keeps_sessions_inside_the_window(self, db_session):
+        recent = T0 - timedelta(days=364)
+        db_session.add(SteamSession(
+            app_id="111", started_at=recent, last_seen_at=recent, ended_at=recent,
+        ))
+        db_session.commit()
+
+        deleted = ledger.cleanup_old_sessions(db_session, now=T0)
+
+        assert deleted == 0
+        assert db_session.query(SteamSession).count() == 1
+
+    def test_never_deletes_an_open_session(self, db_session):
+        """An open session has no ended_at - however old, it is the current one."""
+        ancient = T0 - timedelta(days=500)
+        db_session.add(SteamSession(app_id="111", started_at=ancient, last_seen_at=ancient))
+        db_session.commit()
+
+        deleted = ledger.cleanup_old_sessions(db_session, now=T0)
+
+        assert deleted == 0
+        assert db_session.query(SteamSession).count() == 1

--- a/backend/tests/plugins/test_steam_gaming_ledger.py
+++ b/backend/tests/plugins/test_steam_gaming_ledger.py
@@ -223,6 +223,15 @@ class TestConstants:
         behaviour that the rest of this file only pins relative to itself."""
         assert (ledger.STALE_AFTER_SECONDS, ledger.ADOPT_WINDOW_SECONDS) == (60.0, 600.0)
 
+    def test_the_event_ids_are_the_wire_format_they_must_stay(self):
+        """These strings are persisted as plugin:steam_gaming:<id> in
+        notifications and routing preferences - renaming the constant is free,
+        renaming the value orphans existing rows."""
+        assert (ledger.EVENT_STARTED, ledger.EVENT_ENDED) == (
+            "session_started",
+            "session_ended",
+        )
+
 
 class TestFailureContract:
     """record() must never raise at its caller - the poller has to survive."""

--- a/backend/tests/plugins/test_steam_gaming_ledger.py
+++ b/backend/tests/plugins/test_steam_gaming_ledger.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
 
 from app.models.steam_session import SteamSession
 
@@ -177,3 +178,72 @@ class TestGapRules:
         _record(db_session, "111", T0 + timedelta(seconds=ledger.ADOPT_WINDOW_SECONDS))
 
         assert db_session.query(SteamSession).count() == 1
+
+    def test_after_a_split_the_newest_open_session_is_the_one_that_continues(self, db_session):
+        """Third tick after a split: the query must pick the NEW session, not
+        the closed one and not the older row."""
+        _record(db_session, "111", T0)
+        split = T0 + timedelta(hours=14)
+        _record(db_session, "111", split)          # splits: old closed, new opened
+
+        _record(db_session, "111", split + timedelta(seconds=30))
+
+        rows = db_session.query(SteamSession).order_by(SteamSession.started_at).all()
+        assert len(rows) == 2
+        assert ledger.as_utc(rows[0].ended_at) == T0
+        assert rows[1].ended_at is None
+        assert ledger.as_utc(rows[1].last_seen_at) == split + timedelta(seconds=30)
+
+
+class TestStaleBoundary:
+    def test_a_gap_of_exactly_the_stale_window_still_counts_as_live(self, db_session):
+        _record(db_session, "111", T0)
+        end = T0 + timedelta(seconds=ledger.STALE_AFTER_SECONDS)
+
+        events = _record(db_session, None, end)
+
+        row = db_session.query(SteamSession).one()
+        assert ledger.as_utc(row.ended_at) == end
+        assert [e.event_id for e in events] == [ledger.EVENT_ENDED]
+
+    def test_one_second_past_the_stale_window_books_silently(self, db_session):
+        """The two-minute deploy during which the game ended - the common case."""
+        _record(db_session, "111", T0)
+
+        events = _record(db_session, None, T0 + timedelta(seconds=ledger.STALE_AFTER_SECONDS + 1))
+
+        row = db_session.query(SteamSession).one()
+        assert ledger.as_utc(row.ended_at) == T0
+        assert events == []
+
+
+class TestConstants:
+    def test_the_windows_are_the_values_the_design_fixed(self):
+        """Two poll intervals, and ten minutes - changing either changes
+        behaviour that the rest of this file only pins relative to itself."""
+        assert (ledger.STALE_AFTER_SECONDS, ledger.ADOPT_WINDOW_SECONDS) == (60.0, 600.0)
+
+
+class TestFailureContract:
+    """record() must never raise at its caller - the poller has to survive."""
+
+    def test_database_failure_rolls_back_and_returns_no_events(self, db_session):
+        from sqlalchemy.exc import OperationalError
+
+        broken = MagicMock(wraps=db_session)
+        broken.commit.side_effect = OperationalError("stmt", {}, Exception("gone"))
+
+        events = ledger.record(broken, "111", now=T0, resolve_name=_names)
+
+        assert events == []
+        broken.rollback.assert_called_once()
+
+    def test_unexpected_failure_also_rolls_back_and_returns_no_events(self, db_session):
+        """A throwing resolve_name() must not take the poller down either."""
+        broken = MagicMock(wraps=db_session)
+        broken.commit.side_effect = RuntimeError("boom")
+
+        events = ledger.record(broken, "111", now=T0, resolve_name=_names)
+
+        assert events == []
+        broken.rollback.assert_called_once()

--- a/backend/tests/plugins/test_steam_gaming_ledger.py
+++ b/backend/tests/plugins/test_steam_gaming_ledger.py
@@ -1,0 +1,41 @@
+"""Steam session ledger: persisted play sessions (Teilprojekt 4/4)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.models.steam_session import SteamSession
+
+T0 = datetime(2026, 7, 24, 20, 0, 0, tzinfo=timezone.utc)
+
+
+class TestModel:
+    def test_open_session_round_trips(self, db_session):
+        db_session.add(SteamSession(
+            app_id="1449560",
+            game_name="Metro Exodus Enhanced Edition",
+            started_at=T0,
+            last_seen_at=T0,
+        ))
+        db_session.commit()
+
+        row = db_session.query(SteamSession).one()
+        assert row.app_id == "1449560"
+        assert row.game_name == "Metro Exodus Enhanced Edition"
+        assert row.ended_at is None
+
+    def test_game_name_is_optional(self, db_session):
+        db_session.add(SteamSession(
+            app_id="999", game_name=None, started_at=T0, last_seen_at=T0,
+        ))
+        db_session.commit()
+
+        assert db_session.query(SteamSession).one().game_name is None
+
+    def test_ended_session_stores_its_end(self, db_session):
+        end = T0 + timedelta(hours=1)
+        db_session.add(SteamSession(
+            app_id="1", started_at=T0, last_seen_at=end, ended_at=end,
+        ))
+        db_session.commit()
+
+        assert db_session.query(SteamSession).one().ended_at is not None

--- a/backend/tests/plugins/test_steam_gaming_panel.py
+++ b/backend/tests/plugins/test_steam_gaming_panel.py
@@ -1,0 +1,88 @@
+"""Steam gaming dashboard panel: spec, formatting, empty state (TP 4/4)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.models.steam_session import SteamSession
+from app.plugins.installed.steam_gaming import SteamGamingPlugin
+
+T0 = datetime(2026, 7, 24, 20, 0, 0, tzinfo=timezone.utc)
+
+
+class TestPanelSpec:
+    def test_panel_is_an_admin_only_status_panel(self):
+        spec = SteamGamingPlugin().get_dashboard_panel()
+
+        assert spec is not None
+        assert spec.panel_type == "status"
+        assert spec.title == "Steam Gaming"
+        assert spec.icon == "gamepad-2"
+        assert spec.admin_only is True
+
+
+class TestPanelData:
+    async def test_no_sessions_means_no_panel(self, db_session):
+        assert await SteamGamingPlugin().get_dashboard_data(db_session) is None
+
+    async def test_running_session_shows_bare_duration_and_ok_tone(self, db_session):
+        db_session.add(SteamSession(app_id="111", game_name="Metro", started_at=T0, last_seen_at=T0))
+        db_session.commit()
+
+        data = await SteamGamingPlugin().get_dashboard_data(db_session)
+
+        item = data["items"][0]
+        assert item["label"] == "Metro"
+        assert item["tone"] == "ok"
+        assert item["value"].endswith("m")
+        assert "·" not in item["value"]
+
+    async def test_finished_session_shows_date_and_duration(self, db_session):
+        db_session.add(SteamSession(
+            app_id="222",
+            game_name="Cyberpunk",
+            started_at=T0,
+            last_seen_at=T0 + timedelta(hours=3, minutes=4),
+            ended_at=T0 + timedelta(hours=3, minutes=4),
+        ))
+        db_session.commit()
+
+        data = await SteamGamingPlugin().get_dashboard_data(db_session)
+
+        item = data["items"][0]
+        assert item["tone"] == "neutral"
+        assert item["value"] == "24.07. · 3h 04m"
+
+    async def test_unresolved_name_falls_back_to_the_app_id(self, db_session):
+        db_session.add(SteamSession(
+            app_id="999", game_name=None, started_at=T0, last_seen_at=T0, ended_at=T0,
+        ))
+        db_session.commit()
+
+        data = await SteamGamingPlugin().get_dashboard_data(db_session)
+
+        assert data["items"][0]["label"] == "AppID 999"
+
+    async def test_at_most_five_rows_newest_first(self, db_session):
+        for index in range(7):
+            start = T0 + timedelta(hours=index)
+            db_session.add(SteamSession(
+                app_id=str(index), game_name=f"Game {index}",
+                started_at=start, last_seen_at=start, ended_at=start,
+            ))
+        db_session.commit()
+
+        data = await SteamGamingPlugin().get_dashboard_data(db_session)
+
+        labels = [item["label"] for item in data["items"]]
+        assert labels == ["Game 6", "Game 5", "Game 4", "Game 3", "Game 2"]
+
+    async def test_sub_hour_duration_has_no_hour_part(self, db_session):
+        db_session.add(SteamSession(
+            app_id="111", game_name="Metro", started_at=T0,
+            last_seen_at=T0 + timedelta(minutes=12), ended_at=T0 + timedelta(minutes=12),
+        ))
+        db_session.commit()
+
+        data = await SteamGamingPlugin().get_dashboard_data(db_session)
+
+        assert data["items"][0]["value"] == "24.07. · 12m"

--- a/backend/tests/plugins/test_steam_gaming_panel.py
+++ b/backend/tests/plugins/test_steam_gaming_panel.py
@@ -86,3 +86,47 @@ class TestPanelData:
         data = await SteamGamingPlugin().get_dashboard_data(db_session)
 
         assert data["items"][0]["value"] == "24.07. · 12m"
+
+    async def test_running_session_duration_counts_up_to_now(self, db_session, monkeypatch):
+        """The only now-dependent formatting in the panel - without a fixed
+        clock the assertion could only check that the string ends in 'm'."""
+        import app.plugins.installed.steam_gaming as plugin_module
+
+        db_session.add(SteamSession(app_id="111", game_name="Metro", started_at=T0, last_seen_at=T0))
+        db_session.commit()
+        monkeypatch.setattr(plugin_module, "_utc_now", lambda: T0 + timedelta(hours=2, minutes=5))
+
+        data = await SteamGamingPlugin().get_dashboard_data(db_session)
+
+        assert data["items"][0]["value"] == "2h 05m"
+
+    async def test_a_running_session_sorts_above_the_finished_ones(self, db_session):
+        finished = T0 - timedelta(hours=5)
+        db_session.add_all([
+            SteamSession(
+                app_id="222", game_name="Cyberpunk", started_at=finished,
+                last_seen_at=finished + timedelta(hours=1),
+                ended_at=finished + timedelta(hours=1),
+            ),
+            SteamSession(app_id="111", game_name="Metro", started_at=T0, last_seen_at=T0),
+        ])
+        db_session.commit()
+
+        data = await SteamGamingPlugin().get_dashboard_data(db_session)
+
+        assert [(i["label"], i["tone"]) for i in data["items"]] == [
+            ("Metro", "ok"),
+            ("Cyberpunk", "neutral"),
+        ]
+
+
+class TestDurationFormat:
+    def test_the_boundaries_that_the_panel_relies_on(self):
+        from app.plugins.installed.steam_gaming import _format_duration
+
+        assert _format_duration(0) == "0m"
+        assert _format_duration(59) == "0m"
+        assert _format_duration(720) == "12m"
+        assert _format_duration(3600) == "1h 00m"
+        assert _format_duration(3659) == "1h 00m"
+        assert _format_duration(3660) == "1h 01m"

--- a/backend/tests/plugins/test_steam_gaming_plugin.py
+++ b/backend/tests/plugins/test_steam_gaming_plugin.py
@@ -7,7 +7,8 @@ import pytest
 
 from app.api.routes.plugins import run_plugin_menu_action
 from app.plugins.installed import steam_gaming as plugin_module
-from app.plugins.installed.steam_gaming import SteamGamingPlugin
+from app.plugins.installed.steam_gaming import SteamGamingPlugin, ledger
+from app.plugins.installed.steam_gaming import detection as detection_module
 
 
 @pytest.fixture(autouse=True)
@@ -25,12 +26,12 @@ def plugin():
 @pytest.fixture
 def prod_mode(monkeypatch):
     """`is_dev_mode` is its own settings FIELD, not derived from nas_mode."""
-    monkeypatch.setattr(plugin_module.settings, "is_dev_mode", False)
+    monkeypatch.setattr(detection_module.settings, "is_dev_mode", False)
 
 
 @pytest.fixture
 def dev_mode(monkeypatch):
-    monkeypatch.setattr(plugin_module.settings, "is_dev_mode", True)
+    monkeypatch.setattr(detection_module.settings, "is_dev_mode", True)
 
 
 def test_declares_one_namespaced_pill(plugin):
@@ -46,14 +47,14 @@ def test_declares_one_namespaced_pill(plugin):
 
 
 async def test_stays_silent_when_no_game_runs(plugin, monkeypatch, prod_mode):
-    monkeypatch.setattr(plugin_module, "detect_running_app_id", lambda: None)
+    monkeypatch.setattr(detection_module, "detect_running_app_id", lambda: None)
 
     assert await plugin.collect_status_pill("session", None) is None
 
 
 async def test_reports_the_game_name_when_resolvable(plugin, monkeypatch, prod_mode):
-    monkeypatch.setattr(plugin_module, "detect_running_app_id", lambda: "1449560")
-    monkeypatch.setattr(plugin_module, "resolve_name", lambda _id: "Metro Exodus")
+    monkeypatch.setattr(detection_module, "detect_running_app_id", lambda: "1449560")
+    monkeypatch.setattr(detection_module, "resolve_name", lambda _id: "Metro Exodus")
 
     pill = await plugin.collect_status_pill("session", None)
 
@@ -64,8 +65,8 @@ async def test_reports_the_game_name_when_resolvable(plugin, monkeypatch, prod_m
 
 async def test_falls_back_to_the_bare_label_for_an_unknown_game(plugin, monkeypatch, prod_mode):
     """Non-Steam shortcuts have no manifest — the pill still shows up."""
-    monkeypatch.setattr(plugin_module, "detect_running_app_id", lambda: "3000000000")
-    monkeypatch.setattr(plugin_module, "resolve_name", lambda _id: None)
+    monkeypatch.setattr(detection_module, "detect_running_app_id", lambda: "3000000000")
+    monkeypatch.setattr(detection_module, "resolve_name", lambda _id: None)
 
     pill = await plugin.collect_status_pill("session", None)
 
@@ -80,8 +81,8 @@ async def test_repeated_polls_within_the_ttl_scan_once(plugin, monkeypatch, prod
         calls.append(1)
         return "1449560"
 
-    monkeypatch.setattr(plugin_module, "detect_running_app_id", _counting_detect)
-    monkeypatch.setattr(plugin_module, "resolve_name", lambda _id: "Metro Exodus")
+    monkeypatch.setattr(detection_module, "detect_running_app_id", _counting_detect)
+    monkeypatch.setattr(detection_module, "resolve_name", lambda _id: "Metro Exodus")
 
     clock = {"now": 500.0}
     monkeypatch.setattr(plugin_module, "_monotonic", lambda: clock["now"])
@@ -97,7 +98,7 @@ async def test_repeated_polls_within_the_ttl_scan_once(plugin, monkeypatch, prod
 
 async def test_dev_mode_shows_a_mock_game(plugin, monkeypatch, dev_mode):
     """Windows dev boxes have no /proc — the strip should still render."""
-    monkeypatch.setattr(plugin_module, "detect_running_app_id", lambda: None)
+    monkeypatch.setattr(detection_module, "detect_running_app_id", lambda: None)
 
     pill = await plugin.collect_status_pill("session", None)
 
@@ -256,7 +257,7 @@ class TestGamingModeRunsLauncherOffTheEventLoop:
 class TestNotificationEvents:
     def test_declares_start_and_end(self):
         events = SteamGamingPlugin().get_notification_events()
-        assert {e.id for e in events} == {"session_started", "session_ended"}
+        assert {e.id for e in events} == {ledger.EVENT_STARTED, ledger.EVENT_ENDED}
 
     def test_events_carry_a_cooldown_and_admin_default(self):
         for e in SteamGamingPlugin().get_notification_events():
@@ -271,5 +272,6 @@ class TestBackgroundTask:
         assert len(specs) == 1
         spec = specs[0]
         assert spec.interval_seconds == 30
-        # run_on_startup True is fine: the poller's first tick is a baseline.
+        # run_on_startup True is fine: the first tick books against the DB
+        # state and the gap rules keep it silent after a restart (TP4).
         assert callable(spec.func)

--- a/backend/tests/plugins/test_steam_gaming_poller.py
+++ b/backend/tests/plugins/test_steam_gaming_poller.py
@@ -1,76 +1,131 @@
-"""Steam session poller: play/not-play edge detection (Teilprojekt 3/4)."""
+"""Steam session poller: detect -> book -> announce (Teilprojekt 3+4/4)."""
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
+from app.models.steam_session import SteamSession
+from app.plugins.installed.steam_gaming import ledger
 from app.plugins.installed.steam_gaming.poller import SteamSessionPoller
 
+T0 = datetime(2026, 7, 24, 20, 0, 0, tzinfo=timezone.utc)
 
-def _poller(sequence):
-    """A poller whose detector yields the given app_ids across ticks."""
-    calls = iter(sequence)
-    detect = MagicMock(side_effect=lambda *a, **k: next(calls))
-    resolve = MagicMock(side_effect=lambda app_id: f"Game {app_id}")
+
+def _poller(db_session, app_ids, times):
+    """A poller whose detector and clock walk the given sequences."""
+    detected = iter(app_ids)
+    clock_values = iter(times)
     emit = AsyncMock()
-    return SteamSessionPoller(detect=detect, resolve=resolve, emit=emit), emit
+    poller = SteamSessionPoller(
+        detect=MagicMock(side_effect=lambda *a, **k: next(detected)),
+        resolve=MagicMock(side_effect=lambda app_id: f"Game {app_id}"),
+        emit=emit,
+        session_factory=lambda: db_session,
+        clock=lambda: next(clock_values),
+    )
+    return poller, emit
 
 
-class TestEdgeDetection:
-    async def test_first_tick_only_establishes_a_baseline(self):
-        """A game already running at startup must NOT fire 'started' - that
-        would false-alarm after every backend restart."""
-        poller, emit = _poller(["1449560"])
+class TestTick:
+    async def test_start_is_booked_and_announced(self, db_session):
+        poller, emit = _poller(db_session, ["111"], [T0])
+
         await poller.tick()
-        emit.assert_not_awaited()
 
-    async def test_none_to_game_is_a_start(self):
-        poller, emit = _poller([None, "1449560"])
-        await poller.tick()   # baseline: None
-        await poller.tick()   # None -> game
+        assert db_session.query(SteamSession).count() == 1
         emit.assert_awaited_once()
         args, kwargs = emit.await_args
-        assert args[:2] == ("steam_gaming", "session_started")
-        assert kwargs["entity_id"] == "1449560"
-        assert kwargs["game"] == "Game 1449560"
+        assert args[:2] == ("steam_gaming", ledger.EVENT_STARTED)
+        assert kwargs["entity_id"] == "111"
+        assert kwargs["game"] == "Game 111"
 
-    async def test_game_to_none_is_an_end(self):
-        poller, emit = _poller(["1449560", None])
-        await poller.tick()   # baseline: game
-        await poller.tick()   # game -> None
-        emit.assert_awaited_once()
-        args, kwargs = emit.await_args
-        assert args[:2] == ("steam_gaming", "session_ended")
-        assert kwargs["entity_id"] == "1449560"
-        assert kwargs["game"] == "Game 1449560"
-
-    async def test_same_game_across_ticks_is_no_event(self):
-        poller, emit = _poller([None, "1449560", "1449560"])
+    async def test_end_is_announced_on_the_game_that_ended(self, db_session):
+        poller, emit = _poller(
+            db_session, ["111", None], [T0, T0 + timedelta(seconds=30)]
+        )
         await poller.tick()
-        await poller.tick()   # start
         emit.reset_mock()
-        await poller.tick()   # same game
-        emit.assert_not_awaited()
 
-    async def test_direct_switch_fires_nothing_but_tracks_the_new_game(self):
-        """X -> Y fires no event, but the state must follow to Y so a later
-        Y -> None correctly ends on Y."""
-        poller, emit = _poller([None, "111", "222", None])
-        await poller.tick()   # baseline None
-        await poller.tick()   # None -> 111 (start)
-        emit.reset_mock()
-        await poller.tick()   # 111 -> 222: no event
-        emit.assert_not_awaited()
-        await poller.tick()   # 222 -> None: end, on 222
+        await poller.tick()
+
         emit.assert_awaited_once()
         args, kwargs = emit.await_args
-        assert args[:2] == ("steam_gaming", "session_ended")
-        assert kwargs["entity_id"] == "222"
+        assert args[:2] == ("steam_gaming", ledger.EVENT_ENDED)
+        assert kwargs["entity_id"] == "111"
 
-    async def test_unresolved_name_falls_back_to_the_app_id(self):
-        poller, emit = _poller([None, "999"])
-        poller._resolve = MagicMock(return_value=None)
+    async def test_direct_switch_announces_both_edges(self, db_session):
+        """#462 - TP3 swallowed this."""
+        poller, emit = _poller(
+            db_session, ["111", "222"], [T0, T0 + timedelta(seconds=30)]
+        )
+        await poller.tick()
+        emit.reset_mock()
+
+        await poller.tick()
+
+        assert emit.await_count == 2
+        first, second = emit.await_args_list
+        assert first.args[:2] == ("steam_gaming", ledger.EVENT_ENDED)
+        assert first.kwargs["entity_id"] == "111"
+        assert second.args[:2] == ("steam_gaming", ledger.EVENT_STARTED)
+        assert second.kwargs["entity_id"] == "222"
+
+    async def test_same_game_announces_nothing(self, db_session):
+        poller, emit = _poller(
+            db_session, ["111", "111"], [T0, T0 + timedelta(seconds=30)]
+        )
+        await poller.tick()
+        emit.reset_mock()
+
+        await poller.tick()
+
+        emit.assert_not_awaited()
+
+    async def test_a_restart_mid_session_announces_nothing(self, db_session):
+        """The DB holds the state, so a fresh poller object just picks it up."""
+        first, _ = _poller(db_session, ["111"], [T0])
+        await first.tick()
+
+        second, emit = _poller(db_session, ["111"], [T0 + timedelta(minutes=5)])
+        await second.tick()
+
+        emit.assert_not_awaited()
+        assert db_session.query(SteamSession).count() == 1
+
+
+class TestRetentionSchedule:
+    async def test_cleanup_runs_on_the_first_tick(self, db_session, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            ledger, "cleanup_old_sessions", lambda db, *, now: calls.append(now) or 0
+        )
+        poller, _ = _poller(db_session, [None], [T0])
+
+        await poller.tick()
+
+        assert calls == [T0]
+
+    async def test_cleanup_does_not_run_again_the_next_tick(self, db_session, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            ledger, "cleanup_old_sessions", lambda db, *, now: calls.append(now) or 0
+        )
+        poller, _ = _poller(db_session, [None, None], [T0, T0 + timedelta(hours=1)])
+
         await poller.tick()
         await poller.tick()
-        assert emit.await_args.kwargs["game"] == "999"
+
+        assert calls == [T0]
+
+    async def test_cleanup_runs_again_after_a_day(self, db_session, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            ledger, "cleanup_old_sessions", lambda db, *, now: calls.append(now) or 0
+        )
+        later = T0 + timedelta(hours=25)
+        poller, _ = _poller(db_session, [None, None], [T0, later])
+
+        await poller.tick()
+        await poller.tick()
+
+        assert calls == [T0, later]

--- a/backend/tests/plugins/test_steam_gaming_poller.py
+++ b/backend/tests/plugins/test_steam_gaming_poller.py
@@ -129,3 +129,34 @@ class TestRetentionSchedule:
         await poller.tick()
 
         assert calls == [T0, later]
+
+
+class TestSessionLifetime:
+    """The DB session belongs to ONE tick. Hoisting it into __init__ would keep
+    a transaction open for hours and hand PostgreSQL a stale connection after
+    pool_recycle - and every other test in this file would stay green."""
+
+    async def test_each_tick_opens_and_closes_its_own_session(self, db_session):
+        opened: list[MagicMock] = []
+
+        def _factory():
+            handle = MagicMock(wraps=db_session)
+            handle.close = MagicMock()
+            opened.append(handle)
+            return handle
+
+        clock_values = iter([T0, T0 + timedelta(seconds=30)])
+        poller = SteamSessionPoller(
+            detect=MagicMock(return_value=None),
+            resolve=MagicMock(return_value=None),
+            emit=AsyncMock(),
+            session_factory=_factory,
+            clock=lambda: next(clock_values),
+        )
+
+        await poller.tick()
+        await poller.tick()
+
+        assert len(opened) == 2, "each tick must open its own session"
+        for handle in opened:
+            handle.close.assert_called_once()

--- a/docs/superpowers/plans/2026-07-24-steam-session-history-dashboard-panel.md
+++ b/docs/superpowers/plans/2026-07-24-steam-session-history-dashboard-panel.md
@@ -42,6 +42,7 @@
 | `tests/plugins/test_steam_gaming_ledger.py` (neu) | Ledger-Regeln |
 | `tests/plugins/test_steam_gaming_panel.py` (neu) | Panel-Spec, Formatierung, Gate |
 | `tests/plugins/test_steam_gaming_poller.py` (ändern) | Poller gegen den Ledger |
+| `tests/plugins/test_steam_gaming_plugin.py` (ändern) | Pill-Tests patchen `detection.py` statt der weggezogenen `__init__`-Namen |
 
 **Warum ein Sicherheits-Task, der nicht in der Spec steht (Task 7):** Beim Planen gefunden — `dashboard_panel_ws_bridge()` broadcastet Panel-Daten mit `broadcast_typed()` an **alle** verbundenen WebSocket-Clients. Ein `admin_only`-Gate allein in der REST-Route wäre wirkungslos, sobald der Bridge feuert (er triggert auf Smart-Device-SHM-Änderungen, und Tapo-Geräte laufen auf dieser Box). Ohne Task 7 leakt das Panel die Spielnamen an jeden angemeldeten Nutzer — genau das, was `admin_only` verhindern soll.
 
@@ -1441,6 +1442,7 @@ git commit -m "feat(plugins): admin_only dashboard panels, enforced by the core"
 - Create: `app/plugins/installed/steam_gaming/detection.py`
 - Modify: `app/plugins/installed/steam_gaming/__init__.py`
 - Modify: `app/plugins/installed/steam_gaming/poller.py` (Defaults auf `detection` umstellen)
+- Modify: `tests/plugins/test_steam_gaming_plugin.py` (Patches ziehen auf `detection.py` um — Step 7)
 - Test: `tests/plugins/test_steam_gaming_panel.py` (neu)
 
 **Interfaces:**
@@ -1616,7 +1618,7 @@ und die Defaults in `__init__` anpassen:
 
 In `app/plugins/installed/steam_gaming/__init__.py`:
 
-(a) Importblock — `detector`/`names`-Importe ersetzen und die neuen ergänzen:
+(a) Importblock — **nur** die `detector`/`names`-Importe ersetzen und die neuen ergänzen. `import asyncio`, `import logging`, `import time`, `from typing import …` und `from sqlalchemy.orm import Session` bleiben unangetastet — der Block unten zeigt ausschließlich die `from app…`/`from datetime`-Zeilen, wie sie danach aussehen:
 
 ```python
 from datetime import datetime, timezone
@@ -1755,16 +1757,65 @@ def _panel_value(row: SteamSession, now: datetime) -> str:
 Run: `python -m pytest tests/plugins/test_steam_gaming_panel.py -v --no-cov`
 Expected: PASS (7 passed)
 
-- [ ] **Step 7: Verify nothing else in the plugin broke**
+- [ ] **Step 7: Repoint the existing pill tests at detection.py**
+
+**Ohne diesen Schritt sind sechs bestehende Tests rot.** `tests/plugins/test_steam_gaming_plugin.py` patcht `plugin_module.detect_running_app_id`, `plugin_module.resolve_name` und `plugin_module.settings` — alle drei Namen existieren nach Step 5 in `__init__.py` nicht mehr, und `monkeypatch.setattr` auf ein fehlendes Attribut wirft `AttributeError` (dieselbe Falle wie in der Ruff-F401-Episode: Patch-Ziele verschwinden beim Umzug). Die Patches wandern eine Ebene tiefer auf `detection.py` — dort liegen Detector, Resolver und der `settings`-Import jetzt.
+
+In `tests/plugins/test_steam_gaming_plugin.py`:
+
+(a) Import ergänzen (unter die bestehenden `from app…`-Importe):
+
+```python
+from app.plugins.installed.steam_gaming import detection as detection_module
+```
+
+(b) Die beiden Fixtures ersetzen:
+
+```python
+@pytest.fixture
+def prod_mode(monkeypatch):
+    """`is_dev_mode` is its own settings FIELD, not derived from nas_mode."""
+    monkeypatch.setattr(detection_module.settings, "is_dev_mode", False)
+
+
+@pytest.fixture
+def dev_mode(monkeypatch):
+    monkeypatch.setattr(detection_module.settings, "is_dev_mode", True)
+```
+
+(c) In diesen fünf Tests jedes `monkeypatch.setattr(plugin_module, "detect_running_app_id", …)` durch `monkeypatch.setattr(detection_module, "detect_running_app_id", …)` ersetzen und jedes `monkeypatch.setattr(plugin_module, "resolve_name", …)` durch `monkeypatch.setattr(detection_module, "resolve_name", …)`:
+
+- `test_stays_silent_when_no_game_runs`
+- `test_reports_the_game_name_when_resolvable`
+- `test_falls_back_to_the_bare_label_for_an_unknown_game`
+- `test_repeated_polls_within_the_ttl_scan_once` (das `_monotonic`-Patch bleibt auf `plugin_module` — der TTL-Cache lebt weiterhin dort)
+- `test_dev_mode_shows_a_mock_game`
+
+Bewusst wird `detection_module` gepatcht und nicht `plugin_module.current_app_id`: `test_dev_mode_shows_a_mock_game` soll den Dev-Zweig **in** `detection.py` durchlaufen (Detector liefert `None`, `dev_mode` an → „Dev Mode Game"), nicht an ihm vorbei.
+
+(d) In `TestBackgroundTask.test_declares_the_session_poller` den veralteten Kommentar ersetzen — aus
+
+```python
+        # run_on_startup True is fine: the poller's first tick is a baseline.
+```
+
+wird
+
+```python
+        # run_on_startup True is fine: the first tick books against the DB
+        # state and the gap rules keep it silent after a restart (TP4).
+```
+
+- [ ] **Step 8: Verify nothing else in the plugin broke**
 
 Run: `python -m pytest tests/plugins/ -k steam -v --no-cov`
-Expected: PASS — insbesondere `test_steam_gaming_plugin.py` (Pill-Collector, jetzt ohne eigenen Dev-Zweig)
+Expected: PASS — alle `test_steam_gaming_*`-Dateien, insbesondere die fünf umgezogenen Pill-Tests
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 9: Commit**
 
 ```bash
-git add app/plugins/installed/steam_gaming/ tests/plugins/test_steam_gaming_panel.py
-git commit -m "feat(steam-gaming): admin-only dashboard panel with the last five sessions" -m "detection.py becomes the single source pill, ledger and panel share, including the dev-mode stand-in that used to live in the pill collector only." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+git add app/plugins/installed/steam_gaming/ tests/plugins/test_steam_gaming_panel.py tests/plugins/test_steam_gaming_plugin.py
+git commit -m "feat(steam-gaming): admin-only dashboard panel with the last five sessions" -m "detection.py becomes the single source pill, ledger and panel share, including the dev-mode stand-in that used to live in the pill collector only. Existing pill tests repoint their patches at detection.py - the old targets no longer exist in __init__.py." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```
 
 ---
@@ -1832,20 +1883,20 @@ Expected: PASS
 
 - [ ] **Step 5: Verify the migration once more against a fresh database**
 
-Run: `python -c "import os; os.remove('baluhost.db') if os.path.exists('baluhost.db') else None"`
+Die Dev-DB bleibt unangetastet: `alembic/env.py:25` setzt `sqlalchemy.url` aus `DATABASE_URL` (über `settings.database_url`), also läuft die volle Kette gegen eine Scratch-Datei. **Bash-Tool verwenden** — PowerShell kennt das `VAR=x cmd`-Präfix nicht.
 
-**Achtung:** Das löscht die lokale Dev-DB. Wer sie behalten will, vorher kopieren:
-`python -c "import shutil,os; shutil.copy('baluhost.db','baluhost.db.bak') if os.path.exists('baluhost.db') else None"`
-
-Run: `python -m alembic upgrade head`
+Run: `DATABASE_URL="sqlite:///./migration_check.db" python -m alembic upgrade head`
 Expected: läuft von der ersten Revision bis zur neuen durch, ohne Fehler
 
-Run: `python -c "import sqlite3; print([r[0] for r in sqlite3.connect('baluhost.db').execute(\"select name from sqlite_master where type='table' and name='steam_sessions'\")])"`
+Run: `python -c "import sqlite3; print([r[0] for r in sqlite3.connect('migration_check.db').execute(\"select name from sqlite_master where type='table' and name='steam_sessions'\")])"`
 Expected: `['steam_sessions']`
+
+Run: `python -c "import os; os.remove('migration_check.db')"`
+Expected: kein Output (Scratch-Datei aufgeräumt; sie darf nicht committet werden)
 
 - [ ] **Step 6: PostgreSQL check (Handarbeit, nicht überspringen)**
 
-CI hat keinen Alembic-Smoke-Test (#450). Gegen eine PostgreSQL-Instanz — lokal oder auf der Box vor dem Merge:
+CI hat keinen Alembic-Smoke-Test (#450). Gegen eine PostgreSQL-Instanz — lokal oder auf der Box vor dem Merge (**Bash-Tool**, gleiche Präfix-Syntax wie Step 5):
 
 Run: `DATABASE_URL=postgresql://…/baluhost_test python -m alembic upgrade head`
 Expected: `Running upgrade 71fe791d28d6 -> <rev>, add steam_sessions table`

--- a/docs/superpowers/plans/2026-07-24-steam-session-history-dashboard-panel.md
+++ b/docs/superpowers/plans/2026-07-24-steam-session-history-dashboard-panel.md
@@ -1,0 +1,1891 @@
+# Steam-Session-Historie + Dashboard-Panel — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Steam-Sessions werden in einer eigenen Tabelle verbucht, das Dashboard zeigt die letzten fünf als admin-only Panel, und der direkte Spielwechsel X→Y wird gebucht **und** gemeldet (schließt #462).
+
+**Architecture:** Die offene Session in der DB (`ended_at IS NULL`) **ist** der Zustand des Pollers — kein `_last_app_id`, kein `_initialized`-Flag mehr. Ein neues Modul `ledger.py` übersetzt eine Detektor-Beobachtung in Buchungen und gibt zurück, was zu melden ist; der Poller detektiert, ruft den Ledger und feuert danach die Events. Das Panel liest dieselbe Tabelle über den bereits vorhandenen `status`-Renderer.
+
+**Tech Stack:** Python 3.11+, FastAPI, SQLAlchemy 2.0 (`Mapped[...]`/`mapped_column`), Alembic, pytest (`asyncio_mode = "auto"`).
+
+**Spec:** `docs/superpowers/specs/2026-07-24-steam-session-history-dashboard-panel-design.md`
+**Branch:** `feat/steam-session-history-panel` (existiert bereits, Spec ist dort committed)
+
+## Global Constraints
+
+- **Arbeitsverzeichnis für alle Kommandos:** `backend/` (`cd "D:/Programme (x86)/Baluhost/backend"`). Testpfade im Plan sind relativ dazu.
+- **Kein `&&` in Kommandos** (PowerShell 5.1 kennt es nicht) — mit `;` trennen oder `if ($?) { … }`.
+- **Commit-Nachrichten ASCII-only** (keine Umlaute) und einzeilig via `-m`; Zeilenumbrüche über mehrere `-m`-Flags. Jede Commit-Nachricht endet mit `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` als eigenes `-m`.
+- **Type Hints auf allen Funktionen**, Docstrings auf allen öffentlichen Funktionen/Klassen (`.claude/rules/backend/coding-style.md`).
+- **Die Migration setzt auf `down_revision = '71fe791d28d6'`** — das ist der einzige echte Head im `alembic/versions`-Verzeichnis (verifiziert 2026-07-24, 115 Revisionen). **Niemals** den Head der lokalen Dev-DB verwenden (#123 → #124).
+- **Tests laufen mit `NAS_MODE=dev`** (`tests/conftest.py:23`) — `settings.is_dev_mode` ist in der Suite **True**. Deshalb darf die Dev-Mode-Ersatzerkennung nicht in `detector.py`/`names.py` landen (das würde die bestehenden Detektor-Tests brechen), sondern kommt in ein eigenes Modul `detection.py` (Task 8).
+- **Konstanten aus der Spec, wörtlich:** `STALE_AFTER_SECONDS = 60.0`, `ADOPT_WINDOW_SECONDS = 600.0`, `RETENTION_DAYS = 365`, Panel-Zeilen = 5, Poll-Intervall bleibt 30 s.
+- **Reihenfolge im Tick, verbindlich:** erst buchen **und committen**, dann melden.
+- **Kein Frontend-Diff.** `PluginDashboardPanel.tsx` löst Panel-Icons dynamisch aus lucide auf (kebab→Pascal, Fallback `Plug`), `StatusPanel.tsx` rendert `label`/`value`/`tone`. Wer in `client/` etwas ändern will, hat den Plan verlassen.
+
+---
+
+## Dateistruktur
+
+| Datei | Verantwortung |
+|---|---|
+| `app/models/steam_session.py` (neu) | Nur das ORM-Modell `SteamSession` |
+| `alembic/versions/<rev>_add_steam_sessions_table.py` (neu) | Tabelle anlegen/entfernen |
+| `app/plugins/installed/steam_gaming/ledger.py` (neu) | Flanken- und Lückenregeln, Retention, Dauerberechnung. Kennt die DB, kennt **keine** Notifications |
+| `app/plugins/installed/steam_gaming/detection.py` (neu) | Eine Quelle für „läuft ein Spiel" (Pill, Ledger, Panel), inkl. Dev-Mode-Ersatz |
+| `app/plugins/installed/steam_gaming/poller.py` (ändern) | Detektieren → Ledger → melden. Kein eigener Zustand mehr |
+| `app/plugins/installed/steam_gaming/__init__.py` (ändern) | Panel-Spec + Panel-Daten + Formatierung; Pill nutzt `detection.py` |
+| `app/plugins/base.py` (ändern) | `DashboardPanelSpec.admin_only` |
+| `app/api/routes/dashboard.py` (ändern) | Gate: `admin_only` → `is_privileged` |
+| `app/services/websocket_manager.py` (ändern) | `broadcast_typed(..., admins_only=False)` |
+| `app/services/dashboard_panel_bridge.py` (ändern) | Broadcast admin-only-Panels nur an Admins |
+| `tests/plugins/test_steam_gaming_ledger.py` (neu) | Ledger-Regeln |
+| `tests/plugins/test_steam_gaming_panel.py` (neu) | Panel-Spec, Formatierung, Gate |
+| `tests/plugins/test_steam_gaming_poller.py` (ändern) | Poller gegen den Ledger |
+
+**Warum ein Sicherheits-Task, der nicht in der Spec steht (Task 7):** Beim Planen gefunden — `dashboard_panel_ws_bridge()` broadcastet Panel-Daten mit `broadcast_typed()` an **alle** verbundenen WebSocket-Clients. Ein `admin_only`-Gate allein in der REST-Route wäre wirkungslos, sobald der Bridge feuert (er triggert auf Smart-Device-SHM-Änderungen, und Tapo-Geräte laufen auf dieser Box). Ohne Task 7 leakt das Panel die Spielnamen an jeden angemeldeten Nutzer — genau das, was `admin_only` verhindern soll.
+
+---
+
+## Task 1: Modell + Migration
+
+**Files:**
+- Create: `app/models/steam_session.py`
+- Create: `alembic/versions/<generiert>_add_steam_sessions_table.py`
+- Modify: `app/models/__init__.py`
+- Test: `tests/plugins/test_steam_gaming_ledger.py`
+
+**Interfaces:**
+- Produces: `app.models.steam_session.SteamSession` mit den Feldern `id: int`, `app_id: str`, `game_name: Optional[str]`, `started_at: datetime`, `last_seen_at: datetime`, `ended_at: Optional[datetime]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Neue Datei `tests/plugins/test_steam_gaming_ledger.py`:
+
+```python
+"""Steam session ledger: persisted play sessions (Teilprojekt 4/4)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.models.steam_session import SteamSession
+
+T0 = datetime(2026, 7, 24, 20, 0, 0, tzinfo=timezone.utc)
+
+
+class TestModel:
+    def test_open_session_round_trips(self, db_session):
+        db_session.add(SteamSession(
+            app_id="1449560",
+            game_name="Metro Exodus Enhanced Edition",
+            started_at=T0,
+            last_seen_at=T0,
+        ))
+        db_session.commit()
+
+        row = db_session.query(SteamSession).one()
+        assert row.app_id == "1449560"
+        assert row.game_name == "Metro Exodus Enhanced Edition"
+        assert row.ended_at is None
+
+    def test_game_name_is_optional(self, db_session):
+        db_session.add(SteamSession(
+            app_id="999", game_name=None, started_at=T0, last_seen_at=T0,
+        ))
+        db_session.commit()
+
+        assert db_session.query(SteamSession).one().game_name is None
+
+    def test_ended_session_stores_its_end(self, db_session):
+        end = T0 + timedelta(hours=1)
+        db_session.add(SteamSession(
+            app_id="1", started_at=T0, last_seen_at=end, ended_at=end,
+        ))
+        db_session.commit()
+
+        assert db_session.query(SteamSession).one().ended_at is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_ledger.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.models.steam_session'`
+
+- [ ] **Step 3: Write the model**
+
+Neue Datei `app/models/steam_session.py`:
+
+```python
+"""Steam play sessions recorded by the steam_gaming plugin (Teilprojekt 4/4).
+
+The table lives in app/models/ rather than in the plugin because Alembic's
+autogenerate only sees what is attached to Base.metadata — same reason
+smart_device.py sits here for the Tapo plugin.
+"""
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class SteamSession(Base):
+    """One play session. ``ended_at IS NULL`` means it is still running.
+
+    The duration is deliberately NOT stored: it is derived from
+    ``ended_at - started_at``. A stored value would be a second truth that can
+    drift when a session is adopted across a backend restart.
+    """
+
+    __tablename__ = "steam_sessions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    app_id: Mapped[str] = mapped_column(String(32), index=True, nullable=False)
+    game_name: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), index=True, nullable=False
+    )
+    last_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    ended_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    def __repr__(self) -> str:
+        return f"<SteamSession(app_id='{self.app_id}', started_at={self.started_at})>"
+```
+
+- [ ] **Step 4: Register the model**
+
+In `app/models/__init__.py` direkt nach der Zeile
+`from app.models.status_bar import StatusBarPillConfig, StatusBarSettings` einfügen:
+
+```python
+from app.models.steam_session import SteamSession
+```
+
+und in der `__all__`-Liste direkt nach `"StatusBarSettings",` einfügen:
+
+```python
+    "SteamSession",
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_ledger.py -v --no-cov`
+Expected: PASS (3 passed) — die `db_session`-Fixture legt die Tabelle über `Base.metadata.create_all()` an.
+
+- [ ] **Step 6: Generate the migration skeleton**
+
+Run: `python -m alembic revision -m "add steam_sessions table"`
+Expected: `Generating …/alembic/versions/<rev>_add_steam_sessions_table.py ... done`
+
+**Sofort prüfen:** In der erzeugten Datei muss `down_revision` auf `'71fe791d28d6'` stehen. Steht dort etwas anderes, von Hand korrigieren — das ist der einzige echte Head.
+
+- [ ] **Step 7: Fill in the migration body**
+
+`upgrade()` und `downgrade()` in der neuen Datei komplett ersetzen durch:
+
+```python
+def upgrade() -> None:
+    """Create steam_sessions (play history for the steam_gaming plugin)."""
+    op.create_table(
+        'steam_sessions',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('app_id', sa.String(length=32), nullable=False),
+        sa.Column('game_name', sa.String(length=200), nullable=True),
+        sa.Column('started_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('last_seen_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('ended_at', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_steam_sessions_id', 'steam_sessions', ['id'])
+    op.create_index('ix_steam_sessions_app_id', 'steam_sessions', ['app_id'])
+    op.create_index('ix_steam_sessions_started_at', 'steam_sessions', ['started_at'])
+
+
+def downgrade() -> None:
+    """Drop steam_sessions. Loses the play history — dev/rollback path only."""
+    op.drop_index('ix_steam_sessions_started_at', table_name='steam_sessions')
+    op.drop_index('ix_steam_sessions_app_id', table_name='steam_sessions')
+    op.drop_index('ix_steam_sessions_id', table_name='steam_sessions')
+    op.drop_table('steam_sessions')
+```
+
+Der Docstring am Dateikopf (von Alembic erzeugt) bleibt; ergänze darunter einen Satz:
+`Teilprojekt 4/4 — siehe docs/superpowers/specs/2026-07-24-steam-session-history-dashboard-panel-design.md`
+
+- [ ] **Step 8: Verify the migration applies and reverts**
+
+Run: `python -m alembic upgrade head`
+Expected: `Running upgrade 71fe791d28d6 -> <rev>, add steam_sessions table`
+
+Run: `python -m alembic downgrade -1`
+Expected: `Running downgrade <rev> -> 71fe791d28d6, add steam_sessions table`
+
+Run: `python -m alembic upgrade head`
+Expected: erneut `Running upgrade …` (wieder oben)
+
+Run: `python -m alembic heads`
+Expected: **genau eine** Zeile, die auf `<rev> (head)` endet.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/models/steam_session.py app/models/__init__.py alembic/versions tests/plugins/test_steam_gaming_ledger.py
+git commit -m "feat(steam-gaming): steam_sessions table for the play history" -m "Model in app/models/ so Alembic autogenerate sees it; duration stays derived, never stored." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Ledger — Flanken im Live-Fall
+
+**Files:**
+- Create: `app/plugins/installed/steam_gaming/ledger.py`
+- Test: `tests/plugins/test_steam_gaming_ledger.py`
+
+**Interfaces:**
+- Consumes: `SteamSession` (Task 1)
+- Produces:
+  - `LedgerEvent(event_id: str, app_id: str, game: str)` — frozen dataclass
+  - `record(db: Session, app_id: Optional[str], *, now: datetime, resolve_name: Callable[[str], Optional[str]]) -> List[LedgerEvent]` — bucht **und committet**, gibt die zu meldenden Events zurück
+  - `as_utc(value: datetime) -> datetime` — hängt UTC an naive Werte (SQLite)
+  - Konstanten `EVENT_STARTED = "session_started"`, `EVENT_ENDED = "session_ended"`, `STALE_AFTER_SECONDS = 60.0`, `ADOPT_WINDOW_SECONDS = 600.0`
+
+- [ ] **Step 1: Write the failing test**
+
+An `tests/plugins/test_steam_gaming_ledger.py` anhängen:
+
+```python
+from app.plugins.installed.steam_gaming import ledger
+
+
+def _names(app_id: str):
+    """Stand-in for names.resolve_name()."""
+    return {"111": "Metro", "222": "Cyberpunk"}.get(app_id)
+
+
+def _record(db, app_id, now):
+    return ledger.record(db, app_id, now=now, resolve_name=_names)
+
+
+class TestLiveEdges:
+    def test_nothing_open_and_nothing_running_books_nothing(self, db_session):
+        events = _record(db_session, None, T0)
+
+        assert events == []
+        assert db_session.query(SteamSession).count() == 0
+
+    def test_game_appears_opens_a_session_and_announces_it(self, db_session):
+        events = _record(db_session, "111", T0)
+
+        row = db_session.query(SteamSession).one()
+        assert row.app_id == "111"
+        assert row.game_name == "Metro"
+        assert row.started_at is not None
+        assert row.ended_at is None
+        assert [(e.event_id, e.app_id, e.game) for e in events] == [
+            (ledger.EVENT_STARTED, "111", "Metro")
+        ]
+
+    def test_same_game_next_tick_only_moves_the_heartbeat(self, db_session):
+        _record(db_session, "111", T0)
+        events = _record(db_session, "111", T0 + timedelta(seconds=30))
+
+        row = db_session.query(SteamSession).one()
+        assert events == []
+        assert ledger.as_utc(row.last_seen_at) == T0 + timedelta(seconds=30)
+        assert row.ended_at is None
+
+    def test_game_disappears_closes_at_now_and_announces_the_end(self, db_session):
+        _record(db_session, "111", T0)
+        end = T0 + timedelta(seconds=30)
+        events = _record(db_session, None, end)
+
+        row = db_session.query(SteamSession).one()
+        assert ledger.as_utc(row.ended_at) == end
+        assert [(e.event_id, e.app_id, e.game) for e in events] == [
+            (ledger.EVENT_ENDED, "111", "Metro")
+        ]
+
+    def test_direct_switch_closes_x_opens_y_and_announces_both(self, db_session):
+        """#462: X->Y without a pause was swallowed in TP3."""
+        _record(db_session, "111", T0)
+        switch = T0 + timedelta(seconds=30)
+        events = _record(db_session, "222", switch)
+
+        rows = db_session.query(SteamSession).order_by(SteamSession.started_at).all()
+        assert len(rows) == 2
+        assert ledger.as_utc(rows[0].ended_at) == switch
+        assert rows[1].app_id == "222" and rows[1].ended_at is None
+        assert [(e.event_id, e.app_id, e.game) for e in events] == [
+            (ledger.EVENT_ENDED, "111", "Metro"),
+            (ledger.EVENT_STARTED, "222", "Cyberpunk"),
+        ]
+
+    def test_unresolved_name_falls_back_to_the_app_id_in_the_event(self, db_session):
+        events = _record(db_session, "999", T0)
+
+        assert db_session.query(SteamSession).one().game_name is None
+        assert events[0].game == "999"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_ledger.py -v --no-cov`
+Expected: FAIL — `ImportError: cannot import name 'ledger'`
+
+- [ ] **Step 3: Write the ledger**
+
+Neue Datei `app/plugins/installed/steam_gaming/ledger.py`:
+
+```python
+"""Steam session ledger: turn detector observations into persisted sessions.
+
+The open session in the database IS the poller's state - there is no in-process
+last_app_id and no initialization flag. That is what makes a restart mid-session
+harmless: the gap between `now` and the open session's last_seen_at says what
+happened while the process was away (see the gap rules in Task 3).
+
+This module knows the database and nothing about notifications: it returns what
+is worth announcing and lets the caller deliver it, after the booking is
+committed.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.steam_session import SteamSession
+
+logger = logging.getLogger(__name__)
+
+EVENT_STARTED = "session_started"
+EVENT_ENDED = "session_ended"
+
+# Two poll intervals: within this, the poller was there continuously, so `now`
+# is a truthful end time and the edge is live news worth announcing.
+STALE_AFTER_SECONDS = 60.0
+# The same game across a gap this short is one session (a deploy mid-game).
+ADOPT_WINDOW_SECONDS = 600.0
+
+
+@dataclass(frozen=True)
+class LedgerEvent:
+    """A notification the caller should fire once the booking is committed."""
+
+    event_id: str
+    app_id: str
+    game: str
+
+
+def as_utc(value: datetime) -> datetime:
+    """SQLite hands back naive datetimes even for DateTime(timezone=True)."""
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
+def _label(session: SteamSession) -> str:
+    """Name for a notification; the AppID is the honest fallback."""
+    return session.game_name or session.app_id
+
+
+def _open(
+    db: Session,
+    app_id: str,
+    now: datetime,
+    resolve_name: Callable[[str], Optional[str]],
+) -> SteamSession:
+    """Start a new session. Announcing it is the caller's decision."""
+    session = SteamSession(
+        app_id=app_id,
+        game_name=resolve_name(app_id),
+        started_at=now,
+        last_seen_at=now,
+    )
+    db.add(session)
+    return session
+
+
+def _current_session(db: Session) -> Optional[SteamSession]:
+    """The newest open session, if any."""
+    return (
+        db.query(SteamSession)
+        .filter(SteamSession.ended_at.is_(None))
+        .order_by(SteamSession.started_at.desc())
+        .first()
+    )
+
+
+def record(
+    db: Session,
+    app_id: Optional[str],
+    *,
+    now: datetime,
+    resolve_name: Callable[[str], Optional[str]],
+) -> List[LedgerEvent]:
+    """Book one detector observation; return the events worth announcing.
+
+    Commits on success. Never raises: a database failure rolls back, logs and
+    yields no events, so the next tick simply tries again.
+
+    Args:
+        db: SQLAlchemy session, owned by the caller.
+        app_id: AppID of the running game, or None when nothing is running.
+        now: Current time (injected so tests control the clock).
+        resolve_name: AppID -> display name, or None when unresolvable.
+
+    Returns:
+        Events to deliver, in order.
+    """
+    events: List[LedgerEvent] = []
+    try:
+        current = _current_session(db)
+
+        if current is None:
+            if app_id is not None:
+                opened = _open(db, app_id, now, resolve_name)
+                events.append(LedgerEvent(EVENT_STARTED, opened.app_id, _label(opened)))
+        elif app_id == current.app_id:
+            current.last_seen_at = now
+        else:
+            current.ended_at = now
+            events.append(LedgerEvent(EVENT_ENDED, current.app_id, _label(current)))
+            if app_id is not None:
+                opened = _open(db, app_id, now, resolve_name)
+                events.append(LedgerEvent(EVENT_STARTED, opened.app_id, _label(opened)))
+
+        db.commit()
+    except Exception:  # broad on purpose: a booking failure must not kill the poller
+        db.rollback()
+        logger.warning("steam ledger: booking failed", exc_info=True)
+        return []
+
+    return events
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_ledger.py -v --no-cov`
+Expected: PASS (9 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/plugins/installed/steam_gaming/ledger.py tests/plugins/test_steam_gaming_ledger.py
+git commit -m "feat(steam-gaming): ledger books sessions from detector edges" -m "The open DB session is the state; X->Y now closes X and opens Y (#462)." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Ledger — Lückenregeln
+
+**Files:**
+- Modify: `app/plugins/installed/steam_gaming/ledger.py`
+- Test: `tests/plugins/test_steam_gaming_ledger.py`
+
+**Interfaces:**
+- Consumes: `record()`, `as_utc()`, `STALE_AFTER_SECONDS`, `ADOPT_WINDOW_SECONDS` (Task 2)
+- Produces: unveränderte Signatur von `record()` — nur das Verhalten bei Lücken kommt dazu.
+
+Die drei Regeln aus der Spec:
+1. `ended_at = now`, wenn die Lücke ≤ `STALE_AFTER_SECONDS` — sonst `ended_at = last_seen_at`.
+2. Nach einer Lücke wird nur gebucht, **nie** gemeldet.
+3. Dasselbe Spiel über eine Lücke ≤ `ADOPT_WINDOW_SECONDS` führt die Session fort, darüber wird gesplittet.
+
+- [ ] **Step 1: Write the failing test**
+
+An `tests/plugins/test_steam_gaming_ledger.py` anhängen:
+
+```python
+class TestGapRules:
+    def test_stale_end_is_booked_at_the_last_heartbeat(self, db_session):
+        """The process was away: `now` would book the outage as playtime."""
+        _record(db_session, "111", T0)
+        _record(db_session, "111", T0 + timedelta(seconds=30))  # last heartbeat
+
+        _record(db_session, None, T0 + timedelta(hours=2))
+
+        row = db_session.query(SteamSession).one()
+        assert ledger.as_utc(row.ended_at) == T0 + timedelta(seconds=30)
+
+    def test_stale_end_is_not_announced(self, db_session):
+        """A deploy must not push 'session ended' for a game that ended hours ago."""
+        _record(db_session, "111", T0)
+
+        events = _record(db_session, None, T0 + timedelta(hours=2))
+
+        assert events == []
+
+    def test_stale_switch_books_both_but_announces_nothing(self, db_session):
+        _record(db_session, "111", T0)
+
+        events = _record(db_session, "222", T0 + timedelta(hours=2))
+
+        rows = db_session.query(SteamSession).order_by(SteamSession.started_at).all()
+        assert len(rows) == 2
+        assert ledger.as_utc(rows[0].ended_at) == T0
+        assert rows[1].app_id == "222" and rows[1].ended_at is None
+        assert events == []
+
+    def test_same_game_across_a_short_gap_continues_the_session(self, db_session):
+        """A deploy mid-game is the normal case on this box."""
+        _record(db_session, "111", T0)
+        resumed = T0 + timedelta(minutes=5)
+
+        events = _record(db_session, "111", resumed)
+
+        row = db_session.query(SteamSession).one()
+        assert ledger.as_utc(row.started_at) == T0
+        assert ledger.as_utc(row.last_seen_at) == resumed
+        assert row.ended_at is None
+        assert events == []
+
+    def test_same_game_across_a_long_gap_splits_into_two_sessions(self, db_session):
+        """Off overnight and restarted in the morning is not a 14h session."""
+        _record(db_session, "111", T0)
+        next_day = T0 + timedelta(hours=14)
+
+        events = _record(db_session, "111", next_day)
+
+        rows = db_session.query(SteamSession).order_by(SteamSession.started_at).all()
+        assert len(rows) == 2
+        assert ledger.as_utc(rows[0].ended_at) == T0
+        assert ledger.as_utc(rows[1].started_at) == next_day
+        assert rows[1].ended_at is None
+        assert events == []
+
+    def test_the_adopt_window_boundary_still_continues(self, db_session):
+        _record(db_session, "111", T0)
+
+        _record(db_session, "111", T0 + timedelta(seconds=ledger.ADOPT_WINDOW_SECONDS))
+
+        assert db_session.query(SteamSession).count() == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_ledger.py -k GapRules -v --no-cov`
+Expected: FAIL — u. a. `test_stale_end_is_booked_at_the_last_heartbeat` (bucht noch `now`) und `test_same_game_across_a_long_gap_splits_into_two_sessions` (erzeugt nur eine Zeile)
+
+- [ ] **Step 3: Add the gap rules**
+
+In `ledger.py` die Hilfsfunktion ergänzen (direkt unter `_current_session`):
+
+```python
+def _gap_seconds(session: SteamSession, now: datetime) -> float:
+    """How long the poller was away, measured from the session's last heartbeat."""
+    return (now - as_utc(session.last_seen_at)).total_seconds()
+```
+
+und den `try`-Block in `record()` ersetzen durch:
+
+```python
+        current = _current_session(db)
+
+        if current is None:
+            if app_id is not None:
+                # Nothing open: either nothing was running, or this is the very
+                # first tick after deploying the ledger. Both look identical
+                # here - see the accepted deviation in the design doc.
+                opened = _open(db, app_id, now, resolve_name)
+                events.append(LedgerEvent(EVENT_STARTED, opened.app_id, _label(opened)))
+        else:
+            gap = _gap_seconds(current, now)
+            live = gap <= STALE_AFTER_SECONDS
+
+            if app_id == current.app_id:
+                if gap <= ADOPT_WINDOW_SECONDS:
+                    current.last_seen_at = now
+                else:
+                    # Same game, but far too long ago to be one session.
+                    current.ended_at = as_utc(current.last_seen_at)
+                    _open(db, app_id, now, resolve_name)  # after a gap: book, never announce
+            else:
+                # `now` is only a truthful end time while the poller was there.
+                current.ended_at = now if live else as_utc(current.last_seen_at)
+                if live:
+                    events.append(LedgerEvent(EVENT_ENDED, current.app_id, _label(current)))
+                if app_id is not None:
+                    opened = _open(db, app_id, now, resolve_name)
+                    if live:
+                        events.append(
+                            LedgerEvent(EVENT_STARTED, opened.app_id, _label(opened))
+                        )
+
+        db.commit()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_ledger.py -v --no-cov`
+Expected: PASS (15 passed) — die Live-Tests aus Task 2 bleiben grün, weil dort alle Lücken ≤ 30 s sind.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/plugins/installed/steam_gaming/ledger.py tests/plugins/test_steam_gaming_ledger.py
+git commit -m "feat(steam-gaming): gap rules make restarts and suspend harmless" -m "Stale ends book at last_seen_at and stay silent; the same game across a short gap continues, across a long one splits." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Ledger — Waisen aufräumen, Namen nachtragen, Dauer
+
+**Files:**
+- Modify: `app/plugins/installed/steam_gaming/ledger.py`
+- Test: `tests/plugins/test_steam_gaming_ledger.py`
+
+**Interfaces:**
+- Produces: `duration_seconds(session: SteamSession, now: datetime) -> float` (vom Panel in Task 8 benutzt)
+
+- [ ] **Step 1: Write the failing test**
+
+An `tests/plugins/test_steam_gaming_ledger.py` anhängen:
+
+```python
+class TestHousekeeping:
+    def test_orphaned_open_sessions_are_closed_silently(self, db_session):
+        """The invariant says one open session; a crash can still leave more."""
+        db_session.add_all([
+            SteamSession(app_id="111", started_at=T0, last_seen_at=T0),
+            SteamSession(
+                app_id="222",
+                started_at=T0 + timedelta(hours=1),
+                last_seen_at=T0 + timedelta(hours=1),
+            ),
+        ])
+        db_session.commit()
+
+        events = _record(db_session, "222", T0 + timedelta(hours=1, seconds=30))
+
+        older = db_session.query(SteamSession).filter_by(app_id="111").one()
+        newer = db_session.query(SteamSession).filter_by(app_id="222").one()
+        assert ledger.as_utc(older.ended_at) == T0
+        assert newer.ended_at is None
+        assert events == []
+
+    def test_missing_game_name_is_resolved_on_a_later_heartbeat(self, db_session):
+        """A game started during its own install has no appmanifest yet."""
+        ledger.record(db_session, "111", now=T0, resolve_name=lambda _app_id: None)
+        assert db_session.query(SteamSession).one().game_name is None
+
+        _record(db_session, "111", T0 + timedelta(seconds=30))
+
+        assert db_session.query(SteamSession).one().game_name == "Metro"
+
+    def test_a_resolved_name_is_not_overwritten(self, db_session):
+        _record(db_session, "111", T0)
+
+        ledger.record(
+            db_session, "111", now=T0 + timedelta(seconds=30), resolve_name=lambda _a: None
+        )
+
+        assert db_session.query(SteamSession).one().game_name == "Metro"
+
+
+class TestDuration:
+    def test_closed_session_duration(self, db_session):
+        session = SteamSession(
+            app_id="111",
+            started_at=T0,
+            last_seen_at=T0 + timedelta(minutes=90),
+            ended_at=T0 + timedelta(minutes=90),
+        )
+
+        assert ledger.duration_seconds(session, T0 + timedelta(hours=5)) == 5400.0
+
+    def test_open_session_counts_up_to_now(self, db_session):
+        session = SteamSession(app_id="111", started_at=T0, last_seen_at=T0)
+
+        assert ledger.duration_seconds(session, T0 + timedelta(minutes=12)) == 720.0
+
+    def test_clock_stepping_backwards_clamps_at_zero(self, db_session):
+        """An NTP step backwards must not produce a negative duration."""
+        session = SteamSession(app_id="111", started_at=T0, last_seen_at=T0)
+
+        assert ledger.duration_seconds(session, T0 - timedelta(minutes=5)) == 0.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_ledger.py -k "Housekeeping or Duration" -v --no-cov`
+Expected: FAIL — `AttributeError: module 'app.plugins.installed.steam_gaming.ledger' has no attribute 'duration_seconds'` sowie ein offener Waisen-Datensatz
+
+- [ ] **Step 3: Implement housekeeping and duration**
+
+In `ledger.py` `_current_session()` ersetzen durch:
+
+```python
+def _claim_current_session(db: Session) -> Optional[SteamSession]:
+    """The newest open session; any older open one is an orphan and gets closed.
+
+    The invariant is "at most one open session". A crash at the wrong moment can
+    still leave more behind, so every tick cleans up instead of trusting it.
+    """
+    open_sessions = (
+        db.query(SteamSession)
+        .filter(SteamSession.ended_at.is_(None))
+        .order_by(SteamSession.started_at.desc())
+        .all()
+    )
+    for orphan in open_sessions[1:]:
+        orphan.ended_at = as_utc(orphan.last_seen_at)
+        logger.warning("steam ledger: closed orphaned session id=%s", orphan.id)
+    return open_sessions[0] if open_sessions else None
+```
+
+In `record()` den Aufruf anpassen:
+
+```python
+        current = _claim_current_session(db)
+```
+
+und im Heartbeat-Zweig den Namen nachtragen — aus
+
+```python
+                if gap <= ADOPT_WINDOW_SECONDS:
+                    current.last_seen_at = now
+```
+
+wird
+
+```python
+                if gap <= ADOPT_WINDOW_SECONDS:
+                    current.last_seen_at = now
+                    if current.game_name is None:
+                        # A game started during its own install has no manifest
+                        # yet; resolve_name() retries misses after 60s anyway.
+                        current.game_name = resolve_name(app_id)
+```
+
+Am Ende der Datei ergänzen:
+
+```python
+def duration_seconds(session: SteamSession, now: datetime) -> float:
+    """Seconds played. An open session counts up to *now*.
+
+    Clamped at 0: an NTP step backwards would otherwise produce a negative
+    duration, which is worse in the panel than a flattering zero.
+    """
+    end = as_utc(session.ended_at) if session.ended_at is not None else now
+    return max(0.0, (end - as_utc(session.started_at)).total_seconds())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_ledger.py -v --no-cov`
+Expected: PASS (21 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/plugins/installed/steam_gaming/ledger.py tests/plugins/test_steam_gaming_ledger.py
+git commit -m "feat(steam-gaming): close orphans, backfill names, derive duration" -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Ledger — Retention
+
+**Files:**
+- Modify: `app/plugins/installed/steam_gaming/ledger.py`
+- Test: `tests/plugins/test_steam_gaming_ledger.py`
+
+**Interfaces:**
+- Produces: `cleanup_old_sessions(db: Session, *, now: datetime) -> int` (Anzahl gelöschter Zeilen), Konstante `RETENTION_DAYS = 365`
+
+- [ ] **Step 1: Write the failing test**
+
+An `tests/plugins/test_steam_gaming_ledger.py` anhängen:
+
+```python
+class TestRetention:
+    def test_deletes_sessions_older_than_the_retention_window(self, db_session):
+        old_start = T0 - timedelta(days=400)
+        db_session.add(SteamSession(
+            app_id="111",
+            started_at=old_start,
+            last_seen_at=old_start + timedelta(hours=1),
+            ended_at=old_start + timedelta(hours=1),
+        ))
+        db_session.commit()
+
+        deleted = ledger.cleanup_old_sessions(db_session, now=T0)
+
+        assert deleted == 1
+        assert db_session.query(SteamSession).count() == 0
+
+    def test_keeps_sessions_inside_the_window(self, db_session):
+        recent = T0 - timedelta(days=364)
+        db_session.add(SteamSession(
+            app_id="111", started_at=recent, last_seen_at=recent, ended_at=recent,
+        ))
+        db_session.commit()
+
+        deleted = ledger.cleanup_old_sessions(db_session, now=T0)
+
+        assert deleted == 0
+        assert db_session.query(SteamSession).count() == 1
+
+    def test_never_deletes_an_open_session(self, db_session):
+        """An open session has no ended_at - however old, it is the current one."""
+        ancient = T0 - timedelta(days=500)
+        db_session.add(SteamSession(app_id="111", started_at=ancient, last_seen_at=ancient))
+        db_session.commit()
+
+        deleted = ledger.cleanup_old_sessions(db_session, now=T0)
+
+        assert deleted == 0
+        assert db_session.query(SteamSession).count() == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_ledger.py -k Retention -v --no-cov`
+Expected: FAIL — `AttributeError: … has no attribute 'cleanup_old_sessions'`
+
+- [ ] **Step 3: Implement retention**
+
+In `ledger.py` den Import ergänzen:
+
+```python
+from datetime import datetime, timedelta, timezone
+```
+
+die Konstante unter `ADOPT_WINDOW_SECONDS` ergänzen:
+
+```python
+# Hard-wired on purpose; configurability is tracked in #464.
+RETENTION_DAYS = 365
+```
+
+und am Dateiende anfügen:
+
+```python
+def cleanup_old_sessions(db: Session, *, now: datetime) -> int:
+    """Delete ended sessions older than RETENTION_DAYS.
+
+    Deliberately not wired into monitoring/retention_manager.py: that one hangs
+    off the MetricType enum and monitoring_config rows, so putting a plugin
+    table there would couple the core to a plugin.
+
+    Returns:
+        Number of rows deleted; 0 if the delete failed.
+    """
+    cutoff = now - timedelta(days=RETENTION_DAYS)
+    try:
+        deleted = (
+            db.query(SteamSession)
+            .filter(SteamSession.ended_at.isnot(None), SteamSession.ended_at < cutoff)
+            .delete(synchronize_session=False)
+        )
+        db.commit()
+    except Exception:  # broad on purpose: retention must not kill the poller
+        db.rollback()
+        logger.warning("steam ledger: retention cleanup failed", exc_info=True)
+        return 0
+    return deleted
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_ledger.py -v --no-cov`
+Expected: PASS (24 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/plugins/installed/steam_gaming/ledger.py tests/plugins/test_steam_gaming_ledger.py
+git commit -m "feat(steam-gaming): retention deletes ended sessions after 365 days" -m "Plugin-local instead of the MetricType-bound retention_manager; configurability tracked in #464." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Poller auf den Ledger umstellen
+
+**Files:**
+- Modify: `app/plugins/installed/steam_gaming/poller.py` (komplett ersetzen)
+- Modify: `tests/plugins/test_steam_gaming_poller.py` (komplett ersetzen)
+
+**Interfaces:**
+- Consumes: `ledger.record()`, `ledger.cleanup_old_sessions()`, `ledger.LedgerEvent` (Tasks 2–5)
+- Produces: `SteamSessionPoller(detect=…, resolve=…, emit=…, session_factory=…, clock=…)` mit `async def tick() -> None`. `__init__.py` konstruiert ihn weiterhin ohne Argumente.
+
+Der Poller verliert `_last_app_id` und `_initialized` — der Zustand steht in der DB.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/plugins/test_steam_gaming_poller.py` **komplett ersetzen** durch:
+
+```python
+"""Steam session poller: detect -> book -> announce (Teilprojekt 3+4/4)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from app.models.steam_session import SteamSession
+from app.plugins.installed.steam_gaming import ledger
+from app.plugins.installed.steam_gaming.poller import SteamSessionPoller
+
+T0 = datetime(2026, 7, 24, 20, 0, 0, tzinfo=timezone.utc)
+
+
+def _poller(db_session, app_ids, times):
+    """A poller whose detector and clock walk the given sequences."""
+    detected = iter(app_ids)
+    clock_values = iter(times)
+    emit = AsyncMock()
+    poller = SteamSessionPoller(
+        detect=MagicMock(side_effect=lambda *a, **k: next(detected)),
+        resolve=MagicMock(side_effect=lambda app_id: f"Game {app_id}"),
+        emit=emit,
+        session_factory=lambda: db_session,
+        clock=lambda: next(clock_values),
+    )
+    return poller, emit
+
+
+class TestTick:
+    async def test_start_is_booked_and_announced(self, db_session):
+        poller, emit = _poller(db_session, ["111"], [T0])
+
+        await poller.tick()
+
+        assert db_session.query(SteamSession).count() == 1
+        emit.assert_awaited_once()
+        args, kwargs = emit.await_args
+        assert args[:2] == ("steam_gaming", ledger.EVENT_STARTED)
+        assert kwargs["entity_id"] == "111"
+        assert kwargs["game"] == "Game 111"
+
+    async def test_end_is_announced_on_the_game_that_ended(self, db_session):
+        poller, emit = _poller(
+            db_session, ["111", None], [T0, T0 + timedelta(seconds=30)]
+        )
+        await poller.tick()
+        emit.reset_mock()
+
+        await poller.tick()
+
+        emit.assert_awaited_once()
+        args, kwargs = emit.await_args
+        assert args[:2] == ("steam_gaming", ledger.EVENT_ENDED)
+        assert kwargs["entity_id"] == "111"
+
+    async def test_direct_switch_announces_both_edges(self, db_session):
+        """#462 - TP3 swallowed this."""
+        poller, emit = _poller(
+            db_session, ["111", "222"], [T0, T0 + timedelta(seconds=30)]
+        )
+        await poller.tick()
+        emit.reset_mock()
+
+        await poller.tick()
+
+        assert emit.await_count == 2
+        first, second = emit.await_args_list
+        assert first.args[:2] == ("steam_gaming", ledger.EVENT_ENDED)
+        assert first.kwargs["entity_id"] == "111"
+        assert second.args[:2] == ("steam_gaming", ledger.EVENT_STARTED)
+        assert second.kwargs["entity_id"] == "222"
+
+    async def test_same_game_announces_nothing(self, db_session):
+        poller, emit = _poller(
+            db_session, ["111", "111"], [T0, T0 + timedelta(seconds=30)]
+        )
+        await poller.tick()
+        emit.reset_mock()
+
+        await poller.tick()
+
+        emit.assert_not_awaited()
+
+    async def test_a_restart_mid_session_announces_nothing(self, db_session):
+        """The DB holds the state, so a fresh poller object just picks it up."""
+        first, _ = _poller(db_session, ["111"], [T0])
+        await first.tick()
+
+        second, emit = _poller(db_session, ["111"], [T0 + timedelta(minutes=5)])
+        await second.tick()
+
+        emit.assert_not_awaited()
+        assert db_session.query(SteamSession).count() == 1
+
+
+class TestRetentionSchedule:
+    async def test_cleanup_runs_on_the_first_tick(self, db_session, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            ledger, "cleanup_old_sessions", lambda db, *, now: calls.append(now) or 0
+        )
+        poller, _ = _poller(db_session, [None], [T0])
+
+        await poller.tick()
+
+        assert calls == [T0]
+
+    async def test_cleanup_does_not_run_again_the_next_tick(self, db_session, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            ledger, "cleanup_old_sessions", lambda db, *, now: calls.append(now) or 0
+        )
+        poller, _ = _poller(db_session, [None, None], [T0, T0 + timedelta(hours=1)])
+
+        await poller.tick()
+        await poller.tick()
+
+        assert calls == [T0]
+
+    async def test_cleanup_runs_again_after_a_day(self, db_session, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            ledger, "cleanup_old_sessions", lambda db, *, now: calls.append(now) or 0
+        )
+        later = T0 + timedelta(hours=25)
+        poller, _ = _poller(db_session, [None, None], [T0, later])
+
+        await poller.tick()
+        await poller.tick()
+
+        assert calls == [T0, later]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_poller.py -v --no-cov`
+Expected: FAIL — `TypeError: SteamSessionPoller.__init__() got an unexpected keyword argument 'session_factory'`
+
+- [ ] **Step 3: Rewrite the poller**
+
+`app/plugins/installed/steam_gaming/poller.py` **komplett ersetzen** durch:
+
+```python
+"""Steam session poller: detect, book, announce (Teilprojekt 3+4/4).
+
+Runs as a plugin background task, which thanks to #448 executes primary-only -
+so exactly one instance polls. It keeps no state of its own: the open session
+in the database is the state (see ledger.py), which is what makes a restart
+mid-session harmless.
+
+Order matters: book and commit first, announce afterwards. A failed push must
+never roll back a booking.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Callable, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.database import SessionLocal
+from app.plugins.installed.steam_gaming import ledger
+from app.plugins.installed.steam_gaming.detector import detect_running_app_id
+from app.plugins.installed.steam_gaming.names import resolve_name
+from app.services.notifications.plugin_events import emit_plugin_event
+
+logger = logging.getLogger(__name__)
+
+_PLUGIN = "steam_gaming"
+_CLEANUP_INTERVAL_SECONDS = 24 * 60 * 60.0
+
+
+def _utc_now() -> datetime:
+    """Indirection so tests can control the clock."""
+    return datetime.now(timezone.utc)
+
+
+class SteamSessionPoller:
+    """Books what the detector sees and announces the edges worth announcing."""
+
+    def __init__(
+        self,
+        detect: Callable[[], Optional[str]] = detect_running_app_id,
+        resolve: Callable[[str], Optional[str]] = resolve_name,
+        emit=emit_plugin_event,
+        session_factory: Callable[[], Session] = SessionLocal,
+        clock: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self._detect = detect
+        self._resolve = resolve
+        self._emit = emit
+        self._session_factory = session_factory
+        self._clock = clock
+        self._last_cleanup: Optional[datetime] = None
+
+    async def tick(self) -> None:
+        """One poll: detect, book, then deliver whatever the ledger returned."""
+        # Blocking /proc + manifest + DB work stays off the event loop.
+        app_id = await asyncio.to_thread(self._detect)
+        now = self._clock()
+        events = await asyncio.to_thread(self._book, app_id, now)
+
+        for event in events:
+            await self._emit(
+                _PLUGIN, event.event_id, entity_id=event.app_id, game=event.game
+            )
+
+    def _book(self, app_id: Optional[str], now: datetime) -> List[ledger.LedgerEvent]:
+        """Blocking: owns the database session for this tick."""
+        db = self._session_factory()
+        try:
+            events = ledger.record(db, app_id, now=now, resolve_name=self._resolve)
+            if self._due_for_cleanup(now):
+                ledger.cleanup_old_sessions(db, now=now)
+                self._last_cleanup = now
+            return events
+        finally:
+            db.close()
+
+    def _due_for_cleanup(self, now: datetime) -> bool:
+        """Once a day. The marker lives in the process - a restart costs at most
+        one extra DELETE that finds nothing."""
+        if self._last_cleanup is None:
+            return True
+        return (now - self._last_cleanup).total_seconds() >= _CLEANUP_INTERVAL_SECONDS
+```
+
+**Kein try/except um `self._detect()`:** Die Spec verlangt „Detector wirft → Tick loggt und endet". Das erledigt bereits der Core-Runner — `PluginManager._run_periodic_task()` (`app/plugins/manager.py:648-668`) fängt jede Exception pro Tick, loggt sie mit `logger.exception` und läuft weiter. Ein zweites `try` im Poller wäre toter Code, der nur die Herkunft des Fehlers verschleiert.
+
+**Wichtig:** Die Tests reichen `session_factory=lambda: db_session` herein — `db.close()` würde die Fixture-Session schließen. Damit die Test-Session das überlebt, ist `_book()` so geschrieben, dass es nur `close()` aufruft; die `db_session`-Fixture nutzt `StaticPool` auf einer In-Memory-DB, deren Verbindung dadurch nicht verworfen wird. Sollte ein Test dennoch an einer geschlossenen Session scheitern, ist die Ursache dort und nicht im Produktionscode.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_poller.py -v --no-cov`
+Expected: PASS (8 passed)
+
+- [ ] **Step 5: Run the whole steam suite**
+
+Run: `python -m pytest tests/plugins/ -k steam -v --no-cov`
+Expected: PASS — alle Dateien `test_steam_gaming_*` grün (Detector, Names, Launcher, Plugin, Poller, Ledger)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/plugins/installed/steam_gaming/poller.py tests/plugins/test_steam_gaming_poller.py
+git commit -m "refactor(steam-gaming): poller drops its in-memory state for the ledger" -m "No _last_app_id, no _initialized flag: the open DB session is the state, so a restart mid-session is silent instead of a false alarm." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `admin_only` für Panels — Route **und** WebSocket-Bridge
+
+**Files:**
+- Modify: `app/plugins/base.py` (`DashboardPanelSpec`)
+- Modify: `app/api/routes/dashboard.py`
+- Modify: `app/services/websocket_manager.py` (`broadcast_typed`)
+- Modify: `app/services/dashboard_panel_bridge.py`
+- Test: `tests/plugins/test_dashboard_panel.py`
+
+**Interfaces:**
+- Produces:
+  - `DashboardPanelSpec.admin_only: bool = False`
+  - `WebSocketManager.broadcast_typed(msg_type: str, payload: dict, admins_only: bool = False) -> int`
+  - `_build_panel_update()` liefert zusätzlich den Schlüssel `"admin_only": bool`
+
+**Warum beides:** Das Gate nur in der Route wäre wirkungslos — `dashboard_panel_ws_bridge()` schiebt dieselben Daten per `broadcast_typed()` an **alle** verbundenen Clients.
+
+- [ ] **Step 1: Write the failing test**
+
+An `tests/plugins/test_dashboard_panel.py` anhängen:
+
+```python
+class TestAdminOnlyPanels:
+    def test_spec_defaults_to_public(self):
+        spec = DashboardPanelSpec(panel_type="status", title="Any")
+        assert spec.admin_only is False
+
+    def test_spec_can_be_admin_only(self):
+        spec = DashboardPanelSpec(panel_type="status", title="Any", admin_only=True)
+        assert spec.admin_only is True
+
+    @pytest.mark.asyncio
+    async def test_route_hides_an_admin_only_panel_from_a_normal_user(self):
+        mock_record = MagicMock()
+        mock_record.name = "steam_gaming"
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_record
+
+        mock_plugin = MagicMock()
+        mock_plugin.get_dashboard_panel.return_value = DashboardPanelSpec(
+            panel_type="status", title="Steam Gaming", admin_only=True,
+        )
+        mock_plugin.get_dashboard_data = AsyncMock(return_value={"items": []})
+        mock_pm = MagicMock()
+        mock_pm.get_plugin.return_value = mock_plugin
+
+        with patch("app.api.routes.dashboard.user_limiter.enabled", False), patch(
+            "app.api.routes.dashboard.PluginManager.get_instance", return_value=mock_pm
+        ):
+            result = await get_plugin_panel(
+                request=MagicMock(),
+                response=MagicMock(),
+                db=mock_db,
+                current_user=MagicMock(role="user"),
+            )
+
+        assert result is None
+        mock_plugin.get_dashboard_data.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_route_serves_an_admin_only_panel_to_an_admin(self):
+        mock_record = MagicMock()
+        mock_record.name = "steam_gaming"
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_record
+
+        mock_plugin = MagicMock()
+        mock_plugin.get_dashboard_panel.return_value = DashboardPanelSpec(
+            panel_type="status", title="Steam Gaming", admin_only=True,
+        )
+        mock_plugin.get_dashboard_data = AsyncMock(return_value={"items": []})
+        mock_plugin.get_translations.return_value = None
+        mock_pm = MagicMock()
+        mock_pm.get_plugin.return_value = mock_plugin
+
+        with patch("app.api.routes.dashboard.user_limiter.enabled", False), patch(
+            "app.api.routes.dashboard.PluginManager.get_instance", return_value=mock_pm
+        ):
+            result = await get_plugin_panel(
+                request=MagicMock(),
+                response=MagicMock(),
+                db=mock_db,
+                current_user=MagicMock(role="admin"),
+            )
+
+        assert result is not None
+        assert result.plugin_name == "steam_gaming"
+
+
+class TestAdminOnlyBroadcast:
+    @pytest.mark.asyncio
+    async def test_broadcast_typed_can_skip_non_admins(self):
+        manager = WebSocketManager()
+        admin_ws, user_ws = AsyncMock(), AsyncMock()
+        await manager.connect(admin_ws, user_id=1, is_admin=True)
+        await manager.connect(user_ws, user_id=2, is_admin=False)
+
+        count = await manager.broadcast_typed(
+            "dashboard_panel_update", {"data": {}}, admins_only=True
+        )
+
+        assert count == 1
+        admin_ws.send_json.assert_called_once()
+        user_ws.send_json.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bridge_payload_carries_the_admin_only_flag(self):
+        mock_record = MagicMock()
+        mock_record.name = "steam_gaming"
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_record
+
+        mock_plugin = MagicMock()
+        mock_plugin.get_dashboard_panel.return_value = DashboardPanelSpec(
+            panel_type="status", title="Steam Gaming", admin_only=True,
+        )
+        mock_plugin.get_dashboard_data = AsyncMock(return_value={"items": []})
+        mock_pm = MagicMock()
+        mock_pm.get_plugin.return_value = mock_plugin
+
+        with patch(
+            "app.services.dashboard_panel_bridge.PluginManager.get_instance",
+            return_value=mock_pm,
+        ):
+            payload = await _build_panel_update(mock_db)
+
+        assert payload is not None
+        assert payload["admin_only"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/plugins/test_dashboard_panel.py -k "AdminOnly" -v --no-cov`
+Expected: FAIL — `ValidationError`/`AttributeError` für `admin_only` bzw. `TypeError: broadcast_typed() got an unexpected keyword argument 'admins_only'`
+
+- [ ] **Step 3: Add the spec field**
+
+In `app/plugins/base.py`, in `DashboardPanelSpec` nach dem `accent`-Feld ergänzen:
+
+```python
+    admin_only: bool = Field(
+        default=False,
+        description="Only serve this panel to privileged users",
+    )
+```
+
+Und den Klassendocstring erweitern:
+
+```python
+class DashboardPanelSpec(BaseModel):
+    """Specification for a plugin's Dashboard panel.
+
+    ``admin_only`` is enforced by the core - in the REST route and in the
+    WebSocket bridge - not by the plugin, so no plugin can get its own gate
+    wrong. Same pattern as PluginNavItem.admin_only. (PluginMenuItem
+    deliberately has no such field: an action executes something, a panel
+    displays something.)
+    """
+```
+
+- [ ] **Step 4: Gate the route**
+
+In `app/api/routes/dashboard.py` den Import ergänzen:
+
+```python
+from app.services.permissions import is_privileged
+```
+
+und direkt nach dem bestehenden Block
+
+```python
+    spec = plugin.get_dashboard_panel()
+    if spec is None:
+        return None
+```
+
+einfügen:
+
+```python
+    if spec.admin_only and not is_privileged(current_user):
+        # The game name in the Steam panel is information about the box owner -
+        # same privacy call as the status pill. Enforced here so no plugin has
+        # to implement its own gate.
+        return None
+```
+
+- [ ] **Step 5: Add the admin-scoped broadcast**
+
+In `app/services/websocket_manager.py` die Signatur von `broadcast_typed` ändern:
+
+```python
+    async def broadcast_typed(
+        self, msg_type: str, payload: dict[str, Any], admins_only: bool = False
+    ) -> int:
+        """Broadcast a typed message to connected users.
+
+        Unlike broadcast_to_all() which wraps in {"type": "notification"},
+        this method sends {"type": msg_type, "payload": payload} directly.
+
+        Args:
+            msg_type: Message type string (e.g. "dashboard_panel_update").
+            payload: Message payload dict.
+            admins_only: Skip non-admin connections. Needed for payloads that a
+                REST route would gate behind is_privileged() - without it the
+                gate would be decorative.
+
+        Returns:
+            Number of connections the message was sent to.
+        """
+```
+
+und in der inneren Schleife als erste Zeile einfügen:
+
+```python
+                for conn in connections:
+                    if admins_only and not conn.is_admin:
+                        continue
+```
+
+- [ ] **Step 6: Use it in the bridge**
+
+In `app/services/dashboard_panel_bridge.py` das Rückgabe-Dict von `_build_panel_update()` erweitern:
+
+```python
+    return {
+        "panel_type": spec.panel_type,
+        "plugin_name": record.name,
+        "admin_only": spec.admin_only,
+        "data": data,
+    }
+```
+
+und den Broadcast-Aufruf ersetzen:
+
+```python
+            ws = get_websocket_manager()
+            if ws:
+                # An admin_only panel must not reach every socket - the REST
+                # gate would be decorative otherwise.
+                await ws.broadcast_typed(
+                    "dashboard_panel_update",
+                    payload,
+                    admins_only=bool(payload.get("admin_only")),
+                )
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `python -m pytest tests/plugins/test_dashboard_panel.py -v --no-cov`
+Expected: PASS — die neuen Klassen **und** alle bestehenden Tests der Datei
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/plugins/base.py app/api/routes/dashboard.py app/services/websocket_manager.py app/services/dashboard_panel_bridge.py tests/plugins/test_dashboard_panel.py
+git commit -m "feat(plugins): admin_only dashboard panels, enforced by the core" -m "Gate lives in the REST route AND in the WS bridge: broadcast_typed() pushed panel data to every socket, so a route-only gate would have leaked the payload it was meant to protect." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Steam-Panel + gemeinsame Erkennungsquelle
+
+**Files:**
+- Create: `app/plugins/installed/steam_gaming/detection.py`
+- Modify: `app/plugins/installed/steam_gaming/__init__.py`
+- Modify: `app/plugins/installed/steam_gaming/poller.py` (Defaults auf `detection` umstellen)
+- Test: `tests/plugins/test_steam_gaming_panel.py` (neu)
+
+**Interfaces:**
+- Consumes: `ledger.duration_seconds()`, `ledger.as_utc()` (Task 4), `SteamSession` (Task 1), `DashboardPanelSpec.admin_only` (Task 7)
+- Produces:
+  - `detection.current_app_id() -> Optional[str]`, `detection.resolve_game_name(app_id: str) -> Optional[str]`, `detection.DEV_APP_ID = "0"`
+  - `SteamGamingPlugin.get_dashboard_panel()`, `SteamGamingPlugin.get_dashboard_data(db)`
+
+- [ ] **Step 1: Write the failing test**
+
+Neue Datei `tests/plugins/test_steam_gaming_panel.py`:
+
+```python
+"""Steam gaming dashboard panel: spec, formatting, empty state (TP 4/4)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.models.steam_session import SteamSession
+from app.plugins.installed.steam_gaming import SteamGamingPlugin
+
+T0 = datetime(2026, 7, 24, 20, 0, 0, tzinfo=timezone.utc)
+
+
+class TestPanelSpec:
+    def test_panel_is_an_admin_only_status_panel(self):
+        spec = SteamGamingPlugin().get_dashboard_panel()
+
+        assert spec is not None
+        assert spec.panel_type == "status"
+        assert spec.title == "Steam Gaming"
+        assert spec.icon == "gamepad-2"
+        assert spec.admin_only is True
+
+
+class TestPanelData:
+    async def test_no_sessions_means_no_panel(self, db_session):
+        assert await SteamGamingPlugin().get_dashboard_data(db_session) is None
+
+    async def test_running_session_shows_bare_duration_and_ok_tone(self, db_session):
+        db_session.add(SteamSession(app_id="111", game_name="Metro", started_at=T0, last_seen_at=T0))
+        db_session.commit()
+
+        data = await SteamGamingPlugin().get_dashboard_data(db_session)
+
+        item = data["items"][0]
+        assert item["label"] == "Metro"
+        assert item["tone"] == "ok"
+        assert item["value"].endswith("m")
+        assert "·" not in item["value"]
+
+    async def test_finished_session_shows_date_and_duration(self, db_session):
+        db_session.add(SteamSession(
+            app_id="222",
+            game_name="Cyberpunk",
+            started_at=T0,
+            last_seen_at=T0 + timedelta(hours=3, minutes=4),
+            ended_at=T0 + timedelta(hours=3, minutes=4),
+        ))
+        db_session.commit()
+
+        data = await SteamGamingPlugin().get_dashboard_data(db_session)
+
+        item = data["items"][0]
+        assert item["tone"] == "neutral"
+        assert item["value"] == "24.07. · 3h 04m"
+
+    async def test_unresolved_name_falls_back_to_the_app_id(self, db_session):
+        db_session.add(SteamSession(
+            app_id="999", game_name=None, started_at=T0, last_seen_at=T0, ended_at=T0,
+        ))
+        db_session.commit()
+
+        data = await SteamGamingPlugin().get_dashboard_data(db_session)
+
+        assert data["items"][0]["label"] == "AppID 999"
+
+    async def test_at_most_five_rows_newest_first(self, db_session):
+        for index in range(7):
+            start = T0 + timedelta(hours=index)
+            db_session.add(SteamSession(
+                app_id=str(index), game_name=f"Game {index}",
+                started_at=start, last_seen_at=start, ended_at=start,
+            ))
+        db_session.commit()
+
+        data = await SteamGamingPlugin().get_dashboard_data(db_session)
+
+        labels = [item["label"] for item in data["items"]]
+        assert labels == ["Game 6", "Game 5", "Game 4", "Game 3", "Game 2"]
+
+    async def test_sub_hour_duration_has_no_hour_part(self, db_session):
+        db_session.add(SteamSession(
+            app_id="111", game_name="Metro", started_at=T0,
+            last_seen_at=T0 + timedelta(minutes=12), ended_at=T0 + timedelta(minutes=12),
+        ))
+        db_session.commit()
+
+        data = await SteamGamingPlugin().get_dashboard_data(db_session)
+
+        assert data["items"][0]["value"] == "24.07. · 12m"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_panel.py -v --no-cov`
+Expected: FAIL — `assert None is not None` (das Plugin hat noch kein Panel)
+
+- [ ] **Step 3: Create the shared detection module**
+
+Neue Datei `app/plugins/installed/steam_gaming/detection.py`:
+
+```python
+"""One source of truth for "is a game running" - pill, ledger and panel share it.
+
+The dev-mode stand-in lives HERE and not in detector.py/names.py on purpose:
+the test suite runs with NAS_MODE=dev (tests/conftest.py), so a dev branch
+inside the pure /proc scan would make the detector tests assert the mock
+instead of the real behaviour.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from app.core.config import settings
+from app.plugins.installed.steam_gaming.detector import detect_running_app_id
+from app.plugins.installed.steam_gaming.names import resolve_name
+
+# There is no /proc on a Windows dev box, so nothing would ever be detected and
+# neither the pill nor the panel would have anything to show locally.
+DEV_APP_ID = "0"
+DEV_GAME_NAME = "Dev Mode Game"
+
+
+def current_app_id() -> Optional[str]:
+    """AppID of the running game, or None. Blocking - call via asyncio.to_thread."""
+    app_id = detect_running_app_id()
+    if app_id is None and settings.is_dev_mode:
+        return DEV_APP_ID
+    return app_id
+
+
+def resolve_game_name(app_id: str) -> Optional[str]:
+    """Display name for *app_id*, or None. Blocking - call via asyncio.to_thread."""
+    if settings.is_dev_mode and app_id == DEV_APP_ID:
+        return DEV_GAME_NAME
+    return resolve_name(app_id)
+```
+
+- [ ] **Step 4: Point the poller at it**
+
+In `app/plugins/installed/steam_gaming/poller.py` die beiden Importe
+
+```python
+from app.plugins.installed.steam_gaming.detector import detect_running_app_id
+from app.plugins.installed.steam_gaming.names import resolve_name
+```
+
+ersetzen durch
+
+```python
+from app.plugins.installed.steam_gaming.detection import current_app_id, resolve_game_name
+```
+
+und die Defaults in `__init__` anpassen:
+
+```python
+        detect: Callable[[], Optional[str]] = current_app_id,
+        resolve: Callable[[str], Optional[str]] = resolve_game_name,
+```
+
+- [ ] **Step 5: Rewrite the plugin's detection helper and add the panel**
+
+In `app/plugins/installed/steam_gaming/__init__.py`:
+
+(a) Importblock — `detector`/`names`-Importe ersetzen und die neuen ergänzen:
+
+```python
+from datetime import datetime, timezone
+
+from app.plugins.base import (
+    BackgroundTaskSpec,
+    DashboardPanelSpec,
+    MenuActionResult,
+    PluginBase,
+    PluginEventSpec,
+    PluginMenuItem,
+    PluginMetadata,
+    PluginUIManifest,
+    StatusPillSpec,
+)
+from app.models.steam_session import SteamSession
+from app.plugins.dashboard_panel import StatusItem, StatusPanelData
+from app.plugins.installed.steam_gaming import ledger
+from app.plugins.installed.steam_gaming.detection import current_app_id, resolve_game_name
+from app.plugins.installed.steam_gaming.launcher import open_big_picture
+from app.plugins.installed.steam_gaming.poller import SteamSessionPoller
+from app.services.power.desktop import get_desktop_service
+```
+
+(b) `_current_game()` ersetzen durch:
+
+```python
+def _current_game() -> Optional[tuple[str, Optional[str]]]:
+    """``(app_id, name)`` of the running game, or None. Cached for a few seconds."""
+    now = _monotonic()
+    checked_at = _CACHE.get("checked_at")
+    if isinstance(checked_at, float) and now - checked_at < _CACHE_TTL_SECONDS:
+        return _CACHE.get("game")  # type: ignore[return-value]
+
+    app_id = current_app_id()
+    game = (app_id, resolve_game_name(app_id)) if app_id else None
+    _CACHE["checked_at"] = now
+    _CACHE["game"] = game
+    return game
+```
+
+(c) In `collect_status_pill()` den Dev-Zweig entfernen — aus
+
+```python
+        game = await asyncio.to_thread(_current_game)
+        if game is None:
+            if settings.is_dev_mode:
+                # No /proc on a Windows dev box — render something anyway.
+                game = ("0", "Dev Mode Game")
+            else:
+                return None
+```
+
+wird
+
+```python
+        # The dev-mode stand-in now lives in detection.py, so pill, ledger and
+        # panel agree on what is running.
+        game = await asyncio.to_thread(_current_game)
+        if game is None:
+            return None
+```
+
+**Und die Zeile `from app.core.config import settings` aus dem Importblock entfernen** — nach dem Wegfall des Dev-Zweigs ist `settings` in dieser Datei unbenutzt und der `eslint`-Äquivalent auf Python-Seite (ruff F401) würde anschlagen.
+
+Prüfen: `python -c "import re; src=open('app/plugins/installed/steam_gaming/__init__.py',encoding='utf-8').read(); print(src.count('settings'))"` → Expected: `0`
+
+(d) Panel-Konstanten neben die vorhandenen setzen:
+
+```python
+_PANEL_ROWS = 5
+```
+
+(e) Formatierung und Panel-Methoden ergänzen (Modul-Ebene für die Helfer, Methoden in der Klasse nach `run_menu_action`):
+
+```python
+def _format_duration(seconds: float) -> str:
+    """``3h 04m`` / ``12m`` - digits only, so no string needs translating."""
+    total = int(seconds)
+    hours, remainder = divmod(total, 3600)
+    minutes = remainder // 60
+    if hours:
+        return f"{hours}h {minutes:02d}m"
+    return f"{minutes}m"
+
+
+def _panel_value(row: SteamSession, now: datetime) -> str:
+    """Running sessions show the bare duration; finished ones prepend the date."""
+    duration = _format_duration(ledger.duration_seconds(row, now))
+    if row.ended_at is None:
+        return duration
+    return f"{ledger.as_utc(row.started_at):%d.%m.} · {duration}"
+```
+
+```python
+    def get_dashboard_panel(self) -> Optional[DashboardPanelSpec]:
+        return DashboardPanelSpec(
+            panel_type="status",
+            title="Steam Gaming",
+            icon="gamepad-2",
+            accent="from-indigo-500 to-purple-500",
+            # The game name is information about the box owner - same call as
+            # the pill's default visibility in Teilprojekt 1.
+            admin_only=True,
+        )
+
+    async def get_dashboard_data(self, db: Session) -> Optional[dict]:
+        """The five newest sessions; the running one sorts to the top.
+
+        Returns None when nothing was ever recorded - a placeholder line would
+        be a translatable string, and StatusItem has no key fields.
+        """
+        rows = (
+            db.query(SteamSession)
+            .order_by(SteamSession.started_at.desc())
+            .limit(_PANEL_ROWS)
+            .all()
+        )
+        if not rows:
+            return None
+
+        now = datetime.now(timezone.utc)
+        items = [
+            StatusItem(
+                label=row.game_name or f"AppID {row.app_id}",
+                value=_panel_value(row, now),
+                tone="ok" if row.ended_at is None else "neutral",
+            )
+            for row in rows
+        ]
+        return StatusPanelData(items=items).model_dump()
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_panel.py -v --no-cov`
+Expected: PASS (7 passed)
+
+- [ ] **Step 7: Verify nothing else in the plugin broke**
+
+Run: `python -m pytest tests/plugins/ -k steam -v --no-cov`
+Expected: PASS — insbesondere `test_steam_gaming_plugin.py` (Pill-Collector, jetzt ohne eigenen Dev-Zweig)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/plugins/installed/steam_gaming/ tests/plugins/test_steam_gaming_panel.py
+git commit -m "feat(steam-gaming): admin-only dashboard panel with the last five sessions" -m "detection.py becomes the single source pill, ledger and panel share, including the dev-mode stand-in that used to live in the pill collector only." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Doku, Gesamtsuite, Handprobe
+
+**Files:**
+- Modify: `app/plugins/CLAUDE.md`
+- Modify: `app/models/CLAUDE.md`
+
+- [ ] **Step 1: Document the panel extension point**
+
+In `app/plugins/CLAUDE.md`, im Abschnitt „Creating a Plugin", Punkt 5 (`get_dashboard_panel()`) um diesen Absatz ergänzen:
+
+```markdown
+   `DashboardPanelSpec.admin_only=True` beschränkt ein Panel auf privilegierte
+   Nutzer. Durchgesetzt wird das **im Core** an zwei Stellen, nicht im Plugin:
+   in `api/routes/dashboard.py` (`is_privileged`) und in
+   `services/dashboard_panel_bridge.py`, das seinen WebSocket-Broadcast dann
+   mit `broadcast_typed(..., admins_only=True)` fährt. Beides ist nötig — der
+   Bridge schiebt dieselben Daten unabhängig von der Route an verbundene
+   Clients. Panel-Icons werden im Frontend dynamisch aus lucide aufgelöst
+   (kebab-case → PascalCase, Fallback `Plug`), ein neues Icon braucht also
+   keine Core-Änderung.
+```
+
+- [ ] **Step 2: Fix the documented drift**
+
+In `app/plugins/CLAUDE.md` die Passage, die behauptet, der Dashboard-Panel-Endpunkt sei **nicht** an `reconciled_plugin_state` gehängt, korrigieren. Aus
+
+```markdown
+   The Dashboard plugin panel (`GET /api/dashboard/plugin-panel`) is **not** one
+   of them — it reads `PluginManager.get_plugin()` directly with no DB fallback,
+   so it only catches up once some other reconciled route has run on the same
+   worker.
+```
+
+wird
+
+```markdown
+   The Dashboard plugin panel (`GET /api/dashboard/plugin-panel`) is one of them
+   as well (`api/routes/dashboard.py`), so it catches up on the same request
+   like the other five.
+```
+
+**Vorher verifizieren** (die Doku könnte inzwischen wieder stimmen):
+Run: `python -c "import re; src=open('app/api/routes/dashboard.py',encoding='utf-8').read(); print('reconciled_plugin_state' in src)"`
+Expected: `True` — nur dann diesen Schritt ausführen.
+
+- [ ] **Step 3: Register the model in the models doc**
+
+In `app/models/CLAUDE.md`, Zeile der Gruppe **Plugins & Integrations**, `steam_session.py` ergänzen:
+
+```markdown
+**Plugins & Integrations**: `plugin.py`, `plugin_storage.py`, `steam_session.py`, `pihole.py`, `dns_queries.py`, `ad_discovery.py`, `cloud.py`, `cloud_export.py`, `benchmark.py`, `energy_price_config.py`
+```
+
+- [ ] **Step 4: Run the full plugin and notification suites**
+
+Run: `python -m pytest tests/plugins/ -v --no-cov`
+Expected: PASS — keine Regression in Manager, Sandbox, Tapo, Smart-Device
+
+Run: `python -m pytest tests/ -k "notification or dashboard or websocket" -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 5: Verify the migration once more against a fresh database**
+
+Run: `python -c "import os; os.remove('baluhost.db') if os.path.exists('baluhost.db') else None"`
+
+**Achtung:** Das löscht die lokale Dev-DB. Wer sie behalten will, vorher kopieren:
+`python -c "import shutil,os; shutil.copy('baluhost.db','baluhost.db.bak') if os.path.exists('baluhost.db') else None"`
+
+Run: `python -m alembic upgrade head`
+Expected: läuft von der ersten Revision bis zur neuen durch, ohne Fehler
+
+Run: `python -c "import sqlite3; print([r[0] for r in sqlite3.connect('baluhost.db').execute(\"select name from sqlite_master where type='table' and name='steam_sessions'\")])"`
+Expected: `['steam_sessions']`
+
+- [ ] **Step 6: PostgreSQL check (Handarbeit, nicht überspringen)**
+
+CI hat keinen Alembic-Smoke-Test (#450). Gegen eine PostgreSQL-Instanz — lokal oder auf der Box vor dem Merge:
+
+Run: `DATABASE_URL=postgresql://…/baluhost_test python -m alembic upgrade head`
+Expected: `Running upgrade 71fe791d28d6 -> <rev>, add steam_sessions table`
+
+Run: `DATABASE_URL=postgresql://…/baluhost_test python -m alembic downgrade -1`
+Expected: sauberes `Running downgrade …`, danach existiert `steam_sessions` nicht mehr
+
+Ist keine PostgreSQL-Instanz verfügbar: **im PR ausdrücklich vermerken, dass dieser Schritt offen ist** — nicht stillschweigend überspringen.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/plugins/CLAUDE.md app/models/CLAUDE.md
+git commit -m "docs(plugins): document admin_only panels and fix the reconcile drift" -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Abnahme
+
+Nach Task 9 ist erfüllt:
+
+| Spec-Anforderung | Task |
+|---|---|
+| Tabelle `steam_sessions` + Migration auf dem echten Head | 1 |
+| Flankentabelle (5 Zeilen), Spielwechsel meldet Ende + Start (#462) | 2 |
+| Lückenregel 1 — `ended_at = now` vs. `last_seen_at` | 3 |
+| Lückenregel 2 — nach einer Lücke nur buchen, nie melden | 3 |
+| Lückenregel 3 — Adopt-Fenster 10 min, darüber splitten | 3 |
+| Mehrere offene Sessions aufräumen | 4 |
+| `game_name` nachtragen | 4 |
+| Dauer abgeleitet, bei Uhr-Rücksprung auf 0 geklemmt | 4 |
+| Retention 365 Tage, offene Session unangetastet | 5 |
+| Poller ohne Eigenzustand, erst buchen+committen, dann melden | 6 |
+| Retention einmal je 24 h | 6 |
+| `DashboardPanelSpec.admin_only`, Core setzt durch | 7 |
+| WS-Bridge leakt admin-only-Panels nicht | 7 (über die Spec hinaus) |
+| Panel: `status`, 5 Zeilen, `tone=ok` für laufend, `TT.MM. · Dauer` | 8 |
+| Leerer Zustand → kein Panel | 8 |
+| Dev-Mock als gemeinsame Quelle | 8 |
+| Doku + Doku-Drift | 9 |
+
+**Bewusst nicht im Plan** (Nicht-Ziele der Spec): Big-Picture-Erkennung, Auto-Displays-aus, eigene Steam-Seite, per-Nutzer-Kategorie-Preference, Aggregate über Spielzeit.

--- a/docs/superpowers/plans/2026-07-24-steam-session-history-dashboard-panel.md
+++ b/docs/superpowers/plans/2026-07-24-steam-session-history-dashboard-panel.md
@@ -1883,13 +1883,36 @@ Expected: PASS
 
 - [ ] **Step 5: Verify the migration once more against a fresh database**
 
-Die Dev-DB bleibt unangetastet: `alembic/env.py:25` setzt `sqlalchemy.url` aus `DATABASE_URL` (über `settings.database_url`), also läuft die volle Kette gegen eine Scratch-Datei. **Bash-Tool verwenden** — PowerShell kennt das `VAR=x cmd`-Präfix nicht.
+**Befund aus Task 1 (verifiziert 2026-07-24, pre-existing):** Die volle Alembic-Kette repliziert **nicht** aus einer leeren Datenbank — sie bricht an uralten Revisionen ab (`sqlite3.OperationalError: no such table: users` beim `ALTER TABLE users ADD COLUMN is_active`), weit vor `71fe791d28d6`. Dev-Installationen bootstrappen über `Base.metadata.create_all()`, Produktion ist historisch gewachsen; ein Voll-Replay lief offenbar nie. **Das ist nicht Aufgabe dieses Branches** — der Schritt prüft deshalb die neue Migration isoliert, nicht die Kette.
+
+Die Dev-DB bleibt unangetastet: `alembic/env.py:25` setzt `sqlalchemy.url` aus `DATABASE_URL`, also läuft alles gegen eine Scratch-Datei. **Bash-Tool verwenden** — PowerShell kennt das `VAR=x cmd`-Präfix nicht.
+
+Run:
+```bash
+DATABASE_URL="sqlite:///./migration_check.db" python -c "
+from sqlalchemy import create_engine
+from alembic.config import Config
+from alembic import command
+from app.models.base import Base
+import app.models  # noqa: F401  - registers every model
+
+engine = create_engine('sqlite:///./migration_check.db')
+Base.metadata.drop_all(bind=engine)
+Base.metadata.create_all(bind=engine)
+Base.metadata.tables['steam_sessions'].drop(bind=engine)   # only our table is missing
+command.stamp(Config('alembic.ini'), '71fe791d28d6')
+"
+```
+Expected: läuft ohne Traceback durch (erzeugt das Schema wie vor dieser Migration)
 
 Run: `DATABASE_URL="sqlite:///./migration_check.db" python -m alembic upgrade head`
-Expected: läuft von der ersten Revision bis zur neuen durch, ohne Fehler
+Expected: `Running upgrade 71fe791d28d6 -> <rev>, add steam_sessions table`
 
 Run: `python -c "import sqlite3; print([r[0] for r in sqlite3.connect('migration_check.db').execute(\"select name from sqlite_master where type='table' and name='steam_sessions'\")])"`
 Expected: `['steam_sessions']`
+
+Run: `DATABASE_URL="sqlite:///./migration_check.db" python -m alembic downgrade -1`
+Expected: `Running downgrade <rev> -> 71fe791d28d6`, danach ist die Tabelle weg
 
 Run: `python -c "import os; os.remove('migration_check.db')"`
 Expected: kein Output (Scratch-Datei aufgeräumt; sie darf nicht committet werden)

--- a/docs/superpowers/specs/2026-07-24-steam-session-history-dashboard-panel-design.md
+++ b/docs/superpowers/specs/2026-07-24-steam-session-history-dashboard-panel-design.md
@@ -193,10 +193,40 @@ Darüber liegen drei Lückenregeln. `_STALE_AFTER_SECONDS = 60` (zwei Ticks),
    eröffnet. Über Nacht aus und morgens dasselbe Spiel wieder gestartet ist
    nicht eine 14-Stunden-Session.
 
-Beim Start räumt der Schreiber zusätzlich auf: **mehrere offene Sessions**
-(nach der Invariante unmöglich, aber ein Crash zur Unzeit kann sie erzeugen)
-werden bis auf die neueste stillschweigend bei ihrem `last_seen_at`
-geschlossen.
+Die Regeln erledigen den **Suspend** nebenbei richtig: die Box hat Sleep-Modi,
+beim Aufwachen ist die Lücke = Schlafdauer → Regel 1 schließt bei
+`last_seen_at`, Regel 2 hält still — **Schlafzeit zählt nicht als Spielzeit.**
+Das begründet auch die 60 s: die einzige Fehlklassifikation wäre ein komplett
+verpasster Tick bei gesundem Prozess, und deren Preis ist nur eine
+unterdrückte Push-Meldung, nie eine falsche Buchung.
+
+Findet ein Tick **mehrere offene Sessions** vor (nach der Invariante unmöglich,
+aber ein Crash zur Unzeit kann sie erzeugen), schließt er alle bis auf die
+neueste stillschweigend bei ihrem `last_seen_at`. „Beim Start" gibt es hier
+nicht — der Poller hat keinen Initialisierungszustand mehr, genau das ist der
+Punkt des Designs.
+
+**Namens-Nachauflösung:** ist `game_name` beim INSERT `None` (ein Spiel wird
+während der laufenden Installation gestartet, das `appmanifest` existiert noch
+nicht), versucht der Heartbeat die Auflösung erneut — `resolve_name()` retried
+Misses nach 60 s ohnehin von selbst (`names.py`, `_MISS_TTL_SECONDS`), der
+Ledger muss das Ergebnis nur nachtragen.
+
+**Zwei akzeptierte Abweichungen**, bewusst nicht wegregelt:
+
+- **Erster Tick nach dem allerersten TP4-Deploy, während gerade gespielt
+  wird:** die Tabelle ist leer, es gibt kein `last_seen_at`, an dem eine Lücke
+  messbar wäre → das laufende Spiel wird als frischer Start gebucht **und
+  gemeldet**, mit `started_at = now`. Einmalige Falschmeldung. Die
+  Gegenmaßnahme („der erste Tick eines Prozesses meldet nie") hätte einen
+  dauerhaften Preis — ein Spiel, das während eines Deploy-Fensters gestartet
+  wird, würde für immer stumm verbucht. Einmal falsch schlägt dauerhaft stumm.
+- **Der TP3-Cooldown kann Meldungen schlucken, die die Historie bucht:**
+  Spiel starten, nach 20 s beenden, sofort neu starten — der zweite
+  `session_started` fällt ins 60-s-Cooldown-Fenster (gleicher `entity_id`)
+  und wird verschluckt; der Ledger bucht beide Sessions. Der Cooldown ist
+  Spam-Schutz für die Zustellung; **die Historie ist die Quelle der
+  Wahrheit**, nicht der Notification-Verlauf.
 
 **Reihenfolge, verbindlich: erst buchen und committen, dann melden.** Eine
 fehlgeschlagene Zustellung darf keine Buchung zurückrollen.
@@ -258,11 +288,13 @@ Cyberpunk 2077                  20.07. · 1h 02m   tone=neutral
 
 `label` ist der Spielname, ersatzweise `AppID <n>`. `value` ist Datum + Dauer.
 
-**Bewusst sprachneutral, keine Wörter.** `StatusItem` hat nur
-`label`/`value`/`tone`, keine Key-Felder — der Renderer löst nichts auf. Ein
-serverseitig festgetackertes „läuft · 1h 12m" wäre ein neuer Eintrag in #406.
-Stattdessen trägt `tone=ok` die Information „läuft"; Datum und Dauer sind in
-beiden Sprachen lesbar.
+**Bewusst ohne Wörter.** `StatusItem` hat nur `label`/`value`/`tone`, keine
+Key-Felder — der Renderer löst nichts auf. Ein serverseitig festgetackertes
+„läuft · 1h 12m" wäre ein neuer Eintrag in #406. Stattdessen trägt `tone=ok`
+die Information „läuft". Das Datumsformat `TT.MM.` ist die deutsche
+Konvention — konsistent mit den ohnehin deutschen, serverseitig gerenderten
+Notification-Texten aus TP3, aber keine echte Sprachneutralität; die gäbe es
+erst mit clientseitigem Rendern, das der Panel-Extension-Point nicht hergibt.
 
 **Leerer Zustand:** noch keine Session verbucht → `get_dashboard_data()` gibt
 `None`, das Panel erscheint nicht. Kein Platzhaltertext, der wieder übersetzt
@@ -272,7 +304,11 @@ werden müsste.
 Pill-Collector. Er wandert eine Ebene tiefer in die gemeinsame
 Erkennungsfunktion, sodass Pill, Ledger und Panel dieselbe Quelle benutzen —
 sonst schreibt der Ledger auf einer Windows-Kiste nie eine Zeile und das Panel
-ist lokal nicht testbar.
+ist lokal nicht testbar. Bewusste Folge: auf einer Dev-Kiste läuft damit eine
+**ewig offene Session**, die bei Backend-Neustarts mit mehr als
+`_ADOPT_WINDOW_SECONDS` Pause splittert — die Dev-DB sammelt also
+Mock-Sessions an. Das ist der Zweck (das Panel hat lokal etwas zu zeigen),
+kein Versehen.
 
 **Betriebshinweis:** Es kann nur *ein* Plugin-Panel gleichzeitig aktiv sein;
 `set_dashboard_panel_enabled()` schaltet beim Einschalten alle anderen ab. Läuft
@@ -311,6 +347,8 @@ aber hier zum ersten Mal spürbar.
 - nach einer Lücke wird **nichts** gemeldet;
 - dasselbe Spiel über 5 min → eine Session; über 30 min → zwei;
 - mehrere offene Sessions werden bis auf die neueste geschlossen;
+- `game_name IS NULL` wird vom Heartbeat nachgelöst, sobald `resolve_name()`
+  einen Namen liefert;
 - Retention löscht nur `ended_at < now - 365 d` und lässt die offene Session in
   Ruhe;
 - Uhr-Rücksprung ergibt Dauer 0, keine negative Zahl.

--- a/docs/superpowers/specs/2026-07-24-steam-session-history-dashboard-panel-design.md
+++ b/docs/superpowers/specs/2026-07-24-steam-session-history-dashboard-panel-design.md
@@ -1,0 +1,354 @@
+# Steam-Session-Historie + Dashboard-Panel — Design
+
+**Datum:** 2026-07-24
+**Status:** entworfen, abgenommen
+**Teilprojekt 4 von 4** — Gesamtschnitt siehe
+`docs/superpowers/specs/2026-07-22-status-bar-plugin-pills-steam-gaming-design.md`
+
+## Ziel
+
+Steam-Sessions werden **persistiert** statt nur flüchtig erkannt: wann welches
+Spiel lief und wie lange. Das Dashboard zeigt die letzten fünf Sessions als
+Plugin-Panel. Nebenher wird die Flankenlogik aus Teilprojekt 3 vollständig —
+der direkte Spielwechsel (X→Y ohne Pause), heute bewusst verschluckt, wird
+verbucht **und** gemeldet (schließt #462).
+
+Damit endet der Track: Pill (TP1), Menü-Aktion (TP2), Notifications (TP3),
+Historie + Panel (TP4).
+
+## Ausgangslage (gemessen, nicht angenommen)
+
+### Was das Plugin heute kann
+
+`backend/app/plugins/installed/steam_gaming/` (444 Zeilen):
+
+- `detector.py` — `/proc`-Scan auf `reaper SteamLaunch AppId=<n>`, dedupliziert,
+  niedrigste PID gewinnt.
+- `names.py` — AppID → Spielname über `appmanifest_<id>.acf`.
+- `launcher.py` — `steam://open/bigpicture`, detached.
+- `poller.py` — primary-only Background-Task (30 s), erkennt Flanken
+  None→X und X→None und feuert die TP3-Events.
+- `__init__.py` — Pill-Spec + Collector, Menüpunkt „Gaming-Modus", Event-Specs.
+
+**Es wird nichts gespeichert.** `SteamSessionPoller._last_app_id` lebt im
+Prozess des Primary-Workers; nach jedem Neustart beginnt die Welt neu.
+
+### Dashboard-Panel-Extension-Point
+
+Existiert bereits und braucht keine Erweiterung für die Darstellung:
+
+- `PluginBase.get_dashboard_panel()` → `DashboardPanelSpec`
+  (`panel_type` ∈ `gauge | stat | status | chart`).
+- `PluginBase.get_dashboard_data(db)` → Daten passend zum Typ
+  (`plugins/dashboard_panel.py`).
+- Route `GET /api/dashboard/plugin-panel` (`api/routes/dashboard.py`) —
+  hängt an `get_current_user`, umschließt `get_dashboard_data()` bereits mit
+  try/except und liefert bei Fehler das Panel mit `data=None`.
+- Einziger bisheriger Konsument: `tapo_smart_plug`.
+- Es kann **immer nur ein** Plugin-Panel aktiv sein
+  (`InstalledPlugin.dashboard_panel_enabled`, `plugin_service.py:143`).
+
+Der `status`-Renderer nimmt eine Liste aus `label` / `value` / `tone` —
+genau die Form, die eine Session-Liste braucht. **Kein Frontend-Diff.**
+
+### Big Picture vs. Fenster — gemessen, nicht baubar
+
+Der Gesamtschnitt sah für TP4 „Big Picture vs. Fenster" vor, mit dem Zweck, den
+Menüpunkt „Gaming-Modus" nicht blind feuern zu lassen, wenn Big Picture schon
+läuft. Auf BaluNode gemessen, mit laufendem Steam in beiden Zuständen:
+
+| Signal | Ergebnis |
+|---|---|
+| `pgrep -a steamwebhelper \| grep -i -e gamepadui -e bigpicture` | leer, auch **während** Big Picture aktiv war |
+| `ps -eo args \| grep -o -- '-uimode=[0-9]*'` | `3× -uimode=7` — **identisch** im Fenster- und im Big-Picture-Modus, auch nach 10 s Wartezeit |
+| `grep -i -e bigpicture -e gamepad -e tenfoot ~/.steam/registry.vdf` | leer in beiden Zuständen |
+
+`-uimode` beschreibt nur, wie `steamwebhelper` gestartet wurde, nicht den
+aktuellen Modus — dieselbe Sorte Sackgasse wie `RunningAppID` in TP1
+(ValveSoftware/steam-for-linux#9672). Verbleibender theoretischer Kandidat wäre
+das Mitlesen von Steams `console-linux.txt`; ein fremdes Logformat ohne
+Stabilitätszusage ist für ein Dauerfeature der falsche Anker. **Big Picture
+fällt damit aus TP4 heraus** (siehe Nicht-Ziele).
+
+Nebenbefund von der Box, außerhalb dieses Repos: `/usr/local/bin/steam-bpm-inhibit`
+erkennt Big Picture über genau diesen `gamepadui`-String — dieser Zweig kann
+nach obiger Messung nie greifen; das Sleep-Inhibit lebt allein vom zweiten
+Zweig (`SteamLaunch`, also ein laufendes Spiel).
+
+## Entscheidungen (im Brainstorming getroffen)
+
+- **Persistenz: eigene DB-Tabelle.** Multi-Worker-sicher ohne Zusatzarbeit,
+  Aggregation per SQL. Verworfen: JSON unter `.system/` (Aggregation von Hand,
+  Datei-Lesen pro Panel-Request); gar nicht persistieren (streicht „Historie").
+- **Restart-Policy: `last_seen_at`-Heartbeat.** Jeder Tick schreibt ihn fort;
+  eine Session überlebt Deploys nahtlos, eine hängengebliebene wird bei ihrem
+  letzten Lebenszeichen geschlossen. Verworfen: beim Start alles Offene mit
+  Dauer 0 schließen (verliert jede Session, die ein Deploy überlebt — Deploys
+  passieren hier oft); dangling lassen (Aggregate systematisch zu niedrig).
+- **Spielwechsel meldet Ende + Start.** Historie und Notifications benutzen
+  dieselbe Flankenlogik — eine Wahrheit statt zweier. Schließt #462.
+- **Panel ist `admin_only`.** Spielnamen sind eine Information über den
+  Box-Besitzer — dieselbe Privatsphäre-Entscheidung wie bei der Pill in TP1.
+- **Retention 365 Tage**, im Plugin, ohne Konfigurationsoberfläche.
+  Konfigurierbarkeit ist als Folgearbeit festgehalten (siehe unten).
+- **Kleinster Oberflächenschnitt:** nur das Dashboard-Panel, keine eigene
+  Steam-Seite.
+
+## Nicht-Ziele
+
+- **Big Picture vs. Fenster** — gemessen nicht erkennbar (siehe oben).
+- **Auto-Displays-aus nach Sessionende.** Aus dem TP4-Zuschnitt gestrichen.
+- **Eigene Steam-Seite.** Pill und Panel zeigen weiterhin auf `/plugins`;
+  #451 M-3 (das `href` ist desktop-build- und admin-gegated) bleibt offen.
+- **Per-Nutzer-Kategorie-Preference für Plugin-Events.** Aus TP3 vertagt, aber
+  Core-Arbeit an den Notifications und mit Steam nur indirekt verwandt —
+  bekommt eine eigene Spec.
+- **Aggregate wie „Spielzeit pro Spiel/Woche".** Die Daten erlauben es, das
+  Panel zeigt es nicht; ohne eigene Seite gibt es keinen Ort dafür.
+- **Erkennung außerhalb von Steam** (Lutris, Drittanbieter-Launcher) —
+  unverändert aus TP1.
+
+## Architektur
+
+```
+backend/app/models/steam_session.py            NEU  Tabelle steam_sessions
+backend/alembic/versions/<rev>_…               NEU  Migration
+backend/app/plugins/installed/steam_gaming/
+  ledger.py                                    NEU  Buchung + Flanken- und Lückenregeln
+  poller.py                                    ÄND  Zustand entfällt, ruft den Ledger
+  __init__.py                                  ÄND  Panel-Spec, get_dashboard_data, Dev-Mock
+backend/app/plugins/base.py                    ÄND  DashboardPanelSpec.admin_only
+backend/app/api/routes/dashboard.py            ÄND  Gate: admin_only → is_privileged
+backend/app/models/__init__.py                 ÄND  Registrierung (Alembic-Autogenerate)
+```
+
+Kein Frontend-Diff.
+
+### Datenmodell
+
+Das Model liegt in `app/models/`, nicht im Plugin — nicht weil die Tabelle zum
+Core gehört, sondern weil Alembic-Autogenerate nur sieht, was an
+`Base.metadata` hängt. Dasselbe Muster wie `smart_device.py` für Tapo.
+
+| Spalte | Typ | Zweck |
+|---|---|---|
+| `id` | int, PK | |
+| `app_id` | `String(32)`, Index | Steam-AppID |
+| `game_name` | `String(200)`, nullable | aufgelöster Name; `None`, wenn kein `appmanifest` lesbar war |
+| `started_at` | `DateTime(timezone=True)` | Flanke „Spiel erkannt" |
+| `last_seen_at` | `DateTime(timezone=True)` | Heartbeat, jeder Tick |
+| `ended_at` | `DateTime(timezone=True)`, nullable | `NULL` = laufende Session |
+
+Index auf `started_at DESC` für die Panel-Abfrage.
+
+**Die Dauer wird nicht gespeichert**, sondern aus `ended_at - started_at`
+gerechnet. Ein gespeicherter Wert wäre eine zweite Wahrheit, die beim
+Adoptieren einer Session nach einem Restart auseinanderlaufen kann.
+
+**Invariante: höchstens eine offene Session** (`ended_at IS NULL`). Nicht per
+DB-Constraint erzwungen — ein partieller Unique-Index wäre PostgreSQL-only und
+die Tests laufen auf SQLite — sondern vom Schreiber, der beim Start defensiv
+aufräumt.
+
+Die Migration muss auf den echten `alembic heads` aufsetzen, **nicht** auf den
+Head der Dev-DB (der Fehler hat schon einmal einen Prod-Deploy zerlegt,
+#123 → #124).
+
+### Ledger: die offene Session *ist* der Zustand
+
+`SteamSessionPoller._last_app_id` und das `_initialized`-Flag entfallen
+ersatzlos. Der Poller liest seinen Vorzustand aus der DB — eine Wahrheit statt
+zweier, und der Restart-Sonderfall löst sich mit auf.
+
+Pro Tick (30 s, primary-only dank #448):
+
+```
+app_id = detect_running_app_id()        # wie bisher, in asyncio.to_thread
+open   = neueste Session mit ended_at IS NULL
+luecke = now - open.last_seen_at        # wie lange war der Poller weg?
+```
+
+| offen | erkannt | Buchung | Meldung |
+|---|---|---|---|
+| — | — | nichts | — |
+| — | X | INSERT X (`started_at = now`) | `session_started(X)` |
+| X | X | `last_seen_at = now` | — |
+| X | — | X schließen | `session_ended(X)` |
+| X | Y | X schließen, INSERT Y | `session_ended(X)` + `session_started(Y)` |
+
+Darüber liegen drei Lückenregeln. `_STALE_AFTER_SECONDS = 60` (zwei Ticks),
+`_ADOPT_WINDOW_SECONDS = 600`:
+
+1. **`ended_at = now`, wenn der Poller durchgehend da war** (`luecke ≤
+   _STALE_AFTER_SECONDS`) — sonst `ended_at = last_seen_at`. War der Prozess
+   weg, ist das letzte Lebenszeichen die einzige belastbare Zahl; `now` würde
+   die Ausfallzeit als Spielzeit verbuchen.
+2. **Nach einer Lücke wird nur gebucht, nie gemeldet.** Ein Deploy soll keine
+   „Session beendet"-Push für ein Spiel auslösen, das vor zwei Stunden endete.
+   Dieselbe Entscheidung wie TP3s Baseline-Regel, nur aus der DB statt aus
+   einem Flag.
+3. **Dasselbe Spiel über eine Lücke:** bis `_ADOPT_WINDOW_SECONDS` wird die
+   Session weitergeführt (Deploy mitten im Spielen — der Normalfall auf dieser
+   Box); darüber wird die alte bei `last_seen_at` geschlossen und eine neue
+   eröffnet. Über Nacht aus und morgens dasselbe Spiel wieder gestartet ist
+   nicht eine 14-Stunden-Session.
+
+Beim Start räumt der Schreiber zusätzlich auf: **mehrere offene Sessions**
+(nach der Invariante unmöglich, aber ein Crash zur Unzeit kann sie erzeugen)
+werden bis auf die neueste stillschweigend bei ihrem `last_seen_at`
+geschlossen.
+
+**Reihenfolge, verbindlich: erst buchen und committen, dann melden.** Eine
+fehlgeschlagene Zustellung darf keine Buchung zurückrollen.
+
+### Retention
+
+Einmal je 24 h löscht derselbe Tick Sessions mit `ended_at` älter als 365 Tage;
+die offene Session ist davon nie betroffen. Bewusst **nicht** über
+`monitoring/retention_manager.py`: der hängt am `MetricType`-Enum und an
+`monitoring_config`-Zeilen — eine Plugin-Tabelle dort einzuhängen koppelt den
+Core an ein Plugin. Zehn Zeilen im Plugin statt einer Enum-Erweiterung im Core.
+
+Der Zeitpunkt der letzten Bereinigung lebt im Prozess (kein DB-Feld); ein
+Restart führt höchstens zu einem zusätzlichen `DELETE`, das nichts findet.
+
+### Panel
+
+`DashboardPanelSpec` bekommt ein Feld:
+
+```python
+admin_only: bool = False
+```
+
+Durchgesetzt wird es **im Core**, in `api/routes/dashboard.py`, direkt nach
+`plugin.get_dashboard_panel()`:
+
+```python
+if spec.admin_only and not is_privileged(current_user):
+    return None
+```
+
+Warum im Core und nicht über einen Nutzer-Parameter an `get_dashboard_data()`:
+keine Signaturänderung, das bestehende Tapo-Panel bleibt unangetastet, und kein
+Plugin kann sein eigenes Gate falsch implementieren. Es folgt dem vorhandenen
+Muster — `PluginNavItem` hat exakt dieses Feld. Dass `PluginMenuItem` in TP2
+bewusst *kein* `admin_only` bekam, ist kein Widerspruch: eine Aktion *führt
+etwas aus*, ein Panel *zeigt etwas an*.
+
+Steams Spec: `panel_type="status"`, Titel „Steam Gaming", Icon `gamepad-2`,
+`admin_only=True`.
+
+Das Icon braucht **keine** Core-Frontend-Änderung: `PluginDashboardPanel.tsx:167-173`
+löst den Namen dynamisch aus lucide auf (kebab-case → PascalCase, Fallback
+`Plug`). Bemerkenswert im Vergleich zur Pill, deren `iconMap.ts` eine
+geschlossene Core-Map ist — das ist genau die Lücke, die #451 M-2 beschreibt,
+und der Panel-Pfad zeigt, dass die dort vorgeschlagene Option (b) im Haus
+bereits erprobt ist.
+
+Daten: die fünf neuesten Sessions (`ORDER BY started_at DESC LIMIT 5`); die
+laufende steht durch die Sortierung oben.
+
+```
+Metro Exodus Enhanced Edition   1h 12m            tone=ok        ← ended_at IS NULL
+Cyberpunk 2077                  23.07. · 3h 04m   tone=neutral
+Metro Exodus Enhanced Edition   22.07. · 2h 41m   tone=neutral
+Factorio                        21.07. · 5h 18m   tone=neutral
+Cyberpunk 2077                  20.07. · 1h 02m   tone=neutral
+```
+
+`label` ist der Spielname, ersatzweise `AppID <n>`. `value` ist Datum + Dauer.
+
+**Bewusst sprachneutral, keine Wörter.** `StatusItem` hat nur
+`label`/`value`/`tone`, keine Key-Felder — der Renderer löst nichts auf. Ein
+serverseitig festgetackertes „läuft · 1h 12m" wäre ein neuer Eintrag in #406.
+Stattdessen trägt `tone=ok` die Information „läuft"; Datum und Dauer sind in
+beiden Sprachen lesbar.
+
+**Leerer Zustand:** noch keine Session verbucht → `get_dashboard_data()` gibt
+`None`, das Panel erscheint nicht. Kein Platzhaltertext, der wieder übersetzt
+werden müsste.
+
+**Dev-Modus:** der Mock (`("0", "Dev Mode Game")`) lebt heute im
+Pill-Collector. Er wandert eine Ebene tiefer in die gemeinsame
+Erkennungsfunktion, sodass Pill, Ledger und Panel dieselbe Quelle benutzen —
+sonst schreibt der Ledger auf einer Windows-Kiste nie eine Zeile und das Panel
+ist lokal nicht testbar.
+
+**Betriebshinweis:** Es kann nur *ein* Plugin-Panel gleichzeitig aktiv sein;
+`set_dashboard_panel_enabled()` schaltet beim Einschalten alle anderen ab. Läuft
+auf der Box gerade das Tapo-Panel, verdrängt Steam es. Bestehendes Verhalten,
+aber hier zum ersten Mal spürbar.
+
+## Fehlerbehandlung
+
+| Fall | Verhalten |
+|---|---|
+| DB im Tick nicht erreichbar | Rollback, Warnung ins Log, Tick endet; der nächste Tick greift über die Lückenregel — verloren geht höchstens ein Heartbeat |
+| `emit_plugin_event()` schlägt fehl | Buchung steht bereits; nur die Meldung fehlt (bestehendes Verhalten aus TP3) |
+| `detect_running_app_id()` wirft | Tick loggt und endet; keine Buchung, keine Meldung |
+| `appmanifest` fehlt/kaputt | `game_name=None`, Panel zeigt `AppID <n>` |
+| Plugin wird deaktiviert, während gespielt wird | Background-Task stoppt, Session bleibt offen; beim Wiedereinschalten schließt die Lückenregel sie bei `last_seen_at` — still |
+| Uhr springt rückwärts (NTP) | Dauer wird auf `max(0, …)` geklemmt; eine negative Dauer im Panel wäre schlimmer als eine geschönte Null |
+| `get_dashboard_data()` wirft | Route fängt das bereits ab (`dashboard.py:51-57`) und liefert das Panel mit `data=None` |
+
+## Sicherheit
+
+- Kein neuer Subprocess, kein sudo, keine neue sudoers-Regel, keine neue Route.
+- Was sich ändert: Spielnamen werden **erstmals dauerhaft gespeichert** statt
+  nur flüchtig angezeigt. Deshalb Panel `admin_only` und Retention 365 Tage.
+- Die Tabelle enthält nichts, was unter `REDACT_PATTERN`
+  (`services/audit/admin_db.py:13`) fiele — kein Secret, kein Token. Die
+  Admin-DB-Ansicht zeigt sie im Klartext, was für Admins korrekt ist.
+- Der Ledger schreibt nur Werte, die der Detector aus `/proc` und den
+  `appmanifest`-Dateien liest; keine Benutzereingabe erreicht die Tabelle.
+
+## Tests
+
+**Ledger** (In-Memory-SQLite, injizierte Uhr):
+
+- alle fünf Zeilen der Flankentabelle;
+- frische vs. stale Lücke — `ended_at = now` vs. `ended_at = last_seen_at`;
+- nach einer Lücke wird **nichts** gemeldet;
+- dasselbe Spiel über 5 min → eine Session; über 30 min → zwei;
+- mehrere offene Sessions werden bis auf die neueste geschlossen;
+- Retention löscht nur `ended_at < now - 365 d` und lässt die offene Session in
+  Ruhe;
+- Uhr-Rücksprung ergibt Dauer 0, keine negative Zahl.
+
+**Poller:** meldet genau die Events, die der Ledger zurückgibt — insbesondere
+**beide** beim Spielwechsel (#462).
+
+**Panel:** Admin bekommt Daten, Nicht-Admin bekommt `None` (Gate in der Route,
+nicht im Plugin); Formatierung für laufende Session, `< 1 h`, `> 1 h`; keine
+Sessions → `None`.
+
+**Migration:** `upgrade` und `downgrade` lokal gegen SQLite **und** PostgreSQL
+prüfen. CI hat dafür keinen Smoke-Test (#450) — das ist Handarbeit.
+
+## Umfang
+
+```
+NEU   backend/app/models/steam_session.py                ~30 Z.
+NEU   backend/alembic/versions/<rev>_steam_sessions.py   ~40 Z.
+NEU   .../installed/steam_gaming/ledger.py              ~120 Z.
+NEU   backend/tests/test_steam_gaming_ledger.py         ~250 Z.
+ÄND   .../installed/steam_gaming/poller.py              Zustand entfällt
+ÄND   .../installed/steam_gaming/__init__.py            Panel + Dev-Mock
+ÄND   backend/app/plugins/base.py                       DashboardPanelSpec.admin_only
+ÄND   backend/app/api/routes/dashboard.py               admin_only-Gate
+ÄND   backend/app/models/__init__.py                    Registrierung
+ÄND   backend/app/plugins/CLAUDE.md                     Panel-Doku
+```
+
+## Folgearbeiten
+
+- **Retention konfigurierbar machen** — 365 Tage sind hier fest verdrahtet;
+  Issue wird mit dieser Spec angelegt.
+- **#462** wird von diesem Teilprojekt geschlossen.
+- **#451 M-3** (Pill-`href` auf eine gegatete Route) bleibt offen — ohne eigene
+  Steam-Seite gibt es kein besseres Ziel.
+- **Per-Nutzer-Kategorie-Preference für Plugin-Events** — eigene Core-Spec.
+- Doku-Drift in `backend/app/plugins/CLAUDE.md`: dort steht, der
+  Panel-Endpunkt hänge *nicht* an `reconciled_plugin_state` — im Code hängt er
+  dran (`api/routes/dashboard.py`). Wird hier mitkorrigiert, weil genau dieser
+  Pfad angefasst wird.

--- a/docs/superpowers/specs/2026-07-24-steam-session-history-dashboard-panel-design.md
+++ b/docs/superpowers/specs/2026-07-24-steam-session-history-dashboard-panel-design.md
@@ -369,14 +369,27 @@ prüfen. CI hat dafür keinen Smoke-Test (#450) — das ist Handarbeit.
 NEU   backend/app/models/steam_session.py                ~30 Z.
 NEU   backend/alembic/versions/<rev>_steam_sessions.py   ~40 Z.
 NEU   .../installed/steam_gaming/ledger.py              ~120 Z.
-NEU   backend/tests/test_steam_gaming_ledger.py         ~250 Z.
+NEU   .../installed/steam_gaming/detection.py            ~30 Z.
+NEU   backend/tests/plugins/test_steam_gaming_ledger.py ~250 Z.
+NEU   backend/tests/plugins/test_steam_gaming_panel.py  ~100 Z.
 ÄND   .../installed/steam_gaming/poller.py              Zustand entfällt
 ÄND   .../installed/steam_gaming/__init__.py            Panel + Dev-Mock
 ÄND   backend/app/plugins/base.py                       DashboardPanelSpec.admin_only
 ÄND   backend/app/api/routes/dashboard.py               admin_only-Gate
+ÄND   backend/app/services/websocket_manager.py         broadcast_typed(admins_only=…)
+ÄND   backend/app/services/dashboard_panel_bridge.py    admin-only-Panels nur an Admins
 ÄND   backend/app/models/__init__.py                    Registrierung
 ÄND   backend/app/plugins/CLAUDE.md                     Panel-Doku
 ```
+
+**Nachtrag aus der Planung (2026-07-24):** `dashboard_panel_ws_bridge()` schiebt
+Panel-Daten per `broadcast_typed()` an **alle** verbundenen WebSocket-Clients.
+Ein `admin_only`-Gate allein in der REST-Route wäre damit wirkungslos, sobald
+der Bridge feuert (er triggert auf Smart-Device-SHM-Änderungen, und Tapo läuft
+auf dieser Box). Der Gate muss deshalb an **beiden** Stellen sitzen; dafür
+bekommt `WebSocketManager.broadcast_typed()` einen `admins_only`-Parameter.
+Das erweitert den Umfang gegenüber dem ursprünglichen Entwurf um zwei Dateien —
+ohne diese Ergänzung wäre `admin_only` reine Dekoration.
 
 ## Folgearbeiten
 

--- a/docs/superpowers/specs/2026-07-24-steam-session-history-dashboard-panel-design.md
+++ b/docs/superpowers/specs/2026-07-24-steam-session-history-dashboard-panel-design.md
@@ -342,8 +342,8 @@ NEU   backend/tests/test_steam_gaming_ledger.py         ~250 Z.
 
 ## Folgearbeiten
 
-- **Retention konfigurierbar machen** — 365 Tage sind hier fest verdrahtet;
-  Issue wird mit dieser Spec angelegt.
+- **Retention konfigurierbar machen** — 365 Tage sind hier fest verdrahtet:
+  **#464**.
 - **#462** wird von diesem Teilprojekt geschlossen.
 - **#451 M-3** (Pill-`href` auf eine gegatete Route) bleibt offen — ohne eigene
   Steam-Seite gibt es kein besseres Ziel.


### PR DESCRIPTION
Teilprojekt **4 von 4** des Steam-Tracks — damit ist er abgeschlossen (1: Pill #452, 2: Menü-Aktion #457, 3: Notifications #463).

Closes #462.

## Was der Branch tut

Das `steam_gaming`-Plugin erkannte bisher ein laufendes Spiel und meldete Flanken, **speicherte aber nichts**: der Poller hielt seinen Vorzustand im Prozessspeicher, nach jedem Neustart war die Erinnerung weg. Dieser PR macht daraus eine Buchhaltung.

- **Neue Tabelle `steam_sessions`** (`app_id`, `game_name`, `started_at`, `last_seen_at`, `ended_at`) mit Modell und Migration. Die Dauer wird bewusst **nicht** gespeichert, sondern abgeleitet — ein gespeicherter Wert wäre eine zweite Wahrheit, die beim Adoptieren einer Session über einen Restart auseinanderläuft.
- **Neues Modul `ledger.py`.** Die zentrale Entscheidung: **die offene Session in der DB (`ended_at IS NULL`) ist der Zustand des Pollers.** `_last_app_id` und das `_initialized`-Flag entfallen ersatzlos. Aus der Lücke zwischen `now` und `last_seen_at` liest der Ledger ab, was während eines Deploys, Restarts oder Suspends passiert ist.
- **Der direkte Spielwechsel X→Y** wird jetzt verbucht **und** gemeldet (vorher verschluckt) — das ist #462.
- **Retention:** beendete Sessions verfallen nach 365 Tagen. Konfigurierbarkeit ist bewusst ausgelagert (#464).
- **Dashboard-Panel** („status"-Renderer) mit den fünf neuesten Sessions, `admin_only`. **Kein Frontend-Diff** — der Renderer existiert, und Panel-Icons löst das Frontend dynamisch aus lucide auf.
- **Neu im Extension-Point: `DashboardPanelSpec.admin_only`**, durchgesetzt vom Core.
- **Neues Modul `detection.py`** als gemeinsame Erkennungsquelle für Pill, Poller und Panel — inklusive des Dev-Mode-Ersatzes, der vorher nur im Pill-Collector lag (der Ledger hätte auf einer Windows-Kiste sonst nie eine Zeile geschrieben).

## Die drei Lückenregeln

Sie sind der Kern und erledigen Restart, Deploy und Suspend in einem:

1. **`ended_at = now`, wenn der Poller durchgehend da war** (Lücke ≤ 60 s) — sonst `ended_at = last_seen_at`. War der Prozess weg, würde `now` die Ausfallzeit als Spielzeit verbuchen.
2. **Nach einer Lücke wird nur gebucht, nie gemeldet.** Ein Deploy soll keine „Session beendet"-Push für ein Spiel auslösen, das vor zwei Stunden endete.
3. **Dasselbe Spiel über eine Lücke ≤ 10 min** führt die Session fort (Deploy mitten im Spielen); darüber wird gesplittet. Über Nacht aus und morgens dasselbe Spiel ist nicht eine 14-Stunden-Session.

Nebeneffekt, der dadurch gratis stimmt: **Schlafzeit zählt nicht als Spielzeit.**

## Sicherheit

Spielnamen sind persönliche Daten des Box-Besitzers — dieselbe Privatsphäre-Entscheidung wie bei der Pill in Teilprojekt 1.

Das `admin_only`-Gate sitzt an **zwei** Stellen, und das ist nicht Redundanz: `dashboard_panel_ws_bridge()` schiebt dieselben Panel-Daten per `broadcast_typed()` an **alle** verbundenen WebSocket-Clients, ausgelöst durch Smart-Device-SHM-Änderungen. Ein Gate nur in der REST-Route wäre Dekoration gewesen. Deshalb bekommt `broadcast_typed()` einen `admins_only`-Parameter (Default `False`, kein bestehender Aufrufer ändert sein Verhalten).

Der Review hat alle Ausgabekanäle durchgegangen — REST, WebSocket, Notifications, Logs, Admin-DB-Ansicht — und **keinen Pfad zu einem Nicht-Admin** gefunden. Notifications laufen mit `default_target="admins"`; `get_routed_user_ids()` liefert für die Plugin-Kategorie `[]`, weil `_CATEGORY_FIELD_MAP` sie nicht kennt.

> **Hinweis für die nächste Spec** (per-Nutzer-Kategorie-Preference für Plugin-Events): Wer `steam_gaming` in `_CATEGORY_FIELD_MAP` einträgt, hebelt still dieses Panel-Gate aus. Gehört dort als explizite Randbedingung hinein.

## Nicht enthalten (bewusst)

- **Big Picture vs. Fenster.** Auf BaluNode ausgemessen und negativ: `-uimode=7` steht in beiden Modi identisch (nur der Startzustand von `steamwebhelper`), `registry.vdf` enthält keinen BPM-Schlüssel, `gamepadui` kommt in keiner Kommandozeile vor. Die Messung steht in der Spec, damit sie niemand wiederholt.
- Auto-Displays-aus nach Sessionende, eigene Steam-Seite, Aggregate über Spielzeit.

## Verifikation

| Gate | Ergebnis |
|---|---|
| `tests/plugins/` | **730 passed, 7 skipped** |
| `-k "notification or dashboard or websocket"` | **311 passed** |
| `ruff check .` | clean |
| Migration isoliert (SQLite) | upgrade/downgrade/upgrade sauber |
| **Migration gegen PostgreSQL 17.10** | **upgrade + downgrade + re-upgrade sauber** |

**PostgreSQL-Probe** (Wegwerf-Container, danach entfernt): Schema exakt wie entworfen (`varchar(32)`/`varchar(200)`, `timestamptz`, drei B-Tree-Indizes + PK). Zusätzlich lief der Ledger **live gegen PostgreSQL**: Start → `session_started`; Heartbeat → kein Event; Switch X→Y → **beide** Events; Stale-Ende nach 3 h → still und bei `last_seen_at` statt `now`; Retention löschte korrekt. Verhalten identisch zu SQLite.

Bekanntes, vorbestehendes Windows-Flackern: `tests/auth/test_permissions.py::test_owner_can_delete_own_file` und `::test_admin_can_delete_any_file` fallen nur im großen Sammellauf, standalone 11/11 grün. Der Branch fasst keine Auth-Datei an.

## Ablauf des Reviews

Neun Tasks, jeder mit eigenem Review; die Härtungen daraus stecken als eigene Commits im Branch. Die Reviews haben unter anderem gefunden:

- Der ursprüngliche `except Exception` in `record()` hätte einen Programmierfehler wie einen kurzen DB-Ausfall aussehen lassen, während der Poller dauerhaft stumm nichts bucht → jetzt zweistufig (`SQLAlchemyError` → WARNING, sonst `logger.exception` auf ERROR).
- Der „Session gehört einem Tick"-Vertrag war ungetestet: eine in `__init__` hochgezogene Session wäre unter PostgreSQL eine stundenlange offene Transaktion gewesen — alle anderen Tests wären grün geblieben.
- Meine eigene Test-Vorgabe für das WS-Gate prüfte nur das Payload-Dict, nicht den Broadcast-Aufruf; das Entfernen von `admins_only=` blieb grün. Geschlossen.
- Die Grenzen `60 s`/`600 s` waren nur relativ zueinander gepinnt; jeder Wert in weiten Bereichen wäre grün geblieben.
- Längen-Guards in `detection.py` gegen `VARCHAR`-Überlauf: SQLite ignoriert Längen, PostgreSQL wirft `DataError` — das Fehlerbild wäre alle 30 s „booking failed" ohne je zu buchen.

Alle Härtungen sind mutationsgeprüft (Guard raus → genau der zugehörige Test rot).

## Ausgegliederte Befunde

Sieben Issues, alle vorbestehend oder Core-Frontend, keiner blockiert diesen PR: #465 (Plugin-Enable über die UI startet Background-Tasks ohne Primary-Gate), #466 (Panel-Live-Updates hängen an Tapos SHM-Datei), #467 (`lookup_plugin_event` außerhalb des Fehlerfangs), #468 (`is_admin` ist ein Verbindungs-Snapshot), #469 (leeres Panel zeigt „No plugin configured"), #470 (Panel-Datum: Dev/Prod divergieren — mit Messung kommentiert), #471 (Alembic-Kette läuft nicht von null durch).

## Nach dem Deploy auf der Box prüfen

1. `journalctl -u baluhost-backend | grep 'steam ledger'` — `booking failed` im 30-Sekunden-Takt hieße Migration nicht angekommen; wiederholtes `closed orphaned session` hieße zwei Poller (#465, Behelf: Backend einmal neu starten); `unexpected failure` wäre ein Programmierfehler.
2. `SELECT count(*), count(*) FILTER (WHERE ended_at IS NULL) FROM steam_sessions;` — die zweite Zahl muss **0 oder 1** sein.
3. Spiel starten, kurz spielen, beenden → genau eine Start- und eine Ende-Meldung. Direkt X→Y wechseln → **beide** Meldungen (das ist #462).
4. Backend während laufendem Spiel neu starten → **keine** Meldung, `started_at` unverändert.
5. Als Nicht-Admin einloggen → kein Panel, und keine `dashboard_panel_update`-Frames im Netzwerk-Tab.
6. `SHOW timezone;` auf der Box — beantwortet die offene Frage in #470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK4BdX3g1jyWEMaFoGPwPG
