### PR TITLE
feat(steam-gaming): Power-Menü zeigt nur noch die passende Gaming-Richtung

### DIFF
--- a/backend/app/plugins/installed/steam_gaming/__init__.py
+++ b/backend/app/plugins/installed/steam_gaming/__init__.py
@@ -27,9 +27,10 @@ from app.plugins.base import (
     PluginUIManifest,
     StatusPillSpec,
 )
+from app.core.config import settings
 from app.models.steam_session import SteamSession
 from app.plugins.dashboard_panel import StatusItem, StatusPanelData
-from app.plugins.installed.steam_gaming import ledger
+from app.plugins.installed.steam_gaming import gaming_state, ledger
 from app.plugins.installed.steam_gaming.detection import (
     current_app_id,
     resolve_game_name,
@@ -39,6 +40,7 @@ from app.plugins.installed.steam_gaming.launcher import close_big_picture, open_
 from app.plugins.installed.steam_gaming.poller import SteamSessionPoller
 from app.services.power.desktop import get_desktop_service
 from app.services.power.desktop_windows import show_desktop
+from app.services.power.gpu.display_detector import get_active_display_count_sync
 from app.services.power.session_lock import unlock_if_permitted
 
 logger = logging.getLogger(__name__)
@@ -101,6 +103,70 @@ def _panel_value(row: SteamSession, now: datetime) -> str:
     return f"{ledger.as_utc(row.started_at):%d.%m.} · {duration}"
 
 
+def _start_menu_item() -> PluginMenuItem:
+    return PluginMenuItem(
+        id=_MENU_ACTION_ID,
+        icon="Gamepad2",
+        tone="info",
+        order=10,
+        label_key="menu_gaming_mode",
+        label_text="Gaming Mode",
+        description_key="menu_gaming_mode_desc",
+        description_text="Turn displays on and open Big Picture",
+    )
+
+
+def _end_menu_item() -> PluginMenuItem:
+    # "Monitor", not something more expressive: the frontend icon map is a
+    # closed set (#451), and anything outside it silently degrades to the
+    # generic plug icon.
+    return PluginMenuItem(
+        id=_MENU_END_ACTION_ID,
+        icon="Monitor",
+        tone="neutral",
+        order=10,
+        label_key="menu_gaming_mode_end",
+        label_text="End Gaming Mode",
+        description_key="menu_gaming_mode_end_desc",
+        description_text="Close Big Picture and clear the desktop",
+    )
+
+
+def _displays_on() -> bool:
+    """True while at least one display is lit.
+
+    Read synchronously because the UI manifest is built synchronously - a few
+    small sysfs reads, the async sibling only wraps the same helper in a
+    thread. Unreadable sysfs counts as "off": that steers the menu to the
+    start action, which is the harmless one to offer wrongly.
+    """
+    if settings.is_dev_mode:
+        # No DRM connectors on a Windows dev box, so the count would pin the
+        # menu to "start" forever and the toggle could not be tried locally.
+        return True
+    try:
+        return get_active_display_count_sync() > 0
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("display count unreadable: %s", exc)
+        return False
+
+
+def _end_action_is_current() -> bool:
+    """Whether the menu should offer to END gaming mode rather than start it.
+
+    Two signals, because the obvious one does not exist: whether Big Picture
+    runs is not detectable (design doc 2026-07-24).
+
+    - the marker says BaluHost started gaming mode and has not ended it
+    - the displays are on, so there is something on screen to end
+
+    The display check is what rescues a stale marker: if Big Picture was left
+    at the box and the screens went dark, the menu offers "start" again
+    instead of stranding on "end".
+    """
+    return gaming_state.is_active() and _displays_on()
+
+
 class SteamGamingPlugin(PluginBase):
     """Surfaces a running Steam session in the topbar status strip."""
 
@@ -113,6 +179,17 @@ class SteamGamingPlugin(PluginBase):
             description="Shows a status-strip pill while a Steam game is running",
             author="BaluHost",
         )
