### PR TITLE
feat(steam-gaming): Gaming-Modus aus der Web-App auch wieder beenden

### DIFF
--- a/backend/app/plugins/installed/steam_gaming/__init__.py
+++ b/backend/app/plugins/installed/steam_gaming/__init__.py
@@ -30,16 +30,27 @@ from app.plugins.base import (
 from app.models.steam_session import SteamSession
 from app.plugins.dashboard_panel import StatusItem, StatusPanelData
 from app.plugins.installed.steam_gaming import ledger
-from app.plugins.installed.steam_gaming.detection import current_app_id, resolve_game_name
-from app.plugins.installed.steam_gaming.launcher import open_big_picture
+from app.plugins.installed.steam_gaming.detection import (
+    current_app_id,
+    resolve_game_name,
+    steam_is_running,
+)
+from app.plugins.installed.steam_gaming.launcher import close_big_picture, open_big_picture
 from app.plugins.installed.steam_gaming.poller import SteamSessionPoller
 from app.services.power.desktop import get_desktop_service
+from app.services.power.desktop_windows import show_desktop
 from app.services.power.session_lock import unlock_if_permitted
 
 logger = logging.getLogger(__name__)
 
 _PILL_ID = "session"
 _MENU_ACTION_ID = "gaming_mode"
+_MENU_END_ACTION_ID = "gaming_mode_end"
+# Steam needs a moment to put its windowed UI back on screen after leaving Big
+# Picture. Minimizing before that would clear a desktop the window then pops
+# back onto. Measured on BaluNode with 2s; kept well inside the 20s budget of a
+# plugin menu action.
+_WINDOW_SETTLE_SECONDS = 2.0
 _EVENT_STARTED = ledger.EVENT_STARTED
 _EVENT_ENDED = ledger.EVENT_ENDED
 _POLL_INTERVAL_SECONDS = 30.0
@@ -142,16 +153,31 @@ class SteamGamingPlugin(PluginBase):
     def get_ui_manifest(self) -> PluginUIManifest:
         return PluginUIManifest(
             enabled=True,
-            menu_items=[PluginMenuItem(
-                id=_MENU_ACTION_ID,
-                icon="Gamepad2",
-                tone="info",
-                order=10,
-                label_key="menu_gaming_mode",
-                label_text="Gaming Mode",
-                description_key="menu_gaming_mode_desc",
-                description_text="Turn displays on and open Big Picture",
-            )],
+            menu_items=[
+                PluginMenuItem(
+                    id=_MENU_ACTION_ID,
+                    icon="Gamepad2",
+                    tone="info",
+                    order=10,
+                    label_key="menu_gaming_mode",
+                    label_text="Gaming Mode",
+                    description_key="menu_gaming_mode_desc",
+                    description_text="Turn displays on and open Big Picture",
+                ),
+                # "Monitor", not something more expressive: the frontend icon
+                # map is a closed set (#451), and anything outside it silently
+                # degrades to the generic plug icon.
+                PluginMenuItem(
+                    id=_MENU_END_ACTION_ID,
+                    icon="Monitor",
+                    tone="neutral",
+                    order=20,
+                    label_key="menu_gaming_mode_end",
+                    label_text="End Gaming Mode",
+                    description_key="menu_gaming_mode_end_desc",
+                    description_text="Close Big Picture and clear the desktop",
+                ),
+            ],
         )
 
     async def run_menu_action(
@@ -162,6 +188,8 @@ class SteamGamingPlugin(PluginBase):
         user=None,
         client_host: Optional[str] = None,
     ) -> Optional[MenuActionResult]:
+        if action_id == _MENU_END_ACTION_ID:
+            return await self._end_gaming_mode()
         if action_id != _MENU_ACTION_ID:
             return None
 
@@ -204,6 +232,61 @@ class SteamGamingPlugin(PluginBase):
             ok=True,
             message_key="menu_gaming_mode_started",
             message_text="Gaming mode started",
+        )
+
+    async def _end_gaming_mode(self) -> MenuActionResult:
+        """Leave Big Picture and clear the desktop again.
+
+        Deliberately does NOT turn the displays off - that already exists as
+        its own entry in the power menu, and combining both would make one
+        click do two things the user may not want together.
+        """
+        # A running game is the one state that IS detectable, so it is the one
+        # precondition worth enforcing: nobody wants a remote click pulling the
+        # UI out from under someone playing at the box.
+        game = await asyncio.to_thread(_current_game)
+        if game is not None:
+            app_id, name = game
+            return MenuActionResult(
+                ok=False,
+                message_key="menu_end_game_running",
+                message_text=f"A game is still running: {name or app_id}",
+            )
+
+        # Without this guard the close URL would START Steam - see launcher.py.
+        if not await asyncio.to_thread(steam_is_running):
+            return MenuActionResult(
+                ok=True,
+                message_key="menu_end_steam_not_running",
+                message_text="Steam is not running - nothing to end",
+            )
+
+        closed, detail = await asyncio.to_thread(close_big_picture)
+        if not closed:
+            logger.warning("end gaming mode: Big Picture was not closed: %s", detail)
+            return MenuActionResult(
+                ok=False,
+                message_key="menu_end_close_failed",
+                message_text=f"Big Picture could not be closed: {detail}",
+            )
+
+        await asyncio.sleep(_WINDOW_SETTLE_SECONDS)
+
+        minimized, detail = await asyncio.to_thread(show_desktop)
+        if not minimized:
+            logger.warning("end gaming mode: windows stayed up: %s", detail)
+            return MenuActionResult(
+                ok=False,
+                message_key="menu_end_windows_failed",
+                message_text=f"Big Picture was closed, but the windows stayed up: {detail}",
+            )
+
+        # "ended", not "Big Picture is gone": the close is dispatched to a
+        # detached process and the mode is not observable from here either.
+        return MenuActionResult(
+            ok=True,
+            message_key="menu_gaming_mode_ended",
+            message_text="Gaming mode ended",
         )
 
     def get_dashboard_panel(self) -> Optional[DashboardPanelSpec]:
@@ -285,6 +368,13 @@ class SteamGamingPlugin(PluginBase):
                 "menu_gaming_mode_started": "Gaming mode started",
                 "menu_displays_failed": "Displays could not be turned on",
                 "menu_steam_failed": "Displays are on, but Steam did not start",
