### PR TITLE
chore(deps): axios und react-router-dom anheben (14 Alerts, ausgelieferter Code)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,7 +14,7 @@
         "@tanstack/query-sync-storage-persister": "^5.101.2",
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-query-persist-client": "^5.101.2",
-        "axios": "^1.16.0",
+        "axios": "^1.19.0",
         "i18next": "^25.8.0",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.554.0",
@@ -24,7 +24,7 @@
         "react-i18next": "^16.5.4",
         "react-is": "^19.2.3",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.16.0",
+        "react-router-dom": "^7.18.2",
         "recharts": "^3.4.1"
       },
       "devDependencies": {
@@ -3243,13 +3243,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -7243,9 +7243,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -7265,12 +7265,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -29,7 +29,7 @@
     "@tanstack/query-sync-storage-persister": "^5.101.2",
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-query-persist-client": "^5.101.2",
-    "axios": "^1.16.0",
+    "axios": "^1.19.0",
     "i18next": "^25.8.0",
     "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.554.0",
@@ -39,7 +39,7 @@
     "react-i18next": "^16.5.4",
     "react-is": "^19.2.3",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.16.0",
+    "react-router-dom": "^7.18.2",
     "recharts": "^3.4.1"
   },
   "overrides": {


### PR DESCRIPTION
Zweites Dependency-Bündel: die beiden Pakete, die tatsächlich im Browser landen.

> #490 ist gemergt; dieser PR wurde auf `main` umgehängt und darauf rebased. Der Diff enthält nur noch die eigenen zwei Pakete.

| Paket | von → nach | schließt |
|---|---|---|
| `axios` | 1.16.1 → 1.19.0 | alle 10 axios-Alerts |
| `react-router-dom` | 7.16.0 → 7.18.2 | 4 von 5 react-router-Alerts |

## Breaking-Change-Prüfung

Anders als beim Build-Only-Bündel läuft dieser Code beim Nutzer, also habe ich jede Release zwischen alt und neu gelesen statt auf Semver zu vertrauen.

### axios 1.17.0 → 1.18.0 → 1.19.0

Keine der drei Releases deklariert Breaking Changes. Die vorhandenen Verhaltensänderungen betreffen Optionen, die dieses Projekt nirgends setzt — `validateStatus`, `socketPath`, `paramsSerializer`, `maxBodyLength`, `maxRedirects` und `proxy` kommen in `client/src` außerhalb von Kommentaren nicht vor.

Zwei Änderungen habe ich gezielt gegen `lib/api.ts` geprüft:

- **„Prevented request dispatch after synchronous interceptor failures"** — der Request-Interceptor (`api.ts:48`) liest nur `localStorage` und gibt `config` zurück; der Response-Interceptor endet bereits auf `Promise.reject(error)` (`api.ts:78`). Keiner von beiden kann synchron werfen.
- **„Removed repeated trailing slashes in base URL combinations"** — `API_BASE_URL` ist entweder `''` oder `VITE_API_BASE_URL`, und `buildApiUrl` stellt sicher, dass jeder Pfad mit `/` beginnt. Doppelte Slashes entstanden hier ohnehin nicht.

### react-router 7.18.0 → 7.18.2

7.18.0 bringt den Open-Redirect-Fix (CVE-2026-53669, Backslash in `<Link>`/`useNavigate`) und dazu eine URL-Normalisierung für gemischte Slashes.

Die übrigen 7.18.0-Punkte — die CSRF-Host-Prüfung, die Express-Adapter-Host-Berechnung, die RSC-Änderungen — sind **Framework-/Servermodus** und hier gegenstandslos:

- `App.tsx:1` importiert `BrowserRouter` aus `react-router-dom`, also der deklarative Client-Router
- kein einziges `@react-router/*`-Serverpaket ist installiert
- kein SSR, kein RSC — der Build ist ein reiner Vite-SPA

Von der Routen-Tabelle ist genau **ein** Eintrag ein Splat (`/plugins/:pluginName/*`), alles andere sind literale Pfade. Die Normalisierungsänderung hat hier also kaum Angriffsfläche.

7.18.1 korrigiert das CommonJS-`main`-Feld (wir bündeln ESM über Vite), 7.18.2 härtet RSC-CSRF-Codepfade (nicht anwendbar).

## Ein Alert bleibt bewusst offen

„React Router: RSC Mode CSRF Bypass" verlangt **8.3.0** — einen Major. Die Advisory beschreibt einen Angriff auf den RSC-Modus, den dieser SPA nicht fährt. Einen Router-Major zu ziehen, um eine nicht zutreffende Advisory zu schließen, ist der falsche Tausch; der Alert gehört als *not applicable* dismissed statt weggeupgradet.

## Verifikation

```
npx eslint .    -> 0 errors (279 pre-existing warnings, unverändert)
npm run build   -> ✓ built
npx vitest run  -> 259 Dateien / 1156 Tests grün, Exit 0
npm audit       -> axios taucht nicht mehr auf
```

Die Bundle-Hashes ändern sich hier erwartungsgemäß (`index-7As5wZcQ.js` statt `index-u-SW_cVB.js`) — im Gegensatz zu #490, wo sie identisch blieben. Genau das ist der Unterschied zwischen Build-Only und ausgeliefertem Code.

Nach beiden PRs bleiben 3 Dependabot-Alerts: react-router RSC-CSRF (nicht anwendbar, s. o.) sowie `quinn-proto` und `glib` in `client/src-tauri/Cargo.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
