### PR TITLE
feat(power): KDE-Session beim Displays-Einschalten mit entsperren

### DIFF
--- a/.claude/rules/security-agent.md
+++ b/.claude/rules/security-agent.md
@@ -56,6 +56,13 @@ verify_mobile_device_token — Validates JWT + X-Device-ID header + device expir
 - Roles: `admin`, `user`
 - `is_privileged(user)` checks against `settings.privileged_roles` (configurable)
 - Admin-only endpoints use `Depends(deps.get_current_admin)`
+- `can_unlock_session` (power permission) entsperrt die grafische Desktop-Session
+  beim Einschalten der Displays. Doppelt gegated: Recht **und**
+  `is_private_or_local_ip(request.client.host)` — die Web-App ist von außen
+  erreichbar, und ein gestohlenes Web-Konto darf keinen physischen Desktop
+  öffnen. Durchgesetzt ausschließlich in
+  `services/power/session_lock.unlock_if_permitted()`, die auch den
+  Audit-Eintrag schreibt.
 
 ### Password Policy (`schemas/auth.py:20-59`)
 - Length: 8-128 characters

--- a/backend/alembic/versions/dcabe4cc2ebc_add_can_unlock_session_permission.py
+++ b/backend/alembic/versions/dcabe4cc2ebc_add_can_unlock_session_permission.py
@@ -1,0 +1,31 @@
+"""add can_unlock_session permission
+
+Revision ID: dcabe4cc2ebc
+Revises: b661786568c1
+Create Date: 2026-07-24 16:15:37.524546
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'dcabe4cc2ebc'
+down_revision: Union[str, Sequence[str], None] = 'b661786568c1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add can_unlock_session to user_power_permissions (defaults to off)."""
+    op.add_column(
+        'user_power_permissions',
+        sa.Column('can_unlock_session', sa.Boolean(), nullable=False, server_default='0'),
+    )
+
+
+def downgrade() -> None:
+    """Drop can_unlock_session."""
+    op.drop_column('user_power_permissions', 'can_unlock_session')

--- a/backend/app/api/routes/desktop.py
+++ b/backend/app/api/routes/desktop.py
@@ -112,11 +112,15 @@ async def desktop_enable(
             await emit_desktop_enabled(current_user.username)
         except Exception as exc:  # best-effort: never break the toggle
             logger.warning("Desktop-enabled notification failed: %s", exc)
-    session_unlocked, unlock_message = await unlock_if_permitted(
-        user=current_user,
-        client_host=request.client.host if request.client else None,
-        db=db,
-    )
+    try:
+        session_unlocked, unlock_message = await unlock_if_permitted(
+            user=current_user,
+            client_host=request.client.host if request.client else None,
+            db=db,
+        )
+    except Exception:  # belt and braces: the displays are already on
+        logger.exception("Session unlock failed unexpectedly")
+        session_unlocked, unlock_message = False, "unlock failed unexpectedly"
     return {
         "success": ok,
         "message": message,

--- a/backend/app/api/routes/desktop.py
+++ b/backend/app/api/routes/desktop.py
@@ -5,11 +5,13 @@ Registered under the /system/sleep/desktop prefix in routes/__init__.py.
 import logging
 
 from fastapi import APIRouter, Depends, Request, Response
+from sqlalchemy.orm import Session
 
-from app.api.deps import get_current_user, require_power_toggle_desktop
+from app.api.deps import get_current_user, get_db, require_power_toggle_desktop
 from app.core.rate_limiter import user_limiter, get_limit
 from app.schemas.desktop import DesktopStatus
 from app.services.power.desktop import get_desktop_service
+from app.services.power.session_lock import unlock_if_permitted
 from app.services.notifications.events import emit_desktop_disabled, emit_desktop_enabled
 from app.services.audit.logger_db import get_audit_logger_db
 
@@ -76,10 +78,14 @@ async def desktop_enable(
     request: Request,
     response: Response,
     current_user=Depends(require_power_toggle_desktop),
+    db: Session = Depends(get_db),
 ) -> dict:
-    """Turn the desktop displays back on (DPMS).
+    """Turn the desktop displays back on (DPMS) and unlock the session.
 
-    Admin or a delegated user with the can_toggle_desktop permission.
+    Admin or a delegated user with the can_toggle_desktop permission. The
+    unlock is an ADD-ON: it needs its own permission plus a request from
+    LAN/VPN, and failing it never fails the call - the displays are on either
+    way.
     """
     ok, message = await get_desktop_service().enable()
     audit_logger = get_audit_logger_db()
@@ -106,4 +112,14 @@ async def desktop_enable(
             await emit_desktop_enabled(current_user.username)
         except Exception as exc:  # best-effort: never break the toggle
             logger.warning("Desktop-enabled notification failed: %s", exc)
-    return {"success": ok, "message": message}
+    session_unlocked, unlock_message = await unlock_if_permitted(
+        user=current_user,
+        client_host=request.client.host if request.client else None,
+        db=db,
+    )
+    return {
+        "success": ok,
+        "message": message,
+        "session_unlocked": session_unlocked,
+        "unlock_message": unlock_message,
+    }

--- a/backend/app/api/routes/plugins.py
+++ b/backend/app/api/routes/plugins.py
@@ -880,7 +880,7 @@ async def run_plugin_menu_action(
             detail="Unknown menu action",
         )
 
-    result = await _execute_menu_action(plugin, name, action_id, db)
+    result = await _execute_menu_action(plugin, name, action_id, db, current_user, request)
 
     get_audit_logger_db().log_event(
         event_type="PLUGIN",
@@ -895,17 +895,27 @@ async def run_plugin_menu_action(
 
 
 async def _execute_menu_action(
-    plugin: PluginBase, name: str, action_id: str, db: Session
+    plugin: PluginBase, name: str, action_id: str, db: Session, current_user: User, request: Request
 ) -> MenuActionResult:
     """Run the action under a timeout and an exception guard.
 
     A plugin fault must never become a 5xx and must never leak internals into
     the response - the detail goes to the log, the caller gets a generic
     failure. Mirrors the pill-collector guard in services/status_bar/service.py.
+
+    ``current_user`` and ``request`` are passed through to the plugin so an
+    action can ask the core for a privileged side effect (e.g. unlocking the
+    desktop session) under the core's own rules, instead of relying on the
+    implicit contract that this route already checked admin.
     """
     try:
         result = await asyncio.wait_for(
-            plugin.run_menu_action(action_id, db),
+            plugin.run_menu_action(
+                action_id,
+                db,
+                user=current_user,
+                client_host=request.client.host if request.client else None,
+            ),
             timeout=PLUGIN_MENU_ACTION_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:

--- a/backend/app/api/routes/sleep.py
+++ b/backend/app/api/routes/sleep.py
@@ -357,7 +357,7 @@ async def get_my_power_permissions(
     if current_user.role == "admin":
         return MyPowerPermissionsResponse(
             can_soft_sleep=True, can_wake=True, can_suspend=True, can_wol=True,
-            can_toggle_desktop=True,
+            can_toggle_desktop=True, can_unlock_session=True,
         )
     from app.services.power_permissions import get_permissions
     perms = get_permissions(db, current_user.id)
@@ -367,6 +367,7 @@ async def get_my_power_permissions(
         can_suspend=perms.can_suspend,
         can_wol=perms.can_wol,
         can_toggle_desktop=perms.can_toggle_desktop,
+        can_unlock_session=perms.can_unlock_session,
     )
 
 

--- a/backend/app/models/power_permissions.py
+++ b/backend/app/models/power_permissions.py
@@ -25,6 +25,7 @@ class UserPowerPermission(Base):
     can_suspend: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
     can_wol: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
     can_toggle_desktop: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+    can_unlock_session: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
 
     granted_by: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True

--- a/backend/app/plugins/CLAUDE.md
+++ b/backend/app/plugins/CLAUDE.md
@@ -131,6 +131,18 @@ Two plugin trust tiers with different isolation:
    cannot take effect. Disabled plugins are rejected by
    `PluginGateMiddleware` (403, DB-backed) — `menu-actions` is
    intentionally **not** a management route.
+   `run_menu_action()` bekommt zusätzlich `user` und `client_host` (keyword-only,
+   Default `None`) — den authentifizierten Aufrufer und dessen IP. Damit kann
+   eine Aktion einen privilegierten Seiteneffekt beim Core anfragen, der ihn
+   nach **seinen** Regeln prüft (siehe
+   `services/power/session_lock.unlock_if_permitted()`), statt sich auf den
+   impliziten Vertrag „die Route hat Admin schon geprüft" zu verlassen.
+   **Bewusster API-Bruch:** Ein Plugin, das `run_menu_action` mit der alten
+   Signatur `(self, action_id, db)` überschreibt, scheitert seitdem mit
+   `TypeError`. Verworfen wurde ein Kompatibilitäts-Fallback im Dispatch: ein
+   `TypeError` aus dem Plugin-Rumpf wäre von einem Signatur-Mismatch nicht
+   unterscheidbar, und ein Retry würde eine Aktion, die Displays schaltet und
+   Prozesse startet, ein zweites Mal ausführen.
 8. Override `get_notification_events()` to contribute notification events, and
    `get_background_tasks()` if something needs to emit them on an interval. Each
    `PluginEventSpec` picks only a local `id` (`^[a-z0-9_]+$`); the core

--- a/backend/app/plugins/base.py
+++ b/backend/app/plugins/base.py
@@ -378,8 +378,14 @@ class PluginBase(ABC):
         ``user`` and ``client_host`` describe the CALLER, so an action can ask
         the core for a privileged side effect under the core's own rules (see
         services/power/session_lock.unlock_if_permitted). Both are keyword-only
-        with defaults: an older implementation keeps working, it just cannot
-        request anything caller-dependent.
+        with defaults on THIS signature, so a call site that only passes
+        ``action_id`` and ``db`` still works.
+
+        The defaults apply to the CALL, not to an override: a plugin that
+        overrides this method MUST accept the new keyword parameters (``**kwargs``
+        is enough), otherwise the dispatch raises TypeError. That break is
+        deliberate - see plugins/CLAUDE.md for why a compatibility fallback was
+        rejected.
         """
         return None
 

--- a/backend/app/plugins/base.py
+++ b/backend/app/plugins/base.py
@@ -351,7 +351,12 @@ class PluginBase(ABC):
         return list(manifest.menu_items)
 
     async def run_menu_action(
-        self, action_id: str, db: "Session"
+        self,
+        action_id: str,
+        db: "Session",
+        *,
+        user: Optional[Any] = None,
+        client_host: Optional[str] = None,
     ) -> Optional["MenuActionResult"]:
         """Execute one menu action, or None if this plugin does not know it.
 
@@ -369,6 +374,12 @@ class PluginBase(ABC):
         performance question. If a menu action needs blocking work AND
         database access, open a fresh Session inside the thread instead of
         reusing this one.
+
+        ``user`` and ``client_host`` describe the CALLER, so an action can ask
+        the core for a privileged side effect under the core's own rules (see
+        services/power/session_lock.unlock_if_permitted). Both are keyword-only
+        with defaults: an older implementation keeps working, it just cannot
+        request anything caller-dependent.
         """
         return None
 

--- a/backend/app/plugins/installed/steam_gaming/__init__.py
+++ b/backend/app/plugins/installed/steam_gaming/__init__.py
@@ -34,6 +34,7 @@ from app.plugins.installed.steam_gaming.detection import current_app_id, resolve
 from app.plugins.installed.steam_gaming.launcher import open_big_picture
 from app.plugins.installed.steam_gaming.poller import SteamSessionPoller
 from app.services.power.desktop import get_desktop_service
+from app.services.power.session_lock import unlock_if_permitted
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +154,14 @@ class SteamGamingPlugin(PluginBase):
             )],
         )
 
-    async def run_menu_action(self, action_id: str, db: Session) -> Optional[MenuActionResult]:
+    async def run_menu_action(
+        self,
+        action_id: str,
+        db: Session,
+        *,
+        user=None,
+        client_host: Optional[str] = None,
+    ) -> Optional[MenuActionResult]:
         if action_id != _MENU_ACTION_ID:
             return None
 
@@ -170,6 +178,16 @@ class SteamGamingPlugin(PluginBase):
                 message_key="menu_displays_failed",
                 message_text=f"Displays could not be turned on: {detail}",
             )
+
+        # Then the lock screen - Big Picture behind it would be just as useless
+        # as behind a dark monitor. Same gates as the enable route; a refusal
+        # is not a failure of the action.
+        if user is not None:
+            unlocked, unlock_detail = await unlock_if_permitted(
+                user=user, client_host=client_host, db=db
+            )
+            if not unlocked:
+                logger.info("gaming mode: session not unlocked: %s", unlock_detail)
 
         launched, detail = await asyncio.to_thread(open_big_picture)
         if not launched:

--- a/backend/app/schemas/power_permissions.py
+++ b/backend/app/schemas/power_permissions.py
@@ -15,6 +15,7 @@ class UserPowerPermissionsResponse(BaseModel):
     can_suspend: bool = False
     can_wol: bool = False
     can_toggle_desktop: bool = False
+    can_unlock_session: bool = False
     granted_by: Optional[int] = None
     granted_by_username: Optional[str] = None
     granted_at: Optional[datetime] = None
@@ -30,6 +31,7 @@ class UserPowerPermissionsUpdate(BaseModel):
     can_suspend: Optional[bool] = Field(default=None, description="Allow system suspend")
     can_wol: Optional[bool] = Field(default=None, description="Allow sending Wake-on-LAN")
     can_toggle_desktop: Optional[bool] = Field(default=None, description="Allow toggling the desktop (DPMS on/off)")
+    can_unlock_session: Optional[bool] = Field(default=None, description="Allow unlocking the desktop session from the web app")
 
 
 class MyPowerPermissionsResponse(BaseModel):
@@ -40,3 +42,4 @@ class MyPowerPermissionsResponse(BaseModel):
     can_suspend: bool = False
     can_wol: bool = False
     can_toggle_desktop: bool = False
+    can_unlock_session: bool = False

--- a/backend/app/services/power/session_lock.py
+++ b/backend/app/services/power/session_lock.py
@@ -26,7 +26,11 @@ _COMMAND_TIMEOUT_SECONDS = 10
 
 
 class SessionLockBackend(Protocol):
-    def unlock(self) -> Tuple[bool, str]: ...
+    """Anything that can unlock the user's graphical session."""
+
+    def unlock(self) -> Tuple[bool, str]:
+        """Unlock the session; returns (ok, detail)."""
+        ...
 
 
 class DevSessionLockBackend:
@@ -36,6 +40,7 @@ class DevSessionLockBackend:
         self._locked = True
 
     def unlock(self) -> Tuple[bool, str]:
+        """Pretend to unlock - there is no logind on a dev box."""
         self._locked = False
         return True, "session unlocked (dev)"
 
@@ -124,13 +129,18 @@ class LinuxSessionLockBackend:
                 return False, detail
 
             deadline = self._monotonic() + _POLL_TIMEOUT_SECONDS
+            last_hint: Optional[bool] = None
             while True:
-                if self._locked_hint(session_id) is False:
+                last_hint = self._locked_hint(session_id)
+                if last_hint is False:
                     return True, f"session {session_id} unlocked"
                 if self._monotonic() >= deadline:
-                    return False, (
-                        f"session {session_id} still reports LockedHint=yes"
+                    reason = (
+                        "still reports LockedHint=yes"
+                        if last_hint is True
+                        else "LockedHint could not be read"
                     )
+                    return False, f"session {session_id} {reason}"
                 self._sleep(_POLL_INTERVAL_SECONDS)
         except FileNotFoundError:
             return False, "loginctl not found"

--- a/backend/app/services/power/session_lock.py
+++ b/backend/app/services/power/session_lock.py
@@ -14,8 +14,11 @@ import subprocess
 import time
 from typing import Callable, List, Optional, Protocol, Tuple
 
+from sqlalchemy.orm import Session
+
 from app.core.config import settings
 from app.core.network_utils import is_private_or_local_ip
+from app.schemas.user import UserPublic
 from app.services.audit.logger_db import get_audit_logger_db
 from app.services.power_permissions import check_permission
 
@@ -165,14 +168,16 @@ def get_session_lock_backend() -> SessionLockBackend:
     return _backend
 
 
-def _may_unlock(user, db) -> bool:
+def _may_unlock(user: UserPublic, db: Session) -> bool:
     """Admins pass by role, like every other power permission."""
-    if getattr(user, "role", None) == "admin":
+    if user.role == "admin":
         return True
     return check_permission(db, user.id, "unlock_session")
 
 
-async def unlock_if_permitted(*, user, client_host: Optional[str], db) -> Tuple[bool, str]:
+async def unlock_if_permitted(
+    *, user: UserPublic, client_host: Optional[str], db: Session
+) -> Tuple[bool, str]:
     """Unlock the desktop session if BOTH gates allow it.
 
     This is the only place the gates are evaluated and the only place the audit
@@ -180,7 +185,7 @@ async def unlock_if_permitted(*, user, client_host: Optional[str], db) -> Tuple[
     even a plugin.
 
     Args:
-        user: The authenticated caller (needs .id, .username, .role).
+        user: The authenticated caller.
         client_host: The request's client IP, or None.
         db: SQLAlchemy session.
 
@@ -189,31 +194,38 @@ async def unlock_if_permitted(*, user, client_host: Optional[str], db) -> Tuple[
         refused gate loginctl is never called and the real lock state is
         unknown, so it is False with the reason in ``detail``.
     """
-    if not _may_unlock(user, db):
-        return False, "permission required: power:unlock_session"
+    # Cheap gate first: a WAN request should not cost a database query.
     if not is_private_or_local_ip(client_host):
         return False, "not permitted from this network"
+    if not _may_unlock(user, db):
+        return False, "permission required: power:unlock_session"
 
     ok, detail = await asyncio.to_thread(get_session_lock_backend().unlock)
-    if not ok:
-        logger.warning("session unlock failed for %s: %s", user.username, detail)
-        return False, detail
 
+    # A REFUSED gate above stays unaudited on purpose - that is the normal case
+    # for anyone without the permission and would drown the real entries. An
+    # ATTEMPTED unlock is different: the gates were passed, so both outcomes
+    # belong in the trail, same as the sibling desktop routes.
     audit_logger = get_audit_logger_db()
     audit_logger.log_event(
         event_type="POWER",
         action="desktop_unlock_session",
         user=user.username,
         resource="desktop",
-        success=True,
+        success=ok,
+        ip_address=client_host,
         details={"message": detail},
     )
-    if getattr(user, "role", None) != "admin":
+    if not ok:
+        logger.warning("session unlock failed for %s: %s", user.username, detail)
+        return False, detail
+
+    if user.role != "admin":
         audit_logger.log_security_event(
             action="delegated_power_action",
             user=user.username,
             resource="unlock_session",
-            details={"action": "desktop_unlock_session"},
+            details={"action": "desktop_unlock_session", "client_host": client_host},
             success=True,
         )
     return True, detail

--- a/backend/app/services/power/session_lock.py
+++ b/backend/app/services/power/session_lock.py
@@ -197,10 +197,27 @@ async def unlock_if_permitted(
     # Cheap gate first: a WAN request should not cost a database query.
     if not is_private_or_local_ip(client_host):
         return False, "not permitted from this network"
-    if not _may_unlock(user, db):
+
+    try:
+        permitted = _may_unlock(user, db)
+    except Exception:
+        # A database hiccup must not turn "displays on" into a 500, and it is
+        # not an unlock attempt - so it stays out of the audit trail, like any
+        # other refused gate.
+        logger.exception("session unlock: permission check failed for %s", user.username)
+        return False, "permission check failed"
+    if not permitted:
         return False, "permission required: power:unlock_session"
 
-    ok, detail = await asyncio.to_thread(get_session_lock_backend().unlock)
+    try:
+        ok, detail = await asyncio.to_thread(get_session_lock_backend().unlock)
+    except Exception:
+        # The backend catches FileNotFoundError and TimeoutExpired itself, but
+        # not an OSError from a failing fork, a PermissionError or a decode
+        # error. Neither caller may die of it: the route already reported the
+        # displays as on, and the gaming mode still has to launch Big Picture.
+        logger.exception("session unlock raised for %s", user.username)
+        ok, detail = False, "unlock failed unexpectedly"
 
     # A REFUSED gate above stays unaudited on purpose - that is the normal case
     # for anyone without the permission and would drown the real entries. An
@@ -227,5 +244,6 @@ async def unlock_if_permitted(
             resource="unlock_session",
             details={"action": "desktop_unlock_session", "client_host": client_host},
             success=True,
+            ip_address=client_host,
         )
     return True, detail

--- a/backend/app/services/power/session_lock.py
+++ b/backend/app/services/power/session_lock.py
@@ -29,7 +29,12 @@ logger = logging.getLogger(__name__)
 # would sporadically still say "yes" and report a failure that never happened.
 _POLL_INTERVAL_SECONDS = 0.2
 _POLL_TIMEOUT_SECONDS = 3.0
-_COMMAND_TIMEOUT_SECONDS = 10
+# Per COMMAND, and one unlock runs up to four of them (show-user, optionally
+# list-sessions, unlock-session, the first show-session). At 10s that is a
+# 40s worst case, which would blow the 20s budget of a plugin menu action and
+# leave Big Picture unstarted. loginctl answers in milliseconds; anything that
+# needs three seconds will not become useful at ten.
+_COMMAND_TIMEOUT_SECONDS = 3
 
 
 class SessionLockBackend(Protocol):

--- a/backend/app/services/power/session_lock.py
+++ b/backend/app/services/power/session_lock.py
@@ -1,0 +1,151 @@
+"""Unlock the graphical KDE session via systemd-logind.
+
+`loginctl unlock-session` emits an Unlock signal that kscreenlocker obeys -
+the same path fingerprint readers and smartcards use. Measured on the box: it
+works as the session owner WITHOUT sudo, and the backend already runs as that
+user, so this needs no sudoers rule and no new root path.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from typing import Callable, List, Optional, Protocol, Tuple
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# kscreenlocker processes the Unlock signal asynchronously - the measurement on
+# the box needed roughly two seconds. A single immediate read of LockedHint
+# would sporadically still say "yes" and report a failure that never happened.
+_POLL_INTERVAL_SECONDS = 0.2
+_POLL_TIMEOUT_SECONDS = 3.0
+_COMMAND_TIMEOUT_SECONDS = 10
+
+
+class SessionLockBackend(Protocol):
+    def unlock(self) -> Tuple[bool, str]: ...
+
+
+class DevSessionLockBackend:
+    """In-memory backend for dev mode / non-Linux hosts."""
+
+    def __init__(self) -> None:
+        self._locked = True
+
+    def unlock(self) -> Tuple[bool, str]:
+        self._locked = False
+        return True, "session unlocked (dev)"
+
+
+class LinuxSessionLockBackend:
+    """Unlocks the user's graphical session through loginctl.
+
+    Blocking - call via asyncio.to_thread. The runner/sleep/monotonic seams
+    exist so tests never touch a real loginctl or a real clock.
+    """
+
+    def __init__(
+        self,
+        uid: Optional[int] = None,
+        runner: Optional[Callable[[List[str]], subprocess.CompletedProcess]] = None,
+        sleep: Optional[Callable[[float], None]] = None,
+        monotonic: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._uid = uid if uid is not None else os.getuid()
+        self._run = runner or self._default_runner
+        self._sleep = sleep or time.sleep
+        self._monotonic = monotonic or time.monotonic
+
+    @staticmethod
+    def _default_runner(cmd: List[str]) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_COMMAND_TIMEOUT_SECONDS
+        )
+
+    def _graphical_session_id(self) -> Optional[str]:
+        """The user's graphical session, or None.
+
+        Primary path is logind's own answer (`show-user -p Display`); the
+        fallback scans the session list for a seated session of this user,
+        which skips SSH logins (no seat) and the user manager (class != user).
+        """
+        result = self._run(
+            ["loginctl", "show-user", str(self._uid), "-p", "Display", "--value"]
+        )
+        if result.returncode == 0:
+            session_id = (result.stdout or "").strip()
+            if session_id:
+                return session_id
+
+        result = self._run(["loginctl", "list-sessions", "--no-legend"])
+        if result.returncode != 0:
+            return None
+        for line in (result.stdout or "").splitlines():
+            parts = line.split()
+            # SESSION UID USER SEAT LEADER CLASS TTY IDLE SINCE
+            if len(parts) < 6:
+                continue
+            session_id, uid, _user, seat, _leader, session_class = parts[:6]
+            if uid != str(self._uid) or seat == "-" or session_class != "user":
+                continue
+            return session_id
+        return None
+
+    def _locked_hint(self, session_id: str) -> Optional[bool]:
+        result = self._run(
+            ["loginctl", "show-session", session_id, "-p", "LockedHint", "--value"]
+        )
+        if result.returncode != 0:
+            return None
+        value = (result.stdout or "").strip().lower()
+        if value in ("yes", "true"):
+            return True
+        if value in ("no", "false"):
+            return False
+        return None
+
+    def unlock(self) -> Tuple[bool, str]:
+        """Unlock the graphical session and VERIFY it actually unlocked.
+
+        Returns (ok, detail). ok=True means LockedHint reads "no" afterwards -
+        loginctl's exit code alone only says the signal was dispatched.
+        """
+        try:
+            session_id = self._graphical_session_id()
+            if not session_id:
+                return False, "no graphical session found"
+
+            result = self._run(["loginctl", "unlock-session", session_id])
+            if result.returncode != 0:
+                detail = (result.stderr or "").strip() or f"exit {result.returncode}"
+                return False, detail
+
+            deadline = self._monotonic() + _POLL_TIMEOUT_SECONDS
+            while True:
+                if self._locked_hint(session_id) is False:
+                    return True, f"session {session_id} unlocked"
+                if self._monotonic() >= deadline:
+                    return False, (
+                        f"session {session_id} still reports LockedHint=yes"
+                    )
+                self._sleep(_POLL_INTERVAL_SECONDS)
+        except FileNotFoundError:
+            return False, "loginctl not found"
+        except subprocess.TimeoutExpired:
+            return False, "loginctl timed out"
+
+
+_backend: Optional[SessionLockBackend] = None
+
+
+def get_session_lock_backend() -> SessionLockBackend:
+    """Process-wide backend, chosen once by mode."""
+    global _backend
+    if _backend is None:
+        _backend = (
+            DevSessionLockBackend() if settings.is_dev_mode else LinuxSessionLockBackend()
+        )
+    return _backend

--- a/backend/app/services/power/session_lock.py
+++ b/backend/app/services/power/session_lock.py
@@ -7,6 +7,7 @@ user, so this needs no sudoers rule and no new root path.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import subprocess
@@ -14,6 +15,9 @@ import time
 from typing import Callable, List, Optional, Protocol, Tuple
 
 from app.core.config import settings
+from app.core.network_utils import is_private_or_local_ip
+from app.services.audit.logger_db import get_audit_logger_db
+from app.services.power_permissions import check_permission
 
 logger = logging.getLogger(__name__)
 
@@ -159,3 +163,57 @@ def get_session_lock_backend() -> SessionLockBackend:
             DevSessionLockBackend() if settings.is_dev_mode else LinuxSessionLockBackend()
         )
     return _backend
+
+
+def _may_unlock(user, db) -> bool:
+    """Admins pass by role, like every other power permission."""
+    if getattr(user, "role", None) == "admin":
+        return True
+    return check_permission(db, user.id, "unlock_session")
+
+
+async def unlock_if_permitted(*, user, client_host: Optional[str], db) -> Tuple[bool, str]:
+    """Unlock the desktop session if BOTH gates allow it.
+
+    This is the only place the gates are evaluated and the only place the audit
+    entry is written - so no caller can unlock without leaving a trace, not
+    even a plugin.
+
+    Args:
+        user: The authenticated caller (needs .id, .username, .role).
+        client_host: The request's client IP, or None.
+        db: SQLAlchemy session.
+
+    Returns:
+        (unlocked, detail). ``unlocked`` describes the state afterwards; on a
+        refused gate loginctl is never called and the real lock state is
+        unknown, so it is False with the reason in ``detail``.
+    """
+    if not _may_unlock(user, db):
+        return False, "permission required: power:unlock_session"
+    if not is_private_or_local_ip(client_host):
+        return False, "not permitted from this network"
+
+    ok, detail = await asyncio.to_thread(get_session_lock_backend().unlock)
+    if not ok:
+        logger.warning("session unlock failed for %s: %s", user.username, detail)
+        return False, detail
+
+    audit_logger = get_audit_logger_db()
+    audit_logger.log_event(
+        event_type="POWER",
+        action="desktop_unlock_session",
+        user=user.username,
+        resource="desktop",
+        success=True,
+        details={"message": detail},
+    )
+    if getattr(user, "role", None) != "admin":
+        audit_logger.log_security_event(
+            action="delegated_power_action",
+            user=user.username,
+            resource="unlock_session",
+            details={"action": "desktop_unlock_session"},
+            success=True,
+        )
+    return True, detail

--- a/backend/app/services/power_permissions.py
+++ b/backend/app/services/power_permissions.py
@@ -198,7 +198,8 @@ def check_permission(db: Session, user_id: int, action: str) -> bool:
     Args:
         db: Database session
         user_id: User ID to check
-        action: One of 'soft_sleep', 'wake', 'suspend', 'wol', 'toggle_desktop'
+        action: One of 'soft_sleep', 'wake', 'suspend', 'wol', 'toggle_desktop',
+            'unlock_session'
 
     Returns:
         True if the user has the permission, False otherwise.

--- a/backend/app/services/power_permissions.py
+++ b/backend/app/services/power_permissions.py
@@ -19,6 +19,7 @@ _ACTION_FIELD_MAP = {
     "suspend": "can_suspend",
     "wol": "can_wol",
     "toggle_desktop": "can_toggle_desktop",
+    "unlock_session": "can_unlock_session",
 }
 
 
@@ -45,6 +46,7 @@ def get_permissions(db: Session, user_id: int) -> UserPowerPermissionsResponse:
         can_suspend=perm.can_suspend,
         can_wol=perm.can_wol,
         can_toggle_desktop=perm.can_toggle_desktop,
+        can_unlock_session=perm.can_unlock_session,
         granted_by=perm.granted_by,
         granted_by_username=granted_by_username,
         granted_at=perm.granted_at,
@@ -116,6 +118,7 @@ def update_permissions(
         "can_suspend": perm.can_suspend,
         "can_wol": perm.can_wol,
         "can_toggle_desktop": perm.can_toggle_desktop,
+        "can_unlock_session": perm.can_unlock_session,
     }
 
     # Track which fields were explicitly set so implications can be applied
@@ -146,6 +149,8 @@ def update_permissions(
             explicit_false.add("can_wol")
     if update.can_toggle_desktop is not None:
         perm.can_toggle_desktop = update.can_toggle_desktop
+    if update.can_unlock_session is not None:
+        perm.can_unlock_session = update.can_unlock_session
 
     # Apply implication rules
     perm.can_soft_sleep, perm.can_wake, perm.can_suspend, perm.can_wol = (
@@ -167,6 +172,7 @@ def update_permissions(
         "can_suspend": perm.can_suspend,
         "can_wol": perm.can_wol,
         "can_toggle_desktop": perm.can_toggle_desktop,
+        "can_unlock_session": perm.can_unlock_session,
     }
 
     # Audit log

--- a/backend/tests/api/test_desktop_unlock.py
+++ b/backend/tests/api/test_desktop_unlock.py
@@ -1,0 +1,61 @@
+"""The enable route unlocks the session - but never fails because of it."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def desktop_enabled():
+    service = MagicMock()
+    service.enable = AsyncMock(return_value=(True, "ok"))
+    with patch("app.api.routes.desktop.get_desktop_service", return_value=service):
+        yield service
+
+
+class TestEnableUnlocksTheSession:
+    def test_response_reports_a_successful_unlock(
+        self, client, admin_headers, desktop_enabled
+    ):
+        with patch(
+            "app.api.routes.desktop.unlock_if_permitted",
+            AsyncMock(return_value=(True, "session 2 unlocked")),
+        ):
+            response = client.post(
+                "/api/system/sleep/desktop/enable", headers=admin_headers
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["success"] is True
+        assert body["session_unlocked"] is True
+
+    def test_a_failed_unlock_does_not_fail_the_enable(
+        self, client, admin_headers, desktop_enabled
+    ):
+        """Turning the displays on is the primary action. If it started failing
+        because a lock screen would not budge, the feature would be a
+        regression rather than a convenience."""
+        with patch(
+            "app.api.routes.desktop.unlock_if_permitted",
+            AsyncMock(return_value=(False, "not permitted from this network")),
+        ):
+            response = client.post(
+                "/api/system/sleep/desktop/enable", headers=admin_headers
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["success"] is True
+        assert body["session_unlocked"] is False
+        assert body["unlock_message"] == "not permitted from this network"
+
+    def test_the_client_ip_is_passed_to_the_gate(
+        self, client, admin_headers, desktop_enabled
+    ):
+        gate = AsyncMock(return_value=(True, "unlocked"))
+        with patch("app.api.routes.desktop.unlock_if_permitted", gate):
+            client.post("/api/system/sleep/desktop/enable", headers=admin_headers)
+
+        assert gate.await_args.kwargs["client_host"] is not None

--- a/backend/tests/api/test_desktop_unlock.py
+++ b/backend/tests/api/test_desktop_unlock.py
@@ -59,3 +59,21 @@ class TestEnableUnlocksTheSession:
             client.post("/api/system/sleep/desktop/enable", headers=admin_headers)
 
         assert gate.await_args.kwargs["client_host"] is not None
+
+    def test_a_raising_unlock_does_not_500_the_route(
+        self, client, admin_headers, desktop_enabled
+    ):
+        """Before the guard, an OSError from the unlock path propagated to the
+        global handler - a 500 on a call whose displays were already on."""
+        from unittest.mock import AsyncMock, patch
+
+        with patch(
+            "app.api.routes.desktop.unlock_if_permitted",
+            AsyncMock(side_effect=OSError("boom")),
+        ):
+            response = client.post(
+                "/api/system/sleep/desktop/enable", headers=admin_headers
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["success"] is True

--- a/backend/tests/api/test_power_permissions_routes.py
+++ b/backend/tests/api/test_power_permissions_routes.py
@@ -168,6 +168,51 @@ class TestToggleDesktopPermission:
         assert resp.json()["can_toggle_desktop"] is False
 
 
+class TestUnlockSessionPermission:
+    """The mobile my-permissions endpoint hand-lists every field twice - once
+    in the admin short-circuit, once in the regular-user branch. Removing
+    either passthrough would leave no test red, so this pins both plus the
+    False case that actually distinguishes "value is passed through" from
+    "the field happens to always read true"."""
+
+    def test_admin_gets_true(self, client: TestClient, admin_token: str):
+        resp = client.get(
+            "/api/system/sleep/my-permissions",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["can_unlock_session"] is True
+
+    def test_user_with_permission_gets_true(
+        self, client: TestClient, admin_token: str, user_token: str, regular_user: User,
+    ):
+        client.put(
+            f"/api/users/{regular_user.id}/power-permissions",
+            json={"can_unlock_session": True},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        resp = client.get(
+            "/api/system/sleep/my-permissions",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["can_unlock_session"] is True
+        # Reset so later tests reading this shared regular_user row see the default.
+        client.put(
+            f"/api/users/{regular_user.id}/power-permissions",
+            json={"can_unlock_session": False},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+    def test_user_without_permission_gets_false(self, client: TestClient, user_token: str):
+        resp = client.get(
+            "/api/system/sleep/my-permissions",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["can_unlock_session"] is False
+
+
 class TestDelegatedDesktopAccess:
     @pytest.fixture(autouse=True)
     def _dev_desktop(self):

--- a/backend/tests/plugins/test_plugin_menu_actions.py
+++ b/backend/tests/plugins/test_plugin_menu_actions.py
@@ -227,7 +227,10 @@ class TestMenuActionRoute:
         assert audit.return_value.log_event.call_args.kwargs["success"] is False
 
     async def test_hanging_action_is_cut_off_by_the_timeout(self):
-        async def _hang(action_id, db):
+        # Accepts the caller context the route now passes (user, client_host);
+        # without it the TypeError would arrive before wait_for starts timing
+        # and this test would assert a signature error instead of the timeout.
+        async def _hang(action_id, db, **_kwargs):
             await asyncio.sleep(60)
 
         plugin = _declaring_plugin()

--- a/backend/tests/plugins/test_steam_gaming_plugin.py
+++ b/backend/tests/plugins/test_steam_gaming_plugin.py
@@ -275,3 +275,67 @@ class TestBackgroundTask:
         # run_on_startup True is fine: the first tick books against the DB
         # state and the gap rules keep it silent after a restart (TP4).
         assert callable(spec.func)
+
+
+class TestGamingModeUnlocksTheSession:
+    """Big Picture on a lock screen helps nobody - the gaming mode runs the
+    same gates as the enable route, between displays-on and Big Picture."""
+
+    async def test_unlock_runs_between_displays_and_big_picture(self):
+        order: list[str] = []
+
+        desktop_patch, service = _patch_desktop(True, "ok")
+        service.enable = AsyncMock(side_effect=lambda: order.append("displays") or (True, "ok"))
+
+        async def _unlock(**_kwargs):
+            order.append("unlock")
+            return True, "session 2 unlocked"
+
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.unlock_if_permitted", _unlock
+        ), patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            side_effect=lambda: order.append("bigpicture") or (True, "requested"),
+        ):
+            result = await SteamGamingPlugin().run_menu_action(
+                _ACTION, db=None, user=MagicMock(role="admin"), client_host="192.168.178.29"
+            )
+
+        assert result.ok is True
+        assert order == ["displays", "unlock", "bigpicture"]
+
+    async def test_a_failed_unlock_does_not_stop_big_picture(self):
+        desktop_patch, _service = _patch_desktop(True, "ok")
+
+        async def _unlock(**_kwargs):
+            return False, "not permitted from this network"
+
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.unlock_if_permitted", _unlock
+        ), patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            return_value=(True, "requested"),
+        ) as launcher:
+            result = await SteamGamingPlugin().run_menu_action(
+                _ACTION, db=None, user=MagicMock(role="admin"), client_host="203.0.113.7"
+            )
+
+        launcher.assert_called_once()
+        assert result.ok is True
+
+    async def test_without_a_user_no_unlock_is_attempted(self):
+        """Older callers pass neither user nor client_host - the action must
+        still work, just without unlocking."""
+        desktop_patch, _service = _patch_desktop(True, "ok")
+        gate = AsyncMock(return_value=(True, "unlocked"))
+
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.unlock_if_permitted", gate
+        ), patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            return_value=(True, "requested"),
+        ):
+            result = await SteamGamingPlugin().run_menu_action(_ACTION, db=None)
+
+        gate.assert_not_awaited()
+        assert result.ok is True

--- a/backend/tests/plugins/test_steam_gaming_plugin.py
+++ b/backend/tests/plugins/test_steam_gaming_plugin.py
@@ -218,7 +218,7 @@ class TestManifestAndRouteAgreeOnDeclaredActions:
                 name="steam_gaming",
                 action_id=_ACTION,
                 db=MagicMock(),
-                current_user=MagicMock(username="admin"),
+                current_user=MagicMock(username="admin", role="admin"),
                 plugin_manager=manager,
             )
 

--- a/backend/tests/services/power/test_session_lock.py
+++ b/backend/tests/services/power/test_session_lock.py
@@ -1,0 +1,184 @@
+"""Unlocking the graphical KDE session via logind."""
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from typing import List
+
+from app.services.power.session_lock import (
+    DevSessionLockBackend,
+    LinuxSessionLockBackend,
+)
+
+SHOW_USER = ["loginctl", "show-user", "1000", "-p", "Display", "--value"]
+LIST_SESSIONS = ["loginctl", "list-sessions", "--no-legend"]
+
+# Real output shape measured on the box (2026-07-24):
+# SESSION UID USER SEAT LEADER CLASS TTY IDLE SINCE
+LIST_OUTPUT = (
+    "         1  993 ci-runner -     1975 manager-early -    no   -\n"
+    "         2 1000 sven      seat0 2023 user          tty2 no   -\n"
+    "        27 1000 sven      -    88823 user          -    no   -\n"
+    "         3 1000 sven      -     2115 manager       -    no   -\n"
+)
+
+
+def _proc(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class FakeRunner:
+    """Records commands and answers them from a table."""
+
+    def __init__(self, responses: dict) -> None:
+        self.responses = responses
+        self.calls: List[List[str]] = []
+
+    def __call__(self, cmd):
+        self.calls.append(list(cmd))
+        for key, value in self.responses.items():
+            if list(key) == list(cmd):
+                return value() if callable(value) else value
+        # LockedHint reads are matched by prefix so tests can vary the session id
+        if cmd[:2] == ["loginctl", "show-session"]:
+            value = self.responses.get("locked_hint", _proc(stdout="no\n"))
+            return value() if callable(value) else value
+        return _proc(returncode=1, stderr="unexpected command")
+
+
+def _backend(runner, monotonic_values=None):
+    clock = iter(monotonic_values or [0.0] * 50)
+    return LinuxSessionLockBackend(
+        uid=1000,
+        runner=runner,
+        sleep=lambda _seconds: None,
+        monotonic=lambda: next(clock),
+    )
+
+
+class TestSessionDiscovery:
+    def test_uses_the_display_property_when_present(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "unlock-session", "2"): _proc(),
+        })
+
+        ok, detail = _backend(runner).unlock()
+
+        assert ok is True
+        assert "2" in detail
+        assert LIST_SESSIONS not in runner.calls, "fallback must not run when Display works"
+
+    def test_falls_back_to_list_sessions_when_display_is_empty(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="\n"),
+            tuple(LIST_SESSIONS): _proc(stdout=LIST_OUTPUT),
+            ("loginctl", "unlock-session", "2"): _proc(),
+        })
+
+        ok, _detail = _backend(runner).unlock()
+
+        assert ok is True
+        assert ["loginctl", "unlock-session", "2"] in runner.calls
+
+    def test_fallback_skips_seatless_and_non_user_sessions(self):
+        """Session 27 is the SSH login (no seat), 3 is the user manager,
+        1 belongs to the CI runner - none of them may be picked."""
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="\n"),
+            tuple(LIST_SESSIONS): _proc(stdout=LIST_OUTPUT),
+            ("loginctl", "unlock-session", "2"): _proc(),
+        })
+
+        _backend(runner).unlock()
+
+        unlocked = [c for c in runner.calls if c[:2] == ["loginctl", "unlock-session"]]
+        assert unlocked == [["loginctl", "unlock-session", "2"]]
+
+    def test_no_graphical_session_is_a_clean_failure(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="\n"),
+            tuple(LIST_SESSIONS): _proc(stdout="         1  993 ci-runner - 1975 manager-early - no -\n"),
+        })
+
+        ok, detail = _backend(runner).unlock()
+
+        assert ok is False
+        assert "no graphical session" in detail
+
+
+class TestUnlockVerification:
+    def test_success_requires_locked_hint_to_flip(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "unlock-session", "2"): _proc(),
+            "locked_hint": _proc(stdout="no\n"),
+        })
+
+        ok, _detail = _backend(runner).unlock()
+
+        assert ok is True
+
+    def test_a_locker_that_ignores_the_signal_is_reported_as_failure(self):
+        """loginctl exits 0 as soon as the signal is SENT. Without reading the
+        hint back the API would claim 'unlocked' over a locked screen."""
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "unlock-session", "2"): _proc(),
+            "locked_hint": _proc(stdout="yes\n"),
+        })
+
+        ok, detail = _backend(runner, monotonic_values=[0.0, 0.0, 1.0, 2.0, 9.0]).unlock()
+
+        assert ok is False
+        assert "LockedHint" in detail
+
+    def test_polls_until_the_hint_flips(self):
+        """kscreenlocker needs a moment; a single immediate read would flap."""
+        hints = iter([_proc(stdout="yes\n"), _proc(stdout="yes\n"), _proc(stdout="no\n")])
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "unlock-session", "2"): _proc(),
+            "locked_hint": lambda: next(hints),
+        })
+
+        ok, _detail = _backend(runner).unlock()
+
+        assert ok is True
+
+    def test_nonzero_exit_is_reported(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "unlock-session", "2"): _proc(returncode=1, stderr="Access denied"),
+        })
+
+        ok, detail = _backend(runner).unlock()
+
+        assert ok is False
+        assert "Access denied" in detail
+
+    def test_missing_loginctl_is_reported(self):
+        def _raise(_cmd):
+            raise FileNotFoundError()
+
+        ok, detail = _backend(_raise).unlock()
+
+        assert ok is False
+        assert "loginctl not found" in detail
+
+    def test_timeout_is_reported(self):
+        def _raise(_cmd):
+            raise subprocess.TimeoutExpired(cmd="loginctl", timeout=10)
+
+        ok, detail = _backend(_raise).unlock()
+
+        assert ok is False
+        assert "timed out" in detail
+
+
+class TestDevBackend:
+    def test_dev_backend_reports_success_without_loginctl(self):
+        ok, detail = DevSessionLockBackend().unlock()
+
+        assert ok is True
+        assert "dev" in detail

