### PR TITLE
fix(plugins): Plugin-Runtime ohne process.env bauen — UI-Panels blieben leer

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
-    "build:runtime": "vite build --config vite.runtime.config.ts",
+    "build:runtime": "vite build --config vite.runtime.config.ts && node scripts/assert-runtime-bundle.mjs",
     "prebuild": "npm run build:runtime",
     "build": "tsc -b && vite build",
     "build:pi": "tsc -b && vite build --mode pi",

--- a/client/scripts/assert-runtime-bundle.mjs
+++ b/client/scripts/assert-runtime-bundle.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Fail the build when the plugin runtime bundle still reads `process.env`.
+ *
+ * Vite's library mode deliberately leaves `process.env.NODE_ENV` in place (an
+ * app build replaces it) so the consumer can decide. React reads it to pick its
+ * dev or prod branch, and the very first read happens during module init — so
+ * without the `define` in vite.runtime.config.ts the shipped IIFE throws
+ * "ReferenceError: process is not defined" before a single plugin bundle is
+ * loaded, and every plugin UI renders blank.
+ *
+ * The bundle is gitignored and rebuilt on every deploy (`prebuild` →
+ * `build:runtime`), so a regression here would ship silently and only show up
+ * as an empty page in the browser. This check turns that into a failed build.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const bundlePath = resolve(here, '..', 'public', 'plugin-runtime.js');
+
+const source = readFileSync(bundlePath, 'utf8');
+const hits = source.match(/process\.env/g) ?? [];
+
+if (hits.length > 0) {
+  console.error(
+    `plugin-runtime.js contains ${hits.length} unreplaced \`process.env\` reference(s).\n` +
+      'The browser has no `process`, so the runtime throws on load and every plugin UI stays blank.\n' +
+      "Fix: keep `define: { 'process.env.NODE_ENV': JSON.stringify('production') }` " +
+      'in client/vite.runtime.config.ts.',
+  );
+  process.exit(1);
+}
+
+console.log('plugin-runtime.js: no process.env references');

--- a/client/vite.runtime.config.ts
+++ b/client/vite.runtime.config.ts
@@ -4,6 +4,10 @@ import { defineConfig } from 'vite';
 // serves it at `/plugin-runtime.js` in BOTH dev (public is served at root) and
 // prod (public is copied into dist). host.html references it absolutely.
 export default defineConfig({
+  // Library mode does not replace `process.env.NODE_ENV` the way an app build
+  // does, and React reads it during module init. Without this the IIFE throws
+  // "process is not defined" in the browser and every plugin UI stays blank.
+  define: { 'process.env.NODE_ENV': JSON.stringify('production') },
   build: {
     emptyOutDir: false,
     outDir: 'public',


### PR DESCRIPTION
Jede Plugin-Seite mit iframe-UI rendert leer — aufgefallen beim Öffnen von **Balu Code**, betroffen ist aber der Host, nicht ein einzelnes Plugin.

```
Uncaught ReferenceError: process is not defined
    mp  https://baluhost.local/plugin-runtime.js:23
```

## Ursache

`client/vite.runtime.config.ts` baut die Runtime im **Library-Modus**. Vite ersetzt `process.env.NODE_ENV` dort bewusst nicht — bei einem App-Build tut es das, bei einem lib-Build bleibt die Entscheidung beim Konsumenten. React liest den Wert aber, um zwischen Dev- und Prod-Zweig zu wählen, und der erste Zugriff steht im Modul-Init (`var bn=mp()`, Zeile 23 des Bundles). Das IIFE stirbt damit, **bevor** ein Plugin-Bundle überhaupt geladen wird.

Im gebauten Artefakt standen **10 unersetzte `process.env`-Zugriffe**.

## Warum die Config und nicht nur ein Rebuild

`client/public/plugin-runtime.js` ist gitignored (`client/.gitignore:14`) und wird bei jedem Deploy neu erzeugt:

`deploy/scripts/ci-deploy.sh:520-521` → `npm ci && npm run build` → `prebuild` → `build:runtime`

Ein lokal repariertes Artefakt wäre also beim nächsten Deploy wieder überschrieben.

## Änderungen

- `define: { 'process.env.NODE_ENV': JSON.stringify('production') }` in `vite.runtime.config.ts`.
- `client/scripts/assert-runtime-bundle.mjs` — bricht den Build ab, wenn wieder `process.env` im Bundle landet, mit Klartext-Hinweis auf die Ursache. Eingehängt in `build:runtime`, läuft damit in CI (`npm run build`) **und** bei jedem Deploy.

Der Guard ist hier nicht Zierde: das Artefakt ist gitignored, ein Rückfall würde stillschweigend ausgeliefert und erst als leere Seite im Browser auffallen — genau so ist der Fehler entstanden.

## Verifikation

| | Ergebnis |
|---|---|
| Artefakt vor dem Fix | 10 × `process.env` |
| Artefakt nach dem Fix | 0 × `process.env` |
| Guard gegen repariertes Bundle | Exit 0, `no process.env references` |
| Guard gegen präpariertes Bundle (`process.env.NODE_ENV` angehängt) | Exit 1 mit Klartextmeldung |

Gebaut mit `vite build --config vite.runtime.config.ts` gegen die vorhandenen `client/node_modules`; Bundle 1.082 kB.

**Nicht verifiziert:** dass die Plugin-Seite im Browser danach tatsächlich rendert — das braucht einen Deploy. Der ReferenceError verschwindet nachweislich, ob dahinter noch ein zweites Problem im Plugin-Bundle steckt, zeigt erst der Live-Test.
