### PR TITLE
feat(power): Sitzung entsperren aus dem PowerMenu, wenn die Displays laufen

### DIFF
--- a/backend/app/api/routes/desktop.py
+++ b/backend/app/api/routes/desktop.py
@@ -11,7 +11,7 @@ from app.api.deps import get_current_user, get_db, require_power_toggle_desktop
 from app.core.rate_limiter import user_limiter, get_limit
 from app.schemas.desktop import DesktopStatus
 from app.services.power.desktop import get_desktop_service
-from app.services.power.session_lock import unlock_if_permitted
+from app.services.power.session_lock import current_lock_state, unlock_if_permitted
 from app.services.notifications.events import emit_desktop_disabled, emit_desktop_enabled
 from app.services.audit.logger_db import get_audit_logger_db
 
@@ -27,8 +27,44 @@ async def desktop_status(
     response: Response,
     current_user=Depends(get_current_user),
 ) -> DesktopStatus:
-    """Return whether the desktop displays are on (running) or off (stopped)."""
-    return await get_desktop_service().get_status()
+    """Return whether the desktop displays are on (running) or off (stopped).
+
+    Also carries the session's lock state, so the power menu can decide in a
+    single request whether to offer "unlock".
+    """
+    status = await get_desktop_service().get_status()
+    return status.model_copy(update={"session_locked": await current_lock_state()})
+
+
+@router.post("/unlock")
+@user_limiter.limit(get_limit("admin_operations"))
+async def desktop_unlock(
+    request: Request,
+    response: Response,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Unlock the graphical desktop session, leaving the displays alone.
+
+    The "enable" route unlocks as a side effect of turning the displays on;
+    this is the same action for the case where they are already on.
+
+    Authorization is deliberately NOT a route dependency: ``unlock_if_permitted``
+    is the single place where both gates (LAN/VPN + the ``can_unlock_session``
+    right, admins by role) are evaluated and audited. A role gate in front of it
+    would be a second, silently diverging rule. A refusal is therefore a 200
+    with ``success: false``, not a 403.
+    """
+    try:
+        ok, message = await unlock_if_permitted(
+            user=current_user,
+            client_host=request.client.host if request.client else None,
+            db=db,
+        )
+    except Exception:  # a failed unlock is an outcome, never a 5xx
+        logger.exception("Session unlock failed unexpectedly")
+        ok, message = False, "unlock failed unexpectedly"
+    return {"success": ok, "message": message}
 
 
 @router.post("/disable")

--- a/backend/app/schemas/desktop.py
+++ b/backend/app/schemas/desktop.py
@@ -19,3 +19,12 @@ class DesktopStatus(BaseModel):
     state: DesktopState
     display_manager: str = Field(description="Name of the display-manager unit, e.g. 'sddm'")
     detail: Optional[str] = Field(default=None, description="Optional human-readable detail")
+    session_locked: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Whether the graphical session is locked; None when that cannot be "
+            "determined. Filled in by the status route, not by the desktop "
+            "backend - the status-bar collector polls the service every 10s and "
+            "must not spawn a loginctl for a bit only the power menu reads."
+        ),
+    )

--- a/backend/app/services/power/session_lock.py
+++ b/backend/app/services/power/session_lock.py
@@ -44,6 +44,10 @@ class SessionLockBackend(Protocol):
         """Unlock the session; returns (ok, detail)."""
         ...
 
+    def is_locked(self) -> Optional[bool]:
+        """Whether the session is locked right now, or None if unknowable."""
+        ...
+
 
 class DevSessionLockBackend:
     """In-memory backend for dev mode / non-Linux hosts."""
@@ -55,6 +59,10 @@ class DevSessionLockBackend:
         """Pretend to unlock - there is no logind on a dev box."""
         self._locked = False
         return True, "session unlocked (dev)"
+
+    def is_locked(self) -> Optional[bool]:
+        """Start out locked, so the unlock button is reachable in dev mode."""
+        return self._locked
 
 
 class LinuxSessionLockBackend:
@@ -124,6 +132,24 @@ class LinuxSessionLockBackend:
             return False
         return None
 
+    def is_locked(self) -> Optional[bool]:
+        """Read the lock state without touching the session.
+
+        A pure read: it asks logind and changes nothing. Returns None whenever
+        the answer is unknown (no graphical session, unreadable hint, no
+        loginctl) - callers must not read that as "not locked", or a UI would
+        hide its unlock button on exactly the box where logind is mute.
+        """
+        try:
+            session_id = self._graphical_session_id()
+            if not session_id:
+                return None
+            return self._locked_hint(session_id)
+        except FileNotFoundError:
+            return None
+        except subprocess.TimeoutExpired:
+            return None
+
     def unlock(self) -> Tuple[bool, str]:
         """Unlock the graphical session and VERIFY it actually unlocked.
 
@@ -171,6 +197,22 @@ def get_session_lock_backend() -> SessionLockBackend:
             DevSessionLockBackend() if settings.is_dev_mode else LinuxSessionLockBackend()
         )
     return _backend