+
+    async def on_startup(self) -> None:
+        """Forget a gaming mode that the previous process started.
+
+        A deploy or a crash restarts the backend while Big Picture may well
+        keep running, and the marker would then outlive everything we know
+        about it. Clearing means the menu offers "start" again - wrong at
+        worst by one harmless click, whereas a stale "end" minimizes the
+        windows of someone who never asked for it.
+        """
+        await asyncio.to_thread(gaming_state.mark_ended)
 
     def get_status_pills(self) -> List[StatusPillSpec]:
         return [StatusPillSpec(
@@ -151,34 +228,20 @@ class SteamGamingPlugin(PluginBase):
         }
 
     def get_ui_manifest(self) -> PluginUIManifest:
-        return PluginUIManifest(
-            enabled=True,
-            menu_items=[
-                PluginMenuItem(
-                    id=_MENU_ACTION_ID,
-                    icon="Gamepad2",
-                    tone="info",
-                    order=10,
-                    label_key="menu_gaming_mode",
-                    label_text="Gaming Mode",
-                    description_key="menu_gaming_mode_desc",
-                    description_text="Turn displays on and open Big Picture",
-                ),
-                # "Monitor", not something more expressive: the frontend icon
-                # map is a closed set (#451), and anything outside it silently
-                # degrades to the generic plug icon.
-                PluginMenuItem(
-                    id=_MENU_END_ACTION_ID,
-                    icon="Monitor",
-                    tone="neutral",
-                    order=20,
-                    label_key="menu_gaming_mode_end",
-                    label_text="End Gaming Mode",
-                    description_key="menu_gaming_mode_end_desc",
-                    description_text="Close Big Picture and clear the desktop",
-                ),
-            ],
-        )
+        """Advertise the direction that makes sense right now - only one."""
+        item = _end_menu_item() if _end_action_is_current() else _start_menu_item()
+        return PluginUIManifest(enabled=True, menu_items=[item])
+
+    def get_menu_items(self) -> List[PluginMenuItem]:
+        """Both directions stay dispatchable, whatever the manifest shows.
+
+        The core validates a clicked action_id against THIS list. Deriving it
+        from the manifest (the base class default) would 404 any click that
+        races a state change - the menu in the browser was rendered when the
+        other direction was current. Advertising a subset of what is declared
+        is the safe direction; the reverse is the drift base.py warns about.
+        """
+        return [_start_menu_item(), _end_menu_item()]
 
     async def run_menu_action(
         self,
@@ -226,6 +289,11 @@ class SteamGamingPlugin(PluginBase):
                 message_text=f"Displays are on, but Steam did not start: {detail}",
             )
 
+        # Only now, with Big Picture actually dispatched: the marker drives
+        # which direction the menu offers, so recording a start that never
+        # happened would hide the start action behind a useless end action.
+        await asyncio.to_thread(gaming_state.mark_started)
+
         # "started", not "Big Picture is running": the process is detached, so
         # anything past the spawn is not observable from here.
         return MenuActionResult(
@@ -255,6 +323,9 @@ class SteamGamingPlugin(PluginBase):
 
         # Without this guard the close URL would START Steam - see launcher.py.
         if not await asyncio.to_thread(steam_is_running):
+            # Steam is down, so gaming mode is over no matter what the marker
+            # claims - clearing it here is how a stale one heals.
+            await asyncio.to_thread(gaming_state.mark_ended)
             return MenuActionResult(
                 ok=True,
                 message_key="menu_end_steam_not_running",
@@ -269,6 +340,11 @@ class SteamGamingPlugin(PluginBase):
                 message_key="menu_end_close_failed",
                 message_text=f"Big Picture could not be closed: {detail}",
             )
+
+        # Big Picture is gone, so gaming mode has ended - independently of
+        # whether the windows go down below. Leaving the marker set on that
+        # failure would strand the menu on "end".
+        await asyncio.to_thread(gaming_state.mark_ended)
 
         await asyncio.sleep(_WINDOW_SETTLE_SECONDS)
 

--- a/backend/app/plugins/installed/steam_gaming/gaming_state.py
+++ b/backend/app/plugins/installed/steam_gaming/gaming_state.py
@@ -1,0 +1,65 @@
+"""Remember that BaluHost put the box into gaming mode.
+
+Big Picture's own state is not detectable from the outside (measured, see the
+design doc from 2026-07-24), so the power menu cannot ask the box whether
+gaming mode is running. What it CAN know is what we did ourselves: this module
+records that the start action ran and has not been ended here since.
+
+A marker FILE, not a module global and not a config row:
+
+- all four Uvicorn workers answer manifest requests, so an in-process flag
+  would make the menu flap depending on which worker replied
+- it lives under the storage root's ``.system/``, which survives a deploy
+  (``git reset --hard`` without ``git clean``); ``/tmp`` is ephemeral per
+  service start under PrivateTmp
+- its existence IS the state, so there is nothing to parse and no partial
+  write to guard against
+
+Nothing here raises. This is read while building the power menu, and a storage
+hiccup must degrade to "offer the start action" - the harmless direction -
+rather than break the menu.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_STATE_DIR_NAME = "steam_gaming"
+_MARKER_NAME = "gaming_mode_active"
+
+
+def marker_path() -> Path:
+    """``<storage>/.system/steam_gaming/gaming_mode_active``."""
+    base = Path(str(settings.nas_storage_path)).expanduser()
+    return base / ".system" / _STATE_DIR_NAME / _MARKER_NAME
+
+
+def is_active() -> bool:
+    """True while gaming mode was started here and not ended here."""
+    try:
+        return marker_path().exists()
+    except OSError as exc:
+        logger.debug("gaming mode marker unreadable: %s", exc)
+        return False
+
+
+def mark_started() -> None:
+    """Record that gaming mode is on."""
+    path = marker_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch(exist_ok=True)
+    except OSError as exc:
+        logger.warning("could not record the start of gaming mode: %s", exc)
+
+
+def mark_ended() -> None:
+    """Record that gaming mode is off. Idempotent."""
+    try:
+        marker_path().unlink(missing_ok=True)
+    except OSError as exc:
+        logger.warning("could not record the end of gaming mode: %s", exc)

--- a/backend/app/services/power/gpu/display_detector.py
+++ b/backend/app/services/power/gpu/display_detector.py
@@ -40,3 +40,15 @@ async def get_active_display_count(sysfs_root: Path = Path("/")) -> int:
     `enabled` covers DPMS-off / unused: physically connected but no active mode.
     """
     return await asyncio.to_thread(_count_sync, sysfs_root)
+
+
+def get_active_display_count_sync(sysfs_root: Path = Path("/")) -> int:
+    """Same count, for callers that cannot await.
+
+    The work is a handful of small sysfs reads - the async variant above only
+    wraps it in a thread because it sits on request paths that already are
+    async. The plugin UI manifest is built synchronously and needs the same
+    answer, and reaching into the private helper from there would make this
+    module's public surface a lie.
+    """
+    return _count_sync(sysfs_root)

--- a/backend/tests/plugins/test_steam_gaming_plugin.py
+++ b/backend/tests/plugins/test_steam_gaming_plugin.py
@@ -7,7 +7,7 @@ import pytest
 
 from app.api.routes.plugins import run_plugin_menu_action
 from app.plugins.installed import steam_gaming as plugin_module
-from app.plugins.installed.steam_gaming import SteamGamingPlugin, ledger
+from app.plugins.installed.steam_gaming import SteamGamingPlugin, gaming_state, ledger
 from app.plugins.installed.steam_gaming import detection as detection_module
 
 
@@ -16,6 +16,16 @@ def _clear_cache():
     plugin_module._CACHE.clear()
     yield
     plugin_module._CACHE.clear()
+
+
+@pytest.fixture(autouse=True)
+def _marker_in_tmp(tmp_path, monkeypatch):
+    """Keep the gaming-mode marker out of the real storage root.
+
+    The menu actions write it for real, so without this every run of this file
+    would touch dev-storage - and the assertions would depend on leftovers.
+    """
+    monkeypatch.setattr(gaming_state.settings, "nas_storage_path", str(tmp_path))
 
 
 @pytest.fixture
@@ -150,10 +160,6 @@ def _patch_desktop(ok: bool, message: str = ""):
 
 
 class TestGamingModeMenuItem:
-    def test_manifest_declares_both_directions(self):
-        manifest = SteamGamingPlugin().get_ui_manifest()
-        assert [item.id for item in manifest.menu_items] == [_ACTION, _END_ACTION]
-
     def test_item_carries_key_and_literal_fallback(self):
         item = SteamGamingPlugin().get_ui_manifest().menu_items[0]
         assert item.label_key == "menu_gaming_mode"
@@ -163,7 +169,7 @@ class TestGamingModeMenuItem:
     def test_translations_cover_every_key_the_items_use(self):
         plugin = SteamGamingPlugin()
         translations = plugin.get_translations()
-        for item in plugin.get_ui_manifest().menu_items:
+        for item in plugin.get_menu_items():
             for lang in ("en", "de"):
                 assert item.label_key in translations[lang]
                 assert item.description_key in translations[lang]
@@ -175,8 +181,152 @@ class TestGamingModeMenuItem:
             "Zap", "Shield", "Upload", "RefreshCw", "HardDrive", "Moon", "Lock",
             "Thermometer", "Coffee", "Clock", "Save", "Monitor", "Gamepad2",
         }
-        for item in SteamGamingPlugin().get_ui_manifest().menu_items:
+        for item in SteamGamingPlugin().get_menu_items():
             assert item.icon in known, f"{item.id} uses an icon the frontend cannot resolve"
+
+
+def _patch_visibility(*, active: bool, displays_on: bool = True):
+    return (
+        patch(
+            "app.plugins.installed.steam_gaming.gaming_state.is_active",
+            return_value=active,
+        ),
+        patch("app.plugins.installed.steam_gaming._displays_on", return_value=displays_on),
+    )
+
+
+class TestMenuOffersOneDirectionAtATime:
+    """Whether Big Picture runs is not detectable (design doc 2026-07-24), so
+    the menu goes by what BaluHost itself did - plus the displays, which are.
+    """
+
+    def _ids(self):
+        return [item.id for item in SteamGamingPlugin().get_ui_manifest().menu_items]
+
+    def test_offers_start_while_gaming_mode_is_off(self):
+        marker, displays = _patch_visibility(active=False)
+        with marker, displays:
+            assert self._ids() == [_ACTION]
+
+    def test_offers_end_while_gaming_mode_is_on(self):
+        marker, displays = _patch_visibility(active=True)
+        with marker, displays:
+            assert self._ids() == [_END_ACTION]
+
+    def test_dark_displays_outrank_the_marker(self):
+        """Displays off means nothing is on screen to end - and a stale marker
+        (Big Picture ended at the box, backend never told) must not leave the
+        menu stuck on "end"."""
+        marker, displays = _patch_visibility(active=True, displays_on=False)
+        with marker, displays:
+            assert self._ids() == [_ACTION]
+
+    def test_never_shows_both(self):
+        for active in (True, False):
+            for displays_on in (True, False):
+                marker, displays = _patch_visibility(active=active, displays_on=displays_on)
+                with marker, displays:
+                    assert len(self._ids()) == 1
+
+
+class TestBothActionsStayDispatchable:
+    """The manifest hides one entry; get_menu_items() must still declare both.
+
+    The core validates a clicked action_id against get_menu_items(), so
+    declaring only the visible one would 404 every click that races a state
+    change - the menu was rendered when the other direction was current.
+    Manifest ⊆ declared is the safe direction; the reverse (advertising
+    something undeclared) is the one the base class warns about.
+    """
+
+    def test_declares_both_regardless_of_state(self):
+        for active in (True, False):
+            marker, displays = _patch_visibility(active=active)
+            with marker, displays:
+                declared = {item.id for item in SteamGamingPlugin().get_menu_items()}
+                assert declared == {_ACTION, _END_ACTION}
+
+
+class TestMarkerBookkeeping:
+    async def test_a_successful_start_records_gaming_mode(self):
+        desktop_patch, _service = _patch_desktop(True, "ok")
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            return_value=(True, "requested"),
+        ):
+            await SteamGamingPlugin().run_menu_action(_ACTION, db=None)
+
+        assert gaming_state.is_active() is True
+
+    async def test_a_start_that_never_reached_steam_records_nothing(self):
+        desktop_patch, _service = _patch_desktop(True, "ok")
+        with desktop_patch, patch(
+            "app.plugins.installed.steam_gaming.open_big_picture",
+            return_value=(False, "steam binary not found"),
+        ):
+            await SteamGamingPlugin().run_menu_action(_ACTION, db=None)
+
+        assert gaming_state.is_active() is False
+
+    async def test_a_successful_end_clears_it(self):
+        gaming_state.mark_started()
+        game_p, steam_p, close_p, show_p, sleep_p = _patch_end_action()
+        with game_p, steam_p, close_p, show_p, sleep_p:
+            await SteamGamingPlugin().run_menu_action(_END_ACTION, db=None)
+
+        assert gaming_state.is_active() is False
+
+    async def test_it_is_cleared_even_when_the_windows_stay_up(self):
+        """Big Picture is closed either way - that IS the end of gaming mode.
+        Leaving the marker would strand the menu on "end" forever."""
+        gaming_state.mark_started()
+        game_p, steam_p, close_p, show_p, sleep_p = _patch_end_action(
+            minimized=(False, "qdbus6 not found")
+        )
+        with game_p, steam_p, close_p, show_p, sleep_p:
+            await SteamGamingPlugin().run_menu_action(_END_ACTION, db=None)
+
+        assert gaming_state.is_active() is False
+
+    async def test_steam_being_down_clears_a_stale_marker(self):
+        gaming_state.mark_started()
+        game_p, steam_p, close_p, show_p, sleep_p = _patch_end_action(steam_running=False)
+        with game_p, steam_p, close_p, show_p, sleep_p:
+            await SteamGamingPlugin().run_menu_action(_END_ACTION, db=None)
+
+        assert gaming_state.is_active() is False
+
+    async def test_a_refusal_leaves_the_marker_alone(self):
+        """A game is running, so gaming mode very much still is."""
+        gaming_state.mark_started()
+        game_p, steam_p, close_p, show_p, sleep_p = _patch_end_action(
+            game=("1449560", "Metro Exodus")
+        )
+        with game_p, steam_p, close_p, show_p, sleep_p:
+            await SteamGamingPlugin().run_menu_action(_END_ACTION, db=None)
+
+        assert gaming_state.is_active() is True
+
+    async def test_a_failed_close_leaves_the_marker_alone(self):
+        gaming_state.mark_started()
+        game_p, steam_p, close_p, show_p, sleep_p = _patch_end_action(
+            closed=(False, "steam binary not found")
+        )
+        with game_p, steam_p, close_p, show_p, sleep_p:
+            await SteamGamingPlugin().run_menu_action(_END_ACTION, db=None)
+
+        assert gaming_state.is_active() is True
+
+    async def test_startup_clears_a_marker_that_survived_a_restart(self):
+        """A deploy restarts the backend while Big Picture may well keep
+        running. Clearing means the menu offers "start" again - wrong at worst
+        by one harmless click, whereas a stale "end" minimizes the windows of
+        someone who never asked."""
+        gaming_state.mark_started()
+
+        await SteamGamingPlugin().on_startup()
+
+        assert gaming_state.is_active() is False
 
 
 class TestGamingModeAction:
@@ -323,12 +473,18 @@ class TestManifestAndRouteAgreeOnDeclaredActions:
     """
 
     def test_every_manifest_menu_item_id_is_declared(self):
+        """Subset, not equality, since the menu shows one direction at a time.
+
+        The invariant that matters is unchanged: nothing may be advertised
+        that the route would 404. The other direction (declared but hidden) is
+        deliberate here and safe - see TestBothActionsStayDispatchable.
+        """
         plugin = SteamGamingPlugin()
         manifest_ids = {item.id for item in plugin.get_ui_manifest().menu_items}
         declared_ids = {item.id for item in plugin.get_menu_items()}
 
         assert manifest_ids, "the manifest must actually declare something for this test to mean anything"
-        assert manifest_ids == declared_ids
+        assert manifest_ids <= declared_ids
 
     async def test_route_does_not_404_the_action_the_manifest_advertises(self):
         plugin = SteamGamingPlugin()

--- a/backend/tests/plugins/test_steam_gaming_state.py
+++ b/backend/tests/plugins/test_steam_gaming_state.py
@@ -1,0 +1,81 @@
+"""The marker that remembers BaluHost put the box into gaming mode."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.plugins.installed.steam_gaming import gaming_state
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch) -> Path:
+    monkeypatch.setattr(gaming_state.settings, "nas_storage_path", str(tmp_path))
+    return tmp_path
+
+
+class TestMarkerLocation:
+    def test_lives_under_the_storage_systems_dir(self, storage):
+        """Not /tmp: PrivateTmp makes that ephemeral per service start, and the
+        four Uvicorn workers all have to see the same answer. .system/ survives
+        a deploy (git reset --hard, no git clean)."""
+        path = gaming_state.marker_path()
+
+        assert path.parent.parent == storage / ".system"
+        assert storage in path.parents
+
+
+class TestMarkerLifecycle:
+    def test_starts_out_inactive(self, storage):
+        assert gaming_state.is_active() is False
+
+    def test_start_then_end(self, storage):
+        gaming_state.mark_started()
+        assert gaming_state.is_active() is True
+
+        gaming_state.mark_ended()
+        assert gaming_state.is_active() is False
+
+    def test_marking_started_twice_is_harmless(self, storage):
+        gaming_state.mark_started()
+        gaming_state.mark_started()
+
+        assert gaming_state.is_active() is True
+
+    def test_marking_ended_without_a_marker_is_harmless(self, storage):
+        gaming_state.mark_ended()
+
+        assert gaming_state.is_active() is False
+
+
+class TestNothingHereBreaksTheMenu:
+    """A storage hiccup must degrade to "offer the start action", never raise -
+    this is read while building the power menu."""
+
+    def test_unwritable_storage_does_not_raise(self, storage, monkeypatch):
+        def _boom(*_args, **_kwargs):
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr(Path, "mkdir", _boom)
+        gaming_state.mark_started()
+
+        assert gaming_state.is_active() is False
+
+    def test_unreadable_marker_reads_as_inactive(self, storage, monkeypatch):
+        gaming_state.mark_started()
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("stale NFS handle")
+
+        monkeypatch.setattr(Path, "exists", _boom)
+
+        assert gaming_state.is_active() is False
+
+    def test_failing_unlink_does_not_raise(self, storage, monkeypatch):
+        gaming_state.mark_started()
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("device busy")
+
+        monkeypatch.setattr(Path, "unlink", _boom)
+        gaming_state.mark_ended()  # must not raise

