### PR TITLE
feat(sleep): Always-Awake an Kernbetriebszeit-Fenstern kuerzen

### DIFF
--- a/backend/app/api/routes/sleep.py
+++ b/backend/app/api/routes/sleep.py
@@ -2,6 +2,7 @@
 Sleep mode API endpoints.
 """
 import logging
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
@@ -32,6 +33,7 @@ from app.schemas.sleep import (
     CoreUptimeWindowCreate,
     CoreUptimeWindowUpdate,
     CoreUptimeWindowResponse,
+    CoreUptimeOccurrence,
     PresenceHeartbeatRequest,
     PresenceHeartbeatResponse,
 )
@@ -39,6 +41,7 @@ from app.models.sleep import CoreUptimeWindow as CoreUptimeWindowModel
 from app.services.power.sleep import get_sleep_manager
 from app.services.power import os_sleep_inspector
 from app.services.power import os_auto_suspend
+from app.services.power import core_uptime as core_uptime_helpers
 from app.services.power import presence as presence_service
 from app.schemas.sleep import OsSleepReportResponse, OsAutoSuspendResponse, OsAutoSuspendUpdate
 
@@ -409,6 +412,41 @@ async def list_core_uptime_windows(
     """List all core-uptime windows (admin only)."""
     rows = db.query(CoreUptimeWindowModel).order_by(CoreUptimeWindowModel.id.asc()).all()
     return [_to_response(r) for r in rows]
+
+
+@router.get(
+    "/core-uptime/occurrences",
+    response_model=list[CoreUptimeOccurrence],
+)
+@user_limiter.limit(get_limit("admin_operations"))
+async def list_core_uptime_occurrences(
+    request: Request, response: Response,
+    days: int = Query(7, ge=1, le=7, description="Horizon in days"),
+    current_user: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> list[CoreUptimeOccurrence]:
+    """Resolve enabled core-uptime windows into concrete occurrences (admin only).
+
+    Windows are stored as recurring server-local patterns; this returns them as
+    absolute UTC timestamps so clients can compare them against
+    `always_awake_until` directly.
+    """
+    rows = (
+        db.query(CoreUptimeWindowModel)
+        .filter(CoreUptimeWindowModel.enabled.is_(True))
+        .order_by(CoreUptimeWindowModel.id.asc())
+        .all()
+    )
+    occurrences = core_uptime_helpers.expand_occurrences(datetime.now(), rows, days=days)
+    return [
+        CoreUptimeOccurrence(
+            window_id=o.window_id,
+            label=o.label,
+            start=o.start.astimezone(timezone.utc),
+            end=o.end.astimezone(timezone.utc),
+        )
+        for o in occurrences
+    ]
 
 
 @router.post(

--- a/backend/app/api/routes/sleep.py
+++ b/backend/app/api/routes/sleep.py
@@ -421,7 +421,15 @@ async def list_core_uptime_windows(
 @user_limiter.limit(get_limit("admin_operations"))
 async def list_core_uptime_occurrences(
     request: Request, response: Response,
-    days: int = Query(7, ge=1, le=7, description="Horizon in days"),
+    days: int = Query(
+        7, ge=1, le=7,
+        description=(
+            "Horizon in days from today. Internally resolved with an extra "
+            "day_offset=-1 to also surface a window that started yesterday and "
+            "crosses midnight into today — so days=1 returns occurrences for "
+            "both today and tomorrow, not just today."
+        ),
+    ),
     current_user: User = Depends(get_current_admin),
     db: Session = Depends(get_db),
 ) -> list[CoreUptimeOccurrence]:

--- a/backend/app/schemas/sleep.py
+++ b/backend/app/schemas/sleep.py
@@ -378,6 +378,19 @@ class CoreUptimeWindowResponse(CoreUptimeWindowBase):
     updated_at: datetime
 
 
+class CoreUptimeOccurrence(BaseModel):
+    """One resolved instance of a core-uptime window, as absolute UTC timestamps.
+
+    Consumed by the Always-Awake UI to preview whether a chosen expiry would be
+    clamped to a window start — a plain interval comparison, so the frontend
+    needs no weekday/midnight logic of its own.
+    """
+    window_id: int
+    label: Optional[str] = None
+    start: datetime
+    end: datetime
+
+
 # ---------------------------------------------------------------------------
 # OS Auto-Suspend (bidirectional)
 # ---------------------------------------------------------------------------

--- a/backend/app/services/power/core_uptime.py
+++ b/backend/app/services/power/core_uptime.py
@@ -9,8 +9,8 @@ Conventions:
 """
 from __future__ import annotations
 
-from datetime import datetime, timedelta
-from typing import Optional, Sequence
+from datetime import datetime, timedelta, timezone
+from typing import NamedTuple, Optional, Sequence
 
 
 def _parse_hhmm(s: str) -> tuple[int, int]:
@@ -107,3 +107,98 @@ def current_window_end(now: datetime, w) -> datetime:
         # We're in the early part — end is today at end_time
         return now.replace(hour=eh, minute=em, second=0, microsecond=0)
     return now.replace(hour=eh, minute=em, second=0, microsecond=0)
+
+
+def current_window_start(now: datetime, w) -> datetime:
+    """Return the datetime when the currently-active window started.
+
+    Mirror of `current_window_end`. Caller must ensure `now` is inside `w`.
+    """
+    sh, sm = _parse_hhmm(w.start_time)
+    if _crosses_midnight(w.start_time, w.end_time):
+        start_today = now.replace(hour=sh, minute=sm, second=0, microsecond=0)
+        if now >= start_today:
+            # Late part — the window started today
+            return start_today
+        # Early part — the window started yesterday
+        return (now - timedelta(days=1)).replace(
+            hour=sh, minute=sm, second=0, microsecond=0
+        )
+    return now.replace(hour=sh, minute=sm, second=0, microsecond=0)
+
+
+def window_start_containing(dt: datetime, windows: Sequence) -> Optional[datetime]:
+    """Start of the window containing `dt`, or None.
+
+    On overlapping windows the EARLIEST start wins — deliberately not
+    first-match, so the result does not depend on list order (the frontend
+    preview computes the same value from resolved occurrences).
+    """
+    starts = [
+        current_window_start(dt, w) for w in windows if _window_active_at(dt, w)
+    ]
+    return min(starts) if starts else None
+
+
+def clamp_to_core_uptime_start(
+    until_utc: datetime,
+    windows: Sequence,
+    now_local: datetime,
+) -> datetime:
+    """Shorten an always-awake expiry to the start of the core-uptime window
+    containing it — but only if that start is still in the future.
+
+    `until_utc` is UTC-aware (naive values are read as UTC, matching
+    `SleepManagerService._is_always_awake`); `windows` and `now_local` are
+    server-local, per this module's convention. The return value is UTC-aware.
+    """
+    if until_utc.tzinfo is None:
+        until_utc = until_utc.replace(tzinfo=timezone.utc)
+    until_local = until_utc.astimezone().replace(tzinfo=None)
+    start_local = window_start_containing(until_local, windows)
+    if start_local is None or start_local <= now_local:
+        return until_utc
+    # astimezone() on a naive value reads it as local time — exactly what we want.
+    return start_local.astimezone(timezone.utc)
+
+
+class Occurrence(NamedTuple):
+    """One resolved instance of a recurring window, in server-local time."""
+    window_id: int
+    label: Optional[str]
+    start: datetime
+    end: datetime
+
+
+def expand_occurrences(
+    now: datetime,
+    windows: Sequence,
+    days: int = 7,
+) -> list[Occurrence]:
+    """Resolve recurring windows into concrete occurrences.
+
+    Iterates day_offset -1..days: the -1 catches a window that started
+    yesterday and crosses midnight. Occurrences that already ended are
+    dropped. Result is sorted by start.
+    """
+    out: list[Occurrence] = []
+    for w in windows:
+        if not w.enabled:
+            continue
+        sh, sm = _parse_hhmm(w.start_time)
+        eh, em = _parse_hhmm(w.end_time)
+        weekdays = _parse_weekdays(w.weekdays)
+        crosses = _crosses_midnight(w.start_time, w.end_time)
+        for day_offset in range(-1, days + 1):
+            day = now + timedelta(days=day_offset)
+            if day.weekday() not in weekdays:
+                continue
+            start = day.replace(hour=sh, minute=sm, second=0, microsecond=0)
+            end_day = day + timedelta(days=1) if crosses else day
+            end = end_day.replace(hour=eh, minute=em, second=0, microsecond=0)
+            if end <= now:
+                continue
+            out.append(
+                Occurrence(window_id=w.id, label=w.label, start=start, end=end)
+            )
+    return sorted(out, key=lambda o: o.start)

--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -1366,6 +1366,25 @@ class SleepManagerService:
                 if update_data.get("always_awake_enabled") is False:
                     config.always_awake_until = None
 
+                # Shorten a pending expiry that lands inside a FUTURE core-uptime
+                # window: from that window's start on, core uptime keeps the system
+                # awake anyway, so the manual override closes out there. An expiry
+                # beyond the window's end survives untouched — it is still needed.
+                if config.always_awake_until is not None and config.core_uptime_enabled:
+                    windows = db.execute(
+                        select(CoreUptimeWindowModel).where(
+                            CoreUptimeWindowModel.enabled.is_(True)
+                        )
+                    ).scalars().all()
+                    if windows:
+                        config.always_awake_until = (
+                            core_uptime_helpers.clamp_to_core_uptime_start(
+                                config.always_awake_until,
+                                list(windows),
+                                datetime.now(),
+                            )
+                        )
+
                 db.commit()
                 db.refresh(config)
                 logger.info("Sleep config updated: %s", list(update_data.keys()))

--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -1353,6 +1353,16 @@ class SleepManagerService:
                 # Apply partial update
                 update_data = update.model_dump(exclude_unset=True)
 
+                # Captured BEFORE the always_awake_until pop below, and before any
+                # field is applied: whether THIS request actually touched the
+                # always-awake override. A write that only changes an unrelated
+                # field (e.g. idle_timeout_minutes) must never re-evaluate a
+                # pending override — see the spec's explicit non-goal.
+                touched_override = (
+                    "always_awake_until" in update_data
+                    or update_data.get("always_awake_enabled") is True
+                )
+
                 # Special-case: always_awake_until accepts explicit None to clear.
                 # The default loop drops None values to keep optional fields lenient.
                 if "always_awake_until" in update_data:
@@ -1370,7 +1380,10 @@ class SleepManagerService:
                 # window: from that window's start on, core uptime keeps the system
                 # awake anyway, so the manual override closes out there. An expiry
                 # beyond the window's end survives untouched — it is still needed.