+
+
+async def current_lock_state() -> Optional[bool]:
+    """Whether the desktop session is locked, or None if that cannot be told.
+
+    Deliberately ungated: the answer is a single bit about the machine's own
+    screen, no more revealing than the desktop on/off state next to it, and
+    every caller is already authenticated. Acting on it still runs the full
+    gates in :func:`unlock_if_permitted`.
+    """
+    try:
+        return await asyncio.to_thread(get_session_lock_backend().is_locked)
+    except Exception:
+        # A status endpoint must not 5xx because logind hiccupped.
+        logger.exception("session lock state could not be read")
+        return None
 
 
 def _may_unlock(user: UserPublic, db: Session) -> bool:

--- a/backend/tests/api/test_desktop_unlock.py
+++ b/backend/tests/api/test_desktop_unlock.py
@@ -77,3 +77,134 @@ class TestEnableUnlocksTheSession:
 
         assert response.status_code == 200, response.text
         assert response.json()["success"] is True
+
+
+@pytest.fixture
+def desktop_running():
+    from app.schemas.desktop import DesktopState, DesktopStatus
+
+    service = MagicMock()
+    service.get_status = AsyncMock(
+        return_value=DesktopStatus(
+            state=DesktopState.RUNNING, display_manager="sddm", detail="1 active display(s)"
+        )
+    )
+    with patch("app.api.routes.desktop.get_desktop_service", return_value=service):
+        yield service
+
+
+class TestStatusCarriesTheLockState:
+    """The unlock button's visibility needs displays AND lock state in one read."""
+
+    def test_locked_session_is_reported(self, client, admin_headers, desktop_running):
+        with patch(
+            "app.api.routes.desktop.current_lock_state", AsyncMock(return_value=True)
+        ):
+            response = client.get(
+                "/api/system/sleep/desktop/status", headers=admin_headers
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["state"] == "running"
+        assert body["session_locked"] is True
+
+    def test_unlocked_session_is_reported(self, client, admin_headers, desktop_running):
+        with patch(
+            "app.api.routes.desktop.current_lock_state", AsyncMock(return_value=False)
+        ):
+            response = client.get(
+                "/api/system/sleep/desktop/status", headers=admin_headers
+            )
+
+        assert response.json()["session_locked"] is False
+
+    def test_an_unknown_lock_state_stays_null(self, client, admin_headers, desktop_running):
+        """null must not collapse to false - the frontend hides the button on
+        null, and showing it on a box that cannot answer would be a dead end."""
+        with patch(
+            "app.api.routes.desktop.current_lock_state", AsyncMock(return_value=None)
+        ):
+            response = client.get(
+                "/api/system/sleep/desktop/status", headers=admin_headers
+            )
+
+        assert response.json()["session_locked"] is None
+
+    def test_the_desktop_service_is_never_asked_for_the_lock_state(
+        self, client, admin_headers, desktop_running
+    ):
+        """The status bar polls the SERVICE every 10s; the lock read lives in
+        the route so that poll never spawns a loginctl."""
+        from app.services.power.desktop import DesktopService
+
+        assert not hasattr(DesktopService, "is_locked")
+
+
+class TestUnlockRoute:
+    def test_admin_can_unlock(self, client, admin_headers):
+        with patch(
+            "app.api.routes.desktop.unlock_if_permitted",
+            AsyncMock(return_value=(True, "session 2 unlocked")),
+        ):
+            response = client.post(
+                "/api/system/sleep/desktop/unlock", headers=admin_headers
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["success"] is True
+
+    def test_a_refused_unlock_is_a_200_with_success_false(self, client, admin_headers):
+        """The gates live in the policy; a refusal is an outcome, not an error."""
+        with patch(
+            "app.api.routes.desktop.unlock_if_permitted",
+            AsyncMock(return_value=(False, "not permitted from this network")),
+        ):
+            response = client.post(
+                "/api/system/sleep/desktop/unlock", headers=admin_headers
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["success"] is False
+        assert body["message"] == "not permitted from this network"
+
+    def test_a_raising_policy_does_not_500(self, client, admin_headers):
+        with patch(
+            "app.api.routes.desktop.unlock_if_permitted",
+            AsyncMock(side_effect=OSError("boom")),
+        ):
+            response = client.post(
+                "/api/system/sleep/desktop/unlock", headers=admin_headers
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["success"] is False
+
+    def test_the_client_ip_reaches_the_gate(self, client, admin_headers):
+        gate = AsyncMock(return_value=(True, "unlocked"))
+        with patch("app.api.routes.desktop.unlock_if_permitted", gate):
+            client.post("/api/system/sleep/desktop/unlock", headers=admin_headers)
+
+        assert gate.await_args.kwargs["client_host"] is not None
+
+    def test_anonymous_callers_are_rejected(self, client):
+        response = client.post("/api/system/sleep/desktop/unlock")
+
+        assert response.status_code in (401, 403)
+
+    def test_a_plain_user_reaches_the_policy_rather_than_a_role_gate(
+        self, client, user_headers
+    ):
+        """Deliberately NOT gated on admin at the route: unlock_if_permitted is
+        the single place both gates are evaluated and audited. A second gate in
+        front would silently drift from the delegated can_unlock_session right."""
+        gate = AsyncMock(return_value=(False, "permission required: power:unlock_session"))
+        with patch("app.api.routes.desktop.unlock_if_permitted", gate):
+            response = client.post(
+                "/api/system/sleep/desktop/unlock", headers=user_headers
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["success"] is False
+        gate.assert_awaited_once()

--- a/backend/tests/services/power/test_session_lock.py
+++ b/backend/tests/services/power/test_session_lock.py
@@ -198,3 +198,105 @@ class TestDevBackend:
 
         assert ok is True
         assert "dev" in detail
+
+
+class TestLockStateRead:
+    """Reading the lock state - the half of logind the unlock path never used.
+
+    ``unlock()`` only ever asked "did it work?" after acting. Driving a button's
+    visibility needs the question asked on its own, without touching the
+    session.
+    """
+
+    def test_reports_locked(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            "locked_hint": _proc(stdout="yes\n"),
+        })
+
+        assert _backend(runner).is_locked() is True
+
+    def test_reports_unlocked(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            "locked_hint": _proc(stdout="no\n"),
+        })
+
+        assert _backend(runner).is_locked() is False
+
+    def test_never_unlocks_while_reading(self):
+        """A read must stay a read. If this ever calls unlock-session, opening
+        the power menu would silently unlock the desktop."""
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            "locked_hint": _proc(stdout="yes\n"),
+        })
+
+        _backend(runner).is_locked()
+
+        assert all(cmd[1] != "unlock-session" for cmd in runner.calls)
+
+    def test_unknown_without_a_graphical_session(self):
+        """None, not False - "no session" is not "not locked"."""
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="\n"),
+            tuple(LIST_SESSIONS): _proc(stdout=""),
+        })
+
+        assert _backend(runner).is_locked() is None
+
+    def test_unknown_when_the_hint_cannot_be_read(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            "locked_hint": _proc(returncode=1, stderr="no such session"),
+        })
+
+        assert _backend(runner).is_locked() is None
+
+    def test_unknown_without_loginctl(self):
+        def _raise(_cmd):
+            raise FileNotFoundError("loginctl")
+
+        assert _backend(_raise).is_locked() is None
+
+    def test_unknown_on_timeout(self):
+        def _raise(_cmd):
+            raise subprocess.TimeoutExpired(cmd="loginctl", timeout=3)
+
+        assert _backend(_raise).is_locked() is None
+
+
+class TestDevBackendLockState:
+    def test_starts_locked_so_the_button_is_testable_in_dev(self):
+        assert DevSessionLockBackend().is_locked() is True
+
+    def test_unlocking_flips_it(self):
+        backend = DevSessionLockBackend()
+        backend.unlock()
+
+        assert backend.is_locked() is False
+
+
+class TestCurrentLockState:
+    """The module-level read the route calls: off the event loop, never raises."""
+
+    async def test_returns_the_backend_answer(self):
+        from unittest.mock import MagicMock, patch
+
+        from app.services.power import session_lock
+
+        backend = MagicMock()
+        backend.is_locked.return_value = True
+        with patch.object(session_lock, "get_session_lock_backend", return_value=backend):
+            assert await session_lock.current_lock_state() is True
+
+    async def test_a_raising_backend_becomes_unknown(self):
+        """The status route must not 500 because logind hiccupped."""
+        from unittest.mock import MagicMock, patch
+
+        from app.services.power import session_lock
+
+        backend = MagicMock()
+        backend.is_locked.side_effect = OSError("boom")
+        with patch.object(session_lock, "get_session_lock_backend", return_value=backend):
+            assert await session_lock.current_lock_state() is None

