### PR TITLE
fix(steam-gaming): Desktop wird wirklich abgeraeumt (Shortcut statt wirkungslosem Setter)

### DIFF
--- a/backend/app/services/power/desktop_windows.py
+++ b/backend/app/services/power/desktop_windows.py
@@ -1,34 +1,46 @@
 """Clear the KDE session's screen by minimizing every window.
 
-Driven through KWin's own D-Bus interface rather than a simulated key press:
+Driven through KWin's D-Bus interfaces rather than a simulated key press:
 ydotool/uinput would need privileges the backend does not have and should not
 be given, while the session bus is already in reach - the backend runs under
 the session user's uid (see session_env.py), so the same env that lets
 kscreen-doctor talk to the session works here too.
 
-Measured on BaluNode (2026-08-01), Plasma 6 on Debian 13:
+Measured on BaluNode (2026-08-01), Plasma 6 on Debian 13, with visible windows::
 
-- the binary is ``qdbus6``; there is no plain ``qdbus``
-- ``org.kde.KWin.showDesktop(bool)`` on ``/KWin`` minimizes every window and
-  exits 0. It takes a bool rather than toggling, so calling it twice leaves
-  the windows down - unlike kglobalaccel's "Show Desktop" shortcut, where a
-  second invocation brings them back.
-- ``org.kde.KWin.showingDesktop`` reads **false** one second after that same
-  successful call, with the windows visibly down. It tracks KWin's temporary
-  show-desktop MODE, not "are the windows minimized". **Do not use it to
-  verify this call** - the first version of this module did, and every
-  successful run reported "the windows stayed up" to the user.
+    $ qdbus6 org.kde.KWin /KWin org.kde.KWin.showingDesktop
+    false
+    $ qdbus6 org.kde.KWin /KWin org.kde.KWin.showDesktop true    # exit 0
+    $ qdbus6 org.kde.KWin /KWin org.kde.KWin.showingDesktop
+    false                                    # <- nothing happened, windows up
+    $ qdbus6 org.kde.kglobalaccel /component/kwin invokeShortcut "Show Desktop"
+    $ qdbus6 org.kde.KWin /KWin org.kde.KWin.showingDesktop
+    true                                     # <- windows down
 
-So there is no verification step here: like everything else in ending gaming
-mode, the effect is not observable (Big Picture's own state is not either, see
-the design doc from 2026-07-24). A non-zero exit is the only failure this
-module can honestly report.
+So: the ``showDesktop(bool)`` setter accepts the call and does nothing (it is
+Q_NOREPLY, so its exit code says only that the message was sent - never mistake
+that for an effect). The kglobalaccel shortcut works, and ``showingDesktop``
+tracks exactly that path.
+
+That property is read twice here, for two different jobs:
+
+- BEFORE, because the shortcut is a TOGGLE: firing it while the desktop is
+  already cleared would bring the windows back. Reading first makes this
+  function idempotent without a setter.
+- AFTER, as the one honest verification in the whole "end gaming mode" flow.
+  Big Picture's own state is not observable (design doc 2026-07-24); this is.
+
+History worth keeping: shipping the setter cost two releases. #497 used it
+plus the read-back and reported failure on every run; #499 then removed the
+read-back as a "false alarm" - it had been telling the truth. The measurement
+above is why both the shortcut and the read-back are here now.
 """
 from __future__ import annotations
 
 import logging
 import subprocess
-from typing import Tuple
+import time
+from typing import List, Optional, Tuple
 
 from app.core.config import settings
 from app.services.power.session_env import wayland_session_env
@@ -39,34 +51,86 @@ logger = logging.getLogger(__name__)
 # not slow. Kept well inside the 20s budget of a plugin menu action.
 _TIMEOUT_SECONDS = 10
 
+# KWin applies the shortcut asynchronously - the manual measurement needed a
+# moment before the property flipped. A single immediate read would sporadically
+# report a failure that never happened.
+_VERIFY_TIMEOUT_SECONDS = 2.0
+_VERIFY_INTERVAL_SECONDS = 0.2
+
 SHOW_DESKTOP_CMD = [
+    "qdbus6",
+    "org.kde.kglobalaccel",
+    "/component/kwin",
+    "invokeShortcut",
+    "Show Desktop",
+]
+
+SHOWING_DESKTOP_CMD = [
     "qdbus6",
     "org.kde.KWin",
     "/KWin",
-    "org.kde.KWin.showDesktop",
-    "true",
+    "org.kde.KWin.showingDesktop",
 ]