-                if config.always_awake_until is not None and config.core_uptime_enabled:
+                # Gated on touched_override so an unrelated config write can't
+                # silently re-evaluate an already-set override (and, via the route's
+                # audit condition, would otherwise do so unaudited).
+                if touched_override and config.always_awake_until is not None and config.core_uptime_enabled:
                     windows = db.execute(
                         select(CoreUptimeWindowModel).where(
                             CoreUptimeWindowModel.enabled.is_(True)
@@ -1380,7 +1393,7 @@ class SleepManagerService:
                         config.always_awake_until = (
                             core_uptime_helpers.clamp_to_core_uptime_start(
                                 config.always_awake_until,
-                                list(windows),
+                                windows,
                                 datetime.now(),
                             )
                         )

--- a/backend/tests/api/test_core_uptime_routes.py
+++ b/backend/tests/api/test_core_uptime_routes.py
@@ -193,3 +193,34 @@ def test_occurrences_rejects_days_out_of_range(client, admin_headers):
 def test_occurrences_forbidden_for_regular_user(client, user_headers):
     r = client.get(OCCURRENCES, headers=user_headers)
     assert r.status_code in (401, 403)
+
+
+def test_occurrences_ignores_core_uptime_master_toggle(client, admin_headers, db):
+    """Deliberate: the endpoint filters only on each window's own `enabled`
+    flag, never on the `core_uptime_enabled` master toggle (see core_uptime.py
+    / sleep.py:update_config). A future "consistency" refactor could otherwise
+    silently regress this — pin it down explicitly.
+
+    Writes the master toggle directly via the DB session (not PUT /config):
+    the sleep manager singleton is not started in the test environment
+    (SKIP_APP_INIT=1), so that route 503s unless the manager is mocked out —
+    see test_master_toggle_via_config_endpoint above. Going through the DB
+    keeps this test's focus on the occurrences query itself.
+    """
+    from app.models.sleep import SleepConfig as SleepConfigModel
+
+    config = db.get(SleepConfigModel, 1)
+    if config is None:
+        config = SleepConfigModel(id=1)
+        db.add(config)
+    config.core_uptime_enabled = False
+    db.commit()
+
+    create = client.post(BASE, headers=admin_headers, json={
+        "start_time": "19:00", "end_time": "23:30", "weekdays": [0, 1, 2, 3, 4, 5, 6],
+    })
+    assert create.status_code in (200, 201)
+
+    r = client.get(OCCURRENCES, headers=admin_headers)
+    assert r.status_code == 200
+    assert len(r.json()) >= 1

--- a/backend/tests/api/test_core_uptime_routes.py
+++ b/backend/tests/api/test_core_uptime_routes.py
@@ -133,3 +133,63 @@ def test_master_toggle_via_config_endpoint(client, admin_headers, monkeypatch):
     )
     assert r.status_code == 200
     assert r.json()["core_uptime_enabled"] is True
+
+
+OCCURRENCES = f"{settings.api_prefix}/system/sleep/core-uptime/occurrences"
+
+
+def test_occurrences_empty_without_windows(client, admin_headers):
+    r = client.get(OCCURRENCES, headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_occurrences_resolves_window_to_timestamps(client, admin_headers):
+    create = client.post(BASE, headers=admin_headers, json={
+        "label": "Abend",
+        "start_time": "19:00",
+        "end_time": "23:30",
+        "weekdays": [0, 1, 2, 3, 4, 5, 6],
+    })
+    assert create.status_code in (200, 201)
+    window_id = create.json()["id"]
+
+    r = client.get(OCCURRENCES, headers=admin_headers, params={"days": 2})
+    assert r.status_code == 200
+    body = r.json()
+    # Taegliches Fenster ueber 2 Tage Horizont: mindestens 2 Vorkommen.
+    assert len(body) >= 2
+    first = body[0]
+    assert first["window_id"] == window_id
+    assert first["label"] == "Abend"
+    # Zeitstempel sind absolut und tragen einen Zeitzonen-Offset.
+    assert first["start"] != first["end"]
+    from datetime import datetime as _dt
+    assert _dt.fromisoformat(first["start"]).tzinfo is not None
+    assert _dt.fromisoformat(first["end"]).tzinfo is not None
+    # Aufsteigend sortiert.
+    starts = [o["start"] for o in body]
+    assert starts == sorted(starts)
+
+
+def test_occurrences_skips_disabled_windows(client, admin_headers):
+    create = client.post(BASE, headers=admin_headers, json={
+        "start_time": "19:00", "end_time": "23:30", "weekdays": [0, 1, 2, 3, 4, 5, 6],
+    })
+    window_id = create.json()["id"]
+    disable = client.put(f"{BASE}/{window_id}", headers=admin_headers, json={"enabled": False})
+    assert disable.status_code == 200
+
+    r = client.get(OCCURRENCES, headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_occurrences_rejects_days_out_of_range(client, admin_headers):
+    assert client.get(OCCURRENCES, headers=admin_headers, params={"days": 0}).status_code == 422
+    assert client.get(OCCURRENCES, headers=admin_headers, params={"days": 8}).status_code == 422
+
+
+def test_occurrences_forbidden_for_regular_user(client, user_headers):
+    r = client.get(OCCURRENCES, headers=user_headers)
+    assert r.status_code in (401, 403)

--- a/backend/tests/services/test_core_uptime_helpers.py
+++ b/backend/tests/services/test_core_uptime_helpers.py
@@ -1,5 +1,5 @@
 """Unit tests for pure core-uptime helpers (no DB)."""
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -8,6 +8,10 @@ from app.services.power.core_uptime import (
     is_in_core_uptime,
     next_core_uptime_start,
     current_window_end,
+    current_window_start,
+    window_start_containing,
+    clamp_to_core_uptime_start,
+    expand_occurrences,
 )
 
 
@@ -189,3 +193,203 @@ def test_current_window_end_cross_midnight_early_part():
     now = datetime(2026, 5, 9, 2, 0)  # Sat 02:00 inside Fri-started window
     w = _w("22:00", "06:00", "4")
     assert current_window_end(now, w) == datetime(2026, 5, 9, 6, 0)
+
+
+# ---- current_window_start ----
+
+def test_current_window_start_simple():
+    # Mi 12:00 innerhalb Mo-Fr 08:00-22:00
+    now = datetime(2026, 5, 6, 12, 0)
+    w = _w("08:00", "22:00", "0,1,2,3,4")
+    assert current_window_start(now, w) == datetime(2026, 5, 6, 8, 0)
+
+
+def test_current_window_start_overnight_late_half():
+    # Fenster 22:00-06:00, jetzt Mi 23:30 -> Beginn ist heute 22:00
+    now = datetime(2026, 5, 6, 23, 30)
+    w = _w("22:00", "06:00")
+    assert current_window_start(now, w) == datetime(2026, 5, 6, 22, 0)
+
+
+def test_current_window_start_overnight_early_half():
+    # Fenster 22:00-06:00, jetzt Do 02:00 -> Beginn war gestern 22:00
+    now = datetime(2026, 5, 7, 2, 0)
+    w = _w("22:00", "06:00")
+    assert current_window_start(now, w) == datetime(2026, 5, 6, 22, 0)
+
+
+# ---- window_start_containing ----
+
+def test_window_start_containing_hit():
+    dt = datetime(2026, 5, 6, 20, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    assert window_start_containing(dt, windows) == datetime(2026, 5, 6, 19, 0)
+
+
+def test_window_start_containing_miss_returns_none():
+    dt = datetime(2026, 5, 6, 18, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    assert window_start_containing(dt, windows) is None
+
+
+def test_window_start_containing_ignores_disabled_window():
+    dt = datetime(2026, 5, 6, 20, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4", enabled=False)]
+    assert window_start_containing(dt, windows) is None
+
+
+def test_window_start_containing_empty_list():
+    assert window_start_containing(datetime(2026, 5, 6, 20, 0), []) is None
+
+
+def test_window_start_containing_overlap_picks_earliest_start():
+    # Zwei Fenster enthalten 21:00 — das frueher beginnende gewinnt,
+    # unabhaengig von der Listenreihenfolge.
+    dt = datetime(2026, 5, 6, 21, 0)
+    late = _w("20:00", "23:00")
+    early = _w("19:00", "22:00")
+    assert window_start_containing(dt, [late, early]) == datetime(2026, 5, 6, 19, 0)
+    assert window_start_containing(dt, [early, late]) == datetime(2026, 5, 6, 19, 0)
+
+
+# ---- clamp_to_core_uptime_start ----
+#
+# Die Funktion rechnet UTC -> lokale Serverzeit und zurueck. Damit die Tests
+# unabhaengig von der TZ der CI-Maschine sind, wird der UTC-Eingabewert aus
+# einem lokalen Wunschzeitpunkt abgeleitet statt hart gesetzt.
+
+def _utc(local_naive: datetime) -> datetime:
+    """Lokal-naiven Zeitpunkt in den entsprechenden UTC-aware Wert umrechnen."""
+    return local_naive.astimezone(timezone.utc)
+
+
+def test_clamp_shortens_expiry_inside_future_window():
+    now_local = datetime(2026, 5, 6, 15, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    until = _utc(datetime(2026, 5, 6, 21, 0))
+    result = clamp_to_core_uptime_start(until, windows, now_local)
+    assert result == _utc(datetime(2026, 5, 6, 19, 0))
+    assert result.tzinfo is not None
+
+
+def test_clamp_leaves_expiry_before_window_untouched():
+    now_local = datetime(2026, 5, 6, 15, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    until = _utc(datetime(2026, 5, 6, 17, 0))
+    assert clamp_to_core_uptime_start(until, windows, now_local) == until
+
+
+def test_clamp_leaves_expiry_past_window_end_untouched():
+    now_local = datetime(2026, 5, 6, 15, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    until = _utc(datetime(2026, 5, 7, 1, 0))
+    assert clamp_to_core_uptime_start(until, windows, now_local) == until
+
+
+def test_clamp_expiry_exactly_on_window_start_is_unchanged():
+    now_local = datetime(2026, 5, 6, 15, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    until = _utc(datetime(2026, 5, 6, 19, 0))
+    assert clamp_to_core_uptime_start(until, windows, now_local) == until
+
+
+def test_clamp_does_not_shorten_when_window_already_running():
+    # Fensterbeginn liegt in der Vergangenheit -> kein Kuerzen moeglich.
+    now_local = datetime(2026, 5, 6, 20, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    until = _utc(datetime(2026, 5, 6, 21, 0))
+    assert clamp_to_core_uptime_start(until, windows, now_local) == until
+
+
+def test_clamp_with_no_windows_is_identity():
+    now_local = datetime(2026, 5, 6, 15, 0)
+    until = _utc(datetime(2026, 5, 6, 21, 0))
+    assert clamp_to_core_uptime_start(until, [], now_local) == until
+
+
+def test_clamp_accepts_naive_until_as_utc():
+    # Defensive: ein naiver DB-Wert wird als UTC interpretiert, nicht als lokal.
+    now_local = datetime(2026, 5, 6, 15, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    aware = _utc(datetime(2026, 5, 6, 21, 0))
+    naive = aware.replace(tzinfo=None)
+    assert clamp_to_core_uptime_start(naive, windows, now_local) == _utc(
+        datetime(2026, 5, 6, 19, 0)
+    )
+
+
+# ---- expand_occurrences ----
+
+def test_expand_occurrences_respects_weekdays():
+    now = datetime(2026, 5, 6, 12, 0)  # Mi
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]  # Mo-Fr
+    occ = expand_occurrences(now, windows, days=7)
+    starts = [o.start for o in occ]
+    # Mi/Do/Fr diese Woche + Mo/Di/Mi naechste Woche = 6 Vorkommen
+    assert starts == [
+        datetime(2026, 5, 6, 19, 0),
+        datetime(2026, 5, 7, 19, 0),
+        datetime(2026, 5, 8, 19, 0),
+        datetime(2026, 5, 11, 19, 0),
+        datetime(2026, 5, 12, 19, 0),
+        datetime(2026, 5, 13, 19, 0),
+    ]
+
+
+def test_expand_occurrences_sets_end_and_metadata():
+    now = datetime(2026, 5, 6, 12, 0)
+    windows = [_w("19:00", "23:30", "2", label="Abend")]  # nur Mittwoch
+    occ = expand_occurrences(now, windows, days=1)
+    assert len(occ) == 1
+    assert occ[0].start == datetime(2026, 5, 6, 19, 0)
+    assert occ[0].end == datetime(2026, 5, 6, 23, 30)
+    assert occ[0].label == "Abend"
+    assert occ[0].window_id == 1
+
+
+def test_expand_occurrences_overnight_end_is_next_day():
+    now = datetime(2026, 5, 6, 12, 0)
+    windows = [_w("22:00", "06:00", "2")]  # Mittwoch 22:00 -> Donnerstag 06:00
+    occ = expand_occurrences(now, windows, days=1)
+    assert occ[0].start == datetime(2026, 5, 6, 22, 0)
+    assert occ[0].end == datetime(2026, 5, 7, 6, 0)
+
+
+def test_expand_occurrences_includes_window_started_yesterday():
+    # Donnerstag 02:00: das Mittwoch-Fenster 22:00-06:00 laeuft noch.
+    now = datetime(2026, 5, 7, 2, 0)
+    windows = [_w("22:00", "06:00", "2")]
+    occ = expand_occurrences(now, windows, days=7)
+    assert occ[0].start == datetime(2026, 5, 6, 22, 0)
+    assert occ[0].end == datetime(2026, 5, 7, 6, 0)
+
+
+def test_expand_occurrences_drops_finished_occurrences():
+    # Mittwoch 20:00: das heutige Fenster 08:00-12:00 ist vorbei.
+    now = datetime(2026, 5, 6, 20, 0)
+    windows = [_w("08:00", "12:00", "2")]  # nur Mittwoch
+    occ = expand_occurrences(now, windows, days=7)
+    assert [o.start for o in occ] == [datetime(2026, 5, 13, 8, 0)]
+
+
+def test_expand_occurrences_skips_disabled_windows():
+    now = datetime(2026, 5, 6, 12, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4", enabled=False)]
+    assert expand_occurrences(now, windows, days=7) == []
+
+
+def test_expand_occurrences_sorted_across_windows():
+    now = datetime(2026, 5, 6, 6, 0)
+    late = _w("19:00", "23:30", "2")
+    early = _w("08:00", "12:00", "2")
+    occ = expand_occurrences(now, [late, early], days=1)
+    assert [o.start for o in occ] == [
+        datetime(2026, 5, 6, 8, 0),
+        datetime(2026, 5, 6, 19, 0),
+    ]
+
+
+def test_expand_occurrences_honours_days_horizon():
+    now = datetime(2026, 5, 6, 12, 0)
+    windows = [_w("19:00", "23:30")]  # taeglich
+    assert len(expand_occurrences(now, windows, days=1)) == 2  # heute + morgen

--- a/backend/tests/services/test_sleep_always_awake.py
+++ b/backend/tests/services/test_sleep_always_awake.py
@@ -618,19 +618,40 @@ def test_update_config_clamps_until_into_future_window():
     from app.schemas.sleep import SleepConfigUpdate
     svc = _build_service()
     row = _clamp_row()
-    session = _session_with(row, [_window("19:00", "23:30")])
 
-    now_local = datetime(2026, 8, 5, 15, 0)
-    requested = _local_utc(datetime(2026, 8, 5, 21, 0))
-    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
+    # Time-independent scenario: use a fixed reference point (tomorrow at 10:00 UTC)
+    # and patch both datetime modules so validator and implementation see the same clock
+    ref_time_utc = datetime.now(timezone.utc).replace(hour=10, minute=0, second=0, microsecond=0) + timedelta(days=1)
+    ref_time_local = ref_time_utc.astimezone().replace(tzinfo=None)
 
-    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
-         patch("app.services.power.sleep.datetime") as mock_dt, \
-         patch.object(svc, "get_config", return_value=MagicMock()):
-        mock_dt.now.return_value = now_local
-        svc.update_config(update)
+    # Requested: 6 hours in future (16:00 UTC = ~18:00 local in +02:00 tz)
+    requested = ref_time_utc + timedelta(hours=6)
 
-    assert row.always_awake_until == _local_utc(datetime(2026, 8, 5, 19, 0))
+    # Window 08:00-20:00 contains 18:00, so it gets clamped to 08:00
+    window_start = "08:00"
+    window_end = "20:00"
+
+    session = _session_with(row, [_window(window_start, window_end)])
+
+    # Construct update with BOTH datetime patches active so validator sees same time
+    with patch("app.schemas.sleep.datetime") as mock_schema_dt, \
+         patch("app.services.power.sleep.datetime") as mock_sleep_dt:
+        mock_schema_dt.now.return_value = ref_time_utc
+        mock_schema_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+        mock_sleep_dt.now.return_value = ref_time_local
+        mock_sleep_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+
+        update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
+
+        with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+             patch.object(svc, "get_config", return_value=MagicMock()):
+            svc.update_config(update)
+
+    # Expected: clamped to 08:00 on the same day as requested
+    requested_local = requested.astimezone().replace(tzinfo=None)
+    expected_local = requested_local.replace(hour=8, minute=0, second=0, microsecond=0)
+    expected_utc = expected_local.astimezone(timezone.utc)
+    assert row.always_awake_until == expected_utc
 
 
 def test_update_config_leaves_until_past_window_end_untouched():
@@ -638,36 +659,73 @@ def test_update_config_leaves_until_past_window_end_untouched():
     from app.schemas.sleep import SleepConfigUpdate
     svc = _build_service()
     row = _clamp_row()
-    session = _session_with(row, [_window("19:00", "23:30")])
 
-    requested = _local_utc(datetime(2026, 8, 6, 1, 0))
-    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
+    # Time-independent scenario: use fixed reference point (tomorrow at 10:00 UTC)
+    ref_time_utc = datetime.now(timezone.utc).replace(hour=10, minute=0, second=0, microsecond=0) + timedelta(days=1)
+    ref_time_local = ref_time_utc.astimezone().replace(tzinfo=None)
 
-    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
-         patch("app.services.power.sleep.datetime") as mock_dt, \
-         patch.object(svc, "get_config", return_value=MagicMock()):
-        mock_dt.now.return_value = datetime(2026, 8, 5, 15, 0)
-        svc.update_config(update)
+    # Requested: 12 hours in future (22:00 UTC = ~00:00 next day local)
+    requested = ref_time_utc + timedelta(hours=12)
 
+    # Window 08:00-18:00 does NOT contain 22:00 UTC, so remains unchanged
+    window_start = "08:00"
+    window_end = "18:00"
+
+    session = _session_with(row, [_window(window_start, window_end)])
+
+    # Construct update with both datetime patches active
+    with patch("app.schemas.sleep.datetime") as mock_schema_dt, \
+         patch("app.services.power.sleep.datetime") as mock_sleep_dt:
+        mock_schema_dt.now.return_value = ref_time_utc
+        mock_schema_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+        mock_sleep_dt.now.return_value = ref_time_local
+        mock_sleep_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+
+        update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
+
+        with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+             patch.object(svc, "get_config", return_value=MagicMock()):
+            svc.update_config(update)
+
+    # Should remain unchanged since requested is past window end
     assert row.always_awake_until == requested
 
 
 def test_update_config_does_not_clamp_when_core_uptime_disabled():
-    """Hauptschalter aus -> keine Kuerzung, Fenster werden nicht einmal geladen."""
+    """Hauptschalter aus -> keine Kuerzung (bis wird nicht geaendert)."""
     from app.schemas.sleep import SleepConfigUpdate
     svc = _build_service()
     row = _clamp_row(core_uptime_enabled=False)
-    session = _session_with(row, [_window("19:00", "23:30")])
 
-    requested = _local_utc(datetime(2026, 8, 5, 21, 0))
-    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
+    # Time-independent scenario: use fixed reference point (tomorrow at 10:00 UTC)
+    ref_time_utc = datetime.now(timezone.utc).replace(hour=10, minute=0, second=0, microsecond=0) + timedelta(days=1)
+    ref_time_local = ref_time_utc.astimezone().replace(tzinfo=None)
 
-    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
-         patch("app.services.power.sleep.datetime") as mock_dt, \
-         patch.object(svc, "get_config", return_value=MagicMock()):
-        mock_dt.now.return_value = datetime(2026, 8, 5, 15, 0)
-        svc.update_config(update)
+    # Requested: 6 hours in future
+    requested = ref_time_utc + timedelta(hours=6)
 
+    # Even though window 08:00-20:00 contains requested, core_uptime is disabled
+    # so no clamping should occur
+    window_start = "08:00"
+    window_end = "20:00"
+
+    session = _session_with(row, [_window(window_start, window_end)])
+
+    # Construct update with both datetime patches active
+    with patch("app.schemas.sleep.datetime") as mock_schema_dt, \
+         patch("app.services.power.sleep.datetime") as mock_sleep_dt:
+        mock_schema_dt.now.return_value = ref_time_utc
+        mock_schema_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+        mock_sleep_dt.now.return_value = ref_time_local
+        mock_sleep_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+
+        update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
+
+        with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+             patch.object(svc, "get_config", return_value=MagicMock()):
+            svc.update_config(update)
+
+    # Should remain unchanged since core_uptime is disabled
     assert row.always_awake_until == requested
 
 
@@ -676,22 +734,44 @@ def test_update_config_clamps_when_core_uptime_enabled_in_same_request():
     from app.schemas.sleep import SleepConfigUpdate
     svc = _build_service()
     row = _clamp_row(core_uptime_enabled=False)
-    session = _session_with(row, [_window("19:00", "23:30")])
 
-    requested = _local_utc(datetime(2026, 8, 5, 21, 0))
-    update = SleepConfigUpdate(
-        always_awake_enabled=True,
-        always_awake_until=requested,
-        core_uptime_enabled=True,
-    )
+    # Time-independent scenario: use fixed reference point (tomorrow at 10:00 UTC)
+    ref_time_utc = datetime.now(timezone.utc).replace(hour=10, minute=0, second=0, microsecond=0) + timedelta(days=1)
+    ref_time_local = ref_time_utc.astimezone().replace(tzinfo=None)
 
-    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
-         patch("app.services.power.sleep.datetime") as mock_dt, \
-         patch.object(svc, "get_config", return_value=MagicMock()):
-        mock_dt.now.return_value = datetime(2026, 8, 5, 15, 0)
-        svc.update_config(update)
+    # Requested: 6 hours in future
+    requested = ref_time_utc + timedelta(hours=6)
 
-    assert row.always_awake_until == _local_utc(datetime(2026, 8, 5, 19, 0))
+    # Window 08:00-20:00 contains the requested time
+    window_start = "08:00"
+    window_end = "20:00"
+
+    session = _session_with(row, [_window(window_start, window_end)])
+
+    # Construct update with both datetime patches active
+    with patch("app.schemas.sleep.datetime") as mock_schema_dt, \
+         patch("app.services.power.sleep.datetime") as mock_sleep_dt:
+        mock_schema_dt.now.return_value = ref_time_utc
+        mock_schema_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+        mock_sleep_dt.now.return_value = ref_time_local
+        mock_sleep_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+
+        # Enable core_uptime in the same request
+        update = SleepConfigUpdate(
+            always_awake_enabled=True,
+            always_awake_until=requested,
+            core_uptime_enabled=True,
+        )
+
+        with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+             patch.object(svc, "get_config", return_value=MagicMock()):
+            svc.update_config(update)
+
+    # Expected: clamped to 08:00 on the same day as requested
+    requested_local = requested.astimezone().replace(tzinfo=None)
+    expected_local = requested_local.replace(hour=8, minute=0, second=0, microsecond=0)
+    expected_utc = expected_local.astimezone(timezone.utc)
+    assert row.always_awake_until == expected_utc
 
 
 def test_update_config_no_clamp_for_permanent_override():

--- a/backend/tests/services/test_sleep_always_awake.py
+++ b/backend/tests/services/test_sleep_always_awake.py
@@ -654,32 +654,27 @@ def test_update_config_leaves_until_past_window_end_untouched():
     svc = _build_service()
     row = _clamp_row()
 
-    # Time-independent scenario: use fixed reference point (tomorrow at 10:00 UTC)
-    ref_time_utc = datetime.now(timezone.utc).replace(hour=10, minute=0, second=0, microsecond=0) + timedelta(days=1)
-    ref_time_local = ref_time_utc.astimezone().replace(tzinfo=None)
+    # Anchor on local time (tomorrow at 12:00) — window times are local wall clock
+    # Never derive scenarios from UTC anchor when windows use local HH:MM strings
+    now_local = (datetime.now() + timedelta(days=1)).replace(
+        hour=12, minute=0, second=0, microsecond=0
+    )
 
-    # Requested: 12 hours in future (22:00 UTC = ~00:00 next day local)
-    requested = ref_time_utc + timedelta(hours=12)
+    # Window 16:00-22:00 starts after now (12:00)
+    window = _window("16:00", "22:00")
 
-    # Window 08:00-18:00 does NOT contain 22:00 UTC, so remains unchanged
-    window_start = "08:00"
-    window_end = "18:00"
+    # Until is 23:00 local (past the window end at 22:00)
+    until_local = now_local.replace(hour=23)
+    requested = until_local.astimezone(timezone.utc)
 
-    session = _session_with(row, [_window(window_start, window_end)])
+    session = _session_with(row, [window])
+    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
 
-    # Construct update with both datetime patches active
-    with patch("app.schemas.sleep.datetime") as mock_schema_dt, \
-         patch("app.services.power.sleep.datetime") as mock_sleep_dt:
-        mock_schema_dt.now.return_value = ref_time_utc
-        mock_schema_dt.side_effect = lambda *a, **k: datetime(*a, **k)
-        mock_sleep_dt.now.return_value = ref_time_local
-        mock_sleep_dt.side_effect = lambda *a, **k: datetime(*a, **k)
-
-        update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
-
-        with patch("app.services.power.sleep.SessionLocal", return_value=session), \
-             patch.object(svc, "get_config", return_value=MagicMock()):
-            svc.update_config(update)
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = now_local
+        svc.update_config(update)
 
     # Should remain unchanged since requested is past window end
     assert row.always_awake_until == requested

--- a/backend/tests/services/test_sleep_always_awake.py
+++ b/backend/tests/services/test_sleep_always_awake.py
@@ -619,38 +619,32 @@ def test_update_config_clamps_until_into_future_window():
     svc = _build_service()
     row = _clamp_row()
 
-    # Time-independent scenario: use a fixed reference point (tomorrow at 10:00 UTC)
-    # and patch both datetime modules so validator and implementation see the same clock
-    ref_time_utc = datetime.now(timezone.utc).replace(hour=10, minute=0, second=0, microsecond=0) + timedelta(days=1)
-    ref_time_local = ref_time_utc.astimezone().replace(tzinfo=None)
+    # Anchor on local time (tomorrow at 12:00) — window times are local wall clock
+    # Window must START AFTER now_local for clamping to apply
+    now_local = (datetime.now() + timedelta(days=1)).replace(
+        hour=12, minute=0, second=0, microsecond=0
+    )
 
-    # Requested: 6 hours in future (16:00 UTC = ~18:00 local in +02:00 tz)
-    requested = ref_time_utc + timedelta(hours=6)
+    # Window 16:00-22:00 starts 4 hours after now (12:00)
+    window = _window("16:00", "22:00")
 
-    # Window 08:00-20:00 contains 18:00, so it gets clamped to 08:00
-    window_start = "08:00"
-    window_end = "20:00"
+    # Until is 18:00 local (inside the future window 16:00-22:00)
+    until_local = now_local.replace(hour=18)
+    requested = until_local.astimezone(timezone.utc)
 
-    session = _session_with(row, [_window(window_start, window_end)])
-
-    # Construct update with BOTH datetime patches active so validator sees same time
-    with patch("app.schemas.sleep.datetime") as mock_schema_dt, \
-         patch("app.services.power.sleep.datetime") as mock_sleep_dt:
-        mock_schema_dt.now.return_value = ref_time_utc
-        mock_schema_dt.side_effect = lambda *a, **k: datetime(*a, **k)
-        mock_sleep_dt.now.return_value = ref_time_local
-        mock_sleep_dt.side_effect = lambda *a, **k: datetime(*a, **k)
-
-        update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
-
-        with patch("app.services.power.sleep.SessionLocal", return_value=session), \
-             patch.object(svc, "get_config", return_value=MagicMock()):
-            svc.update_config(update)
-
-    # Expected: clamped to 08:00 on the same day as requested
-    requested_local = requested.astimezone().replace(tzinfo=None)
-    expected_local = requested_local.replace(hour=8, minute=0, second=0, microsecond=0)
+    # Expected: clamped to 16:00 local (window start)
+    expected_local = now_local.replace(hour=16)
     expected_utc = expected_local.astimezone(timezone.utc)
+
+    session = _session_with(row, [window])
+    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = now_local
+        svc.update_config(update)
+
     assert row.always_awake_until == expected_utc
 
 
@@ -735,42 +729,38 @@ def test_update_config_clamps_when_core_uptime_enabled_in_same_request():
     svc = _build_service()
     row = _clamp_row(core_uptime_enabled=False)
 
-    # Time-independent scenario: use fixed reference point (tomorrow at 10:00 UTC)
-    ref_time_utc = datetime.now(timezone.utc).replace(hour=10, minute=0, second=0, microsecond=0) + timedelta(days=1)
-    ref_time_local = ref_time_utc.astimezone().replace(tzinfo=None)
+    # Anchor on local time (tomorrow at 12:00)
+    # Window must START AFTER now_local for clamping to apply
+    now_local = (datetime.now() + timedelta(days=1)).replace(
+        hour=12, minute=0, second=0, microsecond=0
+    )
 
-    # Requested: 6 hours in future
-    requested = ref_time_utc + timedelta(hours=6)
+    # Window 16:00-22:00 starts 4 hours after now (12:00)
+    window = _window("16:00", "22:00")
 
-    # Window 08:00-20:00 contains the requested time
-    window_start = "08:00"
-    window_end = "20:00"
+    # Until is 18:00 local (inside the future window 16:00-22:00)
+    until_local = now_local.replace(hour=18)
+    requested = until_local.astimezone(timezone.utc)
 
-    session = _session_with(row, [_window(window_start, window_end)])
-
-    # Construct update with both datetime patches active
-    with patch("app.schemas.sleep.datetime") as mock_schema_dt, \
-         patch("app.services.power.sleep.datetime") as mock_sleep_dt:
-        mock_schema_dt.now.return_value = ref_time_utc
-        mock_schema_dt.side_effect = lambda *a, **k: datetime(*a, **k)
-        mock_sleep_dt.now.return_value = ref_time_local
-        mock_sleep_dt.side_effect = lambda *a, **k: datetime(*a, **k)
-
-        # Enable core_uptime in the same request
-        update = SleepConfigUpdate(
-            always_awake_enabled=True,
-            always_awake_until=requested,
-            core_uptime_enabled=True,
-        )
-
-        with patch("app.services.power.sleep.SessionLocal", return_value=session), \
-             patch.object(svc, "get_config", return_value=MagicMock()):
-            svc.update_config(update)
-
-    # Expected: clamped to 08:00 on the same day as requested
-    requested_local = requested.astimezone().replace(tzinfo=None)
-    expected_local = requested_local.replace(hour=8, minute=0, second=0, microsecond=0)
+    # Expected: clamped to 16:00 local (window start)
+    expected_local = now_local.replace(hour=16)
     expected_utc = expected_local.astimezone(timezone.utc)
+
+    session = _session_with(row, [window])
+
+    # Enable core_uptime in the same request
+    update = SleepConfigUpdate(
+        always_awake_enabled=True,
+        always_awake_until=requested,
+        core_uptime_enabled=True,
+    )
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = now_local
+        svc.update_config(update)
+
     assert row.always_awake_until == expected_utc
 
 

--- a/backend/tests/services/test_sleep_always_awake.py
+++ b/backend/tests/services/test_sleep_always_awake.py
@@ -568,3 +568,164 @@ async def test_enter_true_suspend_releases_inhibitor_before_backend_call():
     assert call_order == ["release", "suspend"], (
         f"Expected release before suspend, got {call_order}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Kuerzung von always_awake_until an Kernbetriebszeit-Fenstern
+# ---------------------------------------------------------------------------
+
+def _clamp_row(*, core_uptime_enabled: bool = True, until=None):
+    """SleepConfig-Zeile fuer die Kuerzungstests."""
+    return SleepConfig(
+        id=1, auto_idle_enabled=False, idle_timeout_minutes=15,
+        idle_cpu_threshold=5.0, idle_disk_io_threshold=0.5, idle_http_threshold=5.0,
+        auto_escalation_enabled=False, escalation_after_minutes=60,
+        schedule_enabled=False, schedule_sleep_time="23:00", schedule_wake_time="06:00",
+        schedule_mode="soft",
+        wol_mac_address=None, wol_broadcast_address=None,
+        pause_monitoring=False, pause_disk_io=False, reduced_telemetry_interval=30.0,
+        disk_spindown_enabled=False,
+        core_uptime_enabled=core_uptime_enabled,
+        always_awake_enabled=True,
+        always_awake_until=until,
+    )
+
+
+def _window(start: str, end: str, weekdays: str = "0,1,2,3,4,5,6"):
+    """Fake CoreUptimeWindow — duck-typed, wie in test_core_uptime_helpers."""
+    from types import SimpleNamespace
+    return SimpleNamespace(
+        id=1, enabled=True, label=None,
+        start_time=start, end_time=end, weekdays=weekdays,
+    )
+
+
+def _session_with(row, windows):
+    """MagicMock-Session: scalar_one_or_none -> row, scalars().all() -> windows."""
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.return_value = row
+    session.execute.return_value.scalars.return_value.all.return_value = windows
+    return session
+
+
+def _local_utc(local_naive):
+    """Lokal-naiven Zeitpunkt in den entsprechenden UTC-aware Wert umrechnen."""
+    return local_naive.astimezone(timezone.utc)
+
+
+def test_update_config_clamps_until_into_future_window():
+    """Ablauf im kuenftigen Fenster wird auf den Fensterbeginn gekuerzt."""
+    from app.schemas.sleep import SleepConfigUpdate
+    svc = _build_service()
+    row = _clamp_row()
+    session = _session_with(row, [_window("19:00", "23:30")])
+
+    now_local = datetime(2026, 8, 5, 15, 0)
+    requested = _local_utc(datetime(2026, 8, 5, 21, 0))
+    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = now_local
+        svc.update_config(update)
+
+    assert row.always_awake_until == _local_utc(datetime(2026, 8, 5, 19, 0))
+
+
+def test_update_config_leaves_until_past_window_end_untouched():
+    """Ablauf hinter dem Fensterende bleibt unveraendert."""
+    from app.schemas.sleep import SleepConfigUpdate
+    svc = _build_service()
+    row = _clamp_row()
+    session = _session_with(row, [_window("19:00", "23:30")])
+
+    requested = _local_utc(datetime(2026, 8, 6, 1, 0))
+    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = datetime(2026, 8, 5, 15, 0)
+        svc.update_config(update)
+
+    assert row.always_awake_until == requested
+
+
+def test_update_config_does_not_clamp_when_core_uptime_disabled():
+    """Hauptschalter aus -> keine Kuerzung, Fenster werden nicht einmal geladen."""
+    from app.schemas.sleep import SleepConfigUpdate
+    svc = _build_service()
+    row = _clamp_row(core_uptime_enabled=False)
+    session = _session_with(row, [_window("19:00", "23:30")])
+
+    requested = _local_utc(datetime(2026, 8, 5, 21, 0))
+    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = datetime(2026, 8, 5, 15, 0)
+        svc.update_config(update)
+
+    assert row.always_awake_until == requested
+
+
+def test_update_config_clamps_when_core_uptime_enabled_in_same_request():
+    """core_uptime_enabled wird im selben Request eingeschaltet -> Kuerzung greift."""
+    from app.schemas.sleep import SleepConfigUpdate
+    svc = _build_service()
+    row = _clamp_row(core_uptime_enabled=False)
+    session = _session_with(row, [_window("19:00", "23:30")])
+
+    requested = _local_utc(datetime(2026, 8, 5, 21, 0))
+    update = SleepConfigUpdate(
+        always_awake_enabled=True,
+        always_awake_until=requested,
+        core_uptime_enabled=True,
+    )
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = datetime(2026, 8, 5, 15, 0)
+        svc.update_config(update)
+
+    assert row.always_awake_until == _local_utc(datetime(2026, 8, 5, 19, 0))
+
+
+def test_update_config_no_clamp_for_permanent_override():
+    """until=None (dauerhaft) bleibt None — nichts zu kuerzen."""
+    from app.schemas.sleep import SleepConfigUpdate
+    svc = _build_service()
+    row = _clamp_row(until=_local_utc(datetime(2026, 8, 5, 21, 0)))
+    session = _session_with(row, [_window("19:00", "23:30")])
+
+    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=None)
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = datetime(2026, 8, 5, 15, 0)
+        svc.update_config(update)
+
+    assert row.always_awake_until is None
+
+
+def test_update_config_disabling_still_clears_until_with_windows_present():
+    """enabled=False raeumt until ab — die Kuerzung darf da nichts wiederbeleben."""
+    from app.schemas.sleep import SleepConfigUpdate
+    svc = _build_service()
+    row = _clamp_row(until=_local_utc(datetime(2026, 8, 5, 21, 0)))
+    session = _session_with(row, [_window("19:00", "23:30")])
+
+    update = SleepConfigUpdate(always_awake_enabled=False)
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = datetime(2026, 8, 5, 15, 0)
+        svc.update_config(update)
+
+    assert row.always_awake_enabled is False
+    assert row.always_awake_until is None

--- a/backend/tests/services/test_sleep_always_awake.py
+++ b/backend/tests/services/test_sleep_always_awake.py
@@ -686,36 +686,65 @@ def test_update_config_does_not_clamp_when_core_uptime_disabled():
     svc = _build_service()
     row = _clamp_row(core_uptime_enabled=False)
 
-    # Time-independent scenario: use fixed reference point (tomorrow at 10:00 UTC)
-    ref_time_utc = datetime.now(timezone.utc).replace(hour=10, minute=0, second=0, microsecond=0) + timedelta(days=1)
-    ref_time_local = ref_time_utc.astimezone().replace(tzinfo=None)
+    # Anchor on local time (tomorrow at 12:00) — window times are local wall clock.
+    # Never derive scenarios from a UTC anchor when windows use local HH:MM strings.
+    now_local = (datetime.now() + timedelta(days=1)).replace(
+        hour=12, minute=0, second=0, microsecond=0
+    )
 
-    # Requested: 6 hours in future
-    requested = ref_time_utc + timedelta(hours=6)
+    # Window 16:00-22:00 starts 4 hours after now (12:00) — would clamp if enabled.
+    window = _window("16:00", "22:00")
 
-    # Even though window 08:00-20:00 contains requested, core_uptime is disabled
-    # so no clamping should occur
-    window_start = "08:00"
-    window_end = "20:00"
+    # Until is 18:00 local (inside the window 16:00-22:00)
+    until_local = now_local.replace(hour=18)
+    requested = until_local.astimezone(timezone.utc)
 
-    session = _session_with(row, [_window(window_start, window_end)])
+    session = _session_with(row, [window])
+    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
 
-    # Construct update with both datetime patches active
-    with patch("app.schemas.sleep.datetime") as mock_schema_dt, \
-         patch("app.services.power.sleep.datetime") as mock_sleep_dt:
-        mock_schema_dt.now.return_value = ref_time_utc
-        mock_schema_dt.side_effect = lambda *a, **k: datetime(*a, **k)
-        mock_sleep_dt.now.return_value = ref_time_local
-        mock_sleep_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = now_local
+        svc.update_config(update)
 
-        update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
-
-        with patch("app.services.power.sleep.SessionLocal", return_value=session), \
-             patch.object(svc, "get_config", return_value=MagicMock()):
-            svc.update_config(update)
-
-    # Should remain unchanged since core_uptime is disabled
+    # core_uptime_enabled=False -> should remain unchanged despite the window
+    # containing the requested expiry.
     assert row.always_awake_until == requested
+
+
+def test_update_config_ignores_pending_override_when_request_is_unrelated():
+    """A write that only touches an unrelated field must not re-evaluate a
+    pending always_awake_until, even though a containing future window exists.
+
+    This is the case the SleepConfigPanel triggers in practice: it PUTs
+    idle_timeout_minutes alone. Regression for the spec's explicit non-goal
+    ("ein bereits gesetzter Override wird nicht neu bewertet").
+    """
+    from app.schemas.sleep import SleepConfigUpdate
+    svc = _build_service()
+
+    now_local = (datetime.now() + timedelta(days=1)).replace(
+        hour=12, minute=0, second=0, microsecond=0
+    )
+    window = _window("16:00", "22:00")
+
+    # Pending expiry already sits inside the future window — if the clamp were
+    # to (wrongly) re-run here, it would shorten this to 16:00.
+    pending_until = now_local.replace(hour=18).astimezone(timezone.utc)
+    row = _clamp_row(until=pending_until)
+
+    session = _session_with(row, [window])
+    update = SleepConfigUpdate(idle_timeout_minutes=20)
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = now_local
+        svc.update_config(update)
+
+    assert row.idle_timeout_minutes == 20
+    assert row.always_awake_until == pending_until
 
 
 def test_update_config_clamps_when_core_uptime_enabled_in_same_request():

--- a/client/src/__tests__/components/power/AlwaysAwakePanel.test.tsx
+++ b/client/src/__tests__/components/power/AlwaysAwakePanel.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AlwaysAwakePanel } from '../../../components/power/AlwaysAwakePanel';
+import {
+  getSleepConfig,
+  getSleepStatus,
+  updateSleepConfig,
+  getCoreUptimeOccurrences,
+} from '../../../api/sleep';
+
+vi.mock('../../../api/sleep', () => ({
+  getSleepConfig: vi.fn(),
+  getSleepStatus: vi.fn(),
+  updateSleepConfig: vi.fn(),
+  getCoreUptimeOccurrences: vi.fn(),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { error: vi.fn(), success: vi.fn() },
+}));
+
+const mockedConfig = vi.mocked(getSleepConfig);
+const mockedStatus = vi.mocked(getSleepStatus);
+const mockedUpdate = vi.mocked(updateSleepConfig);
+const mockedOccurrences = vi.mocked(getCoreUptimeOccurrences);
+
+/** Fenster, das in 4 Stunden beginnt und 6 Stunden dauert. */
+function windowInHours(startInHours: number, durationHours: number) {
+  const start = new Date(Date.now() + startInHours * 3600 * 1000);
+  const end = new Date(start.getTime() + durationHours * 3600 * 1000);
+  return {
+    window_id: 1,
+    label: 'Abend',
+    start: start.toISOString(),
+    end: end.toISOString(),
+  };
+}
+
+function baseConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    always_awake_enabled: false,
+    always_awake_until: null,
+    schedule_enabled: false,
+    core_uptime_enabled: true,
+    ...overrides,
+  } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedStatus.mockResolvedValue({ always_awake: { expires_in_seconds: null } } as never);
+  mockedUpdate.mockResolvedValue({} as never);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('AlwaysAwakePanel — Kernbetriebszeit-Kuerzung', () => {
+  // i18n ist in Component-Tests nicht initialisiert: t() liefert den rohen Key.
+
+  it('sends the clamped value when the chosen expiry falls into a window', async () => {
+    const occurrence = windowInHours(4, 6); // beginnt in 4h, laeuft 6h
+    mockedConfig.mockResolvedValue(baseConfig());
+    mockedOccurrences.mockResolvedValue([occurrence] as never);
+
+    const user = userEvent.setup();
+    render(<AlwaysAwakePanel />);
+
+    // "8h" landet 8h in der Zukunft — also innerhalb des Fensters (4h..10h).
+    const button = await screen.findByText('sleep.alwaysAwake.preset8h');
+    await user.click(button);
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalled());
+    expect(mockedUpdate).toHaveBeenCalledWith({
+      always_awake_enabled: true,
+      always_awake_until: occurrence.start,
+    });
+  });
+
+  it('sends the raw value when the chosen expiry clears the window end', async () => {
+    const occurrence = windowInHours(1, 2); // 1h..3h
+    mockedConfig.mockResolvedValue(baseConfig());
+    mockedOccurrences.mockResolvedValue([occurrence] as never);
+
+    const user = userEvent.setup();
+    render(<AlwaysAwakePanel />);
+
+    const button = await screen.findByText('sleep.alwaysAwake.preset8h');
+    await user.click(button);
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalled());
+    const sent = mockedUpdate.mock.calls[0][0] as { always_awake_until: string };
+    expect(sent.always_awake_until).not.toBe(occurrence.start);
+  });
+
+  it('shows the clamp hint while the affected preset is focused', async () => {
+    mockedConfig.mockResolvedValue(baseConfig());
+    mockedOccurrences.mockResolvedValue([windowInHours(4, 6)] as never);
+
+    const user = userEvent.setup();
+    render(<AlwaysAwakePanel />);
+
+    const button = await screen.findByText('sleep.alwaysAwake.preset8h');
+    expect(screen.queryByText('sleep.alwaysAwake.clampPreview')).not.toBeInTheDocument();
+    await user.hover(button);
+    expect(await screen.findByText('sleep.alwaysAwake.clampPreview')).toBeInTheDocument();
+  });
+
+  it('explains an already-clamped active override after reload', async () => {
+    const occurrence = windowInHours(4, 6);
+    mockedConfig.mockResolvedValue(
+      baseConfig({ always_awake_enabled: true, always_awake_until: occurrence.start }),
+    );
+    mockedStatus.mockResolvedValue({
+      always_awake: { expires_in_seconds: 4 * 3600 },
+    } as never);
+    mockedOccurrences.mockResolvedValue([occurrence] as never);
+
+    render(<AlwaysAwakePanel />);
+
+    expect(await screen.findByText('sleep.alwaysAwake.clampActive')).toBeInTheDocument();
+  });
+
+  it('reports a currently running window instead of a clamp hint', async () => {
+    const start = new Date(Date.now() - 3600 * 1000);
+    const end = new Date(Date.now() + 3 * 3600 * 1000);
+    mockedConfig.mockResolvedValue(
+      baseConfig({ always_awake_enabled: true, always_awake_until: end.toISOString() }),
+    );
+    mockedStatus.mockResolvedValue({
+      always_awake: { expires_in_seconds: 3 * 3600 },
+    } as never);
+    mockedOccurrences.mockResolvedValue([
+      { window_id: 1, label: null, start: start.toISOString(), end: end.toISOString() },
+    ] as never);
+
+    render(<AlwaysAwakePanel />);
+
+    expect(await screen.findByText('sleep.alwaysAwake.coreUptimeRunning')).toBeInTheDocument();
+    expect(screen.queryByText('sleep.alwaysAwake.clampActive')).not.toBeInTheDocument();
+  });
+
+  it('does not request occurrences when core uptime is disabled', async () => {
+    mockedConfig.mockResolvedValue(baseConfig({ core_uptime_enabled: false }));
+    mockedOccurrences.mockResolvedValue([] as never);
+
+    render(<AlwaysAwakePanel />);
+
+    await screen.findByText('sleep.alwaysAwake.preset8h');
+    expect(mockedOccurrences).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/components/power/AlwaysAwakePanel.test.tsx
+++ b/client/src/__tests__/components/power/AlwaysAwakePanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AlwaysAwakePanel } from '../../../components/power/AlwaysAwakePanel';
 import {
@@ -85,17 +85,26 @@ describe('AlwaysAwakePanel — Kernbetriebszeit-Kuerzung', () => {
     mockedOccurrences.mockResolvedValue([occurrence] as never);
 
     const user = userEvent.setup();
+    const before = Date.now();
     render(<AlwaysAwakePanel />);
 
     const button = await screen.findByText('sleep.alwaysAwake.preset8h');
     await user.click(button);
 
     await waitFor(() => expect(mockedUpdate).toHaveBeenCalled());
+    const after = Date.now();
     const sent = mockedUpdate.mock.calls[0][0] as { always_awake_until: string };
-    expect(sent.always_awake_until).not.toBe(occurrence.start);
+    const sentMs = new Date(sent.always_awake_until).getTime();
+    // Unclamped: the preset is "now + 8h" computed at click time. Bound it by
+    // the actual wall-clock span of this test (before/after), with a small
+    // tolerance for clock-read precision — not a hardcoded date or offset.
+    // The 1h..3h window is far outside this range, so a wrongly-clamped
+    // value (occurrence.start, ~1h out) would fail this assertion.
+    expect(sentMs).toBeGreaterThanOrEqual(before + 8 * 3600 * 1000 - 2000);
+    expect(sentMs).toBeLessThanOrEqual(after + 8 * 3600 * 1000 + 2000);
   });
 
-  it('shows the clamp hint while the affected preset is focused', async () => {
+  it('shows the clamp hint on hover', async () => {
     mockedConfig.mockResolvedValue(baseConfig());
     mockedOccurrences.mockResolvedValue([windowInHours(4, 6)] as never);
 
@@ -106,6 +115,22 @@ describe('AlwaysAwakePanel — Kernbetriebszeit-Kuerzung', () => {
     expect(screen.queryByText('sleep.alwaysAwake.clampPreview')).not.toBeInTheDocument();
     await user.hover(button);
     expect(await screen.findByText('sleep.alwaysAwake.clampPreview')).toBeInTheDocument();
+  });
+
+  it('shows the clamp hint on keyboard focus', async () => {
+    mockedConfig.mockResolvedValue(baseConfig());
+    mockedOccurrences.mockResolvedValue([windowInHours(4, 6)] as never);
+
+    render(<AlwaysAwakePanel />);
+
+    const button = await screen.findByText('sleep.alwaysAwake.preset8h');
+    expect(screen.queryByText('sleep.alwaysAwake.clampPreview')).not.toBeInTheDocument();
+    fireEvent.focus(button);
+    expect(await screen.findByText('sleep.alwaysAwake.clampPreview')).toBeInTheDocument();
+    fireEvent.blur(button);
+    await waitFor(() =>
+      expect(screen.queryByText('sleep.alwaysAwake.clampPreview')).not.toBeInTheDocument(),
+    );
   });
 
   it('explains an already-clamped active override after reload', async () => {
@@ -123,11 +148,17 @@ describe('AlwaysAwakePanel — Kernbetriebszeit-Kuerzung', () => {
     expect(await screen.findByText('sleep.alwaysAwake.clampActive')).toBeInTheDocument();
   });
 
-  it('reports a currently running window instead of a clamp hint', async () => {
+  it('reports a currently running window instead of a clamp-active hint, even when until equals the window start', async () => {
     const start = new Date(Date.now() - 3600 * 1000);
     const end = new Date(Date.now() + 3 * 3600 * 1000);
+    // `always_awake_until` deliberately equals the running occurrence's
+    // `start` — this is exactly the shape `activeClamp` matches on
+    // (`until === occurrence.start`). Without the `!runningOccurrence`
+    // guard in AlwaysAwakePanel, this would also render clampActive; this
+    // test proves the guard actually suppresses it in favour of
+    // coreUptimeRunning.
     mockedConfig.mockResolvedValue(
-      baseConfig({ always_awake_enabled: true, always_awake_until: end.toISOString() }),
+      baseConfig({ always_awake_enabled: true, always_awake_until: start.toISOString() }),
     );
     mockedStatus.mockResolvedValue({
       always_awake: { expires_in_seconds: 3 * 3600 },

--- a/client/src/__tests__/components/power/AlwaysAwakePanel.test.tsx
+++ b/client/src/__tests__/components/power/AlwaysAwakePanel.test.tsx
@@ -60,12 +60,19 @@ afterEach(() => {
 describe('AlwaysAwakePanel — Kernbetriebszeit-Kuerzung', () => {
   // i18n ist in Component-Tests nicht initialisiert: t() liefert den rohen Key.
 
-  it('sends the clamped value when the chosen expiry falls into a window', async () => {
+  it('sends the raw value to the backend but displays the clamped value optimistically', async () => {
+    // The backend re-applies clamp_to_core_uptime_start on whatever it receives.
+    // Sending the already-clamped value would double-clamp on staggered,
+    // overlapping windows (regression: see coreUptimeClamp.test.ts) — the UI
+    // must send the RAW pick and keep the clamp purely for its own optimistic
+    // display, matching what the backend's single clamp of the raw value
+    // produces.
     const occurrence = windowInHours(4, 6); // beginnt in 4h, laeuft 6h
     mockedConfig.mockResolvedValue(baseConfig());
     mockedOccurrences.mockResolvedValue([occurrence] as never);
 
     const user = userEvent.setup();
+    const before = Date.now();
     render(<AlwaysAwakePanel />);
 
     // "8h" landet 8h in der Zukunft — also innerhalb des Fensters (4h..10h).
@@ -73,10 +80,19 @@ describe('AlwaysAwakePanel — Kernbetriebszeit-Kuerzung', () => {
     await user.click(button);
 
     await waitFor(() => expect(mockedUpdate).toHaveBeenCalled());
-    expect(mockedUpdate).toHaveBeenCalledWith({
-      always_awake_enabled: true,
-      always_awake_until: occurrence.start,
-    });
+    const after = Date.now();
+
+    // Sent value: the RAW "now + 8h" pick, unclamped. Bounded by the actual
+    // wall-clock span of this test, not a hardcoded offset — a wrongly-sent
+    // clamped value (occurrence.start, ~4h out) would fail this assertion.
+    const sent = mockedUpdate.mock.calls[0][0] as { always_awake_until: string };
+    const sentMs = new Date(sent.always_awake_until).getTime();
+    expect(sentMs).toBeGreaterThanOrEqual(before + 8 * 3600 * 1000 - 2000);
+    expect(sentMs).toBeLessThanOrEqual(after + 8 * 3600 * 1000 + 2000);
+
+    // Displayed value: the clamped occurrence start — what the backend's own
+    // clamp of that raw value will also settle on.
+    expect(await screen.findByText('sleep.alwaysAwake.clampActive')).toBeInTheDocument();
   });
 
   it('sends the raw value when the chosen expiry clears the window end', async () => {

--- a/client/src/__tests__/lib/coreUptimeClamp.test.ts
+++ b/client/src/__tests__/lib/coreUptimeClamp.test.ts
@@ -86,6 +86,35 @@ describe('clampToCoreUptime', () => {
     expect(result.until).toBe(until);
     expect(result.clampedTo).toBeNull();
   });
+
+  it('previewed (single-clamp) value agrees with what the backend stores from the raw pick — staggered overlap', () => {
+    // Regression for the non-idempotency bug (AlwaysAwakePanel used to send
+    // the ALREADY-clamped value to the backend, which clamped it a second
+    // time). Window A 19:00-21:00 and window B 20:00-23:00, both enabled,
+    // `now` 15:00, raw pick 22:00:
+    //
+    //   once  = clampToCoreUptime(raw)       -> 20:00 (only B contains 22:00)
+    //   twice = clampToCoreUptime(once)      -> 19:00 (A now contains 20:00 too)
+    //
+    // `once` is exactly what the frontend now previews AND what it sends as
+    // the raw payload; the backend applies the identical rule exactly once to
+    // that raw value and therefore also lands on 20:00 — the round trip
+    // agrees. `twice` is kept here only to document the hazard the fix
+    // removes: it must differ from `once`, proving a caller that (wrongly)
+    // re-clamps an already-clamped value would silently drift to a different,
+    // over-shortened result.
+    const now = new Date('2026-05-06T15:00:00');
+    const windowA = occ('2026-05-06T19:00:00', '2026-05-06T21:00:00', 1, 'A');
+    const windowB = occ('2026-05-06T20:00:00', '2026-05-06T23:00:00', 2, 'B');
+    const raw = new Date('2026-05-06T22:00:00').toISOString();
+
+    const once = clampToCoreUptime(raw, [windowA, windowB], now);
+    expect(once.until).toBe(windowB.start);
+
+    const twice = clampToCoreUptime(once.until, [windowA, windowB], now);
+    expect(twice.until).toBe(windowA.start);
+    expect(twice.until).not.toBe(once.until);
+  });
 });
 
 describe('findRunningOccurrence', () => {

--- a/client/src/__tests__/lib/coreUptimeClamp.test.ts
+++ b/client/src/__tests__/lib/coreUptimeClamp.test.ts
@@ -64,6 +64,22 @@ describe('clampToCoreUptime', () => {
     expect(clampToCoreUptime(until, [early, late], NOW).until).toBe(early.start);
   });
 
+  it('does not clamp when a running window overlaps a future window that also contains until', () => {
+    // Window A is already running (started before `now`); window B starts later
+    // but both contain `until`. The earliest start across ALL containing
+    // windows is A's — and A's start is already in the past, so the backend
+    // (`clamp_to_core_uptime_start`) leaves `until` unchanged. A frontend that
+    // filters to future-start windows BEFORE picking the earliest would wrongly
+    // clamp to B instead.
+    const now = new Date('2026-05-06T14:00:00');
+    const running = occ('2026-05-06T08:00:00', '2026-05-06T23:00:00', 4, 'Tag');
+    const future = occ('2026-05-06T19:00:00', '2026-05-06T21:00:00', 5, 'Abend');
+    const until = new Date('2026-05-06T20:00:00').toISOString();
+    const result = clampToCoreUptime(until, [running, future], now);
+    expect(result.until).toBe(until);
+    expect(result.clampedTo).toBeNull();
+  });
+
   it('is the identity with no occurrences', () => {
     const until = new Date('2026-05-06T21:00:00').toISOString();
     const result = clampToCoreUptime(until, [], NOW);

--- a/client/src/__tests__/lib/coreUptimeClamp.test.ts
+++ b/client/src/__tests__/lib/coreUptimeClamp.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { clampToCoreUptime, findRunningOccurrence } from '../../lib/coreUptimeClamp';
+import type { CoreUptimeOccurrence } from '../../api/sleep';
+
+/** Occurrence aus lokalen Wanduhrzeiten bauen — unabhaengig von der TZ der CI. */
+function occ(
+  startLocal: string,
+  endLocal: string,
+  window_id = 1,
+  label: string | null = null,
+): CoreUptimeOccurrence {
+  return {
+    window_id,
+    label,
+    start: new Date(startLocal).toISOString(),
+    end: new Date(endLocal).toISOString(),
+  };
+}
+
+const NOW = new Date('2026-05-06T15:00:00');
+const WINDOW = occ('2026-05-06T19:00:00', '2026-05-06T23:30:00', 7, 'Abend');
+
+describe('clampToCoreUptime', () => {
+  it('shortens an expiry that falls inside a future window', () => {
+    const until = new Date('2026-05-06T21:00:00').toISOString();
+    const result = clampToCoreUptime(until, [WINDOW], NOW);
+    expect(result.until).toBe(WINDOW.start);
+    expect(result.clampedTo).toEqual(WINDOW);
+  });
+
+  it('leaves an expiry before the window untouched', () => {
+    const until = new Date('2026-05-06T17:00:00').toISOString();
+    const result = clampToCoreUptime(until, [WINDOW], NOW);
+    expect(result.until).toBe(until);
+    expect(result.clampedTo).toBeNull();
+  });
+
+  it('leaves an expiry past the window end untouched', () => {
+    const until = new Date('2026-05-07T01:00:00').toISOString();
+    const result = clampToCoreUptime(until, [WINDOW], NOW);
+    expect(result.until).toBe(until);
+    expect(result.clampedTo).toBeNull();
+  });
+
+  it('treats an expiry exactly on the window start as already clamped', () => {
+    const result = clampToCoreUptime(WINDOW.start, [WINDOW], NOW);
+    expect(result.until).toBe(WINDOW.start);
+    expect(result.clampedTo).toEqual(WINDOW);
+  });
+
+  it('does not shorten when the window is already running', () => {
+    const now = new Date('2026-05-06T20:00:00');
+    const until = new Date('2026-05-06T21:00:00').toISOString();
+    const result = clampToCoreUptime(until, [WINDOW], now);
+    expect(result.until).toBe(until);
+    expect(result.clampedTo).toBeNull();
+  });
+
+  it('returns the earliest start when windows overlap', () => {
+    const late = occ('2026-05-06T20:00:00', '2026-05-06T23:00:00', 2);
+    const early = occ('2026-05-06T19:00:00', '2026-05-06T22:00:00', 3);
+    const until = new Date('2026-05-06T21:00:00').toISOString();
+    expect(clampToCoreUptime(until, [late, early], NOW).until).toBe(early.start);
+    expect(clampToCoreUptime(until, [early, late], NOW).until).toBe(early.start);
+  });
+
+  it('is the identity with no occurrences', () => {
+    const until = new Date('2026-05-06T21:00:00').toISOString();
+    const result = clampToCoreUptime(until, [], NOW);
+    expect(result.until).toBe(until);
+    expect(result.clampedTo).toBeNull();
+  });
+});
+
+describe('findRunningOccurrence', () => {
+  it('returns the occurrence covering now', () => {
+    const now = new Date('2026-05-06T20:00:00');
+    expect(findRunningOccurrence([WINDOW], now)).toEqual(WINDOW);
+  });
+
+  it('returns null before the window starts', () => {
+    expect(findRunningOccurrence([WINDOW], NOW)).toBeNull();
+  });
+
+  it('returns null exactly at the end (end is exclusive)', () => {
+    const now = new Date('2026-05-06T23:30:00');
+    expect(findRunningOccurrence([WINDOW], now)).toBeNull();
+  });
+});

--- a/client/src/api/sleep.ts
+++ b/client/src/api/sleep.ts
@@ -48,6 +48,13 @@ export interface CoreUptimeStatus {
   next_start: string | null;
 }
 
+export interface CoreUptimeOccurrence {
+  window_id: number;
+  label: string | null;
+  start: string;  // ISO 8601, UTC
+  end: string;    // ISO 8601, UTC
+}
+
 export interface AlwaysAwakeStatus {
   enabled: boolean;
   until: string | null;            // ISO 8601 UTC, null = permanent
@@ -292,6 +299,14 @@ export async function getSleepHistory(
 
 export async function getSleepCapabilities(): Promise<SleepCapabilities> {
   const response = await apiClient.get<SleepCapabilities>('/api/system/sleep/capabilities');
+  return response.data;
+}
+
+export async function getCoreUptimeOccurrences(days = 7): Promise<CoreUptimeOccurrence[]> {
+  const response = await apiClient.get<CoreUptimeOccurrence[]>(
+    '/api/system/sleep/core-uptime/occurrences',
+    { params: { days } },
+  );
   return response.data;
 }
 

--- a/client/src/components/power/AlwaysAwakePanel.tsx
+++ b/client/src/components/power/AlwaysAwakePanel.tsx
@@ -14,7 +14,10 @@ import {
   getSleepConfig,
   getSleepStatus,
   updateSleepConfig,
+  getCoreUptimeOccurrences,
+  type CoreUptimeOccurrence,
 } from '../../api/sleep';
+import { clampToCoreUptime, findRunningOccurrence } from '../../lib/coreUptimeClamp';
 
 type Preset = '1h' | '4h' | '8h' | 'permanent' | 'custom';
 
@@ -71,6 +74,8 @@ export function AlwaysAwakePanel() {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerValue, setPickerValue] = useState<string>('');
   const [pickerError, setPickerError] = useState<string | null>(null);
+  const [occurrences, setOccurrences] = useState<CoreUptimeOccurrence[]>([]);
+  const [hoveredPreset, setHoveredPreset] = useState<Exclude<Preset, 'permanent' | 'custom'> | null>(null);
   const tickRef = useRef<number | null>(null);
   const pickerRef = useRef<HTMLDivElement | null>(null);
 
@@ -82,6 +87,12 @@ export function AlwaysAwakePanel() {
       setExpiresIn(status.always_awake?.expires_in_seconds ?? null);
       setScheduleEnabled(cfg.schedule_enabled);
       setCoreUptimeEnabled(cfg.core_uptime_enabled ?? false);
+
+      if (cfg.core_uptime_enabled) {
+        setOccurrences(await getCoreUptimeOccurrences(7));
+      } else {
+        setOccurrences([]);
+      }
 
       if (!cfg.always_awake_enabled) {
         setActivePreset(null);
@@ -156,17 +167,24 @@ export function AlwaysAwakePanel() {
   }, [pickerOpen]);
 
   const setPreset = async (preset: Exclude<Preset, 'custom'>) => {
-    const newUntil =
+    const rawUntil =
       preset === 'permanent'
         ? null
         : new Date(Date.now() + PRESET_HOURS[preset] * 3600 * 1000).toISOString();
+    // Ein Ablauf innerhalb eines kuenftigen Kernbetriebszeit-Fensters wird auf
+    // dessen Beginn gekuerzt — dieselbe Regel wie im Backend. Der optimistische
+    // State muss den gekuerzten Wert tragen, sonst springt die Anzeige nach dem
+    // naechsten refresh() zurueck.
+    const newUntil = rawUntil ? clampToCoreUptime(rawUntil, occurrences).until : null;
     const previousEnabled = enabled;
     const previousUntil = until;
     const previousExpiresIn = expiresIn;
     const previousActivePreset = activePreset;
     setEnabled(true);
     setUntil(newUntil);
-    setExpiresIn(newUntil ? PRESET_HOURS[preset as keyof typeof PRESET_HOURS] * 3600 : null);
+    setExpiresIn(
+      newUntil ? Math.max(0, Math.floor((new Date(newUntil).getTime() - Date.now()) / 1000)) : null,
+    );
     setActivePreset(preset);
     try {
       await updateSleepConfig({
@@ -199,16 +217,15 @@ export function AlwaysAwakePanel() {
       return;
     }
     const target = new Date(localValue);
-    const delta = target.getTime() - Date.now();
 
-    const newUntil = target.toISOString();
+    const newUntil = clampToCoreUptime(target.toISOString(), occurrences).until;
     const previousEnabled = enabled;
     const previousUntil = until;
     const previousExpiresIn = expiresIn;
     const previousActivePreset = activePreset;
     setEnabled(true);
     setUntil(newUntil);
-    setExpiresIn(Math.floor(delta / 1000));
+    setExpiresIn(Math.max(0, Math.floor((new Date(newUntil).getTime() - Date.now()) / 1000)));
     setActivePreset('custom');
     setPickerOpen(false);
     setPickerError(null);
@@ -260,6 +277,25 @@ export function AlwaysAwakePanel() {
       await setPreset('permanent');
     }
   };
+
+  const runningOccurrence = findRunningOccurrence(occurrences);
+
+  const activeClamp =
+    until && !runningOccurrence
+      ? occurrences.find((o) => new Date(o.start).getTime() === new Date(until).getTime()) ?? null
+      : null;
+
+  const previewFor = (p: Exclude<Preset, 'permanent' | 'custom'>) =>
+    clampToCoreUptime(
+      new Date(Date.now() + PRESET_HOURS[p] * 3600 * 1000).toISOString(),
+      occurrences,
+    );
+
+  const hoveredClamp = hoveredPreset ? previewFor(hoveredPreset) : null;
+  const pickerClamp =
+    pickerOpen && pickerValue && !pickerError
+      ? clampToCoreUptime(new Date(pickerValue).toISOString(), occurrences)
+      : null;
 
   if (loading) {
     return (
@@ -323,7 +359,22 @@ export function AlwaysAwakePanel() {
             </button>
           </div>
 
-          {(scheduleEnabled || coreUptimeEnabled) && until && (
+          {runningOccurrence && (
+            <div className="rounded border border-emerald-500/20 bg-emerald-500/10 p-2 text-xs text-emerald-300">
+              {t('sleep.alwaysAwake.coreUptimeRunning', {
+                end: formatTime(runningOccurrence.end),
+              })}
+            </div>
+          )}
+          {activeClamp && (
+            <div className="rounded border border-amber-500/20 bg-amber-500/10 p-2 text-xs text-amber-300">
+              {t('sleep.alwaysAwake.clampActive', {
+                time: formatTime(activeClamp.start),
+                end: formatTime(activeClamp.end),
+              })}
+            </div>
+          )}
+          {(scheduleEnabled || coreUptimeEnabled) && until && !runningOccurrence && !activeClamp && (
             <div className="rounded border border-amber-500/20 bg-amber-500/10 p-2 text-xs text-amber-300">
               {t('sleep.alwaysAwake.hintScheduleResumes', { time: formatTime(until) })}
             </div>
@@ -343,15 +394,23 @@ export function AlwaysAwakePanel() {
             p === 'permanent'
               ? 'sleep.alwaysAwake.presetPermanent'
               : (`sleep.alwaysAwake.preset${p}` as const);
+          const clampPreview = p === 'permanent' ? null : previewFor(p).clampedTo;
           return (
             <button
               key={p}
               type="button"
               onClick={() => setPreset(p)}
+              title={clampPreview ? t('sleep.alwaysAwake.clampBadge') : undefined}
+              onMouseEnter={() => { if (p !== 'permanent') setHoveredPreset(p); }}
+              onMouseLeave={() => setHoveredPreset(null)}
+              onFocus={() => { if (p !== 'permanent') setHoveredPreset(p); }}
+              onBlur={() => setHoveredPreset(null)}
               className={`min-w-[3.5rem] rounded px-3 py-1.5 text-xs font-medium transition-colors ${
                 isActive
                   ? 'bg-amber-500/30 text-amber-200 border border-amber-500/50'
-                  : 'bg-slate-800/40 text-slate-400 border border-slate-700/40 hover:text-amber-300 hover:border-amber-500/30'
+                  : clampPreview
+                    ? 'bg-slate-800/40 text-slate-400 border border-dashed border-amber-500/40 hover:text-amber-300'
+                    : 'bg-slate-800/40 text-slate-400 border border-slate-700/40 hover:text-amber-300 hover:border-amber-500/30'
               }`}
             >
               {t(labelKey)}
@@ -398,6 +457,14 @@ export function AlwaysAwakePanel() {
               {pickerError && (
                 <p className="text-xs text-red-400">{pickerError}</p>
               )}
+              {pickerClamp?.clampedTo && (
+                <p className="text-[11px] text-amber-300">
+                  {t('sleep.alwaysAwake.clampPreview', {
+                    time: formatTime(pickerClamp.until),
+                    end: formatTime(pickerClamp.clampedTo.end),
+                  })}
+                </p>
+              )}
               <div className="flex justify-end gap-2 pt-1">
                 <button
                   type="button"
@@ -419,6 +486,14 @@ export function AlwaysAwakePanel() {
           )}
         </div>
       </div>
+      {hoveredClamp?.clampedTo && (
+        <p className="text-[11px] text-amber-300">
+          {t('sleep.alwaysAwake.clampPreview', {
+            time: formatTime(hoveredClamp.until),
+            end: formatTime(hoveredClamp.clampedTo.end),
+          })}
+        </p>
+      )}
     </div>
   );
 }

--- a/client/src/components/power/AlwaysAwakePanel.tsx
+++ b/client/src/components/power/AlwaysAwakePanel.tsx
@@ -88,8 +88,17 @@ export function AlwaysAwakePanel() {
       setScheduleEnabled(cfg.schedule_enabled);
       setCoreUptimeEnabled(cfg.core_uptime_enabled ?? false);
 
+      // Isolated on purpose: the clamp hints are a supplementary feature.
+      // A failure here (e.g. the occurrences endpoint 500s) must not trip
+      // the generic loadFailed toast, and must not skip the activePreset
+      // computation below — the panel stays fully usable, just without
+      // clamp hints.
       if (cfg.core_uptime_enabled) {
-        setOccurrences(await getCoreUptimeOccurrences(7));
+        try {
+          setOccurrences(await getCoreUptimeOccurrences(7));
+        } catch {
+          setOccurrences([]);
+        }
       } else {
         setOccurrences([]);
       }

--- a/client/src/components/power/AlwaysAwakePanel.tsx
+++ b/client/src/components/power/AlwaysAwakePanel.tsx
@@ -30,6 +30,9 @@ const PRESET_HOURS: Record<Exclude<Preset, 'permanent' | 'custom'>, number> = {
 const MIN_HORIZON_MS = 5 * 60 * 1000;        // 5 minutes
 const MAX_HORIZON_MS = 7 * 24 * 3600 * 1000; // 7 days
 
+/** Stable id for the hovered/focused preset's clamp-detail <p>, referenced via aria-describedby. */
+const CLAMP_DETAIL_ID = 'always-awake-clamp-detail';
+
 function formatTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
@@ -183,8 +186,13 @@ export function AlwaysAwakePanel() {
     // Ein Ablauf innerhalb eines kuenftigen Kernbetriebszeit-Fensters wird auf
     // dessen Beginn gekuerzt — dieselbe Regel wie im Backend. Der optimistische
     // State muss den gekuerzten Wert tragen, sonst springt die Anzeige nach dem
-    // naechsten refresh() zurueck.
+    // naechsten refresh() zurueck. Das Backend bekommt aber den ROHEN Wert: es
+    // wendet dieselbe Kuerzung selbst genau einmal an. Wuerden wir stattdessen
+    // den bereits gekuerzten Wert schicken, wuerde das Backend ihn ein zweites
+    // Mal kuerzen (nicht idempotent bei ueberlappenden, gestaffelten Fenstern)
+    // und DB/UI liefen auseinander.
     const newUntil = rawUntil ? clampToCoreUptime(rawUntil, occurrences).until : null;
+    const wasClamped = newUntil !== rawUntil;
     const previousEnabled = enabled;
     const previousUntil = until;
     const previousExpiresIn = expiresIn;
@@ -194,12 +202,16 @@ export function AlwaysAwakePanel() {
     setExpiresIn(
       newUntil ? Math.max(0, Math.floor((new Date(newUntil).getTime() - Date.now()) / 1000)) : null,
     );
-    setActivePreset(preset);
+    // A clamped preset no longer matches its own duration — a reload would
+    // reclassify it as 'custom' (see refresh()'s remaining-seconds matching),
+    // so reflect that immediately instead of showing a stale preset as active.
+    setActivePreset(wasClamped ? 'custom' : preset);
     try {
       await updateSleepConfig({
         always_awake_enabled: true,
-        always_awake_until: newUntil,
+        always_awake_until: rawUntil,
       });
+      setHoveredPreset(null);
     } catch (err) {
       setEnabled(previousEnabled);
       setUntil(previousUntil);
@@ -226,8 +238,12 @@ export function AlwaysAwakePanel() {
       return;
     }
     const target = new Date(localValue);
+    const rawUntil = target.toISOString();
 
-    const newUntil = clampToCoreUptime(target.toISOString(), occurrences).until;
+    // See setPreset() above: the backend applies the same clamp itself, so it
+    // must receive the RAW value — the clamped value stays local-only, for the
+    // optimistic display.
+    const newUntil = clampToCoreUptime(rawUntil, occurrences).until;
     const previousEnabled = enabled;
     const previousUntil = until;
     const previousExpiresIn = expiresIn;
@@ -241,8 +257,9 @@ export function AlwaysAwakePanel() {
     try {
       await updateSleepConfig({
         always_awake_enabled: true,
-        always_awake_until: newUntil,
+        always_awake_until: rawUntil,
       });
+      setHoveredPreset(null);
     } catch (err) {
       setEnabled(previousEnabled);
       setUntil(previousUntil);
@@ -404,12 +421,19 @@ export function AlwaysAwakePanel() {
               ? 'sleep.alwaysAwake.presetPermanent'
               : (`sleep.alwaysAwake.preset${p}` as const);
           const clampPreview = p === 'permanent' ? null : previewFor(p).clampedTo;
+          // Only link to the detail <p> when it will actually be rendered for
+          // THIS button (hoveredPreset === p and a clamp applies) — an
+          // aria-describedby pointing at an absent id is silently ignored by
+          // screen readers, but keeping the condition explicit avoids relying
+          // on that.
+          const describesClampDetail = hoveredPreset === p && !!clampPreview;
           return (
             <button
               key={p}
               type="button"
               onClick={() => setPreset(p)}
               title={clampPreview ? t('sleep.alwaysAwake.clampBadge') : undefined}
+              aria-describedby={describesClampDetail ? CLAMP_DETAIL_ID : undefined}
               onMouseEnter={() => { if (p !== 'permanent') setHoveredPreset(p); }}
               onMouseLeave={() => setHoveredPreset(null)}
               onFocus={() => { if (p !== 'permanent') setHoveredPreset(p); }}
@@ -496,7 +520,7 @@ export function AlwaysAwakePanel() {
         </div>
       </div>
       {hoveredClamp?.clampedTo && (
-        <p className="text-[11px] text-amber-300">
+        <p id={CLAMP_DETAIL_ID} className="text-[11px] text-amber-300">
           {t('sleep.alwaysAwake.clampPreview', {
             time: formatTime(hoveredClamp.until),
             end: formatTime(hoveredClamp.clampedTo.end),

--- a/client/src/i18n/locales/de/system.json
+++ b/client/src/i18n/locales/de/system.json
@@ -739,7 +739,11 @@
       "hintPermanentClearToResume": "Dauerhaft aktiv — schalte aus, damit Schedule/Kernbetriebszeit wieder greifen.",
       "bannerActiveWithUntil": "Immer wach aktiv bis {{time}} — Auto-Sleep blockiert.",
       "bannerActivePermanent": "Immer wach aktiv (dauerhaft) — Auto-Sleep blockiert.",
-      "scheduleHint": "ℹ Always-Awake hat Vorrang. Sleep-Schedule-Trigger werden ignoriert."
+      "scheduleHint": "ℹ Always-Awake hat Vorrang. Sleep-Schedule-Trigger werden ignoriert.",
+      "clampPreview": "Wird auf {{time}} gekürzt — ab dann übernimmt die Kernbetriebszeit (wach bis {{end}}).",
+      "clampActive": "Endet um {{time}} mit dem Beginn der Kernbetriebszeit (wach bis {{end}}).",
+      "clampBadge": "Wird auf den Beginn der Kernbetriebszeit gekürzt",
+      "coreUptimeRunning": "Kernbetriebszeit läuft bis {{end}} — bis dahin bleibt das System ohnehin wach."
     },
     "osSettings": {
       "title": "OS-Sleep-Einstellungen",

--- a/client/src/i18n/locales/en/system.json
+++ b/client/src/i18n/locales/en/system.json
@@ -744,7 +744,11 @@
       "hintPermanentClearToResume": "Permanently active — turn off to let schedule/core hours resume.",
       "bannerActiveWithUntil": "Always-awake active until {{time}} — auto-sleep blocked.",
       "bannerActivePermanent": "Always-awake active (permanent) — auto-sleep blocked.",
-      "scheduleHint": "ℹ Always-awake takes precedence. Sleep-schedule triggers are ignored."
+      "scheduleHint": "ℹ Always-awake takes precedence. Sleep-schedule triggers are ignored.",
+      "clampPreview": "Will be shortened to {{time}} — core operating hours take over from then (awake until {{end}}).",
+      "clampActive": "Ends at {{time}} when core operating hours begin (awake until {{end}}).",
+      "clampBadge": "Will be shortened to the start of core operating hours",
+      "coreUptimeRunning": "Core operating hours run until {{end}} — the system stays awake until then anyway."
     },
     "osSettings": {
       "title": "OS sleep settings",

--- a/client/src/lib/coreUptimeClamp.ts
+++ b/client/src/lib/coreUptimeClamp.ts
@@ -3,9 +3,25 @@
  *
  * Reiner Intervallvergleich auf bereits aufgeloesten Fenster-Terminen — die
  * Wochentags- und Mitternachtslogik bleibt im Backend
- * (`services/power/core_uptime.py`). Ergebnisse muessen mit
- * `clamp_to_core_uptime_start()` dort uebereinstimmen; darum gewinnt bei
- * Ueberlappung ebenfalls der FRUEHESTE Start.
+ * (`services/power/core_uptime.py`). Muss `clamp_to_core_uptime_start()`
+ * dort exakt spiegeln, in zwei getrennten Schritten:
+ *
+ * 1. Unter ALLEN Occurrences, die `until` enthalten (unabhaengig davon, ob
+ *    ihr Start in Vergangenheit oder Zukunft liegt), den FRUEHESTEN Start
+ *    finden (`window_start_containing`) — bei Ueberlappung gewinnt der
+ *    fruehere Start, damit das Ergebnis nicht von der Listenreihenfolge
+ *    abhaengt.
+ * 2. Erst danach EINMAL prüfen, ob dieser eine gefundene Start noch in der
+ *    Zukunft liegt. Ist er `<= now` (das Fenster laeuft schon), bleibt
+ *    `until` unveraendert — auch wenn ein anderes, spaeter startendes
+ *    Fenster `until` ebenfalls enthaelt.
+ *
+ * Ein Future/Past-Filter VOR der Minimum-Bildung (statt danach) waere ein
+ * Bug: ein bereits laufendes Fenster A (Start in der Vergangenheit) kann ein
+ * kuenftiges Fenster B ueberlappen, das `until` ebenfalls enthaelt. Dann
+ * gewinnt (weil A vor now startet) fuer den Backend-Vergleich A — kein
+ * Clamp. Wuerde man A vorab herausfiltern, saehe die Vorschau faelschlich
+ * ein Clamp auf B vor, das das Backend nie durchsetzt.
  */
 import type { CoreUptimeOccurrence } from '../api/sleep';
 
@@ -24,22 +40,27 @@ export function clampToCoreUptime(
   const until = new Date(untilIso).getTime();
   const nowMs = now.getTime();
 
-  let best: CoreUptimeOccurrence | null = null;
-  let bestStart = Number.POSITIVE_INFINITY;
+  // Schritt 1: fruehesten Start ueber ALLE Occurrences finden, die `until`
+  // enthalten — kein Future/Past-Filter an dieser Stelle (mirrors
+  // `window_start_containing`).
+  let earliest: CoreUptimeOccurrence | null = null;
+  let earliestStart = Number.POSITIVE_INFINITY;
 
   for (const o of occurrences) {
     const start = new Date(o.start).getTime();
     const end = new Date(o.end).getTime();
-    // Nur kuenftige Fensterbeginne kuerzen: ein bereits laufendes Fenster
-    // hat seinen Beginn in der Vergangenheit, da gibt es nichts zu kuerzen.
-    if (start > nowMs && until >= start && until < end && start < bestStart) {
-      best = o;
-      bestStart = start;
+    if (until >= start && until < end && start < earliestStart) {
+      earliest = o;
+      earliestStart = start;
     }
   }
 
-  if (best === null) return { until: untilIso, clampedTo: null };
-  return { until: best.start, clampedTo: best };
+  // Schritt 2: genau EIN Gate auf dem gefundenen Kandidaten (mirrors
+  // `clamp_to_core_uptime_start`'s `start_local <= now_local` check).
+  if (earliest === null || earliestStart <= nowMs) {
+    return { until: untilIso, clampedTo: null };
+  }
+  return { until: earliest.start, clampedTo: earliest };
 }
 
 export function findRunningOccurrence(

--- a/client/src/lib/coreUptimeClamp.ts
+++ b/client/src/lib/coreUptimeClamp.ts
@@ -1,0 +1,57 @@
+/**
+ * Kernbetriebszeit-Kuerzung fuer den Always-Awake-Override.
+ *
+ * Reiner Intervallvergleich auf bereits aufgeloesten Fenster-Terminen — die
+ * Wochentags- und Mitternachtslogik bleibt im Backend
+ * (`services/power/core_uptime.py`). Ergebnisse muessen mit
+ * `clamp_to_core_uptime_start()` dort uebereinstimmen; darum gewinnt bei
+ * Ueberlappung ebenfalls der FRUEHESTE Start.
+ */
+import type { CoreUptimeOccurrence } from '../api/sleep';
+
+export interface ClampResult {
+  /** ISO-Zeitstempel, der gespeichert werden soll (gekuerzt oder original). */
+  until: string;
+  /** Das Fenster, auf dessen Beginn gekuerzt wurde — null, wenn nicht gekuerzt. */
+  clampedTo: CoreUptimeOccurrence | null;
+}
+
+export function clampToCoreUptime(
+  untilIso: string,
+  occurrences: CoreUptimeOccurrence[],
+  now: Date = new Date(),
+): ClampResult {
+  const until = new Date(untilIso).getTime();
+  const nowMs = now.getTime();
+
+  let best: CoreUptimeOccurrence | null = null;
+  let bestStart = Number.POSITIVE_INFINITY;
+
+  for (const o of occurrences) {
+    const start = new Date(o.start).getTime();
+    const end = new Date(o.end).getTime();
+    // Nur kuenftige Fensterbeginne kuerzen: ein bereits laufendes Fenster
+    // hat seinen Beginn in der Vergangenheit, da gibt es nichts zu kuerzen.
+    if (start > nowMs && until >= start && until < end && start < bestStart) {
+      best = o;
+      bestStart = start;
+    }
+  }
+
+  if (best === null) return { until: untilIso, clampedTo: null };
+  return { until: best.start, clampedTo: best };
+}
+
+export function findRunningOccurrence(
+  occurrences: CoreUptimeOccurrence[],
+  now: Date = new Date(),
+): CoreUptimeOccurrence | null {
+  const nowMs = now.getTime();
+  for (const o of occurrences) {
+    // start inklusiv, end exklusiv — wie im Backend.
+    if (new Date(o.start).getTime() <= nowMs && nowMs < new Date(o.end).getTime()) {
+      return o;
+    }
+  }
+  return null;
+}

--- a/docs/superpowers/plans/2026-08-03-always-awake-core-uptime-clamp.md
+++ b/docs/superpowers/plans/2026-08-03-always-awake-core-uptime-clamp.md
@@ -1,0 +1,1523 @@
+# Always-Awake an Kernbetriebszeit-Fenstern kürzen — Implementierungsplan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fällt der Always-Awake-Ablaufzeitpunkt in ein künftiges Kernbetriebszeit-Fenster, wird er beim Speichern auf dessen Beginn gekürzt; die UI kündigt die Kürzung vorher an und erklärt sie nachher.
+
+**Architecture:** Vier reine Helper in `backend/app/services/power/core_uptime.py` (lokal-naive Zeitlogik, wie die Datei sie bereits durchgängig verwendet) tragen die Regel. `SleepManagerService.update_config()` ruft sie auf, bevor `always_awake_until` committet wird — der gespeicherte Wert ist damit die Wahrheit, alle Anzeige-Pfade (Status-Endpoint, Countdown, Topbar-Pill) bleiben unverändert. Ein neuer Read-Only-Endpoint löst die Fenster in konkrete Zeitstempel auf, sodass das Frontend die Vorschau mit einem reinen Intervallvergleich berechnet, statt Wochentags- und Mitternachtslogik in TypeScript nachzubauen.
+
+**Tech Stack:** Python 3.11 / FastAPI / SQLAlchemy 2.0 / Pydantic v2 / pytest — React 18 / TypeScript / Vite / Vitest / i18next.
+
+**Spec:** `docs/superpowers/specs/2026-08-03-always-awake-core-uptime-clamp-design.md`
+
+## Global Constraints
+
+- **Keine Alembic-Migration, kein neues DB-Feld.** `SleepConfig`, `AlwaysAwakeStatus` und `SleepConfigResponse` bleiben unverändert.
+- **Zeitkonvention:** Kernbetriebszeit-Fenster sind durchgängig **lokal-naiv** (`datetime.now()` ohne tzinfo), `always_awake_until` ist **UTC-aware**. Umgerechnet wird ausschließlich in `clamp_to_core_uptime_start()` und im neuen Route-Handler.
+- **Fenster-Semantik:** `start_time` inklusiv, `end_time` exklusiv, `weekdays` CSV `0..6` (0=Montag), `end < start` bedeutet Mitternachtsüberlauf. Nicht ändern.
+- **Bei überlappenden Fenstern gilt der früheste Start** (`min`), nicht der erste Treffer — nur so liefern Backend-Kürzung und Frontend-Vorschau garantiert dasselbe Ergebnis.
+- **SQLAlchemy-Filter:** immer `.is_(True)`, nie `== True` — ein Ruff-E712-Autofix zerlegt sonst die Query.
+- **Zeilen-Konvention:** `backend/app/services/power/sleep.py` hat bereits 1520 Zeilen. Neue Logik gehört in `core_uptime.py`, nicht dorthin; in `sleep.py` landet nur der Aufruf.
+- **Neue Routen:** `Depends(get_current_admin)` + `@user_limiter.limit(get_limit("admin_operations"))`, exakt wie die bestehenden `/core-uptime/*`-Routen.
+- **Kein `git push`, kein PR** im Rahmen dieses Plans — nur lokale Commits.
+
+---
+
+## Dateiübersicht
+
+| Datei | Rolle |
+|---|---|
+| `backend/app/services/power/core_uptime.py` | **Modify** — vier neue reine Helper: `Occurrence`, `current_window_start`, `window_start_containing`, `clamp_to_core_uptime_start`, `expand_occurrences` |
+| `backend/tests/services/test_core_uptime_helpers.py` | **Modify** — Tests für die neuen Helper, an die bestehenden angehängt |
+| `backend/app/services/power/sleep.py` | **Modify** — Aufruf der Kürzung in `update_config()` (~8 Zeilen) |
+| `backend/tests/services/test_sleep_always_awake.py` | **Modify** — Tests der Kürzung in `update_config()` |
+| `backend/app/schemas/sleep.py` | **Modify** — `CoreUptimeOccurrence`-Response-Schema |
+| `backend/app/api/routes/sleep.py` | **Modify** — `GET /core-uptime/occurrences` |
+| `backend/tests/api/test_core_uptime_routes.py` | **Modify** — Route-Tests für den neuen Endpoint |
+| `client/src/api/sleep.ts` | **Modify** — `CoreUptimeOccurrence` + `getCoreUptimeOccurrences()` |
+| `client/src/lib/coreUptimeClamp.ts` | **Create** — reine `clampToCoreUptime()` / `findRunningOccurrence()` |
+| `client/src/__tests__/lib/coreUptimeClamp.test.ts` | **Create** — Vitest für die reinen Funktionen |
+| `client/src/components/power/AlwaysAwakePanel.tsx` | **Modify** — Occurrences laden, Vorher-/Nachher-Hinweise, gekürzter Wert beim Speichern |
+| `client/src/__tests__/components/power/AlwaysAwakePanel.test.tsx` | **Create** — Panel-Test |
+| `client/src/i18n/locales/de/system.json`, `.../en/system.json` | **Modify** — vier neue Keys unter `sleep.alwaysAwake` |
+
+---
+
+## Task 1: Reine Helper in `core_uptime.py`
+
+**Files:**
+- Modify: `backend/app/services/power/core_uptime.py`
+- Test: `backend/tests/services/test_core_uptime_helpers.py`
+
+**Interfaces:**
+- Consumes: bestehende private Helper derselben Datei — `_parse_hhmm`, `_parse_weekdays`, `_crosses_midnight`, `_window_active_at`, `is_in_core_uptime`
+- Produces:
+  - `class Occurrence(NamedTuple)` mit `window_id: int`, `label: Optional[str]`, `start: datetime`, `end: datetime` (lokal-naiv)
+  - `current_window_start(now: datetime, w) -> datetime`
+  - `window_start_containing(dt: datetime, windows: Sequence) -> Optional[datetime]`
+  - `clamp_to_core_uptime_start(until_utc: datetime, windows: Sequence, now_local: datetime) -> datetime`
+  - `expand_occurrences(now: datetime, windows: Sequence, days: int = 7) -> list[Occurrence]`
+
+- [ ] **Step 1: Die fehlschlagenden Tests schreiben**
+
+An das **Ende** von `backend/tests/services/test_core_uptime_helpers.py` anhängen. Der Datei-lokale Builder `_w(start, end, weekdays, enabled, label)` existiert dort bereits (Zeile 14) und wird wiederverwendet — nicht neu definieren.
+
+Ergänze zuerst die Import-Zeile am Dateikopf (die bestehende `from app.services.power.core_uptime import (...)`-Gruppe erweitern), sodass sie lautet:
+
+```python
+from app.services.power.core_uptime import (
+    is_in_core_uptime,
+    next_core_uptime_start,
+    current_window_end,
+    current_window_start,
+    window_start_containing,
+    clamp_to_core_uptime_start,
+    expand_occurrences,
+)
+```
+
+Zusätzlich am Dateikopf ergänzen (die bestehende `from datetime import datetime`-Zeile erweitern):
+
+```python
+from datetime import datetime, timedelta, timezone
+```
+
+Dann die Tests anhängen:
+
+```python
+# ---- current_window_start ----
+
+def test_current_window_start_simple():
+    # Mi 12:00 innerhalb Mo-Fr 08:00-22:00
+    now = datetime(2026, 5, 6, 12, 0)
+    w = _w("08:00", "22:00", "0,1,2,3,4")
+    assert current_window_start(now, w) == datetime(2026, 5, 6, 8, 0)
+
+
+def test_current_window_start_overnight_late_half():
+    # Fenster 22:00-06:00, jetzt Mi 23:30 -> Beginn ist heute 22:00
+    now = datetime(2026, 5, 6, 23, 30)
+    w = _w("22:00", "06:00")
+    assert current_window_start(now, w) == datetime(2026, 5, 6, 22, 0)
+
+
+def test_current_window_start_overnight_early_half():
+    # Fenster 22:00-06:00, jetzt Do 02:00 -> Beginn war gestern 22:00
+    now = datetime(2026, 5, 7, 2, 0)
+    w = _w("22:00", "06:00")
+    assert current_window_start(now, w) == datetime(2026, 5, 6, 22, 0)
+
+
+# ---- window_start_containing ----
+
+def test_window_start_containing_hit():
+    dt = datetime(2026, 5, 6, 20, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    assert window_start_containing(dt, windows) == datetime(2026, 5, 6, 19, 0)
+
+
+def test_window_start_containing_miss_returns_none():
+    dt = datetime(2026, 5, 6, 18, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    assert window_start_containing(dt, windows) is None
+
+
+def test_window_start_containing_ignores_disabled_window():
+    dt = datetime(2026, 5, 6, 20, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4", enabled=False)]
+    assert window_start_containing(dt, windows) is None
+
+
+def test_window_start_containing_empty_list():
+    assert window_start_containing(datetime(2026, 5, 6, 20, 0), []) is None
+
+
+def test_window_start_containing_overlap_picks_earliest_start():
+    # Zwei Fenster enthalten 21:00 — das frueher beginnende gewinnt,
+    # unabhaengig von der Listenreihenfolge.
+    dt = datetime(2026, 5, 6, 21, 0)
+    late = _w("20:00", "23:00")
+    early = _w("19:00", "22:00")
+    assert window_start_containing(dt, [late, early]) == datetime(2026, 5, 6, 19, 0)
+    assert window_start_containing(dt, [early, late]) == datetime(2026, 5, 6, 19, 0)
+
+
+# ---- clamp_to_core_uptime_start ----
+#
+# Die Funktion rechnet UTC -> lokale Serverzeit und zurueck. Damit die Tests
+# unabhaengig von der TZ der CI-Maschine sind, wird der UTC-Eingabewert aus
+# einem lokalen Wunschzeitpunkt abgeleitet statt hart gesetzt.
+
+def _utc(local_naive: datetime) -> datetime:
+    """Lokal-naiven Zeitpunkt in den entsprechenden UTC-aware Wert umrechnen."""
+    return local_naive.astimezone(timezone.utc)
+
+
+def test_clamp_shortens_expiry_inside_future_window():
+    now_local = datetime(2026, 5, 6, 15, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    until = _utc(datetime(2026, 5, 6, 21, 0))
+    result = clamp_to_core_uptime_start(until, windows, now_local)
+    assert result == _utc(datetime(2026, 5, 6, 19, 0))
+    assert result.tzinfo is not None
+
+
+def test_clamp_leaves_expiry_before_window_untouched():
+    now_local = datetime(2026, 5, 6, 15, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    until = _utc(datetime(2026, 5, 6, 17, 0))
+    assert clamp_to_core_uptime_start(until, windows, now_local) == until
+
+
+def test_clamp_leaves_expiry_past_window_end_untouched():
+    now_local = datetime(2026, 5, 6, 15, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    until = _utc(datetime(2026, 5, 7, 1, 0))
+    assert clamp_to_core_uptime_start(until, windows, now_local) == until
+
+
+def test_clamp_expiry_exactly_on_window_start_is_unchanged():
+    now_local = datetime(2026, 5, 6, 15, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    until = _utc(datetime(2026, 5, 6, 19, 0))
+    assert clamp_to_core_uptime_start(until, windows, now_local) == until
+
+
+def test_clamp_does_not_shorten_when_window_already_running():
+    # Fensterbeginn liegt in der Vergangenheit -> kein Kuerzen moeglich.
+    now_local = datetime(2026, 5, 6, 20, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    until = _utc(datetime(2026, 5, 6, 21, 0))
+    assert clamp_to_core_uptime_start(until, windows, now_local) == until
+
+
+def test_clamp_with_no_windows_is_identity():
+    now_local = datetime(2026, 5, 6, 15, 0)
+    until = _utc(datetime(2026, 5, 6, 21, 0))
+    assert clamp_to_core_uptime_start(until, [], now_local) == until
+
+
+def test_clamp_accepts_naive_until_as_utc():
+    # Defensive: ein naiver DB-Wert wird als UTC interpretiert, nicht als lokal.
+    now_local = datetime(2026, 5, 6, 15, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]
+    aware = _utc(datetime(2026, 5, 6, 21, 0))
+    naive = aware.replace(tzinfo=None)
+    assert clamp_to_core_uptime_start(naive, windows, now_local) == _utc(
+        datetime(2026, 5, 6, 19, 0)
+    )
+
+
+# ---- expand_occurrences ----
+
+def test_expand_occurrences_respects_weekdays():
+    now = datetime(2026, 5, 6, 12, 0)  # Mi
+    windows = [_w("19:00", "23:30", "0,1,2,3,4")]  # Mo-Fr
+    occ = expand_occurrences(now, windows, days=7)
+    starts = [o.start for o in occ]
+    # Mi/Do/Fr diese Woche + Mo/Di/Mi naechste Woche = 6 Vorkommen
+    assert starts == [
+        datetime(2026, 5, 6, 19, 0),
+        datetime(2026, 5, 7, 19, 0),
+        datetime(2026, 5, 8, 19, 0),
+        datetime(2026, 5, 11, 19, 0),
+        datetime(2026, 5, 12, 19, 0),
+        datetime(2026, 5, 13, 19, 0),
+    ]
+
+
+def test_expand_occurrences_sets_end_and_metadata():
+    now = datetime(2026, 5, 6, 12, 0)
+    windows = [_w("19:00", "23:30", "2", label="Abend")]  # nur Mittwoch
+    occ = expand_occurrences(now, windows, days=1)
+    assert len(occ) == 1
+    assert occ[0].start == datetime(2026, 5, 6, 19, 0)
+    assert occ[0].end == datetime(2026, 5, 6, 23, 30)
+    assert occ[0].label == "Abend"
+    assert occ[0].window_id == 1
+
+
+def test_expand_occurrences_overnight_end_is_next_day():
+    now = datetime(2026, 5, 6, 12, 0)
+    windows = [_w("22:00", "06:00", "2")]  # Mittwoch 22:00 -> Donnerstag 06:00
+    occ = expand_occurrences(now, windows, days=1)
+    assert occ[0].start == datetime(2026, 5, 6, 22, 0)
+    assert occ[0].end == datetime(2026, 5, 7, 6, 0)
+
+
+def test_expand_occurrences_includes_window_started_yesterday():
+    # Donnerstag 02:00: das Mittwoch-Fenster 22:00-06:00 laeuft noch.
+    now = datetime(2026, 5, 7, 2, 0)
+    windows = [_w("22:00", "06:00", "2")]
+    occ = expand_occurrences(now, windows, days=7)
+    assert occ[0].start == datetime(2026, 5, 6, 22, 0)
+    assert occ[0].end == datetime(2026, 5, 7, 6, 0)
+
+
+def test_expand_occurrences_drops_finished_occurrences():
+    # Mittwoch 20:00: das heutige Fenster 08:00-12:00 ist vorbei.
+    now = datetime(2026, 5, 6, 20, 0)
+    windows = [_w("08:00", "12:00", "2")]  # nur Mittwoch
+    occ = expand_occurrences(now, windows, days=7)
+    assert [o.start for o in occ] == [datetime(2026, 5, 13, 8, 0)]
+
+
+def test_expand_occurrences_skips_disabled_windows():
+    now = datetime(2026, 5, 6, 12, 0)
+    windows = [_w("19:00", "23:30", "0,1,2,3,4", enabled=False)]
+    assert expand_occurrences(now, windows, days=7) == []
+
+
+def test_expand_occurrences_sorted_across_windows():
+    now = datetime(2026, 5, 6, 6, 0)
+    late = _w("19:00", "23:30", "2")
+    early = _w("08:00", "12:00", "2")
+    occ = expand_occurrences(now, [late, early], days=1)
+    assert [o.start for o in occ] == [
+        datetime(2026, 5, 6, 8, 0),
+        datetime(2026, 5, 6, 19, 0),
+    ]
+
+
+def test_expand_occurrences_honours_days_horizon():
+    now = datetime(2026, 5, 6, 12, 0)
+    windows = [_w("19:00", "23:30")]  # taeglich
+    assert len(expand_occurrences(now, windows, days=1)) == 2  # heute + morgen
+```
+
+- [ ] **Step 2: Tests laufen lassen — sie müssen fehlschlagen**
+
+```bash
+cd backend && python -m pytest tests/services/test_core_uptime_helpers.py -v
+```
+
+Erwartet: `ImportError: cannot import name 'current_window_start'` — die ganze Datei bricht beim Import ab. Das ist der erwartete Fehlschlag.
+
+- [ ] **Step 3: Die Helper implementieren**
+
+In `backend/app/services/power/core_uptime.py` den Import-Block am Dateikopf ersetzen:
+
+```python
+from datetime import datetime, timedelta, timezone
+from typing import NamedTuple, Optional, Sequence
+```
+
+Danach `current_window_end` (endet in Zeile 109) als letzten Block belassen und **darunter** anfügen:
+
+```python
+def current_window_start(now: datetime, w) -> datetime:
+    """Return the datetime when the currently-active window started.
+
+    Mirror of `current_window_end`. Caller must ensure `now` is inside `w`.
+    """
+    sh, sm = _parse_hhmm(w.start_time)
+    if _crosses_midnight(w.start_time, w.end_time):
+        start_today = now.replace(hour=sh, minute=sm, second=0, microsecond=0)
+        if now >= start_today:
+            # Late part — the window started today
+            return start_today
+        # Early part — the window started yesterday
+        return (now - timedelta(days=1)).replace(
+            hour=sh, minute=sm, second=0, microsecond=0
+        )
+    return now.replace(hour=sh, minute=sm, second=0, microsecond=0)
+
+
+def window_start_containing(dt: datetime, windows: Sequence) -> Optional[datetime]:
+    """Start of the window containing `dt`, or None.
+
+    On overlapping windows the EARLIEST start wins — deliberately not
+    first-match, so the result does not depend on list order (the frontend
+    preview computes the same value from resolved occurrences).
+    """
+    starts = [
+        current_window_start(dt, w) for w in windows if _window_active_at(dt, w)
+    ]
+    return min(starts) if starts else None
+
+
+def clamp_to_core_uptime_start(
+    until_utc: datetime,
+    windows: Sequence,
+    now_local: datetime,
+) -> datetime:
+    """Shorten an always-awake expiry to the start of the core-uptime window
+    containing it — but only if that start is still in the future.
+
+    `until_utc` is UTC-aware (naive values are read as UTC, matching
+    `SleepManagerService._is_always_awake`); `windows` and `now_local` are
+    server-local, per this module's convention. The return value is UTC-aware.
+    """
+    if until_utc.tzinfo is None:
+        until_utc = until_utc.replace(tzinfo=timezone.utc)
+    until_local = until_utc.astimezone().replace(tzinfo=None)
+    start_local = window_start_containing(until_local, windows)
+    if start_local is None or start_local <= now_local:
+        return until_utc
+    # astimezone() on a naive value reads it as local time — exactly what we want.
+    return start_local.astimezone(timezone.utc)
+
+
+class Occurrence(NamedTuple):
+    """One resolved instance of a recurring window, in server-local time."""
+    window_id: int
+    label: Optional[str]
+    start: datetime
+    end: datetime
+
+
+def expand_occurrences(
+    now: datetime,
+    windows: Sequence,
+    days: int = 7,
+) -> list[Occurrence]:
+    """Resolve recurring windows into concrete occurrences.
+
+    Iterates day_offset -1..days: the -1 catches a window that started
+    yesterday and crosses midnight. Occurrences that already ended are
+    dropped. Result is sorted by start.
+    """
+    out: list[Occurrence] = []
+    for w in windows:
+        if not w.enabled:
+            continue
+        sh, sm = _parse_hhmm(w.start_time)
+        eh, em = _parse_hhmm(w.end_time)
+        weekdays = _parse_weekdays(w.weekdays)
+        crosses = _crosses_midnight(w.start_time, w.end_time)
+        for day_offset in range(-1, days + 1):
+            day = now + timedelta(days=day_offset)
+            if day.weekday() not in weekdays:
+                continue
+            start = day.replace(hour=sh, minute=sm, second=0, microsecond=0)
+            end_day = day + timedelta(days=1) if crosses else day
+            end = end_day.replace(hour=eh, minute=em, second=0, microsecond=0)
+            if end <= now:
+                continue
+            out.append(
+                Occurrence(window_id=w.id, label=w.label, start=start, end=end)
+            )
+    return sorted(out, key=lambda o: o.start)
+```
+
+- [ ] **Step 4: Tests laufen lassen — sie müssen bestehen**
+
+```bash
+cd backend && python -m pytest tests/services/test_core_uptime_helpers.py -v
+```
+
+Erwartet: alle Tests PASS (die bestehenden ebenso wie die neuen).
+
+- [ ] **Step 5: Regression der Kernbetriebszeit-Nachbarn**
+
+```bash
+cd backend && python -m pytest tests/services/test_core_uptime_inhibitor.py tests/services/test_core_uptime_rtc_guard.py tests/services/test_sleep_core_uptime_integration.py -q
+```
+
+Erwartet: alle PASS — die neuen Funktionen sind rein additiv.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/power/core_uptime.py backend/tests/services/test_core_uptime_helpers.py
+git commit -m "feat(sleep): Helper zum Aufloesen und Kuerzen an Kernbetriebszeit-Fenstern"
+```
+
+---
+
+## Task 2: Kürzung in `update_config()`
+
+**Files:**
+- Modify: `backend/app/services/power/sleep.py:1339-1378` (`update_config`)
+- Test: `backend/tests/services/test_sleep_always_awake.py`
+
+**Interfaces:**
+- Consumes: `core_uptime_helpers.clamp_to_core_uptime_start(until_utc, windows, now_local)` aus Task 1. `sleep.py` importiert das Modul bereits als `core_uptime_helpers` (Zeile 28) und `CoreUptimeWindow as CoreUptimeWindowModel` (Zeile 26) — keine neuen Imports nötig.
+- Produces: keine neue öffentliche API. `update_config()` schreibt ab jetzt einen ggf. gekürzten `always_awake_until`.
+
+- [ ] **Step 1: Die fehlschlagenden Tests schreiben**
+
+An das Ende von `backend/tests/services/test_sleep_always_awake.py` anhängen. `_build_service`, `patch`, `MagicMock`, `datetime`, `timedelta`, `timezone` und `SleepConfig` sind dort bereits importiert.
+
+```python
+# ---------------------------------------------------------------------------
+# Kuerzung von always_awake_until an Kernbetriebszeit-Fenstern
+# ---------------------------------------------------------------------------
+
+def _clamp_row(*, core_uptime_enabled: bool = True, until=None):
+    """SleepConfig-Zeile fuer die Kuerzungstests."""
+    return SleepConfig(
+        id=1, auto_idle_enabled=False, idle_timeout_minutes=15,
+        idle_cpu_threshold=5.0, idle_disk_io_threshold=0.5, idle_http_threshold=5.0,
+        auto_escalation_enabled=False, escalation_after_minutes=60,
+        schedule_enabled=False, schedule_sleep_time="23:00", schedule_wake_time="06:00",
+        schedule_mode="soft",
+        wol_mac_address=None, wol_broadcast_address=None,
+        pause_monitoring=False, pause_disk_io=False, reduced_telemetry_interval=30.0,
+        disk_spindown_enabled=False,
+        core_uptime_enabled=core_uptime_enabled,
+        always_awake_enabled=True,
+        always_awake_until=until,
+    )
+
+
+def _window(start: str, end: str, weekdays: str = "0,1,2,3,4,5,6"):
+    """Fake CoreUptimeWindow — duck-typed, wie in test_core_uptime_helpers."""
+    from types import SimpleNamespace
+    return SimpleNamespace(
+        id=1, enabled=True, label=None,
+        start_time=start, end_time=end, weekdays=weekdays,
+    )
+
+
+def _session_with(row, windows):
+    """MagicMock-Session: scalar_one_or_none -> row, scalars().all() -> windows."""
+    session = MagicMock()
+    session.execute.return_value.scalar_one_or_none.return_value = row
+    session.execute.return_value.scalars.return_value.all.return_value = windows
+    return session
+
+
+def _local_utc(local_naive):
+    """Lokal-naiven Zeitpunkt in den entsprechenden UTC-aware Wert umrechnen."""
+    return local_naive.astimezone(timezone.utc)
+
+
+def test_update_config_clamps_until_into_future_window():
+    """Ablauf im kuenftigen Fenster wird auf den Fensterbeginn gekuerzt."""
+    from app.schemas.sleep import SleepConfigUpdate
+    svc = _build_service()
+    row = _clamp_row()
+    session = _session_with(row, [_window("19:00", "23:30")])
+
+    now_local = datetime(2026, 5, 6, 15, 0)
+    requested = _local_utc(datetime(2026, 5, 6, 21, 0))
+    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = now_local
+        svc.update_config(update)
+
+    assert row.always_awake_until == _local_utc(datetime(2026, 5, 6, 19, 0))
+
+
+def test_update_config_leaves_until_past_window_end_untouched():
+    """Ablauf hinter dem Fensterende bleibt unveraendert."""
+    from app.schemas.sleep import SleepConfigUpdate
+    svc = _build_service()
+    row = _clamp_row()
+    session = _session_with(row, [_window("19:00", "23:30")])
+
+    requested = _local_utc(datetime(2026, 5, 7, 1, 0))
+    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = datetime(2026, 5, 6, 15, 0)
+        svc.update_config(update)
+
+    assert row.always_awake_until == requested
+
+
+def test_update_config_does_not_clamp_when_core_uptime_disabled():
+    """Hauptschalter aus -> keine Kuerzung, Fenster werden nicht einmal geladen."""
+    from app.schemas.sleep import SleepConfigUpdate
+    svc = _build_service()
+    row = _clamp_row(core_uptime_enabled=False)
+    session = _session_with(row, [_window("19:00", "23:30")])
+
+    requested = _local_utc(datetime(2026, 5, 6, 21, 0))
+    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=requested)
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = datetime(2026, 5, 6, 15, 0)
+        svc.update_config(update)
+
+    assert row.always_awake_until == requested
+
+
+def test_update_config_clamps_when_core_uptime_enabled_in_same_request():
+    """core_uptime_enabled wird im selben Request eingeschaltet -> Kuerzung greift."""
+    from app.schemas.sleep import SleepConfigUpdate
+    svc = _build_service()
+    row = _clamp_row(core_uptime_enabled=False)
+    session = _session_with(row, [_window("19:00", "23:30")])
+
+    requested = _local_utc(datetime(2026, 5, 6, 21, 0))
+    update = SleepConfigUpdate(
+        always_awake_enabled=True,
+        always_awake_until=requested,
+        core_uptime_enabled=True,
+    )
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = datetime(2026, 5, 6, 15, 0)
+        svc.update_config(update)
+
+    assert row.always_awake_until == _local_utc(datetime(2026, 5, 6, 19, 0))
+
+
+def test_update_config_no_clamp_for_permanent_override():
+    """until=None (dauerhaft) bleibt None — nichts zu kuerzen."""
+    from app.schemas.sleep import SleepConfigUpdate
+    svc = _build_service()
+    row = _clamp_row(until=_local_utc(datetime(2026, 5, 6, 21, 0)))
+    session = _session_with(row, [_window("19:00", "23:30")])
+
+    update = SleepConfigUpdate(always_awake_enabled=True, always_awake_until=None)
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = datetime(2026, 5, 6, 15, 0)
+        svc.update_config(update)
+
+    assert row.always_awake_until is None
+
+
+def test_update_config_disabling_still_clears_until_with_windows_present():
+    """enabled=False raeumt until ab — die Kuerzung darf da nichts wiederbeleben."""
+    from app.schemas.sleep import SleepConfigUpdate
+    svc = _build_service()
+    row = _clamp_row(until=_local_utc(datetime(2026, 5, 6, 21, 0)))
+    session = _session_with(row, [_window("19:00", "23:30")])
+
+    update = SleepConfigUpdate(always_awake_enabled=False)
+
+    with patch("app.services.power.sleep.SessionLocal", return_value=session), \
+         patch("app.services.power.sleep.datetime") as mock_dt, \
+         patch.object(svc, "get_config", return_value=MagicMock()):
+        mock_dt.now.return_value = datetime(2026, 5, 6, 15, 0)
+        svc.update_config(update)
+
+    assert row.always_awake_enabled is False
+    assert row.always_awake_until is None
+```
+
+> **Hinweis zum `datetime`-Patch:** `patch("app.services.power.sleep.datetime")` ersetzt das ganze Modul-Symbol. Der bestehende Test `test_schedule_loop_skips_sleep_trigger_during_core_uptime` in `tests/services/test_sleep_core_uptime_integration.py` verwendet dasselbe Muster — es ist in diesem Repo etabliert. `datetime.now(timezone.utc)` im Ablauf-Cleanup wird davon nicht berührt, weil `update_config` diesen Pfad nicht ausführt.
+
+- [ ] **Step 2: Tests laufen lassen — sie müssen fehlschlagen**
+
+```bash
+cd backend && python -m pytest tests/services/test_sleep_always_awake.py -k clamp -v
+```
+
+Erwartet: `test_update_config_clamps_until_into_future_window` und `test_update_config_clamps_when_core_uptime_enabled_in_same_request` schlagen fehl (`until` bleibt beim Wunschwert 21:00). Die übrigen neuen Tests bestehen bereits — sie sichern ab, dass die Implementierung sie nicht bricht.
+
+- [ ] **Step 3: Die Kürzung implementieren**
+
+In `backend/app/services/power/sleep.py`, in `update_config()`, direkt **nach** dem Block
+
+```python
+                # Disabling always-awake clears any pending expiry
+                if update_data.get("always_awake_enabled") is False:
+                    config.always_awake_until = None
+```
+
+und **vor** `db.commit()` einfügen:
+
+```python
+                # Shorten a pending expiry that lands inside a FUTURE core-uptime
+                # window: from that window's start on, core uptime keeps the system
+                # awake anyway, so the manual override closes out there. An expiry
+                # beyond the window's end survives untouched — it is still needed.
+                if config.always_awake_until is not None and config.core_uptime_enabled:
+                    windows = db.execute(
+                        select(CoreUptimeWindowModel).where(
+                            CoreUptimeWindowModel.enabled.is_(True)
+                        )
+                    ).scalars().all()
+                    if windows:
+                        config.always_awake_until = (
+                            core_uptime_helpers.clamp_to_core_uptime_start(
+                                config.always_awake_until,
+                                list(windows),
+                                datetime.now(),
+                            )
+                        )
+```
+
+- [ ] **Step 4: Tests laufen lassen — sie müssen bestehen**
+
+```bash
+cd backend && python -m pytest tests/services/test_sleep_always_awake.py -v
+```
+
+Erwartet: alle Tests PASS, inklusive der bestehenden `test_update_config_can_clear_until` und `test_update_config_disabling_normalizes_until`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/power/sleep.py backend/tests/services/test_sleep_always_awake.py
+git commit -m "feat(sleep): Always-Awake-Ablauf auf Kernbetriebszeit-Fensterbeginn kuerzen"
+```
+
+---
+
+## Task 3: Endpoint `GET /core-uptime/occurrences`
+
+**Files:**
+- Modify: `backend/app/schemas/sleep.py`
+- Modify: `backend/app/api/routes/sleep.py`
+- Test: `backend/tests/api/test_core_uptime_routes.py`
+
+**Interfaces:**
+- Consumes: `core_uptime_helpers.expand_occurrences(now, windows, days)` und `Occurrence` aus Task 1
+- Produces: `GET /api/system/sleep/core-uptime/occurrences?days=<1..7>` → `list[CoreUptimeOccurrence]` mit `window_id: int`, `label: str | null`, `start: datetime` (UTC), `end: datetime` (UTC)
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+An das Ende von `backend/tests/api/test_core_uptime_routes.py` anhängen. Die Fixtures `admin_headers`/`user_headers` und die Konstante `BASE` existieren dort bereits.
+
+```python
+OCCURRENCES = f"{settings.api_prefix}/system/sleep/core-uptime/occurrences"
+
+
+def test_occurrences_empty_without_windows(client, admin_headers):
+    r = client.get(OCCURRENCES, headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_occurrences_resolves_window_to_timestamps(client, admin_headers):
+    create = client.post(BASE, headers=admin_headers, json={
+        "label": "Abend",
+        "start_time": "19:00",
+        "end_time": "23:30",
+        "weekdays": [0, 1, 2, 3, 4, 5, 6],
+    })
+    assert create.status_code in (200, 201)
+    window_id = create.json()["id"]
+
+    r = client.get(OCCURRENCES, headers=admin_headers, params={"days": 2})
+    assert r.status_code == 200
+    body = r.json()
+    # Taegliches Fenster ueber 2 Tage Horizont: mindestens 2 Vorkommen.
+    assert len(body) >= 2
+    first = body[0]
+    assert first["window_id"] == window_id
+    assert first["label"] == "Abend"
+    # Zeitstempel sind absolut und tragen einen Zeitzonen-Offset.
+    assert first["start"] != first["end"]
+    from datetime import datetime as _dt
+    assert _dt.fromisoformat(first["start"]).tzinfo is not None
+    assert _dt.fromisoformat(first["end"]).tzinfo is not None
+    # Aufsteigend sortiert.
+    starts = [o["start"] for o in body]
+    assert starts == sorted(starts)
+
+
+def test_occurrences_skips_disabled_windows(client, admin_headers):
+    create = client.post(BASE, headers=admin_headers, json={
+        "start_time": "19:00", "end_time": "23:30", "weekdays": [0, 1, 2, 3, 4, 5, 6],
+    })
+    window_id = create.json()["id"]
+    disable = client.put(f"{BASE}/{window_id}", headers=admin_headers, json={"enabled": False})
+    assert disable.status_code == 200
+
+    r = client.get(OCCURRENCES, headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_occurrences_rejects_days_out_of_range(client, admin_headers):
+    assert client.get(OCCURRENCES, headers=admin_headers, params={"days": 0}).status_code == 422
+    assert client.get(OCCURRENCES, headers=admin_headers, params={"days": 8}).status_code == 422
+
+
+def test_occurrences_forbidden_for_regular_user(client, user_headers):
+    r = client.get(OCCURRENCES, headers=user_headers)
+    assert r.status_code in (401, 403)
+```
+
+- [ ] **Step 2: Tests laufen lassen — sie müssen fehlschlagen**
+
+```bash
+cd backend && python -m pytest tests/api/test_core_uptime_routes.py -k occurrences -v
+```
+
+Erwartet: 404 statt 200 — die Route existiert noch nicht.
+
+- [ ] **Step 3: Das Response-Schema ergänzen**
+
+In `backend/app/schemas/sleep.py` direkt **nach** der bestehenden Klasse `CoreUptimeWindowResponse` einfügen:
+
+```python
+class CoreUptimeOccurrence(BaseModel):
+    """One resolved instance of a core-uptime window, as absolute UTC timestamps.
+
+    Consumed by the Always-Awake UI to preview whether a chosen expiry would be
+    clamped to a window start — a plain interval comparison, so the frontend
+    needs no weekday/midnight logic of its own.
+    """
+    window_id: int
+    label: Optional[str] = None
+    start: datetime
+    end: datetime
+```
+
+`BaseModel`, `Optional` und `datetime` sind in dieser Datei bereits importiert.
+
+- [ ] **Step 4: Die Route ergänzen**
+
+In `backend/app/api/routes/sleep.py`:
+
+Zuerst den Datei-Kopf um zwei Importe erweitern — nach `import logging` (Zeile 4):
+
+```python
+from datetime import datetime, timezone
+```
+
+und nach `from app.services.power import os_auto_suspend` (Zeile 41):
+
+```python
+from app.services.power import core_uptime as core_uptime_helpers
+```
+
+Außerdem `CoreUptimeOccurrence` in den bestehenden `from app.schemas.sleep import (...)`-Block aufnehmen (neben `CoreUptimeWindowResponse`).
+
+Dann **nach** `list_core_uptime_windows` (endet Zeile 411) einfügen:
+
+```python
+@router.get(
+    "/core-uptime/occurrences",
+    response_model=list[CoreUptimeOccurrence],
+)
+@user_limiter.limit(get_limit("admin_operations"))
+async def list_core_uptime_occurrences(
+    request: Request, response: Response,
+    days: int = Query(7, ge=1, le=7, description="Horizon in days"),
+    current_user: User = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+) -> list[CoreUptimeOccurrence]:
+    """Resolve enabled core-uptime windows into concrete occurrences (admin only).
+
+    Windows are stored as recurring server-local patterns; this returns them as
+    absolute UTC timestamps so clients can compare them against
+    `always_awake_until` directly.
+    """
+    rows = (
+        db.query(CoreUptimeWindowModel)
+        .filter(CoreUptimeWindowModel.enabled.is_(True))
+        .order_by(CoreUptimeWindowModel.id.asc())
+        .all()
+    )
+    occurrences = core_uptime_helpers.expand_occurrences(datetime.now(), rows, days=days)
+    return [
+        CoreUptimeOccurrence(
+            window_id=o.window_id,
+            label=o.label,
+            start=o.start.astimezone(timezone.utc),
+            end=o.end.astimezone(timezone.utc),
+        )
+        for o in occurrences
+    ]
+```
+
+- [ ] **Step 5: Tests laufen lassen — sie müssen bestehen**
+
+```bash
+cd backend && python -m pytest tests/api/test_core_uptime_routes.py -v
+```
+
+Erwartet: alle PASS, auch die bestehenden Fenster-Tests.
+
+- [ ] **Step 6: Die volle Sleep-Testgruppe als Regression**
+
+```bash
+cd backend && python -m pytest tests/test_sleep.py tests/test_sleep_schemas.py tests/services/test_sleep_always_awake.py tests/services/test_sleep_core_uptime_integration.py tests/api/test_sleep_always_awake_routes.py tests/api/test_core_uptime_routes.py -q
+```
+
+Erwartet: alle PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/schemas/sleep.py backend/app/api/routes/sleep.py backend/tests/api/test_core_uptime_routes.py
+git commit -m "feat(sleep): Endpoint fuer aufgeloeste Kernbetriebszeit-Termine"
+```
+
+---
+
+## Task 4: Frontend-API-Client und reiner Clamp-Helper
+
+**Files:**
+- Modify: `client/src/api/sleep.ts`
+- Create: `client/src/lib/coreUptimeClamp.ts`
+- Test: `client/src/__tests__/lib/coreUptimeClamp.test.ts`
+
+**Interfaces:**
+- Consumes: `GET /api/system/sleep/core-uptime/occurrences` aus Task 3
+- Produces:
+  - `interface CoreUptimeOccurrence { window_id: number; label: string | null; start: string; end: string }` (exportiert aus `api/sleep.ts`)
+  - `getCoreUptimeOccurrences(days?: number): Promise<CoreUptimeOccurrence[]>`
+  - `clampToCoreUptime(untilIso: string, occurrences: CoreUptimeOccurrence[], now?: Date): { until: string; clampedTo: CoreUptimeOccurrence | null }`
+  - `findRunningOccurrence(occurrences: CoreUptimeOccurrence[], now?: Date): CoreUptimeOccurrence | null`
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+Neue Datei `client/src/__tests__/lib/coreUptimeClamp.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { clampToCoreUptime, findRunningOccurrence } from '../../lib/coreUptimeClamp';
+import type { CoreUptimeOccurrence } from '../../api/sleep';
+
+/** Occurrence aus lokalen Wanduhrzeiten bauen — unabhaengig von der TZ der CI. */
+function occ(
+  startLocal: string,
+  endLocal: string,
+  window_id = 1,
+  label: string | null = null,
+): CoreUptimeOccurrence {
+  return {
+    window_id,
+    label,
+    start: new Date(startLocal).toISOString(),
+    end: new Date(endLocal).toISOString(),
+  };
+}
+
+const NOW = new Date('2026-05-06T15:00:00');
+const WINDOW = occ('2026-05-06T19:00:00', '2026-05-06T23:30:00', 7, 'Abend');
+
+describe('clampToCoreUptime', () => {
+  it('shortens an expiry that falls inside a future window', () => {
+    const until = new Date('2026-05-06T21:00:00').toISOString();
+    const result = clampToCoreUptime(until, [WINDOW], NOW);
+    expect(result.until).toBe(WINDOW.start);
+    expect(result.clampedTo).toEqual(WINDOW);
+  });
+
+  it('leaves an expiry before the window untouched', () => {
+    const until = new Date('2026-05-06T17:00:00').toISOString();
+    const result = clampToCoreUptime(until, [WINDOW], NOW);
+    expect(result.until).toBe(until);
+    expect(result.clampedTo).toBeNull();
+  });
+
+  it('leaves an expiry past the window end untouched', () => {
+    const until = new Date('2026-05-07T01:00:00').toISOString();
+    const result = clampToCoreUptime(until, [WINDOW], NOW);
+    expect(result.until).toBe(until);
+    expect(result.clampedTo).toBeNull();
+  });
+
+  it('treats an expiry exactly on the window start as already clamped', () => {
+    const result = clampToCoreUptime(WINDOW.start, [WINDOW], NOW);
+    expect(result.until).toBe(WINDOW.start);
+    expect(result.clampedTo).toEqual(WINDOW);
+  });
+
+  it('does not shorten when the window is already running', () => {
+    const now = new Date('2026-05-06T20:00:00');
+    const until = new Date('2026-05-06T21:00:00').toISOString();
+    const result = clampToCoreUptime(until, [WINDOW], now);
+    expect(result.until).toBe(until);
+    expect(result.clampedTo).toBeNull();
+  });
+
+  it('returns the earliest start when windows overlap', () => {
+    const late = occ('2026-05-06T20:00:00', '2026-05-06T23:00:00', 2);
+    const early = occ('2026-05-06T19:00:00', '2026-05-06T22:00:00', 3);
+    const until = new Date('2026-05-06T21:00:00').toISOString();
+    expect(clampToCoreUptime(until, [late, early], NOW).until).toBe(early.start);
+    expect(clampToCoreUptime(until, [early, late], NOW).until).toBe(early.start);
+  });
+
+  it('is the identity with no occurrences', () => {
+    const until = new Date('2026-05-06T21:00:00').toISOString();
+    const result = clampToCoreUptime(until, [], NOW);
+    expect(result.until).toBe(until);
+    expect(result.clampedTo).toBeNull();
+  });
+});
+
+describe('findRunningOccurrence', () => {
+  it('returns the occurrence covering now', () => {
+    const now = new Date('2026-05-06T20:00:00');
+    expect(findRunningOccurrence([WINDOW], now)).toEqual(WINDOW);
+  });
+
+  it('returns null before the window starts', () => {
+    expect(findRunningOccurrence([WINDOW], NOW)).toBeNull();
+  });
+
+  it('returns null exactly at the end (end is exclusive)', () => {
+    const now = new Date('2026-05-06T23:30:00');
+    expect(findRunningOccurrence([WINDOW], now)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Test laufen lassen — er muss fehlschlagen**
+
+```bash
+cd client && npx vitest run src/__tests__/lib/coreUptimeClamp.test.ts
+```
+
+Erwartet: `Failed to resolve import "../../lib/coreUptimeClamp"`.
+
+- [ ] **Step 3: Typ und API-Funktion ergänzen**
+
+In `client/src/api/sleep.ts` nach dem bestehenden `CoreUptimeStatus`-Interface (Zeile 43-49) einfügen:
+
+```ts
+export interface CoreUptimeOccurrence {
+  window_id: number;
+  label: string | null;
+  start: string;  // ISO 8601, UTC
+  end: string;    // ISO 8601, UTC
+}
+```
+
+Und ans Ende des Abschnitts „API functions", nach `getSleepCapabilities()`:
+
+```ts
+export async function getCoreUptimeOccurrences(days = 7): Promise<CoreUptimeOccurrence[]> {
+  const response = await apiClient.get<CoreUptimeOccurrence[]>(
+    '/api/system/sleep/core-uptime/occurrences',
+    { params: { days } },
+  );
+  return response.data;
+}
+```
+
+- [ ] **Step 4: Den reinen Helper implementieren**
+
+Neue Datei `client/src/lib/coreUptimeClamp.ts`:
+
+```ts
+/**
+ * Kernbetriebszeit-Kuerzung fuer den Always-Awake-Override.
+ *
+ * Reiner Intervallvergleich auf bereits aufgeloesten Fenster-Terminen — die
+ * Wochentags- und Mitternachtslogik bleibt im Backend
+ * (`services/power/core_uptime.py`). Ergebnisse muessen mit
+ * `clamp_to_core_uptime_start()` dort uebereinstimmen; darum gewinnt bei
+ * Ueberlappung ebenfalls der FRUEHESTE Start.
+ */
+import type { CoreUptimeOccurrence } from '../api/sleep';
+
+export interface ClampResult {
+  /** ISO-Zeitstempel, der gespeichert werden soll (gekuerzt oder original). */
+  until: string;
+  /** Das Fenster, auf dessen Beginn gekuerzt wurde — null, wenn nicht gekuerzt. */
+  clampedTo: CoreUptimeOccurrence | null;
+}
+
+export function clampToCoreUptime(
+  untilIso: string,
+  occurrences: CoreUptimeOccurrence[],
+  now: Date = new Date(),
+): ClampResult {
+  const until = new Date(untilIso).getTime();
+  const nowMs = now.getTime();
+
+  let best: CoreUptimeOccurrence | null = null;
+  let bestStart = Number.POSITIVE_INFINITY;
+
+  for (const o of occurrences) {
+    const start = new Date(o.start).getTime();
+    const end = new Date(o.end).getTime();
+    // Nur kuenftige Fensterbeginne kuerzen: ein bereits laufendes Fenster
+    // hat seinen Beginn in der Vergangenheit, da gibt es nichts zu kuerzen.
+    if (start > nowMs && until >= start && until < end && start < bestStart) {
+      best = o;
+      bestStart = start;
+    }
+  }
+
+  if (best === null) return { until: untilIso, clampedTo: null };
+  return { until: best.start, clampedTo: best };
+}
+
+export function findRunningOccurrence(
+  occurrences: CoreUptimeOccurrence[],
+  now: Date = new Date(),
+): CoreUptimeOccurrence | null {
+  const nowMs = now.getTime();
+  for (const o of occurrences) {
+    // start inklusiv, end exklusiv — wie im Backend.
+    if (new Date(o.start).getTime() <= nowMs && nowMs < new Date(o.end).getTime()) {
+      return o;
+    }
+  }
+  return null;
+}
+```
+
+- [ ] **Step 5: Test laufen lassen — er muss bestehen**
+
+```bash
+cd client && npx vitest run src/__tests__/lib/coreUptimeClamp.test.ts
+```
+
+Erwartet: alle 10 Tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/api/sleep.ts client/src/lib/coreUptimeClamp.ts client/src/__tests__/lib/coreUptimeClamp.test.ts
+git commit -m "feat(sleep): Frontend-Helper fuer die Kernbetriebszeit-Kuerzung"
+```
+
+---
+
+## Task 5: Panel-Integration, Hinweise und i18n
+
+**Files:**
+- Modify: `client/src/components/power/AlwaysAwakePanel.tsx`
+- Modify: `client/src/i18n/locales/de/system.json`
+- Modify: `client/src/i18n/locales/en/system.json`
+- Test: `client/src/__tests__/components/power/AlwaysAwakePanel.test.tsx` (Create)
+
+**Interfaces:**
+- Consumes: `getCoreUptimeOccurrences()`, `clampToCoreUptime()`, `findRunningOccurrence()`, `CoreUptimeOccurrence` aus Task 4
+- Produces: keine — Endpunkt der Feature-Kette
+
+- [ ] **Step 1: Die i18n-Keys ergänzen**
+
+In `client/src/i18n/locales/de/system.json`, im Block `sleep.alwaysAwake`, nach `"scheduleHint"` einfügen (Komma am vorigen Eintrag nicht vergessen):
+
+```json
+      "clampPreview": "Wird auf {{time}} gekürzt — ab dann übernimmt die Kernbetriebszeit (wach bis {{end}}).",
+      "clampActive": "Endet um {{time}} mit dem Beginn der Kernbetriebszeit (wach bis {{end}}).",
+      "clampBadge": "Wird auf den Beginn der Kernbetriebszeit gekürzt",
+      "coreUptimeRunning": "Kernbetriebszeit läuft bis {{end}} — bis dahin bleibt das System ohnehin wach."
+```
+
+In `client/src/i18n/locales/en/system.json`, an derselben Stelle:
+
+```json
+      "clampPreview": "Will be shortened to {{time}} — core operating hours take over from then (awake until {{end}}).",
+      "clampActive": "Ends at {{time}} when core operating hours begin (awake until {{end}}).",
+      "clampBadge": "Will be shortened to the start of core operating hours",
+      "coreUptimeRunning": "Core operating hours run until {{end}} — the system stays awake until then anyway."
+```
+
+- [ ] **Step 2: JSON-Gültigkeit prüfen**
+
+```bash
+cd client && node -e "const de=require('./src/i18n/locales/de/system.json'); const en=require('./src/i18n/locales/en/system.json'); const d=Object.keys(de.sleep.alwaysAwake), e=Object.keys(en.sleep.alwaysAwake); console.log('DE', d.length, 'EN', e.length); const miss=d.filter(k=>!e.includes(k)).concat(e.filter(k=>!d.includes(k))); if (miss.length) { console.error('MISMATCH', miss); process.exit(1); } console.log('keys match');"
+```
+
+Erwartet: gleiche Anzahl, Ausgabe `keys match`.
+
+- [ ] **Step 3: Den fehlschlagenden Panel-Test schreiben**
+
+Neue Datei `client/src/__tests__/components/power/AlwaysAwakePanel.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AlwaysAwakePanel } from '../../../components/power/AlwaysAwakePanel';
+import {
+  getSleepConfig,
+  getSleepStatus,
+  updateSleepConfig,
+  getCoreUptimeOccurrences,
+} from '../../../api/sleep';
+
+vi.mock('../../../api/sleep', () => ({
+  getSleepConfig: vi.fn(),
+  getSleepStatus: vi.fn(),
+  updateSleepConfig: vi.fn(),
+  getCoreUptimeOccurrences: vi.fn(),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { error: vi.fn(), success: vi.fn() },
+}));
+
+const mockedConfig = vi.mocked(getSleepConfig);
+const mockedStatus = vi.mocked(getSleepStatus);
+const mockedUpdate = vi.mocked(updateSleepConfig);
+const mockedOccurrences = vi.mocked(getCoreUptimeOccurrences);
+
+/** Fenster, das in 4 Stunden beginnt und 6 Stunden dauert. */
+function windowInHours(startInHours: number, durationHours: number) {
+  const start = new Date(Date.now() + startInHours * 3600 * 1000);
+  const end = new Date(start.getTime() + durationHours * 3600 * 1000);
+  return {
+    window_id: 1,
+    label: 'Abend',
+    start: start.toISOString(),
+    end: end.toISOString(),
+  };
+}
+
+function baseConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    always_awake_enabled: false,
+    always_awake_until: null,
+    schedule_enabled: false,
+    core_uptime_enabled: true,
+    ...overrides,
+  } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedStatus.mockResolvedValue({ always_awake: { expires_in_seconds: null } } as never);
+  mockedUpdate.mockResolvedValue({} as never);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('AlwaysAwakePanel — Kernbetriebszeit-Kuerzung', () => {
+  // i18n ist in Component-Tests nicht initialisiert: t() liefert den rohen Key.
+
+  it('sends the clamped value when the chosen expiry falls into a window', async () => {
+    const occurrence = windowInHours(4, 6); // beginnt in 4h, laeuft 6h
+    mockedConfig.mockResolvedValue(baseConfig());
+    mockedOccurrences.mockResolvedValue([occurrence] as never);
+
+    const user = userEvent.setup();
+    render(<AlwaysAwakePanel />);
+
+    // "8h" landet 8h in der Zukunft — also innerhalb des Fensters (4h..10h).
+    const button = await screen.findByText('sleep.alwaysAwake.preset8h');
+    await user.click(button);
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalled());
+    expect(mockedUpdate).toHaveBeenCalledWith({
+      always_awake_enabled: true,
+      always_awake_until: occurrence.start,
+    });
+  });
+
+  it('sends the raw value when the chosen expiry clears the window end', async () => {
+    const occurrence = windowInHours(1, 2); // 1h..3h
+    mockedConfig.mockResolvedValue(baseConfig());
+    mockedOccurrences.mockResolvedValue([occurrence] as never);
+
+    const user = userEvent.setup();
+    render(<AlwaysAwakePanel />);
+
+    const button = await screen.findByText('sleep.alwaysAwake.preset8h');
+    await user.click(button);
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalled());
+    const sent = mockedUpdate.mock.calls[0][0] as { always_awake_until: string };
+    expect(sent.always_awake_until).not.toBe(occurrence.start);
+  });
+
+  it('shows the clamp hint while the affected preset is focused', async () => {
+    mockedConfig.mockResolvedValue(baseConfig());
+    mockedOccurrences.mockResolvedValue([windowInHours(4, 6)] as never);
+
+    const user = userEvent.setup();
+    render(<AlwaysAwakePanel />);
+
+    const button = await screen.findByText('sleep.alwaysAwake.preset8h');
+    expect(screen.queryByText('sleep.alwaysAwake.clampPreview')).not.toBeInTheDocument();
+    await user.hover(button);
+    expect(await screen.findByText('sleep.alwaysAwake.clampPreview')).toBeInTheDocument();
+  });
+
+  it('explains an already-clamped active override after reload', async () => {
+    const occurrence = windowInHours(4, 6);
+    mockedConfig.mockResolvedValue(
+      baseConfig({ always_awake_enabled: true, always_awake_until: occurrence.start }),
+    );
+    mockedStatus.mockResolvedValue({
+      always_awake: { expires_in_seconds: 4 * 3600 },
+    } as never);
+    mockedOccurrences.mockResolvedValue([occurrence] as never);
+
+    render(<AlwaysAwakePanel />);
+
+    expect(await screen.findByText('sleep.alwaysAwake.clampActive')).toBeInTheDocument();
+  });
+
+  it('reports a currently running window instead of a clamp hint', async () => {
+    const start = new Date(Date.now() - 3600 * 1000);
+    const end = new Date(Date.now() + 3 * 3600 * 1000);
+    mockedConfig.mockResolvedValue(
+      baseConfig({ always_awake_enabled: true, always_awake_until: end.toISOString() }),
+    );
+    mockedStatus.mockResolvedValue({
+      always_awake: { expires_in_seconds: 3 * 3600 },
+    } as never);
+    mockedOccurrences.mockResolvedValue([
+      { window_id: 1, label: null, start: start.toISOString(), end: end.toISOString() },
+    ] as never);
+
+    render(<AlwaysAwakePanel />);
+
+    expect(await screen.findByText('sleep.alwaysAwake.coreUptimeRunning')).toBeInTheDocument();
+    expect(screen.queryByText('sleep.alwaysAwake.clampActive')).not.toBeInTheDocument();
+  });
+
+  it('does not request occurrences when core uptime is disabled', async () => {
+    mockedConfig.mockResolvedValue(baseConfig({ core_uptime_enabled: false }));
+    mockedOccurrences.mockResolvedValue([] as never);
+
+    render(<AlwaysAwakePanel />);
+
+    await screen.findByText('sleep.alwaysAwake.preset8h');
+    expect(mockedOccurrences).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 4: Test laufen lassen — er muss fehlschlagen**
+
+```bash
+cd client && npx vitest run src/__tests__/components/power/AlwaysAwakePanel.test.tsx
+```
+
+Erwartet: FAIL — `getCoreUptimeOccurrences` wird vom Panel noch nicht importiert, der ungekürzte Wert wird gesendet, die Hinweis-Keys existieren im DOM nicht.
+
+- [ ] **Step 5: Das Panel anpassen**
+
+In `client/src/components/power/AlwaysAwakePanel.tsx`:
+
+**5a — Importe erweitern** (Zeile 13-17):
+
+```tsx
+import {
+  getSleepConfig,
+  getSleepStatus,
+  updateSleepConfig,
+  getCoreUptimeOccurrences,
+  type CoreUptimeOccurrence,
+} from '../../api/sleep';
+import { clampToCoreUptime, findRunningOccurrence } from '../../lib/coreUptimeClamp';
+```
+
+**5b — State ergänzen** (neben den bestehenden `useState`-Zeilen):
+
+```tsx
+  const [occurrences, setOccurrences] = useState<CoreUptimeOccurrence[]>([]);
+  const [hoveredPreset, setHoveredPreset] = useState<Exclude<Preset, 'permanent' | 'custom'> | null>(null);
+```
+
+**5c — In `refresh()`** direkt nach `setCoreUptimeEnabled(cfg.core_uptime_enabled ?? false);` einfügen:
+
+```tsx
+      if (cfg.core_uptime_enabled) {
+        setOccurrences(await getCoreUptimeOccurrences(7));
+      } else {
+        setOccurrences([]);
+      }
+```
+
+**5d — `setPreset()`**: die Berechnung von `newUntil` (Zeile 159-162) ersetzen durch:
+
+```tsx
+    const rawUntil =
+      preset === 'permanent'
+        ? null
+        : new Date(Date.now() + PRESET_HOURS[preset] * 3600 * 1000).toISOString();
+    // Ein Ablauf innerhalb eines kuenftigen Kernbetriebszeit-Fensters wird auf
+    // dessen Beginn gekuerzt — dieselbe Regel wie im Backend. Der optimistische
+    // State muss den gekuerzten Wert tragen, sonst springt die Anzeige nach dem
+    // naechsten refresh() zurueck.
+    const newUntil = rawUntil ? clampToCoreUptime(rawUntil, occurrences).until : null;
+```
+
+und die Zeile `setExpiresIn(newUntil ? PRESET_HOURS[...] * 3600 : null);` ersetzen durch:
+
+```tsx
+    setExpiresIn(
+      newUntil ? Math.max(0, Math.floor((new Date(newUntil).getTime() - Date.now()) / 1000)) : null,
+    );
+```
+
+**5e — `setCustomPreset()`**: nach `const target = new Date(localValue);` die Zeile `const newUntil = target.toISOString();` ersetzen durch:
+
+```tsx
+    const newUntil = clampToCoreUptime(target.toISOString(), occurrences).until;
+```
+
+und `setExpiresIn(Math.floor(delta / 1000));` ersetzen durch:
+
+```tsx
+    setExpiresIn(Math.max(0, Math.floor((new Date(newUntil).getTime() - Date.now()) / 1000)));
+```
+
+Die Zeile `const delta = target.getTime() - Date.now();` wird dadurch verwaist und **muss gelöscht** werden — sonst schlägt `npx eslint .` mit `no-unused-vars` fehl (0-Error-Gate). Die Validierung rechnet ihr eigenes Delta in `computePickerError()`.
+
+**5f — Abgeleitete Werte** vor dem `if (loading)`-Block einfügen:
+
+```tsx
+  const runningOccurrence = findRunningOccurrence(occurrences);
+
+  const activeClamp =
+    until && !runningOccurrence
+      ? occurrences.find((o) => new Date(o.start).getTime() === new Date(until).getTime()) ?? null
+      : null;
+
+  const previewFor = (p: Exclude<Preset, 'permanent' | 'custom'>) =>
+    clampToCoreUptime(
+      new Date(Date.now() + PRESET_HOURS[p] * 3600 * 1000).toISOString(),
+      occurrences,
+    );
+
+  const hoveredClamp = hoveredPreset ? previewFor(hoveredPreset) : null;
+  const pickerClamp =
+    pickerOpen && pickerValue && !pickerError
+      ? clampToCoreUptime(new Date(pickerValue).toISOString(), occurrences)
+      : null;
+```
+
+**5g — Hinweise im aktiven Bereich**: den bestehenden Block
+
+```tsx
+          {(scheduleEnabled || coreUptimeEnabled) && until && (
+```
+
+so erweitern, dass die neuen Hinweise **davor** stehen und der bestehende Hinweis nur greift, wenn keiner der neuen zutrifft:
+
+```tsx
+          {runningOccurrence && (
+            <div className="rounded border border-emerald-500/20 bg-emerald-500/10 p-2 text-xs text-emerald-300">
+              {t('sleep.alwaysAwake.coreUptimeRunning', {
+                end: formatTime(runningOccurrence.end),
+              })}
+            </div>
+          )}
+          {activeClamp && (
+            <div className="rounded border border-amber-500/20 bg-amber-500/10 p-2 text-xs text-amber-300">
+              {t('sleep.alwaysAwake.clampActive', {
+                time: formatTime(activeClamp.start),
+                end: formatTime(activeClamp.end),
+              })}
+            </div>
+          )}
+          {(scheduleEnabled || coreUptimeEnabled) && until && !runningOccurrence && !activeClamp && (
+```
+
+Der `!until`-Zweig (`hintPermanentClearToResume`) bleibt unverändert.
+
+**5h — Preset-Buttons markieren**: im `.map()` über `['1h','4h','8h','permanent']` vor dem `return` ergänzen:
+
+```tsx
+          const clampPreview = p === 'permanent' ? null : previewFor(p).clampedTo;
+```
+
+und am `<button>` ergänzen:
+
+```tsx
+              title={clampPreview ? t('sleep.alwaysAwake.clampBadge') : undefined}
+              onMouseEnter={() => { if (p !== 'permanent') setHoveredPreset(p); }}
+              onMouseLeave={() => setHoveredPreset(null)}
+              onFocus={() => { if (p !== 'permanent') setHoveredPreset(p); }}
+              onBlur={() => setHoveredPreset(null)}
+```
+
+> **Wichtig:** die `if`-Form ist Pflicht. Mit `p !== 'permanent' && setHoveredPreset(p)` narrowt TypeScript `p` nicht auf `Exclude<Preset, 'permanent' | 'custom'>`, und `npm run build` (tsc -b) schlägt fehl.
+
+sowie im `className`-Ausdruck den Nicht-Aktiv-Zweig um den Marker erweitern — aus
+
+```tsx
+                  : 'bg-slate-800/40 text-slate-400 border border-slate-700/40 hover:text-amber-300 hover:border-amber-500/30'
+```
+
+wird
+
+```tsx
+                  : clampPreview
+                    ? 'bg-slate-800/40 text-slate-400 border border-dashed border-amber-500/40 hover:text-amber-300'
+                    : 'bg-slate-800/40 text-slate-400 border border-slate-700/40 hover:text-amber-300 hover:border-amber-500/30'
+```
+
+**5i — Vorschauzeile unter der Preset-Reihe**: direkt **nach** dem schließenden `</div>` des `flex flex-wrap gap-2 pt-1`-Containers einfügen:
+
+```tsx
+      {hoveredClamp?.clampedTo && (
+        <p className="text-[11px] text-amber-300">
+          {t('sleep.alwaysAwake.clampPreview', {
+            time: formatTime(hoveredClamp.until),
+            end: formatTime(hoveredClamp.clampedTo.end),
+          })}
+        </p>
+      )}
+```
+
+**5j — Vorschau im Picker**: im Popover nach dem `{pickerError && ...}`-Block einfügen:
+
+```tsx
+              {pickerClamp?.clampedTo && (
+                <p className="text-[11px] text-amber-300">
+                  {t('sleep.alwaysAwake.clampPreview', {
+                    time: formatTime(pickerClamp.until),
+                    end: formatTime(pickerClamp.clampedTo.end),
+                  })}
+                </p>
+              )}
+```
+
+- [ ] **Step 6: Test laufen lassen — er muss bestehen**
+
+```bash
+cd client && npx vitest run src/__tests__/components/power/AlwaysAwakePanel.test.tsx
+```
+
+Erwartet: alle 6 Tests PASS.
+
+- [ ] **Step 7: Frontend-Gates**
+
+```bash
+cd client && npx eslint . ; if ($?) { npm run build }
+```
+
+Erwartet: eslint mit 0 Fehlern (das CI-Gate ist 0-Error), `npm run build` (tsc -b über app/node/TEST-Projekte + Vite-Build) ohne Fehler.
+
+- [ ] **Step 8: Volle Frontend-Suite als Regression**
+
+```bash
+cd client && npx vitest run
+```
+
+Erwartet: alle PASS — insbesondere `AlwaysAwakePill.test.tsx` und `SleepConfigPanel.test.tsx`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add client/src/components/power/AlwaysAwakePanel.tsx client/src/i18n/locales/de/system.json client/src/i18n/locales/en/system.json client/src/__tests__/components/power/AlwaysAwakePanel.test.tsx
+git commit -m "feat(sleep): UI-Hinweise fuer die Kernbetriebszeit-Kuerzung von Always-Awake"
+```
+
+---
+
+## Abschluss
+
+- [ ] **Backend-Regression über die betroffenen Suiten**
+
+```bash
+cd backend && python -m pytest tests/services/test_core_uptime_helpers.py tests/services/test_core_uptime_inhibitor.py tests/services/test_core_uptime_rtc_guard.py tests/services/test_sleep_always_awake.py tests/services/test_sleep_core_uptime_integration.py tests/api/test_core_uptime_routes.py tests/api/test_sleep_always_awake_routes.py tests/test_sleep.py tests/test_sleep_schemas.py -q
+```
+
+Erwartet: alle PASS.
+
+> Die **vollständige** Backend-Suite unter Windows ist bekanntermaßen unzuverlässig (Isolations-Flakes in Permission-Tests, `os_sleep_inspector`-Subprozess-Tests). Sie gehört in die CI, nicht in diesen Durchlauf.
+
+- [ ] **Doku-Abgleich**
+
+Prüfen, ob `docs/` eine Beschreibung des Always-Awake-Verhaltens enthält, die die Kürzungsregel erwähnen sollte. `grep`/`rg` sind in diesem Repo per Hook gesperrt — stattdessen PowerShell:
+
+```powershell
+Get-ChildItem "D:\Programme (x86)\Baluhost\docs" -Recurse -Include *.md |
+  Where-Object { $_.FullName -notmatch "superpowers" } |
+  Select-String -Pattern "always.awake|immer wach" |
+  Select-Object -ExpandProperty Path -Unique
+```
+
+Falls Treffer: die Kürzungsregel dort in zwei Sätzen ergänzen und mitcommitten. Falls keine Treffer: nichts tun.
+
+- [ ] **CHANGELOG**
+
+Nicht anfassen. Der `## [Unreleased]`-Abschnitt wird beim Release-Prepare hand-kuratiert (siehe `.claude/rules/production.md`).

--- a/docs/superpowers/specs/2026-08-03-always-awake-core-uptime-clamp-design.md
+++ b/docs/superpowers/specs/2026-08-03-always-awake-core-uptime-clamp-design.md
@@ -105,9 +105,20 @@ def expand_occurrences(
 In `update_config()` (Zeile 1339 ff.), nachdem `always_awake_until` gesetzt und
 bevor `db.commit()` aufgerufen wird:
 
-1. Nur aktiv, wenn `config.always_awake_until is not None` **und** der nach dem
-   Update gültige `config.core_uptime_enabled` wahr ist (der Wert kann im selben
-   Request mitgeändert worden sein — deshalb erst nach dem Anwenden prüfen).
+1. Nur aktiv, wenn der Request den Override überhaupt angefasst hat
+   (`"always_awake_until" in update_data` — **vor** dem `pop` erfasst — oder
+   `always_awake_enabled is True`), **und** `config.always_awake_until is not None`,
+   **und** der nach dem Update gültige `config.core_uptime_enabled` wahr ist (der
+   Wert kann im selben Request mitgeändert worden sein — deshalb erst nach dem
+   Anwenden prüfen).
+
+   Ohne das erste Kriterium würde jeder `PUT /config` einen laufenden Override
+   neu bewerten — auch einer, der nur `idle_timeout_minutes` ändert. Das
+   widerspräche dem Non-Goal weiter unten und bliebe unauditiert, weil der
+   Audit-Eintrag nur bei Always-Awake-Feldern im Payload feuert. Bewusste
+   Konsequenz: ein Request, der **ausschließlich** `core_uptime_enabled: true`
+   setzt, kürzt einen bereits gesetzten Override nicht mehr — funktional
+   folgenlos, weil die Kernbetriebszeit in diesem Intervall ohnehin wach hält.
 2. Fenster in derselben Session laden:
    `db.query(CoreUptimeWindowModel).filter(CoreUptimeWindowModel.enabled.is_(True))`
    — `.is_(True)` statt `== True`, damit ein Ruff-E712-Autofix die Query nicht
@@ -128,8 +139,10 @@ if start_local is not None and start_local > now_local:
 Rückkonvertierung ist damit korrekt und braucht keine externe TZ-Bibliothek.
 
 4. Die Kürzung sitzt bewusst im Service, nicht im Route-Handler: sie greift
-   damit für jeden Schreibpfad, auch für direkte API-Aufrufe außerhalb der
-   Web-UI.
+   damit auf jedem Schreibpfad, der den Override setzt — auch bei direkten
+   API-Aufrufen außerhalb der Web-UI. Genau deshalb muss der Client den
+   **ungekürzten** Wunschwert senden (siehe Frontend-Abschnitt): das Backend
+   ist die einzige Instanz, die kürzt, und es kürzt genau einmal.
 
 Der bestehende Audit-Log-Eintrag `always_awake_toggled` in
 `backend/app/api/routes/sleep.py` protokolliert bereits das Ergebnis-`until` aus
@@ -195,8 +208,17 @@ export function clampToCoreUptime(
 ```
 
 Reiner Intervallvergleich — dieselbe Semantik wie im Backend, ohne dessen
-Wochentags- und Mitternachtslogik nachzubauen:
-Treffer ist die erste Occurrence mit `start > now && until >= start && until < end`.
+Wochentags- und Mitternachtslogik nachzubauen. Zwingend **zweistufig**, exakt wie
+`window_start_containing` + `clamp_to_core_uptime_start`:
+
+1. den **frühesten** `start` über **alle** Occurrences mit
+   `until >= start && until < end` bestimmen — ohne Vorfilter auf die Zukunft,
+2. erst danach das einzige Zukunfts-Gate anlegen: liegt dieser früheste Start
+   `<= now`, wird **nicht** gekürzt.
+
+Ein Vorfilter `start > now` **vor** dem Minimum wäre falsch: bei einem laufenden
+Fenster, das ein künftiges überlappt, würde das Frontend kürzen, wo das Backend
+nicht kürzt.
 
 Zweite, ebenso reine Funktion für den Sonderfall „läuft gerade":
 `findRunningOccurrence(occurrences, now)` → erste mit `start <= now < end`.
@@ -220,9 +242,23 @@ Zweite, ebenso reine Funktion für den Sonderfall „läuft gerade":
 - **Läuft gerade:** liefert `findRunningOccurrence` einen Treffer, ersetzt dessen
   Hinweis den Kürzungshinweis („Kernbetriebszeit läuft bis 23:30 — bis dahin
   bleibt das System ohnehin wach").
-- **Optimistisches Update:** `setPreset()` und `setCustomPreset()` müssen den
-  **gekürzten** Wert in `setUntil`/`setExpiresIn` schreiben und senden, sonst
-  springt die Anzeige nach dem nächsten `refresh()` sichtbar zurück.
+- **Optimistisches Update — gekürzt anzeigen, ungekürzt senden:**
+  `setPreset()` und `setCustomPreset()` schreiben den **gekürzten** Wert in
+  `setUntil`/`setExpiresIn` (sonst springt die Anzeige nach dem nächsten
+  `refresh()` sichtbar zurück), senden aber den **ungekürzten** Wunschwert an
+  `updateSleepConfig`.
+
+  Der Grund ist die Nicht-Idempotenz der Kürzung: bei gestaffelt überlappenden
+  Fenstern (A 19:00–21:00, B 20:00–23:00, jetzt 15:00, Wunsch 22:00) ergibt eine
+  Kürzung 20:00, eine zweite auf dieses Ergebnis aber 19:00 — weil 20:00 in A
+  liegt. Sendete der Client den bereits gekürzten Wert, kürzte das Backend
+  erneut, und die Anzeige verspräche 20:00, während die Datenbank 19:00 hielte.
+  Sendet der Client den Rohwert, kürzt genau eine Instanz genau einmal, und
+  Vorschau und gespeicherter Wert sind identisch.
+
+  Zweiter Effekt: eine veraltete Occurrence-Liste (Fenster in einem anderen Tab
+  gelöscht, seit dem letzten `refresh()`) kann den Override nicht mehr
+  eigenmächtig verkürzen — das Backend bleibt die einzige Autorität.
 - Die Preset-Erkennung in `refresh()` (Toleranz ±5 min gegen 1h/4h/8h) ordnet
   einen gekürzten Wert korrekterweise `custom` zu — gewolltes Verhalten, keine
   Anpassung nötig.
@@ -263,9 +299,15 @@ Verhaltenstabelle, plus:
 
 **Vitest:**
 - `clampToCoreUptime` / `findRunningOccurrence` als reine Funktionen entlang
-  derselben Tabelle
-- Panel: Kürzungshinweis erscheint, und `updateSleepConfig` wird mit dem
-  gekürzten Wert aufgerufen
+  derselben Tabelle, plus die gestaffelte Überlappung (A 19–21, B 20–23,
+  Wunsch 22:00), die die Nicht-Idempotenz dokumentiert
+- Panel: Kürzungshinweis erscheint; `updateSleepConfig` wird mit dem
+  **ungekürzten** Wert aufgerufen, während die Anzeige den **gekürzten** zeigt —
+  beides in einem Test, damit keine der beiden Hälften stillschweigend wegfallen
+  kann
+- Panel: laufendes Fenster unterdrückt den Kürzungshinweis, auch wenn
+  `until` exakt auf dem Fensterbeginn liegt (sonst prüft der Test die
+  Vorrangregel nicht)
 
 ## Nicht Teil dieser Änderung
 

--- a/docs/superpowers/specs/2026-08-03-always-awake-core-uptime-clamp-design.md
+++ b/docs/superpowers/specs/2026-08-03-always-awake-core-uptime-clamp-design.md
@@ -51,9 +51,11 @@ Fenster 19:00–23:30, aktueller Zeitpunkt 15:00, Kernbetriebszeit-Hauptschalter
 
 Weitere Festlegungen:
 
-- **Mehrere Fenster:** es zählt das Fenster, das den Zeitpunkt enthält —
-  erste Übereinstimmung in ID-Reihenfolge, konsistent zu `is_in_core_uptime`
-  („first-match wins on overlap").
+- **Mehrere Fenster:** es zählt das Fenster, das den Zeitpunkt enthält.
+  Enthalten ihn mehrere (überlappende Fenster), gewinnt der **früheste Start** —
+  bewusst nicht der erste Treffer wie bei `is_in_core_uptime`. Nur so hängt das
+  Ergebnis nicht von der Listenreihenfolge ab, und die Frontend-Vorschau, die
+  über aufgelöste Termine rechnet, kommt garantiert auf denselben Wert.
 - **Laufendes Fenster:** wird nie gekürzt, weil sein Beginn in der Vergangenheit
   liegt. Die Bedingung `start > now` deckt das ohne Sonderfall ab.
 - **Kurze Restdauer:** die Kürzung darf beliebig kurze Restlaufzeiten erzeugen

--- a/docs/superpowers/specs/2026-08-03-always-awake-core-uptime-clamp-design.md
+++ b/docs/superpowers/specs/2026-08-03-always-awake-core-uptime-clamp-design.md
@@ -1,0 +1,273 @@
+# Always-Awake an Kernbetriebszeit-Fenstern kürzen
+
+**Datum:** 2026-08-03
+**Status:** Design freigegeben, Umsetzung ausstehend
+**Betrifft:** `always_awake` (Spec 2026-05-07), Kernbetriebszeit (Spec 2026-05-01)
+
+---
+
+## Problem
+
+Always-Awake wird mit einer Dauer gesetzt (1h / 4h / 8h / Custom bis 7 Tage) und
+läuft dann bis zum errechneten Zeitpunkt. Die Kernbetriebszeit-Fenster
+(`core_uptime_windows`) bleiben dabei unberücksichtigt.
+
+Fällt der Ablaufzeitpunkt **in** ein künftiges Kernbetriebszeit-Fenster, ist der
+Rest des Overrides wirkungslos: ab dem Fensterbeginn hält die Kernbetriebszeit
+das System ohnehin wach. Der Override läuft trotzdem weiter, überlagert die
+reguläre Steuerung länger als nötig und verschleiert in der UI, wer das System
+gerade wach hält.
+
+Beispiel: Fenster 19:00–23:30, es ist 15:00, Nutzer wählt „8h" → 23:00. Zwischen
+19:00 und 23:00 ändert der Override nichts am Verhalten — er ist reine
+Redundanz mit unklarer Zuständigkeit.
+
+## Lösung
+
+Beim Setzen von `always_awake_until` wird der Zeitpunkt auf den **Beginn** des
+Kernbetriebszeit-Fensters gekürzt, in dem er liegt — sofern dieser Beginn noch
+in der Zukunft liegt. Ab da übernimmt die Kernbetriebszeit; der manuelle
+Override schließt sauber ab. Reicht der Zeitpunkt über das Fensterende hinaus,
+bleibt er unverändert: dann wird der Override nach dem Fenster noch gebraucht.
+
+Der gekürzte Wert wird persistiert. Damit ist der gespeicherte Wert die
+Wahrheit — Countdown, Status-Endpoint und Topbar-Pill funktionieren
+unverändert, ohne dass irgendein Consumer eine effektive Zeit nachrechnen muss.
+
+### Verhaltenstabelle
+
+Fenster 19:00–23:30, aktueller Zeitpunkt 15:00, Kernbetriebszeit-Hauptschalter an:
+
+| Situation | Gewählter Ablauf | Gespeichert | UI-Hinweis |
+|---|---|---|---|
+| Ablauf vor dem Fenster | 17:00 | 17:00 | — |
+| Ablauf **im** Fenster | 21:00 | **19:00** | Kürzungshinweis |
+| Ablauf hinter dem Fensterende | 01:00 | 01:00 | — |
+| Ablauf exakt auf Fensterbeginn | 19:00 | 19:00 | Kürzungshinweis (Wortlaut identisch — das Ergebnis ist dasselbe) |
+| Fenster läuft bereits (jetzt 20:00) | 21:00 | 21:00 | „Kernbetriebszeit läuft bis 23:30" |
+| „Dauerhaft" (kein Ablauf) | `NULL` | `NULL` | bestehender `hintPermanentClearToResume` |
+| Hauptschalter `core_uptime_enabled` aus | 21:00 | 21:00 | — |
+| Keine oder nur deaktivierte Fenster | 21:00 | 21:00 | — |
+
+Weitere Festlegungen:
+
+- **Mehrere Fenster:** es zählt das Fenster, das den Zeitpunkt enthält —
+  erste Übereinstimmung in ID-Reihenfolge, konsistent zu `is_in_core_uptime`
+  („first-match wins on overlap").
+- **Laufendes Fenster:** wird nie gekürzt, weil sein Beginn in der Vergangenheit
+  liegt. Die Bedingung `start > now` deckt das ohne Sonderfall ab.
+- **Kurze Restdauer:** die Kürzung darf beliebig kurze Restlaufzeiten erzeugen
+  (18:57 + „1h" → 3 Minuten). Bewusst zugelassen; die UI kündigt es vorher an.
+  Der 5-Minuten-Mindestabstand des Custom-Pickers gilt für die **Eingabe**, nicht
+  für das Kürzungsergebnis.
+- **Nachträgliche Fensteränderung:** ein bereits gesetzter Override wird nicht
+  neu bewertet, wenn danach Fenster geändert werden. Bewusste Vereinfachung —
+  die Alternative (dynamische Auswertung) lässt Anzeige und Wirkung
+  auseinanderlaufen.
+- **Kein Einfluss auf den Sleep-Zeitplan** (`schedule_sleep_time` /
+  `schedule_wake_time`). Der bleibt unangetastet.
+
+## Backend
+
+### Neue reine Helper — `backend/app/services/power/core_uptime.py`
+
+Die Datei ist bereits die Heimat der Fensterlogik (lokal-naive Zeiten,
+`start` inklusiv, `end` exklusiv, Mitternachtsüberlauf). Drei Ergänzungen:
+
+```python
+def current_window_start(now: datetime, w) -> datetime:
+    """Beginn des aktuell aktiven Fensters. Gegenstück zu current_window_end.
+       Caller stellt sicher, dass `now` tatsächlich in `w` liegt."""
+
+def window_start_containing(dt: datetime, windows: Sequence) -> Optional[datetime]:
+    """Beginn des Fensters, das `dt` enthält — sonst None."""
+
+def expand_occurrences(
+    now: datetime, windows: Sequence, days: int = 7,
+) -> list[tuple[datetime, datetime]]:
+    """Konkrete (start, end)-Paare aller aktivierten Fenster im Horizont."""
+```
+
+- `current_window_start` spiegelt `current_window_end` (Zeile 95 ff.): bei
+  Mitternachtsüberlauf und `now >= start_today` ist der Beginn heute, sonst
+  gestern.
+- `window_start_containing` baut auf `is_in_core_uptime`/`_window_active_at` auf,
+  erbt damit Wochentags- und Mitternachtssemantik ohne Duplikat.
+- `expand_occurrences` iteriert `day_offset` von **-1** bis `days` (das `-1`
+  fängt ein über Mitternacht laufendes Fenster von gestern ein), erzeugt je
+  Treffer `start` und `end` (`end` +1 Tag bei Mitternachtsüberlauf), verwirft
+  Vorkommen mit `end <= now` und sortiert nach `start`.
+
+### Kürzung — `backend/app/services/power/sleep.py`
+
+In `update_config()` (Zeile 1339 ff.), nachdem `always_awake_until` gesetzt und
+bevor `db.commit()` aufgerufen wird:
+
+1. Nur aktiv, wenn `config.always_awake_until is not None` **und** der nach dem
+   Update gültige `config.core_uptime_enabled` wahr ist (der Wert kann im selben
+   Request mitgeändert worden sein — deshalb erst nach dem Anwenden prüfen).
+2. Fenster in derselben Session laden:
+   `db.query(CoreUptimeWindowModel).filter(CoreUptimeWindowModel.enabled.is_(True))`
+   — `.is_(True)` statt `== True`, damit ein Ruff-E712-Autofix die Query nicht
+   zerlegt (bekannte Landmine in diesem Repo: E711/E712-Fixes brechen
+   SQLAlchemy-Filter).
+3. Zeitzonengrenze — der einzige heikle Punkt: `always_awake_until` ist
+   **UTC-aware**, die Fensterlogik durchgängig **lokal-naiv**.
+
+```python
+until_local = config.always_awake_until.astimezone().replace(tzinfo=None)
+now_local = datetime.now()
+start_local = core_uptime_helpers.window_start_containing(until_local, windows)
+if start_local is not None and start_local > now_local:
+    config.always_awake_until = start_local.astimezone(timezone.utc)
+```
+
+`datetime.astimezone()` interpretiert einen naiven Wert als lokale Zeit — die
+Rückkonvertierung ist damit korrekt und braucht keine externe TZ-Bibliothek.
+
+4. Die Kürzung sitzt bewusst im Service, nicht im Route-Handler: sie greift
+   damit für jeden Schreibpfad, auch für direkte API-Aufrufe außerhalb der
+   Web-UI.
+
+Der bestehende Audit-Log-Eintrag `always_awake_toggled` in
+`backend/app/api/routes/sleep.py` protokolliert bereits das Ergebnis-`until` aus
+der Service-Antwort und zeichnet den gekürzten Wert damit automatisch auf. Keine
+Änderung nötig.
+
+Der Ablauf-Aufräumpfad in `_schedule_check_loop` (Zeile 552 ff.) bleibt
+unverändert: er sieht schlicht ein früheres `until` und räumt entsprechend
+früher auf.
+
+### Kein Schema- oder Migrations-Bedarf
+
+`SleepConfig`, `AlwaysAwakeStatus` und `SleepConfigResponse` bleiben unverändert.
+Der ursprünglich gewünschte Zeitpunkt wird **nicht** gespeichert — der
+Kürzungshinweis in der UI wird stattdessen aus „`until` fällt exakt auf einen
+Fensterbeginn" abgeleitet (siehe Frontend). Damit entfällt eine Alembic-Migration
+vollständig.
+
+## API
+
+Ein neuer Endpoint neben den bestehenden Kernbetriebszeit-Routen in
+`backend/app/api/routes/sleep.py`, exakt nach deren Muster
+(`Depends(get_current_admin)` + `@user_limiter.limit(get_limit("admin_operations"))`):
+
+```
+GET /api/system/sleep/core-uptime/occurrences?days=7
+→ 200 list[CoreUptimeOccurrence]
+```
+
+```python
+class CoreUptimeOccurrence(BaseModel):
+    window_id: int
+    label: Optional[str] = None
+    start: datetime   # absolut, UTC-aware
+    end: datetime     # absolut, UTC-aware
+```
+
+- `days`: `Query(7, ge=1, le=7)` — deckt exakt den 7-Tage-Cap des Custom-Pickers ab.
+- Der Server rechnet lokal (`expand_occurrences`) und liefert UTC-aware
+  Zeitstempel aus, damit das Frontend sie direkt mit `always_awake_until`
+  vergleichen kann.
+- Liefert `[]`, wenn keine aktivierten Fenster existieren. Der
+  Hauptschalter `core_uptime_enabled` filtert **nicht** — das entscheidet der
+  Aufrufer; so bleibt der Endpoint für andere Consumer brauchbar.
+
+## Frontend
+
+### API-Client
+
+`client/src/api/sleep.ts`: `getCoreUptimeOccurrences(days = 7)` plus
+`CoreUptimeOccurrence`-Typ, analog zu den bestehenden Fenster-Funktionen.
+
+### Reiner Helper
+
+Neu, als eigene Datei mit eigenem Vitest-Test (keine Logik im Panel):
+
+```ts
+export function clampToCoreUptime(
+  untilIso: string,
+  occurrences: CoreUptimeOccurrence[],
+  now = new Date(),
+): { until: string; clampedTo: CoreUptimeOccurrence | null }
+```
+
+Reiner Intervallvergleich — dieselbe Semantik wie im Backend, ohne dessen
+Wochentags- und Mitternachtslogik nachzubauen:
+Treffer ist die erste Occurrence mit `start > now && until >= start && until < end`.
+
+Zweite, ebenso reine Funktion für den Sonderfall „läuft gerade":
+`findRunningOccurrence(occurrences, now)` → erste mit `start <= now < end`.
+
+### `AlwaysAwakePanel.tsx`
+
+- `refresh()` lädt die Occurrences zusätzlich, aber nur wenn
+  `cfg.core_uptime_enabled` — sonst leeres Array, alle Hinweise entfallen.
+- **Vorher-Hinweis, Touch-tauglich:** Preset-Buttons, deren Wert gekürzt würde,
+  bekommen einen dezenten Marker (Icon + abweichende Randfarbe) sowie ein
+  `title`-Attribut. Zusätzlich erscheint unter der Preset-Reihe eine Detailzeile
+  für den gerade gehoverten **oder fokussierten** Button (Maus und Tastatur).
+  Auf reinen Touch-Geräten trägt der Marker die Information; die Detailzeile ist
+  Ergänzung, nicht Voraussetzung.
+- **Custom-Picker:** derselbe Hinweis live bei jeder Änderung des
+  `datetime-local`-Werts, neben der bestehenden Validierung. Die Kürzung ist
+  **kein** Fehler — der Apply-Button bleibt aktiv.
+- **Nachher-Hinweis:** im aktiven Bereich, abgeleitet aus
+  `occurrences.some(o => o.start === until)`. Überlebt damit den Reload, ohne den
+  ursprünglich gewünschten Zeitpunkt zu persistieren.
+- **Läuft gerade:** liefert `findRunningOccurrence` einen Treffer, ersetzt dessen
+  Hinweis den Kürzungshinweis („Kernbetriebszeit läuft bis 23:30 — bis dahin
+  bleibt das System ohnehin wach").
+- **Optimistisches Update:** `setPreset()` und `setCustomPreset()` müssen den
+  **gekürzten** Wert in `setUntil`/`setExpiresIn` schreiben und senden, sonst
+  springt die Anzeige nach dem nächsten `refresh()` sichtbar zurück.
+- Die Preset-Erkennung in `refresh()` (Toleranz ±5 min gegen 1h/4h/8h) ordnet
+  einen gekürzten Wert korrekterweise `custom` zu — gewolltes Verhalten, keine
+  Anpassung nötig.
+
+`AlwaysAwakePill.tsx` (Topbar) zeigt den gespeicherten Wert und damit automatisch
+den gekürzten — dort ist nichts zu ändern.
+
+### i18n
+
+Neue Keys unter `sleep.alwaysAwake` in `client/src/i18n/locales/{de,en}/system.json`:
+
+| Key | DE |
+|---|---|
+| `clampPreview` | „Wird auf {{time}} gekürzt — ab dann übernimmt die Kernbetriebszeit (wach bis {{end}})." |
+| `clampActive` | „Endet um {{time}} mit dem Beginn der Kernbetriebszeit (wach bis {{end}})." |
+| `clampBadge` | „Wird gekürzt" (title/aria am Preset-Button) |
+| `coreUptimeRunning` | „Kernbetriebszeit läuft bis {{end}} — bis dahin bleibt das System ohnehin wach." |
+
+EN-Block parallel dazu.
+
+## Tests
+
+**pytest — Helper (`backend/tests/`, rein, ohne DB):**
+- `current_window_start`: normales Fenster; Mitternachtsüberlauf in der späten
+  Hälfte (Beginn heute) und in der frühen Hälfte (Beginn gestern)
+- `window_start_containing`: Treffer, kein Treffer, deaktiviertes Fenster wird
+  ignoriert, leere Liste
+- `expand_occurrences`: Wochentagsfilter, Mitternachtsüberlauf, laufendes
+  Fenster von gestern erscheint, abgelaufene Vorkommen fehlen, Sortierung,
+  `days`-Horizont
+
+**pytest — Kürzung in `update_config`:** je ein Fall pro Zeile der
+Verhaltenstabelle, plus:
+- UTC↔lokal-Grenze: gekürzter Wert kommt UTC-aware zurück und entspricht dem
+  lokalen Fensterbeginn
+- `core_uptime_enabled` wird im selben Request eingeschaltet → Kürzung greift
+- `always_awake_enabled: false` → `until` wird geleert, keine Kürzung
+
+**Vitest:**
+- `clampToCoreUptime` / `findRunningOccurrence` als reine Funktionen entlang
+  derselben Tabelle
+- Panel: Kürzungshinweis erscheint, und `updateSleepConfig` wird mit dem
+  gekürzten Wert aufgerufen
+
+## Nicht Teil dieser Änderung
+
+- Der Sleep-Zeitplan (`schedule_sleep_time`/`schedule_wake_time`) bleibt
+  unberührt — die Kürzung gilt ausschließlich für Kernbetriebszeit-Fenster.
+- Kein Neubewerten bereits gesetzter Overrides beim Ändern von Fenstern.
+- Kein Speichern des ursprünglich gewünschten Zeitpunkts (keine Migration).


### PR DESCRIPTION
## Was sich ändert

Always-Awake und Kernbetriebszeit wissen jetzt voneinander. Fällt der gewählte Ablaufzeitpunkt **in** ein künftiges Kernbetriebszeit-Fenster, wird er beim Speichern auf dessen **Beginn** gekürzt — ab da hält die Kernbetriebszeit das System ohnehin wach, der manuelle Override schließt sauber ab. Reicht der Zeitpunkt über das **Fensterende hinaus**, bleibt er unverändert: dann wird der Override danach noch gebraucht.

Fenster 19:00–23:30, aktuell 15:00:

| Gewählter Ablauf | Gespeichert | UI |
|---|---|---|
| 17:00 (vor dem Fenster) | 17:00 | — |
| 21:00 (**im** Fenster) | **19:00** | Kürzungshinweis vorher + nachher |
| 01:00 (hinter dem Ende) | 01:00 | — |
| 21:00, Fenster läuft schon | 21:00 | „Kernbetriebszeit läuft bis 23:30" |
| „Dauerhaft" | unverändert | bestehender Hinweis |
| Kernbetriebszeit-Hauptschalter aus | unverändert | — |

Bei überlappenden Fenstern gewinnt der **früheste** Start — bewusst nicht der erste Treffer, damit das Ergebnis nicht von der Listenreihenfolge abhängt und Vorschau und gespeicherter Wert garantiert übereinstimmen.

## Umsetzung

**Backend**
- `services/power/core_uptime.py`: vier reine Helfer — `current_window_start`, `window_start_containing`, `clamp_to_core_uptime_start`, `expand_occurrences` (+ `Occurrence`). Die gesamte Zeitlogik bleibt hier; `sleep.py` bekommt nur den Aufruf.
- `services/power/sleep.py`: Kürzung in `update_config()`, gegated auf „dieser Request hat den Override angefasst" — sonst würde ein `PUT /config`, das nur den Idle-Timeout ändert, einen laufenden Override still und unauditiert neu bewerten.
- `GET /api/system/sleep/core-uptime/occurrences?days=1..7`: löst die Fenster in absolute UTC-Zeitstempel auf. Admin-only, gleiche Rate-Limit-Konvention wie die bestehenden `/core-uptime/*`-Routen.
- **Keine Alembic-Migration, keine Schemaänderung.** Der „wurde gekürzt"-Zustand wird abgeleitet (`until === Fensterbeginn`), nicht persistiert.

**Frontend**
- `lib/coreUptimeClamp.ts`: reiner Intervallvergleich auf den aufgelösten Terminen — keine Wochentags- oder Mitternachtslogik in TypeScript nachgebaut.
- `AlwaysAwakePanel.tsx`: Marker an betroffenen Preset-Buttons (touch-tauglich), Detailzeile bei Hover **und** Tastaturfokus, Live-Hinweis im Custom-Picker, Nachher-Hinweis reload-fest. Ein laufendes Fenster hat Vorrang vor dem Kürzungshinweis. Der Occurrences-Abruf hat einen eigenen `try`/`catch` — ein Zusatz-Hinweis darf das Laden des Panels nicht abreißen.
- i18n DE + EN, vier neue Keys.

## Der Bug, den der Review gefunden hat

Die Kürzung ist **nicht idempotent**. Ursprünglich sendete das Frontend den bereits gekürzten Wert, das Backend kürzte ihn erneut. Bei gestaffelt überlappenden Fenstern (A 19:00–21:00, B 20:00–23:00, jetzt 15:00, Wunsch 22:00) versprach die UI 20:00 und die Datenbank hielt 19:00 — weil 20:00 in A liegt.

Jetzt sendet der Client den **Rohwert** und zeigt nur die Vorschau gekürzt an. Genau eine Instanz kürzt, genau einmal. Nebeneffekt: eine veraltete Terminliste (Fenster in einem anderen Tab gelöscht) kann den Override nicht mehr eigenmächtig verkürzen.

## Tests

- **Backend:** 208 Tests in den Sleep-Suiten grün. Die Helfer sind rein und einzeln getestet (Mitternachtsüberlauf in beiden Hälften, Wochentagsgrenzen, Überlappung, Horizont); `update_config` deckt jede Zeile der Tabelle oben ab, inklusive UTC↔lokal-Grenze und „Request fasst den Override nicht an".
- **Frontend:** volle Vitest-Suite grün (1250 Tests), darunter die gestaffelte Überlappung, „sendet roh, zeigt gekürzt", der Tastaturfokus-Pfad und die Vorrangregel bei laufendem Fenster.
- ESLint 0 Fehler (Warnungszahl unverändert), `npm run build` sauber.

Alle Zeitszenarien sind auf einen **lokalen** Anker gebaut und nur dort nach UTC konvertiert, wo die API es verlangt — drei Fix-Runden gingen dafür drauf, dass Tests sonst nur auf der Zeitzone des Autors oder nur für ein paar Tage grün sind.

## Nicht Teil dieser Änderung

- Der Sleep-Zeitplan (`schedule_sleep_time`/`schedule_wake_time`) bleibt unberührt.
- Bereits gesetzte Overrides werden nicht neu bewertet, wenn danach Fenster geändert werden.
- Der ursprünglich gewünschte Zeitpunkt wird nicht gespeichert (spart die Migration).

Design: `docs/superpowers/specs/2026-08-03-always-awake-core-uptime-clamp-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmAoV5o4F1aNLZfJ8RWTnF