--- a/backend/tests/services/power/test_session_lock.py
+++ b/backend/tests/services/power/test_session_lock.py
@@ -13,13 +13,15 @@ from app.services.power.session_lock import (
 SHOW_USER = ["loginctl", "show-user", "1000", "-p", "Display", "--value"]
 LIST_SESSIONS = ["loginctl", "list-sessions", "--no-legend"]
 
-# Real output shape measured on the box (2026-07-24):
+# Real output shape measured on the box (2026-07-24), reordered so the rows
+# that MUST be skipped come first: with session 2 in front, the test would
+# pass even without the seat/class filter.
 # SESSION UID USER SEAT LEADER CLASS TTY IDLE SINCE
 LIST_OUTPUT = (
     "         1  993 ci-runner -     1975 manager-early -    no   -\n"
-    "         2 1000 sven      seat0 2023 user          tty2 no   -\n"
     "        27 1000 sven      -    88823 user          -    no   -\n"
     "         3 1000 sven      -     2115 manager       -    no   -\n"
+    "         2 1000 sven      seat0 2023 user          tty2 no   -\n"
 )
 
 
@@ -174,6 +176,20 @@ class TestUnlockVerification:
 
         assert ok is False
         assert "timed out" in detail
+
+    def test_an_unreadable_hint_is_reported_as_such(self):
+        """A failing show-session must not be logged as 'still locked' - the
+        lock state is unknown in that case, and the log should say so."""
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "unlock-session", "2"): _proc(),
+            "locked_hint": _proc(returncode=1, stderr="no such session"),
+        })
+
+        ok, detail = _backend(runner, monotonic_values=[0.0, 0.0, 9.0]).unlock()
+
+        assert ok is False
+        assert "could not be read" in detail
 
 
 class TestDevBackend:

--- a/backend/tests/services/power/test_session_unlock_policy.py
+++ b/backend/tests/services/power/test_session_unlock_policy.py
@@ -67,6 +67,7 @@ class TestPermissionGate:
         )
 
         assert ok is True
+        unlock_called.unlock.assert_called_once()
 
     async def test_user_without_the_permission_is_refused(
         self, db_session, regular_user, unlock_called
@@ -146,3 +147,30 @@ class TestAuditTrail:
         )
 
         _silent_audit.log_security_event.assert_called_once()
+
+    async def test_an_admin_gets_no_delegated_security_event(
+        self, db_session, unlock_called, _silent_audit
+    ):
+        """The security event marks a DELEGATED user exercising a privileged
+        action - for an admin it would just be noise."""
+        await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=LAN, db=db_session
+        )
+
+        _silent_audit.log_security_event.assert_not_called()
+
+    async def test_a_failed_unlock_is_audited_as_a_failure(
+        self, db_session, unlock_called, _silent_audit
+    ):
+        """Gates passed, loginctl did not deliver. Without this the function
+        would report success=True over a still-locked screen."""
+        unlock_called.unlock.return_value = (False, "session 2 still reports LockedHint=yes")
+
+        ok, _detail = await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=LAN, db=db_session
+        )
+
+        assert ok is False
+        kwargs = _silent_audit.log_event.call_args.kwargs
+        assert kwargs["success"] is False
+        assert kwargs["ip_address"] == LAN

