### PR TITLE
fix(ci): Podman-Reparatur raeumt keine fremden Container mehr ab und killt den Job nicht (#498)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,7 @@
 /deploy/             @Xveyn
 /scripts/bootstrap-runner-ubuntu.sh  @Xveyn
 /scripts/bootstrap-ci-runner.sh      @Xveyn
+/scripts/ci-podman-health.sh         @Xveyn
 /ci-config.example.conf              @Xveyn
 /scripts/configure-ci.sh             @Xveyn
 

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -79,10 +79,12 @@ jobs:
           # `podman info` initialises the runtime and would recreate the pause
           # process itself, so the probe has to be serialized too — hence flock
           # around the whole check rather than a bare `||`.
-          # `podman system migrate` runs ONLY when podman is already broken:
-          # resetting the pause process unconditionally would rip it out from
-          # under a container the other runner instance is running right now.
-          flock "$HOME/.podman-health.lock" -c 'podman info >/dev/null 2>&1 || podman system migrate'
+          # The repair itself lives in the script (identical in all three
+          # sandbox jobs) because it needs more than one line to be safe:
+          # `podman system migrate` STOPS running containers and has crashed
+          # doing so (#498), so it must not run while another job is mid-flight
+          # and its exit code must not become this job's result.
+          flock "$HOME/.podman-health.lock" -c "bash '$GITHUB_WORKSPACE/scripts/ci-podman-health.sh'"
 
       - name: Lint + backend tests (with coverage) in rootless Podman container
         env:
@@ -184,7 +186,7 @@ jobs:
         if: github.repository == 'Xveyn/BaluHost'
         run: |
           set -euo pipefail
-          flock "$HOME/.podman-health.lock" -c 'podman info >/dev/null 2>&1 || podman system migrate'
+          flock "$HOME/.podman-health.lock" -c "bash '$GITHUB_WORKSPACE/scripts/ci-podman-health.sh'"
 
       - name: Lint + build + unit tests (with coverage) in rootless Podman container
         env:

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -80,7 +80,7 @@ jobs:
         if: github.repository == 'Xveyn/BaluHost'
         run: |
           set -euo pipefail
-          flock "$HOME/.podman-health.lock" -c 'podman info >/dev/null 2>&1 || podman system migrate'
+          flock "$HOME/.podman-health.lock" -c "bash '$GITHUB_WORKSPACE/scripts/ci-podman-health.sh'"
 
       - name: Mocked Playwright tests in rootless Podman container
         env:

--- a/scripts/ci-podman-health.sh
+++ b/scripts/ci-podman-health.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Bring the shared rootless Podman state on the ci-sandbox pool into a usable
+# shape — without ever taking the job down with it.
+#
+# Why this exists (#394, #436, #498)
+# ----------------------------------
+# BaluNode-ci-sandbox and BaluNode-ci-sandbox-2 run as the SAME POSIX user
+# (ci-runner), so all three sandbox jobs share ONE rootless Podman state,
+# including the pause process that holds the user namespace. A job that starts
+# while another job's podman is coming up loses that race and dies before any
+# test runs ("invalid internal status ... could not find any running process").
+# #436 serialized the check with flock, which fixed the race on the PROBE.
+#
+# It did not fix the REPAIR. `podman system migrate` stops every running
+# container as part of resetting the pause process, and on 2026-08-01 it did
+# exactly that to a container left over from another job and then segfaulted
+# tearing down its network:
+#
+#     stopped d8993442c3fc...
+#     panic: runtime error: invalid memory address or nil pointer dereference
+#     [signal SIGSEGV] libpod.(*Runtime).Migrate -> teardownNetworkBackend
+#     ##[error]Process completed with exit code 2
+#
+# The job was red 7 seconds in, before installing anything. The guard in place
+# then was "only migrate when podman is broken" — but a broken `podman info`
+# says nothing about whether containers are running, which is what makes
+# migrate destructive.
+#
+# What this does differently
+# --------------------------
+#   1. probe first; a healthy runtime needs no repair at all
+#   2. if it is unhealthy but containers are running, WAIT — another job is
+#      mid-flight and migrating would rip the floor out from under it
+#   3. migrate only when unhealthy AND nothing is running
+#   4. never propagate migrate's exit code. A crash while cleaning up is not a
+#      reason to fail this job; what matters is whether podman works afterwards
+#   5. never exit non-zero at all. If podman is still unusable, the container
+#      step that follows fails on its own with a far more specific message
+#      than "the health check said no"
+#
+# Called from the three sandbox jobs (ci-check.yml x2, playwright-e2e.yml)
+# under a shared flock, so only one instance of this runs at a time.
+
+# NOT `set -e`: every failure in here is something to inspect and report, not
+# something to die on. That is the whole point of the script.
+set -uo pipefail
+
+# Overridable so the behaviour can be exercised without waiting half a minute
+# (scripts/tests/test-ci-podman-health.sh). Nothing in CI sets them; the worst
+# a wrong value can do is wait longer or shorter.
+: "${PODMAN_HEALTH_MAX_ATTEMPTS:=6}"
+: "${PODMAN_HEALTH_BUSY_WAIT:=5}"
+: "${PODMAN_HEALTH_SETTLE:=2}"
+
+readonly MAX_ATTEMPTS="${PODMAN_HEALTH_MAX_ATTEMPTS}"
+readonly BUSY_WAIT_SECONDS="${PODMAN_HEALTH_BUSY_WAIT}"
+readonly SETTLE_SECONDS="${PODMAN_HEALTH_SETTLE}"
+
+log() { echo "podman-health: $*"; }
+
+is_healthy() {
+    podman info >/dev/null 2>&1
+}
+
+# Are containers running RIGHT NOW? Asked two ways on purpose: `podman ps`
+# needs a working runtime, which is exactly what we cannot assume here, while
+# conmon (one process per running container) is visible in the process table no
+# matter how confused podman itself is.
+containers_running() {
+    if command -v pgrep >/dev/null 2>&1 && pgrep -u "$(id -u)" -x conmon >/dev/null 2>&1; then
+        return 0
+    fi
+    [ -n "$(podman ps -q 2>/dev/null)" ]
+}
+
+main() {
+    for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+        if is_healthy; then
+            [ "${attempt}" -eq 1 ] && log "healthy" || log "healthy after ${attempt} attempts"
+            return 0
+        fi
+
+        if containers_running; then
+            log "unhealthy, but containers are running — another job is using this podman."
+            log "waiting ${BUSY_WAIT_SECONDS}s instead of migrating (attempt ${attempt}/${MAX_ATTEMPTS})"
+            sleep "${BUSY_WAIT_SECONDS}"
+            continue
+        fi
+
+        log "unhealthy and nothing running — resetting the pause process (attempt ${attempt}/${MAX_ATTEMPTS})"
+        if ! podman system migrate 2>&1 | sed 's/^/podman-health:   /'; then
+            # Includes the SIGSEGV from #498. Deliberately swallowed: the next
+            # probe decides, not the exit code of the cleanup.
+            log "migrate reported a failure — checking whether podman works anyway"
+        fi
+        sleep "${SETTLE_SECONDS}"
+    done
+
+    if is_healthy; then
+        log "healthy"
+        return 0
+    fi
+
+    # A warning, not an error: if podman really is unusable, the podman run
+    # step fails next with a specific message. Failing here would only replace
+    # that message with a vaguer one.
+    echo "::warning::rootless podman still reports unhealthy after ${MAX_ATTEMPTS} attempts — the container step may fail"
+    return 0
+}
+
+main "$@"

--- a/scripts/tests/test-ci-podman-health.sh
+++ b/scripts/tests/test-ci-podman-health.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Exercise scripts/ci-podman-health.sh against a fake podman.
+#
+# The script's whole job is to behave well when podman misbehaves, and that is
+# not observable on the runner without breaking CI on purpose. A stub on PATH
+# reproduces every branch in a second:
+#
+#   healthy            -> no repair at all
+#   unhealthy, busy    -> waits, never migrates (this is #498: migrating here
+#                         stops the other job's container and can crash)
+#   unhealthy, idle    -> migrates, then reports healthy
+#   migrate crashes    -> job still passes, warning only
+#
+# Run:  bash scripts/tests/test-ci-podman-health.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly TARGET="${SCRIPT_DIR}/ci-podman-health.sh"
+
+failures=0
+
+# Builds a stub podman whose behaviour is driven by files in the sandbox:
+#   info_fails_times : how many `podman info` calls report unhealthy
+#   ps_output        : what `podman ps -q` prints
+#   migrate_exit     : exit code of `podman system migrate`
+make_sandbox() {
+    local dir="$1" info_fails="$2" ps_output="$3" migrate_exit="$4"
+    mkdir -p "${dir}/bin"
+    echo "${info_fails}" > "${dir}/info_fails_times"
+    printf '%s' "${ps_output}" > "${dir}/ps_output"
+    echo "${migrate_exit}" > "${dir}/migrate_exit"
+    : > "${dir}/calls"
+
+    cat > "${dir}/bin/podman" <<'STUB'
+#!/usr/bin/env bash
+sandbox="$(dirname "$(dirname "$0")")"
+echo "$*" >> "${sandbox}/calls"
+case "$1 ${2:-}" in
+  "info ")
+    remaining="$(cat "${sandbox}/info_fails_times")"
+    if [ "${remaining}" -gt 0 ]; then
+      echo "$((remaining - 1))" > "${sandbox}/info_fails_times"
+      echo "invalid internal status" >&2
+      exit 125
+    fi
+    exit 0
+    ;;
+  "ps -q") cat "${sandbox}/ps_output" ;;
+  "system migrate")
+    code="$(cat "${sandbox}/migrate_exit")"
+    [ "${code}" -ne 0 ] && echo "panic: runtime error: invalid memory address" >&2
+    exit "${code}"
+    ;;
+esac
+exit 0
+STUB
+    chmod +x "${dir}/bin/podman"
+
+    # pgrep must not find a real conmon on the developer's machine, and must be
+    # able to *pretend* to find one - the stub answers from a file.
+    cat > "${dir}/bin/pgrep" <<'STUB'
+#!/usr/bin/env bash
+sandbox="$(dirname "$(dirname "$0")")"
+[ -f "${sandbox}/conmon_running" ] && exit 0
+exit 1
+STUB
+    chmod +x "${dir}/bin/pgrep"
+}
+
+run_target() {
+    local dir="$1"
+    PATH="${dir}/bin:${PATH}" \
+    PODMAN_HEALTH_MAX_ATTEMPTS=3 \
+    PODMAN_HEALTH_BUSY_WAIT=0 \
+    PODMAN_HEALTH_SETTLE=0 \
+        bash "${TARGET}" 2>&1
+}
+
+check() {
+    local label="$1" condition="$2"
+    if [ "${condition}" = "ok" ]; then
+        echo "  PASS  ${label}"
+    else
+        echo "  FAIL  ${label}"
+        failures=$((failures + 1))
+    fi
+}
+
+# ---------------------------------------------------------------- healthy ---
+echo "case: podman is healthy"
+sandbox="$(mktemp -d)"
+make_sandbox "${sandbox}" 0 "" 0
+output="$(run_target "${sandbox}")"
+status=$?
+check "exits 0" "$([ ${status} -eq 0 ] && echo ok)"
+check "does not migrate" "$(grep -q 'system migrate' "${sandbox}/calls" && echo no || echo ok)"
+check "says healthy" "$(echo "${output}" | grep -q 'healthy' && echo ok)"
+rm -rf "${sandbox}"
+
+# ------------------------------------------------- unhealthy but busy (#498) ---
+echo "case: unhealthy while another job has a container running"
+sandbox="$(mktemp -d)"
+make_sandbox "${sandbox}" 99 "abc123" 0
+: > "${sandbox}/conmon_running"
+output="$(run_target "${sandbox}")"
+status=$?
+check "exits 0 (never fails the job)" "$([ ${status} -eq 0 ] && echo ok)"
+check "does NOT migrate under a running container" \
+      "$(grep -q 'system migrate' "${sandbox}/calls" && echo no || echo ok)"
+check "explains the wait" "$(echo "${output}" | grep -q 'another job' && echo ok)"
+check "warns at the end" "$(echo "${output}" | grep -q '::warning::' && echo ok)"
+rm -rf "${sandbox}"
+
+# ------------------------------------------------------- unhealthy and idle ---
+echo "case: unhealthy with nothing running"
+sandbox="$(mktemp -d)"
+make_sandbox "${sandbox}" 1 "" 0
+output="$(run_target "${sandbox}")"
+status=$?
+check "exits 0" "$([ ${status} -eq 0 ] && echo ok)"
+check "migrates once" \
+      "$([ "$(grep -c 'system migrate' "${sandbox}/calls")" -eq 1 ] && echo ok)"
+check "reports healthy afterwards" "$(echo "${output}" | grep -q 'healthy' && echo ok)"
+rm -rf "${sandbox}"
+
+# ------------------------------------------------------ migrate itself dies ---
+echo "case: migrate segfaults (the #498 crash)"
+sandbox="$(mktemp -d)"
+make_sandbox "${sandbox}" 1 "" 2
+output="$(run_target "${sandbox}")"
+status=$?
+check "exits 0 despite the crash" "$([ ${status} -eq 0 ] && echo ok)"
+check "reports healthy afterwards" "$(echo "${output}" | grep -q 'healthy' && echo ok)"
+rm -rf "${sandbox}"
+
+# --------------------------------------------------- broken beyond repair ---
+echo "case: podman stays broken"
+sandbox="$(mktemp -d)"
+make_sandbox "${sandbox}" 99 "" 2
+output="$(run_target "${sandbox}")"
+status=$?
+check "still exits 0 — the container step reports the real error" \
+      "$([ ${status} -eq 0 ] && echo ok)"
+check "warns instead of failing" "$(echo "${output}" | grep -q '::warning::' && echo ok)"
+rm -rf "${sandbox}"
+
+echo
+if [ "${failures}" -eq 0 ]; then
+    echo "all checks passed"
+    exit 0
+fi
+echo "${failures} check(s) failed"
+exit 1


