### PR TITLE
docs(plugins): CLAUDE.md je gebuendeltem Plugin, README und Uebersicht nachgezogen

### DIFF
--- a/backend/app/plugins/CLAUDE.md
+++ b/backend/app/plugins/CLAUDE.md
@@ -25,11 +25,16 @@ plugins/
 ├── sandbox/             # Subprocess-isolation layer (protocol, channel, transport, worker, supervisor, capabilities, host_capabilities, proxy, spawn, loader)
 ├── sdk/                 # Plugin authoring toolkit (cli, validator, dry_install)
 ├── smart_device/        # SmartDevice plugin framework (base class, manager, poller, capabilities)
-└── installed/           # Plugin implementations
-    ├── optical_drive/   # CD/DVD burning, reading, ISO browsing
-    ├── storage_analytics/  # Storage usage analytics
-    └── tapo_smart_plug/ # TP-Link Tapo smart plug integration with mock backend
+└── installed/           # Bundled plugin implementations (one CLAUDE.md each)
+    ├── optical_drive/      # CD/DVD burning, reading, ISO browsing (own router)
+    ├── steam_gaming/       # Status pill, session ledger, Gaming-Mode menu action
+    ├── storage_analytics/  # DEMO ONLY — every number is hard-coded, see its CLAUDE.md
+    └── tapo_smart_plug/    # TP-Link Tapo smart plugs via the SmartDevice framework
 ```
+
+Each bundled plugin has its own `CLAUDE.md` with its layout, invariants and
+pitfalls. Read that one before changing a plugin; this file covers the framework
+they plug into.
 
 ## Trust Tiers
 

--- a/backend/app/plugins/README.md
+++ b/backend/app/plugins/README.md
@@ -106,11 +106,16 @@ plugins/
 │   ├── manager.py           # SmartDeviceManager (CRUD, command dispatch, SHM state)
 │   ├── poller.py            # SmartDevicePoller (runs in monitoring-worker process)
 │   └── schemas.py           # Pydantic request/response schemas
-└── installed/               # Bundled plugin implementations
-    ├── optical_drive/       # CD/DVD burning, reading, ISO browsing
-    ├── storage_analytics/   # Storage usage analytics
-    └── tapo_smart_plug/     # TP-Link Tapo smart plug integration with mock backend
+└── installed/               # Bundled plugin implementations (one CLAUDE.md each)
+    ├── optical_drive/       # CD/DVD burning, reading, ISO browsing (own router)
+    ├── steam_gaming/        # Status pill, session ledger, Gaming-Mode menu action
+    ├── storage_analytics/   # DEMO ONLY — every number is hard-coded (#524)
+    └── tapo_smart_plug/     # TP-Link Tapo smart plugs via the SmartDevice framework
 ```
+
+Every bundled plugin carries its own `CLAUDE.md` next to the code, covering its
+layout, its invariants and the traps specific to it. Read that file before
+changing a plugin; this README covers the framework they plug into.
 
 ## Plugin Lifecycle (Bundled)
 
@@ -482,14 +487,47 @@ Authoring toolkit for external plugin developers. Not used by bundled plugins.
 
 ## Bundled Plugins (Reference Implementations)
 
+Each of these has a `CLAUDE.md` in its own directory with the details; the table
+below is the map, not the documentation.
+
 | Plugin | Category | Description |
 |---|---|---|
 | `optical_drive` | storage | CD/DVD/Blu-ray: read, rip (ISO/WAV), burn, blank |