--- a/backend/tests/services/power/test_session_unlock_policy.py
+++ b/backend/tests/services/power/test_session_unlock_policy.py
@@ -1,0 +1,148 @@
+"""Both gates for unlocking the desktop session, plus the audit trail."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.models.power_permissions import UserPowerPermission
+from app.services.power import session_lock
+
+LAN = "192.168.178.29"
+VPN = "10.8.0.3"
+# NOTE: deviates from the brief's literal "203.0.113.7". That address is the
+# RFC 5737 documentation range (TEST-NET-3); Python's ipaddress.is_private
+# treats it (and 192.0.2.0/24, 198.51.100.0/24) as "private" because it is
+# merely "not globally routable", not because it is a real LAN/VPN range. That
+# makes app/core/network_utils.is_private_or_local_ip() wrongly ALLOW it,
+# which is a pre-existing gap in shared code out of this task's scope - see
+# the flagged finding in the task report. 8.8.8.8 is unambiguously global.
+PUBLIC = "8.8.8.8"
+
+
+def _admin():
+    return SimpleNamespace(id=1, username="admin", role="admin")
+
+
+def _user(user_id: int):
+    return SimpleNamespace(id=user_id, username="sven", role="user")
+
+
+@pytest.fixture
+def unlock_called():
+    """Replaces the backend so no loginctl is ever invoked."""
+    backend = MagicMock()
+    backend.unlock.return_value = (True, "session 2 unlocked")
+    with patch.object(session_lock, "get_session_lock_backend", return_value=backend):
+        yield backend
+
+
+@pytest.fixture(autouse=True)
+def _silent_audit():
+    with patch.object(session_lock, "get_audit_logger_db") as factory:
+        factory.return_value = MagicMock()
+        yield factory.return_value
+
+
+class TestPermissionGate:
+    async def test_admin_from_lan_unlocks(self, db_session, unlock_called):
+        ok, _detail = await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=LAN, db=db_session
+        )
+
+        assert ok is True
+        unlock_called.unlock.assert_called_once()
+
+    async def test_delegated_user_with_the_permission_unlocks(
+        self, db_session, regular_user, unlock_called
+    ):
+        db_session.add(
+            UserPowerPermission(user_id=regular_user.id, can_unlock_session=True)
+        )
+        db_session.commit()
+
+        ok, _detail = await session_lock.unlock_if_permitted(
+            user=_user(regular_user.id), client_host=LAN, db=db_session
+        )
+
+        assert ok is True
+
+    async def test_user_without_the_permission_is_refused(
+        self, db_session, regular_user, unlock_called
+    ):
+        ok, detail = await session_lock.unlock_if_permitted(
+            user=_user(regular_user.id), client_host=LAN, db=db_session
+        )
+
+        assert ok is False
+        assert "permission" in detail
+        unlock_called.unlock.assert_not_called()
+
+
+class TestNetworkGate:
+    async def test_vpn_is_allowed(self, db_session, unlock_called):
+        ok, _detail = await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=VPN, db=db_session
+        )
+
+        assert ok is True
+
+    async def test_public_address_is_refused_even_for_an_admin(
+        self, db_session, unlock_called
+    ):
+        """The web app is reachable from the open internet via duckdns. This
+        assertion is the one that fails if the IP gate ever breaks - testing
+        only the allowed direction would stay green on a wide-open gate."""
+        ok, detail = await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=PUBLIC, db=db_session
+        )
+
+        assert ok is False
+        assert "network" in detail
+        unlock_called.unlock.assert_not_called()
+
+    async def test_missing_client_host_is_refused(self, db_session, unlock_called):
+        ok, _detail = await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=None, db=db_session
+        )
+
+        assert ok is False
+        unlock_called.unlock.assert_not_called()
+
+
+class TestAuditTrail:
+    async def test_successful_unlock_is_audited(
+        self, db_session, unlock_called, _silent_audit
+    ):
+        await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=LAN, db=db_session
+        )
+
+        _silent_audit.log_event.assert_called_once()
+        kwargs = _silent_audit.log_event.call_args.kwargs
+        assert kwargs["action"] == "desktop_unlock_session"
+        assert kwargs["event_type"] == "POWER"
+
+    async def test_a_refused_unlock_writes_no_audit_noise(
+        self, db_session, unlock_called, _silent_audit
+    ):
+        await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=PUBLIC, db=db_session
+        )
+
+        _silent_audit.log_event.assert_not_called()
+
+    async def test_delegated_user_also_gets_a_security_event(
+        self, db_session, regular_user, unlock_called, _silent_audit
+    ):
+        db_session.add(
+            UserPowerPermission(user_id=regular_user.id, can_unlock_session=True)
+        )
+        db_session.commit()
+
+        await session_lock.unlock_if_permitted(
+            user=_user(regular_user.id), client_host=LAN, db=db_session
+        )
+
+        _silent_audit.log_security_event.assert_called_once()

--- a/backend/tests/services/power/test_session_unlock_policy.py
+++ b/backend/tests/services/power/test_session_unlock_policy.py
@@ -174,3 +174,37 @@ class TestAuditTrail:
         kwargs = _silent_audit.log_event.call_args.kwargs
         assert kwargs["success"] is False
         assert kwargs["ip_address"] == LAN
+
+
+class TestNeverRaises:
+    """The whole feature rests on this: unlocking is an add-on and must never
+    take down the caller that only wanted the displays on."""
+
+    async def test_a_raising_backend_is_swallowed_and_audited(
+        self, db_session, unlock_called, _silent_audit
+    ):
+        unlock_called.unlock.side_effect = OSError("fork failed under memory pressure")
+
+        ok, detail = await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=LAN, db=db_session
+        )
+
+        assert ok is False
+        assert "unexpectedly" in detail
+        assert _silent_audit.log_event.call_args.kwargs["success"] is False
+
+    async def test_a_failing_permission_check_is_swallowed_without_audit(
+        self, db_session, unlock_called, _silent_audit
+    ):
+        """A database hiccup is not an unlock attempt - no trail entry."""
+        with patch.object(
+            session_lock, "check_permission", side_effect=RuntimeError("db gone")
+        ):
+            ok, detail = await session_lock.unlock_if_permitted(
+                user=_user(1234), client_host=LAN, db=db_session
+            )
+
+        assert ok is False
+        assert "permission check failed" in detail
+        _silent_audit.log_event.assert_not_called()
+        unlock_called.unlock.assert_not_called()

--- a/backend/tests/services/power/test_unlock_session_permission.py
+++ b/backend/tests/services/power/test_unlock_session_permission.py
@@ -55,7 +55,11 @@ class TestRoundTrip:
 
         assert get_permissions(db_session, regular_user.id).can_unlock_session is True
 
-    def test_revoking_works_too(self, db_session, regular_user, admin_user):
+    def test_implication_logic_leaves_the_new_permission_alone(
+        self, db_session, regular_user, admin_user
+    ):
+        """soft_sleep implies wake, suspend implies wol - unlock_session takes
+        part in neither and must survive an unrelated update untouched."""
         from app.schemas.power_permissions import UserPowerPermissionsUpdate
         from app.services.power_permissions import get_permissions, update_permissions
 
@@ -63,6 +67,28 @@ class TestRoundTrip:
             db_session, regular_user.id,
             UserPowerPermissionsUpdate(can_unlock_session=True), granted_by=admin_user.id,
         )
+        update_permissions(
+            db_session, regular_user.id,
+            UserPowerPermissionsUpdate(can_soft_sleep=True), granted_by=admin_user.id,
+        )
+
+        perms = get_permissions(db_session, regular_user.id)
+        assert perms.can_wake is True, "sanity: the implication itself still fires"
+        assert perms.can_unlock_session is True
+
+    def test_revoking_works_too(self, db_session, regular_user, admin_user):
+        """Asserting only the final False would pass even with a broken write
+        path - False is also the column default. The intermediate assertion is
+        what makes this test mean anything."""
+        from app.schemas.power_permissions import UserPowerPermissionsUpdate
+        from app.services.power_permissions import get_permissions, update_permissions
+
+        update_permissions(
+            db_session, regular_user.id,
+            UserPowerPermissionsUpdate(can_unlock_session=True), granted_by=admin_user.id,
+        )
+        assert get_permissions(db_session, regular_user.id).can_unlock_session is True
+
         update_permissions(
             db_session, regular_user.id,
             UserPowerPermissionsUpdate(can_unlock_session=False), granted_by=admin_user.id,
@@ -91,3 +117,6 @@ class TestRoundTrip:
 
         details = logger.log_security_event.call_args.kwargs["details"]
         assert details["new"]["can_unlock_session"] is True
+        assert "can_unlock_session" in details["old"], (
+            "a missing entry in old_values would hide the previous state"
+        )

--- a/backend/tests/services/power/test_unlock_session_permission.py
+++ b/backend/tests/services/power/test_unlock_session_permission.py
@@ -1,0 +1,93 @@
+"""The can_unlock_session permission and its action mapping."""
+from __future__ import annotations
+
+from app.models.power_permissions import UserPowerPermission
+from app.services.power_permissions import _ACTION_FIELD_MAP, check_permission
+
+
+class TestActionMapping:
+    def test_unlock_session_is_mapped(self):
+        """check_permission() returns False for unknown actions instead of
+        raising, so a missing map entry is invisible: the feature would simply
+        never work for delegated users, with no error anywhere."""
+        assert _ACTION_FIELD_MAP["unlock_session"] == "can_unlock_session"
+
+
+class TestCheckPermission:
+    def test_granted_user_passes(self, db_session, regular_user):
+        db_session.add(
+            UserPowerPermission(user_id=regular_user.id, can_unlock_session=True)
+        )
+        db_session.commit()
+
+        assert check_permission(db_session, regular_user.id, "unlock_session") is True
+
+    def test_user_without_the_permission_is_rejected(self, db_session, regular_user):
+        db_session.add(
+            UserPowerPermission(user_id=regular_user.id, can_toggle_desktop=True)
+        )
+        db_session.commit()
+
+        assert check_permission(db_session, regular_user.id, "unlock_session") is False
+
+    def test_default_is_off(self, db_session, regular_user):
+        """No row at all must not grant anything."""
+        assert check_permission(db_session, regular_user.id, "unlock_session") is False
+
+
+class TestRoundTrip:
+    """Nothing in this repo passes power permissions through generically -
+    every read and write lists the fields one by one. A column plus a schema
+    field yields a checkbox that saves nothing and reports itself as off."""
+
+    def test_update_then_get_returns_the_granted_permission(
+        self, db_session, regular_user, admin_user
+    ):
+        from app.schemas.power_permissions import UserPowerPermissionsUpdate
+        from app.services.power_permissions import get_permissions, update_permissions
+
+        update_permissions(
+            db_session,
+            regular_user.id,
+            UserPowerPermissionsUpdate(can_unlock_session=True),
+            granted_by=admin_user.id,
+        )
+
+        assert get_permissions(db_session, regular_user.id).can_unlock_session is True
+
+    def test_revoking_works_too(self, db_session, regular_user, admin_user):
+        from app.schemas.power_permissions import UserPowerPermissionsUpdate
+        from app.services.power_permissions import get_permissions, update_permissions
+
+        update_permissions(
+            db_session, regular_user.id,
+            UserPowerPermissionsUpdate(can_unlock_session=True), granted_by=admin_user.id,
+        )
+        update_permissions(
+            db_session, regular_user.id,
+            UserPowerPermissionsUpdate(can_unlock_session=False), granted_by=admin_user.id,
+        )
+
+        assert get_permissions(db_session, regular_user.id).can_unlock_session is False
+
+    def test_the_change_reaches_the_audit_diff(
+        self, db_session, regular_user, admin_user
+    ):
+        """old/new are built from explicit dicts - a missing entry hides the
+        grant from the security trail."""
+        from unittest.mock import MagicMock, patch
+
+        from app.schemas.power_permissions import UserPowerPermissionsUpdate
+        from app.services import power_permissions as svc
+
+        with patch.object(svc, "get_audit_logger_db") as factory:
+            logger = MagicMock()
+            factory.return_value = logger
+            svc.update_permissions(
+                db_session, regular_user.id,
+                UserPowerPermissionsUpdate(can_unlock_session=True),
+                granted_by=admin_user.id,
+            )
+
+        details = logger.log_security_event.call_args.kwargs["details"]
+        assert details["new"]["can_unlock_session"] is True

--- a/client/src/__tests__/components/PowerMenu.test.tsx
+++ b/client/src/__tests__/components/PowerMenu.test.tsx
@@ -187,3 +187,53 @@ describe('PowerMenu — enable desktop quick action', () => {
     expect(getDesktopStatus).not.toHaveBeenCalled();
   });
 });
+
+describe('PowerMenu session unlock hint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getSleepStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({});
+  });
+
+  it('shows an extra hint when the session could not be unlocked', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'stopped',
+    });
+    (enableDesktop as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      message: 'ok',
+      session_unlocked: false,
+      unlock_message: 'not permitted from this network',
+    });
+
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    const button = await screen.findByText('Enable desktop');
+    fireEvent.click(button);
+
+    await waitFor(() => expect(enableDesktop).toHaveBeenCalledTimes(1));
+    // The raw English debug string must never reach the user (#406).
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/not permitted from this network/i),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it('shows no hint when the session was unlocked', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'stopped',
+    });
+    (enableDesktop as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      message: 'ok',
+      session_unlocked: true,
+      unlock_message: 'session 2 unlocked',
+    });
+
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByText('Enable desktop'));
+
+    await waitFor(() => expect(enableDesktop).toHaveBeenCalledTimes(1));
+  });
+});

--- a/client/src/api/desktop.ts
+++ b/client/src/api/desktop.ts
@@ -23,6 +23,8 @@ export interface DesktopStatus {
 export interface DesktopActionResult {
   success: boolean;
   message: string;
+  session_unlocked?: boolean;
+  unlock_message?: string;
 }
 
 // ============================================================================

--- a/client/src/api/powerPermissions.ts
+++ b/client/src/api/powerPermissions.ts
@@ -11,6 +11,7 @@ export interface UserPowerPermissions {
   can_suspend: boolean;
   can_wol: boolean;
   can_toggle_desktop: boolean;
+  can_unlock_session: boolean;
   granted_by: number | null;
   granted_by_username: string | null;
   granted_at: string | null;
@@ -22,6 +23,7 @@ export interface UserPowerPermissionsUpdate {
   can_suspend?: boolean;
   can_wol?: boolean;
   can_toggle_desktop?: boolean;
+  can_unlock_session?: boolean;
 }
 
 export interface MyPowerPermissions {
@@ -30,6 +32,7 @@ export interface MyPowerPermissions {
   can_suspend: boolean;
   can_wol: boolean;
   can_toggle_desktop: boolean;
+  can_unlock_session: boolean;
 }
 
 /**

--- a/client/src/components/PowerMenu.tsx
+++ b/client/src/components/PowerMenu.tsx
@@ -120,6 +120,10 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
       const result = await enableDesktop();
       if (result.success) {
         toast.success(t('powerMenu.desktopEnabled', 'Desktop enabled'));
+        // unlock_message is an English debug string and stays out of the UI (#406).
+        if (result.session_unlocked === false) {
+          toast(t('powerMenu.desktopStillLocked', 'Displays on - the session is still locked'));
+        }
       } else {
         toast.error(result.message || t('powerMenu.desktopEnableFailed', 'Failed to enable desktop'));
       }

--- a/client/src/components/user-management/PowerPermissionsSection.tsx
+++ b/client/src/components/user-management/PowerPermissionsSection.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Moon, Sun, Power, Wifi, MonitorOff, Loader2 } from 'lucide-react';
+import { Moon, Sun, Power, Wifi, MonitorOff, LockOpen, Loader2 } from 'lucide-react';
 import {
   getUserPowerPermissions,
   updateUserPowerPermissions,
@@ -30,6 +30,7 @@ const FIELD_TO_I18N: Record<keyof UserPowerPermissionsUpdate, string> = {
   can_suspend: 'suspend',
   can_wol: 'wol',
   can_toggle_desktop: 'toggleDesktop',
+  can_unlock_session: 'unlockSession',
 };
 
 const PERMISSION_TOGGLES: PermissionToggle[] = [
@@ -38,6 +39,7 @@ const PERMISSION_TOGGLES: PermissionToggle[] = [
   { key: 'can_suspend', icon: <Power className="h-4 w-4" />, implies: 'can_wol' },
   { key: 'can_wol', icon: <Wifi className="h-4 w-4" />, impliedBy: 'can_suspend' },
   { key: 'can_toggle_desktop', icon: <MonitorOff className="h-4 w-4" /> },
+  { key: 'can_unlock_session', icon: <LockOpen className="h-4 w-4" /> },
 ];
 
 export function PowerPermissionsSection({ userId, userRole }: PowerPermissionsSectionProps) {

--- a/client/src/i18n/locales/de/admin.json
+++ b/client/src/i18n/locales/de/admin.json
@@ -90,7 +90,11 @@
         "wake": { "label": "Wake", "desc": "Server aus Soft Sleep aufwecken" },
         "suspend": { "label": "Suspend", "desc": "System Suspend (S3 Sleep)" },
         "wol": { "label": "Wake-on-LAN", "desc": "WoL Magic Packet senden" },
-        "toggleDesktop": { "label": "Desktop", "desc": "Desktop aktivieren/deaktivieren (spart GPU-Strom)" }
+        "toggleDesktop": { "label": "Desktop", "desc": "Desktop aktivieren/deaktivieren (spart GPU-Strom)" },
+        "unlockSession": {
+          "label": "Session entsperren",
+          "desc": "Beim Einschalten der Displays die Desktop-Sitzung mit entsperren (nur aus dem Heimnetz oder VPN)"
+        }
       }
     }
   },

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -263,6 +263,7 @@
     "desktopEnable": "Desktop aktivieren",
     "desktopEnableDesc": "Bildschirme wieder einschalten",
     "desktopEnabled": "Desktop aktiviert",
+    "desktopStillLocked": "Displays an - die Sitzung ist weiterhin gesperrt",
     "desktopEnableFailed": "Desktop konnte nicht aktiviert werden",
     "pluginActionFailed": "Aktion fehlgeschlagen"
   },

--- a/client/src/i18n/locales/en/admin.json
+++ b/client/src/i18n/locales/en/admin.json
@@ -90,7 +90,11 @@
         "wake": { "label": "Wake", "desc": "Wake the server from soft sleep" },
         "suspend": { "label": "Suspend", "desc": "System suspend (S3 sleep)" },
         "wol": { "label": "Wake-on-LAN", "desc": "Send a WoL magic packet" },
-        "toggleDesktop": { "label": "Desktop", "desc": "Enable/disable the desktop (saves GPU power)" }
+        "toggleDesktop": { "label": "Desktop", "desc": "Enable/disable the desktop (saves GPU power)" },
+        "unlockSession": {
+          "label": "Unlock session",
+          "desc": "Also unlock the desktop session when turning the displays on (home network or VPN only)"
+        }
       }
     }
   },

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -263,6 +263,7 @@
     "desktopEnable": "Enable desktop",
     "desktopEnableDesc": "Turn displays back on",
     "desktopEnabled": "Desktop enabled",
+    "desktopStillLocked": "Displays on - the session is still locked",
     "desktopEnableFailed": "Failed to enable desktop",
     "pluginActionFailed": "Action failed"
   },

--- a/docs/superpowers/plans/2026-07-24-session-unlock-on-desktop-enable.md
+++ b/docs/superpowers/plans/2026-07-24-session-unlock-on-desktop-enable.md
@@ -473,10 +473,13 @@ git commit -m "feat(power): logind-based session unlock with verified LockedHint
 
 **Files:**
 - Modify: `app/models/power_permissions.py`
-- Modify: `app/services/power_permissions.py`
+- Modify: `app/services/power_permissions.py` (**vier** Stellen: Map, `get_permissions`, `update_permissions`, Audit-Diff)
 - Modify: `app/schemas/power_permissions.py`
+- Modify: `app/api/routes/sleep.py:357-370`
 - Create: `alembic/versions/<generiert>_add_can_unlock_session.py`
 - Test: `tests/services/power/test_unlock_session_permission.py`
+
+**Warnung vorweg:** Dieses Repo reicht Power-Rechte **nirgends generisch** durch — jede der vier Stellen listet die Felder einzeln auf. Wer nur Spalte, Map und Schema ergänzt, bekommt eine Checkbox, die sich anklicken lässt, **nie speichert** und nach jedem Reload wieder aus steht. Kein Fehler, keine Warnung. Der Round-Trip-Test in Step 1 ist genau dagegen gebaut.
 
 **Interfaces:**
 - Produces: Spalte `UserPowerPermission.can_unlock_session`, Aktionsschlüssel `"unlock_session"` für `check_permission()`, Feld in `UserPowerPermissionsResponse`, `UserPowerPermissionsUpdate`, `MyPowerPermissionsResponse`.
@@ -521,6 +524,64 @@ class TestCheckPermission:
     def test_default_is_off(self, db_session, regular_user):
         """No row at all must not grant anything."""
         assert check_permission(db_session, regular_user.id, "unlock_session") is False
+
+
+class TestRoundTrip:
+    """Nothing in this repo passes power permissions through generically -
+    every read and write lists the fields one by one. A column plus a schema
+    field yields a checkbox that saves nothing and reports itself as off."""
+
+    def test_update_then_get_returns_the_granted_permission(
+        self, db_session, regular_user, admin_user
+    ):
+        from app.schemas.power_permissions import UserPowerPermissionsUpdate
+        from app.services.power_permissions import get_permissions, update_permissions
+
+        update_permissions(
+            db_session,
+            regular_user.id,
+            UserPowerPermissionsUpdate(can_unlock_session=True),
+            granted_by=admin_user.id,
+        )
+
+        assert get_permissions(db_session, regular_user.id).can_unlock_session is True
+
+    def test_revoking_works_too(self, db_session, regular_user, admin_user):
+        from app.schemas.power_permissions import UserPowerPermissionsUpdate
+        from app.services.power_permissions import get_permissions, update_permissions
+
+        update_permissions(
+            db_session, regular_user.id,
+            UserPowerPermissionsUpdate(can_unlock_session=True), granted_by=admin_user.id,
+        )
+        update_permissions(
+            db_session, regular_user.id,
+            UserPowerPermissionsUpdate(can_unlock_session=False), granted_by=admin_user.id,
+        )
+
+        assert get_permissions(db_session, regular_user.id).can_unlock_session is False
+
+    def test_the_change_reaches_the_audit_diff(
+        self, db_session, regular_user, admin_user
+    ):
+        """old/new are built from explicit dicts - a missing entry hides the
+        grant from the security trail."""
+        from unittest.mock import MagicMock, patch
+
+        from app.schemas.power_permissions import UserPowerPermissionsUpdate
+        from app.services import power_permissions as svc
+
+        with patch.object(svc, "get_audit_logger_db") as factory:
+            logger = MagicMock()
+            factory.return_value = logger
+            svc.update_permissions(
+                db_session, regular_user.id,
+                UserPowerPermissionsUpdate(can_unlock_session=True),
+                granted_by=admin_user.id,
+            )
+
+        details = logger.log_security_event.call_args.kwargs["details"]
+        assert details["new"]["can_unlock_session"] is True
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -573,7 +634,55 @@ In `MyPowerPermissionsResponse` nach `can_toggle_desktop`:
     can_unlock_session: bool = False
 ```
 
-- [ ] **Step 6: Generate the migration**
+- [ ] **Step 6: Pass the field through `get_permissions()`**
+
+In `app/services/power_permissions.py`, im `return UserPowerPermissionsResponse(...)` nach `can_toggle_desktop=perm.can_toggle_desktop,`:
+
+```python
+        can_unlock_session=perm.can_unlock_session,
+```
+
+Ohne diese Zeile liest die API immer `false`, egal was in der DB steht.
+
+- [ ] **Step 7: Make `update_permissions()` write the field**
+
+In derselben Datei, nach dem `if update.can_toggle_desktop is not None:`-Block:
+
+```python
+    if update.can_unlock_session is not None:
+        perm.can_unlock_session = update.can_unlock_session
+```
+
+**Das ist die Zeile, ohne die die Checkbox nie speichert.** Sie gehört bewusst *nicht* in `_apply_implications` — das neue Recht impliziert nichts und wird von nichts impliziert.
+
+Außerdem beide Audit-Dictionaries erweitern, jeweils nach `"can_toggle_desktop": perm.can_toggle_desktop,`:
+
+```python
+        "can_unlock_session": perm.can_unlock_session,
+```
+
+(einmal in `old_values`, einmal in `new_values` — sonst fehlt die Rechteänderung im Sicherheits-Audit).
+
+- [ ] **Step 8: Pass the field through the mobile endpoint**
+
+In `app/api/routes/sleep.py` beide `MyPowerPermissionsResponse(...)`-Konstruktionen erweitern — im Admin-Kurzschluss:
+
+```python
+        return MyPowerPermissionsResponse(
+            can_soft_sleep=True, can_wake=True, can_suspend=True, can_wol=True,
+            can_toggle_desktop=True, can_unlock_session=True,
+        )
+```
+
+und im Zweig für normale Nutzer:
+
+```python
+        can_toggle_desktop=perms.can_toggle_desktop,
+        can_unlock_session=perms.can_unlock_session,
+    )
+```
+
+- [ ] **Step 9: Generate the migration**
 
 Run: `python -m alembic revision -m "add can_unlock_session permission"`
 
@@ -595,20 +704,31 @@ def downgrade() -> None:
     op.drop_column('user_power_permissions', 'can_unlock_session')
 ```
 
-- [ ] **Step 7: Run test to verify it passes**
+- [ ] **Step 10: Run test to verify it passes**
 
 Run: `python -m pytest tests/services/power/test_unlock_session_permission.py -v --no-cov`
-Expected: PASS (4 passed)
+Expected: PASS (7 passed)
 
-- [ ] **Step 8: Verify the map entry is load-bearing**
+- [ ] **Step 11: Verify the map entry is load-bearing**
 
-Entferne die Zeile `"unlock_session": "can_unlock_session",` testweise, lass die Datei laufen: **drei** Tests müssen rot werden (der Mapping-Test und beide `check_permission`-Tests, die `True` erwarten bzw. das Mapping durchlaufen). Zurücksetzen. Ergebnis berichten.
+Entferne die Zeile `"unlock_session": "can_unlock_session",` testweise, lass die Datei laufen: der Mapping-Test und der `check_permission`-Test mit erteiltem Recht **müssen rot werden**. Zurücksetzen.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 12: Verify the write-through is load-bearing**
+
+Entferne den `if update.can_unlock_session is not None:`-Block aus Step 7 testweise, lass die Datei laufen: **beide Round-Trip-Tests und der Audit-Test müssen rot werden**. Zurücksetzen.
+
+Das ist die wichtigste der drei Proben: ohne sie sähe die fertige UI genauso aus wie eine funktionierende — Häkchen setzbar, Speichern ohne Fehler, Recht wirkungslos. Ergebnis beider Proben im Report festhalten.
+
+- [ ] **Step 13: Check the existing permission tests**
+
+Run: `python -m pytest tests/ -k "power_permission or powerPermission" -v --no-cov`
+Expected: PASS — die bestehenden Tests der Implikationslogik bleiben grün (das neue Feld nimmt an keiner Implikation teil)
+
+- [ ] **Step 14: Commit**
 
 ```bash
-git add app/models/power_permissions.py app/services/power_permissions.py app/schemas/power_permissions.py alembic/versions tests/services/power/test_unlock_session_permission.py
-git commit -m "feat(power): separate can_unlock_session permission" -m "Keeps can_toggle_desktop a pure power permission instead of silently turning it into a desktop key. The _ACTION_FIELD_MAP entry is load-bearing: check_permission returns False for unknown actions, so forgetting it fails closed and invisibly." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+git add app/models/power_permissions.py app/services/power_permissions.py app/schemas/power_permissions.py app/api/routes/sleep.py alembic/versions tests/services/power/test_unlock_session_permission.py
+git commit -m "feat(power): separate can_unlock_session permission" -m "Keeps can_toggle_desktop a pure power permission instead of silently turning it into a desktop key." -m "Two silent traps this closes: check_permission returns False for unknown actions, so a missing _ACTION_FIELD_MAP entry fails closed and invisibly; and nothing in this repo passes permissions through generically - get_permissions, update_permissions, both audit dicts and the mobile endpoint each list every field by hand, so a column alone yields a checkbox that never saves." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```
 
 ---
@@ -1513,7 +1633,8 @@ Zwei Nachweise, die nur am Gerät zu führen sind und deshalb in die PR-Beschrei
 | `LockedHint`-Polling statt Einzelread | 2 |
 | Dev-Backend ohne `loginctl` | 2 |
 | Recht `can_unlock_session` + Migration | 3 |
-| `_ACTION_FIELD_MAP`-Eintrag (stille Falle) | 3 |
+| `_ACTION_FIELD_MAP`-Eintrag (stille Falle 1) | 3 |
+| Vier Durchreich-Stellen: get/update/Audit/Mobile (stille Falle 2) | 3 |
 | Beide Gates in genau einer Funktion | 4 |
 | Audit-Eintrag nur im Erfolgsfall, geschrieben von der Policy | 4 |
 | Öffentliche IP wird abgelehnt (nicht nur private akzeptiert) | 4 |

--- a/docs/superpowers/plans/2026-07-24-session-unlock-on-desktop-enable.md
+++ b/docs/superpowers/plans/2026-07-24-session-unlock-on-desktop-enable.md
@@ -1,0 +1,1528 @@
+# KDE-Session entsperren beim Displays-Einschalten — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `POST /system/sleep/desktop/enable` entsperrt zusätzlich die grafische KDE-Session — aber nur für Berechtigte und nur aus LAN/VPN.
+
+**Architecture:** Ein neues Modul `session_lock.py` kapselt den Mechanismus (`loginctl`, Session-Ermittlung, `LockedHint`-Polling) hinter einem Protocol mit Dev- und Linux-Backend, exakt wie `desktop_backend.py`. Die Policy — beide Gates plus Audit — steckt in **genau einer** Modulfunktion `unlock_if_permitted()`, die sowohl die Route als auch der Gaming-Modus aufruft.
+
+**Tech Stack:** Python 3.11+, FastAPI, SQLAlchemy 2.0, Alembic, pytest (`asyncio_mode = "auto"`), React + TypeScript + Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-24-session-unlock-on-desktop-enable-design.md`
+**Branch:** `feat/session-unlock-on-desktop-enable` (existiert, Spec ist dort committed)
+
+## Global Constraints
+
+- **Arbeitsverzeichnis Backend:** `backend/` — Testpfade relativ dazu. Frontend: `client/`.
+- **Kein `&&` im PowerShell-Tool** (PowerShell 5.1); mit `;` trennen. Im Bash-Tool erlaubt.
+- **Commit-Nachrichten ASCII-only**, einzeilig je `-m`, letzte Zeile `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- **Type Hints auf allen Funktionen**, Docstrings auf öffentlichen Funktionen/Klassen.
+- **Migration setzt auf `down_revision = 'b661786568c1'`** — verifiziert der einzige Head (116 Revisionen, 2026-07-24). Niemals den Dev-DB-Head nehmen (#123 → #124).
+- **Die Alembic-Kette läuft nicht von null durch (#471).** Migrationen werden isoliert geprüft: Schema stampen, dann `upgrade`/`downgrade`.
+- **Grundregel, die keine Aufgabe verletzen darf:** Ein fehlgeschlagenes oder verweigertes Entsperren lässt `enable` weiterhin `success=true` liefern. Displays anschalten darf nie an der Sperre scheitern.
+- **Konstanten wörtlich:** `_POLL_INTERVAL_SECONDS = 0.2`, `_POLL_TIMEOUT_SECONDS = 3.0`, `_COMMAND_TIMEOUT_SECONDS = 10`, Aktionsschlüssel `"unlock_session"`, Spalte `can_unlock_session`, Audit-Aktion `desktop_unlock_session`.
+- **`unlock_message` ist ein englischer Debug-String** und wird nie wörtlich in der UI gerendert (#406).
+
+---
+
+## Dateistruktur
+
+| Datei | Verantwortung |
+|---|---|
+| `app/services/power/session_lock.py` (neu) | Mechanismus (Protocol + Dev/Linux) **und** die eine Policy-Funktion |
+| `app/models/power_permissions.py` (ändern) | Spalte `can_unlock_session` |
+| `alembic/versions/<rev>_…` (neu) | Spalte anlegen/entfernen |
+| `app/services/power_permissions.py` (ändern) | `_ACTION_FIELD_MAP`-Eintrag — **ohne ihn schlägt nichts fehl, es funktioniert nur nie** |
+| `app/schemas/power_permissions.py` (ändern) | Feld in drei Schemas |
+| `app/api/routes/desktop.py` (ändern) | `enable()` versucht den Unlock |
+| `app/plugins/base.py` (ändern) | `run_menu_action`-Kontext |
+| `app/api/routes/plugins.py` (ändern) | reicht `user` + `client_host` durch |
+| `app/plugins/installed/steam_gaming/__init__.py` (ändern) | Gaming-Modus entsperrt zwischen Displays und Big Picture |
+| `client/src/api/powerPermissions.ts` (ändern) | drei Interfaces |
+| `client/src/api/desktop.ts` (ändern) | zwei Antwortfelder |
+| `client/src/components/user-management/PowerPermissionsSection.tsx` (ändern) | Checkbox |
+| `client/src/components/PowerMenu.tsx` (ändern) | übersetzter Hinweis statt Debug-String |
+| `client/src/i18n/locales/{de,en}/admin.json` (ändern) | Label des neuen Rechts |
+| `client/src/i18n/locales/{de,en}/common.json` (ändern) | Hinweis-Text |
+
+---
+
+## Task 1: Messung des Dienst-Kontexts (kein Code)
+
+Die bisherige Messung lief aus einer **SSH-Session**, die selbst eine logind-Session ist. Das Backend ist ein session-loser Systemdienst. Diese Aufgabe klärt, ob der Unlock auch von dort geht — **bevor Code entsteht.**
+
+**Files:** keine. Ergebnis wird berichtet.
+
+- [ ] **Step 1: Grafische Session-ID ermitteln**
+
+Auf BaluNode:
+
+```bash
+loginctl list-sessions
+```
+
+Gesucht: die Zeile mit `seat0` und Klasse `user` (bei der Vormessung `2`).
+
+- [ ] **Step 2: Aus einem session-losen Dienst-Kontext sperren und entsperren**
+
+```bash
+loginctl show-session <ID> -p LockedHint
+sudo systemd-run --uid=1000 --pipe --wait loginctl lock-session <ID>
+sleep 2; loginctl show-session <ID> -p LockedHint
+sudo systemd-run --uid=1000 --pipe --wait loginctl unlock-session <ID>
+sleep 2; loginctl show-session <ID> -p LockedHint
+```
+
+Erwartet: `no` → `yes` → `no`.
+
+- [ ] **Step 3: Session-Ermittlung prüfen**
+
+```bash
+loginctl show-user 1000 -p Display --value
+```
+
+Erwartet: dieselbe ID wie in Step 1. Kommt nichts, greift später der Fallback — auch das ist ein gültiges Ergebnis, es muss nur bekannt sein.
+
+- [ ] **Step 4: Ergebnis melden — und bei Fehlschlag stoppen**
+
+Bleibt `LockedHint` nach Step 2 auf `yes` oder kommt eine polkit-Fehlermeldung, ist die tragende Annahme des Designs widerlegt. **Dann nicht weiterbauen**, sondern melden: das Design bräuchte dann einen sudoers-Eintrag und ist neu abzuwägen.
+
+---
+
+## Task 2: `session_lock.py` — Mechanismus
+
+**Files:**
+- Create: `app/services/power/session_lock.py`
+- Test: `tests/services/power/test_session_lock.py`
+
+**Interfaces:**
+- Produces: `SessionLockBackend` (Protocol, `unlock() -> Tuple[bool, str]`), `DevSessionLockBackend`, `LinuxSessionLockBackend(uid=None, runner=None, sleep=None, monotonic=None)`, `get_session_lock_backend()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Neue Datei `tests/services/power/test_session_lock.py`:
+
+```python
+"""Unlocking the graphical KDE session via logind."""
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from typing import List
+
+from app.services.power.session_lock import (
+    DevSessionLockBackend,
+    LinuxSessionLockBackend,
+)
+
+SHOW_USER = ["loginctl", "show-user", "1000", "-p", "Display", "--value"]
+LIST_SESSIONS = ["loginctl", "list-sessions", "--no-legend"]
+
+# Real output shape measured on the box (2026-07-24):
+# SESSION UID USER SEAT LEADER CLASS TTY IDLE SINCE
+LIST_OUTPUT = (
+    "         1  993 ci-runner -     1975 manager-early -    no   -\n"
+    "         2 1000 sven      seat0 2023 user          tty2 no   -\n"
+    "        27 1000 sven      -    88823 user          -    no   -\n"
+    "         3 1000 sven      -     2115 manager       -    no   -\n"
+)
+
+
+def _proc(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class FakeRunner:
+    """Records commands and answers them from a table."""
+
+    def __init__(self, responses: dict) -> None:
+        self.responses = responses
+        self.calls: List[List[str]] = []
+
+    def __call__(self, cmd):
+        self.calls.append(list(cmd))
+        for key, value in self.responses.items():
+            if list(key) == list(cmd):
+                return value() if callable(value) else value
+        # LockedHint reads are matched by prefix so tests can vary the session id
+        if cmd[:2] == ["loginctl", "show-session"]:
+            return self.responses.get("locked_hint", _proc(stdout="no\n"))
+        return _proc(returncode=1, stderr="unexpected command")
+
+
+def _backend(runner, monotonic_values=None):
+    clock = iter(monotonic_values or [0.0] * 50)
+    return LinuxSessionLockBackend(
+        uid=1000,
+        runner=runner,
+        sleep=lambda _seconds: None,
+        monotonic=lambda: next(clock),
+    )
+
+
+class TestSessionDiscovery:
+    def test_uses_the_display_property_when_present(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "unlock-session", "2"): _proc(),
+        })
+
+        ok, detail = _backend(runner).unlock()
+
+        assert ok is True
+        assert "2" in detail
+        assert LIST_SESSIONS not in runner.calls, "fallback must not run when Display works"
+
+    def test_falls_back_to_list_sessions_when_display_is_empty(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="\n"),
+            tuple(LIST_SESSIONS): _proc(stdout=LIST_OUTPUT),
+            ("loginctl", "unlock-session", "2"): _proc(),
+        })
+
+        ok, _detail = _backend(runner).unlock()
+
+        assert ok is True
+        assert ["loginctl", "unlock-session", "2"] in runner.calls
+
+    def test_fallback_skips_seatless_and_non_user_sessions(self):
+        """Session 27 is the SSH login (no seat), 3 is the user manager,
+        1 belongs to the CI runner - none of them may be picked."""
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="\n"),
+            tuple(LIST_SESSIONS): _proc(stdout=LIST_OUTPUT),
+            ("loginctl", "unlock-session", "2"): _proc(),
+        })
+
+        _backend(runner).unlock()
+
+        unlocked = [c for c in runner.calls if c[:2] == ["loginctl", "unlock-session"]]
+        assert unlocked == [["loginctl", "unlock-session", "2"]]
+
+    def test_no_graphical_session_is_a_clean_failure(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="\n"),
+            tuple(LIST_SESSIONS): _proc(stdout="         1  993 ci-runner - 1975 manager-early - no -\n"),
+        })
+
+        ok, detail = _backend(runner).unlock()
+
+        assert ok is False
+        assert "no graphical session" in detail
+
+
+class TestUnlockVerification:
+    def test_success_requires_locked_hint_to_flip(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "unlock-session", "2"): _proc(),
+            "locked_hint": _proc(stdout="no\n"),
+        })
+
+        ok, _detail = _backend(runner).unlock()
+
+        assert ok is True
+
+    def test_a_locker_that_ignores_the_signal_is_reported_as_failure(self):
+        """loginctl exits 0 as soon as the signal is SENT. Without reading the
+        hint back the API would claim 'unlocked' over a locked screen."""
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "unlock-session", "2"): _proc(),
+            "locked_hint": _proc(stdout="yes\n"),
+        })
+
+        ok, detail = _backend(runner, monotonic_values=[0.0, 0.0, 1.0, 2.0, 9.0]).unlock()
+
+        assert ok is False
+        assert "LockedHint" in detail
+
+    def test_polls_until_the_hint_flips(self):
+        """kscreenlocker needs a moment; a single immediate read would flap."""
+        hints = iter([_proc(stdout="yes\n"), _proc(stdout="yes\n"), _proc(stdout="no\n")])
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "unlock-session", "2"): _proc(),
+            "locked_hint": lambda: next(hints),
+        })
+
+        ok, _detail = _backend(runner).unlock()
+
+        assert ok is True
+
+    def test_nonzero_exit_is_reported(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "unlock-session", "2"): _proc(returncode=1, stderr="Access denied"),
+        })
+
+        ok, detail = _backend(runner).unlock()
+
+        assert ok is False
+        assert "Access denied" in detail
+
+    def test_missing_loginctl_is_reported(self):
+        def _raise(_cmd):
+            raise FileNotFoundError()
+
+        ok, detail = _backend(_raise).unlock()
+
+        assert ok is False
+        assert "loginctl not found" in detail
+
+    def test_timeout_is_reported(self):
+        def _raise(_cmd):
+            raise subprocess.TimeoutExpired(cmd="loginctl", timeout=10)
+
+        ok, detail = _backend(_raise).unlock()
+
+        assert ok is False
+        assert "timed out" in detail
+
+
+class TestDevBackend:
+    def test_dev_backend_reports_success_without_loginctl(self):
+        ok, detail = DevSessionLockBackend().unlock()
+
+        assert ok is True
+        assert "dev" in detail
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/services/power/test_session_lock.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.power.session_lock'`
+
+- [ ] **Step 3: Write the module**
+
+Neue Datei `app/services/power/session_lock.py`:
+
+```python
+"""Unlock the graphical KDE session via systemd-logind.
+
+`loginctl unlock-session` emits an Unlock signal that kscreenlocker obeys -
+the same path fingerprint readers and smartcards use. Measured on the box: it
+works as the session owner WITHOUT sudo, and the backend already runs as that
+user, so this needs no sudoers rule and no new root path.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from typing import Callable, List, Optional, Protocol, Tuple
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# kscreenlocker processes the Unlock signal asynchronously - the measurement on
+# the box needed roughly two seconds. A single immediate read of LockedHint
+# would sporadically still say "yes" and report a failure that never happened.
+_POLL_INTERVAL_SECONDS = 0.2
+_POLL_TIMEOUT_SECONDS = 3.0
+_COMMAND_TIMEOUT_SECONDS = 10
+
+
+class SessionLockBackend(Protocol):
+    def unlock(self) -> Tuple[bool, str]: ...
+
+
+class DevSessionLockBackend:
+    """In-memory backend for dev mode / non-Linux hosts."""
+
+    def __init__(self) -> None:
+        self._locked = True
+
+    def unlock(self) -> Tuple[bool, str]:
+        self._locked = False
+        return True, "session unlocked (dev)"
+
+
+class LinuxSessionLockBackend:
+    """Unlocks the user's graphical session through loginctl.
+
+    Blocking - call via asyncio.to_thread. The runner/sleep/monotonic seams
+    exist so tests never touch a real loginctl or a real clock.
+    """
+
+    def __init__(
+        self,
+        uid: Optional[int] = None,
+        runner: Optional[Callable[[List[str]], subprocess.CompletedProcess]] = None,
+        sleep: Optional[Callable[[float], None]] = None,
+        monotonic: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._uid = uid if uid is not None else os.getuid()
+        self._run = runner or self._default_runner
+        self._sleep = sleep or time.sleep
+        self._monotonic = monotonic or time.monotonic
+
+    @staticmethod
+    def _default_runner(cmd: List[str]) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_COMMAND_TIMEOUT_SECONDS
+        )
+
+    def _graphical_session_id(self) -> Optional[str]:
+        """The user's graphical session, or None.
+
+        Primary path is logind's own answer (`show-user -p Display`); the
+        fallback scans the session list for a seated session of this user,
+        which skips SSH logins (no seat) and the user manager (class != user).
+        """
+        result = self._run(
+            ["loginctl", "show-user", str(self._uid), "-p", "Display", "--value"]
+        )
+        if result.returncode == 0:
+            session_id = (result.stdout or "").strip()
+            if session_id:
+                return session_id
+
+        result = self._run(["loginctl", "list-sessions", "--no-legend"])
+        if result.returncode != 0:
+            return None
+        for line in (result.stdout or "").splitlines():
+            parts = line.split()
+            # SESSION UID USER SEAT LEADER CLASS TTY IDLE SINCE
+            if len(parts) < 6:
+                continue
+            session_id, uid, _user, seat, _leader, session_class = parts[:6]
+            if uid != str(self._uid) or seat == "-" or session_class != "user":
+                continue
+            return session_id
+        return None
+
+    def _locked_hint(self, session_id: str) -> Optional[bool]:
+        result = self._run(
+            ["loginctl", "show-session", session_id, "-p", "LockedHint", "--value"]
+        )
+        if result.returncode != 0:
+            return None
+        value = (result.stdout or "").strip().lower()
+        if value in ("yes", "true"):
+            return True
+        if value in ("no", "false"):
+            return False
+        return None
+
+    def unlock(self) -> Tuple[bool, str]:
+        """Unlock the graphical session and VERIFY it actually unlocked.
+
+        Returns (ok, detail). ok=True means LockedHint reads "no" afterwards -
+        loginctl's exit code alone only says the signal was dispatched.
+        """
+        try:
+            session_id = self._graphical_session_id()
+            if not session_id:
+                return False, "no graphical session found"
+
+            result = self._run(["loginctl", "unlock-session", session_id])
+            if result.returncode != 0:
+                detail = (result.stderr or "").strip() or f"exit {result.returncode}"
+                return False, detail
+
+            deadline = self._monotonic() + _POLL_TIMEOUT_SECONDS
+            while True:
+                if self._locked_hint(session_id) is False:
+                    return True, f"session {session_id} unlocked"
+                if self._monotonic() >= deadline:
+                    return False, (
+                        f"session {session_id} still reports LockedHint=yes"
+                    )
+                self._sleep(_POLL_INTERVAL_SECONDS)
+        except FileNotFoundError:
+            return False, "loginctl not found"
+        except subprocess.TimeoutExpired:
+            return False, "loginctl timed out"
+
+
+_backend: Optional[SessionLockBackend] = None
+
+
+def get_session_lock_backend() -> SessionLockBackend:
+    """Process-wide backend, chosen once by mode."""
+    global _backend
+    if _backend is None:
+        _backend = (
+            DevSessionLockBackend() if settings.is_dev_mode else LinuxSessionLockBackend()
+        )
+    return _backend
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/services/power/test_session_lock.py -v --no-cov`
+Expected: PASS (11 passed)
+
+- [ ] **Step 5: Verify the polling test is discriminating**
+
+Setze `_POLL_TIMEOUT_SECONDS` testweise auf `0.0`, lass die Datei laufen: `test_polls_until_the_hint_flips` **muss rot werden**. Setze zurück, danach wieder 11 grün. Ergebnis im Report festhalten — ohne diesen Nachweis ist die Polling-Regel nicht belegt.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/power/session_lock.py tests/services/power/test_session_lock.py
+git commit -m "feat(power): logind-based session unlock with verified LockedHint" -m "loginctl exits 0 once the Unlock signal is dispatched, so the hint is polled back - otherwise the API would claim success over a still-locked screen." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Recht `can_unlock_session`
+
+**Files:**
+- Modify: `app/models/power_permissions.py`
+- Modify: `app/services/power_permissions.py`
+- Modify: `app/schemas/power_permissions.py`
+- Create: `alembic/versions/<generiert>_add_can_unlock_session.py`
+- Test: `tests/services/power/test_unlock_session_permission.py`
+
+**Interfaces:**
+- Produces: Spalte `UserPowerPermission.can_unlock_session`, Aktionsschlüssel `"unlock_session"` für `check_permission()`, Feld in `UserPowerPermissionsResponse`, `UserPowerPermissionsUpdate`, `MyPowerPermissionsResponse`.
+
+- [ ] **Step 1: Write the failing test**
+
+Neue Datei `tests/services/power/test_unlock_session_permission.py`:
+
+```python
+"""The can_unlock_session permission and its action mapping."""
+from __future__ import annotations
+
+from app.models.power_permissions import UserPowerPermission
+from app.services.power_permissions import _ACTION_FIELD_MAP, check_permission
+
+
+class TestActionMapping:
+    def test_unlock_session_is_mapped(self):
+        """check_permission() returns False for unknown actions instead of
+        raising, so a missing map entry is invisible: the feature would simply
+        never work for delegated users, with no error anywhere."""
+        assert _ACTION_FIELD_MAP["unlock_session"] == "can_unlock_session"
+
+
+class TestCheckPermission:
+    def test_granted_user_passes(self, db_session, regular_user):
+        db_session.add(
+            UserPowerPermission(user_id=regular_user.id, can_unlock_session=True)
+        )
+        db_session.commit()
+
+        assert check_permission(db_session, regular_user.id, "unlock_session") is True
+
+    def test_user_without_the_permission_is_rejected(self, db_session, regular_user):
+        db_session.add(
+            UserPowerPermission(user_id=regular_user.id, can_toggle_desktop=True)
+        )
+        db_session.commit()
+
+        assert check_permission(db_session, regular_user.id, "unlock_session") is False
+
+    def test_default_is_off(self, db_session, regular_user):
+        """No row at all must not grant anything."""
+        assert check_permission(db_session, regular_user.id, "unlock_session") is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/services/power/test_unlock_session_permission.py -v --no-cov`
+Expected: FAIL — `KeyError: 'unlock_session'` bzw. `TypeError: 'can_unlock_session' is an invalid keyword argument`
+
+- [ ] **Step 3: Add the column**
+
+In `app/models/power_permissions.py` nach der `can_toggle_desktop`-Zeile einfügen:
+
+```python
+    can_unlock_session: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+```
+
+- [ ] **Step 4: Add the map entry**
+
+In `app/services/power_permissions.py` `_ACTION_FIELD_MAP` erweitern:
+
+```python
+_ACTION_FIELD_MAP = {
+    "soft_sleep": "can_soft_sleep",
+    "wake": "can_wake",
+    "suspend": "can_suspend",
+    "wol": "can_wol",
+    "toggle_desktop": "can_toggle_desktop",
+    "unlock_session": "can_unlock_session",
+}
+```
+
+- [ ] **Step 5: Add the schema fields**
+
+In `app/schemas/power_permissions.py` drei Ergänzungen:
+
+In `UserPowerPermissionsResponse` nach `can_toggle_desktop`:
+
+```python
+    can_unlock_session: bool = False
+```
+
+In `UserPowerPermissionsUpdate` nach `can_toggle_desktop`:
+
+```python
+    can_unlock_session: Optional[bool] = Field(default=None, description="Allow unlocking the desktop session from the web app")
+```
+
+In `MyPowerPermissionsResponse` nach `can_toggle_desktop`:
+
+```python
+    can_unlock_session: bool = False
+```
+
+- [ ] **Step 6: Generate the migration**
+
+Run: `python -m alembic revision -m "add can_unlock_session permission"`
+
+**Sofort prüfen:** `down_revision` muss `'b661786568c1'` sein. Steht dort etwas anderes, von Hand korrigieren.
+
+`upgrade()`/`downgrade()` ersetzen durch:
+
+```python
+def upgrade() -> None:
+    """Add can_unlock_session to user_power_permissions (defaults to off)."""
+    op.add_column(
+        'user_power_permissions',
+        sa.Column('can_unlock_session', sa.Boolean(), nullable=False, server_default='0'),
+    )
+
+
+def downgrade() -> None:
+    """Drop can_unlock_session."""
+    op.drop_column('user_power_permissions', 'can_unlock_session')
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `python -m pytest tests/services/power/test_unlock_session_permission.py -v --no-cov`
+Expected: PASS (4 passed)
+
+- [ ] **Step 8: Verify the map entry is load-bearing**
+
+Entferne die Zeile `"unlock_session": "can_unlock_session",` testweise, lass die Datei laufen: **drei** Tests müssen rot werden (der Mapping-Test und beide `check_permission`-Tests, die `True` erwarten bzw. das Mapping durchlaufen). Zurücksetzen. Ergebnis berichten.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/models/power_permissions.py app/services/power_permissions.py app/schemas/power_permissions.py alembic/versions tests/services/power/test_unlock_session_permission.py
+git commit -m "feat(power): separate can_unlock_session permission" -m "Keeps can_toggle_desktop a pure power permission instead of silently turning it into a desktop key. The _ACTION_FIELD_MAP entry is load-bearing: check_permission returns False for unknown actions, so forgetting it fails closed and invisibly." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Policy `unlock_if_permitted()` + Audit
+
+**Files:**
+- Modify: `app/services/power/session_lock.py`
+- Test: `tests/services/power/test_session_unlock_policy.py`
+
+**Interfaces:**
+- Consumes: `get_session_lock_backend()` (Task 2), `check_permission(db, user_id, "unlock_session")` (Task 3), `is_private_or_local_ip()` aus `app/core/network_utils.py`.
+- Produces: `async def unlock_if_permitted(*, user, client_host: Optional[str], db) -> Tuple[bool, str]` — die **einzige** Stelle, an der die Gates ausgewertet werden, und die Stelle, die den Audit-Eintrag schreibt.
+
+- [ ] **Step 1: Write the failing test**
+
+Neue Datei `tests/services/power/test_session_unlock_policy.py`:
+
+```python
+"""Both gates for unlocking the desktop session, plus the audit trail."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.models.power_permissions import UserPowerPermission
+from app.services.power import session_lock
+
+LAN = "192.168.178.29"
+VPN = "10.8.0.3"
+PUBLIC = "203.0.113.7"
+
+
+def _admin():
+    return SimpleNamespace(id=1, username="admin", role="admin")
+
+
+def _user(user_id: int):
+    return SimpleNamespace(id=user_id, username="sven", role="user")
+
+
+@pytest.fixture
+def unlock_called():
+    """Replaces the backend so no loginctl is ever invoked."""
+    backend = MagicMock()
+    backend.unlock.return_value = (True, "session 2 unlocked")
+    with patch.object(session_lock, "get_session_lock_backend", return_value=backend):
+        yield backend
+
+
+@pytest.fixture(autouse=True)
+def _silent_audit():
+    with patch.object(session_lock, "get_audit_logger_db") as factory:
+        factory.return_value = MagicMock()
+        yield factory.return_value
+
+
+class TestPermissionGate:
+    async def test_admin_from_lan_unlocks(self, db_session, unlock_called):
+        ok, _detail = await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=LAN, db=db_session
+        )
+
+        assert ok is True
+        unlock_called.unlock.assert_called_once()
+
+    async def test_delegated_user_with_the_permission_unlocks(
+        self, db_session, regular_user, unlock_called
+    ):
+        db_session.add(
+            UserPowerPermission(user_id=regular_user.id, can_unlock_session=True)
+        )
+        db_session.commit()
+
+        ok, _detail = await session_lock.unlock_if_permitted(
+            user=_user(regular_user.id), client_host=LAN, db=db_session
+        )
+
+        assert ok is True
+
+    async def test_user_without_the_permission_is_refused(
+        self, db_session, regular_user, unlock_called
+    ):
+        ok, detail = await session_lock.unlock_if_permitted(
+            user=_user(regular_user.id), client_host=LAN, db=db_session
+        )
+
+        assert ok is False
+        assert "permission" in detail
+        unlock_called.unlock.assert_not_called()
+
+
+class TestNetworkGate:
+    async def test_vpn_is_allowed(self, db_session, unlock_called):
+        ok, _detail = await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=VPN, db=db_session
+        )
+
+        assert ok is True
+
+    async def test_public_address_is_refused_even_for_an_admin(
+        self, db_session, unlock_called
+    ):
+        """The web app is reachable from the open internet via duckdns. This
+        assertion is the one that fails if the IP gate ever breaks - testing
+        only the allowed direction would stay green on a wide-open gate."""
+        ok, detail = await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=PUBLIC, db=db_session
+        )
+
+        assert ok is False
+        assert "network" in detail
+        unlock_called.unlock.assert_not_called()
+
+    async def test_missing_client_host_is_refused(self, db_session, unlock_called):
+        ok, _detail = await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=None, db=db_session
+        )
+
+        assert ok is False
+        unlock_called.unlock.assert_not_called()
+
+
+class TestAuditTrail:
+    async def test_successful_unlock_is_audited(
+        self, db_session, unlock_called, _silent_audit
+    ):
+        await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=LAN, db=db_session
+        )
+
+        _silent_audit.log_event.assert_called_once()
+        kwargs = _silent_audit.log_event.call_args.kwargs
+        assert kwargs["action"] == "desktop_unlock_session"
+        assert kwargs["event_type"] == "POWER"
+
+    async def test_a_refused_unlock_writes_no_audit_noise(
+        self, db_session, unlock_called, _silent_audit
+    ):
+        await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=PUBLIC, db=db_session
+        )
+
+        _silent_audit.log_event.assert_not_called()
+
+    async def test_delegated_user_also_gets_a_security_event(
+        self, db_session, regular_user, unlock_called, _silent_audit
+    ):
+        db_session.add(
+            UserPowerPermission(user_id=regular_user.id, can_unlock_session=True)
+        )
+        db_session.commit()
+
+        await session_lock.unlock_if_permitted(
+            user=_user(regular_user.id), client_host=LAN, db=db_session
+        )
+
+        _silent_audit.log_security_event.assert_called_once()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/services/power/test_session_unlock_policy.py -v --no-cov`
+Expected: FAIL — `AttributeError: module 'app.services.power.session_lock' has no attribute 'unlock_if_permitted'`
+
+- [ ] **Step 3: Add the policy function**
+
+In `app/services/power/session_lock.py` die Importe ergänzen:
+
+```python
+import asyncio
+
+from app.core.network_utils import is_private_or_local_ip
+from app.services.audit.logger_db import get_audit_logger_db
+from app.services.power_permissions import check_permission
+```
+
+und am Dateiende anfügen:
+
+```python
+def _may_unlock(user, db) -> bool:
+    """Admins pass by role, like every other power permission."""
+    if getattr(user, "role", None) == "admin":
+        return True
+    return check_permission(db, user.id, "unlock_session")
+
+
+async def unlock_if_permitted(*, user, client_host: Optional[str], db) -> Tuple[bool, str]:
+    """Unlock the desktop session if BOTH gates allow it.
+
+    This is the only place the gates are evaluated and the only place the audit
+    entry is written - so no caller can unlock without leaving a trace, not
+    even a plugin.
+
+    Args:
+        user: The authenticated caller (needs .id, .username, .role).
+        client_host: The request's client IP, or None.
+        db: SQLAlchemy session.
+
+    Returns:
+        (unlocked, detail). ``unlocked`` describes the state afterwards; on a
+        refused gate loginctl is never called and the real lock state is
+        unknown, so it is False with the reason in ``detail``.
+    """
+    if not _may_unlock(user, db):
+        return False, "permission required: power:unlock_session"
+    if not is_private_or_local_ip(client_host):
+        return False, "not permitted from this network"
+
+    ok, detail = await asyncio.to_thread(get_session_lock_backend().unlock)
+    if not ok:
+        logger.warning("session unlock failed for %s: %s", user.username, detail)
+        return False, detail
+
+    audit_logger = get_audit_logger_db()
+    audit_logger.log_event(
+        event_type="POWER",
+        action="desktop_unlock_session",
+        user=user.username,
+        resource="desktop",
+        success=True,
+        details={"message": detail},
+    )
+    if getattr(user, "role", None) != "admin":
+        audit_logger.log_security_event(
+            action="delegated_power_action",
+            user=user.username,
+            resource="unlock_session",
+            details={"action": "desktop_unlock_session"},
+            success=True,
+        )
+    return True, detail
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/services/power/test_session_unlock_policy.py -v --no-cov`
+Expected: PASS (9 passed)
+
+- [ ] **Step 5: Verify the network gate is discriminating**
+
+Ersetze `is_private_or_local_ip(client_host)` testweise durch `True`, lass die Datei laufen: `test_public_address_is_refused_even_for_an_admin` und `test_missing_client_host_is_refused` **müssen rot werden**. Zurücksetzen. Ergebnis berichten.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/power/session_lock.py tests/services/power/test_session_unlock_policy.py
+git commit -m "feat(power): single policy gate for the session unlock" -m "Permission plus LAN/VPN check plus audit entry in one function, so route and plugin cannot drift apart and no path can unlock without a trace." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Route-Anbindung
+
+**Files:**
+- Modify: `app/api/routes/desktop.py`
+- Test: `tests/api/test_desktop_unlock.py`
+
+**Interfaces:**
+- Consumes: `unlock_if_permitted()` (Task 4).
+- Produces: `POST /api/system/sleep/desktop/enable` liefert zusätzlich `session_unlocked: bool` und `unlock_message: str`.
+
+- [ ] **Step 1: Write the failing test**
+
+Neue Datei `tests/api/test_desktop_unlock.py`:
+
+```python
+"""The enable route unlocks the session - but never fails because of it."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def desktop_enabled():
+    service = MagicMock()
+    service.enable = AsyncMock(return_value=(True, "ok"))
+    with patch("app.api.routes.desktop.get_desktop_service", return_value=service):
+        yield service
+
+
+class TestEnableUnlocksTheSession:
+    def test_response_reports_a_successful_unlock(
+        self, client, admin_headers, desktop_enabled
+    ):
+        with patch(
+            "app.api.routes.desktop.unlock_if_permitted",
+            AsyncMock(return_value=(True, "session 2 unlocked")),
+        ):
+            response = client.post(
+                "/api/system/sleep/desktop/enable", headers=admin_headers
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["success"] is True
+        assert body["session_unlocked"] is True
+
+    def test_a_failed_unlock_does_not_fail_the_enable(
+        self, client, admin_headers, desktop_enabled
+    ):
+        """Turning the displays on is the primary action. If it started failing
+        because a lock screen would not budge, the feature would be a
+        regression rather than a convenience."""
+        with patch(
+            "app.api.routes.desktop.unlock_if_permitted",
+            AsyncMock(return_value=(False, "not permitted from this network")),
+        ):
+            response = client.post(
+                "/api/system/sleep/desktop/enable", headers=admin_headers
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["success"] is True
+        assert body["session_unlocked"] is False
+        assert body["unlock_message"] == "not permitted from this network"
+
+    def test_the_client_ip_is_passed_to_the_gate(
+        self, client, admin_headers, desktop_enabled
+    ):
+        gate = AsyncMock(return_value=(True, "unlocked"))
+        with patch("app.api.routes.desktop.unlock_if_permitted", gate):
+            client.post("/api/system/sleep/desktop/enable", headers=admin_headers)
+
+        assert gate.await_args.kwargs["client_host"] is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/api/test_desktop_unlock.py -v --no-cov`
+Expected: FAIL — `KeyError: 'session_unlocked'` bzw. `AttributeError: … has no attribute 'unlock_if_permitted'`
+
+- [ ] **Step 3: Wire the route**
+
+In `app/api/routes/desktop.py` die Importe ergänzen:
+
+```python
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.services.power.session_lock import unlock_if_permitted
+```
+
+`desktop_enable` bekommt eine DB-Session und den Unlock-Versuch:
+
+```python
+@router.post("/enable")
+@user_limiter.limit(get_limit("admin_operations"))
+async def desktop_enable(
+    request: Request,
+    response: Response,
+    current_user=Depends(require_power_toggle_desktop),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Turn the desktop displays back on (DPMS) and unlock the session.
+
+    Admin or a delegated user with the can_toggle_desktop permission. The
+    unlock is an ADD-ON: it needs its own permission plus a request from
+    LAN/VPN, and failing it never fails the call - the displays are on either
+    way.
+    """
+    ok, message = await get_desktop_service().enable()
+```
+
+Der bestehende Audit- und Notification-Block bleibt unverändert. Vor dem `return` einfügen und das `return` ersetzen:
+
+```python
+    session_unlocked, unlock_message = await unlock_if_permitted(
+        user=current_user,
+        client_host=request.client.host if request.client else None,
+        db=db,
+    )
+    return {
+        "success": ok,
+        "message": message,
+        "session_unlocked": session_unlocked,
+        "unlock_message": unlock_message,
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/api/test_desktop_unlock.py -v --no-cov`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Check for regressions in the existing desktop tests**
+
+Run: `python -m pytest tests/ -k desktop -v --no-cov`
+Expected: PASS — bestehende Tests der Enable/Disable-Routen bleiben grün (die zwei neuen Felder sind additiv)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/api/routes/desktop.py tests/api/test_desktop_unlock.py
+git commit -m "feat(desktop): enable route unlocks the session when allowed" -m "The unlock is additive: a refused or failed unlock still returns success=true with the displays on." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Extension-Point + Gaming-Modus
+
+**Files:**
+- Modify: `app/plugins/base.py`
+- Modify: `app/api/routes/plugins.py`
+- Modify: `app/plugins/installed/steam_gaming/__init__.py`
+- Test: `tests/plugins/test_steam_gaming_plugin.py` (anhängen)
+
+**Interfaces:**
+- Consumes: `unlock_if_permitted()` (Task 4).
+- Produces: `run_menu_action(self, action_id, db, *, user=None, client_host=None)`.
+
+- [ ] **Step 1: Write the failing test**
+
+An `tests/plugins/test_steam_gaming_plugin.py` anhängen:
+
+```python
+class TestGamingModeUnlocksTheSession:
+    """Big Picture on a lock screen helps nobody - the gaming mode runs the
+    same gates as the enable route, between displays-on and Big Picture."""
+
+    async def test_unlock_runs_between_displays_and_big_picture(self):
+        order: list[str] = []
+
+        desktop_patch, service = _patch_desktop(True, "ok")
+        service.enable = AsyncMock(side_effect=lambda: order.append("displays") or (True, "ok"))
+
+        async def _unlock(**_kwargs):
+            order.append("unlock")
+            return True, "session 2 unlocked"
+
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.unlock_if_permitted", _unlock
+        ), patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            side_effect=lambda: order.append("bigpicture") or (True, "requested"),
+        ):
+            result = await SteamGamingPlugin().run_menu_action(
+                _ACTION, db=None, user=MagicMock(role="admin"), client_host="192.168.178.29"
+            )
+
+        assert result.ok is True
+        assert order == ["displays", "unlock", "bigpicture"]
+
+    async def test_a_failed_unlock_does_not_stop_big_picture(self):
+        desktop_patch, _service = _patch_desktop(True, "ok")
+
+        async def _unlock(**_kwargs):
+            return False, "not permitted from this network"
+
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.unlock_if_permitted", _unlock
+        ), patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            return_value=(True, "requested"),
+        ) as launcher:
+            result = await SteamGamingPlugin().run_menu_action(
+                _ACTION, db=None, user=MagicMock(role="admin"), client_host="203.0.113.7"
+            )
+
+        launcher.assert_called_once()
+        assert result.ok is True
+
+    async def test_without_a_user_no_unlock_is_attempted(self):
+        """Older callers pass neither user nor client_host - the action must
+        still work, just without unlocking."""
+        desktop_patch, _service = _patch_desktop(True, "ok")
+        gate = AsyncMock(return_value=(True, "unlocked"))
+
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.unlock_if_permitted", gate
+        ), patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            return_value=(True, "requested"),
+        ):
+            result = await SteamGamingPlugin().run_menu_action(_ACTION, db=None)
+
+        gate.assert_not_awaited()
+        assert result.ok is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_plugin.py -k GamingModeUnlocks -v --no-cov`
+Expected: FAIL — `TypeError: run_menu_action() got an unexpected keyword argument 'user'`
+
+- [ ] **Step 3: Extend the extension point**
+
+In `app/plugins/base.py` die Signatur von `run_menu_action` ersetzen:
+
+```python
+    async def run_menu_action(
+        self,
+        action_id: str,
+        db: "Session",
+        *,
+        user: Optional[Any] = None,
+        client_host: Optional[str] = None,
+    ) -> Optional["MenuActionResult"]:
+        """Execute a menu action this plugin declared.
+
+        ``user`` and ``client_host`` describe the CALLER, so an action can ask
+        the core for a privileged side effect under the core's own rules (see
+        services/power/session_lock.unlock_if_permitted). Both are keyword-only
+        with defaults: an older implementation keeps working, it just cannot
+        request anything caller-dependent.
+        """
+        return None
+```
+
+- [ ] **Step 4: Pass the context through**
+
+In `app/api/routes/plugins.py` den Aufruf ersetzen:
+
+```python
+        result = await asyncio.wait_for(
+            plugin.run_menu_action(
+                action_id,
+                db,
+                user=current_user,
+                client_host=request.client.host if request.client else None,
+            ),
+            timeout=PLUGIN_MENU_ACTION_TIMEOUT_SECONDS,
+        )
+```
+
+- [ ] **Step 5: Unlock in the gaming mode**
+
+In `app/plugins/installed/steam_gaming/__init__.py` den Import ergänzen:
+
+```python
+from app.services.power.session_lock import unlock_if_permitted
+```
+
+und `run_menu_action` anpassen — Signatur und der neue Block zwischen Displays und Big Picture:
+
+```python
+    async def run_menu_action(
+        self,
+        action_id: str,
+        db: Session,
+        *,
+        user=None,
+        client_host: Optional[str] = None,
+    ) -> Optional[MenuActionResult]:
+        if action_id != _MENU_ACTION_ID:
+            return None
+
+        # Displays first: opening Big Picture onto dark screens helps nobody.
+        # LinuxDesktopBackend.enable() runs kscreen-doctor in a thread, so the
+        # core's wait_for stays effective.
+        ok, detail = await get_desktop_service().enable()
+        if not ok:
+            # The user only ever sees the translated key, so without this line
+            # the reason kscreen-doctor refused is lost for good.
+            logger.warning("gaming mode: turning the displays on failed: %s", detail)
+            return MenuActionResult(
+                ok=False,
+                message_key="menu_displays_failed",
+                message_text=f"Displays could not be turned on: {detail}",
+            )
+
+        # Then the lock screen - Big Picture behind it would be just as useless
+        # as behind a dark monitor. Same gates as the enable route; a refusal
+        # is not a failure of the action.
+        if user is not None:
+            unlocked, unlock_detail = await unlock_if_permitted(
+                user=user, client_host=client_host, db=db
+            )
+            if not unlocked:
+                logger.info("gaming mode: session not unlocked: %s", unlock_detail)
+
+        launched, detail = await asyncio.to_thread(open_big_picture)
+```
+
+Der Rest der Methode bleibt unverändert.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `python -m pytest tests/plugins/test_steam_gaming_plugin.py -v --no-cov`
+Expected: PASS — die drei neuen Tests plus alle bestehenden
+
+- [ ] **Step 7: Check the whole plugin suite**
+
+Run: `python -m pytest tests/plugins/ -v --no-cov`
+Expected: PASS — insbesondere `test_plugin_menu_actions.py` (der Dispatch-Aufruf hat sich geändert)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/plugins/base.py app/api/routes/plugins.py app/plugins/installed/steam_gaming/__init__.py tests/plugins/test_steam_gaming_plugin.py
+git commit -m "feat(plugins): menu actions learn who called them, gaming mode unlocks" -m "run_menu_action gets keyword-only user and client_host so an action can ask the core for a privileged side effect under the core's rules, instead of relying on the implicit contract that the route already checked admin." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Frontend
+
+**Files:**
+- Modify: `client/src/api/powerPermissions.ts`
+- Modify: `client/src/api/desktop.ts`
+- Modify: `client/src/components/user-management/PowerPermissionsSection.tsx`
+- Modify: `client/src/components/PowerMenu.tsx`
+- Modify: `client/src/i18n/locales/de/admin.json`, `client/src/i18n/locales/en/admin.json`
+- Modify: `client/src/i18n/locales/de/common.json`, `client/src/i18n/locales/en/common.json`
+- Test: `client/src/__tests__/components/PowerMenu.test.tsx` (anhängen)
+
+**Interfaces:**
+- Consumes: die zwei Antwortfelder aus Task 5, das Recht aus Task 3.
+
+- [ ] **Step 1: Write the failing test**
+
+An `client/src/__tests__/components/PowerMenu.test.tsx` anhängen (innerhalb der bestehenden Desktop-Beschreibung, am Dateiende als eigener Block):
+
+```tsx
+describe('PowerMenu session unlock hint', () => {
+  it('shows an extra hint when the session could not be unlocked', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'stopped',
+    });
+    (enableDesktop as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      message: 'ok',
+      session_unlocked: false,
+      unlock_message: 'not permitted from this network',
+    });
+
+    render(<PowerMenu {...baseProps} />);
+    const button = await screen.findByText('Enable desktop');
+    fireEvent.click(button);
+
+    await waitFor(() => expect(enableDesktop).toHaveBeenCalledTimes(1));
+    // The raw English debug string must never reach the user (#406).
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/not permitted from this network/i),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it('shows no hint when the session was unlocked', async () => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'stopped',
+    });
+    (enableDesktop as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      message: 'ok',
+      session_unlocked: true,
+      unlock_message: 'session 2 unlocked',
+    });
+
+    render(<PowerMenu {...baseProps} />);
+    fireEvent.click(await screen.findByText('Enable desktop'));
+
+    await waitFor(() => expect(enableDesktop).toHaveBeenCalledTimes(1));
+  });
+});
+```
+
+**Hinweis:** Die Datei hat **keinen** Render-Helfer — die bestehenden Tests rufen `render(<PowerMenu {...baseProps} />)` mit dem oben in der Datei definierten `baseProps`-Objekt. Genau dieses Muster verwenden; `render`, `screen`, `fireEvent` und `waitFor` sind dort bereits importiert.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (aus `client/`): `npx vitest run src/__tests__/components/PowerMenu.test.tsx`
+Expected: FAIL — TypeScript kennt `session_unlocked` auf `DesktopActionResult` nicht
+
+- [ ] **Step 3: Extend the API types**
+
+In `client/src/api/desktop.ts` das Interface `DesktopActionResult` ersetzen — es hat heute genau zwei Felder, die beiden neuen sind optional, weil ein älteres Backend sie nicht sendet:
+
+```ts
+export interface DesktopActionResult {
+  success: boolean;
+  message: string;
+  session_unlocked?: boolean;
+  unlock_message?: string;
+}
+```
+
+In `client/src/api/powerPermissions.ts` in **allen drei** Interfaces nach `can_toggle_desktop` ergänzen:
+
+```ts
+  can_unlock_session: boolean;
+```
+
+bzw. in `UserPowerPermissionsUpdate`:
+
+```ts
+  can_unlock_session?: boolean;
+```
+
+- [ ] **Step 4: Add the permission toggle**
+
+In `client/src/components/user-management/PowerPermissionsSection.tsx`:
+
+`FIELD_TO_I18N` erweitern:
+
+```tsx
+  can_toggle_desktop: 'toggleDesktop',
+  can_unlock_session: 'unlockSession',
+```
+
+`PERMISSION_TOGGLES` erweitern (Import `LockOpen` aus `lucide-react` zu den bestehenden Icon-Importen ergänzen):
+
+```tsx
+  { key: 'can_toggle_desktop', icon: <MonitorOff className="h-4 w-4" /> },
+  { key: 'can_unlock_session', icon: <LockOpen className="h-4 w-4" /> },
+```
+
+- [ ] **Step 5: Add the i18n entries**
+
+In `client/src/i18n/locales/de/admin.json` unter `users.systemPermissions.items` nach `toggleDesktop`:
+
+```json
+      "unlockSession": {
+        "label": "Session entsperren",
+        "desc": "Beim Einschalten der Displays die Desktop-Sitzung mit entsperren (nur aus dem Heimnetz oder VPN)"
+      }
+```
+
+In `client/src/i18n/locales/en/admin.json` an derselben Stelle:
+
+```json
+      "unlockSession": {
+        "label": "Unlock session",
+        "desc": "Also unlock the desktop session when turning the displays on (home network or VPN only)"
+      }
+```
+
+In `client/src/i18n/locales/de/common.json` unter `powerMenu` nach `desktopEnabled`:
+
+```json
+    "desktopStillLocked": "Displays an - die Sitzung ist weiterhin gesperrt",
+```
+
+In `client/src/i18n/locales/en/common.json` an derselben Stelle:
+
+```json
+    "desktopStillLocked": "Displays on - the session is still locked",
+```
+
+- [ ] **Step 6: Show the hint**
+
+In `client/src/components/PowerMenu.tsx` in `handleEnableDesktop` nach dem Erfolgs-Toast ergänzen:
+
+```tsx
+      if (result.success) {
+        toast.success(t('powerMenu.desktopEnabled', 'Desktop enabled'));
+        // unlock_message is an English debug string and stays out of the UI (#406).
+        if (result.session_unlocked === false) {
+          toast(t('powerMenu.desktopStillLocked', 'Displays on - the session is still locked'));
+        }
+      } else {
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run (aus `client/`): `npx vitest run src/__tests__/components/PowerMenu.test.tsx`
+Expected: PASS
+
+- [ ] **Step 8: Run the frontend gates**
+
+Run (aus `client/`): `npx eslint .`
+Expected: keine Fehler
+
+Run (aus `client/`): `npm run build`
+Expected: erfolgreich (`tsc -b` über App-, Node- und Test-Projekte)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add client/src
+git commit -m "feat(ui): unlock-session permission toggle and a translated lock hint" -m "The backend's unlock_message stays a debug string; the menu shows a translated generic hint instead." -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Doku, Gates, Migrations-Handprobe
+
+**Files:**
+- Modify: `.claude/rules/security-agent.md`
+- Modify: `backend/app/plugins/CLAUDE.md`
+
+- [ ] **Step 1: Document the new permission**
+
+In `.claude/rules/security-agent.md` im Abschnitt „Role Model" nach der `is_privileged`-Zeile ergänzen:
+
+```markdown
+- `can_unlock_session` (power permission) entsperrt die grafische Desktop-Session
+  beim Einschalten der Displays. Doppelt gegated: Recht **und**
+  `is_private_or_local_ip(request.client.host)` — die Web-App ist von außen
+  erreichbar, und ein gestohlenes Web-Konto darf keinen physischen Desktop
+  öffnen. Durchgesetzt ausschließlich in
+  `services/power/session_lock.unlock_if_permitted()`, die auch den
+  Audit-Eintrag schreibt.
+```
+
+- [ ] **Step 2: Document the extension-point change**
+
+In `backend/app/plugins/CLAUDE.md` bei Punkt 7 (Menü-Contribution) ergänzen:
+
+```markdown
+   `run_menu_action()` bekommt zusätzlich `user` und `client_host` (keyword-only,
+   Default `None`) — den authentifizierten Aufrufer und dessen IP. Damit kann
+   eine Aktion einen privilegierten Seiteneffekt beim Core anfragen, der ihn
+   nach **seinen** Regeln prüft (siehe
+   `services/power/session_lock.unlock_if_permitted()`), statt sich auf den
+   impliziten Vertrag „die Route hat Admin schon geprüft" zu verlassen.
+```
+
+- [ ] **Step 3: Run the backend gates**
+
+Run (aus `backend/`): `python -m pytest tests/ -q --no-cov -k "power or desktop or plugin"`
+Expected: PASS — tatsächliche Zahlen im Report festhalten
+
+Run (aus `backend/`): `python -m ruff check .`
+Expected: `All checks passed!`
+
+**Hinweis:** `tests/auth/test_permissions.py::test_owner_can_delete_own_file` und `::test_admin_can_delete_any_file` sind bekannt flaky im großen Sammellauf (Windows-Isolation) und standalone grün. Falls sie auftauchen: standalone gegenprüfen, nicht reparieren.
+
+- [ ] **Step 4: Migration isolation probe (SQLite)**
+
+**Bash-Tool verwenden** — PowerShell kennt das `VAR=x cmd`-Präfix nicht.
+
+```bash
+DATABASE_URL="sqlite:///./migration_check.db" python -c "
+from sqlalchemy import create_engine
+from alembic.config import Config
+from alembic import command
+from app.models.base import Base
+import app.models  # noqa: F401
+
+engine = create_engine('sqlite:///./migration_check.db')
+Base.metadata.drop_all(bind=engine)
+Base.metadata.create_all(bind=engine)
+engine.dispose()
+import sqlite3
+con = sqlite3.connect('migration_check.db')
+con.execute('ALTER TABLE user_power_permissions DROP COLUMN can_unlock_session')
+con.commit(); con.close()
+command.stamp(Config('alembic.ini'), 'b661786568c1')
+"
+```
+
+Run: `DATABASE_URL="sqlite:///./migration_check.db" python -m alembic upgrade head`
+Expected: `Running upgrade b661786568c1 -> <rev>, add can_unlock_session permission`
+
+Run: `DATABASE_URL="sqlite:///./migration_check.db" python -m alembic downgrade -1`
+Expected: sauberes `Running downgrade`
+
+Run: `python -c "import os; os.remove('migration_check.db')"`
+Expected: kein Output
+
+- [ ] **Step 5: Migration probe against PostgreSQL**
+
+Docker Desktop muss laufen. **Bash-Tool.**
+
+```bash
+docker run -d --name balu-pgprobe -e POSTGRES_PASSWORD=probe -e POSTGRES_DB=baluprobe -p 55432:5432 postgres:17
+```
+
+Dann dasselbe Schema-Stampen wie in Step 4, aber mit
+`DATABASE_URL="postgresql://postgres:probe@127.0.0.1:55432/baluprobe"` und
+`ALTER TABLE user_power_permissions DROP COLUMN can_unlock_session` über psql:
+
+```bash
+docker exec balu-pgprobe psql -U postgres -d baluprobe -c "ALTER TABLE user_power_permissions DROP COLUMN can_unlock_session;"
+```
+
+Danach `upgrade head`, `\d user_power_permissions` prüfen (Spalte `boolean not null default false`), `downgrade -1`, und aufräumen:
+
+```bash
+docker rm -f balu-pgprobe
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude/rules/security-agent.md backend/app/plugins/CLAUDE.md
+git commit -m "docs: document the unlock-session permission and the menu-action context" -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 7: Manueller Abschluss durch Xveyn (nicht dispatchen)**
+
+Zwei Nachweise, die nur am Gerät zu führen sind und deshalb in die PR-Beschreibung gehören:
+
+1. **Sperrbildschirm verschwindet wirklich.** Session sperren, dann in der Web-App „Displays an" — der Monitor muss ohne Passworteingabe nutzbar sein. `LockedHint` allein ist loginds Sicht, nicht die des Bildschirms.
+2. **Das Ortsgate greift.** Dieselbe Aktion einmal über `baluhost.duckdns.org` von außerhalb (ohne VPN): Displays gehen an, die Sitzung bleibt gesperrt, und die UI zeigt den übersetzten Hinweis statt des englischen Debug-Strings.
+
+---
+
+## Abnahme
+
+| Spec-Anforderung | Task |
+|---|---|
+| Messung des Dienst-Kontexts vor jedem Code | 1 |
+| `loginctl`-Mechanismus, Session-Ermittlung mit Fallback | 2 |
+| `LockedHint`-Polling statt Einzelread | 2 |
+| Dev-Backend ohne `loginctl` | 2 |
+| Recht `can_unlock_session` + Migration | 3 |
+| `_ACTION_FIELD_MAP`-Eintrag (stille Falle) | 3 |
+| Beide Gates in genau einer Funktion | 4 |
+| Audit-Eintrag nur im Erfolgsfall, geschrieben von der Policy | 4 |
+| Öffentliche IP wird abgelehnt (nicht nur private akzeptiert) | 4 |
+| Enable bleibt erfolgreich bei fehlgeschlagenem Unlock | 5 |
+| Antwortfelder `session_unlocked` / `unlock_message` | 5 |
+| Extension-Point mit `user` + `client_host` | 6 |
+| Gaming-Modus: Displays → Unlock → Big Picture | 6 |
+| `unlock_message` nie in der UI | 7 |
+| Checkbox + i18n de/en | 7 |
+| Doku + Gates + Migrations-Handproben | 8 |
+
+**Bewusst nicht im Plan** (Nicht-Ziele der Spec): Step-up-Auth vor dem Entsperren, Abschalten des KDE-Locks, ein „Session sperren"-Knopf, eine eigene Notification.

