### PR TITLE
test(client): Upload-Queue abdecken — und ein Token, das nie ankam (T3/#317)

### DIFF
--- a/client/src/__tests__/contexts/UploadContext.test.tsx
+++ b/client/src/__tests__/contexts/UploadContext.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * The upload queue — the NAS's core interaction, and the last big untested
+ * area from T3/#317 besides the notification socket.
+ *
+ * What is worth pinning down here is not the happy path (a POST goes out) but
+ * the decisions the context makes BEFORE anything is sent: does it ask about
+ * duplicates, does it respect a "skip", does the rename land where a user
+ * expects it, and does it refuse an upload that cannot fit.
+ *
+ * Runs on renderWithProviders (T2/#316): real providers, real i18n, one route
+ * table for both transports — the batch upload uses raw `fetch`, the duplicate
+ * check goes through axios.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+
+import { renderWithProviders } from '../helpers/renderWithProviders';
+import { useAuth } from '../../contexts/AuthContext';
+import { useUpload, type DuplicateDecision } from '../../contexts/UploadContext';
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+const CHECK = '/api/files/check-exists';
+const UPLOAD = '/api/files/upload';
+
+function file(name: string, size = 10): File {
+  return new File([new Uint8Array(size)], name);
+}
+
+/** FileList is not constructible in jsdom; the context only does Array.from(). */
+function asFileList(files: File[]): FileList {
+  return { ...files, length: files.length, item: (i: number) => files[i] } as unknown as FileList;
+}
+
+function Harness({
+  files,
+  availableBytes,
+  decisions = [],
+}: {
+  files: File[];
+  availableBytes?: number | null;
+  decisions?: DuplicateDecision[];
+}) {
+  const { startUpload, uploads, pendingUpload, handleDuplicateResolution } = useUpload();
+  // UploadProvider reads its token from AuthContext and silently returns
+  // without one, so every test has to wait for the sign-in to land first -
+  // exactly like a user who cannot click before the app has loaded.
+  const { token } = useAuth();
+  return (
+    <div>
+      <p data-testid="auth">{token ? 'angemeldet' : 'lädt'}</p>
+      <button onClick={() => startUpload(asFileList(files), '/Shared', availableBytes)}>hochladen</button>
+      <button onClick={() => handleDuplicateResolution(decisions)}>entscheiden</button>
+      <p data-testid="pending">{pendingUpload ? 'dialog' : 'kein-dialog'}</p>
+      <p data-testid="queue">{uploads.size}</p>
+    </div>
+  );
+}
+
+async function setup(props: React.ComponentProps<typeof Harness>, routes: Record<string, unknown>) {
+  const rendered = renderWithProviders(<Harness {...props} />, {
+    auth: { username: 'sven' },
+    withUpload: true,
+    api: { [CHECK]: { duplicates: [] }, [UPLOAD]: { uploaded: [] }, ...routes },
+  });
+  await screen.findByText('angemeldet');
+  return rendered;
+}
+
+/** The names the app actually put into the multipart body. */
+function uploadedNames(body: unknown): string[] {
+  return (body as FormData).getAll('files').map((f) => (f as File).name);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('the duplicate gate', () => {
+  it('uploads straight away when nothing collides', async () => {
+    const { user, api } = await setup({ files: [file('neu.txt')] }, {});
+
+    await user.click(screen.getByRole('button', { name: 'hochladen' }));
+
+    await waitFor(() => expect(api.callsTo(UPLOAD, 'POST')).toHaveLength(1));
+    expect(screen.getByTestId('pending')).toHaveTextContent('kein-dialog');
+  });
+
+  it('asks first and sends nothing while the question is open', async () => {
+    const { user, api } = await setup(
+      { files: [file('bericht.pdf')] },
+      { [CHECK]: { duplicates: [{ filename: 'bericht.pdf', size_bytes: 10, modified_at: '', checksum: null }] } },
+    );
+
+    await user.click(screen.getByRole('button', { name: 'hochladen' }));
+
+    await waitFor(() => expect(screen.getByTestId('pending')).toHaveTextContent('dialog'));
+    expect(api.callsTo(UPLOAD, 'POST')).toHaveLength(0);
+  });
+
+  it('uploads anyway when the duplicate check itself fails', async () => {
+    // Deliberate: a broken check must not block the upload. Documented here so
+    // the fallback is a decision, not an accident.
+    const { user, api } = await setup(
+      { files: [file('neu.txt')] },
+      { [CHECK]: { status: 500, body: { detail: 'boom' } } },
+    );
+
+    await user.click(screen.getByRole('button', { name: 'hochladen' }));
+
+    await waitFor(() => expect(api.callsTo(UPLOAD, 'POST')).toHaveLength(1));
+  });
+});
+
+describe('what the user decides in the dialog', () => {
+  const collide = (name: string) => ({
+    [CHECK]: { duplicates: [{ filename: name, size_bytes: 10, modified_at: '', checksum: null }] },
+  });
+
+  async function openDialogAndDecide(
+    files: File[],
+    decisions: DuplicateDecision[],
+    duplicateName: string,
+  ) {
+    const rendered = await setup({ files, decisions }, collide(duplicateName));
+    await rendered.user.click(screen.getByRole('button', { name: 'hochladen' }));
+    await waitFor(() => expect(screen.getByTestId('pending')).toHaveTextContent('dialog'));
+    await rendered.user.click(screen.getByRole('button', { name: 'entscheiden' }));
+    return rendered;
+  }
+
+  it('skip really skips — no request at all when it was the only file', async () => {
+    const { api } = await openDialogAndDecide(
+      [file('bericht.pdf')],
+      [{ filename: 'bericht.pdf', resolution: 'skip' }],
+      'bericht.pdf',
+    );
+
+    await waitFor(() => expect(screen.getByTestId('pending')).toHaveTextContent('kein-dialog'));
+    expect(api.callsTo(UPLOAD, 'POST')).toHaveLength(0);
+  });
+
+  it('keep-both renames before the extension, not after it', async () => {
+    const { api } = await openDialogAndDecide(
+      [file('bericht.pdf')],
+      [{ filename: 'bericht.pdf', resolution: 'keep-both' }],
+      'bericht.pdf',
+    );
+
+    await waitFor(() => expect(api.callsTo(UPLOAD, 'POST')).toHaveLength(1));
+    expect(uploadedNames(api.callsTo(UPLOAD, 'POST')[0].body)).toEqual(['bericht (1).pdf']);
+  });
+
+  it('keep-both appends when there is no extension', async () => {
+    const { api } = await openDialogAndDecide(
+      [file('README')],
+      [{ filename: 'README', resolution: 'keep-both' }],
+      'README',
+    );
+
+    await waitFor(() => expect(api.callsTo(UPLOAD, 'POST')).toHaveLength(1));
+    expect(uploadedNames(api.callsTo(UPLOAD, 'POST')[0].body)).toEqual(['README (1)']);
+  });
+
+  it('overwrite keeps the original name', async () => {
+    const { api } = await openDialogAndDecide(
+      [file('bericht.pdf')],
+      [{ filename: 'bericht.pdf', resolution: 'overwrite' }],
+      'bericht.pdf',
+    );
+
+    await waitFor(() => expect(api.callsTo(UPLOAD, 'POST')).toHaveLength(1));
+    expect(uploadedNames(api.callsTo(UPLOAD, 'POST')[0].body)).toEqual(['bericht.pdf']);
+  });
+
+  it('carries the non-colliding files along untouched', async () => {
+    const { api } = await openDialogAndDecide(
+      [file('bericht.pdf'), file('anderes.txt')],
+      [{ filename: 'bericht.pdf', resolution: 'skip' }],
+      'bericht.pdf',
+    );
+
+    await waitFor(() => expect(api.callsTo(UPLOAD, 'POST')).toHaveLength(1));
+    expect(uploadedNames(api.callsTo(UPLOAD, 'POST')[0].body)).toEqual(['anderes.txt']);
+  });
+});
+
+describe('capacity', () => {
+  it('refuses an upload that does not fit and sends nothing', async () => {
+    const { user, api } = await setup({ files: [file('gross.bin', 500)], availableBytes: 100 }, {});
+
+    await user.click(screen.getByRole('button', { name: 'hochladen' }));
+
+    await waitFor(() => expect(api.callsTo(CHECK, 'POST')).toHaveLength(1));
+    expect(api.callsTo(UPLOAD, 'POST')).toHaveLength(0);
+  });
+
+  it('proceeds when the free space is unknown', async () => {
+    const { user, api } = await setup({ files: [file('gross.bin', 500)], availableBytes: null }, {});
+
+    await user.click(screen.getByRole('button', { name: 'hochladen' }));
+
+    await waitFor(() => expect(api.callsTo(UPLOAD, 'POST')).toHaveLength(1));
+  });
+});
+
+describe('batching', () => {
+  it('splits at 50 files per request', async () => {
+    const files = Array.from({ length: 51 }, (_, i) => file(`datei-${i}.txt`));
+    const { user, api } = await setup({ files }, {});
+
+    await user.click(screen.getByRole('button', { name: 'hochladen' }));
+
+    await waitFor(() => expect(api.callsTo(UPLOAD, 'POST')).toHaveLength(2));
+    const [first, second] = api.callsTo(UPLOAD, 'POST');
+    expect(uploadedNames(first.body)).toHaveLength(50);
+    expect(uploadedNames(second.body)).toHaveLength(1);
+  });
+
+  it('sends the target path with every batch', async () => {
+    const { user, api } = await setup({ files: [file('a.txt')] }, {});
+
+    await user.click(screen.getByRole('button', { name: 'hochladen' }));
+
+    await waitFor(() => expect(api.callsTo(UPLOAD, 'POST')).toHaveLength(1));
+    expect((api.callsTo(UPLOAD, 'POST')[0].body as FormData).get('path')).toBe('/Shared');
+  });
+});

--- a/client/src/__tests__/helpers/renderWithProviders.tsx
+++ b/client/src/__tests__/helpers/renderWithProviders.tsx
@@ -15,13 +15,14 @@
  *             token is stored, which is what the `auth` option does. Mounting
  *             it unconditionally means a component using useAuth() just works
  *             instead of throwing "must be used within an AuthProvider".
- *   opt-in  PluginProvider (`withPlugins`)
- *           - fetches the plugin list AND the UI manifest as soon as a user is
- *             signed in, so a test that does not need it should not have to
- *             stub two more routes
- *   never   NotificationProvider, UploadProvider
- *           - they open a WebSocket and hold upload state. Add them here when
- *             a test needs one, together with the fake that makes it safe.
+ *   opt-in  PluginProvider (`withPlugins`), UploadProvider (`withUpload`)
+ *           - PluginProvider fetches the plugin list AND the UI manifest as
+ *             soon as a user is signed in; UploadProvider holds queue state
+ *             and lazy-loads the duplicate dialog. Neither should be paid for
+ *             by a test that does not use it.
+ *   never   NotificationProvider
+ *           - opens a WebSocket. Add it here when a test needs one, together
+ *             with the fake that makes it safe.
  *
  * The network comes from ONE route table for both transports - see apiStub.ts;
  * AuthProvider talks raw `fetch`, everything else goes through axios.
@@ -36,6 +37,7 @@ import type { ReactElement, ReactNode } from 'react';
 
 import { AuthProvider } from '../../contexts/AuthContext';
 import { PluginProvider } from '../../contexts/PluginContext';
+import { UploadProvider } from '../../contexts/UploadContext';
 import { ThemeProvider } from '../../contexts/ThemeContext';
 import { createTestQueryClient } from './queryClient';
 import { createTestI18n } from './i18nTest';
@@ -63,6 +65,8 @@ export interface RenderWithProvidersOptions extends Omit<RenderOptions, 'wrapper
   auth?: TestUser | false;
   /** Mount PluginProvider (needs `auth`, it only loads with a token). */
   withPlugins?: boolean;
+  /** Mount UploadProvider (needs `auth`; uploads are skipped without a token). */
+  withUpload?: boolean;
 }
 
 export interface RenderWithProvidersResult extends RenderResult {
@@ -95,6 +99,7 @@ export function renderWithProviders(
     api = {},
     auth = false,
     withPlugins = false,
+    withUpload = false,
     ...renderOptions
   } = options;
 
@@ -116,6 +121,7 @@ export function renderWithProviders(
 
   function Wrapper({ children }: { children: ReactNode }) {
     let tree = <>{children}</>;
+    if (withUpload) tree = <UploadProvider>{tree}</UploadProvider>;
     if (withPlugins) tree = <PluginProvider>{tree}</PluginProvider>;
     tree = <AuthProvider>{tree}</AuthProvider>;
     return (

--- a/client/src/contexts/UploadContext.tsx
+++ b/client/src/contexts/UploadContext.tsx
@@ -340,7 +340,14 @@ export function UploadProvider({ children }: { children: ReactNode }) {
       // Fire completion callbacks so FileManager can reload
       fireCompletionCallbacks();
     })();
-  }, [t, fireCompletionCallbacks]);
+    // `token` belongs in here: getToken() closes over the value from the
+    // render that created this callback, and AuthProvider only sets the token
+    // in its mount effect - so the FIRST render always has null. Without the
+    // dependency the callback keeps that null, and every upload started after
+    // sign-in silently does nothing but show "Session expired". That it works
+    // in the browser today rests on react-i18next handing out a fresh `t`
+    // often enough to rebuild the callback by accident (T3/#317).
+  }, [t, fireCompletionCallbacks, token]);
 
   /**
    * Start an upload: checks for duplicates first, then either shows the


### PR DESCRIPTION
Nimmt das vorletzte offene Ziel aus **T3 (#317)**: `UploadContext.tsx` (450 Zeilen, bisher ohne jeden Test). Baut auf der Infrastruktur aus #507.

## Der Fund, der beim Schreiben herausfiel

`executeUpload` ist ein `useCallback` mit den Dependencies `[t, fireCompletionCallbacks]` — beide stabil. Es hält damit das `getToken` **des ersten Renders** fest, und dort ist `token === null`, weil `AuthProvider` es erst in seinem Mount-Effekt setzt.

Die Folge, im Test reproduziert: **ein Upload nach dem Anmelden schickt gar nichts.** Keine Duplikatsprüfung, kein POST — nur der Toast „Session expired. Please sign in again.", während der Nutzer sehr wohl angemeldet ist.

Warum das im Browser heute nicht auffällt: react-i18next gibt oft genug ein frisches `t` heraus, sodass der Callback zufällig mit einem aktuellen Token neu gebaut wird. Korrektheit, die auf der Memoisierung einer fremden Bibliothek ruht, ist keine — und die Test-i18n-Instanz (Ressourcen vorgeladen, kein Nachladen, also stabiles `t`) nimmt diesen Zufall weg, worauf der Fehler sofort sichtbar wird.

`token` in die Dependencies aufzunehmen ist der Fix. eslints Vorschlag, stattdessen `getToken` einzutragen, würde den Callback bei **jedem** Render neu bauen — die Funktion wird jedes Mal neu definiert; abhängig ist der Callback vom Wert, nicht von der Hülle.

**Mutationsgeprüft:** ohne den Fix fallen 10 der 12 Tests.

## Was die 12 Tests prüfen

Nicht den Happy Path, sondern die Entscheidungen **vor** dem ersten Byte:

| Bereich | Geprüft |
|---|---|
| Duplikat-Gate | lädt sofort, wenn nichts kollidiert; **fragt erst und schickt nichts**, solange die Frage offen ist; lädt trotzdem, wenn die Prüfung selbst scheitert |
| Nutzerentscheidung | `skip` überspringt wirklich (kein Request, wenn es die einzige Datei war); `keep-both` benennt **vor** der Endung um (`bericht (1).pdf`, nicht `bericht.pdf (1)`) und hängt an, wenn es keine gibt; `overwrite` behält den Namen; nicht kollidierende Dateien fahren unverändert mit |
| Kapazität | was nicht passt, wird nicht geschickt; unbekannter freier Platz gilt **nicht** als null |
| Batching | 51 Dateien werden zwei Requests (50 + 1), jeder mit dem Zielpfad |

Die Umbenennung ist der klassische Off-by-one-Kandidat, und die Assertions schauen auf die Namen im **tatsächlichen Multipart-Body**, nicht auf eine gemockte Funktion.

## Warum der Helper aus #507 hier zählt

`checkFilesExist` geht über **axios**, der Batch-Upload über **rohes `fetch`** — genau die Doppelspurigkeit, für die `apiStub.ts` eine gemeinsame Route-Tabelle bietet. Mit nur einem der beiden Stubs wäre der halbe Ablauf unsichtbar.

Der Helper bekommt dafür `withUpload`. `UploadProvider` bleibt wie `PluginProvider` opt-in: er hält Queue-Zustand und lädt den Duplikat-Dialog lazy nach.

Der Harness wartet auf das Anmelden, bevor er klickt — so, wie ein Nutzer nicht klicken kann, bevor die App geladen ist. Das ist keine Zeremonie, sondern genau das, was den Token-Fehler sichtbar gemacht hat.

## Verifikation

263 Testdateien / **1216 Tests** grün, `eslint` 0 Errors, `npm run build` sauber.

Refs #317 — danach fehlt nur noch `useNotificationSocket`, und dafür braucht es einen WebSocket-Fake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
