### PR TITLE
fix(notifications): Plugin-Kategorien legen nicht mehr jeden Lese-Endpunkt lahm

### DIFF
--- a/backend/app/api/routes/notifications.py
+++ b/backend/app/api/routes/notifications.py
@@ -20,7 +20,6 @@ from app.schemas.notification import (
     MarkReadResponse,
     NotificationPreferencesUpdate,
     NotificationPreferencesResponse,
-    NotificationCategoryEnum,
 )
 from app.schemas.notification_routing import MyNotificationRoutingResponse
 from app.services.notifications import get_notification_service
@@ -35,7 +34,10 @@ router = APIRouter(prefix="/notifications", tags=["notifications"])
 async def get_notifications(
     request: Request, response: Response,
     unread_only: bool = Query(False, description="Only return unread notifications"),
-    category: Optional[NotificationCategoryEnum] = Query(None, description="Filter by category"),
+    # Plain str, not NotificationCategoryEnum: plugin-contributed notifications
+    # carry the plugin name as their category (an open set), so a closed Literal
+    # would 422 any attempt to filter for them.
+    category: Optional[str] = Query(None, description="Filter by category (core category or plugin name)"),
     notification_type: Optional[str] = Query(None, description="Filter by type (info, warning, critical)"),
     created_after: Optional[datetime] = Query(None, description="Only return notifications after this time"),
     created_before: Optional[datetime] = Query(None, description="Only return notifications before this time"),
@@ -422,7 +424,7 @@ async def get_my_notification_routing(
 @user_limiter.limit(get_limit("admin_operations"))
 async def get_trash(
     request: Request, response: Response,
-    category: Optional[NotificationCategoryEnum] = Query(None),
+    category: Optional[str] = Query(None),  # open set, see get_notifications
     notification_type: Optional[str] = Query(None),
     created_after: Optional[datetime] = Query(None),
     created_before: Optional[datetime] = Query(None),

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -57,6 +57,16 @@ class NotificationResponse(NotificationBase):
     """Schema for notification API responses."""
 
     id: int
+    # Deliberately widened from NotificationCategoryEnum. Since plugins can
+    # contribute notification events, the core derives their category from the
+    # PLUGIN NAME (never plugin-chosen, so a plugin cannot widen its own
+    # delivery reach) - which makes the category an open set at runtime.
+    # A response must report what is stored: with the closed Literal, a single
+    # plugin notification raised ValidationError inside from_db() and turned
+    # every read endpoint into a 500, hiding all other notifications with it.
+    category: str = Field(
+        description="Core category, or the name of the contributing plugin"
+    )
     created_at: datetime
     user_id: Optional[int] = None
     is_read: bool = False
@@ -140,9 +150,12 @@ class MarkReadRequest(BaseModel):
         default=None,
         description="Specific notification IDs (None = mark all)"
     )
-    category: Optional[NotificationCategoryEnum] = Field(
+    category: Optional[str] = Field(
         default=None,
-        description="Filter by category when marking all"
+        # Open set: plugin categories are the plugin's name (see
+        # NotificationResponse.category), so a closed Literal would make plugin
+        # notifications unaddressable.
+        description="Filter by category when marking all (core category or plugin name)"
     )
 
 

--- a/backend/tests/api/test_notification_plugin_category.py
+++ b/backend/tests/api/test_notification_plugin_category.py
@@ -1,0 +1,136 @@
+"""Plugin-derived notification categories must survive the REST read path.
+
+Since subproject 3 of the Steam track (#463) the core derives a plugin event's
+category from the PLUGIN NAME - deliberately, so a plugin cannot widen its own
+delivery reach by choosing a routing key. That makes the category an OPEN set at
+runtime.
+
+NotificationResponse.category used to be a closed Literal of the nine core
+categories. The first plugin notification ever persisted therefore turned every
+read endpoint into a 500 - and because the list endpoint fails as a whole, that
+ONE row hid every other notification with it. Observed in production on
+2026-07-24 (GET /api/notifications and POST /api/notifications/{id}/read).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.models.notification import Notification
+
+PLUGIN_CATEGORY = "steam_gaming"
+
+
+@pytest.fixture
+def plugin_notification(db_session, admin_user) -> Notification:
+    """A notification exactly as emit_plugin_event() persists one."""
+    row = Notification(
+        user_id=admin_user.id,
+        notification_type="info",
+        category=PLUGIN_CATEGORY,
+        title="Gaming-Session beendet",
+        message="Metro Exodus Enhanced Edition wurde beendet.",
+        action_url="/plugins",
+        priority=0,
+    )
+    db_session.add(row)
+    db_session.commit()
+    db_session.refresh(row)
+    return row
+
+
+class TestPluginCategorySurvivesTheReadPath:
+    def test_list_returns_the_plugin_notification(
+        self, client, admin_headers, plugin_notification
+    ):
+        response = client.get("/api/notifications", headers=admin_headers)
+
+        assert response.status_code == 200, response.text
+        categories = [n["category"] for n in response.json()["notifications"]]
+        assert PLUGIN_CATEGORY in categories
+
+    def test_one_plugin_row_does_not_hide_the_core_notifications(
+        self, client, admin_headers, db_session, admin_user, plugin_notification
+    ):
+        """The 500 was on the whole list, so a single plugin row buried
+        everything else - that is what made this a total outage of the page."""
+        db_session.add(
+            Notification(
+                user_id=admin_user.id,
+                notification_type="warning",
+                category="raid",
+                title="RAID degraded",
+                message="md1 is degraded.",
+                priority=2,
+            )
+        )
+        db_session.commit()
+
+        response = client.get("/api/notifications", headers=admin_headers)
+
+        assert response.status_code == 200, response.text
+        categories = [n["category"] for n in response.json()["notifications"]]
+        assert "raid" in categories
+        assert PLUGIN_CATEGORY in categories
+
+    def test_mark_read_returns_the_plugin_notification(
+        self, client, admin_headers, plugin_notification
+    ):
+        """Without this the user cannot even dismiss the notification that
+        breaks the page."""
+        response = client.post(
+            f"/api/notifications/{plugin_notification.id}/read", headers=admin_headers
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["category"] == PLUGIN_CATEGORY
+
+    def test_filtering_by_a_plugin_category_is_accepted(
+        self, client, admin_headers, plugin_notification
+    ):
+        """A closed Literal on the query parameter would 422 here, so plugin
+        notifications could never be filtered for."""
+        response = client.get(
+            "/api/notifications",
+            params={"category": PLUGIN_CATEGORY},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200, response.text
+        categories = {n["category"] for n in response.json()["notifications"]}
+        assert categories == {PLUGIN_CATEGORY}
+
+    def test_trash_returns_the_plugin_notification(
+        self, client, admin_headers, db_session, plugin_notification
+    ):
+        plugin_notification.deleted_at = datetime.now(timezone.utc)
+        db_session.commit()
+
+        response = client.get("/api/notifications/trash", headers=admin_headers)
+
+        assert response.status_code == 200, response.text
+        categories = [n["category"] for n in response.json()["notifications"]]
+        assert PLUGIN_CATEGORY in categories
+
+
+class TestCoreCategoriesAreUnaffected:
+    def test_a_core_category_still_round_trips(
+        self, client, admin_headers, db_session, admin_user
+    ):
+        db_session.add(
+            Notification(
+                user_id=admin_user.id,
+                notification_type="critical",
+                category="security",
+                title="Failed logins",
+                message="5 failed logins.",
+                priority=3,
+            )
+        )
+        db_session.commit()
+
+        response = client.get("/api/notifications", headers=admin_headers)
+
+        assert response.status_code == 200, response.text
+        assert "security" in [n["category"] for n in response.json()["notifications"]]


### PR DESCRIPTION
**Produktionsfehler, seit heute aktiv.** Die Notifications-Seite lädt nicht mehr, und die auslösende Meldung lässt sich nicht einmal wegklicken.

## Symptom

`GET /api/notifications` → 500. Das Dropdown in der Topbar zeigt die Meldung trotzdem an — es bekommt sie über den WebSocket-Push, der die Daten als rohes Dict verschickt und keine Schema-Validierung durchläuft. Nur der REST-Lesepfad fällt.

## Root Cause

Seit Teilprojekt 3 des Steam-Tracks (#463) können Plugins Notification-Ereignisse beitragen. Der Core leitet deren **Kategorie aus dem Plugin-Namen** ab — bewusst, damit ein Plugin seine Zustellreichweite nicht selbst wählen kann, indem es einen fremden Routing-Key setzt. Damit ist die Kategorie zur Laufzeit eine **offene Menge**.

`NotificationResponse.category` war aber weiterhin ein geschlossenes `Literal` der neun Core-Kategorien:

```python
NotificationCategoryEnum = Literal[
    "raid", "smart", "backup", "scheduler", "system", "security", "sync", "vpn", "lifecycle"
]
```

`NotificationResponse.from_db()` ruft `cls(...)` — also **mit** Validierung. Die erste jemals persistierte Plugin-Notification löst daher aus:

```
pydantic_core.ValidationError: 1 validation error for NotificationResponse
category
  Input should be 'raid', 'smart', … or 'lifecycle'
  [type=literal_error, input_value='steam_gaming']
```

Die Schichten im Überblick:

| Pfad | Validierung? | Ergebnis |
|---|---|---|
| Schreiben (`service.create`) | rohe Argumente, kein Schema | Zeile wird gespeichert ✅ |
| WebSocket-Push (`notification.to_dict()`) | keine | Dropdown zeigt sie ✅ |
| REST-Lesen (`NotificationResponse.from_db`) | `Literal` | **500** ❌ |

Der Bug wurde mit #463 ausgeliefert und lag seitdem latent — auslösbar erst, sobald ein Plugin tatsächlich eine Notification schreibt. Das geschah mit der ersten Steam-Session nach dem Deploy von #472.

## Warum das mehr ist als eine kaputte Seite

Betroffen ist **jeder** Endpunkt, der `NotificationResponse` zurückgibt: Liste, Papierkorb, „als gelesen markieren", „verwerfen", „schlummern", „wiederherstellen".

Zwei Verstärker machen daraus einen Totalausfall:

1. **Die Liste scheitert als Ganzes.** Eine einzige Plugin-Zeile verdeckt damit *alle* anderen Benachrichtigungen — auch kritische wie RAID-Warnungen.
2. **Die Zeile ist nicht wegklickbar**, weil Dismiss und Mark-Read denselben Response benutzen. Aus Produktion, beide Fälle belegt:

```
Unhandled exception on GET /api/notifications
Unhandled exception on POST /api/notifications/6624/read
```

## Fix

`NotificationResponse.category` wird auf `str` geweitet — eine Antwort muss abbilden, was gespeichert *ist*, nicht was zum Zeitpunkt des Schemaschreibens bekannt war. Ebenso die Kategorie-Filter (`GET /notifications`, `GET /notifications/trash`, `MarkReadRequest`), weil ein geschlossenes `Literal` dort jeden Filterversuch auf eine Plugin-Kategorie mit 422 quittiert hätte.

**`NotificationCreate` behält das `Literal`.** Core-seitig erzeugte Notifications sollen in der bekannten Menge bleiben; Plugin-Events laufen nicht durch dieses Schema (`service.create()` nimmt rohe Argumente — deshalb wurde die Zeile überhaupt erst gespeichert).

## Tests

Neue Datei `backend/tests/api/test_notification_plugin_category.py` — Endpunkt-Tests gegen eine Zeile, wie `emit_plugin_event()` sie schreibt:

- Liste liefert die Plugin-Notification
- **eine Plugin-Zeile verdeckt die Core-Notifications nicht** (das war der eigentliche Schaden)
- Mark-Read liefert sie zurück (sonst nicht wegklickbar)
- Filtern nach Plugin-Kategorie wird akzeptiert
- Papierkorb liefert sie
- Kontrolltest: Core-Kategorien unverändert

Vor dem Fix: **5 failed, 1 passed** — der Kontrolltest ist der eine grüne. Nach dem Fix: **6 passed**.

| Gate | Ergebnis |
|---|---|
| Neue Regressionstests | 6 passed (vorher 5 failed) |
| `-k notification` | 169 passed |
| `tests/schemas` + `tests/api` | 436 passed |
| `ruff check .` | clean |

## Nach dem Deploy

Die Seite lädt wieder — die bestehende `steam_gaming`-Zeile bleibt erhalten und ist danach normal les- und löschbar. Ein manuelles `DELETE FROM notifications WHERE category = 'steam_gaming'` ist **nicht** nötig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK4BdX3g1jyWEMaFoGPwPG