--- a/docs/superpowers/specs/2026-07-24-session-unlock-on-desktop-enable-design.md
+++ b/docs/superpowers/specs/2026-07-24-session-unlock-on-desktop-enable-design.md
@@ -1,0 +1,276 @@
+# KDE-Session entsperren beim Displays-Einschalten — Design
+
+**Datum:** 2026-07-24
+**Status:** entworfen, abgenommen
+
+## Ziel
+
+Wer die Displays über die Web-App einschaltet, hat sich dort bereits mit Passwort
+(und je nach Konto mit 2FA) authentifiziert. Trotzdem steht danach der
+KDE-Sperrbildschirm im Weg und verlangt dieselbe Person ein zweites Mal nach
+einem Passwort. Dieses Design lässt `POST /system/sleep/desktop/enable` die
+grafische Session mit entsperren — unter zwei Bedingungen, die beide erfüllt
+sein müssen.
+
+## Ausgangslage (gemessen, nicht angenommen)
+
+### Was heute passiert
+
+`desktop_enable` (`api/routes/desktop.py`) ruft `kscreen-doctor --dpms on` als
+User `sven` auf. Das ist **reine Display-Ansteuerung**. Der KDE-Sessionlock ist
+eine davon unabhängige Schicht, die BaluHost nirgends berührt: eine Suche über
+`backend/app` nach `loginctl`, `kscreenlocker`, `ScreenSaver`, `unlock-session`
+oder `lock-session` liefert keinen einzigen funktionalen Treffer.
+
+### Warum überhaupt gesperrt wird
+
+Auf BaluNode existiert **keine** `~/.config/kscreenlockerrc`
+(`cat` → „Datei oder Verzeichnis nicht gefunden“; `kreadconfig6` und
+`kreadconfig5` sind beide unter `/usr/bin` vorhanden, das leere Ergebnis kam
+also nicht von einem fehlenden Binary). Damit greifen die KDE-Vorgaben:
+Auto-Lock **an**, Timeout **5 Minuten**, Sperren nach dem Aufwachen **an**. Das
+sind die beiden Auslöser.
+
+### Der Mechanismus funktioniert ohne root
+
+Auf der Box gemessen, Session 2 ist die grafische (`seat0`, `tty2`, Klasse
+`user`; Session 27 war die SSH-Verbindung, 3 der User-Manager, 1 der CI-Runner):
+
+```
+$ loginctl lock-session 2
+$ loginctl show-session 2 -p LockedHint
+LockedHint=yes
+$ loginctl unlock-session 2
+$ loginctl show-session 2 -p LockedHint
+LockedHint=no
+```
+
+**Ohne `sudo`, ohne polkit-Rückfrage.** Der Grund: `systemd-logind` sendet ein
+`Unlock`-Signal an die Session, und kscreenlocker befolgt es — derselbe Weg, über
+den Fingerabdrucksensoren und Smartcards entsperren. Und das Backend läuft
+bereits als genau der User, dem die Session gehört (`sven`, UID 1000 — in
+Teilprojekt 1 des Steam-Tracks nachgemessen, dort steht auch, dass es keinen
+`baluhost`-User auf der Box gibt).
+
+Daraus folgt: **keine sudoers-Regel, kein Wrapper, kein Privilegienzuwachs auf
+Systemebene.** Das ist der Grund, warum dieses Feature überhaupt vertretbar ist.
+
+### Bestehendes Rechtemodell
+
+`UserPowerPermission` (`models/power_permissions.py`) hat eine Boolean-Spalte je
+Aktion (`can_soft_sleep`, `can_wake`, `can_suspend`, `can_wol`,
+`can_toggle_desktop`). `_make_power_dependency(action)` in `api/deps.py` lässt
+**Admins per Rolle durch** und prüft für alle anderen
+`check_permission(db, user.id, action)`.
+
+`run_plugin_menu_action` (`api/routes/plugins.py`) hängt an `get_current_admin` —
+Plugin-Menüaktionen sind ohnehin admin-only.
+
+## Entscheidungen (im Brainstorming getroffen)
+
+- **Auslöser: der bestehende Enable-Knopf entsperrt mit**, nicht ein zweiter
+  Knopf. Dafür bekommt das Entsperren aber ein **eigenes, separat vergebenes
+  Recht** — `can_toggle_desktop` bleibt eine reine Strom-Berechtigung und wächst
+  nicht heimlich zum Desktop-Schlüssel.
+- **Exposition: nur LAN und VPN.** Über `baluhost.duckdns.org` aus dem offenen
+  Netz wird nicht entsperrt.
+- **Der Gaming-Modus (Teilprojekt 2) entsperrt nach denselben Regeln.** Er
+  schaltet dieselben Displays ein und liefe sonst genauso gegen den
+  Sperrbildschirm — mit dem Unterschied, dass niemand erklären könnte, warum der
+  eine Knopf funktioniert und der andere nicht.
+- **Admins dürfen automatisch**, wie bei allen anderen Power-Rechten. Das neue
+  Recht steuert ausschließlich delegierte Nutzer.
+
+## Nicht-Ziele
+
+- **Keine erneute Passwort- oder 2FA-Abfrage** vor dem Entsperren. Der
+  Ausgangspunkt war „ich habe mich doch schon angemeldet"; eine Step-up-Abfrage
+  würde genau das aufheben. Preis, ausgesprochen: ein gestohlenes Token aus dem
+  `localStorage` reicht innerhalb seiner 15 Minuten, sofern der Dieb im LAN oder
+  VPN ist.
+- **Kein Abschalten des KDE-Locks.** Die codefreie Alternative (Auto-Lock und
+  `LockOnResume` per `kwriteconfig6` aus) wurde erwogen und verworfen: sie
+  entfernt den Schutz gegen physischen Zugriff vollständig.
+- **Kein Sperren aus der Web-App.** Nur Entsperren. Ein „Session sperren"-Knopf
+  wäre trivial nachzurüsten, wird aber nicht gebraucht.
+- **Keine eigene Notification.** Das Entsperren begleitet immer ein „Displays
+  an", das bereits eine auslöst.
+
+## Architektur
+
+```
+backend/app/services/power/session_lock.py          NEU  ~130 Z.
+backend/app/models/power_permissions.py             ÄND  + can_unlock_session
+backend/alembic/versions/<rev>_…                    NEU  Spalte, server_default "0"
+backend/app/services/power_permissions.py           ÄND  _ACTION_FIELD_MAP-Eintrag
+backend/app/schemas/power_permissions.py            ÄND  Feld in Response + Update
+backend/app/api/routes/desktop.py                   ÄND  enable() versucht Unlock
+backend/app/plugins/base.py                         ÄND  run_menu_action-Kontext
+backend/app/api/routes/plugins.py                   ÄND  reicht user + client_host durch
+backend/app/plugins/installed/steam_gaming/__init__.py  ÄND  Gaming-Modus entsperrt
+client/src/… (Power-Permissions-UI)                 ÄND  Checkbox für das neue Recht
+```
+
+### Trennung von Mechanismus und Policy
+
+`session_lock.py` enthält beides, aber sauber getrennt:
+
+- **Mechanismus** — `SessionLockBackend` (Protocol) mit `DevSessionLockBackend`
+  (In-Memory, für Windows/Dev) und `LinuxSessionLockBackend` (`loginctl`).
+  Spiegelt exakt das Muster von `desktop_backend.py`.
+- **Policy** — die Modulfunktion `unlock_if_permitted(user, client_host, db)`.
+  Sie ist die **einzige** Stelle, an der die beiden Gates ausgewertet werden.
+
+Route und Plugin rufen dieselbe Funktion. Es gibt keine zweite Stelle, an der
+jemand die Regeln nachbaut oder eine davon vergisst.
+
+### Die zwei Gates
+
+| Gate | Prüfung |
+|---|---|
+| Recht | `user.role == "admin"` **oder** `check_permission(db, user.id, "unlock_session")` |
+| Ort | `is_private_or_local_ip(request.client.host)` (`core/network_utils.py`) |
+
+**Achtung, stille Falle:** `check_permission()` schlägt die Aktion in
+`_ACTION_FIELD_MAP` nach und gibt für einen unbekannten Schlüssel schlicht
+`False` zurück (`services/power_permissions.py`). Wer nur die DB-Spalte und das
+Schema ergänzt, aber den Map-Eintrag `"unlock_session" → "can_unlock_session"`
+vergisst, bekommt kein Fehlerbild, sondern ein Feature, das für delegierte
+Nutzer dauerhaft und begründungslos nicht funktioniert — fail-closed, aber
+unsichtbar. Der Map-Eintrag gehört zum Pflichtumfang und braucht einen eigenen
+Test.
+
+Beide müssen zutreffen. Der Ortsfilter nutzt bewusst die **Client-IP**, nicht
+`request.state.channel`: der Channel ist in Produktion hartverdrahtet `remote`
+(er markiert den UDS-Pfad der Tauri-App) und würde jeden Browser aussperren —
+eine Falle, die im Repo bereits einmal zugeschlagen hat. WireGuard-Clients haben
+private Adressen und gelten damit als erlaubt; das ist beabsichtigt, denn wer im
+VPN ist, hat sich bereits mit einem Schlüssel ausgewiesen.
+
+### Session-Ermittlung
+
+Die Session-ID ist nicht stabil (die gemessene `2` gilt bis zum nächsten
+Neustart), sie wird also zur Laufzeit ermittelt:
+
+1. **Primär:** `loginctl show-user <uid> -p Display --value` — liefert die
+   grafische Session des Nutzers.
+2. **Fallback:** `loginctl list-sessions` und die erste Session dieses Nutzers
+   mit Seat und Klasse `user`.
+
+Beide Wege werden bei der Umsetzung gegen die Box gemessen. Dass
+`unlock-session` funktioniert, ist belegt; **wie man die ID zuverlässig findet,
+ist es noch nicht** — das ist die einzige offene Messfrage dieses Designs.
+
+### Der Extension-Point
+
+```python
+async def run_menu_action(
+    self, action_id: str, db: Session, *,
+    user: Optional[UserPublic] = None,
+    client_host: Optional[str] = None,
+) -> Optional[MenuActionResult]:
+```
+
+Keyword-only mit Defaults, damit kein Implementierer bricht; `steam_gaming` ist
+der einzige im Repo. Es werden **beide** Werte durchgereicht, nicht nur der Ort:
+so ruft das Plugin dieselbe `unlock_if_permitted()` wie die Route, statt sich auf
+den impliziten Vertrag „der Core hat Admin schon geprüft" zu verlassen. Solche
+Verträge reißen beim nächsten Umbau, und zwar lautlos.
+
+### Kein neues Route-Gate
+
+Das Recht wird **innerhalb** der Enable-Route geprüft, nicht als `Depends`. Ein
+fehlendes Recht darf den Aufruf nicht mit 403 abweisen: Displays einschalten
+muss weiterhin für jeden funktionieren, der es heute darf. Deshalb entsteht auch
+keine `require_power_unlock_session`-Dependency.
+
+### Antwortformat
+
+```json
+{
+  "success": true,
+  "message": "ok",
+  "session_unlocked": false,
+  "unlock_message": "not permitted from this network"
+}
+```
+
+`session_unlocked` beschreibt den **Zustand danach**, nicht ob etwas verändert
+wurde: eine ohnehin unversperrte Session meldet `true`.
+
+## Fehlerbehandlung
+
+**Grundregel: das Entsperren darf den Enable-Aufruf nie kippen.**
+
+| Fall | Verhalten |
+|---|---|
+| Keine grafische Session gefunden | `session_unlocked=false` mit Begründung, Displays trotzdem an |
+| Session war nicht gesperrt | `true` (Zustand danach) |
+| Recht fehlt oder falsches Netz | `false` mit Begründung, kein 403, kein Audit-Eintrag |
+| `loginctl` fehlt / Timeout | `false`, Warnung ins Log |
+| kscreenlocker befolgt das Signal nicht | wird erkannt, siehe unten |
+
+**Nachlesen statt vertrauen:** `loginctl unlock-session` liefert Exit 0, sobald
+das Signal *abgesetzt* ist — ob der Locker es befolgt hat, steht auf einem
+anderen Blatt. Deshalb wird nach dem Unlock `LockedHint` zurückgelesen und nur
+bei `no` ein Erfolg gemeldet. Ohne diesen Schritt würde die API „entsperrt"
+behaupten, während der Bildschirm gesperrt bleibt — eine Lüge, die man erst
+bemerkt, wenn man vor dem Rechner steht.
+
+## Sicherheit
+
+- Kein sudo, keine sudoers-Änderung, kein neuer Rootpfad. Das Backend nutzt
+  ausschließlich, was sein eigener User ohnehin darf.
+- `loginctl` wird mit Argumentliste aufgerufen, nie als Zeichenkette. Die
+  Session-ID stammt aus `loginctl` selbst und nie aus einer Benutzereingabe.
+- **`unlock_if_permitted()` schreibt den Audit-Eintrag selbst**, nicht der
+  Aufrufer. Damit kann kein Pfad protokolllos entsperren — auch der Gaming-Modus
+  nicht. Erfolgreiche Unlocks werden als POWER-Event `desktop_unlock_session`
+  geloggt, für delegierte Nutzer zusätzlich als `delegated_power_action`, analog
+  zu den bestehenden Power-Routen. (#455 — dass der Gaming-Modus für den
+  Display-Toggle generell kein POWER-Event schreibt — bleibt davon unberührt und
+  offen.)
+
+**Ausgesprochene Konsequenz:** Weil Admins die Power-Rechte per Rolle
+durchlaufen, ist das Feature ab dem Deploy sofort scharf; es gibt keinen
+Schalter, der erst umgelegt wird. Der Ortsfilter ist damit der einzige Riegel,
+der ein übernommenes Admin-Konto aufhält. Aus dem offenen Netz geht nichts, aus
+dem LAN und aus dem VPN schon.
+
+## Tests
+
+**`session_lock`** gegen einen injizierten Kommando-Runner (kein echtes
+`loginctl`):
+
+- Session-Ermittlung über den primären Weg;
+- Fallback greift, wenn `Display` leer ist;
+- keine Session vorhanden → sauberes `false` statt Absturz;
+- Unlock erfolgreich (`LockedHint=no` danach);
+- Unlock mit Exit ≠ 0;
+- **`LockedHint` bleibt `yes` → es wird `false` gemeldet** (der Test, der die
+  Nachlese-Regel festnagelt);
+- Dev-Backend meldet Erfolg ohne `loginctl`.
+
+**Policy-Matrix** für `unlock_if_permitted()`: Admin × LAN → entsperrt; Admin ×
+extern → nein; delegiert mit Recht × LAN → ja; delegiert ohne Recht × LAN →
+nein; Audit-Eintrag genau im Erfolgsfall.
+
+**Route:** ein fehlgeschlagener Unlock lässt `enable` weiterhin `success=true`
+liefern — der Test, der die Grundregel festnagelt. Dazu die beiden neuen
+Antwortfelder.
+
+**Gaming-Modus:** reicht `user` und `client_host` durch und entsperrt unter
+denselben Regeln.
+
+**Migration:** `upgrade`/`downgrade` isoliert gegen SQLite **und** PostgreSQL
+prüfen. Die Kette läuft nicht von null durch (#471), also wird das Schema
+gestampt und nur das Delta gefahren — wie bei der `steam_sessions`-Migration.
+
+## Offene Punkte
+
+- Die **Session-Ermittlung** ist der einzige ungemessene Teil (siehe oben). Sie
+  wird als erste Aufgabe des Implementierungsplans gegen die Box geprüft.
+- Eine visuelle Bestätigung, dass der Sperrbildschirm bei `unlock-session`
+  tatsächlich verschwindet, steht noch aus. `LockedHint` sprang auf `no`, was
+  stark dafür spricht — dieser Wert wird von kscreenlocker selbst gesetzt —,
+  aber gesehen hat es noch niemand.

--- a/docs/superpowers/specs/2026-07-24-session-unlock-on-desktop-enable-design.md
+++ b/docs/superpowers/specs/2026-07-24-session-unlock-on-desktop-enable-design.md
@@ -269,6 +269,15 @@ Vorgabe: **Polling auf `LockedHint`, 200-ms-Schritte, Abbruch bei `no`,
 Obergrenze 3 s.** Erst nach Ablauf der Obergrenze gilt der Unlock als
 fehlgeschlagen.
 
+**Gesamtschranke, nicht nur Polling-Schranke.** Die 3 s oben begrenzen das
+Nachlesen; hinzu kommt das Kommando-Timeout, und zwar **je Aufruf**. Ein Unlock
+fährt bis zu vier: `show-user`, ggf. `list-sessions`, `unlock-session` und das
+erste `show-session`. Bei 10 s je Kommando läge der Worst Case bei 40 s — jenseits
+des 20-Sekunden-Budgets einer Plugin-Menüaktion, sodass der Gaming-Modus dann
+abbräche, bevor Big Picture startet. Deshalb `_COMMAND_TIMEOUT_SECONDS = 3`:
+maximal 12 s Kommandozeit plus 3 s Polling, also unter 15 s. `loginctl` antwortet
+real in Millisekunden; was drei Sekunden braucht, wird in zehn nicht brauchbar.
+
 ## Sicherheit
 
 - Kein sudo, keine sudoers-Änderung, kein neuer Rootpfad. Das Backend nutzt

--- a/docs/superpowers/specs/2026-07-24-session-unlock-on-desktop-enable-design.md
+++ b/docs/superpowers/specs/2026-07-24-session-unlock-on-desktop-enable-design.md
@@ -55,6 +55,16 @@ Teilprojekt 1 des Steam-Tracks nachgemessen, dort steht auch, dass es keinen
 Daraus folgt: **keine sudoers-Regel, kein Wrapper, kein Privilegienzuwachs auf
 Systemebene.** Das ist der Grund, warum dieses Feature überhaupt vertretbar ist.
 
+**Grenze dieser Messung, ehrlich benannt:** Sie lief aus einer SSH-Verbindung —
+die ist selbst eine logind-Session. Das Backend ist dagegen ein **session-loser
+Systemdienst** unter `system.slice`. Sehr wahrscheinlich greift loginds
+Owner-Regel (Caller-UID == Session-Owner-UID, per D-Bus-Credentials), die vom
+Session-Status des Callers unabhängig ist — aber das ist eine Annahme über
+logind-Interna, kein Messwert. Der Dienst-Kontext wird deshalb vor der
+Implementierung separat gemessen (siehe Offene Punkte); fällt die Messung
+negativ aus, braucht das Design einen sudoers-Eintrag im Muster von
+`sudoers-baluhost-power` und ist neu abzuwägen.
+
 ### Bestehendes Rechtemodell
 
 `UserPowerPermission` (`models/power_permissions.py`) hat eine Boolean-Spalte je
@@ -147,6 +157,15 @@ eine Falle, die im Repo bereits einmal zugeschlagen hat. WireGuard-Clients haben
 private Adressen und gelten damit als erlaubt; das ist beabsichtigt, denn wer im
 VPN ist, hat sich bereits mit einem Schlüssel ausgewiesen.
 
+**Tragende Annahme, benannt:** `request.client.host` ist hinter Nginx nur
+deshalb die echte Client-IP, weil Uvicorn mit dem bestehenden
+Proxy-Headers-Pin läuft (X-Forwarded-For, nur vom lokalen Nginx akzeptiert).
+Ohne diesen Pin sähe jeder Request wie 127.0.0.1 aus und das Ortsgate wäre
+dauerhaft offen. Der Pin existiert und trägt bereits die anderen LAN-Gates —
+aber wer ihn je entfernt, entfernt damit auch diesen Riegel. Ein Test prüft
+deshalb, dass eine öffentliche IP abgelehnt wird (nicht nur, dass eine private
+durchkommt).
+
 ### Session-Ermittlung
 
 Die Session-ID ist nicht stabil (die gemessene `2` gilt bis zum nächsten
@@ -177,6 +196,14 @@ so ruft das Plugin dieselbe `unlock_if_permitted()` wie die Route, statt sich au
 den impliziten Vertrag „der Core hat Admin schon geprüft" zu verlassen. Solche
 Verträge reißen beim nächsten Umbau, und zwar lautlos.
 
+**Reihenfolge im Gaming-Modus:** Displays an → **Unlock** → Big Picture. Der
+Unlock sitzt zwischen den beiden bestehenden Schritten — Big Picture auf einen
+Sperrbildschirm zu öffnen ist genau das Szenario, das dieses Feature beseitigen
+soll. Ein fehlgeschlagener Unlock bricht die Aktion nicht ab (Big Picture
+startet trotzdem; es wird eben erst nach manuellem Entsperren sichtbar). Das
+Zeitbudget bleibt eingehalten: Enable + Unlock-Polling (max. 3 s) + Spawn
+liegen deutlich unter dem 20-s-Timeout der Menüaktionen.
+
 ### Kein neues Route-Gate
 
 Das Recht wird **innerhalb** der Enable-Route geprüft, nicht als `Depends`. Ein
@@ -195,8 +222,24 @@ keine `require_power_unlock_session`-Dependency.
 }
 ```
 
-`session_unlocked` beschreibt den **Zustand danach**, nicht ob etwas verändert
-wurde: eine ohnehin unversperrte Session meldet `true`.
+Präzise Semantik von `session_unlocked`, damit sie nicht zweideutig wird:
+
+- **`true`** — beide Gates passiert, und die Session ist danach nachweislich
+  entsperrt (`LockedHint=no`). Eine ohnehin unversperrte Session meldet `true`.
+- **`false`** — alles andere: Gate verweigert (dann wurde `loginctl` nie
+  gerufen und der tatsächliche Sperrzustand ist unbekannt), keine Session
+  gefunden, Kommando fehlgeschlagen oder `LockedHint` blieb `yes`.
+  `unlock_message` nennt den Grund.
+
+Das Feld behauptet also nie mehr, als geprüft wurde — bei verweigerten Gates
+sagt es nichts über den Sperrzustand aus, sondern nur, dass nicht entsperrt
+wurde.
+
+**Frontend-Verhalten:** `unlock_message` ist ein serverseitig englischer
+Debug-String und wird **nicht** wörtlich gerendert — das wäre der nächste
+Eintrag in #406. Die UI zeigt bei `session_unlocked=false` einen übersetzten,
+generischen Hinweis (i18n-Key, de/en) und loggt `unlock_message` höchstens in
+die Konsole.
 
 ## Fehlerbehandlung
 
@@ -216,6 +259,15 @@ anderen Blatt. Deshalb wird nach dem Unlock `LockedHint` zurückgelesen und nur
 bei `no` ein Erfolg gemeldet. Ohne diesen Schritt würde die API „entsperrt"
 behaupten, während der Bildschirm gesperrt bleibt — eine Lüge, die man erst
 bemerkt, wenn man vor dem Rechner steht.
+
+**Das Nachlesen braucht ein Zeitfenster, kein Einzelread.** kscreenlocker
+verarbeitet das Signal asynchron; die Messung auf der Box hatte zwischen Signal
+und Nachlesen bewusst zwei Sekunden Pause. Ein sofortiger Read liefert
+sporadisch noch `yes` und würde fälschlich „nicht entsperrt" melden — ein
+flackernder Fehlbericht, der schwerer zu debuggen ist als ein ehrlicher.
+Vorgabe: **Polling auf `LockedHint`, 200-ms-Schritte, Abbruch bei `no`,
+Obergrenze 3 s.** Erst nach Ablauf der Obergrenze gilt der Unlock als
+fehlgeschlagen.
 
 ## Sicherheit
 
@@ -257,7 +309,13 @@ nein; Audit-Eintrag genau im Erfolgsfall.
 
 **Route:** ein fehlgeschlagener Unlock lässt `enable` weiterhin `success=true`
 liefern — der Test, der die Grundregel festnagelt. Dazu die beiden neuen
-Antwortfelder.
+Antwortfelder, und ein Test, der eine **öffentliche** IP explizit ablehnt
+(nicht nur eine private akzeptiert — sonst bliebe ein kaputtes Ortsgate
+unsichtbar grün).
+
+**Nachlese-Polling:** `LockedHint` wird erst nach mehreren Reads `no` →
+Erfolg; bleibt es über die Obergrenze `yes` → `false`. Uhr und Runner
+injiziert, kein echtes Warten im Test.
 
 **Gaming-Modus:** reicht `user` und `client_host` durch und entsperrt unter
 denselben Regeln.
@@ -268,9 +326,26 @@ gestampt und nur das Delta gefahren — wie bei der `steam_sessions`-Migration.
 
 ## Offene Punkte
 
-- Die **Session-Ermittlung** ist der einzige ungemessene Teil (siehe oben). Sie
-  wird als erste Aufgabe des Implementierungsplans gegen die Box geprüft.
-- Eine visuelle Bestätigung, dass der Sperrbildschirm bei `unlock-session`
-  tatsächlich verschwindet, steht noch aus. `LockedHint` sprang auf `no`, was
-  stark dafür spricht — dieser Wert wird von kscreenlocker selbst gesetzt —,
-  aber gesehen hat es noch niemand.
+Drei Messungen stehen aus; die erste ist tragend und läuft als Aufgabe 1 des
+Implementierungsplans, **bevor** Code entsteht:
+
+1. **Funktioniert der Unlock aus einem session-losen Dienst-Kontext?** Die
+   bisherige Messung lief aus einer SSH-Session; das Backend hat keine. Die
+   ehrliche Simulation (transiente Unit unter `system.slice`, UID 1000, keine
+   logind-Session):
+
+   ```bash
+   loginctl list-sessions   # grafische ID: seat0, Klasse user
+   sudo systemd-run --uid=1000 --pipe --wait loginctl lock-session <ID>
+   loginctl show-session <ID> -p LockedHint     # erwartet: yes
+   sudo systemd-run --uid=1000 --pipe --wait loginctl unlock-session <ID>
+   loginctl show-session <ID> -p LockedHint     # erwartet: no
+   ```
+
+   Fällt sie negativ aus, ist das Design neu abzuwägen (sudoers-Weg).
+2. **Session-Ermittlung:** liefert `loginctl show-user 1000 -p Display --value`
+   auf der Box die grafische Session? Sonst greift der Fallback über
+   `list-sessions`.
+3. **Visuelle Bestätigung**, dass der Sperrbildschirm wirklich verschwindet.
+   `LockedHint` sprang auf `no`, und diesen Hint pflegt die Session-Software
+   selbst — aber gesehen hat es noch niemand.


### PR DESCRIPTION
Wer über die Web-App die Displays einschaltet, hat sich dort bereits mit Passwort (und je nach Konto 2FA) angemeldet — steht danach aber vor dem KDE-Sperrbildschirm und gibt dasselbe Passwort ein zweites Mal ein. Dieser PR entsperrt die grafische Sitzung mit.

## Die Messung, auf der alles steht

`loginctl unlock-session` sendet ein `Unlock`-Signal, dem kscreenlocker folgt — derselbe Weg, über den Fingerabdrucksensoren entsperren. Auf BaluNode gemessen, und zwar **aus einem session-losen Dienst-Kontext**, also genau so, wie das Backend läuft:

```
$ sudo systemd-run --uid=1000 --pipe --wait loginctl lock-session 2
  Finished with result: success   →  LockedHint=yes
$ sudo systemd-run --uid=1000 --pipe --wait loginctl unlock-session 2
  Finished with result: success   →  LockedHint=no
```

Beide als transiente Unit unter `system.slice`, ohne `sudo` für das eigentliche Kommando, ohne polkit-Rückfrage. Der erste Anlauf hatte aus einer SSH-Sitzung gemessen — die ist selbst eine logind-Session und beweist den Dienstfall nicht. Das wurde nachgeholt, bevor eine Zeile Code entstand.

**Konsequenz: keine sudoers-Regel, kein Wrapper, kein neuer Rootpfad.** Das Backend läuft bereits als der User, dem die Sitzung gehört. Genau das macht dieses Feature vertretbar.

## Zwei Gates, beide müssen zutreffen

Das Entsperren macht die Web-Credentials faktisch zum **Zweitschlüssel für den physischen Desktop**, und die Web-App ist über duckdns aus dem offenen Internet erreichbar. Deshalb:

| Gate | Prüfung |
|---|---|
| Recht | Admin-Rolle **oder** das neue, separat vergebene `can_unlock_session` |
| Ort | `is_private_or_local_ip(request.client.host)` — LAN und WireGuard ja, offenes Netz nein |

Beide werden in **genau einer** Funktion ausgewertet, `session_lock.unlock_if_permitted()`, die auch den Audit-Eintrag schreibt. Zwei Aufrufer nutzen sie: die Route `POST /system/sleep/desktop/enable` und die Menüaktion „Gaming-Modus" (Displays an → **Unlock** → Big Picture). Läge die Prüfung bei den Aufrufern, müsste jeder beide Gates nachbauen — und einer würde es beim nächsten Umbau vergessen.

`can_toggle_desktop` bleibt dadurch eine reine Strom-Berechtigung und wächst nicht heimlich zum Desktop-Schlüssel.

## Die Grundregel

**Das Entsperren ist ein Zusatz und darf den Aufruf nie kippen.** Schlägt es fehl oder ist es nicht erlaubt, sind die Displays trotzdem an und der Aufruf meldet `success=true`. Die Antwort trägt zwei zusätzliche Felder:

```json
{ "success": true, "message": "ok",
  "session_unlocked": false,
  "unlock_message": "not permitted from this network" }
```

`unlock_message` ist ein interner Debug-String und wird **nie** gerendert; die UI zeigt einen übersetzten Hinweis (eigener Test sichert das ab, #406).

## Wahrheitstreue statt Optimismus

`loginctl` liefert Exit 0, sobald das Signal **abgesetzt** ist — nicht, wenn der Locker es befolgt hat. Ohne Nachlesen würde die API „entsperrt" behaupten, während der Bildschirm gesperrt bleibt. Deshalb wird `LockedHint` zurückgelesen, und zwar **gepollt** (200-ms-Schritte, 3 s Obergrenze): kscreenlocker verarbeitet das Signal asynchron, ein einzelner sofortiger Read hätte sporadisch einen Fehlschlag gemeldet, den es nie gab.

## Was die Reviews gefunden haben

Acht Tasks, jeder einzeln geprüft, dazu ein Abschluss-Review über den ganzen Branch. Die Funde, die zählen:

- **Der Whole-Branch-Review fand einen Regressionspfad, den keine Einzelprüfung sehen konnte:** `unlock_if_permitted()` hatte kein `try/except`. Die „darf nie kippen"-Zusage hing allein an zwei schmalen Zweigen im Backend. Ein `OSError` beim Fork unter Speicherdruck, ein `PermissionError` oder ein DB-Aussetzer im Rechte-Check wäre bis zum globalen Handler gelaufen — **HTTP 500 auf einer Route, die nach erfolgreichem Enable nicht mehr scheitern konnte**, und im Plugin-Pfad „Action failed" statt Big Picture. Jetzt sauber getrennt: ein gescheiterter Rechte-Check ist kein Entsperr-Versuch und bleibt unauditiert; ein geworfener Unlock wird als Fehlschlag protokolliert.
- **Vier handgeschriebene Durchreich-Stellen.** Dieses Repo reicht Power-Rechte nirgends generisch durch. Spalte und Schema allein hätten eine Checkbox ergeben, die sich klicken lässt, **nie speichert** und als „aus" zurückliest — ohne Fehler, ohne roten Test.
- **Ein Test, der sein eigenes Versprechen nicht hielt:** der Fallback-Test der Sitzungssuche prüfte nicht, was sein Name behauptet — die brauchbare Sitzung stand in der Fixture vor den zu überspringenden, also passte sie auch ohne Filter. Umsortiert und mutationsgeprüft.
- **`test_revoking_works_too` bewies nichts**, weil `False` zugleich der Spaltendefault ist. Prüft jetzt den Übergang.
- **Ein falscher Docstring am Extension-Point:** er behauptete, alte Implementierungen liefen weiter — das Gegenteil dessen, was `plugins/CLAUDE.md` korrekt festhält. Der Plugin-Autor liest den Docstring, nicht die CLAUDE.md.
- **Der Kommando-Timeout galt pro Aufruf**, und ein Unlock fährt bis zu vier — 40 s Worst Case statt der behaupteten 3 s, jenseits des 20-s-Budgets einer Menüaktion. Auf 3 s gesenkt, Spec nachgeführt.

Alle Härtungen sind mutationsgeprüft: Guard entfernt → genau der zugehörige Test wird rot.

## Bewusster API-Bruch

`run_menu_action()` bekommt zwei keyword-only Parameter (`user`, `client_host`), damit das Plugin dieselbe Policy-Funktion ruft wie die Route, statt sich auf „der Core hat Admin schon geprüft" zu verlassen. Ein Plugin, das die Methode mit der **alten** Signatur überschreibt, scheitert seitdem mit `TypeError`.

Verworfen wurde ein Kompatibilitäts-Fallback: ein `TypeError` aus dem Plugin-Rumpf wäre von einem Signatur-Mismatch nicht unterscheidbar, und ein Retry würde eine Aktion, die Displays schaltet und Prozesse startet, **ein zweites Mal** ausführen. Im Repo gibt es genau einen Implementierer (`steam_gaming`, angepasst), null externe Plugins sind deployed. Dokumentiert in `plugins/CLAUDE.md` **und** im Docstring.

## Verifikation

| Gate | Ergebnis |
|---|---|
| `-k "power or desktop or plugin or session"` | **1361 passed**, 3 failed, 10 skipped |
| `ruff check .` | clean |
| Frontend (Vitest) | 1156 Tests grün |
| `npx eslint .` | 0 errors |
| `npm run build` | exit 0 |
| Migration SQLite (isoliert) | upgrade + downgrade sauber |
| **Migration PostgreSQL 17** | upgrade + downgrade sauber, `can_unlock_session \| boolean \| not null \| false` |

Die 3 Fehlschläge sind vorbestehend und branch-unabhängig: `LinuxDesktopBackend` ruft ungeschützt `os.getuid()`, das es unter Windows nicht gibt (per `git stash` nachgewiesen, Issue #478).

## Bekannte Einschränkung

Die Tauri-Companion-App erreicht das Backend über einen Unix-Socket und hat kein `request.client` — für sie ist `client_host` leer, das Ortsgate verweigert. Ausgerechnet der Aufrufer, der physisch am Rechner sitzt, kann also nicht entsperren. Fail-closed und damit harmlos, aber es sei benannt.

## Ausgegliederte Befunde

#475 (`is_private_or_local_ip` nutzt Pythons `is_private` statt einer RFC-1918-Whitelist — Dokubereiche gelten als LAN, und die Klassifikation ist versionsabhängig), #476 (der uvicorn-Pin `<0.31` trägt alle IP-Gates, ohne dass das irgendwo steht), #477 (`json.dumps` außerhalb des Audit-Fehlerfangs), #478 (`os.getuid()` unter Windows).

## Nach dem Deploy auf der Box prüfen

1. **Sehen, nicht nur `LockedHint` lesen:** Sitzung sperren, dann aus dem LAN „Desktop aktivieren" — verschwindet der Sperrbildschirm wirklich? Der Hint wird von der Sitzungssoftware selbst gepflegt; gesehen hat es noch niemand.
2. **Primärpfad der Sitzungssuche:** `loginctl show-user 1000 -p Display --value` — liefert das die grafische Sitzung? Wenn leer, läuft dauerhaft der `list-sessions`-Fallback.
3. **Ortsgate scharf gegenprüfen:** derselbe Klick über duckdns aus dem Mobilfunknetz (ohne VPN) muss `session_unlocked=false` liefern — und im Audit darf **keine** `desktop_unlock_session`-Zeile stehen. Das kann kein Unit-Test gegen die echte nginx/uvicorn-Kette beweisen.
4. **Audit sichten:** je erfolgreichem Versuch eine `POWER / desktop_unlock_session`-Zeile mit gefüllter `ip_address`.
5. **Gaming-Modus** über das Power-Menü: Displays an → Sperrbildschirm weg → Big Picture im Vordergrund.
6. **Merken für später:** ein Bump auf uvicorn 0.31+ muss gegen `ProxyHeadersMiddleware` gegengelesen werden (#476).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK4BdX3g1jyWEMaFoGPwPG
