### PR TITLE
fix(steam-gaming): Fehlalarm beim Beenden des Gaming-Modus (showingDesktop taugt nicht als Kontrolle)

### DIFF
--- a/backend/app/services/power/desktop_windows.py
+++ b/backend/app/services/power/desktop_windows.py
@@ -6,25 +6,29 @@ be given, while the session bus is already in reach - the backend runs under
 the session user's uid (see session_env.py), so the same env that lets
 kscreen-doctor talk to the session works here too.
 
-Measured on BaluNode (2026-08-01): Plasma 6 on Debian 13 ships ``qdbus6`` and
-no plain ``qdbus``, and ``org.kde.KWin`` on ``/KWin`` exposes both halves this
-module needs::
+Measured on BaluNode (2026-08-01), Plasma 6 on Debian 13:
 
-    method Q_NOREPLY void org.kde.KWin.showDesktop(bool showing)
-    property read bool org.kde.KWin.showingDesktop
+- the binary is ``qdbus6``; there is no plain ``qdbus``
+- ``org.kde.KWin.showDesktop(bool)`` on ``/KWin`` minimizes every window and
+  exits 0. It takes a bool rather than toggling, so calling it twice leaves
+  the windows down - unlike kglobalaccel's "Show Desktop" shortcut, where a
+  second invocation brings them back.
+- ``org.kde.KWin.showingDesktop`` reads **false** one second after that same
+  successful call, with the windows visibly down. It tracks KWin's temporary
+  show-desktop MODE, not "are the windows minimized". **Do not use it to
+  verify this call** - the first version of this module did, and every
+  successful run reported "the windows stayed up" to the user.
 
-The setter is used deliberately instead of kglobalaccel's "Show Desktop"
-shortcut, which is a TOGGLE: a second invocation would bring the windows back,
-so a retry or a double click would undo the action. ``showDesktop(true)`` is
-idempotent. The property makes this the one step of ending gaming mode whose
-effect can actually be verified - Big Picture's own state cannot be (see the
-design doc from 2026-07-24).
+So there is no verification step here: like everything else in ending gaming
+mode, the effect is not observable (Big Picture's own state is not either, see
+the design doc from 2026-07-24). A non-zero exit is the only failure this
+module can honestly report.
 """
 from __future__ import annotations
 
 import logging
 import subprocess
-from typing import List, Optional, Tuple
+from typing import Tuple
 
 from app.core.config import settings
 from app.services.power.session_env import wayland_session_env
@@ -43,54 +47,26 @@ SHOW_DESKTOP_CMD = [
     "true",
 ]
 
-SHOWING_DESKTOP_CMD = [
-    "qdbus6",
-    "org.kde.KWin",
-    "/KWin",
-    "org.kde.KWin.showingDesktop",
-]
-
-
-def _run(cmd: List[str]) -> subprocess.CompletedProcess:
-    return subprocess.run(  # fixed argv, no shell, no user input
-        cmd,
-        capture_output=True,
-        text=True,
-        timeout=_TIMEOUT_SECONDS,
-        env=wayland_session_env(),
-    )
-
-
-def _showing_desktop() -> Optional[bool]:
-    """KWin's own answer, or None when it cannot be read."""
-    try:
-        result = _run(SHOWING_DESKTOP_CMD)
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        return None
-    if result.returncode != 0:
-        return None
-    value = (result.stdout or "").strip().lower()
-    if value == "true":
-        return True
-    if value == "false":
-        return False
-    return None
-
 
 def show_desktop() -> Tuple[bool, str]:
     """Minimize all windows. Blocking - call via asyncio.to_thread.
 
     Returns:
-        (ok, detail). ok=True means KWin accepted the call and did not
-        contradict it afterwards. Safe to call repeatedly: unlike the
-        "Show Desktop" shortcut this sets the state instead of toggling it.
+        (ok, detail). ok=True means KWin accepted the call. Safe to repeat:
+        the call sets the state instead of toggling it.
     """
     if settings.is_dev_mode:
         # No KWin, no session bus on a Windows dev box.
         return True, "show desktop requested (dev)"
 
     try:
-        result = _run(SHOW_DESKTOP_CMD)
+        result = subprocess.run(  # fixed argv, no shell, no user input
+            SHOW_DESKTOP_CMD,
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_SECONDS,
+            env=wayland_session_env(),
+        )
     except FileNotFoundError:
         return False, "qdbus6 not found (is the desktop session running?)"
     except subprocess.TimeoutExpired:
@@ -100,11 +76,4 @@ def show_desktop() -> Tuple[bool, str]:
         detail = (result.stderr or "").strip() or f"exit {result.returncode}"
         logger.warning("show desktop failed: %s", detail)
         return False, detail
-
-    # Only an explicit contradiction counts as a failure. A property that
-    # cannot be read says nothing about the windows, and turning that into a
-    # red toast would report a problem that may not exist.
-    if _showing_desktop() is False:
-        logger.warning("show desktop: KWin still reports showingDesktop=false")
-        return False, "KWin still reports the windows as visible"
     return True, "windows minimized"