+                "menu_gaming_mode_end": "End Gaming Mode",
+                "menu_gaming_mode_end_desc": "Close Big Picture + clear the desktop",
+                "menu_gaming_mode_ended": "Gaming mode ended",
+                "menu_end_game_running": "A game is still running",
+                "menu_end_steam_not_running": "Steam is not running - nothing to end",
+                "menu_end_close_failed": "Big Picture could not be closed",
+                "menu_end_windows_failed": "Big Picture was closed, but the windows stayed up",
             },
             "de": {
                 "pill_name": "Gaming-Session",
@@ -294,5 +384,12 @@ class SteamGamingPlugin(PluginBase):
                 "menu_gaming_mode_started": "Gaming-Modus gestartet",
                 "menu_displays_failed": "Displays konnten nicht eingeschaltet werden",
                 "menu_steam_failed": "Displays sind an, aber Steam startete nicht",
+                "menu_gaming_mode_end": "Gaming-Modus beenden",
+                "menu_gaming_mode_end_desc": "Big Picture schließen + Fenster minimieren",
+                "menu_gaming_mode_ended": "Gaming-Modus beendet",
+                "menu_end_game_running": "Es läuft noch ein Spiel",
+                "menu_end_steam_not_running": "Steam läuft nicht - nichts zu beenden",
+                "menu_end_close_failed": "Big Picture konnte nicht geschlossen werden",
+                "menu_end_windows_failed": "Big Picture ist zu, aber die Fenster blieben offen",
             },
         }

--- a/backend/app/plugins/installed/steam_gaming/detection.py
+++ b/backend/app/plugins/installed/steam_gaming/detection.py
@@ -11,7 +11,10 @@ import logging
 from typing import Optional
 
 from app.core.config import settings
-from app.plugins.installed.steam_gaming.detector import detect_running_app_id
+from app.plugins.installed.steam_gaming.detector import (
+    detect_running_app_id,
+    steam_is_running as _detect_steam_is_running,
+)
 from app.plugins.installed.steam_gaming.names import resolve_name
 
 logger = logging.getLogger(__name__)
@@ -49,6 +52,18 @@ def current_app_id() -> Optional[str]:
     if app_id is None and settings.is_dev_mode:
         return DEV_APP_ID
     return app_id
+
+
+def steam_is_running() -> bool:
+    """True while the Steam client is up. Blocking - call via asyncio.to_thread.
+
+    Mirrors current_app_id()'s shape: the real scan answers first so a Linux
+    dev box with a real Steam still tells the truth, and only a box without
+    /proc falls back to the dev stand-in.
+    """
+    if _detect_steam_is_running():
+        return True
+    return bool(settings.is_dev_mode)
 
 
 def resolve_game_name(app_id: str) -> Optional[str]:

--- a/backend/app/plugins/installed/steam_gaming/detector.py
+++ b/backend/app/plugins/installed/steam_gaming/detector.py
@@ -18,6 +18,14 @@ DEFAULT_PROC_ROOT = Path("/proc")
 
 _APPID_RE = re.compile(r"SteamLaunch\s+AppId=(\d+)")
 
+# The Steam CLIENT itself, not its helpers: `steam` as a whole path segment,
+# followed by whitespace or the end of the command line. `steamwebhelper` and
+# `steamerrorreporter` deliberately do NOT match - a false positive is the
+# expensive direction, because it would let the exit action fire
+# `steam steam://close/bigpicture` at a box where Steam is down, which STARTS
+# Steam instead of closing anything.
+_STEAM_CLIENT_RE = re.compile(r"(?:^|/)steam(?:\s|$)")
+
 
 def _iter_cmdlines(proc_root: Path) -> Iterator[tuple[int, str]]:
     """Yield ``(pid, cmdline)`` for every readable process directory."""
@@ -52,3 +60,15 @@ def detect_running_app_id(proc_root: Path = DEFAULT_PROC_ROOT) -> Optional[str]:
         if best_pid is None or pid < best_pid:
             best_pid, best_app_id = pid, match.group(1)
     return best_app_id
+
+
+def steam_is_running(proc_root: Path = DEFAULT_PROC_ROOT) -> bool:
+    """True while a Steam client process exists.
+
+    Same /proc scan as the game detection, different question: this one asks
+    whether Steam is up at all, which is the precondition for handing it a
+    steam:// URL that must not launch it.
+    """
+    return any(
+        _STEAM_CLIENT_RE.search(cmdline) for _pid, cmdline in _iter_cmdlines(proc_root)
+    )

--- a/backend/app/plugins/installed/steam_gaming/launcher.py
+++ b/backend/app/plugins/installed/steam_gaming/launcher.py
@@ -1,13 +1,17 @@
-"""Open Steam's Big Picture mode in the user's desktop session.
+"""Enter and leave Steam's Big Picture mode in the user's desktop session.
 
 On the production box Steam runs permanently (app-steam@autostart.service), so
-this hands a steam:// URL to the running instance, which then switches to Big
-Picture and the invoked process exits immediately.
+these hand a steam:// URL to the running instance, which then switches modes;
+the invoked process exits immediately.
 
-The call is deliberately detached: if Steam is NOT running, the very same
+Both calls are deliberately detached: if Steam is NOT running, the very same
 command starts it in the foreground, and an attached child would live for as
 long as the gaming session - hanging off the backend process. start_new_session
 puts it in its own session/process group and nothing is ever waited on.
+
+That "starts Steam" behaviour is a footgun for the CLOSE direction in
+particular - ending gaming mode must not boot Steam - so its caller checks
+first that a Steam client is running (see detection.steam_is_running).
 """
 from __future__ import annotations
 
@@ -20,6 +24,31 @@ from app.services.power.session_env import wayland_session_env
 logger = logging.getLogger(__name__)
 
 BIG_PICTURE_URL = "steam://open/bigpicture"
+CLOSE_BIG_PICTURE_URL = "steam://close/bigpicture"
+
+
+def _dispatch(url: str, what: str) -> tuple[bool, str]:
+    """Hand *url* to Steam, detached. Blocking - call via asyncio.to_thread."""
+    if settings.is_dev_mode:
+        # No desktop session on a Windows dev box.
+        return True, f"{what} requested (dev)"
+
+    try:
+        subprocess.Popen(  # fixed argv, no shell, no user input
+            ["steam", url],
+            env=wayland_session_env(),
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        return False, "steam binary not found"
+    except OSError as exc:
+        logger.warning("failed to dispatch %s: %s", url, exc)
+        return False, "could not start steam"
+
+    return True, f"{what} requested"
 
 
 def open_big_picture() -> tuple[bool, str]:
@@ -30,23 +59,19 @@ def open_big_picture() -> tuple[bool, str]:
         Picture is on screen - the process is detached, so anything beyond the
         spawn is unobservable from here.
     """
