### PR TITLE
fix(websocket): smart_device_update nicht doppelt einwickeln (#511)

### DIFF
--- a/backend/app/core/lifespan.py
+++ b/backend/app/core/lifespan.py
@@ -198,6 +198,9 @@ async def _write_service_heartbeats() -> None:
         await asyncio.sleep(_HEARTBEAT_INTERVAL_SECONDS)
 
 
+_SMART_DEVICE_BRIDGE_INTERVAL_SECONDS = 1.0
+
+
 async def _smart_device_ws_bridge() -> None:
     """Poll smart_devices_changes.json SHM and broadcast via WebSocket (primary only).
 
@@ -210,7 +213,7 @@ async def _smart_device_ws_bridge() -> None:
     _last_broadcast_ts: float = 0.0
 
     while True:
-        await asyncio.sleep(1.0)
+        await asyncio.sleep(_SMART_DEVICE_BRIDGE_INTERVAL_SECONDS)
         try:
             data = read_shm(SMART_DEVICES_CHANGES_FILE, max_age_seconds=10.0)
             if data is None:
@@ -226,10 +229,12 @@ async def _smart_device_ws_bridge() -> None:
 
             ws = get_websocket_manager()
             if ws:
-                await ws.broadcast_to_all({
-                    "type": "smart_device_update",
-                    "payload": changes,
-                })
+                # broadcast_typed(), not broadcast_to_all(): the latter wraps
+                # whatever it gets in a {"type": "notification"} envelope, which
+                # buried this message one level deep and broke every consumer
+                # matching on the top-level type (#511). admins_only stays off —
+                # device state goes to every connection, as it always has.
+                await ws.broadcast_typed("smart_device_update", changes)
             _last_broadcast_ts = ts
         except Exception as exc:
             logger.debug("SmartDevice WS bridge error: %s", exc)

--- a/backend/app/services/websocket_manager.py
+++ b/backend/app/services/websocket_manager.py
@@ -187,53 +187,23 @@ class WebSocketManager:
 
         return sent_count
 
-    async def broadcast_to_all(self, message: dict[str, Any]) -> int:
-        """Broadcast a message to all connected users.
-
-        Args:
-            message: Message to send
-
-        Returns:
-            Number of connections the message was sent to
-        """
-        sent_count = 0
-        async with self._lock:
-            for user_id, connections in list(self._user_connections.items()):
-                disconnected = []
-
-                for conn in connections:
-                    try:
-                        await conn.websocket.send_json({
-                            "type": "notification",
-                            "payload": message,
-                        })
-                        sent_count += 1
-                    except Exception as e:
-                        logger.warning(f"Failed to broadcast to user {user_id}: {e}")
-                        disconnected.append(conn)
-
-                # Clean up disconnected connections
-                for conn in disconnected:
-                    if conn in connections:
-                        connections.remove(conn)
-
-                if not connections and user_id in self._user_connections:
-                    del self._user_connections[user_id]
-                    self._admin_users.discard(user_id)
-
-        return sent_count
-
     async def broadcast_typed(
-        self, msg_type: str, payload: dict[str, Any], admins_only: bool = False
+        self, msg_type: str, payload: Any, admins_only: bool = False
     ) -> int:
         """Broadcast a typed message to connected users.
 
-        Unlike broadcast_to_all() which wraps in {"type": "notification"},
-        this method sends {"type": msg_type, "payload": payload} directly.
+        Sends {"type": msg_type, "payload": payload} — the caller names the
+        type and it reaches the wire unchanged. This is the only all-users
+        broadcast. There used to be a broadcast_to_all() next to it that
+        force-set "type": "notification" and nested the caller's dict under
+        it; a caller that had already typed its message got wrapped twice and
+        no client could match on it (#511). Pass "notification" as msg_type if
+        that is genuinely what you are sending.
 
         Args:
             msg_type: Message type string (e.g. "dashboard_panel_update").
-            payload: Message payload dict.
+            payload: Message payload — a dict for most message types, a list
+                for the batch-shaped ones like "smart_device_update".
             admins_only: Skip non-admin connections. Needed for payloads that a
                 REST route would gate behind is_privileged() - without it the
                 gate would be decorative. "Admin" here means conn.is_admin,

--- a/backend/tests/core/test_lifespan_background_tasks.py
+++ b/backend/tests/core/test_lifespan_background_tasks.py
@@ -10,6 +10,7 @@ never retrieved, so a dead heartbeat writer looked exactly like a healthy one.
 
 import asyncio
 import logging
+from unittest.mock import AsyncMock, MagicMock
 
 from app.core import lifespan
 
@@ -107,6 +108,72 @@ async def test_heartbeat_writer_survives_a_failing_write(monkeypatch, caplog):
         r.getMessage() for r in caplog.records if r.name == lifespan.logger.name
     ]
     assert any("db hiccup" in m for m in messages), messages
+
+
+async def _run_smart_device_bridge_once(monkeypatch, changes, *, is_admin=False):
+    """Drive one iteration of the SMART-device bridge against a live manager.
+
+    Returns the frame the mock socket actually received, i.e. the bytes a
+    client would parse — not the argument the bridge passed inward.
+    """
+    from app.services import websocket_manager as wsm
+    from app.services.monitoring import shm
+
+    manager = wsm.WebSocketManager()
+    ws = MagicMock()
+    ws.send_json = AsyncMock()
+    await manager.connect(ws, user_id=1, is_admin=is_admin)
+
+    monkeypatch.setattr(lifespan, "_SMART_DEVICE_BRIDGE_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(wsm, "get_websocket_manager", lambda: manager)
+    monkeypatch.setattr(
+        shm, "read_shm", lambda *a, **kw: {"timestamp": 1.0, "changes": changes}
+    )
+
+    task = asyncio.create_task(lifespan._smart_device_ws_bridge())
+    for _ in range(500):
+        await asyncio.sleep(0)
+        if ws.send_json.await_count:
+            break
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert ws.send_json.await_count, "bridge never broadcast the changes"
+    return ws.send_json.await_args[0][0]
+
+
+async def test_smart_device_bridge_sends_one_envelope_not_two(monkeypatch):
+    """#511: the frame carries its own type at the top level.
+
+    The bridge used to hand an already-typed message to `broadcast_to_all()`,
+    which wrapped it a second time as `{"type": "notification", ...}`. Web
+    clients match on the top-level type and saw nothing; the Android client
+    trusted the "notification" label, deserialized the inner envelope into a
+    NotificationDto whose non-null fields came back null, and crashed.
+    """
+    changes = [
+        {
+            "device_id": 9,
+            "name": "Sven PC Power Plug",
+            "state": {"switch": {"is_on": False}},
+            "timestamp": "2026-08-03T11:00:54.393785+00:00",
+        }
+    ]
+
+    frame = await _run_smart_device_bridge_once(monkeypatch, changes)
+
+    assert frame == {"type": "smart_device_update", "payload": changes}
+
+
+async def test_smart_device_bridge_still_reaches_non_admins(monkeypatch):
+    """Reach must not narrow: these updates always went to every connection."""
+    frame = await _run_smart_device_bridge_once(
+        monkeypatch, [{"device_id": 1}], is_admin=False
+    )
+    assert frame["type"] == "smart_device_update"
 
 
 async def test_shutdown_cancellation_is_not_reported_as_a_crash(caplog):

--- a/backend/tests/services/test_websocket_manager.py
+++ b/backend/tests/services/test_websocket_manager.py
@@ -107,17 +107,33 @@ class TestBroadcastToAdmins:
 
 @pytest.mark.asyncio
 class TestBroadcastToAll:
+    """All-users reach, now via broadcast_typed() — broadcast_to_all() is gone (#511)."""
+
     async def test_sends_to_all_users(self, manager: WebSocketManager):
         ws1, ws2 = _make_ws(), _make_ws()
         await manager.connect(ws1, user_id=1)
         await manager.connect(ws2, user_id=2)
 
-        count = await manager.broadcast_to_all({"event": "update"})
+        count = await manager.broadcast_typed("some_event", {"event": "update"})
         assert count == 2
 
     async def test_empty_when_no_connections(self, manager: WebSocketManager):
-        count = await manager.broadcast_to_all({"event": "update"})
+        count = await manager.broadcast_typed("some_event", {"event": "update"})
         assert count == 0
+
+    async def test_caller_type_is_not_overwritten(self, manager: WebSocketManager):
+        """The regression that made #511 possible: an envelope forced onto the caller."""
+        ws = _make_ws()
+        await manager.connect(ws, user_id=1)
+
+        await manager.broadcast_typed("smart_device_update", [{"device_id": 9}])
+
+        frame = ws.send_json.await_args[0][0]
+        assert frame == {"type": "smart_device_update", "payload": [{"device_id": 9}]}
+
+    async def test_broadcast_to_all_is_removed(self, manager: WebSocketManager):
+        """Keep it gone: re-adding it re-opens the double-wrap trap."""
+        assert not hasattr(manager, "broadcast_to_all")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #511.

## Root Cause

`broadcast_to_all()` hatte genau eine Aufgabe: alles hart als `{"type": "notification", "payload": ...}` einwickeln. Der SMART-Device-Bridge (`core/lifespan.py:229`) schickte dort aber eine **bereits getypte** Nachricht hinein — also wurde sie ein zweites Mal eingewickelt:

```json
{"type":"notification","payload":{"type":"smart_device_update","payload":[...]}}
```

Solange eine Steckdose überwacht wird, alle ~5 Sekunden.

## Änderungen

| Datei | Was |
|---|---|
| `core/lifespan.py` | Bridge nutzt `broadcast_typed("smart_device_update", changes)`; `admins_only` bleibt aus → Reichweite unverändert (alle Verbundenen) |
| `services/websocket_manager.py` | `broadcast_to_all()` **entfernt** — nach dem Umzug ohne Prod-Aufrufer und genau die Falle, die diesen Bug erzeugt hat |
| `services/websocket_manager.py` | `broadcast_typed`-`payload` von `dict[str, Any]` auf `Any` geweitet: `smart_device_update` schickt eine **Liste** |
| `core/lifespan.py` | Sleep-Intervall des Bridges in eine Modulkonstante (Muster wie `_HEARTBEAT_INTERVAL_SECONDS`), damit der Test ihn ohne 1s-Wartezeit treiben kann |

Zur Entfernung statt „nur dokumentieren": `broadcast_typed("notification", payload)` deckt den Fall exakt ab, falls je eine echte Notification an alle gehen soll — explizit statt implizit. Ein Test hält sie entfernt.

## Konsumenten nach dem Fix

- **Web** (`SmartDevicesPage.tsx:89`): matcht auf Top-Level-`type` → greift jetzt. Keine Frontend-Änderung nötig.
- **Android** (`NotificationWebSocketManager.kt:76`): sieht `type == "smart_device_update"`, fällt in den `Unknown message type`-Zweig, gibt `null` zurück. Kein Crash, keine App-Änderung nötig. Der clientseitige `isNotification()`-Guard bleibt sinnvoll als Verteidigung.

## Tests

Neuer Regressionstest prüft den Frame so, wie ihn der Mock-Socket **tatsächlich empfängt** — nicht das Argument, das der Bridge nach innen reicht. Ein Test, der nur `broadcast_typed` gemockt hätte, wäre für den ursprünglichen Bug blind gewesen.

- `test_smart_device_bridge_sends_one_envelope_not_two` — verifiziert rot vor dem Fix
- `test_smart_device_bridge_still_reaches_non_admins` — die Reichweite darf sich nicht verengen
- `test_caller_type_is_not_overwritten`, `test_broadcast_to_all_is_removed`

`tests/core tests/services tests/plugins`: 2105 passed, 1 failed. Der Fehlschlag (`test_supervisor.py::test_auto_restart_after_unexpected_exit`) ist **pre-existing** — er failt mit gestashten Änderungen identisch. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