--- a/backend/tests/services/power/test_desktop_windows.py
+++ b/backend/tests/services/power/test_desktop_windows.py
@@ -4,11 +4,8 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import MagicMock, patch
 
-from app.services.power.desktop_windows import (
-    SHOW_DESKTOP_CMD,
-    SHOWING_DESKTOP_CMD,
-    show_desktop,
-)
+from app.services.power import desktop_windows
+from app.services.power.desktop_windows import SHOW_DESKTOP_CMD, show_desktop
 
 
 def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
@@ -19,18 +16,10 @@ def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> Magic
     return result
 
 
-def _patch_run(*results):
-    """Patch subprocess.run; consecutive calls get consecutive *results*."""
-    if len(results) == 1:
-        return patch("subprocess.run", return_value=results[0])
-    return patch("subprocess.run", side_effect=list(results))
-
-
-class TestShowDesktopCommands:
+class TestShowDesktopCommand:
     def test_uses_qdbus6(self):
         """Measured on BaluNode: Plasma 6 on Debian 13 ships no plain qdbus."""
         assert SHOW_DESKTOP_CMD[0] == "qdbus6"
-        assert SHOWING_DESKTOP_CMD[0] == "qdbus6"
 
     def test_sets_the_state_instead_of_toggling_it(self):
         """kglobalaccel's "Show Desktop" shortcut is a TOGGLE - a second call
@@ -39,24 +28,40 @@ class TestShowDesktopCommands:
         assert SHOW_DESKTOP_CMD[-2:] == ["org.kde.KWin.showDesktop", "true"]
         assert "invokeShortcut" not in SHOW_DESKTOP_CMD
 
-    def test_reads_kwins_own_property_back(self):
-        assert SHOWING_DESKTOP_CMD[-1] == "org.kde.KWin.showingDesktop"
-
 
 class TestShowDesktop:
     def test_calls_the_setter_and_reports_success(self):
         with patch("app.services.power.desktop_windows.settings") as cfg, \
-             _patch_run(_completed(stdout=""), _completed(stdout="true")) as run, \
+             patch("subprocess.run", return_value=_completed()) as run, \
              patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
             cfg.is_dev_mode = False
             ok, _detail = show_desktop()
 
         assert ok is True
-        assert run.call_args_list[0].args[0] == SHOW_DESKTOP_CMD
+        assert run.call_args.args[0] == SHOW_DESKTOP_CMD
+
+    def test_does_not_second_guess_kwin_afterwards(self):
+        """Regression guard for the false alarm shipped in #497.
+
+        The obvious verification - reading org.kde.KWin.showingDesktop back -
+        is WRONG: measured on the box, it reads false right after a successful
+        call with the windows visibly down, because it tracks KWin's temporary
+        show-desktop mode. Every successful run reported failure to the user.
+        One call, no read-back.
+        """
+        with patch("app.services.power.desktop_windows.settings") as cfg, \
+             patch("subprocess.run", return_value=_completed()) as run, \
+             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+            cfg.is_dev_mode = False
+            ok, _detail = show_desktop()
+
+        assert ok is True
+        assert run.call_count == 1
+        assert "showingDesktop" not in " ".join(run.call_args.args[0])
 
     def test_passes_the_wayland_session_env(self):
         with patch("app.services.power.desktop_windows.settings") as cfg, \
-             _patch_run(_completed(), _completed(stdout="true")) as run, \
+             patch("subprocess.run", return_value=_completed()) as run, \
              patch(
                  "app.services.power.desktop_windows.wayland_session_env",
                  return_value={"XDG_RUNTIME_DIR": "/run/user/1000"},
@@ -64,25 +69,25 @@ class TestShowDesktop:
             cfg.is_dev_mode = False
             show_desktop()
 
-        assert run.call_args_list[0].kwargs["env"] == {"XDG_RUNTIME_DIR": "/run/user/1000"}
+        assert run.call_args.kwargs["env"] == {"XDG_RUNTIME_DIR": "/run/user/1000"}
 
     def test_never_uses_a_shell(self):
         with patch("app.services.power.desktop_windows.settings") as cfg, \
-             _patch_run(_completed(), _completed(stdout="true")) as run, \
+             patch("subprocess.run", return_value=_completed()) as run, \
              patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
             cfg.is_dev_mode = False
             show_desktop()
 
-        assert "shell" not in run.call_args_list[0].kwargs
+        assert "shell" not in run.call_args.kwargs
 
     def test_sets_a_timeout_so_a_stuck_session_cannot_hang_the_action(self):
         with patch("app.services.power.desktop_windows.settings") as cfg, \
-             _patch_run(_completed(), _completed(stdout="true")) as run, \
+             patch("subprocess.run", return_value=_completed()) as run, \
              patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
             cfg.is_dev_mode = False
             show_desktop()
 
-        assert run.call_args_list[0].kwargs["timeout"] > 0
+        assert run.call_args.kwargs["timeout"] > 0
 
     def test_missing_qdbus_binary_is_reported_not_raised(self):
         with patch("app.services.power.desktop_windows.settings") as cfg, \
@@ -106,7 +111,7 @@ class TestShowDesktop:
 
     def test_non_zero_exit_carries_the_stderr(self):
         with patch("app.services.power.desktop_windows.settings") as cfg, \
-             _patch_run(_completed(1, stderr="no such service")), \
+             patch("subprocess.run", return_value=_completed(1, stderr="no such service")), \
              patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
             cfg.is_dev_mode = False
             ok, detail = show_desktop()
@@ -124,39 +129,7 @@ class TestShowDesktop:
         run.assert_not_called()
 
 
-class TestVerificationAgainstKwinsProperty:
-    """The one step of ending gaming mode whose effect IS observable."""
-
-    def test_kwin_contradicting_the_call_is_a_failure(self):
-        with patch("app.services.power.desktop_windows.settings") as cfg, \
-             _patch_run(_completed(), _completed(stdout="false")), \
-             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
-            cfg.is_dev_mode = False
-            ok, detail = show_desktop()
-
-        assert ok is False
-        assert "visible" in detail
-
-    def test_an_unreadable_property_does_not_invent_a_failure(self):
-        """A property that cannot be read says nothing about the windows -
-        reporting a red toast for it would announce a problem that may not
-        exist."""
-        with patch("app.services.power.desktop_windows.settings") as cfg, \
-             _patch_run(_completed(), _completed(1, stderr="boom")), \
-             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
-            cfg.is_dev_mode = False
-            ok, _detail = show_desktop()
-
-        assert ok is True
-
-    def test_a_property_read_that_raises_does_not_escape(self):
-        with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch(
-                 "subprocess.run",
-                 side_effect=[_completed(), subprocess.TimeoutExpired("qdbus6", 10)],
-             ), \
-             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
-            cfg.is_dev_mode = False
-            ok, _detail = show_desktop()
-
-        assert ok is True
+def test_the_module_no_longer_exposes_a_read_back_command():
+    """Belt and braces for the same regression: the constant is gone, so a
+    future edit cannot quietly wire the misleading property back in."""
+    assert not hasattr(desktop_windows, "SHOWING_DESKTOP_CMD")


### PR DESCRIPTION
## Problem

„Gaming-Modus beenden" (#497) funktioniert in Prod — Big Picture geht zu, die Fenster gehen runter — meldet aber jedes Mal einen Fehler:

> ❌ Big Picture was closed, but the windows stayed up

Im Journal sechs Treffer in vier Minuten, alle identisch:

```
WARNING app.services.power.desktop_windows
        show desktop: KWin still reports showingDesktop=false
WARNING app.plugins.installed.steam_gaming
        end gaming mode: windows stayed up: KWin still reports the windows as visible
```

## Ursache

An der Box nachgemessen:

```
$ qdbus6 org.kde.KWin /KWin org.kde.KWin.showDesktop true
exit=0                     # ... und die Fenster gehen sichtbar runter
$ sleep 1
$ qdbus6 org.kde.KWin /KWin org.kde.KWin.showingDesktop
false
```

`showingDesktop` beschreibt KWins temporären **Show-Desktop-Modus**, nicht „sind die Fenster minimiert". Als Bestätigung für `showDesktop(true)` taugt die Property damit nicht — sie macht aus jedem erfolgreichen Lauf eine rote Meldung.

Das war mein Fehler in #497: den Setter habe ich aus der Schnittstellen-Auflistung übernommen und eingebaut, ohne ihn — anders als jeden anderen Baustein dieser Aktion — vorher an der Box laufen zu sehen. Die Auflistung sagt, dass eine Property existiert; sie sagt nicht, was sie bedeutet.

## Änderung

Der Setter bleibt (bestätigt: minimiert, exit 0, idempotent, weil er einen Bool nimmt statt umzuschalten). Die Rücklese-Prüfung fliegt raus, samt Konstante und Hilfsfunktion.

Damit hat die Aktion **keinen** Verifikationsschritt mehr — was der ehrliche Zustand ist: wie Big Pictures eigener Modus ist auch hier die Wirkung von außen nicht beobachtbar. Ein Exit ≠ 0 ist der einzige Fehler, den das Modul redlich melden kann. Der Modul-Docstring hält die Messung samt der Warnung fest, damit die Property nicht als „naheliegende Verbesserung" zurückkommt.

## Tests

Zwei Regressionswächter gegen genau diesen Rückfall:

- `test_does_not_second_guess_kwin_afterwards` — pinnt die Zahl der Aufrufe auf **einen** und verbietet `showingDesktop` in der Kommandozeile.
- `test_the_module_no_longer_exposes_a_read_back_command` — die Konstante ist weg und darf nicht still zurückkehren.

43 Tests grün (`tests/services/power/test_desktop_windows.py` + `tests/plugins/test_steam_gaming_plugin.py`), `ruff check` sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