-    if settings.is_dev_mode:
-        # No desktop session on a Windows dev box.
-        return True, "big picture requested (dev)"
+    return _dispatch(BIG_PICTURE_URL, "big picture")
 
-    try:
-        subprocess.Popen(  # fixed argv, no shell, no user input
-            ["steam", BIG_PICTURE_URL],
-            env=wayland_session_env(),
-            start_new_session=True,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-    except FileNotFoundError:
-        return False, "steam binary not found"
-    except OSError as exc:
-        logger.warning("failed to launch Big Picture: %s", exc)
-        return False, "could not start steam"
 
-    return True, "big picture requested"
+def close_big_picture() -> tuple[bool, str]:
+    """Ask Steam to leave Big Picture. Blocking - call via asyncio.to_thread.
+
+    Measured on BaluNode (2026-08-01): the running client drops back to the
+    windowed UI and keeps running.
+
+    Returns:
+        (ok, detail). ok=True means the request was dispatched. Whether Big
+        Picture is actually gone stays unobservable - the mode is not
+        detectable from the outside at all (see the design doc from
+        2026-07-24), which is exactly why there is no verification step here.
+    """
+    return _dispatch(CLOSE_BIG_PICTURE_URL, "big picture close")

--- a/backend/app/services/power/desktop_windows.py
+++ b/backend/app/services/power/desktop_windows.py
@@ -1,0 +1,68 @@
+"""Clear the KDE session's screen by minimizing every window.
+
+Driven through KWin's global-shortcut D-Bus interface rather than a simulated
+key press: ydotool/uinput would need privileges the backend does not have and
+should not be given, while the session bus is already in reach - the backend
+runs under the session user's uid (see session_env.py), so the same env that
+lets kscreen-doctor talk to the session works here too.
+
+Measured on BaluNode (2026-08-01): Plasma 6 on Debian 13 ships ``qdbus6`` and
+no plain ``qdbus``, and KWin lists the shortcut under exactly "Show Desktop"
+(``org.kde.kglobalaccel.Component.shortcutNames`` on the kwin component).
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from typing import Tuple
+
+from app.core.config import settings
+from app.services.power.session_env import wayland_session_env
+
+logger = logging.getLogger(__name__)
+
+# kglobalaccel answers in milliseconds; anything that needs several seconds is
+# broken, not slow. Kept well inside the 20s budget of a plugin menu action.
+_TIMEOUT_SECONDS = 10
+
+SHOW_DESKTOP_CMD = [
+    "qdbus6",
+    "org.kde.kglobalaccel",
+    "/component/kwin",
+    "invokeShortcut",
+    "Show Desktop",
+]
+
+
+def show_desktop() -> Tuple[bool, str]:
+    """Minimize all windows. Blocking - call via asyncio.to_thread.
+
+    Returns:
+        (ok, detail). ok=True means KWin accepted the shortcut.
+
+    Note this is KWin's TOGGLE, not a setter: invoking it while the desktop is
+    already cleared brings the windows back. Callers must fire it as the last
+    step of an action the user asked for, never speculatively or on a retry.
+    """
+    if settings.is_dev_mode:
+        # No KWin, no session bus on a Windows dev box.
+        return True, "show desktop requested (dev)"
+
+    try:
+        result = subprocess.run(  # fixed argv, no shell, no user input
+            SHOW_DESKTOP_CMD,
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_SECONDS,
+            env=wayland_session_env(),
+        )
+    except FileNotFoundError:
+        return False, "qdbus6 not found (is the desktop session running?)"
+    except subprocess.TimeoutExpired:
+        return False, "qdbus6 timed out"
+
+    if result.returncode != 0:
+        detail = (result.stderr or "").strip() or f"exit {result.returncode}"
+        logger.warning("show desktop failed: %s", detail)
+        return False, detail
+    return True, "windows minimized"

--- a/backend/app/services/power/desktop_windows.py
+++ b/backend/app/services/power/desktop_windows.py
@@ -1,61 +1,96 @@
 """Clear the KDE session's screen by minimizing every window.
 
-Driven through KWin's global-shortcut D-Bus interface rather than a simulated
-key press: ydotool/uinput would need privileges the backend does not have and
-should not be given, while the session bus is already in reach - the backend
-runs under the session user's uid (see session_env.py), so the same env that
-lets kscreen-doctor talk to the session works here too.
+Driven through KWin's own D-Bus interface rather than a simulated key press:
+ydotool/uinput would need privileges the backend does not have and should not
+be given, while the session bus is already in reach - the backend runs under
+the session user's uid (see session_env.py), so the same env that lets
+kscreen-doctor talk to the session works here too.
 
 Measured on BaluNode (2026-08-01): Plasma 6 on Debian 13 ships ``qdbus6`` and
-no plain ``qdbus``, and KWin lists the shortcut under exactly "Show Desktop"
-(``org.kde.kglobalaccel.Component.shortcutNames`` on the kwin component).
+no plain ``qdbus``, and ``org.kde.KWin`` on ``/KWin`` exposes both halves this
+module needs::
+
+    method Q_NOREPLY void org.kde.KWin.showDesktop(bool showing)
+    property read bool org.kde.KWin.showingDesktop
+
+The setter is used deliberately instead of kglobalaccel's "Show Desktop"
+shortcut, which is a TOGGLE: a second invocation would bring the windows back,
+so a retry or a double click would undo the action. ``showDesktop(true)`` is
+idempotent. The property makes this the one step of ending gaming mode whose
+effect can actually be verified - Big Picture's own state cannot be (see the
+design doc from 2026-07-24).
 """
 from __future__ import annotations
 
 import logging
 import subprocess
-from typing import Tuple
+from typing import List, Optional, Tuple
 
 from app.core.config import settings
 from app.services.power.session_env import wayland_session_env
 
 logger = logging.getLogger(__name__)
 
-# kglobalaccel answers in milliseconds; anything that needs several seconds is
-# broken, not slow. Kept well inside the 20s budget of a plugin menu action.
+# KWin answers in milliseconds; anything that needs several seconds is broken,
+# not slow. Kept well inside the 20s budget of a plugin menu action.
 _TIMEOUT_SECONDS = 10
 
 SHOW_DESKTOP_CMD = [
     "qdbus6",
-    "org.kde.kglobalaccel",
-    "/component/kwin",
-    "invokeShortcut",
-    "Show Desktop",
+    "org.kde.KWin",
+    "/KWin",
+    "org.kde.KWin.showDesktop",
+    "true",
 ]
+
+SHOWING_DESKTOP_CMD = [
+    "qdbus6",
+    "org.kde.KWin",
+    "/KWin",
+    "org.kde.KWin.showingDesktop",
+]
+
+
+def _run(cmd: List[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(  # fixed argv, no shell, no user input
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT_SECONDS,
+        env=wayland_session_env(),
+    )
+
+
+def _showing_desktop() -> Optional[bool]:
+    """KWin's own answer, or None when it cannot be read."""
+    try:
+        result = _run(SHOWING_DESKTOP_CMD)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    value = (result.stdout or "").strip().lower()
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    return None
 
 
 def show_desktop() -> Tuple[bool, str]:
     """Minimize all windows. Blocking - call via asyncio.to_thread.
 
     Returns:
-        (ok, detail). ok=True means KWin accepted the shortcut.
-
-    Note this is KWin's TOGGLE, not a setter: invoking it while the desktop is
-    already cleared brings the windows back. Callers must fire it as the last
-    step of an action the user asked for, never speculatively or on a retry.
+        (ok, detail). ok=True means KWin accepted the call and did not
+        contradict it afterwards. Safe to call repeatedly: unlike the
+        "Show Desktop" shortcut this sets the state instead of toggling it.
     """
     if settings.is_dev_mode:
         # No KWin, no session bus on a Windows dev box.
         return True, "show desktop requested (dev)"
 
     try:
-        result = subprocess.run(  # fixed argv, no shell, no user input
-            SHOW_DESKTOP_CMD,
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT_SECONDS,
-            env=wayland_session_env(),
-        )
+        result = _run(SHOW_DESKTOP_CMD)
     except FileNotFoundError:
         return False, "qdbus6 not found (is the desktop session running?)"
     except subprocess.TimeoutExpired:
@@ -65,4 +100,11 @@ def show_desktop() -> Tuple[bool, str]:
         detail = (result.stderr or "").strip() or f"exit {result.returncode}"
         logger.warning("show desktop failed: %s", detail)
         return False, detail
+
+    # Only an explicit contradiction counts as a failure. A property that
+    # cannot be read says nothing about the windows, and turning that into a
+    # red toast would report a problem that may not exist.
+    if _showing_desktop() is False:
+        logger.warning("show desktop: KWin still reports showingDesktop=false")
+        return False, "KWin still reports the windows as visible"
     return True, "windows minimized"

--- a/backend/tests/plugins/test_steam_gaming_detector.py
+++ b/backend/tests/plugins/test_steam_gaming_detector.py
@@ -66,3 +66,39 @@ def test_unreadable_and_vanished_entries_are_skipped(tmp_path):
 def test_missing_proc_returns_none(tmp_path):
     """Windows dev boxes have no /proc at all."""
     assert detector.detect_running_app_id(tmp_path / "nope") is None
+
+
+class TestSteamIsRunning:
+    """Guard for the exit action: `steam steam://close/bigpicture` STARTS Steam
+    when it is not already running, so the caller has to know first."""
+
+    def test_finds_the_client_started_from_its_install_dir(self, tmp_path):
+        root = _fake_proc(tmp_path, {
+            1: "/sbin/init",
+            4367: "/home/sven/.local/share/Steam/ubuntu12_32/steam",
+        })
+
+        assert detector.steam_is_running(root) is True
+
+    def test_finds_the_client_started_with_arguments(self, tmp_path):
+        root = _fake_proc(tmp_path, {4367: "/usr/bin/steam -silent"})
+
+        assert detector.steam_is_running(root) is True
+
+    def test_no_steam_process_means_false(self, tmp_path):
+        root = _fake_proc(tmp_path, {1: "/sbin/init", 900: "/usr/bin/firefox"})
+
+        assert detector.steam_is_running(root) is False
+
+    def test_helpers_alone_do_not_count_as_the_client(self, tmp_path):
+        """A false positive is the expensive direction - it would let the exit
+        action boot Steam. Helper processes never outlive the client anyway."""
+        root = _fake_proc(tmp_path, {
+            5001: "/home/sven/.local/share/Steam/ubuntu12_32/steamwebhelper --type=zygote",
+            5002: "/usr/bin/steamerrorreporter",
+        })
+
+        assert detector.steam_is_running(root) is False
+
+    def test_missing_proc_means_false(self, tmp_path):
+        assert detector.steam_is_running(tmp_path / "nope") is False

--- a/backend/tests/plugins/test_steam_gaming_launcher.py
+++ b/backend/tests/plugins/test_steam_gaming_launcher.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import MagicMock, patch
 
-from app.plugins.installed.steam_gaming.launcher import BIG_PICTURE_URL, open_big_picture
+from app.plugins.installed.steam_gaming.launcher import (
+    BIG_PICTURE_URL,
+    CLOSE_BIG_PICTURE_URL,
+    close_big_picture,
+    open_big_picture,
+)
 
 
 class TestOpenBigPicture:
@@ -85,3 +90,66 @@ class TestOpenBigPicture:
 
         handle.wait.assert_not_called()
         handle.communicate.assert_not_called()