--- a/backend/tests/services/power/gpu/test_display_detector.py
+++ b/backend/tests/services/power/gpu/test_display_detector.py
@@ -2,7 +2,10 @@
 from pathlib import Path
 import pytest
 
-from app.services.power.gpu.display_detector import get_active_display_count
+from app.services.power.gpu.display_detector import (
+    get_active_display_count,
+    get_active_display_count_sync,
+)
 
 
 @pytest.fixture
@@ -71,3 +74,20 @@ async def test_multiple_connectors(fake_sysfs: Path):
     _make_connector(fake_sysfs, "card0-DP-2", "connected", "enabled")
     count = await get_active_display_count(sysfs_root=fake_sysfs)
     assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_variant_agrees_with_the_async_one(fake_sysfs: Path):
+    """The plugin UI manifest is built synchronously and needs the same answer;
+    the async variant is only a to_thread wrapper around the same helper."""
+    _make_connector(fake_sysfs, "card0-HDMI-A-1", "connected", "enabled")
+    _make_connector(fake_sysfs, "card0-DP-1", "connected", "disabled")
+
+    assert get_active_display_count_sync(sysfs_root=fake_sysfs) == 1
+    assert get_active_display_count_sync(sysfs_root=fake_sysfs) == (
+        await get_active_display_count(sysfs_root=fake_sysfs)
+    )
+
+
+def test_sync_variant_without_drm_returns_zero(tmp_path: Path):
+    assert get_active_display_count_sync(sysfs_root=tmp_path) == 0

