### PR TITLE
chore: tote WS-Schemas, Supervisor-Test-Race und ConnectionError-Mapping

### DIFF
--- a/backend/app/plugins/sandbox/supervisor.py
+++ b/backend/app/plugins/sandbox/supervisor.py
@@ -141,6 +141,16 @@ class SandboxSupervisor:
                 raise SupervisorTimeout(
                     f"plugin {self.plugin_name} request timed out"
                 ) from exc
+            except ConnectionError as exc:
+                # The worker died while we were waiting on its answer. That is
+                # an expected failure mode of a supervised subprocess — the
+                # supervise loop is already restarting it — so it belongs in
+                # this class's own error type. Letting the channel's exception
+                # escape leaked the transport into the caller's contract and
+                # got the request logged as an unexpected crash.
+                raise SupervisorError(
+                    f"plugin {self.plugin_name} worker connection lost"
+                ) from exc
             finally:
                 self._inflight.pop(request_id, None)
         return resp.body

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -269,18 +269,12 @@ class NotificationPreferencesResponse(NotificationPreferencesBase):
         )
 
 
-# WebSocket message schemas
-class WebSocketMessage(BaseModel):
-    """WebSocket message format."""
-
-    type: Literal["notification", "unread_count", "ping", "pong"] = Field(
-        description="Message type"
-    )
-    payload: Any = Field(description="Message payload")
-
-
-class NotificationWebSocketPayload(BaseModel):
-    """Payload for notification WebSocket messages."""
-
-    notification: NotificationResponse
-    unread_count: int
+# No schema describes the WebSocket frames. `services/websocket_manager.py`
+# builds them and is the only source of truth; two models here claimed to
+# document them, were never imported by anything, and had drifted into being
+# wrong. WebSocketMessage's Literal listed four types and was never extended
+# for dashboard_panel_update or smart_device_update, and
+# NotificationWebSocketPayload described a {notification, unread_count} pair
+# that is not sent — the unread count is its own "unread_count" frame. A
+# schema no route validates against cannot go stale loudly, so it went stale
+# quietly (#511 follow-up).

--- a/backend/app/schemas/update.py
+++ b/backend/app/schemas/update.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Optional, Literal, Any
+from typing import Optional, Literal
 
 from pydantic import BaseModel, Field
 
@@ -261,17 +261,6 @@ class UpdateConfigResponse(UpdateConfigBase):
     updated_by: Optional[int] = None
 
     model_config = {"from_attributes": True}
-
-
-# WebSocket message schemas for real-time updates
-class UpdateWebSocketMessage(BaseModel):
-    """WebSocket message for update events."""
-
-    type: Literal[
-        "update_available", "update_progress", "update_complete",
-        "update_failed", "rollback_complete"
-    ] = Field(description="Message type")
-    payload: Any = Field(description="Message payload")
 
 
 class ReleaseNoteCategory(BaseModel):

--- a/backend/tests/plugins/sandbox/test_supervisor.py
+++ b/backend/tests/plugins/sandbox/test_supervisor.py
@@ -137,15 +137,33 @@ async def test_auto_restart_after_unexpected_exit(tmp_path):
     try:
         assert await sup.health() is True
         # Kill the worker out from under the supervisor.
-        sup._process.kill()
-        # The supervise loop should detect the exit and respawn a healthy worker.
-        async def _healthy_again() -> bool:
-            for _ in range(50):
-                if not sup.disabled and await sup.health():
+        old_process = sup._process
+        old_process.kill()
+
+        # Wait for the *replacement* to answer, not merely for "something"
+        # to answer. health() alone cannot tell the two apart: kill() only
+        # requests the exit, so for a moment the doomed worker still serves
+        # pings on the old channel. Gating on that returned True on the very
+        # first poll, before the supervise loop had even observed the exit,
+        # and the dispatch below then went out on a channel that was about to
+        # close -> ConnectionError. On Linux the exit lands before the first
+        # poll, which is why this only ever failed on Windows. Requiring a
+        # *new* process object makes the wait mean what it says.
+        async def _respawned_and_healthy() -> bool:
+            for _ in range(100):
+                process = sup._process
+                if (
+                    not sup.disabled
+                    and process is not None
+                    and process is not old_process
+                    and await sup.health()
+                ):
                     return True
                 await asyncio.sleep(0.1)
             return False
-        assert await _healthy_again() is True
+
+        assert await _respawned_and_healthy() is True
+        assert sup._process is not old_process
         # And it serves requests again via the SDK-dispatched route.
         resp = await sup.dispatch("GET", "again", b"", {"user_id": 1, "username": "testuser", "role": "user"})
         assert resp["body"]["path"] == "again"

--- a/backend/tests/plugins/sandbox/test_supervisor.py
+++ b/backend/tests/plugins/sandbox/test_supervisor.py
@@ -53,6 +53,26 @@ def _write_echo_plugin(plugin_dir: Path) -> None:
     (plugin_dir / "__init__.py").write_text(code, encoding="utf-8")
 
 
