### PR TITLE
i18n: VCL-Reconciliation-Karte und Geschwister übersetzen (#406)

### DIFF
--- a/client/src/__tests__/components/vcl/VCLSettings.test.tsx
+++ b/client/src/__tests__/components/vcl/VCLSettings.test.tsx
@@ -30,14 +30,14 @@ describe('VCLSettings', () => {
   it('renders the stats grid + user table for a populated fixture', () => {
     render(<VCLSettings />);
     expect(screen.getByText('alice')).toBeInTheDocument();           // user table
-    expect(screen.getByText('Ownership Reconciliation')).toBeInTheDocument(); // recon card
+    expect(screen.getByText('vcl.reconciliation.title')).toBeInTheDocument(); // recon card
   });
 
   it('renders none of the dashboard content while loading (early-return spinner)', () => {
     hookValue.loading = true;
     render(<VCLSettings />);
     expect(screen.queryByText('alice')).not.toBeInTheDocument();
-    expect(screen.queryByText('Ownership Reconciliation')).not.toBeInTheDocument();
+    expect(screen.queryByText('vcl.reconciliation.title')).not.toBeInTheDocument();
   });
 
   it('renders nothing when overview is null (and not loading)', () => {

--- a/client/src/__tests__/components/vcl/vcl-settings/VclReconciliationCard.test.tsx
+++ b/client/src/__tests__/components/vcl/vcl-settings/VclReconciliationCard.test.tsx
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { ReconciliationPreview } from '../../../../types/vcl';
+// Keeps the interpolated value visible so the count assertions still mean something.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (k: string, o?: { versions?: number; total?: number }) =>
+      (o?.versions ?? o?.total) != null ? `${k}:${o?.versions ?? o?.total}` : k,
+  }),
+}));
 import { VclReconciliationCard } from '../../../../components/vcl/vcl-settings/VclReconciliationCard';
 
 const preview = (over: Partial<ReconciliationPreview> = {}): ReconciliationPreview => ({
@@ -9,15 +16,15 @@ const preview = (over: Partial<ReconciliationPreview> = {}): ReconciliationPrevi
 const base = { reconLoading: false, forceOverQuota: false, onScan: () => {}, onForceChange: () => {}, onApply: () => {} };
 
 describe('VclReconciliationCard', () => {
-  it('fires onScan when Scan for Mismatches is clicked', () => {
+  it('fires onScan when the scan button is clicked', () => {
     const onScan = vi.fn();
     render(<VclReconciliationCard {...base} reconPreview={null} onScan={onScan} />);
-    fireEvent.click(screen.getByText('Scan for Mismatches'));
+    fireEvent.click(screen.getByText('vcl.reconciliation.scan'));
     expect(onScan).toHaveBeenCalledTimes(1);
   });
   it('hides Apply + force checkbox when there are no mismatches', () => {
     render(<VclReconciliationCard {...base} reconPreview={preview({ total_mismatches: 0 })} />);
-    expect(screen.queryByText(/^Apply \(/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^vcl\.reconciliation\.apply/)).not.toBeInTheDocument();
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
   });
   it('shows Apply with the mismatch count when there are mismatches', () => {
@@ -28,7 +35,7 @@ describe('VclReconciliationCard', () => {
       ],
       affected_users: [{ user_id: 2, username: 'bob', quota_delta: 100, current_usage: 0, max_size: 1000, would_exceed_quota: false }],
     })} />);
-    expect(screen.getByText('Apply (2 versions)')).toBeInTheDocument();
+    expect(screen.getByText('vcl.reconciliation.apply:2')).toBeInTheDocument();
     expect(screen.getByRole('checkbox')).toBeInTheDocument();
     expect(screen.getByText('b.txt')).toBeInTheDocument();
   });

--- a/client/src/__tests__/components/vcl/vcl-settings/VclStorageInfoCard.test.tsx
+++ b/client/src/__tests__/components/vcl/vcl-settings/VclStorageInfoCard.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import type { VCLStorageInfo } from '../../../../types/vcl';
-vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (_k: string, fb?: string) => fb ?? _k }) }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
 import { VclStorageInfoCard } from '../../../../components/vcl/vcl-settings/VclStorageInfoCard';
 
 const info = (over: Partial<VCLStorageInfo> = {}): VCLStorageInfo => ({
@@ -17,8 +17,8 @@ describe('VclStorageInfoCard', () => {
   });
   it('shows the Custom Path badge only when is_custom_path', () => {
     const { rerender } = render(<VclStorageInfoCard storageInfo={info({ is_custom_path: false })} />);
-    expect(screen.queryByText('Custom Path')).not.toBeInTheDocument();
+    expect(screen.queryByText('vcl.storageInfo.customPath')).not.toBeInTheDocument();
     rerender(<VclStorageInfoCard storageInfo={info({ is_custom_path: true })} />);
-    expect(screen.getByText('Custom Path')).toBeInTheDocument();
+    expect(screen.getByText('vcl.storageInfo.customPath')).toBeInTheDocument();
   });
 });

--- a/client/src/__tests__/components/vcl/vcl-settings/VclUserQuotasTable.test.tsx
+++ b/client/src/__tests__/components/vcl/vcl-settings/VclUserQuotasTable.test.tsx
@@ -24,6 +24,6 @@ describe('VclUserQuotasTable', () => {
   });
   it('shows the Manual badge for manual-mode users', () => {
     render(<VclUserQuotasTable users={[user({ vcl_mode: 'manual' })]} onEditUser={() => {}} />);
-    expect(screen.getByText('Manual')).toBeInTheDocument();
+    expect(screen.getByText('vcl.userQuotas.modeManual')).toBeInTheDocument();
   });
 });