--- a/client/src/__tests__/components/PowerMenu.test.tsx
+++ b/client/src/__tests__/components/PowerMenu.test.tsx
@@ -20,6 +20,7 @@ vi.mock('../../api/desktop', () => ({
   getDesktopStatus: vi.fn(),
   disableDesktop: vi.fn(),
   enableDesktop: vi.fn(),
+  unlockSession: vi.fn(),
 }));
 
 vi.mock('../../contexts/PluginContext', () => ({
@@ -28,7 +29,7 @@ vi.mock('../../contexts/PluginContext', () => ({
 
 import PowerMenu from '../../components/PowerMenu';
 import { getSleepStatus } from '../../api/sleep';
-import { getDesktopStatus, disableDesktop, enableDesktop } from '../../api/desktop';
+import { getDesktopStatus, disableDesktop, enableDesktop, unlockSession } from '../../api/desktop';
 import toast from 'react-hot-toast';
 
 const baseProps = {
@@ -235,5 +236,101 @@ describe('PowerMenu session unlock hint', () => {
     fireEvent.click(await screen.findByText('Enable desktop'));
 
     await waitFor(() => expect(enableDesktop).toHaveBeenCalledTimes(1));
+  });
+});
+
+
+describe('PowerMenu — unlock session quick action', () => {
+  const mockStatus = (state: string, sessionLocked: boolean | null) => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state, display_manager: 'sddm', detail: null, session_locked: sessionLocked,
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getSleepStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({});
+  });
+
+  it('shows "Unlock session" when displays are on and the session is locked', async () => {
+    mockStatus('running', true);
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    expect(await screen.findByText('Unlock session')).toBeInTheDocument();
+  });
+
+  it('hides it when the session is not locked', async () => {
+    mockStatus('running', false);
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    await waitFor(() => {
+      expect(getDesktopStatus).toHaveBeenCalled();
+      expect(screen.queryByText('Unlock session')).not.toBeInTheDocument();
+    });
+  });
+
+  it('hides it while the displays are off, where "Enable desktop" already unlocks', async () => {
+    mockStatus('stopped', true);
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    await waitFor(() => {
+      expect(screen.findByText('Enable desktop')).toBeTruthy();
+      expect(screen.queryByText('Unlock session')).not.toBeInTheDocument();
+    });
+  });
+
+  it('hides it when the lock state is unknown', async () => {
+    // null must not be treated as "locked" - on a host logind cannot answer
+    // for, the button would be a dead end.
+    mockStatus('running', null);
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    await waitFor(() => {
+      expect(getDesktopStatus).toHaveBeenCalled();
+      expect(screen.queryByText('Unlock session')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show it for non-admins', async () => {
+    mockStatus('running', true);
+    render(<PowerMenu {...baseProps} isAdmin={false} />);
+    openMenu();
+    await act(async () => {});
+    expect(screen.queryByText('Unlock session')).not.toBeInTheDocument();
+    expect(getDesktopStatus).not.toHaveBeenCalled();
+  });
+
+  it('clicking it calls unlockSession and shows a success toast', async () => {
+    mockStatus('running', true);
+    (unlockSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true, message: 'session 2 unlocked',
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByText('Unlock session'));
+    await waitFor(() => expect(unlockSession).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+  });
+
+  it('shows a translated error when the unlock is refused', async () => {
+    // The server's message is an English debug string (#406) - a refused
+    // unlock must not leak it into the UI.
+    mockStatus('running', true);
+    (unlockSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false, message: 'not permitted from this network',
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByText('Unlock session'));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to unlock the session'));
+  });
+
+  it('shows an error toast when the request itself fails', async () => {
+    mockStatus('running', true);
+    (unlockSession as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('offline'));
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByText('Unlock session'));
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
   });
 });

--- a/client/src/api/desktop.ts
+++ b/client/src/api/desktop.ts
@@ -18,6 +18,11 @@ export interface DesktopStatus {
   state: DesktopState;
   display_manager: string;
   detail: string | null;
+  /**
+   * Whether the graphical session is locked. `null` means the server could not
+   * tell (no session, no loginctl) — never treat that as "unlocked".
+   */
+  session_locked?: boolean | null;
 }
 
 export interface DesktopActionResult {
@@ -43,5 +48,17 @@ export async function disableDesktop(): Promise<DesktopActionResult> {
 
 export async function enableDesktop(): Promise<DesktopActionResult> {
   const { data } = await apiClient.post<DesktopActionResult>('/api/system/sleep/desktop/enable');
+  return data;
+}
+
+/**
+ * Unlock the KDE session without touching the displays.
+ *
+ * `enableDesktop()` unlocks as a side effect of turning the screens on; this is
+ * the same action for when they are already on. A refusal (wrong network, no
+ * permission) comes back as `success: false`, not as an HTTP error.
+ */
+export async function unlockSession(): Promise<DesktopActionResult> {
+  const { data } = await apiClient.post<DesktopActionResult>('/api/system/sleep/desktop/unlock');
   return data;
 }

--- a/client/src/components/PowerMenu.tsx
+++ b/client/src/components/PowerMenu.tsx
@@ -1,9 +1,9 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Power, PowerOff, RotateCcw, LogOut, Moon, Pause, MonitorOff, Monitor, Plug } from 'lucide-react';
+import { Power, PowerOff, RotateCcw, LogOut, Moon, Pause, MonitorOff, Monitor, Plug, Unlock } from 'lucide-react';
 import { ConfirmDialog } from './ui/ConfirmDialog';
 import { getSleepStatus, enterSoftSleep, enterSuspend } from '../api/sleep';
-import { getDesktopStatus, disableDesktop, enableDesktop, type DesktopState } from '../api/desktop';
+import { getDesktopStatus, disableDesktop, enableDesktop, unlockSession, type DesktopState } from '../api/desktop';
 import { usePlugins } from '../contexts/PluginContext';
 import { runPluginMenuAction } from '../api/plugins';
 import { resolvePluginString } from '../lib/pluginI18n';
@@ -40,6 +40,8 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
   const [confirmAction, setConfirmAction] = useState<'shutdown' | 'restart' | 'sleep' | 'suspend' | null>(null);
   const [sleepAvailable, setSleepAvailable] = useState(false);
   const [desktopState, setDesktopState] = useState<DesktopState | null>(null);
+  // null = the server could not tell; the unlock entry stays hidden then.
+  const [sessionLocked, setSessionLocked] = useState<boolean | null>(null);
   const { pluginMenuItems, refreshMenuItems } = usePlugins();
   const [runningAction, setRunningAction] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -53,8 +55,14 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
         .then(() => setSleepAvailable(true))
         .catch(() => setSleepAvailable(false));
       getDesktopStatus()
-        .then((s) => setDesktopState(s.state))
-        .catch(() => setDesktopState(null));
+        .then((s) => {
+          setDesktopState(s.state);
+          setSessionLocked(s.session_locked ?? null);
+        })
+        .catch(() => {
+          setDesktopState(null);
+          setSessionLocked(null);
+        });
       // Plugin entries can depend on server-side state too — the Steam plugin
       // offers "start" or "end" gaming mode, never both — and the manifest is
       // otherwise only fetched at page load.
@@ -133,6 +141,21 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
       }
     } catch {
       toast.error(t('powerMenu.desktopEnableFailed', 'Failed to enable desktop'));
+    }
+  };
+
+  const handleUnlockSession = async () => {
+    setIsOpen(false);
+    try {
+      const result = await unlockSession();
+      if (result.success) {
+        toast.success(t('powerMenu.sessionUnlocked', 'Session unlocked'));
+      } else {
+        // result.message is an English debug string and stays out of the UI (#406).
+        toast.error(t('powerMenu.sessionUnlockFailed', 'Failed to unlock the session'));
+      }
+    } catch {
+      toast.error(t('powerMenu.sessionUnlockFailed', 'Failed to unlock the session'));
     }
   };
 
@@ -232,6 +255,23 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
                         </div>
                       </button>
                     </>
+                  )}
+
+                  {/* Only while the displays are ON: with them off, "Enable
+                      desktop" below already unlocks as part of turning them on. */}
+                  {desktopState === 'running' && sessionLocked === true && (
+                    <button
+                      onClick={handleUnlockSession}
+                      className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-sky-500/10"
+                    >
+                      <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-sky-500/30 bg-sky-500/10">
+                        <Unlock className="h-4 w-4 text-sky-400" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium text-slate-100">{t('powerMenu.unlockSession', 'Unlock session')}</p>
+                        <p className="text-xs text-slate-400">{t('powerMenu.unlockSessionDesc', 'Dismiss the KDE lock screen')}</p>
+                      </div>
+                    </button>
                   )}
 
                   {desktopState === 'running' && (

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -265,6 +265,10 @@
     "desktopEnabled": "Desktop aktiviert",
     "desktopStillLocked": "Displays an - die Sitzung ist weiterhin gesperrt",
     "desktopEnableFailed": "Desktop konnte nicht aktiviert werden",
+    "unlockSession": "Sitzung entsperren",
+    "unlockSessionDesc": "KDE-Sperrbildschirm schließen",
+    "sessionUnlocked": "Sitzung entsperrt",
+    "sessionUnlockFailed": "Sitzung konnte nicht entsperrt werden",
     "pluginActionFailed": "Aktion fehlgeschlagen"
   },
   "adminOnly": "Nur für Admins",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -265,6 +265,10 @@
     "desktopEnabled": "Desktop enabled",
     "desktopStillLocked": "Displays on - the session is still locked",
     "desktopEnableFailed": "Failed to enable desktop",
+    "unlockSession": "Unlock session",
+    "unlockSessionDesc": "Dismiss the KDE lock screen",
+    "sessionUnlocked": "Session unlocked",
+    "sessionUnlockFailed": "Failed to unlock the session",
     "pluginActionFailed": "Action failed"
   },
   "adminOnly": "Admin only",


### PR DESCRIPTION
## Problem

Wenn die Displays laufen und die KDE-Sitzung gesperrt ist, gibt es aus der Web-App keinen Weg zum Sperrbildschirm. „Desktop aktivieren" entsperrt zwar mit — der Eintrag erscheint aber nur, solange die Displays **aus** sind. Genau der andere Fall war unbedient.

## Lösung

Ein Eintrag „Sitzung entsperren" im PowerMenu, sichtbar nur bei `state === 'running' && session_locked === true`.

**Backend**
- `SessionLockBackend.is_locked()` — reiner Lesezugriff über die schon vorhandenen `loginctl`-Helfer. Unbekannt ist `None`, nicht `False`: „keine Sitzung" ist nicht „nicht gesperrt".
- `current_lock_state()` — ruft das off-loop und schluckt jeden Fehler, damit eine Status-Route nie an logind stirbt.
- `DesktopStatus.session_locked` wird in der **Route** gefüllt, nicht im `DesktopService`. Der Statusbar-Collector pollt den Service alle 10 s und soll dafür kein `loginctl` starten.
- `POST /api/system/sleep/desktop/unlock` ruft ausschließlich `unlock_if_permitted()`. Bewusst **ohne** Rollen-Dependency: die Policy ist die einzige Stelle, an der LAN/VPN-Gate und `can_unlock_session` geprüft **und** auditiert werden; eine zweite Hürde davor würde davon abdriften. Eine Ablehnung ist deshalb `200` mit `success: false`, kein `403`.

**Frontend**
- `unlockSession()` + `session_locked` im Typ; Menüeintrag über „Desktop deaktivieren".
- Unbekannter Sperrzustand blendet den Eintrag aus, statt einen Knopf ins Leere anzubieten.
- Die Servermeldung ist ein englischer Debug-String und bleibt aus der UI (#406) — der Toast nutzt den übersetzten Schlüssel. i18n de + en.

## Messung statt Annahme

Auf BaluNode am 2026-09-03 gemessen: `LockedHint` meldet bei **sichtbarem** KDE-Sperrbildschirm `yes`, nach `unlock-session` wieder `no` — als Session-Owner ohne sudo, also genau auf dem Weg, den das Backend ohnehin geht. Ohne diese Probe wäre die Sichtbarkeitsregel geraten gewesen.

## Tests

- Backend: 58 Tests grün (`test_session_lock.py`, `test_desktop_unlock.py`, `test_session_unlock_policy.py`, `test_unlock_session_permission.py`), darunter „ein Lesezugriff ruft nie `unlock-session`" und „`null` bleibt `null`".
- Frontend: volle Vitest-Suite 268 Dateien / 1276 Tests grün; `eslint .` 0 Fehler; `npm run build` grün.

## Nicht dabei

Kein „Sperren"-Knopf, kein Polling/Push, keine eigene Notification, und der Eintrag bleibt admin-only wie der ganze Block — das Recht `can_unlock_session` für delegierte Nutzer wirkt weiter über die Enable-Route.

## Abnahme nach dem Deploy

Displays an lassen, Sitzung sperren (`loginctl lock-session 2`), im Browser das Power-Menü öffnen → „Sitzung entsperren" muss erscheinen, ein Klick den Sperrbildschirm **sichtbar** verschwinden lassen. Dieselbe Aktion von außen über `baluhost.duckdns.org` ohne VPN muss abgelehnt werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HT7gX6VGaYADnBqwQWyuND