### PR DESCRIPTION
Behebt #498.

## Problem

Der Reparaturzweig des Podman-Health-Steps konnte den Job härter beschädigen als das Problem, das er beheben sollte. Am 2026-08-01 (PR #497) starb `Mocked E2E` nach **7 Sekunden**, bevor irgendetwas installiert war:

```
flock "$HOME/.podman-health.lock" -c 'podman info >/dev/null 2>&1 || podman system migrate'
  stopped d8993442c3fc...
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV] libpod.(*Runtime).Migrate → teardownNetworkBackend
##[error]Process completed with exit code 2
```

Der Kommentar über dem Step formulierte die Absicht schon richtig — *„migrate runs ONLY when podman is already broken: resetting the pause process unconditionally would rip it out from under a container the other runner instance is running right now"* — aber die Bedingung trägt nicht: **dass `podman info` scheitert, heißt nicht, dass kein Container läuft.** Genau das ist eingetreten.

## Änderung

Die Reparatur ist aus dem Einzeiler herausgewachsen und liegt jetzt in `scripts/ci-podman-health.sh`, aufgerufen von allen drei Sandbox-Jobs unter demselben `flock` wie bisher:

1. **Erst prüfen** — ein gesunder Runtime braucht gar keine Reparatur.
2. **Ungesund, aber Container laufen → warten.** Ein anderer Job ist mitten drin; migrieren würde ihm den Boden wegziehen. Gefragt wird über `conmon` in der Prozessliste **und** `podman ps` — letzteres braucht genau den Runtime, den wir hier nicht voraussetzen können, ersteres ist unabhängig davon sichtbar.
3. **Migrieren nur bei ungesund UND nichts läuft.**
4. **Der Exit-Code von `migrate` wird nie zum Jobergebnis.** Ein Absturz beim Aufräumen sagt nichts darüber, ob Podman danach funktioniert — das entscheidet die nächste Prüfung.
5. **Das Skript endet nie mit ≠ 0.** Ist Podman wirklich unbrauchbar, scheitert der folgende `podman run`-Step mit einer viel spezifischeren Meldung als „der Health-Check sagt nein".

## Verifikation

`scripts/tests/test-ci-podman-health.sh` fährt das Skript gegen ein gefälschtes `podman` — **16 Checks, alle grün**:

| Fall | Erwartung |
|---|---|
| Podman gesund | kein `migrate`, exit 0 |
| ungesund + fremder Container läuft | **kein** `migrate`, wartet, exit 0 |
| ungesund + nichts läuft | genau ein `migrate`, danach gesund |
| `migrate` segfaultet (#498) | Job bleibt grün |
| dauerhaft kaputt | Warnung statt Fehler, exit 0 |

Der Harness existiert, weil dieses Verhalten sonst nur beobachtbar ist, indem man CI absichtlich kaputt macht. Läuft lokal in einer Sekunde: `bash scripts/tests/test-ci-podman-health.sh`.

Zusätzlich: beide Workflow-Dateien parsen, alle drei Aufrufstellen ersetzt (`ci-check.yml` ×2, `playwright-e2e.yml` ×1), `bash -n` sauber.

## Sicherheits-Einordnung (Checkliste aus `.claude/rules/ci-cd-security.md`)

- **Runner, Trigger, Environment-Gates, Actor-Gate: unverändert.** Kein Job wechselt den Runner, keiner bekommt einen neuen Trigger, `ci-tests` bleibt dran.
- **Layer B unberührt.** Untrusted PR-Code läuft weiterhin ausschließlich in `podman run`. Das Skript verwaltet nur Podman-Zustand.
- **Kein neuer Vertrauensbereich.** Bei `pull_request` stammt die Workflow-YAML ohnehin aus dem PR — ein Skript im Repo ist derselbe Trust-Level wie der bisherige Inline-Einzeiler, nicht ein schwächerer.
- **CODEOWNERS** erweitert um `/scripts/ci-podman-health.sh`, analog zu `bootstrap-ci-runner.sh` und `configure-ci.sh`.
- Die Timing-Konstanten sind per Env überschreibbar (nur für den Test). CI setzt sie nicht; das Schlimmste, was ein falscher Wert bewirkt, ist eine längere oder kürzere Wartezeit — und `timeout-minutes: 15` deckelt das ohnehin.

## Nicht enthalten

Der noch offene Punkt aus #394 (der Bootstrap-Selbsttest prüft die Podman-Gesundheit nur zur Provisionierungszeit) bleibt offen — anderes Thema, eigener Zuschnitt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