--- a/client/src/__tests__/components/PowerMenu.pluginActions.test.tsx
+++ b/client/src/__tests__/components/PowerMenu.pluginActions.test.tsx
@@ -17,8 +17,9 @@ vi.mock('../../api/plugins', () => ({ runPluginMenuAction: vi.fn() }));
 // top-level array would hit the temporal dead zone. vi.hoisted lifts the state
 // alongside the mock.
 const menuItems = vi.hoisted(() => [] as unknown[]);
+const refreshMenuItems = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 vi.mock('../../contexts/PluginContext', () => ({
-  usePlugins: () => ({ pluginMenuItems: menuItems }),
+  usePlugins: () => ({ pluginMenuItems: menuItems, refreshMenuItems }),
 }));
 
 import PowerMenu from '../../components/PowerMenu';
@@ -131,6 +132,25 @@ describe('PowerMenu — plugin menu actions', () => {
     render(<PowerMenu {...baseProps} />);
     openMenu();
     expect(await screen.findByText('Gaming Mode')).toBeInTheDocument();
+  });
+
+  it('re-fetches the menu items on every open', async () => {
+    // The Steam plugin advertises "start" or "end" gaming mode depending on
+    // server-side state. Without this the menu would keep showing whichever
+    // direction was current when the page loaded.
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    await waitFor(() => expect(refreshMenuItems).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTitle('Power'));  // close
+    openMenu();
+    await waitFor(() => expect(refreshMenuItems).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not re-fetch the menu items for a non-admin', async () => {
+    render(<PowerMenu {...baseProps} isAdmin={false} />);
+    openMenu();
+    expect(refreshMenuItems).not.toHaveBeenCalled();
   });
 
   it('renders no plugin actions for a non-admin', async () => {

--- a/client/src/__tests__/components/PowerMenu.test.tsx
+++ b/client/src/__tests__/components/PowerMenu.test.tsx
@@ -23,7 +23,7 @@ vi.mock('../../api/desktop', () => ({
 }));
 
 vi.mock('../../contexts/PluginContext', () => ({
-  usePlugins: () => ({ pluginMenuItems: [] }),
+  usePlugins: () => ({ pluginMenuItems: [], refreshMenuItems: vi.fn().mockResolvedValue(undefined) }),
 }));
 
 import PowerMenu from '../../components/PowerMenu';

--- a/client/src/components/PowerMenu.tsx
+++ b/client/src/components/PowerMenu.tsx
@@ -40,7 +40,7 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
   const [confirmAction, setConfirmAction] = useState<'shutdown' | 'restart' | 'sleep' | 'suspend' | null>(null);
   const [sleepAvailable, setSleepAvailable] = useState(false);
   const [desktopState, setDesktopState] = useState<DesktopState | null>(null);
-  const { pluginMenuItems } = usePlugins();
+  const { pluginMenuItems, refreshMenuItems } = usePlugins();
   const [runningAction, setRunningAction] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -55,8 +55,12 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
       getDesktopStatus()
         .then((s) => setDesktopState(s.state))
         .catch(() => setDesktopState(null));
+      // Plugin entries can depend on server-side state too — the Steam plugin
+      // offers "start" or "end" gaming mode, never both — and the manifest is
+      // otherwise only fetched at page load.
+      void refreshMenuItems();
     }
-  }, [isOpen, isAdmin]);
+  }, [isOpen, isAdmin, refreshMenuItems]);
 
   // Close dropdown when clicking outside
   useEffect(() => {

--- a/client/src/contexts/PluginContext.tsx
+++ b/client/src/contexts/PluginContext.tsx
@@ -29,6 +29,7 @@ interface PluginContextType {
   isLoading: boolean;
   error: string | null;
   refreshPlugins: () => Promise<void>;
+  refreshMenuItems: () => Promise<void>;
 }
 
 const PluginContext = createContext<PluginContextType | undefined>(undefined);
@@ -73,6 +74,29 @@ export function PluginProvider({ children }: PluginProviderProps) {
     }
   }, [token]);
 