+def _write_suicidal_plugin(plugin_dir: Path) -> None:
+    """Write a plugin whose route kills its own worker mid-request.
+
+    os._exit() skips cleanup deliberately: it reproduces a worker that dies
+    while the host is waiting on its answer, which is the case the channel
+    reports as ConnectionError.
+    """
+    (plugin_dir / "__init__.py").write_text(
+        textwrap.dedent("""\
+            import os
+
+            def register(host):
+                @host.route("GET", "die")
+                async def die(request):
+                    os._exit(1)
+        """),
+        encoding="utf-8",
+    )
+
+
 def _write_trivial_plugin(plugin_dir: Path) -> None:
     """Write a no-route plugin that satisfies the worker's plugin-load requirement."""
     (plugin_dir / "__init__.py").write_text(
@@ -167,6 +187,29 @@ async def test_auto_restart_after_unexpected_exit(tmp_path):
         # And it serves requests again via the SDK-dispatched route.
         resp = await sup.dispatch("GET", "again", b"", {"user_id": 1, "username": "testuser", "role": "user"})
         assert resp["body"]["path"] == "again"
+    finally:
+        await sup.stop()
+
+
+async def test_dispatch_maps_a_dying_worker_to_supervisor_error(tmp_path):
+    """A worker dying mid-request is an expected failure, not an unexpected one.
+
+    dispatch() mapped only asyncio.TimeoutError, so this escaped as a raw
+    ConnectionError. The proxy's catch-all still turned it into a 502, so the
+    client saw the right status — but it was logged via logger.exception as
+    "Unexpected error" with a traceback, next to the same 502 that a plain
+    SupervisorError logs as a one-line warning. The exception type is the
+    supervisor's contract with its only caller; leaking the channel's is a
+    leak of the transport.
+    """
+    _write_suicidal_plugin(tmp_path)
+    sup = SandboxSupervisor("suicide_plugin", tmp_path)
+    await sup.start()
+    try:
+        with pytest.raises(SupervisorError):
+            await sup.dispatch(
+                "GET", "die", b"", {"user_id": 1, "username": "u", "role": "user"}
+            )
     finally:
         await sup.stop()
 


### PR DESCRIPTION
Die drei Nebenbefunde aus #512.

## 1. Drei tote WebSocket-Envelope-Schemas

| Schema | Datei | Status |
|---|---|---|
| `WebSocketMessage` | `schemas/notification.py` | nie importiert, `Literal` veraltet |
| `NotificationWebSocketPayload` | `schemas/notification.py` | nie importiert, beschrieb ein Frame, das es nicht gibt |
| `UpdateWebSocketMessage` | `schemas/update.py` | nie importiert |

Keine Route validiert dagegen, also konnten sie nur *leise* veralten — und haben es getan:

- `WebSocketMessage.type` listete `notification | unread_count | ping | pong` und wurde weder um `dashboard_panel_update` noch um `smart_device_update` erweitert. Nach dem Wortlaut dieses Schemas war der Frame aus #511 in *beiden* Varianten ungültig.
- `NotificationWebSocketPayload` beschrieb ein `{notification, unread_count}`-Paar. Das wird so nie gesendet: `broadcast_to_user()` schickt die Notification direkt, der Unread-Count ist ein eigener `unread_count`-Frame.

**Ersatzlos entfernt** statt korrigiert: `services/websocket_manager.py` baut die Frames und ist die einzige Quelle der Wahrheit. Ein zweites, unverdrahtetes Abbild driftet wieder weg — genau das ist hier passiert. An der Fundstelle steht jetzt ein Kommentar, der das festhält, damit nicht jemand das Schema „wiederherstellt".

## 2. `test_auto_restart_after_unexpected_exit` — echter Test-Bug, kein Flake

Der Test wartete mit `health()` darauf, dass *irgendwer* wieder antwortet. Das ist nicht dasselbe wie „der Ersatz-Worker steht": `kill()` fordert den Exit nur an, für einen Moment bedient der sterbende Worker noch Pings auf dem alten Channel.

Gemessen mit einer Instrumentierungs-Probe statt geraten:

```
BEFORE KILL: channel=1970178245696 pid=16200
  poll 0: healthy=True channel=1970178245696 is_old_channel=True pid=16200 is_old_pid=True
AT DISPATCH: channel=1970178245696 is_old_channel=True
DISPATCH FAILED: ConnectionError: channel closed
```

Der **erste** Poll meldet `healthy=True` — auf altem Channel und alter PID, bevor die Supervise-Schleife den Exit überhaupt gesehen hat. Das `dispatch()` danach geht auf genau diesen Channel, der Sekundenbruchteile später schließt.

Unter Linux landet der Exit vor dem ersten Poll, deshalb war nur Windows betroffen und CI durchgehend grün. Die Wartebedingung verlangt jetzt zusätzlich ein **neues Prozessobjekt** — damit prüft sie, was sie behauptet. Der Auto-Restart selbst funktionierte die ganze Zeit korrekt.

## 3. `dispatch()` ließ die Transport-Exception durch

`dispatch()` mappte nur `asyncio.TimeoutError`. Stirbt der Worker, während der Host auf seine Antwort wartet, entkam der `ConnectionError` des Channels roh an den Aufrufer.

**Korrektur zu meiner ersten Einschätzung in #512:** das war *kein* falscher Statuscode. Der Catch-all in `proxy.py:97` macht daraus ohnehin 502 — genau wie bei `SupervisorError`. Der Unterschied lag im Logging: derselbe Vorgang landete als `logger.exception("Unexpected error")` mit Traceback statt als einzeilige Warnung, obwohl ein sterbender Subprozess ein erwarteter Zustand ist und die Supervise-Schleife ihn bereits neu startet. Dazu war die Transport-Exception Teil des Vertrags zwischen Supervisor und seinem einzigen Aufrufer.

Der Test fährt das echt nach — ein Plugin, dessen Route `os._exit(1)` ruft, stirbt mitten im Request. Vor dem Fix rot mit rohem `ConnectionError`.

## Verifikation

- Der Restart-Test lokal **10/10 grün** (vorher 10/10 rot) — bei einem Race sagt ein einzelner Lauf nichts
- `tests/plugins tests/services tests/core`: **2107 passed, 0 failed** (Ausgangslage: 2105 passed, 1 failed)
- `tests/plugins/sandbox`: 82 passed
- `tests/api -k "notification or update"`: 39 passed
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