+
+
+def _run(cmd: List[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(  # fixed argv, no shell, no user input
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT_SECONDS,
+        env=wayland_session_env(),
+    )
+
+
+def _showing_desktop() -> Optional[bool]:
+    """KWin's own answer, or None when it cannot be read."""
+    try:
+        result = _run(SHOWING_DESKTOP_CMD)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.debug("showingDesktop unreadable: %s", exc)
+        return None
+    if result.returncode != 0:
+        return None
+    value = (result.stdout or "").strip().lower()
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    return None
+
+
+def _wait_until_showing_desktop() -> Optional[bool]:
+    """Poll the property until it reads true, or the deadline passes."""
+    deadline = time.monotonic() + _VERIFY_TIMEOUT_SECONDS
+    while True:
+        state = _showing_desktop()
+        if state is not False:
+            return state  # True, or unreadable - neither contradicts the call
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_VERIFY_INTERVAL_SECONDS)
 
 
 def show_desktop() -> Tuple[bool, str]:
     """Minimize all windows. Blocking - call via asyncio.to_thread.
 
+    Idempotent: when KWin already reports the desktop as shown, the toggling
+    shortcut is not fired at all.
+
     Returns:
-        (ok, detail). ok=True means KWin accepted the call. Safe to repeat:
-        the call sets the state instead of toggling it.
+        (ok, detail). ok=False only when KWin refused the call or still
+        reports the windows as visible afterwards.
     """
     if settings.is_dev_mode:
         # No KWin, no session bus on a Windows dev box.
         return True, "show desktop requested (dev)"
 
+    if _showing_desktop() is True:
+        return True, "windows already minimized"
+
     try:
-        result = subprocess.run(  # fixed argv, no shell, no user input
-            SHOW_DESKTOP_CMD,
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT_SECONDS,
-            env=wayland_session_env(),
-        )
+        result = _run(SHOW_DESKTOP_CMD)
     except FileNotFoundError:
         return False, "qdbus6 not found (is the desktop session running?)"
     except subprocess.TimeoutExpired:
@@ -76,4 +140,8 @@ def show_desktop() -> Tuple[bool, str]:
         detail = (result.stderr or "").strip() or f"exit {result.returncode}"
         logger.warning("show desktop failed: %s", detail)
         return False, detail
+
+    if _wait_until_showing_desktop() is False:
+        logger.warning("show desktop: KWin still reports showingDesktop=false")
+        return False, "KWin still reports the windows as visible"
     return True, "windows minimized"

--- a/backend/tests/services/power/test_desktop_windows.py
+++ b/backend/tests/services/power/test_desktop_windows.py
@@ -1,11 +1,15 @@
-"""Minimizing every window of the KDE session (KWin's showDesktop setter)."""
+"""Minimizing every window of the KDE session (KWin's Show Desktop shortcut)."""
 from __future__ import annotations
 
 import subprocess
 from unittest.mock import MagicMock, patch
 
 from app.services.power import desktop_windows
-from app.services.power.desktop_windows import SHOW_DESKTOP_CMD, show_desktop
+from app.services.power.desktop_windows import (
+    SHOW_DESKTOP_CMD,
+    SHOWING_DESKTOP_CMD,
+    show_desktop,
+)
 
 
 def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
@@ -16,52 +20,69 @@ def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> Magic
     return result
 
 
-class TestShowDesktopCommand:
+def _visible() -> MagicMock:
+    return _completed(stdout="false")
+
+
+def _minimized() -> MagicMock:
+    return _completed(stdout="true")
+
+
+def _patch_run(*results):
+    """Patch subprocess.run; consecutive calls get consecutive *results*."""
+    return patch("subprocess.run", side_effect=list(results))
+
+
+def _prod():
+    return patch("app.services.power.desktop_windows.settings")
+
+
+def _env():
+    return patch("app.services.power.desktop_windows.wayland_session_env", return_value={})
+
+
+class TestCommands:
     def test_uses_qdbus6(self):
         """Measured on BaluNode: Plasma 6 on Debian 13 ships no plain qdbus."""
         assert SHOW_DESKTOP_CMD[0] == "qdbus6"
+        assert SHOWING_DESKTOP_CMD[0] == "qdbus6"
 
-    def test_sets_the_state_instead_of_toggling_it(self):
-        """kglobalaccel's "Show Desktop" shortcut is a TOGGLE - a second call
-        would bring the windows back. A regression to it would make the exit
-        action undo itself on a retry, which no behavioural test can see."""
-        assert SHOW_DESKTOP_CMD[-2:] == ["org.kde.KWin.showDesktop", "true"]
-        assert "invokeShortcut" not in SHOW_DESKTOP_CMD
+    def test_minimizes_through_the_shortcut_not_the_setter(self):
+        """Regression guard for #497/#499. `org.kde.KWin.showDesktop(bool)`
+        accepts the call and does nothing - it is Q_NOREPLY, so exit 0 means
+        only that the message was sent. Measured on the box: the property
+        stayed false and the windows stayed up. The shortcut works."""
+        assert SHOW_DESKTOP_CMD[-2:] == ["invokeShortcut", "Show Desktop"]
+        assert "showDesktop" not in " ".join(SHOW_DESKTOP_CMD)
+
+    def test_reads_kwins_own_property_back(self):
+        assert SHOWING_DESKTOP_CMD[-1] == "org.kde.KWin.showingDesktop"
 
 
 class TestShowDesktop:
-    def test_calls_the_setter_and_reports_success(self):
-        with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run", return_value=_completed()) as run, \
-             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+    def test_probes_first_then_invokes_then_verifies(self):
+        with _prod() as cfg, _patch_run(_visible(), _completed(), _minimized()) as run, _env():
             cfg.is_dev_mode = False
             ok, _detail = show_desktop()
 
         assert ok is True
-        assert run.call_args.args[0] == SHOW_DESKTOP_CMD
+        assert [call.args[0] for call in run.call_args_list] == [
+            SHOWING_DESKTOP_CMD, SHOW_DESKTOP_CMD, SHOWING_DESKTOP_CMD,
+        ]
 
-    def test_does_not_second_guess_kwin_afterwards(self):
-        """Regression guard for the false alarm shipped in #497.
-
-        The obvious verification - reading org.kde.KWin.showingDesktop back -
-        is WRONG: measured on the box, it reads false right after a successful
-        call with the windows visibly down, because it tracks KWin's temporary
-        show-desktop mode. Every successful run reported failure to the user.
-        One call, no read-back.
-        """
-        with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run", return_value=_completed()) as run, \
-             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+    def test_does_not_fire_the_toggle_when_the_desktop_is_already_clear(self):
+        """The shortcut TOGGLES - firing it now would bring the windows back."""
+        with _prod() as cfg, _patch_run(_minimized()) as run, _env():
             cfg.is_dev_mode = False
-            ok, _detail = show_desktop()
+            ok, detail = show_desktop()
 
         assert ok is True
+        assert "already" in detail
         assert run.call_count == 1
-        assert "showingDesktop" not in " ".join(run.call_args.args[0])
 
     def test_passes_the_wayland_session_env(self):
-        with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run", return_value=_completed()) as run, \
+        with _prod() as cfg, \
+             _patch_run(_visible(), _completed(), _minimized()) as run, \
              patch(
                  "app.services.power.desktop_windows.wayland_session_env",
                  return_value={"XDG_RUNTIME_DIR": "/run/user/1000"},
@@ -69,30 +90,27 @@ class TestShowDesktop:
             cfg.is_dev_mode = False
             show_desktop()
 
-        assert run.call_args.kwargs["env"] == {"XDG_RUNTIME_DIR": "/run/user/1000"}
+        assert run.call_args_list[1].kwargs["env"] == {"XDG_RUNTIME_DIR": "/run/user/1000"}
 
     def test_never_uses_a_shell(self):
-        with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run", return_value=_completed()) as run, \
-             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+        with _prod() as cfg, _patch_run(_visible(), _completed(), _minimized()) as run, _env():
             cfg.is_dev_mode = False
             show_desktop()
 
-        assert "shell" not in run.call_args.kwargs
+        for call in run.call_args_list:
+            assert "shell" not in call.kwargs
 
     def test_sets_a_timeout_so_a_stuck_session_cannot_hang_the_action(self):
-        with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run", return_value=_completed()) as run, \
-             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+        with _prod() as cfg, _patch_run(_visible(), _completed(), _minimized()) as run, _env():
             cfg.is_dev_mode = False
             show_desktop()
 
-        assert run.call_args.kwargs["timeout"] > 0
+        for call in run.call_args_list:
+            assert call.kwargs["timeout"] > 0
 
     def test_missing_qdbus_binary_is_reported_not_raised(self):
-        with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run", side_effect=FileNotFoundError()), \
-             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+        with _prod() as cfg, \
+             patch("subprocess.run", side_effect=FileNotFoundError()), _env():
             cfg.is_dev_mode = False
             ok, detail = show_desktop()
 
@@ -100,9 +118,8 @@ class TestShowDesktop:
         assert "qdbus6" in detail
 
     def test_timeout_is_reported_not_raised(self):
-        with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run", side_effect=subprocess.TimeoutExpired("qdbus6", 10)), \
-             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+        with _prod() as cfg, \
+             patch("subprocess.run", side_effect=subprocess.TimeoutExpired("qdbus6", 10)), _env():
             cfg.is_dev_mode = False
             ok, detail = show_desktop()
 
@@ -110,9 +127,8 @@ class TestShowDesktop:
         assert "timed out" in detail
 
     def test_non_zero_exit_carries_the_stderr(self):
-        with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run", return_value=_completed(1, stderr="no such service")), \
-             patch("app.services.power.desktop_windows.wayland_session_env", return_value={}):
+        with _prod() as cfg, \
+             _patch_run(_visible(), _completed(1, stderr="no such service")), _env():
             cfg.is_dev_mode = False
             ok, detail = show_desktop()
 
@@ -120,8 +136,7 @@ class TestShowDesktop:
         assert detail == "no such service"
 
     def test_dev_mode_does_not_spawn_anything(self):
-        with patch("app.services.power.desktop_windows.settings") as cfg, \
-             patch("subprocess.run") as run:
+        with _prod() as cfg, patch("subprocess.run") as run:
             cfg.is_dev_mode = True
             ok, _detail = show_desktop()
 
@@ -129,7 +144,56 @@ class TestShowDesktop:
         run.assert_not_called()
 
 
-def test_the_module_no_longer_exposes_a_read_back_command():
-    """Belt and braces for the same regression: the constant is gone, so a
-    future edit cannot quietly wire the misleading property back in."""
-    assert not hasattr(desktop_windows, "SHOWING_DESKTOP_CMD")
+class TestVerification:
+    """The one step of ending gaming mode whose effect IS observable - and the
+    reason #497 shipped a permanently failing action: the property was right,
+    the setter was not."""
+
+    def test_a_still_visible_desktop_is_a_failure(self):
+        with _prod() as cfg, \
+             patch("app.services.power.desktop_windows._VERIFY_TIMEOUT_SECONDS", 0), \
+             _patch_run(_visible(), _completed(), _visible()), _env():
+            cfg.is_dev_mode = False
+            ok, detail = show_desktop()
+
+        assert ok is False
+        assert "visible" in detail
+
+    def test_it_waits_for_kwin_instead_of_reading_once(self):
+        """KWin applies the shortcut asynchronously; the manual measurement
+        needed a moment. A single read would flag failures that never were."""
+        with _prod() as cfg, \
+             patch("time.sleep") as sleep, \
+             _patch_run(_visible(), _completed(), _visible(), _minimized()), _env():
+            cfg.is_dev_mode = False
+            ok, _detail = show_desktop()
+
+        assert ok is True
+        sleep.assert_called()
+
+    def test_an_unreadable_property_does_not_invent_a_failure(self):
+        """A property that cannot be read says nothing about the windows -
+        a red toast for it would announce a problem that may not exist."""
+        with _prod() as cfg, \
+             _patch_run(_completed(1, stderr="boom"), _completed(), _completed(1)), _env():
+            cfg.is_dev_mode = False
+            ok, _detail = show_desktop()
+
+        assert ok is True
+
+    def test_an_unreadable_probe_still_fires_the_shortcut(self):
+        with _prod() as cfg, \
+             _patch_run(_completed(1), _completed(), _minimized()) as run, _env():
+            cfg.is_dev_mode = False
+            show_desktop()
+
+        assert run.call_args_list[1].args[0] == SHOW_DESKTOP_CMD
+
+
+def test_the_module_does_not_expose_the_useless_setter():
+    """Belt and braces: nobody re-adds showDesktop(bool) from the interface
+    listing without measuring it again."""
+    for name in dir(desktop_windows):
+        value = getattr(desktop_windows, name)
+        if isinstance(value, list):
+            assert "org.kde.KWin.showDesktop" not in value


### PR DESCRIPTION
## Problem

„Gaming-Modus beenden" schließt Big Picture, **räumt den Desktop aber nicht ab**. Gemeldet aus dem Praxistest an der Box.

## Messung (BaluNode, 2026-08-01, mit sichtbaren Fenstern)

```
$ qdbus6 org.kde.KWin /KWin org.kde.KWin.showingDesktop
false
$ qdbus6 org.kde.KWin /KWin org.kde.KWin.showDesktop true      # exit 0
$ qdbus6 org.kde.KWin /KWin org.kde.KWin.showingDesktop
false          <- nichts passiert, Fenster stehen
$ qdbus6 org.kde.kglobalaccel /component/kwin invokeShortcut "Show Desktop"
$ qdbus6 org.kde.KWin /KWin org.kde.KWin.showingDesktop
true           <- Fenster unten
```

Der Setter `org.kde.KWin.showDesktop(bool)` nimmt die Nachricht an und tut nichts. Er ist `Q_NOREPLY` — sein Exit-Code sagt nur, dass die D-Bus-Nachricht rausging.

## Was hier schiefgelaufen ist

Zwei Releases, ein Fehler:

- **#497** hat den Setter aus der Schnittstellen-Auflistung übernommen, ohne ihn je laufen zu sehen, und die Property zur Kontrolle gelesen. Ergebnis: die Aktion meldete bei **jedem** Lauf einen Fehler.
- **#499** hat daraufhin die Kontrolle als „Fehlalarm" entfernt — sie hatte die ganze Zeit recht. Damit war die Aktion still wirkungslos statt laut kaputt.

Beides kam von derselben Abkürzung: `exit=0` als Wirkungsnachweis zu lesen. Bei jedem anderen Baustein dieser Aktion (`steam://close/bigpicture`, `kscreen-doctor`, `loginctl`) wurde vorher an der Box gemessen.

## Änderung

Beide Teile kommen zurück, richtig herum:

- **Auslösen** über den kglobalaccel-Shortcut — der nachweislich wirkende Weg.
- **Property zweimal lesen.** *Vorher*, weil der Shortcut ein **Umschalter** ist: auf einem bereits leeren Desktop würde er die Fenster zurückholen. Das Vorher-Lesen macht die Funktion idempotent, ganz ohne Setter. *Nachher* als Verifikation — der einzige Schritt im ganzen „Gaming-Modus beenden", dessen Wirkung überhaupt beobachtbar ist.

Die Nachkontrolle **pollt bis zu 2 s** statt einmal zu lesen: KWin wendet den Shortcut asynchron an, die Handmessung brauchte einen Moment. Eine nicht lesbare Property gilt weiterhin als Erfolg — sie sagt nichts über die Fenster aus.

## Tests

48 Tests grün (`test_desktop_windows.py` + `test_steam_gaming_plugin.py`), 969 in `tests/services/power` + `tests/plugins`, `ruff` sauber.

Drei Wächter gegen genau diesen Rückfall:

- `test_minimizes_through_the_shortcut_not_the_setter` — `invokeShortcut` ja, `showDesktop` nein, mit der Messung als Begründung im Docstring.
- `test_does_not_fire_the_toggle_when_the_desktop_is_already_clear` — sonst holt die Aktion die Fenster zurück.
- `test_the_module_does_not_expose_the_useless_setter` — der Methodenname darf in keiner Kommandozeile des Moduls auftauchen.

Dazu `test_it_waits_for_kwin_instead_of_reading_once` für das Poll-Verhalten und `test_probes_first_then_invokes_then_verifies` für die Aufrufreihenfolge.

## Zusammenspiel mit #500

Unabhängig, keine gemeinsamen Dateien. #500 (nur eine Richtung im Menü) reduziert nebenbei das Umschalt-Risiko weiter: nach dem Beenden verschwindet der Eintrag, er lässt sich also gar nicht zweimal hintereinander klicken. Verlassen tut sich dieser PR darauf nicht — das Vorher-Lesen genügt für sich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