+  /**
+   * Re-fetch only the UI manifest.
+   *
+   * Menu items can depend on server-side state (the Steam plugin offers
+   * "start" or "end" gaming mode, never both), so a menu opened minutes after
+   * page load would otherwise show the state from page load.
+   *
+   * Deliberately narrower than refreshPlugins(): no plugin list, and no
+   * isLoading flip. The power menu calls this on every open, and toggling the
+   * shared loading flag would flash a spinner on an open Plugins page for a
+   * fetch it never asked for. On error the last known items stay — a stale
+   * entry beats an empty power menu.
+   */
+  const refreshMenuItems = useCallback(async () => {
+    if (!token || isPi) return;
+    try {
+      const manifest = await getUIManifest();
+      setEnabledPlugins(manifest?.plugins ?? []);
+    } catch {
+      // keep what we have
+    }
+  }, [token]);
+
   useEffect(() => {
     loadPlugins();
   }, [loadPlugins]);
@@ -112,6 +136,7 @@ export function PluginProvider({ children }: PluginProviderProps) {
     isLoading,
     error,
     refreshPlugins: loadPlugins,
+    refreshMenuItems,
   };
 
   return (


### PR DESCRIPTION
## Problem

Nach #497 standen beide Gaming-Einträge unabhängig vom Zustand nebeneinander: „End Gaming Mode" wurde auch bei dunklen Displays und ohne Big Picture angeboten, „Gaming Mode" auch dann, wenn es längst lief. Zwei Zeilen darüber im selben Menü macht der Core es seit jeher richtig — „Enable desktop" bzw. „Disable desktop" erscheinen abhängig vom Display-Zustand (`PowerMenu.tsx:233-248`).

## Warum das nicht trivial ist

Ob Big Picture läuft, ist **nicht messbar** — das ist die ausgemessene Sackgasse aus dem Steam-Track (Design-Doc 2026-07-24: `-uimode=7` steht in beiden Modi, `gamepadui` in keiner Kommandozeile, `registry.vdf` schweigt). Ein Umschalter braucht also eine Zustandsquelle, die wir selbst führen.

## Lösung: zwei Signale, die wir haben

| Signal | Woher | Wozu |
|---|---|---|
| **Merker** | Datei `<storage>/.system/steam_gaming/gaming_mode_active` | „BaluHost hat den Gaming-Modus gestartet und hier nicht beendet" |
| **Displays** | DRM-Connector-Zählung (dieselbe wie beim Desktop-Status) | rettet einen veralteten Merker |

„Beenden" erscheint nur bei **Merker an und Displays an**. Wurde Big Picture direkt an der Box beendet und die Schirme sind aus, zeigt das Menü wieder „Gaming Mode", statt auf „Beenden" festzuhängen.

**Jeder Zweifelsfall löst zu „Start" auf** — die harmlose Richtung. Ein falsches „Beenden" würde die Fenster von jemandem minimieren, der nicht danach gefragt hat; ein falsches „Start" öffnet ein bereits offenes Big Picture noch einmal. Aus demselben Grund löscht der Backend-Start den Merker: ein Deploy startet uns neu, während Big Picture weiterlaufen kann.

**Warum eine Datei und kein Modul-Global:** alle vier Uvicorn-Worker beantworten Manifest-Anfragen — ein prozesslokales Flag würde den Eintrag je nach antwortendem Worker flackern lassen. `.system/` überlebt den Deploy (`git reset --hard` ohne `git clean`), `/tmp` unter PrivateTmp nicht.

## Wichtiges Detail: beide Aktionen bleiben klickbar

`get_menu_items()` deklariert weiterhin **beide** Aktionen, während das Manifest eine zeigt. Der Core prüft eine geklickte `action_id` gegen diese Liste — deklarierte man nur die sichtbare, würde jeder Klick 404en, der einen Zustandswechsel überholt (das Menü im Browser wurde gerendert, als die andere Richtung aktuell war). „Manifest ⊆ deklariert" ist die sichere Richtung; vor der umgekehrten warnt `base.py`.

Der bestehende Regressionstest dafür wurde von Gleichheit auf Teilmenge gelockert, mit genau dieser Begründung im Docstring.

## Zwei Zuarbeiten

- **`display_detector.get_active_display_count_sync()`** (neu, öffentlich): Die Zählung sind ein paar kleine sysfs-Reads, die die `async`-Variante nur in einen Thread wickelt. Das UI-Manifest wird synchron gebaut. Damit entfällt die ursprünglich geplante `PluginBase`-Erweiterung für async-Zustand komplett — kein Core-API-Bruch, kein größerer PR.
- **`PluginContext.refreshMenuItems()`** (neu), aufgerufen von `PowerMenu` bei jedem Öffnen. Das Manifest wurde sonst nur beim Seitenaufbau geholt, der Eintrag wäre also von damals. Bewusst schmaler als `refreshPlugins()`: nur das Manifest, und **ohne** `isLoading` zu setzen — sonst blinkt eine offene Plugins-Seite einen Spinner für einen Fetch, den sie nie angefordert hat.

## Tests

**Backend** (986 passed in `tests/plugins` + `tests/services/power`, `ruff` sauber):
- `test_steam_gaming_state.py` (neu, 8): Ablageort unter `.system/`, Lebenszyklus, Idempotenz, und drei Fälle „Storage kaputt → nicht werfen, sondern inaktiv melden".
- `TestMenuOffersOneDirectionAtATime`: alle vier Kombinationen aus Merker × Displays, inkl. „nie beide".
- `TestBothActionsStayDispatchable`: beide Aktionen bleiben deklariert.
- `TestMarkerBookkeeping`: gesetzt nur bei erfolgreichem Start; gelöscht bei Erfolg, bei fehlgeschlagenem Minimieren und bei „Steam läuft nicht" (Selbstheilung); **nicht** gelöscht bei laufendem Spiel oder fehlgeschlagenem Schließen; Startup räumt auf.
- `test_display_detector.py`: sync- und async-Variante liefern dasselbe.

**Frontend** (259 Dateien / 1158 Tests grün, `eslint .` 0 Errors, `npm run build` sauber):
- Menü wird bei **jedem** Öffnen neu geholt, und für Nicht-Admins gar nicht.
- Die `usePlugins`-Mocks in beiden PowerMenu-Testdateien wurden um `refreshMenuItems` ergänzt (unvollständige `vi.mock`-Factories sind hier eine bekannte Fehlerquelle).

## Nicht enthalten

Kein Auto-Refresh im geöffneten Menü und keine WebSocket-Benachrichtigung: der Zustand ändert sich durch genau diese Klicks, und das Menü schließt sich nach jedem davon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