+
+
+class TestCloseBigPicture:
+    """The counterpart, measured on BaluNode 2026-08-01: the running client
+    leaves Big Picture and stays up."""
+
+    def test_launches_steam_with_the_close_url(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen") as popen, \
+             patch("app.plugins.installed.steam_gaming.launcher.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            ok, _detail = close_big_picture()
+
+        assert ok is True
+        assert popen.call_args.args[0] == ["steam", CLOSE_BIG_PICTURE_URL]
+
+    def test_close_url_is_not_the_open_url(self):
+        """A copy-paste slip here would make the exit action re-open Big
+        Picture, and nothing downstream could tell the difference."""
+        assert CLOSE_BIG_PICTURE_URL != BIG_PICTURE_URL
+
+    def test_detaches_like_the_open_direction(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen") as popen, \
+             patch("app.plugins.installed.steam_gaming.launcher.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            close_big_picture()
+
+        kwargs = popen.call_args.kwargs
+        assert kwargs["start_new_session"] is True
+        assert kwargs["stdin"] == subprocess.DEVNULL
+        assert "shell" not in kwargs
+
+    def test_passes_the_wayland_session_env(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen") as popen, \
+             patch(
+                 "app.plugins.installed.steam_gaming.launcher.wayland_session_env",
+                 return_value={"XDG_RUNTIME_DIR": "/run/user/1000"},
+             ):
+            cfg.is_dev_mode = False
+            close_big_picture()
+
+        assert popen.call_args.kwargs["env"] == {"XDG_RUNTIME_DIR": "/run/user/1000"}
+
+    def test_missing_steam_binary_is_reported_not_raised(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen", side_effect=FileNotFoundError()), \
+             patch("app.plugins.installed.steam_gaming.launcher.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            ok, detail = close_big_picture()
+
+        assert ok is False
+        assert "steam" in detail.lower()
+
+    def test_dev_mode_does_not_spawn_anything(self):
+        with patch("app.plugins.installed.steam_gaming.launcher.settings") as cfg, \
+             patch("subprocess.Popen") as popen:
+            cfg.is_dev_mode = True
+            ok, _detail = close_big_picture()
+
+        assert ok is True
+        popen.assert_not_called()

--- a/backend/tests/plugins/test_steam_gaming_plugin.py
+++ b/backend/tests/plugins/test_steam_gaming_plugin.py
@@ -110,6 +110,34 @@ async def test_an_unknown_pill_id_is_silent(plugin, dev_mode):
 
 
 _ACTION = "gaming_mode"
+_END_ACTION = "gaming_mode_end"
+
+
+def _patch_end_action(
+    *,
+    game=None,
+    steam_running: bool = True,
+    closed: tuple = (True, "requested"),
+    minimized: tuple = (True, "windows minimized"),
+):
+    """Patch everything the exit action touches.
+
+    The last element stubs the settle delay - without it every test that walks
+    the happy path would really wait _WINDOW_SETTLE_SECONDS.
+    """
+    return (
+        patch("app.plugins.installed.steam_gaming._current_game", return_value=game),
+        patch(
+            "app.plugins.installed.steam_gaming.steam_is_running",
+            return_value=steam_running,
+        ),
+        patch(
+            "app.plugins.installed.steam_gaming.close_big_picture",
+            return_value=closed,
+        ),
+        patch("app.plugins.installed.steam_gaming.show_desktop", return_value=minimized),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    )
 
 
 def _patch_desktop(ok: bool, message: str = ""):
@@ -122,9 +150,9 @@ def _patch_desktop(ok: bool, message: str = ""):
 
 
 class TestGamingModeMenuItem:
-    def test_manifest_declares_the_action(self):
+    def test_manifest_declares_both_directions(self):
         manifest = SteamGamingPlugin().get_ui_manifest()
-        assert [item.id for item in manifest.menu_items] == [_ACTION]
+        assert [item.id for item in manifest.menu_items] == [_ACTION, _END_ACTION]
 
     def test_item_carries_key_and_literal_fallback(self):
         item = SteamGamingPlugin().get_ui_manifest().menu_items[0]
@@ -132,13 +160,23 @@ class TestGamingModeMenuItem:
         assert item.label_text
         assert item.icon == "Gamepad2"
 
-    def test_translations_cover_every_key_the_item_uses(self):
+    def test_translations_cover_every_key_the_items_use(self):
         plugin = SteamGamingPlugin()
-        item = plugin.get_ui_manifest().menu_items[0]
         translations = plugin.get_translations()
-        for lang in ("en", "de"):
-            assert item.label_key in translations[lang]
-            assert item.description_key in translations[lang]
+        for item in plugin.get_ui_manifest().menu_items:
+            for lang in ("en", "de"):
+                assert item.label_key in translations[lang]
+                assert item.description_key in translations[lang]
+
+    def test_every_icon_resolves_in_the_frontend_icon_map(self):
+        """client/src/components/topbar/iconMap.ts is a CLOSED map (#451) - an
+        icon outside it silently degrades to the generic Plug fallback."""
+        known = {
+            "Zap", "Shield", "Upload", "RefreshCw", "HardDrive", "Moon", "Lock",
+            "Thermometer", "Coffee", "Clock", "Save", "Monitor", "Gamepad2",
+        }
+        for item in SteamGamingPlugin().get_ui_manifest().menu_items:
+            assert item.icon in known, f"{item.id} uses an icon the frontend cannot resolve"
 
 
 class TestGamingModeAction:
@@ -179,6 +217,98 @@ class TestGamingModeAction:
 
         assert result.ok is False
         assert result.message_key == "menu_steam_failed"
+
+
+class TestEndGamingModeAction:
+    """Closing Big Picture and clearing the desktop again.
+
+    Big Picture's state is not observable (design doc 2026-07-24), so this
+    direction is as fire-and-forget as the start direction - what CAN be
+    checked are the two preconditions: no game running, Steam running.
+    """
+
+    async def test_closes_big_picture_then_minimizes_the_windows(self):
+        calls: list[str] = []
+        game_p, steam_p, close_p, show_p, sleep_p = _patch_end_action()
+        with game_p, steam_p, close_p as close, show_p as show, sleep_p:
+            close.side_effect = lambda: (calls.append("close"), (True, "requested"))[1]
+            show.side_effect = lambda: (calls.append("show"), (True, "minimized"))[1]
+            result = await SteamGamingPlugin().run_menu_action(_END_ACTION, db=None)
+
+        assert calls == ["close", "show"]
+        assert result.ok is True
+        assert result.message_key == "menu_gaming_mode_ended"
+
+    async def test_lets_the_windowed_ui_settle_before_minimizing(self):
+        """Steam repaints its normal window a moment after leaving Big
+        Picture - minimizing first would clear a desktop it then pops onto."""
+        assert plugin_module._WINDOW_SETTLE_SECONDS > 0
+
+        game_p, steam_p, close_p, show_p, sleep_p = _patch_end_action()
+        with game_p, steam_p, close_p, show_p, sleep_p as sleep:
+            await SteamGamingPlugin().run_menu_action(_END_ACTION, db=None)
+
+        sleep.assert_awaited_once_with(plugin_module._WINDOW_SETTLE_SECONDS)
+
+    async def test_refuses_while_a_game_is_running(self):
+        game_p, steam_p, close_p, show_p, sleep_p = _patch_end_action(
+            game=("1449560", "Metro Exodus")
+        )
+        with game_p, steam_p, close_p as close, show_p as show, sleep_p:
+            result = await SteamGamingPlugin().run_menu_action(_END_ACTION, db=None)
+
+        close.assert_not_called()
+        show.assert_not_called()
+        assert result.ok is False
+        assert result.message_key == "menu_end_game_running"
+        assert "Metro Exodus" in result.message_text
+
+    async def test_does_not_start_steam_just_to_close_big_picture(self):
+        """`steam steam://close/bigpicture` STARTS Steam when it is not
+        running - the whole point of the guard."""
+        game_p, steam_p, close_p, show_p, sleep_p = _patch_end_action(steam_running=False)
+        with game_p, steam_p, close_p as close, show_p as show, sleep_p:
+            result = await SteamGamingPlugin().run_menu_action(_END_ACTION, db=None)
+
+        close.assert_not_called()
+        show.assert_not_called()
+        assert result.ok is True  # nothing to end is not a failure
+        assert result.message_key == "menu_end_steam_not_running"
+
+    async def test_does_not_minimize_when_big_picture_could_not_be_closed(self):
+        """Clearing the desktop while Big Picture is still up would hide the
+        failure behind an empty screen."""
+        game_p, steam_p, close_p, show_p, sleep_p = _patch_end_action(
+            closed=(False, "steam binary not found")
+        )
+        with game_p, steam_p, close_p, show_p as show, sleep_p:
+            result = await SteamGamingPlugin().run_menu_action(_END_ACTION, db=None)
+
+        show.assert_not_called()
+        assert result.ok is False
+        assert result.message_key == "menu_end_close_failed"
+
+    async def test_reports_partial_success_when_the_windows_stay_up(self):
+        game_p, steam_p, close_p, show_p, sleep_p = _patch_end_action(
+            minimized=(False, "qdbus6 not found")
+        )
+        with game_p, steam_p, close_p, show_p, sleep_p:
+            result = await SteamGamingPlugin().run_menu_action(_END_ACTION, db=None)
+
+        assert result.ok is False
+        assert result.message_key == "menu_end_windows_failed"
+
+    async def test_blocking_calls_run_off_the_event_loop(self):
+        """Same reason as the start direction: asyncio.wait_for() in the route
+        cannot interrupt a blocking call made on the loop thread."""
+        idents: list[int] = []
+        game_p, steam_p, close_p, show_p, sleep_p = _patch_end_action()
+        with game_p, steam_p, close_p as close, show_p as show, sleep_p:
+            close.side_effect = lambda: (idents.append(threading.get_ident()), (True, "x"))[1]
+            show.side_effect = lambda: (idents.append(threading.get_ident()), (True, "x"))[1]
+            await SteamGamingPlugin().run_menu_action(_END_ACTION, db=None)
+
+        assert idents and all(ident != threading.get_ident() for ident in idents)
 
 
 class TestManifestAndRouteAgreeOnDeclaredActions:

--- a/backend/tests/services/power/test_desktop_windows.py
+++ b/backend/tests/services/power/test_desktop_windows.py
@@ -1,0 +1,102 @@
+"""Minimizing every window of the KDE session ("Show Desktop")."""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from app.services.power.desktop_windows import SHOW_DESKTOP_CMD, show_desktop
+
+
+def _completed(returncode: int = 0, stderr: str = "") -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = ""
+    result.stderr = stderr
+    return result
+
+
+class TestShowDesktop:
+    def test_invokes_kwins_show_desktop_shortcut(self):
+        with patch("app.services.power.desktop_windows.settings") as cfg, \
+             patch("subprocess.run", return_value=_completed()) as run, \
+             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            ok, _detail = show_desktop()
+
+        assert ok is True
+        assert run.call_args.args[0] == SHOW_DESKTOP_CMD
+
+    def test_uses_qdbus6_and_the_measured_shortcut_name(self):
+        """Both were measured on BaluNode - Plasma 6 ships no plain `qdbus`,
+        and the shortcut is registered as exactly "Show Desktop"."""
+        assert SHOW_DESKTOP_CMD[0] == "qdbus6"
+        assert SHOW_DESKTOP_CMD[-1] == "Show Desktop"
+
+    def test_passes_the_wayland_session_env(self):
+        with patch("app.services.power.desktop_windows.settings") as cfg, \
+             patch("subprocess.run", return_value=_completed()) as run, \
+             patch(
+                 "app.services.power.desktop_windows.wayland_session_env",
+                 return_value={"XDG_RUNTIME_DIR": "/run/user/1000"},
+             ):
+            cfg.is_dev_mode = False
+            show_desktop()
+
+        assert run.call_args.kwargs["env"] == {"XDG_RUNTIME_DIR": "/run/user/1000"}
+
+    def test_never_uses_a_shell(self):
+        with patch("app.services.power.desktop_windows.settings") as cfg, \
+             patch("subprocess.run", return_value=_completed()) as run, \
+             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            show_desktop()
+
+        assert "shell" not in run.call_args.kwargs
+
+    def test_sets_a_timeout_so_a_stuck_session_cannot_hang_the_action(self):
+        with patch("app.services.power.desktop_windows.settings") as cfg, \
+             patch("subprocess.run", return_value=_completed()) as run, \
+             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            show_desktop()
+
+        assert run.call_args.kwargs["timeout"] > 0
+
+    def test_missing_qdbus_binary_is_reported_not_raised(self):
+        with patch("app.services.power.desktop_windows.settings") as cfg, \
+             patch("subprocess.run", side_effect=FileNotFoundError()), \
+             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            ok, detail = show_desktop()
+
+        assert ok is False
+        assert "qdbus6" in detail
+
+    def test_timeout_is_reported_not_raised(self):
+        with patch("app.services.power.desktop_windows.settings") as cfg, \
+             patch("subprocess.run", side_effect=subprocess.TimeoutExpired("qdbus6", 10)), \
+             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            ok, detail = show_desktop()
+
+        assert ok is False
+        assert "timed out" in detail
+
+    def test_non_zero_exit_carries_the_stderr(self):
+        with patch("app.services.power.desktop_windows.settings") as cfg, \
+             patch("subprocess.run", return_value=_completed(1, "no such service")), \
+             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            ok, detail = show_desktop()
+
+        assert ok is False
+        assert detail == "no such service"
+
+    def test_dev_mode_does_not_spawn_anything(self):
+        with patch("app.services.power.desktop_windows.settings") as cfg, \
+             patch("subprocess.run") as run:
+            cfg.is_dev_mode = True
+            ok, _detail = show_desktop()
+
+        assert ok is True
+        run.assert_not_called()

--- a/backend/tests/services/power/test_desktop_windows.py
+++ b/backend/tests/services/power/test_desktop_windows.py
@@ -1,40 +1,62 @@
-"""Minimizing every window of the KDE session ("Show Desktop")."""
+"""Minimizing every window of the KDE session (KWin's showDesktop setter)."""
 from __future__ import annotations
 
 import subprocess
 from unittest.mock import MagicMock, patch
 
-from app.services.power.desktop_windows import SHOW_DESKTOP_CMD, show_desktop
+from app.services.power.desktop_windows import (
+    SHOW_DESKTOP_CMD,
+    SHOWING_DESKTOP_CMD,
+    show_desktop,
+)
 
 
-def _completed(returncode: int = 0, stderr: str = "") -> MagicMock:
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
     result = MagicMock()
     result.returncode = returncode
-    result.stdout = ""
+    result.stdout = stdout
     result.stderr = stderr
     return result
 
 
+def _patch_run(*results):
+    """Patch subprocess.run; consecutive calls get consecutive *results*."""
+    if len(results) == 1:
+        return patch("subprocess.run", return_value=results[0])
+    return patch("subprocess.run", side_effect=list(results))
+
+
+class TestShowDesktopCommands:
+    def test_uses_qdbus6(self):
+        """Measured on BaluNode: Plasma 6 on Debian 13 ships no plain qdbus."""
+        assert SHOW_DESKTOP_CMD[0] == "qdbus6"
+        assert SHOWING_DESKTOP_CMD[0] == "qdbus6"
+
+    def test_sets_the_state_instead_of_toggling_it(self):
+        """kglobalaccel's "Show Desktop" shortcut is a TOGGLE - a second call
+        would bring the windows back. A regression to it would make the exit
+        action undo itself on a retry, which no behavioural test can see."""
+        assert SHOW_DESKTOP_CMD[-2:] == ["org.kde.KWin.showDesktop", "true"]
+        assert "invokeShortcut" not in SHOW_DESKTOP_CMD
+
+    def test_reads_kwins_own_property_back(self):
+        assert SHOWING_DESKTOP_CMD[-1] == "org.kde.KWin.showingDesktop"
+
+
 class TestShowDesktop:
-    def test_invokes_kwins_show_desktop_shortcut(self):
+    def test_calls_the_setter_and_reports_success(self):
         with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run", return_value=_completed()) as run, \
+             _patch_run(_completed(stdout=""), _completed(stdout="true")) as run, \
              patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
             cfg.is_dev_mode = False
             ok, _detail = show_desktop()
 
         assert ok is True
-        assert run.call_args.args[0] == SHOW_DESKTOP_CMD
-
-    def test_uses_qdbus6_and_the_measured_shortcut_name(self):
-        """Both were measured on BaluNode - Plasma 6 ships no plain `qdbus`,
-        and the shortcut is registered as exactly "Show Desktop"."""
-        assert SHOW_DESKTOP_CMD[0] == "qdbus6"
-        assert SHOW_DESKTOP_CMD[-1] == "Show Desktop"
+        assert run.call_args_list[0].args[0] == SHOW_DESKTOP_CMD
 
     def test_passes_the_wayland_session_env(self):
         with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run", return_value=_completed()) as run, \
+             _patch_run(_completed(), _completed(stdout="true")) as run, \
              patch(
                  "app.services.power.desktop_windows.wayland_session_env",
                  return_value={"XDG_RUNTIME_DIR": "/run/user/1000"},
@@ -42,25 +64,25 @@ class TestShowDesktop:
             cfg.is_dev_mode = False
             show_desktop()
 
-        assert run.call_args.kwargs["env"] == {"XDG_RUNTIME_DIR": "/run/user/1000"}
+        assert run.call_args_list[0].kwargs["env"] == {"XDG_RUNTIME_DIR": "/run/user/1000"}
 
     def test_never_uses_a_shell(self):
         with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run", return_value=_completed()) as run, \
+             _patch_run(_completed(), _completed(stdout="true")) as run, \
              patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
             cfg.is_dev_mode = False
             show_desktop()
 
-        assert "shell" not in run.call_args.kwargs
+        assert "shell" not in run.call_args_list[0].kwargs
 
     def test_sets_a_timeout_so_a_stuck_session_cannot_hang_the_action(self):
         with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run", return_value=_completed()) as run, \
+             _patch_run(_completed(), _completed(stdout="true")) as run, \
              patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
             cfg.is_dev_mode = False
             show_desktop()
 
-        assert run.call_args.kwargs["timeout"] > 0
+        assert run.call_args_list[0].kwargs["timeout"] > 0
 
     def test_missing_qdbus_binary_is_reported_not_raised(self):
         with patch("app.services.power.desktop_windows.settings") as cfg, \
@@ -84,7 +106,7 @@ class TestShowDesktop:
 
     def test_non_zero_exit_carries_the_stderr(self):
         with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run", return_value=_completed(1, "no such service")), \
+             _patch_run(_completed(1, stderr="no such service")), \
              patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
             cfg.is_dev_mode = False
             ok, detail = show_desktop()
@@ -100,3 +122,41 @@ class TestShowDesktop:
 
         assert ok is True
         run.assert_not_called()
+
+
+class TestVerificationAgainstKwinsProperty:
+    """The one step of ending gaming mode whose effect IS observable."""
+
+    def test_kwin_contradicting_the_call_is_a_failure(self):
+        with patch("app.services.power.desktop_windows.settings") as cfg, \
+             _patch_run(_completed(), _completed(stdout="false")), \
+             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            ok, detail = show_desktop()
+
+        assert ok is False
+        assert "visible" in detail
+
+    def test_an_unreadable_property_does_not_invent_a_failure(self):
+        """A property that cannot be read says nothing about the windows -
+        reporting a red toast for it would announce a problem that may not
+        exist."""
+        with patch("app.services.power.desktop_windows.settings") as cfg, \
+             _patch_run(_completed(), _completed(1, stderr="boom")), \
+             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            ok, _detail = show_desktop()
+
+        assert ok is True
+
+    def test_a_property_read_that_raises_does_not_escape(self):
+        with patch("app.services.power.desktop_windows.settings") as cfg, \
+             patch(
+                 "subprocess.run",
+                 side_effect=[_completed(), subprocess.TimeoutExpired("qdbus6", 10)],
+             ), \
+             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            ok, _detail = show_desktop()
+
+        assert ok is True


### PR DESCRIPTION
## Problem

Der Gaming-Modus im Power-Menü ging bisher nur in eine Richtung: Displays an, Session entsperren, Big Picture öffnen. Es gab keinen Weg, ihn aus der Web-App wieder zu beenden — weder einen Menüpunkt noch eine Funktion. Der Display-Teil war längst bidirektional (`POST /api/desktop/disable`), nur der Steam-Teil nicht.

Die Sackgasse aus dem Steam-Track (Design-Doc 2026-07-24, "Big Picture vs. Fenster — gemessen, nicht baubar") betraf das **Erkennen** von Big Picture. Das **Beenden** ist ein anderes Problem und war nie ausgemessen worden.

## Messungen auf BaluNode (2026-08-01)

Beide Hälften sind herstellerseitig nicht dokumentiert, deshalb an der echten Box gemessen:

| Was | Ergebnis |
|---|---|
| `steam steam://close/bigpicture` bei laufendem Big Picture | verlässt BPM, Client bleibt oben (`pgrep -c steam` = 12 danach) |
| `which qdbus` | leer — Plasma 6 auf Debian 13 liefert nur `qdbus6` |
| `shortcutNames` der kwin-Komponente | enthält exakt `Show Desktop` (und `Window Minimize` als zielgenauere Alternative) |
| `qdbus6 … invokeShortcut "Show Desktop"` | exit 0, Fenster minimiert |

## Umsetzung

Zweiter Menüpunkt „Gaming-Modus beenden" im selben Plugin:

1. **Läuft ein Spiel? → Abbruch.** Das ist der einzige Zustand, den wir zuverlässig erkennen (`detector.py`), und ein Klick aus der Ferne soll niemandem am Gerät die Oberfläche wegziehen.
2. **Läuft Steam gar nicht? → No-op mit Meldung.** Ohne diesen Guard würde `steam://close/bigpicture` Steam *starten* — derselbe Fallstrick, den die Startrichtung schon im Docstring dokumentiert.
3. **Big Picture schließen** → 2 s warten (Steam malt sein Fenster verzögert) → **`Show Desktop`**.

Neu dabei: `app/services/power/desktop_windows.py` (KWin-Shortcut über den Session-Bus, gleiche Env wie `kscreen-doctor`, Dev-Mode-Kurzschluss, Timeout, kein `shell=True`) und `detector.steam_is_running()` (derselbe `/proc`-Scan, andere Frage; `steamwebhelper`/`steamerrorreporter` zählen bewusst **nicht**, weil ein False Positive die teure Richtung ist).

**Die Displays bleiben unangetastet** — „Displays aus" ist ein eigener Eintrag im Power-Menü, und beides zu koppeln würde einen Klick zwei Dinge tun lassen.

**Kein Frontend-Diff:** der Menü-Renderer ist generisch, und das Icon (`Monitor`) kommt aus der geschlossenen Icon-Map statt sie zu erweitern (#451).

## Tests

- `tests/services/power/test_desktop_windows.py` (neu, 14 Tests): Kommando (Setter, **kein** `invokeShortcut`), Env, Timeout, kein Shell, FileNotFound/Timeout/Exit≠0, Dev-Mode, und die drei Verifikationsfälle (`true` / `false` / nicht lesbar).
- `test_steam_gaming_launcher.py`: `TestCloseBigPicture` — u. a. dass Close-URL ≠ Open-URL ist (ein Copy-Paste-Fehler wäre sonst unsichtbar).
- `test_steam_gaming_detector.py`: `TestSteamIsRunning` — inkl. „Helfer-Prozesse zählen nicht".
- `test_steam_gaming_plugin.py`: Reihenfolge close→show, beide Guards, beide Teilfehler, Settle-Delay, und dass die blockierenden Aufrufe über `asyncio.to_thread` laufen (sonst wäre der Route-Timeout dekorativ).

Lokal: 973 passed in `tests/plugins` + `tests/services/power` + Desktop-Tests. Die 3 Fehlschläge in `test_desktop_backend.py` sind pre-existing und Windows-spezifisch (`os.getuid` gibt es dort nicht) — sie fallen auf einem unveränderten Checkout genauso aus. `ruff check` sauber.

## Kein offener Punkt mehr

Die erste Fassung fuhr kglobalaccels `Show Desktop`-Shortcut — einen **Umschalter**, der bei einem zweiten Aufruf die Fenster zurückgeholt hätte. Die Nachmessung zeigte, dass `org.kde.KWin` auf `/KWin` beides anbietet:

```
method Q_NOREPLY void org.kde.KWin.showDesktop(bool showing)
property read bool     org.kde.KWin.showingDesktop
```

Der zweite Commit stellt deshalb auf den **Setter** um (idempotent) und liest die Property danach zurück. Damit ist das Minimieren der einzige Schritt des ganzen Ablaufs, dessen Wirkung überhaupt überprüfbar ist — Big Pictures eigener Zustand ist es nicht. Nur ein ausdrückliches `false` gilt als Fehler; eine nicht lesbare Property sagt nichts über die Fenster aus und würde sonst einen Fehler melden, den es nicht gibt.

Timing ebenfalls bestätigt: `close ; sleep 2 ; showDesktop` landet auf einem sauberen Desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