--- a/client/src/__tests__/hooks/useVclSettings.test.ts
+++ b/client/src/__tests__/hooks/useVclSettings.test.ts
@@ -53,7 +53,7 @@ describe('useVclSettings', () => {
     const { result } = renderHook(() => useVclSettings());
     await waitFor(() => expect(result.current.overview).not.toBeNull());
     await act(async () => { await result.current.handleScanMismatches(); });
-    expect(result.current.successMessage).toBe('No ownership mismatches found');
+    expect(result.current.successMessage).toBe('vcl.reconciliation.noMismatches');
   });
 
   it('handleSaveUserSettings sends the edit form for the editing user', async () => {

--- a/client/src/components/vcl/vcl-settings/VclReconciliationCard.tsx
+++ b/client/src/components/vcl/vcl-settings/VclReconciliationCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Search, Check, ArrowRight, AlertTriangle } from 'lucide-react';
 import { formatBytes } from '../../../api/vcl';
 import type { ReconciliationPreview } from '../../../types/vcl';
@@ -17,14 +18,16 @@ export function VclReconciliationCard({
   onForceChange: (v: boolean) => void;
   onApply: () => void;
 }) {
+  const { t } = useTranslation('admin');
+
   return (
     <div className="card border-slate-800/60 bg-slate-900/55">
       <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
         <Search className="w-5 h-5 text-sky-400" />
-        Ownership Reconciliation
+        {t('vcl.reconciliation.title')}
       </h3>
       <p className="text-sm text-slate-400 mb-4">
-        Scan for version ownership mismatches (e.g. after file transfers) and fix them.
+        {t('vcl.reconciliation.description')}
       </p>
       <div className="flex flex-wrap items-center gap-3 mb-4">
         <button
@@ -33,7 +36,7 @@ export function VclReconciliationCard({
           className="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
         >
           <Search className={`w-4 h-4 ${reconLoading ? 'animate-spin' : ''}`} />
-          Scan for Mismatches
+          {t('vcl.reconciliation.scan')}
         </button>
         {reconPreview && reconPreview.total_mismatches > 0 && (
           <>
@@ -44,7 +47,7 @@ export function VclReconciliationCard({
                 onChange={(e) => onForceChange(e.target.checked)}
                 className="w-4 h-4 rounded border-slate-700 bg-slate-800"
               />
-              Force even if quota exceeded
+              {t('vcl.reconciliation.forceOverQuota')}
             </label>
             <button
               onClick={onApply}
@@ -52,7 +55,7 @@ export function VclReconciliationCard({
               className="px-4 py-2 bg-amber-500 hover:bg-amber-600 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
             >
               <Check className="w-4 h-4" />
-              Apply ({reconPreview.total_mismatches} versions)
+              {t('vcl.reconciliation.apply', { versions: reconPreview.total_mismatches })}
             </button>
           </>
         )}
@@ -63,7 +66,7 @@ export function VclReconciliationCard({
           {/* Affected Users Summary */}
           {reconPreview.affected_users.length > 0 && (
             <div className="space-y-2">
-              <h4 className="text-sm font-medium text-slate-300">Quota Impact</h4>
+              <h4 className="text-sm font-medium text-slate-300">{t('vcl.reconciliation.quotaImpact')}</h4>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 {reconPreview.affected_users.map((u) => (
                   <div
@@ -80,7 +83,7 @@ export function VclReconciliationCard({
                     </span>
                     {u.would_exceed_quota && (
                       <span className="ml-2 text-amber-400 text-xs flex items-center gap-1 inline-flex">
-                        <AlertTriangle className="w-3 h-3" /> exceeds quota
+                        <AlertTriangle className="w-3 h-3" /> {t('vcl.reconciliation.exceedsQuota')}
                       </span>
                     )}
                   </div>
@@ -94,12 +97,12 @@ export function VclReconciliationCard({
             <table className="w-full text-xs">
               <thead className="sticky top-0 bg-slate-900">
                 <tr className="text-left border-b border-slate-800">
-                  <th className="pb-2 text-slate-400 font-medium">File</th>
-                  <th className="pb-2 text-slate-400 font-medium">Version</th>
-                  <th className="pb-2 text-slate-400 font-medium">Current Owner</th>
+                  <th className="pb-2 text-slate-400 font-medium">{t('vcl.reconciliation.table.file')}</th>
+                  <th className="pb-2 text-slate-400 font-medium">{t('vcl.reconciliation.table.version')}</th>
+                  <th className="pb-2 text-slate-400 font-medium">{t('vcl.reconciliation.table.currentOwner')}</th>
                   <th className="pb-2 text-slate-400 font-medium"></th>
-                  <th className="pb-2 text-slate-400 font-medium">File Owner</th>
-                  <th className="pb-2 text-slate-400 font-medium">Size</th>
+                  <th className="pb-2 text-slate-400 font-medium">{t('vcl.reconciliation.table.fileOwner')}</th>
+                  <th className="pb-2 text-slate-400 font-medium">{t('vcl.reconciliation.table.size')}</th>
                 </tr>
               </thead>
               <tbody>
@@ -119,7 +122,7 @@ export function VclReconciliationCard({
             </table>
             {reconPreview.total_mismatches > 100 && (
               <p className="text-xs text-slate-500 mt-2">
-                Showing 100 of {reconPreview.total_mismatches} mismatches
+                {t('vcl.reconciliation.showingLimited', { total: reconPreview.total_mismatches })}
               </p>
             )}
           </div>

--- a/client/src/components/vcl/vcl-settings/VclStorageInfoCard.tsx
+++ b/client/src/components/vcl/vcl-settings/VclStorageInfoCard.tsx
@@ -12,30 +12,30 @@ export function VclStorageInfoCard({ storageInfo }: { storageInfo: VCLStorageInf
     <div className="card border-slate-800/60 bg-slate-900/55">
       <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
         <FolderOpen className="w-5 h-5 text-sky-400" />
-        {t('vcl.storageInfo.title', 'Storage Location')}
+        {t('vcl.storageInfo.title')}
       </h3>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 text-sm">
         <div>
-          <p className="text-slate-400">{t('vcl.storageInfo.path', 'Storage Path')}</p>
+          <p className="text-slate-400">{t('vcl.storageInfo.path')}</p>
           <p className="text-white font-semibold mt-1 truncate" title={storageInfo.storage_path}>
             {storageInfo.storage_path}
           </p>
           {storageInfo.is_custom_path && (
             <span className="mt-1 inline-block px-2 py-0.5 rounded-full text-[10px] font-medium bg-violet-500/20 text-violet-300">
-              Custom Path
+              {t('vcl.storageInfo.customPath')}
             </span>
           )}
         </div>
         <div>
-          <p className="text-slate-400">{t('vcl.storageInfo.blobCount', 'Blob Count')}</p>
+          <p className="text-slate-400">{t('vcl.storageInfo.blobCount')}</p>
           <p className="text-white font-semibold mt-1">{storageInfo.blob_count.toLocaleString()}</p>
         </div>
         <div>
-          <p className="text-slate-400">{t('vcl.storageInfo.compressedSize', 'Compressed Size')}</p>
+          <p className="text-slate-400">{t('vcl.storageInfo.compressedSize')}</p>
           <p className="text-white font-semibold mt-1">{formatBytes(storageInfo.total_compressed_bytes)}</p>
         </div>
         <div>
-          <p className="text-slate-400">{t('vcl.storageInfo.diskUsage', 'Disk Usage')}</p>
+          <p className="text-slate-400">{t('vcl.storageInfo.diskUsage')}</p>
           <p className="text-white font-semibold mt-1">
             {formatNumber(storageInfo.disk_used_percent, 1)}%
           </p>
@@ -46,7 +46,7 @@ export function VclStorageInfoCard({ storageInfo }: { storageInfo: VCLStorageInf
             />
           </div>
           <p className="text-xs text-slate-500 mt-1">
-            {formatBytes(storageInfo.disk_available_bytes)} {t('vcl.storageInfo.free', 'free')} / {formatBytes(storageInfo.disk_total_bytes)}
+            {formatBytes(storageInfo.disk_available_bytes)} {t('vcl.storageInfo.free')} / {formatBytes(storageInfo.disk_total_bytes)}
           </p>
         </div>
       </div>

--- a/client/src/components/vcl/vcl-settings/VclUserQuotasTable.tsx
+++ b/client/src/components/vcl/vcl-settings/VclUserQuotasTable.tsx
@@ -29,7 +29,7 @@ export function VclUserQuotasTable({
               <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.used')}</th>
               <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.usage')}</th>
               <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.versions')}</th>
-              <th className="pb-3 text-slate-400 font-medium">Mode</th>
+              <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.mode')}</th>
               <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.status')}</th>
               <th className="pb-3 text-slate-400 font-medium">{t('vcl.userQuotas.actions')}</th>
             </tr>
@@ -65,7 +65,7 @@ export function VclUserQuotasTable({
                         ? 'bg-violet-500/20 text-violet-300'
                         : 'bg-sky-500/20 text-sky-300'
                     }`}>
-                      {user.vcl_mode === 'manual' ? 'Manual' : 'Auto'}
+                      {user.vcl_mode === 'manual' ? t('vcl.userQuotas.modeManual') : t('vcl.userQuotas.modeAuto')}
                     </span>
                   </td>
                   <td className="py-3">

--- a/client/src/hooks/useVclSettings.ts
+++ b/client/src/hooks/useVclSettings.ts
@@ -122,18 +122,18 @@ export function useVclSettings(): UseVclSettingsResult {
       const preview = await getReconciliationPreview({});
       setReconPreview(preview);
       if (preview.total_mismatches === 0) {
-        setSuccessMessage('No ownership mismatches found');
+        setSuccessMessage(t('vcl.reconciliation.noMismatches'));
         setTimeout(() => setSuccessMessage(null), 3000);
       }
     } catch (err: unknown) {
-      setError(getApiErrorMessage(err, 'Failed to scan for mismatches'));
+      setError(getApiErrorMessage(err, t('vcl.errors.scanFailed')));
     } finally {
       setReconLoading(false);
     }
   };
 
   const handleApplyReconciliation = async () => {
-    if (!confirm('Apply ownership reconciliation? This will update version ownership to match file ownership.')) return;
+    if (!confirm(t('vcl.reconciliation.confirmApply'))) return;
     try {
       setReconLoading(true);
       setError(null);
@@ -143,7 +143,7 @@ export function useVclSettings(): UseVclSettingsResult {
       setReconPreview(null);
       loadData();
     } catch (err: unknown) {
-      setError(getApiErrorMessage(err, 'Failed to apply reconciliation'));
+      setError(getApiErrorMessage(err, t('vcl.errors.applyFailed')));
     } finally {
       setReconLoading(false);
     }

--- a/client/src/i18n/locales/de/admin.json
+++ b/client/src/i18n/locales/de/admin.json
@@ -368,13 +368,24 @@
     "errors": {
       "loadFailed": "VCL-Daten konnten nicht geladen werden",
       "cleanupFailed": "Bereinigung fehlgeschlagen",
-      "updateFailed": "Einstellungen konnten nicht aktualisiert werden"
+      "updateFailed": "Einstellungen konnten nicht aktualisiert werden",
+      "scanFailed": "Suche nach Abweichungen fehlgeschlagen",
+      "applyFailed": "Eigentümer-Abgleich fehlgeschlagen"
     },
     "cleanup": {
       "dryRunResult": "Simulation: Würde {{versions}} Versionen löschen, {{freed}} freigeben",
       "result": "{{versions}} Versionen gelöscht, {{freed}} freigegeben"
     },
     "settingsUpdated": "Einstellungen für {{username}} aktualisiert",
+    "storageInfo": {
+      "title": "Speicherort",
+      "path": "Speicherpfad",
+      "customPath": "Eigener Pfad",
+      "blobCount": "Blob-Anzahl",
+      "compressedSize": "Komprimierte Größe",
+      "diskUsage": "Speicherbelegung",
+      "free": "frei"
+    },
     "storageDetails": {
       "title": "Speicherdetails",
       "compressionRatio": "Komprimierungsverhältnis",
@@ -397,6 +408,25 @@
       "dryRun": "Simulation: Würde löschen",
       "deleted": "Gelöscht"
     },
+    "reconciliation": {
+      "title": "Eigentümer-Abgleich",
+      "description": "Sucht nach Versionen, deren Eigentümer nicht zur Datei passt (z. B. nach Dateiübertragungen), und korrigiert sie.",
+      "scan": "Abweichungen suchen",
+      "forceOverQuota": "Auch bei überschrittenem Kontingent erzwingen",
+      "apply": "Übernehmen ({{versions}} Versionen)",
+      "quotaImpact": "Auswirkung auf Kontingente",
+      "exceedsQuota": "Kontingent überschritten",
+      "noMismatches": "Keine Eigentümer-Abweichungen gefunden",
+      "confirmApply": "Eigentümer-Abgleich übernehmen? Damit wird der Eigentümer der Versionen an den Eigentümer der Datei angeglichen.",
+      "showingLimited": "Zeige 100 von {{total}} Abweichungen",
+      "table": {
+        "file": "Datei",
+        "version": "Version",
+        "currentOwner": "Aktueller Eigentümer",
+        "fileOwner": "Datei-Eigentümer",
+        "size": "Größe"
+      }
+    },
     "userQuotas": {
       "title": "Benutzer-Kontingente",
       "user": "Benutzer",
@@ -405,6 +435,9 @@
       "usage": "Nutzung",
       "usagePercent": "Nutzung %",
       "versions": "Versionen",
+      "mode": "Modus",
+      "modeManual": "Manuell",
+      "modeAuto": "Automatisch",
       "status": "Status",
       "actions": "Aktionen",
       "enabled": "Aktiviert",

--- a/client/src/i18n/locales/en/admin.json
+++ b/client/src/i18n/locales/en/admin.json
@@ -368,13 +368,24 @@
     "errors": {
       "loadFailed": "Failed to load VCL data",
       "cleanupFailed": "Cleanup failed",
-      "updateFailed": "Failed to update settings"
+      "updateFailed": "Failed to update settings",
+      "scanFailed": "Failed to scan for mismatches",
+      "applyFailed": "Failed to apply reconciliation"
     },
     "cleanup": {
       "dryRunResult": "Dry run: Would delete {{versions}} versions, freeing {{freed}}",
       "result": "Deleted {{versions}} versions, freed {{freed}}"
     },
     "settingsUpdated": "Settings updated for {{username}}",
+    "storageInfo": {
+      "title": "Storage Location",
+      "path": "Storage Path",
+      "customPath": "Custom Path",
+      "blobCount": "Blob Count",
+      "compressedSize": "Compressed Size",
+      "diskUsage": "Disk Usage",
+      "free": "free"
+    },
     "storageDetails": {
       "title": "Storage Details",
       "compressionRatio": "Compression Ratio",
@@ -397,6 +408,25 @@
       "dryRun": "Dry run: Would delete",
       "deleted": "Deleted"
     },
+    "reconciliation": {
+      "title": "Ownership Reconciliation",
+      "description": "Scan for version ownership mismatches (e.g. after file transfers) and fix them.",
+      "scan": "Scan for Mismatches",
+      "forceOverQuota": "Force even if quota exceeded",
+      "apply": "Apply ({{versions}} versions)",
+      "quotaImpact": "Quota Impact",
+      "exceedsQuota": "exceeds quota",
+      "noMismatches": "No ownership mismatches found",
+      "confirmApply": "Apply ownership reconciliation? This will update version ownership to match file ownership.",
+      "showingLimited": "Showing 100 of {{total}} mismatches",
+      "table": {
+        "file": "File",
+        "version": "Version",
+        "currentOwner": "Current Owner",
+        "fileOwner": "File Owner",
+        "size": "Size"
+      }
+    },
     "userQuotas": {
       "title": "User Quotas",
       "user": "User",
@@ -405,6 +435,9 @@
       "usage": "Usage",
       "usagePercent": "Usage %",
       "versions": "Versions",
+      "mode": "Mode",
+      "modeManual": "Manual",
+      "modeAuto": "Auto",
       "status": "Status",
       "actions": "Actions",
       "enabled": "Enabled",


### PR DESCRIPTION
Arbeitet den `VCLSettings.tsx`-Eintrag aus dem i18n-Sammel-Issue #406 ab (inkl. der Nachträge aus dem Kommentar vom 11.07.). Reiner Frontend-Change, keine API-Berührung.

## Was umgestellt wurde

| Fundort | Vorher |
|---|---|
| `vcl-settings/VclReconciliationCard.tsx` | komplette Karte hartcodiert Englisch — Titel, Beschreibung, Scan-/Apply-Button, Quota-Impact-Block, Tabellenköpfe, „Showing 100 of N" |
| `hooks/useVclSettings.ts` | die zwei Reconciliation-Fehler-Fallbacks, „No ownership mismatches found", der `confirm()`-Text beim Übernehmen |
| `vcl-settings/VclUserQuotasTable.tsx` | Spaltenkopf „Mode" + die Werte „Manual"/„Auto" |
| `vcl-settings/VclStorageInfoCard.tsx` | Badge „Custom Path" |

## Nebenbefund, direkt mitbehoben

Beim Anlegen der Keys fiel auf, dass **`vcl.storageInfo.*` in beiden Locales nie existiert hat**. `VclStorageInfoCard` rief die Keys durchgehend mit Inline-Fallback auf (`t('vcl.storageInfo.title', 'Storage Location')`), also hat die deutsche Oberfläche dort still „Storage Location" / „Storage Path" / „Blob Count" / „Compressed Size" / „Disk Usage" / „free" angezeigt — ohne dass es irgendwo aufgefallen wäre.

Die sechs Keys liegen jetzt in `de` **und** `en`, und die Inline-Fallbacks sind entfernt: mit Fallback bleibt ein fehlender Key unsichtbar, genau das war ja die Ursache.

## Entscheidungen

- Keys landen im **bestehenden** `admin`-Namespace unter `vcl.*` — `i18n/index.ts` bleibt unangetastet.
- Interpolation über `{{versions}}` / `{{total}}` statt `{{count}}`. `count` ist bei i18next der Plural-Trigger und würde nach `apply_one`/`apply_other` suchen; die bestehenden `vcl.cleanup.*`-Keys machen es genauso.
- DE/EN-Parität der `vcl`-Teilbäume ist geprüft (keine einseitigen Keys).

## Tests

Die vier betroffenen Suites prüften auf die englischen Literale. Sie prüfen jetzt auf Keys — das ist die Konvention im Rest der Suite (der `react-i18next`-Mock gibt den Key zurück; `vcl.userQuotas.noUsers` und `common.edit` wurden dort schon so geprüft).

`VclReconciliationCard.test.tsx` hatte bisher gar keinen i18n-Mock. Der neue Mock reicht den interpolierten Wert durch (`vcl.reconciliation.apply:2`), damit die Zählerprüfung nicht zu einem reinen Key-Vergleich verkommt.

## Verifikation

```
npx eslint .      -> 0 errors (279 pre-existing warnings, unverändert)
npm run build     -> ✓ built
npx vitest run    -> 259 Dateien / 1156 Tests grün, Exit 0
```

Refs #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)