-| `storage_analytics` | storage | Storage usage analytics per user, file-type breakdown, top files |
+| `steam_gaming` | general | Status pill for a running Steam game, session ledger in the DB, Gaming-Mode power-menu action |
+| `storage_analytics` | storage | **Demo only** — serves hard-coded numbers, scans nothing (#524) |
 | `tapo_smart_plug` | smart_device | TP-Link Tapo P110/P115 with Switch + Power Monitoring |
 
 Patterns covered:
 
 - **`optical_drive`** — own API routes, UI manifest, config schema, async job management
-- **`storage_analytics`** — background tasks, Pluggy hook implementations (`@hookimpl`), periodic scans
+- **`steam_gaming`** — status pill, power-menu action, notification events, background poller with its own DB table; the reference for the contribution hooks listed below. Ships **no** router and no `plugin.json`, so enable/disable takes effect without a restart
+- **`storage_analytics`** — background tasks, Pluggy hook implementations (`@hookimpl`), periodic scans. Useful as an API example only; do not treat its output as data
 - **`tapo_smart_plug`** — `SmartDevicePlugin` subclass, capability protocols, dashboard panel, i18n, dev/prod-mode split
+
+### Newer contribution hooks
+
+Three `PluginBase` override points came after the sections above and are **not**
+documented here — the core owns their namespacing, gating, timeouts and audit
+entries, and the rules are exhaustive in `CLAUDE.md` (same directory):
+
+| Hook | Contributes | Reference implementation |
+|---|---|---|
+| `get_status_pills()` + `collect_status_pill()` | A pill in the topbar status strip | `steam_gaming` |
+| `get_ui_manifest().menu_items` + `run_menu_action()` | An action in the system/power menu | `steam_gaming` |
+| `get_notification_events()` | Notification event types, fired via `emit_plugin_event()` | `steam_gaming` |
+
+Common rule for all three: the plugin picks only a local `id` (`^[a-z0-9_]+$`);
+the core composes the public id as `plugin:<plugin_name>:<suffix>`. Read
+`CLAUDE.md` before implementing one — several of the constraints (the menu-item
+declaration site, the notification category being derived rather than chosen,
+the collector timeout) are not guessable from the signatures.
+
+### Restart semantics
+
+A plugin that contributes a **router** has its routes mounted once at startup
+(`core/lifespan.py`), so enabling it at runtime leaves `/api/plugins/{name}/*` at
+404 until `baluhost-backend` restarts — surfaced as
+`PluginDetailResponse.restart_required`. Method-based contributions (pills, menu
+items, panels, background tasks) reconcile across all workers within seconds
+(#448) and never need a restart. Of the bundled plugins, `optical_drive` and
+`storage_analytics` ship a router; `steam_gaming` and `tapo_smart_plug` do not.

--- a/backend/app/plugins/installed/optical_drive/CLAUDE.md
+++ b/backend/app/plugins/installed/optical_drive/CLAUDE.md
@@ -1,0 +1,149 @@
+# Optical Drive Plugin
+
+Bundled (in-process, fully trusted) plugin: detect optical drives, browse/rip/burn
+discs and ISOs, manage the resulting jobs. Ships its own FastAPI router and a
+hand-written UI bundle.
+
+Trust tier, lifecycle and the `PluginBase` contract are in `../../CLAUDE.md` —
+this file only covers what is specific to this plugin.
+
+## Layout
+
+| File | Lines | Contents |
+|---|---|---|
+| `__init__.py` | 429 | `OpticalDrivePlugin`, and the **entire** router (built inside `get_router()`) |
+| `service.py` | 614 | `OpticalDriveService`: drive detection, validation, dev-mode simulation, job bookkeeping |
+| `reading.py` | 278 | `ReadingMixin` — ISO copy (`dd`), audio rip (`cdparanoia`) |
+| `burning.py` | 330 | `BurningMixin` — burn ISO / audio (`wodim`), blank, `dvd+rw-mediainfo` |
+| `browsing.py` | 768 | `BrowsingMixin` — disc + ISO listing (`isoinfo`, `7z`), extract, preview |
+| `models.py` | 236 | Pydantic request/response models, `MediaType`/`JobType`/`JobStatus` enums, `OpticalDriveConfig` |
+| `ui/bundle.js` | 894 | Plugin UI, hand-written against the sandbox runtime (`window.BaluHost`) |
+| `plugin.json` | — | Marketplace manifest (see "plugin.json vs. metadata") |
+
+`OpticalDriveService(ReadingMixin, BurningMixin, BrowsingMixin)` — the mixins call
+back into helpers the service owns (`_run_command`, `_create_job`, `_update_job`,
+`validate_*`, `self.config`, `self._is_dev_mode`). They are **not** standalone;
+adding a mixin method means it may use anything on the service.
+
+Module-level singleton via `get_optical_drive_service()`; the route dependency
+`get_service()` returns that same instance.
+
+## The router is built lazily on purpose
+
+`get_router()` imports `app.api.deps`, the models and `fastapi.Depends` **inside**
+the method and caches the result in `self._router`. This avoids circular imports
+at plugin-load time — the manager imports the plugin package while the core app is
+still being assembled. Do not hoist those imports to module scope.
+
+Because the plugin contributes a router, it is mounted **once at startup**
+(`core/lifespan.py`). Enabling it at runtime makes its method-based contributions
+work immediately but leaves `/api/plugins/optical_drive/*` returning 404 until
+`baluhost-backend` restarts; `GET /api/plugins/optical_drive` reports this as
+`restart_required`. Same for any route added here.
+
+Routes (all `Depends(get_current_user)`, no admin gate):
+
+```
+GET  /drives                            POST /drives/{device}/read/iso
+GET  /drives/{device}/info               POST /drives/{device}/read/audio
+POST /drives/{device}/eject              POST /drives/{device}/read/audio/{track}
+POST /drives/{device}/close              POST /drives/{device}/extract
+GET  /drives/{device}/blank-info         GET  /drives/{device}/files[/{path}]
+POST /drives/{device}/burn/iso           GET  /drives/{device}/preview/{path}
+POST /drives/{device}/burn/audio         POST /iso/list | /iso/extract | /iso/preview
+POST /drives/{device}/blank              GET  /jobs | /jobs/{id} · POST /jobs/{id}/cancel
+```
+
+`{device:path}` arrives without the `/dev/` prefix from the frontend, so every
+handler re-prefixes it before calling the service. Keep that line when adding a
+device-scoped route — `validate_device()` rejects a bare `sr0`.
+
+## Safety invariants
+
+Every entry point re-validates; the mixins do **not** trust their caller.
+
+- `validate_device()` — `^/dev/sr[0-9]+$`. The only accepted device shape; this is
+  what keeps a caller-supplied string out of `dd if=…`, `wodim dev=…` and `eject`.
+- `validate_path()` — resolves the path and requires it under
+  `settings.nas_storage_path` or `settings.nas_backup_path` (plus `./dev-storage`
+  in dev mode). Used for every **output** path (ISO target, rip dir, extract
+  destination).
+- `validate_source_file()` — `validate_path()` **and** the file must exist. Used
+  for every **input** path (ISO to burn, WAV list, ISO to browse).
+- All external tools run through `asyncio.create_subprocess_exec(*cmd)` with
+  argument lists. No `shell=True`, no string commands, anywhere in this plugin.
+  Keep it that way — several args are user-influenced (`iso_path`, `output_path`,
+  the WAV list, `speed`).
+
+**Known weakness, do not "clean up" silently:** `validate_path()` compares with
+`str(resolved).startswith(str(root))`, a plain string prefix without a separator
+check — a sibling directory such as `/mnt/storage-scratch` passes for the root
+`/mnt/storage`. Tightening it means comparing with `Path.is_relative_to()`; treat
+that as its own change with its own test, not a drive-by edit.
+
+## Job model — per-process, in-memory
+
+`_jobs` / `_job_tasks` are plain dicts on the singleton, and jobs run as
+`asyncio.create_task`. Consequences that matter in production (4 Uvicorn workers):
+
+- A job started through worker A is invisible to `GET /jobs` on worker B, and
+  `POST /jobs/{id}/cancel` on the wrong worker returns 400.
+- Everything is lost on restart; a burn in flight is orphaned, not resumed.
+
+**The stored config never reaches the service.** `get_config_schema()` exposes
+`OpticalDriveConfig` to the settings form, but both `on_startup()` and the route
+dependency call `get_optical_drive_service()` **without arguments**, so the
+singleton is built from `OpticalDriveConfig()` defaults and an admin's saved
+values are silently ignored. Only `auto_eject_after_operation` is read at all
+(after every job); `max_concurrent_jobs`, `scan_interval_seconds`,
+`default_output_dir` and `default_burn_speed` have no consumer anywhere in the
+codebase.
+
+Progress comes from parsing tool stdout/stderr line by line (`wodim`'s
+`N of M MB written`, `cdparanoia`'s `N of M sectors`, `7z`'s `N%`). Blanking has
+no progress at all — the parse loop is an empty `pass`.
+
+## Dev mode
+
+`self._is_dev_mode = settings.is_dev_mode`, and it is checked *everywhere*, not
+centrally. Two layers:
+
+- `_run_command()` short-circuits into `_simulate_command()`, which returns canned
+  stdout per tool name (`lsblk`, `cd-info`, `isoinfo`, `dvd+rw-mediainfo`, `wodim`,
+  `cdparanoia`, `dd`).
+- Individual operations have their own dev branches that sleep through a fake
+  progress curve and write dummy files (`b"RIFF" + …` for WAVs,
+  `b"SIMULATED ISO DATA" * 100` for ISOs).
+
+Simulated hardware: `/dev/sr0` = 5-track audio CD, `/dev/sr1` = blank DVD.
+`_simulate_disc_files()` / `_simulate_iso_files()` supply fixed trees for the
+browser. A new operation needs a dev branch too, or it dies on a Windows box.
+
+## External tool dependencies (prod only)
+
+`wodim` (burn + blank), `cdparanoia` (audio rip), `dd` (ISO copy), `isoinfo`
+(disc listing + file extract for preview), `7z` (ISO listing, data-file extract),
+`eject`, `udevadm` (media detection), `dvd+rw-mediainfo` (blank media info).
+Drive discovery reads `/sys/class/block/sr*`. None of these are declared as a
+dependency anywhere — a missing binary surfaces as return code 127 from
+`_run_command()` or as a failed job.
+
+Media detection uses `udevadm info --query=property` rather than `cd-info`,
+deliberately: `cd-info` hangs on some drives. `cd-info` parsing
+(`_parse_audio_tracks`) still exists but is only reached in the dev simulation
+path, so real audio CDs report tracks with `duration_seconds=0`.
+
+## plugin.json vs. metadata
+
+`plugin.json` is the **marketplace** manifest (`min_baluhost_version`,
+`ui.bundle`, `api_scopes`, `min_runtime_abi`) and its `homepage` points at the
+external `BaluHost-Plugin-Market` repo. Bundled discovery does not need it — the
+manager finds the `PluginBase` subclass in `__init__.py`. The `required_permissions`
+list therefore exists twice (`plugin.json` and `PluginMetadata`) and the two
+`homepage` values already disagree. When editing one, check the other.
+
+## Tests
+
+`backend/tests/plugins/test_optical_drive_plugin.py`. Runs in dev mode
+(`conftest.py` sets `NAS_MODE=dev`), so it exercises the simulation branches, not
+the tool invocations.

--- a/backend/app/plugins/installed/steam_gaming/CLAUDE.md
+++ b/backend/app/plugins/installed/steam_gaming/CLAUDE.md
@@ -1,0 +1,147 @@
+# Steam Gaming Plugin
+
+Bundled (in-process, fully trusted) plugin. Surfaces a running Steam game as a
+topbar status pill, books play sessions into the database, sends notifications on
+the session edges, shows the last five sessions as a dashboard panel, and offers a
+"Gaming Mode" toggle in the system/power menu.
+
+**No router, no `plugin.json`.** Everything is contributed through `PluginBase`
+method overrides, so enabling/disabling takes effect within seconds across all
+workers — no `baluhost-backend` restart needed (`restart_required` is always
+false). Bundled discovery works off the `PluginBase` subclass in `__init__.py`;
+a marketplace manifest is not required for that.
+
+Trust tier, lifecycle and the `PluginBase` contract are in `../../CLAUDE.md`.
+
+## Layout
+
+| File | Contents |
+|---|---|
+| `__init__.py` | `SteamGamingPlugin` — pill, menu items, dashboard panel, notification specs, background task, translations |
+| `detection.py` | The **single** "is a game running" source for pill, ledger and panel; owns the dev-mode stand-in and the column-width clamps |
+| `detector.py` | Pure `/proc` scan. No dev branch, no config — testable against a fake `proc_root` |
+| `names.py` | AppID → display name from `appmanifest_<id>.acf`, with hit/miss caches |
+| `gaming_state.py` | Marker file recording that *we* started gaming mode |
+| `launcher.py` | Detached `steam steam://open|close/bigpicture` dispatch |
+| `ledger.py` | Observations → `SteamSession` rows; returns what is worth announcing |
+| `poller.py` | Background task: detect → book → announce |
+
+Related core code: `app/models/steam_session.py`,
+`app/services/game_libraries/` (`steam.py`, `vdf.py`),
+`app/services/power/` (`desktop`, `desktop_windows`, `session_lock`, `session_env`,
+`gpu/display_detector`).
+
+## Detection
+
+Steam launches every title — native or Proton — through
+`reaper SteamLaunch AppId=<n> -- …`, so `detector.py` greps `/proc/*/cmdline` for
+that. Two alternatives were measured and rejected: `registry.vdf`'s `RunningAppID`
+is dead upstream (always 0), and Steam creates no per-game systemd scope.
+
+Layering matters and is deliberate:
+
+- `detector.py` stays **pure** — no `settings`, no dev branch. The test suite runs
+  with `NAS_MODE=dev`, so a dev branch here would make the detector tests assert
+  the mock instead of the real scan.
+- `detection.py` is the layer everything else imports. It adds the dev stand-in
+  (`DEV_APP_ID="0"`, `"Dev Mode Game"` — there is no `/proc` on the Windows dev
+  box) and clamps to the DB column widths: app_id > 32 chars is discarded, names
+  are truncated at 200. Without the clamps every booking would fail with a
+  PostgreSQL `DataError` in prod while passing on SQLite locally.
+- `_STEAM_CLIENT_RE` in `detector.py` matches the Steam **client** only —
+  `steamwebhelper`/`steamerrorreporter` must not match. A false positive there
+  would let the end action fire `steam steam://close/bigpicture` at a box where
+  Steam is down, which **starts** Steam.
+
+All of this is blocking filesystem I/O. Call it via `asyncio.to_thread` —
+`asyncio.wait_for` cannot cancel blocking sync code, so a spun-down library mount
+would otherwise stall a whole worker's event loop past the collector timeout.
+
+## State: three different stores, on purpose
+
+| State | Where | Why there |
+|---|---|---|
+| "what is running right now" | per-worker dict `_CACHE`, 3s TTL | The pill is an activity indicator, not a ledger; a per-worker cache avoids sharing state between the four workers entirely |
+| "what was played" | `steam_sessions` table | The open row **is** the poller's state — no in-process `last_app_id`, which is what makes a restart mid-session harmless |
+| "did we start gaming mode" | marker file under `<storage>/.system/steam_gaming/` | An in-process flag would flap between workers; `/tmp` is ephemeral under `PrivateTmp`; the storage root survives a deploy (`git reset --hard` without `git clean`) |
+
+`names.py` adds a fourth, process-lifetime cache: name hits are permanent (a
+game's name never changes), misses retry after 60s (a manifest appears while a
+game is still installing; non-Steam shortcuts never get one).
+
+## The ledger
+
+`ledger.record()` books one observation and **never raises** — a DB failure rolls
+back, logs and returns no events, so the next tick simply retries. Two thresholds
+drive the behaviour:
+
+- `STALE_AFTER_SECONDS = 60` (two poll intervals) — only while the poller was
+  demonstrably present is `now` a truthful end time, and only then is an edge
+  announced as live news.
+- `ADOPT_WINDOW_SECONDS = 600` — the same game across a shorter gap (a deploy
+  mid-game) is adopted as one session; a longer gap opens a new one **without**
+  announcing it.
+
+Invariant: at most one open session. `_claim_current_session()` re-establishes it
+every tick instead of trusting it, closing orphans at their `last_seen_at`.
+
+`RETENTION_DAYS = 365`, enforced by the poller once a day. Deliberately **not**
+wired into `services/monitoring/retention_manager.py`: that hangs off the
+`MetricType` enum and `monitoring_config` rows, so putting a plugin table there
+would couple the core to a plugin. Configurability is tracked in #464.
+
+Order in `poller.py` is load-bearing: book and commit first, announce afterwards.
+A failed push must never roll back a booking. The task runs **primary-only**
+(#448), so exactly one instance polls and no cross-worker guard is needed.
+
+## Gaming Mode (the menu action)
+
+Big Picture's own state is **not detectable from the outside** (measured
+2026-07-24). That single fact explains most of the design:
+
+- `get_ui_manifest()` advertises exactly one direction, chosen by
+  `_end_action_is_current()` = marker set **and** at least one display lit. The
+  display check is what rescues a stale marker.
+- `get_menu_items()` is overridden to return **both** directions. The core
+  validates a clicked `action_id` against this list, so deriving it from the
+  manifest (the base-class default) would 404 any click that raced a state
+  change. Advertising a subset of what is declared is the safe direction.
+- `on_startup()` clears the marker: a deploy or crash restarts the backend while
+  Big Picture may keep running. Offering "start" wrongly costs one harmless
+  click; a stale "end" minimizes the windows of someone who never asked.
+- Start order is displays → unlock (via `unlock_if_permitted()`, which applies
+  its own right + LAN gate and writes the audit entry) → Big Picture → *then*
+  mark started. Recording a start that never happened would hide the start
+  action behind a useless end action.
+- End refuses while a game is running, and refuses to run `steam://close` when no
+  Steam client is up (that URL would **start** Steam — see `launcher.py`).
+  It does **not** turn displays off: that is its own power-menu entry.
+- Every result is phrased as "started"/"ended", never "Big Picture is running" —
+  the process is detached, so nothing past the spawn is observable.
+
+Icons come from a **closed** frontend map (#451); anything outside it silently
+degrades to the generic plug icon. `Gamepad2` and `Monitor` are known-good.
+
+## Contributions in one place
+
+- **Pill** `plugin:steam_gaming:session` — `default_visibility="admin"`,
+  `silent_when_ok=True` (nothing shown when no game runs). The collector runs
+  under a 2s timeout and an exception guard; a failure silences only this pill.
+- **Panel** — five newest sessions, `admin_only=True` (the game name is
+  information about the box owner). Returns `None` when nothing was ever
+  recorded, because `StatusItem` has no translation-key fields and a placeholder
+  line would be an untranslatable string.
+- **Notifications** — `session_started` / `session_ended`, `default_target="admins"`,
+  60s cooldown. Texts are server-rendered German templates, like the core events.
+- **Translations** — `get_translations()` (en/de), resolved client-side via
+  `resolvePluginString`; `*_text` fields are the literal fallback.
+- Durations are formatted digits-only (`3h 04m`, `12m`) so no string needs
+  translating.
+
+## Tests
+
+`backend/tests/plugins/test_steam_gaming_*.py` — one file per module
+(`detection`, `detector`, `launcher`, `ledger`, `names`, `panel`, `plugin`,
+`poller`, `state`). Clocks are injectable everywhere (`_monotonic()`, `_utc_now()`,
+the poller's `clock=`), `names.reset_caches()` clears the module caches, and
+`detector` takes a `proc_root` — use those rather than monkeypatching time.

--- a/backend/app/plugins/installed/storage_analytics/CLAUDE.md
+++ b/backend/app/plugins/installed/storage_analytics/CLAUDE.md
@@ -1,0 +1,71 @@
+# Storage Analytics Plugin
+
+> **Read this first: the numbers are fake.** Every value this plugin serves is
+> hard-coded in `_perform_storage_scan()` — 1234 files, 50 GB, two invented users
+> named `admin`/`user`, a fixed `.jpg/.mp4/.pdf/.docx` distribution and three
+> made-up "top files". Nothing scans the filesystem, nothing reads the database,
+> and the two hook implementations (`on_file_uploaded`, `on_file_deleted`) are
+> `pass`. It is a **reference/demo plugin** for the plugin API, not a feature.
+
+Do not treat its output as data, do not wire it into anything, and do not "fix a
+bug" in the numbers. If real analytics are wanted, that is a new implementation —
+the honest storage figures already live in `services/files/` and the
+`storage-breakdown` endpoint (`backend/tests/test_storage_breakdown.py`).
+
+Trust tier, lifecycle and the `PluginBase` contract are in `../../CLAUDE.md`.
+
+## What it does demonstrate
+
+It is the most complete example of the **classic bundled-plugin surface** in one
+small file, which is why it is worth keeping:
+
+| `PluginBase` hook | Used for |
+|---|---|
+| `get_router()` | Five routes under `/api/plugins/storage_analytics/` |
+| `on_startup` / `on_shutdown` | Warm and clear the module-level cache |
+| `get_background_tasks()` | `storage_scan` every 6 h, `run_on_startup=False` |
+| `get_ui_manifest()` | A `PluginNavItem` (`analytics`, `bar-chart-2`, order 50) + `bundle_path` + `dashboard_widgets` |
+| `get_config_schema()` / `get_default_config()` | `StorageAnalyticsConfig` (Pydantic → settings form) |
+| `@hookimpl` | Pluggy hooks `on_file_uploaded` / `on_file_deleted` |
+
+## Layout
+
+| File | Contents |
+|---|---|
+| `__init__.py` | Everything: config + response schemas, the fake scan, the router, `StorageAnalyticsPlugin` |
+| `ui/bundle.js` | Plugin UI, hand-written against the sandbox runtime (`window.BaluHost`) |
+| `plugin.json` | Marketplace manifest |
+
+## Things that will bite you
+
+- **Contributes a router**, so it is mounted once at startup
+  (`core/lifespan.py`). Enabling it at runtime leaves
+  `/api/plugins/storage_analytics/*` at 404 until `baluhost-backend` restarts;
+  `GET /api/plugins/storage_analytics` reports this as `restart_required`.
+- **`_storage_cache` is a module global**, so in production each of the four
+  Uvicorn workers holds its own copy with its own `last_scan` timestamp. Two
+  identical requests can report different values. Same for the background task,
+  which runs primary-only (#448) and therefore only ever refreshes one worker's
+  cache.
+- **`on_shutdown()` calls `_storage_cache.clear()`**, which removes the keys
+  entirely rather than resetting them to `None`. The `if _storage_cache["stats"]
+  is None` guards in the routes would then raise `KeyError`. Only reachable if a
+  request is served after shutdown, but do not copy this pattern.
+- `StorageAnalyticsConfig` is declared but never read — the 6 h interval and the
+  30-day retention in the code are hard-coded, not driven by the config.
+- The routes use `Depends(get_current_user)` only: **any** logged-in user sees the
+  (fake) per-user breakdown. If this ever serves real data, that gate has to
+  become `get_current_admin` or a per-user filter, and the endpoints need a
+  `@limiter.limit(...)` — they currently have none, and there is no global
+  fallback limit (see `.claude/rules/security-agent.md`).
+- `min_baluhost_version` in `plugin.json` is `1.29.0`; its `homepage` points at
+  the external `BaluHost-Plugin-Market` repo, while `PluginMetadata.homepage` in
+  the code points somewhere else. The manifest is not read for bundled discovery —
+  the manager finds the `PluginBase` subclass in `__init__.py` — so the two drift
+  silently.
+
+## Tests
+
+**None.** `backend/tests/plugins/test_plugins.py` and `test_plugin_manager*.py`
+build their own throwaway plugins under `tmp_path`, so nothing in the suite loads
+this package. Any change here is unverified until you add a test.

--- a/backend/app/plugins/installed/tapo_smart_plug/CLAUDE.md
+++ b/backend/app/plugins/installed/tapo_smart_plug/CLAUDE.md
@@ -1,0 +1,126 @@
+# Tapo Smart Plug Plugin
+
+Bundled (in-process, fully trusted) plugin for TP-Link Tapo **P110 / P115** smart
+plugs: on/off switching, live power monitoring, a dashboard gauge, and an
+admin-triggered import of the device's own energy history.
+
+**No router.** This plugin extends `SmartDevicePlugin` (not `PluginBase`
+directly), so all interaction goes through the unified `/api/smart-devices/` API.
+Nothing here is reachable at `/api/plugins/tapo_smart_plug/*`, and no restart is
+needed to enable/disable it.
+
+Trust tier and lifecycle: `../../CLAUDE.md`. The SmartDevice framework it plugs
+into: `../../smart_device/` (`base.py`, `manager.py`, `poller.py`,
+`capabilities.py`, `schemas.py`).
+
+## Layout
+
+| File | Contents |
+|---|---|
+| `__init__.py` | `TapoSmartPlugPlugin` — device types, capabilities, dashboard panel, config schema, credential resolution |
+| `service.py` | `TapoService` — real device I/O via **plugp100**, with a per-device client cache |
+| `mock.py` | `TapoMockService` — dev-mode live data (60–180 W, 230 V ± 5, 1.5–3.5 kWh/day) |
+| `history.py` | `TapoHistoryFetcher` — historical energy buckets via the **tapo** library |
+| `history_mock.py` | Deterministic dev-mode history fetcher |
+| `import_service.py` | `TapoHistoryImportService` — buckets → `SmartDeviceSample` rows with conflict handling |
+| `plugin.json` | Marketplace manifest (see below) |
+
+## Two Tapo libraries, deliberately
+
+- **plugp100** (`>=5.0.0,<6.0.0`) — live polling and switching (`service.py`).
+- **tapo** (mihai-dinculescu) — history import only (`history.py`). It exposes a
+  typed `get_energy_data` with hourly/daily/monthly intervals that plugp100 v5.x
+  does not surface.
+
+Do not "consolidate" these without checking that the replacement covers both
+paths. Only plugp100 is declared in `plugin.json`'s `python_requirements`; the
+`tapo` import is lazy, so a box without it fails at import time, not at startup.
+
+`_patch_plugp100_bugs()` monkey-patches plugp100 v5.1.5's
+`InvalidAuthentication.__init__`, which calls `super(f"...")` instead of
+`super().__init__(f"...")` and therefore raises `TypeError` instead of the real
+auth error. The patch is guarded: it first *tries* to construct the exception and
+only patches if the bug is still present, so a fixed upstream version is left
+alone. Delete it once the floor moves past the fix.
+
+## Credentials
+
+Tapo credentials (account email + password) live **encrypted** in
+`SmartDevice.config_secret` (Fernet, via `services/vpn/encryption.py`, keyed by
+`VPN_ENCRYPTION_KEY`). Two paths reach them:
+
+- `connect_device()` — the manager passes an already-decrypted config dict; the
+  plugin caches it in `self._device_info` as `_DeviceInfo(ip, email, password)`.
+- `_ensure_device_info()` — the **fallback**. The poller runs in a separate
+  process with its own plugin instance where `connect_device()` was never called,
+  so it re-reads the row and decrypts it itself. If `vpn_encryption_key` is unset
+  it falls back to parsing `config_secret` as plain JSON.
+
+Credentials are held in memory as plaintext for the lifetime of the process and
+are passed to every service call. They must never reach a log line, a response
+model, or an exception message — `logger.warning` calls in this file deliberately
+log only the device id.
+
+## Live path
+
+`poll_device()` / `poll_device_mock()` are picked by the framework; the switch and
+power capability methods pick for themselves via `_is_dev_mode()`. Poll interval
+is **5 s** (`get_poll_interval_seconds`). `TapoService` caches one connected
+plugp100 client per `device_id:ip` and evicts it on timeout or error so the next
+call reconnects from scratch; `_DEVICE_TIMEOUT = 10 s` per operation.
+
+The dashboard panel (`gauge`) does **not** poll — it reads the SHM snapshot
+`SMART_DEVICES_FILE` (`max_age_seconds=30`) written by the monitoring worker and
+joins it against active+online `SmartDevice` rows. `progress` is against a
+hard-coded `max_power = 150.0 W`. Returns `None` (panel hidden) when no device
+reported a non-zero reading. `TapoPluginConfig.panel_devices` narrows which
+devices count; it is read straight off `InstalledPlugin.config`.
+
+## History import
+
+Admin-only; the API route enforces authorization, `import_history()` assumes it.
+Flow: resolve cached credentials → `fetch_buckets()` (real or mock) →
+`TapoHistoryImportService.write_buckets()` → `ImportHistoryResponse`.
+
+- Long ranges are split into several API calls to respect the library's
+  constraints (hourly ≤ 8 days, daily per quarter, monthly per year).
+- Watts are **synthesized** from bucket energy using `_BUCKET_HOURS`; monthly uses
+  an average month (30.4375 d). Acceptable because aggregation divides by the
+  actual observed `period_hours` at query time (`energy.py`).
+- `_DEFAULT_VOLTAGE = 230.0`, consistent with the live extraction.
+- Idempotency and the live-sample conflict strategy live in `import_service.py`,
+  keyed on a marker in `data_json` that live samples never contain.
+- `_fetcher_override` is a test seam — set it to inject a stub fetcher rather
+  than monkeypatching the `tapo` import.
+
+## Dev mode
+
+`_is_dev_mode()` swallows exceptions and defaults to **False** (prod). Every
+service getter (`_get_service`, `_build_fetcher`, each capability method) branches
+on it separately; there is no single switch. `TapoMockService` and
+`TapoHistoryMockFetcher` need no hardware and run on Windows.
+
+## Operator note
+
+Each device needs **"Third-Party Compatibility"** enabled in the Tapo app or it
+may not respond — that is why `settings_third_party_hint` exists in
+`get_translations()`.
+
+`TapoPluginConfig` exposes `panel_devices` (dashboard filter) and `retention_days`
+(0 = unlimited) with `x-options-source` / `x-presets` hints the settings UI reads.
+
+## plugin.json vs. metadata
+
+`plugin.json` is the **marketplace** manifest and its `homepage` points at the
+external `BaluHost-Plugin-Market` repo. Bundled discovery does not read it — the
+manager finds the `SmartDevicePlugin` subclass in `__init__.py`. `version`,
+`description` and `required_permissions` therefore exist twice; when editing one,
+check the other.
+
+## Tests
+
+- `backend/tests/plugins/tapo_smart_plug/` — `test_history_fetcher.py`,
+  `test_history_mock.py`, `test_import_service.py`, `test_plugin_import_history.py`
+- `backend/tests/plugins/test_tapo_plugin_config.py`
+- Framework-level coverage that exercises this plugin:
+  `test_smart_device_{base,manager,poller,retention,routes,schemas}.py`


### PR DESCRIPTION
Jedes gebündelte Plugin unter `backend/app/plugins/installed/` bekommt eine
eigene `CLAUDE.md`, und die beiden übergeordneten Dokumente werden nachgezogen.
**Nur Dokumentation, kein Code.**

## Neue Dateien

| Datei | Schwerpunkt |
|---|---|
| `optical_drive/CLAUDE.md` | Mixin-Komposition + Singleton, lazy Router (Zirkelimport-Grund), die `validate_*`-Schranken, prozesslokales Job-Modell, Dev-Simulation, externe Tools |
| `steam_gaming/CLAUDE.md` | Schichtung `detector` (pur) → `detection` (Dev-Ersatz + Spaltenbreiten-Clamps), die drei getrennten State-Stores und warum, Ledger-Schwellen, Gaming-Mode-Logik |
| `tapo_smart_plug/CLAUDE.md` | Zwei Tapo-Libs mit Absicht, plugp100-Monkeypatch, Credential-Pfade inkl. Poller-Fallback, Live- vs. History-Pfad, SHM-Panel |
| `storage_analytics/CLAUDE.md` | Warnung vorneweg, dass alle Zahlen hartkodiert sind |

Schwerpunkt liegt jeweils auf dem, was man aus den Signaturen **nicht** raten
kann — warum `detector.py` keinen Dev-Branch haben darf, warum `steam_gaming`
`get_menu_items()` überschreibt, warum bei Tapo zwei Bibliotheken koexistieren,
warum `optical_drive` seinen Router lazy baut.

## Nachgezogen

`plugins/CLAUDE.md` und `plugins/README.md` trugen beide denselben veralteten
`installed/`-Baum: `steam_gaming` fehlte komplett, `storage_analytics` war als
echtes Feature beschrieben („Storage usage analytics per user, file-type
breakdown, top files").

- **`plugins/CLAUDE.md`** — Baum vervollständigt, Verweis auf die Einzeldateien.
- **`plugins/README.md`** (die Datei, auf die `docs/README.md` als Plugin-Einstieg
  zeigt) — Baum und Referenz-Tabelle korrigiert; dazu zwei neue Abschnitte:
  - *Newer contribution hooks* — Status-Pills, Menü-Actions und
    Notification-Events kamen nach dem Authoring-Teil dazu und wurden im README
    bisher gar nicht erwähnt. Als Tabelle mit der gemeinsamen
    Namespacing-Regel und Zeiger auf die `CLAUDE.md`, statt die Regeln zu
    duplizieren.
  - *Restart semantics* — welches Plugin einen Router hat und damit einen
    Neustart braucht, welches nicht.

`docs/plugins/` (Sandbox-ABI + Author-Migration) bleibt unangetastet — die decken
ausschließlich den externen Tier ab, dort ist nichts veraltet.

## Nicht enthalten

- **`audio_control`** liegt nur auf dem ungemergten `feat/audio-control` und
  existiert auf `main` nicht. Eine `CLAUDE.md` dafür würde hier einen Dateibaum
  beschreiben, den es im Branch nicht gibt — die gehört auf den Audio-Branch
  bzw. nach dessen Merge.
- **Die Befunde aus #524.** Beim Lesen sind vier pre-existing Probleme
  aufgefallen (Präfix-Vergleich in `validate_path()`, nicht angewandte
  Plugin-Config, prozesslokale Jobs bei 4 Workern, `storage_analytics` als
  Fake-Daten-Plugin mit `KeyError` nach Shutdown). Sie sind in den neuen Dateien
  **beschrieben, nicht gefixt** — jeder Punkt ist eigenständig fixbar und steht
  in #524.

Refs #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qdj2KxcvSfdRJqhdL8fqX4
