### PR TITLE
feat(auth): Sitzungsdauer und Idle-Abmeldung durch Admins einstellbar

### DIFF
--- a/.claude/rules/security-agent.md
+++ b/.claude/rules/security-agent.md
@@ -37,7 +37,7 @@ Active security enforcement rule for BaluHost. Applies to all changes in `backen
 ### Token Types
 | Type | TTL | Claim `type` | Features |
 |------|-----|---------------|----------|
-| Access | 15 min (`ACCESS_TOKEN_EXPIRE_MINUTES`) | `"access"` | Contains `sub`, `username`, `role` |
+| Access | admin-configurable via `auth_policy.access_token_minutes`, default 15 min (`ACCESS_TOKEN_EXPIRE_MINUTES` is now only the fallback when the policy is unreadable) | `"access"` | Contains `sub`, `username`, `role`. Issued exclusively through `routes/auth.py:_issue_session_token()` — a route calling `auth_service.create_access_token()` directly would silently ignore the setting, and `tests/api/test_session_token_ttl.py` fails if one does |
 | Refresh | 7 days (`REFRESH_TOKEN_EXPIRE_DAYS`) | `"refresh"` | Contains `jti` for revocation |
 | SSE | 60 sec | `"sse"` | Scoped to single `upload_id`, safe for query params |
 | WS | 60 sec | `"ws"` | WebSocket handshake, contains `sub` + `username` |

--- a/backend/alembic/versions/c4b18e9a2f37_auth_policy_session_limits.py
+++ b/backend/alembic/versions/c4b18e9a2f37_auth_policy_session_limits.py
@@ -1,0 +1,40 @@
+"""auth_policy: admin-configurable session limits
+
+Revision ID: c4b18e9a2f37
+Revises: a7d3c9f18e42
+Create Date: 2026-09-03
+
+Additive only. The server_defaults reproduce the values that were hardcoded
+before (frontend hook: 4 min + 60 s; config.py: 15 min), so an existing
+installation behaves exactly as it did until an admin changes something.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c4b18e9a2f37"
+down_revision = "a7d3c9f18e42"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the three session-limit columns to auth_policy."""
+    op.add_column(
+        "auth_policy",
+        sa.Column("idle_timeout_minutes", sa.Integer(), nullable=False, server_default="4"),
+    )
+    op.add_column(
+        "auth_policy",
+        sa.Column("idle_warning_seconds", sa.Integer(), nullable=False, server_default="60"),
+    )
+    op.add_column(
+        "auth_policy",
+        sa.Column("access_token_minutes", sa.Integer(), nullable=False, server_default="15"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the session-limit columns."""
+    op.drop_column("auth_policy", "access_token_minutes")
+    op.drop_column("auth_policy", "idle_warning_seconds")
+    op.drop_column("auth_policy", "idle_timeout_minutes")

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -16,8 +16,10 @@ from app.schemas.auth import (
     RecoveryCodesGenerateRequest, RecoveryCodesResponse, RecoveryCodesStatusResponse,
     RecoveryResetRequest,
 )
+from app.schemas.auth_policy import SessionPolicyResponse
 from app.schemas.user import UserPublic, UserCreate
 from app.services import auth as auth_service
+from app.services.auth_policy import get_auth_policy, session_token_minutes
 from app.services import users as user_service
 from app.services import totp_service
 from app.models.user import User as UserModel
@@ -40,6 +42,31 @@ router = APIRouter()
 _failed_login_attempts: TTLCache = TTLCache(maxsize=10000, ttl=1800)
 _BRUTE_FORCE_WINDOW = 300  # 5 minutes
 _BRUTE_FORCE_THRESHOLD = 5  # failures before alert
+
+
+def _session_token_minutes(db: Session) -> int:
+    """Configured access-token lifetime; falls back to the config default."""
+    try:
+        return session_token_minutes(db)
+    except Exception:
+        # A policy read must never turn a working login into a 500. Losing the
+        # configured value for one login is recoverable; refusing the login is
+        # not.
+        logger.exception("auth policy unreadable, falling back to the config TTL")
+        return settings.ACCESS_TOKEN_EXPIRE_MINUTES
+
+
+def _issue_session_token(user_record, db: Session) -> str:
+    """Mint an access token with the admin-configured lifetime.
+
+    Every session-issuing route in this module goes through here. Calling
+    auth_service.create_access_token() directly would silently fall back to the
+    config default and quietly exempt that one login path from the setting -
+    tests/api/test_session_token_ttl.py fails if a route does.
+    """
+    return auth_service.create_access_token(
+        user_record, expires_minutes=_session_token_minutes(db)
+    )
 
 
 @router.post("/login")
@@ -103,7 +130,7 @@ async def login(payload: LoginRequest, request: Request, response: Response, db:
         db=db
     )
 
-    token = auth_service.create_access_token(user_record)
+    token = _issue_session_token(user_record, db)
     user_public = user_service.serialize_user(user_record)
 
     # Emit plugin hook for successful login
@@ -189,7 +216,7 @@ async def verify_2fa(payload: TwoFactorVerifyRequest, request: Request, response
         user_record.pin_grace_until = _dt.now(_tz.utc) + _td(seconds=window)
         db.commit()
 
-    token = auth_service.create_access_token(user_record)
+    token = _issue_session_token(user_record, db)
     user_public = user_service.serialize_user(user_record)
 
     emit_hook(
@@ -262,7 +289,7 @@ async def login_pin(payload: PinLoginRequest, request: Request, response: Respon
             action="pin_login_grace", user=user_record.username,
             details={"ip_address": ip_address}, success=True, db=db,
         )
-        token = auth_service.create_access_token(user_record)
+        token = _issue_session_token(user_record, db)
         return TokenResponse(access_token=token, user=user_service.serialize_user(user_record))
 
     # Window expired → require TOTP via the existing pending flow.
@@ -684,7 +711,7 @@ async def register(payload: RegisterRequest, request: Request, response: Respons
         db=db
     )
 
-    token = auth_service.create_access_token(user_record)
+    token = _issue_session_token(user_record, db)
     user_public = user_service.serialize_user(user_record)
 
     # Emit plugin hook for user registration
@@ -748,6 +775,27 @@ async def change_password(
     )
 
     return {"message": "Password changed successfully"}
+
+
+@router.get("/session-policy", response_model=SessionPolicyResponse)
+@limiter.limit(get_limit("user_operations"))
+async def session_policy(
+    request: Request,
+    response: Response,
+    current_user: UserPublic = Depends(deps.get_current_user),
+    db: Session = Depends(get_db),
+) -> SessionPolicyResponse:
+    """The idle-logout numbers, for any logged-in user.
+
+    The admin policy lives behind get_current_admin, but the idle hook runs in
+    every session - so the two values it needs get their own read path instead
+    of widening the admin route.
+    """
+    policy = get_auth_policy(db)
+    return SessionPolicyResponse(
+        idle_timeout_minutes=policy.idle_timeout_minutes,
+        idle_warning_seconds=policy.idle_warning_seconds,
+    )
 
 
 @router.post("/logout")
@@ -854,7 +902,7 @@ async def refresh_token(
             token_service.update_token_usage(db, jti, ip_address=ip_address)
 
         # Generate new access token
-        new_access_token = auth_service.create_access_token(user_record)
+        new_access_token = _issue_session_token(user_record, db)
 
         # Log successful token refresh
         audit_logger.log_security_event(

--- a/backend/app/api/routes/auth_policy.py
+++ b/backend/app/api/routes/auth_policy.py
@@ -1,5 +1,5 @@
 """Admin endpoints for the system-wide auth policy."""
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy.orm import Session
 
 from app.api import deps
@@ -16,7 +16,37 @@ def _to_response(p) -> AuthPolicyResponse:
     return AuthPolicyResponse(
         pin_login_enabled=p.pin_login_enabled,
         pin_grace_window_seconds=p.pin_grace_window_seconds,
+        idle_timeout_minutes=p.idle_timeout_minutes,
+        idle_warning_seconds=p.idle_warning_seconds,
+        access_token_minutes=p.access_token_minutes,
     )
+
+
+def _check_idle_window_fits(policy) -> None:
+    """The idle window must end before the access token does.
+
+    Otherwise the session dies at the token's expiry - a 401 that logs the user
+    out with no dialog and no countdown, which looks like a bug rather than a
+    setting. Validated against the MERGED state, so a partial update cannot
+    sneak past by changing one field at a time.
+
+    An idle timeout of 0 means "no idle logout"; then the token is the only
+    limit, which is honest and needs no check.
+    """
+    if policy.idle_timeout_minutes == 0:
+        return
+    idle_window = policy.idle_timeout_minutes * 60 + policy.idle_warning_seconds
+    token_window = policy.access_token_minutes * 60
+    if idle_window > token_window:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"The idle window ({idle_window // 60} min including the warning) "
+                f"outlives the access token ({policy.access_token_minutes} min). "
+                "Users would be logged out without the warning dialog. Raise the "
+                "token lifetime or shorten the idle timeout."
+            ),
+        )
 
 
 @router.get("", response_model=AuthPolicyResponse)
@@ -42,6 +72,14 @@ async def update_auth_policy(
     for field, value in data.items():
         if value is not None:
             setattr(policy, field, value)
+    try:
+        _check_idle_window_fits(policy)
+    except HTTPException:
+        # Nothing is committed yet, but the instance already carries the
+        # rejected values - expire it so a later read in this request sees the
+        # stored ones again.
+        db.rollback()
+        raise
     db.commit()
     db.refresh(policy)
     get_audit_logger_db().log_security_event(

--- a/backend/app/models/auth_policy.py
+++ b/backend/app/models/auth_policy.py
@@ -1,4 +1,4 @@
-"""Singleton auth policy: PIN-login window + global kill switch."""
+"""Singleton auth policy: PIN-login window, kill switch, session limits."""
 from __future__ import annotations
 
 from sqlalchemy import Integer, Boolean
@@ -18,4 +18,16 @@ class AuthPolicy(Base):
     )
     pin_grace_window_seconds: Mapped[int] = mapped_column(
         Integer, nullable=False, default=86400, server_default="86400"
+    )
+    # Session limits. The defaults reproduce the values that were hardcoded
+    # before (frontend hook: 4 min + 60 s; config.py: 15 min), so landing the
+    # migration changes no behavior - only who may change it afterwards.
+    idle_timeout_minutes: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=4, server_default="4"
+    )  # 0 disables the idle logout entirely
+    idle_warning_seconds: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=60, server_default="60"
+    )
+    access_token_minutes: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=15, server_default="15"
     )

--- a/backend/app/schemas/auth_policy.py
+++ b/backend/app/schemas/auth_policy.py
@@ -3,10 +3,22 @@ from pydantic import BaseModel, Field
 MIN_WINDOW_SECONDS = 60
 MAX_WINDOW_SECONDS = 604800  # 7 days
 
+# Session limits. 0 minutes is the documented "off" value for the idle logout;
+# every other bound exists to keep an admin from configuring something that
+# cannot work (a 30 s warning nobody can react to, a 3-day access token).
+MAX_IDLE_MINUTES = 1440  # 24 h
+MIN_WARNING_SECONDS = 10
+MAX_WARNING_SECONDS = 300
+MIN_TOKEN_MINUTES = 5
+MAX_TOKEN_MINUTES = 1440  # 24 h
+
 
 class AuthPolicyResponse(BaseModel):
     pin_login_enabled: bool
     pin_grace_window_seconds: int
+    idle_timeout_minutes: int
+    idle_warning_seconds: int
+    access_token_minutes: int
 
 
 class AuthPolicyUpdate(BaseModel):
@@ -14,3 +26,26 @@ class AuthPolicyUpdate(BaseModel):
     pin_grace_window_seconds: int | None = Field(
         default=None, ge=MIN_WINDOW_SECONDS, le=MAX_WINDOW_SECONDS
     )
+    idle_timeout_minutes: int | None = Field(
+        default=None, ge=0, le=MAX_IDLE_MINUTES,
+        description="Minutes of inactivity before the logout warning; 0 disables it",
+    )
+    idle_warning_seconds: int | None = Field(
+        default=None, ge=MIN_WARNING_SECONDS, le=MAX_WARNING_SECONDS,
+        description="Countdown shown before the automatic logout",
+    )
+    access_token_minutes: int | None = Field(
+        default=None, ge=MIN_TOKEN_MINUTES, le=MAX_TOKEN_MINUTES,
+        description="Lifetime of a newly issued access token",
+    )
+
+
+class SessionPolicyResponse(BaseModel):
+    """The two numbers the idle hook needs - readable by any logged-in user.
+
+    Deliberately does NOT carry the token TTL: the client never acts on it, and
+    the PIN policy is admin business.
+    """
+
+    idle_timeout_minutes: int
+    idle_warning_seconds: int

--- a/backend/app/services/auth_policy.py
+++ b/backend/app/services/auth_policy.py
@@ -15,3 +15,8 @@ def get_auth_policy(db: Session) -> AuthPolicy:
         db.commit()
         db.refresh(policy)
     return policy
+
+
+def session_token_minutes(db: Session) -> int:
+    """TTL for a newly issued access token, as configured by the admin."""
+    return get_auth_policy(db).access_token_minutes

--- a/backend/tests/api/test_session_policy.py
+++ b/backend/tests/api/test_session_policy.py
@@ -1,0 +1,159 @@
+"""Admin-configurable session limits: idle logout + access-token TTL.
+
+Both numbers were hardcoded before - 4 min + 60 s in the frontend hook, 15 min
+in ``config.py``. The pair is coupled: an idle window longer than the token's
+life means the session dies without the warning dialog ever showing, which is
+exactly the state the production box was in.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+
+ADMIN_URL = f"{settings.api_prefix}/admin/auth-policy"
+SESSION_URL = f"{settings.api_prefix}/auth/session-policy"
+
+
+class TestPolicyFields:
+    def test_defaults_match_the_previously_hardcoded_values(self, client, admin_headers):
+        """The migration must not change behavior on the day it lands."""
+        body = client.get(ADMIN_URL, headers=admin_headers).json()
+
+        assert body["idle_timeout_minutes"] == 4
+        assert body["idle_warning_seconds"] == 60
+        assert body["access_token_minutes"] == 15
+
+    def test_round_trip(self, client, admin_headers):
+        r = client.put(
+            ADMIN_URL,
+            headers=admin_headers,
+            json={
+                "idle_timeout_minutes": 30,
+                "idle_warning_seconds": 120,
+                "access_token_minutes": 720,
+            },
+        )
+
+        assert r.status_code == 200, r.text
+        assert r.json()["idle_timeout_minutes"] == 30
+        assert r.json()["access_token_minutes"] == 720
+        # and it survives a re-read, not just the echo
+        assert client.get(ADMIN_URL, headers=admin_headers).json()["idle_warning_seconds"] == 120
+
+    def test_zero_disables_the_idle_logout(self, client, admin_headers):
+        r = client.put(ADMIN_URL, headers=admin_headers, json={"idle_timeout_minutes": 0})
+
+        assert r.status_code == 200, r.text
+        assert r.json()["idle_timeout_minutes"] == 0
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"idle_timeout_minutes": -1},
+            {"idle_timeout_minutes": 1441},
+            {"idle_warning_seconds": 9},
+            {"idle_warning_seconds": 301},
+            {"access_token_minutes": 4},
+            {"access_token_minutes": 1441},
+        ],
+    )
+    def test_out_of_range_is_rejected(self, client, admin_headers, payload):
+        assert client.put(ADMIN_URL, headers=admin_headers, json=payload).status_code == 422
+
+
+class TestIdleWindowMustFitInTheToken:
+    """The trap this feature exists to close.
+
+    With idle 30 min against a 15 min token, the user is thrown out at minute
+    15 by a 401 - no dialog, no countdown. Refuse the combination instead of
+    letting an admin configure a lie.
+    """
+
+    def test_idle_window_longer_than_the_token_is_refused(self, client, admin_headers):
+        r = client.put(
+            ADMIN_URL,
+            headers=admin_headers,
+            json={"idle_timeout_minutes": 30, "access_token_minutes": 15},
+        )
+
+        assert r.status_code == 400, r.text
+        assert "token" in r.json()["detail"].lower()
+
+    def test_the_warning_seconds_count_towards_the_window(self, client, admin_headers):
+        """15 min idle + 60 s warning is 16 minutes, one minute too long."""
+        r = client.put(
+            ADMIN_URL,
+            headers=admin_headers,
+            json={
+                "idle_timeout_minutes": 15,
+                "idle_warning_seconds": 60,
+                "access_token_minutes": 15,
+            },
+        )
+
+        assert r.status_code == 400, r.text
+
+    def test_an_exactly_fitting_window_is_accepted(self, client, admin_headers):
+        r = client.put(
+            ADMIN_URL,
+            headers=admin_headers,
+            json={
+                "idle_timeout_minutes": 14,
+                "idle_warning_seconds": 60,
+                "access_token_minutes": 15,
+            },
+        )
+
+        assert r.status_code == 200, r.text
+
+    def test_a_partial_update_is_checked_against_the_stored_values(
+        self, client, admin_headers
+    ):
+        """PUT is a patch. Lowering only the token must still be validated
+        against the idle window already in the database, or the check is
+        trivially bypassed by sending one field at a time."""
+        client.put(
+            ADMIN_URL,
+            headers=admin_headers,
+            json={"idle_timeout_minutes": 60, "access_token_minutes": 120},
+        )
+
+        r = client.put(ADMIN_URL, headers=admin_headers, json={"access_token_minutes": 15})
+
+        assert r.status_code == 400, r.text
+
+    def test_a_disabled_idle_logout_lifts_the_constraint(self, client, admin_headers):
+        """With no idle logout the token IS the only limit - that is honest,
+        not a misconfiguration."""
+        r = client.put(
+            ADMIN_URL,
+            headers=admin_headers,
+            json={"idle_timeout_minutes": 0, "access_token_minutes": 5},
+        )
+
+        assert r.status_code == 200, r.text
+
+
+class TestSessionPolicyReadRoute:
+    """The idle hook runs for every user, so the read path cannot be admin-only."""
+
+    def test_a_plain_user_may_read_the_idle_values(self, client, user_headers):
+        r = client.get(SESSION_URL, headers=user_headers)
+
+        assert r.status_code == 200, r.text
+        assert r.json() == {"idle_timeout_minutes": 4, "idle_warning_seconds": 60}
+
+    def test_it_does_not_leak_the_token_ttl_or_the_pin_policy(self, client, admin_headers):
+        """Only what the hook needs. The token TTL is nothing the client acts on."""
+        body = client.get(SESSION_URL, headers=admin_headers).json()
+
+        assert set(body) == {"idle_timeout_minutes", "idle_warning_seconds"}
+
+    def test_it_reflects_an_admin_change(self, client, admin_headers, user_headers):
+        client.put(ADMIN_URL, headers=admin_headers, json={"idle_timeout_minutes": 10})
+
+        assert client.get(SESSION_URL, headers=user_headers).json()["idle_timeout_minutes"] == 10
+
+    def test_anonymous_callers_are_rejected(self, client):
+        assert client.get(SESSION_URL).status_code in (401, 403)

--- a/backend/tests/api/test_session_token_ttl.py
+++ b/backend/tests/api/test_session_token_ttl.py
@@ -1,0 +1,112 @@
+"""Every session token must carry the TTL the admin configured.
+
+Five routes in auth.py hand out access tokens. Before this change each one
+silently inherited ``settings.ACCESS_TOKEN_EXPIRE_MINUTES``; the production box
+had a well-meant ``TOKEN_EXPIRE_MINUTES=720`` in its env file that never
+matched a settings field and therefore did nothing for months. The fix is one
+issuing helper plus a test that notices when a sixth route bypasses it.
+"""
+from __future__ import annotations
+
+import re
+
+import jwt as pyjwt
+import pytest
+
+from app.core.config import settings
+
+ADMIN_URL = f"{settings.api_prefix}/admin/auth-policy"
+LOGIN_URL = f"{settings.api_prefix}/auth/login"
+
+
+def _ttl_minutes(token: str) -> float:
+    """Lifetime the token was actually minted with, from its own claims."""
+    claims = pyjwt.decode(
+        token, settings.SECRET_KEY, algorithms=["HS256"], options={"verify_exp": False}
+    )
+    return (claims["exp"] - claims["iat"]) / 60
+
+
+def _login(client) -> str:
+    r = client.post(
+        LOGIN_URL,
+        json={"username": settings.admin_username, "password": settings.admin_password},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+class TestLoginHonoursThePolicy:
+    def test_default_policy_gives_the_documented_fifteen_minutes(
+        self, client, admin_user
+    ):
+        assert _ttl_minutes(_login(client)) == pytest.approx(15, abs=0.2)
+
+    def test_a_raised_policy_reaches_the_token(self, client, admin_headers):
+        """The assertion that would have caught the dead env variable."""
+        client.put(ADMIN_URL, headers=admin_headers, json={"access_token_minutes": 720})
+
+        assert _ttl_minutes(_login(client)) == pytest.approx(720, abs=0.2)
+
+    def test_registration_issues_the_same_ttl(self, client, admin_headers):
+        client.put(ADMIN_URL, headers=admin_headers, json={"access_token_minutes": 90})
+
+        r = client.post(
+            f"{settings.api_prefix}/auth/register",
+            json={
+                "username": "ttluser",
+                "email": "ttl@example.com",
+                "password": "Testpass123!",
+            },
+        )
+
+        if r.status_code in (403, 404):
+            pytest.skip("registration is closed in this configuration")
+        assert r.status_code in (200, 201), r.text
+        assert _ttl_minutes(r.json()["access_token"]) == pytest.approx(90, abs=0.2)
+
+
+class TestNoRouteMintsItsOwnTtl:
+    """A structural guard, not a behavioral one.
+
+    Each token route is three lines of boilerplate; the next one will be
+    written by copying a neighbour. If that copy calls the auth service
+    directly it inherits the config default again and the admin's setting
+    silently stops applying to one login path. Cheaper to fail here than to
+    debug "only PIN logins expire early" later.
+    """
+
+    def test_auth_routes_issue_tokens_only_through_the_helper(self):
+        from pathlib import Path
+
+        import app.api.routes.auth as auth_routes
+
+        source = Path(auth_routes.__file__).read_text(encoding="utf-8")
+
+        enclosing = "<module>"
+        direct = []
+        for line in source.splitlines():
+            match = re.match(r"(?:async )?def (\w+)", line)
+            if match:
+                enclosing = match.group(1)
+            if "auth_service.create_access_token(" in line:
+                # The helper itself is the one legitimate caller.
+                if enclosing != "_issue_session_token":
+                    direct.append(f"{enclosing}: {line.strip()}")
+
+        assert direct == [], (
+            "these bypass _issue_session_token() and would ignore the "
+            f"configured token TTL: {direct}"
+        )
+
+    def test_the_helper_actually_reads_the_policy(self, db_session):
+        """Guard against the guard: a helper that ignores the policy would keep
+        the scan test green while changing nothing."""
+        from app.api.routes import auth as auth_routes
+        from app.services.auth_policy import get_auth_policy
+
+        policy = get_auth_policy(db_session)
+        policy.access_token_minutes = 33
+        db_session.commit()
+
+        assert auth_routes._session_token_minutes(db_session) == 33

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import { NotificationProvider } from './contexts/NotificationContext';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { buildApiUrl } from './lib/api';
 import { useIdleTimeout } from './hooks/useIdleTimeout';
+import { useSessionPolicy } from './hooks/useSessionPolicy';
 import { IdleWarningDialog } from './components/ui/IdleWarningDialog';
 import { usePresenceHeartbeat } from './hooks/usePresenceHeartbeat';
 import { FEATURES, isDesktop } from './lib/features';
@@ -136,9 +137,14 @@ function LoadingScreen({ backendReady, backendCheckAttempts }: { backendReady: b
 export function AppRoutes() {
   const { user, logout, loading, isAdmin } = useAuth();
 
+  // Timings are admin-configurable (auth_policy); until they load, the hook
+  // runs on its own 4 min / 60 s fallbacks.
+  const { idleMs, warningSec, idleEnabled } = useSessionPolicy(user !== null);
   const { warningVisible, secondsRemaining, resetTimer } = useIdleTimeout({
     onLogout: logout,
-    enabled: user !== null,
+    enabled: user !== null && idleEnabled,
+    idleMs,
+    warningSec,
   });
 
   usePresenceHeartbeat({ paused: warningVisible, enabled: user !== null });

--- a/client/src/__tests__/components/admin/SessionPolicySettings.test.tsx
+++ b/client/src/__tests__/components/admin/SessionPolicySettings.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../../api/pin', () => ({
+  getAuthPolicy: vi.fn(),
+  updateAuthPolicy: vi.fn(),
+}));
+
+import toast from 'react-hot-toast';
+import { getAuthPolicy, updateAuthPolicy } from '../../../api/pin';
+import { SessionPolicySettings } from '../../../components/admin/SessionPolicySettings';
+
+const mockedGet = getAuthPolicy as unknown as ReturnType<typeof vi.fn>;
+const mockedUpdate = updateAuthPolicy as unknown as ReturnType<typeof vi.fn>;
+
+const POLICY = {
+  pin_login_enabled: true,
+  pin_grace_window_seconds: 86400,
+  idle_timeout_minutes: 4,
+  idle_warning_seconds: 60,
+  access_token_minutes: 15,
+};
+
+function field(testId: string): HTMLInputElement {
+  return screen.getByTestId(testId) as HTMLInputElement;
+}
+
+describe('SessionPolicySettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGet.mockResolvedValue({ ...POLICY });
+    mockedUpdate.mockImplementation((body) => Promise.resolve({ ...POLICY, ...body }));
+  });
+
+  it('shows the stored values', async () => {
+    render(<SessionPolicySettings />);
+
+    await waitFor(() => expect(field('session-idle-minutes').value).toBe('4'));
+    expect(field('session-warning-seconds').value).toBe('60');
+    expect(field('session-token-minutes').value).toBe('15');
+  });
+
+  it('saves all three fields in one request', async () => {
+    // Deliberately one Save button rather than save-on-change: the server
+    // refuses an idle window that outlives the token, so raising both needs to
+    // travel together or the intermediate state gets rejected.
+    render(<SessionPolicySettings />);
+    await waitFor(() => expect(field('session-idle-minutes')).toBeTruthy());
+
+    fireEvent.change(field('session-idle-minutes'), { target: { value: '30' } });
+    fireEvent.change(field('session-token-minutes'), { target: { value: '720' } });
+    fireEvent.click(screen.getByTestId('session-policy-save'));
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledWith({
+      idle_timeout_minutes: 30,
+      idle_warning_seconds: 60,
+      access_token_minutes: 720,
+    }));
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('refuses an idle window that outlives the token without asking the server', async () => {
+    render(<SessionPolicySettings />);
+    await waitFor(() => expect(field('session-idle-minutes')).toBeTruthy());
+
+    fireEvent.change(field('session-idle-minutes'), { target: { value: '30' } });
+    fireEvent.click(screen.getByTestId('session-policy-save'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+
+  it('allows a long idle window once the token covers it', async () => {
+    render(<SessionPolicySettings />);
+    await waitFor(() => expect(field('session-idle-minutes')).toBeTruthy());
+
+    fireEvent.change(field('session-idle-minutes'), { target: { value: '60' } });
+    fireEvent.change(field('session-token-minutes'), { target: { value: '61' } });
+    fireEvent.click(screen.getByTestId('session-policy-save'));
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalled());
+  });
+
+  it('skips the coupling check when the idle logout is switched off', async () => {
+    render(<SessionPolicySettings />);
+    await waitFor(() => expect(field('session-idle-minutes')).toBeTruthy());
+
+    fireEvent.change(field('session-idle-minutes'), { target: { value: '0' } });
+    fireEvent.click(screen.getByTestId('session-policy-save'));
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ idle_timeout_minutes: 0 }),
+    ));
+  });
+
+  it('warns about the risk of a long token', async () => {
+    // There is no revocation for access tokens — the number deserves a note
+    // next to it, not just a spin box.
+    render(<SessionPolicySettings />);
+
+    await waitFor(() => expect(screen.getByTestId('session-token-hint')).toBeTruthy());
+  });
+
+  it('surfaces a server rejection', async () => {
+    mockedUpdate.mockRejectedValue({
+      response: { data: { detail: 'The idle window outlives the access token.' } },
+    });
+    render(<SessionPolicySettings />);
+    await waitFor(() => expect(field('session-idle-minutes')).toBeTruthy());
+
+    fireEvent.click(screen.getByTestId('session-policy-save'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+  });
+});

--- a/client/src/__tests__/hooks/useIdleTimeout.test.ts
+++ b/client/src/__tests__/hooks/useIdleTimeout.test.ts
@@ -90,3 +90,63 @@ describe('useIdleTimeout', () => {
     expect(onLogout).not.toHaveBeenCalled();
   });
 });
+
+describe('useIdleTimeout — configurable durations', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('uses the 4 min / 60 s defaults when nothing is passed', () => {
+    const onLogout = vi.fn();
+    const { result } = renderHook(() => useIdleTimeout({ onLogout, enabled: true }));
+
+    act(() => { vi.advanceTimersByTime(4 * 60 * 1000 - 1000); });
+    expect(result.current.warningVisible).toBe(false);
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(result.current.warningVisible).toBe(true);
+  });
+
+  it('waits the configured idle time before warning', () => {
+    const onLogout = vi.fn();
+    const { result } = renderHook(() =>
+      useIdleTimeout({ onLogout, enabled: true, idleMs: 30 * 60 * 1000 }),
+    );
+
+    // The old hardcoded 4 minutes must NOT fire any more.
+    act(() => { vi.advanceTimersByTime(4 * 60 * 1000); });
+    expect(result.current.warningVisible).toBe(false);
+
+    act(() => { vi.advanceTimersByTime(26 * 60 * 1000); });
+    expect(result.current.warningVisible).toBe(true);
+  });
+
+  it('counts down from the configured warning seconds', () => {
+    const onLogout = vi.fn();
+    const { result } = renderHook(() =>
+      useIdleTimeout({ onLogout, enabled: true, idleMs: 60_000, warningSec: 120 }),
+    );
+
+    expect(result.current.secondsRemaining).toBe(120);
+    act(() => { vi.advanceTimersByTime(60_000); });
+    expect(result.current.secondsRemaining).toBe(120);
+
+    act(() => { vi.advanceTimersByTime(119_000); });
+    expect(onLogout).not.toHaveBeenCalled();
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(onLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it('picks up changed durations without a remount', () => {
+    // The values arrive from the server one render after login, so the hook is
+    // always mounted with the defaults first.
+    const onLogout = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ idleMs }) => useIdleTimeout({ onLogout, enabled: true, idleMs }),
+      { initialProps: { idleMs: 4 * 60 * 1000 } },
+    );
+
+    rerender({ idleMs: 30 * 60 * 1000 });
+    act(() => { vi.advanceTimersByTime(4 * 60 * 1000); });
+
+    expect(result.current.warningVisible).toBe(false);
+  });
+});

--- a/client/src/__tests__/hooks/useSessionPolicy.test.ts
+++ b/client/src/__tests__/hooks/useSessionPolicy.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+vi.mock('../../api/pin', () => ({
+  getSessionPolicy: vi.fn(),
+}));
+
+import { getSessionPolicy } from '../../api/pin';
+import { useSessionPolicy } from '../../hooks/useSessionPolicy';
+import { DEFAULT_IDLE_MS, DEFAULT_WARNING_SEC } from '../../lib/sessionDefaults';
+
+const mocked = getSessionPolicy as unknown as ReturnType<typeof vi.fn>;
+
+describe('useSessionPolicy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocked.mockResolvedValue({ idle_timeout_minutes: 4, idle_warning_seconds: 60 });
+  });
+
+  it('starts on the hardcoded fallbacks before the server answers', () => {
+    const { result } = renderHook(() => useSessionPolicy(true));
+
+    expect(result.current.idleMs).toBe(DEFAULT_IDLE_MS);
+    expect(result.current.warningSec).toBe(DEFAULT_WARNING_SEC);
+    expect(result.current.idleEnabled).toBe(true);
+  });
+
+  it('applies the configured values', async () => {
+    mocked.mockResolvedValue({ idle_timeout_minutes: 30, idle_warning_seconds: 120 });
+    const { result } = renderHook(() => useSessionPolicy(true));
+
+    await waitFor(() => expect(result.current.idleMs).toBe(30 * 60 * 1000));
+    expect(result.current.warningSec).toBe(120);
+    expect(result.current.idleEnabled).toBe(true);
+  });
+
+  it('reports the idle logout as disabled at 0 minutes', async () => {
+    mocked.mockResolvedValue({ idle_timeout_minutes: 0, idle_warning_seconds: 60 });
+    const { result } = renderHook(() => useSessionPolicy(true));
+
+    await waitFor(() => expect(result.current.idleEnabled).toBe(false));
+  });
+
+  it('keeps the fallbacks when the request fails', async () => {
+    // Losing the setting must never mean losing the idle logout: a broken
+    // read silently disabling it would be a security regression.
+    mocked.mockRejectedValue(new Error('offline'));
+    const { result } = renderHook(() => useSessionPolicy(true));
+
+    await waitFor(() => expect(mocked).toHaveBeenCalled());
+    expect(result.current.idleMs).toBe(DEFAULT_IDLE_MS);
+    expect(result.current.warningSec).toBe(DEFAULT_WARNING_SEC);
+    expect(result.current.idleEnabled).toBe(true);
+  });
+
+  it('asks for nothing while logged out', () => {
+    renderHook(() => useSessionPolicy(false));
+
+    expect(mocked).not.toHaveBeenCalled();
+  });
+
+  it('fetches once per login, not on every render', async () => {
+    const { rerender, result } = renderHook(({ on }) => useSessionPolicy(on), {
+      initialProps: { on: true },
+    });
+
+    await waitFor(() => expect(mocked).toHaveBeenCalledTimes(1));
+    rerender({ on: true });
+    rerender({ on: true });
+
+    expect(mocked).toHaveBeenCalledTimes(1);
+    expect(result.current.idleEnabled).toBe(true);
+  });
+});

--- a/client/src/api/pin.ts
+++ b/client/src/api/pin.ts
@@ -9,6 +9,18 @@ export interface PinStatus {
 export interface AuthPolicy {
   pin_login_enabled: boolean;
   pin_grace_window_seconds: number;
+  /** Inactivity before the logout warning, in minutes. 0 disables it. */
+  idle_timeout_minutes: number;
+  /** Countdown shown in the warning dialog, in seconds. */
+  idle_warning_seconds: number;
+  /** Lifetime of a newly issued access token, in minutes. */
+  access_token_minutes: number;
+}
+
+/** The subset every logged-in user may read — what the idle hook needs. */
+export interface SessionPolicy {
+  idle_timeout_minutes: number;
+  idle_warning_seconds: number;
 }
 
 /** Either a finished login (access_token) or a 2FA challenge (pending_token). */
@@ -54,5 +66,17 @@ export async function getAuthPolicy(): Promise<AuthPolicy> {
 
 export async function updateAuthPolicy(body: Partial<AuthPolicy>): Promise<AuthPolicy> {
   const res = await apiClient.put<AuthPolicy>('/api/admin/auth-policy', body);
+  return res.data;
+}
+
+/**
+ * Session limits for the current user's idle timer.
+ *
+ * Separate from `getAuthPolicy()`, which is admin-only: the idle logout runs in
+ * every session, so its two numbers have their own read path that leaks neither
+ * the token lifetime nor the PIN policy.
+ */
+export async function getSessionPolicy(): Promise<SessionPolicy> {
+  const res = await apiClient.get<SessionPolicy>('/api/auth/session-policy');
   return res.data;
 }

--- a/client/src/components/admin/SessionPolicySettings.tsx
+++ b/client/src/components/admin/SessionPolicySettings.tsx
@@ -1,0 +1,114 @@
+/** Admin: how long a session lives — idle logout and access-token lifetime. */
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { getAuthPolicy, updateAuthPolicy } from '../../api/pin';
+import { handleApiError } from '../../lib/errorHandling';
+
+export function SessionPolicySettings() {
+  const { t } = useTranslation('admin');
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [idleMinutes, setIdleMinutes] = useState(4);
+  const [warningSeconds, setWarningSeconds] = useState(60);
+  const [tokenMinutes, setTokenMinutes] = useState(15);
+
+  useEffect(() => {
+    getAuthPolicy()
+      .then((p) => {
+        setIdleMinutes(p.idle_timeout_minutes);
+        setWarningSeconds(p.idle_warning_seconds);
+        setTokenMinutes(p.access_token_minutes);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  /**
+   * One Save for all three, rather than the save-on-change the PIN card uses.
+   * The server refuses an idle window that outlives the token, so raising the
+   * idle timeout and the token lifetime has to travel in one request —
+   * otherwise every such change would be rejected halfway through.
+   */
+  const save = async () => {
+    const idleWindow = idleMinutes * 60 + warningSeconds;
+    if (idleMinutes > 0 && idleWindow > tokenMinutes * 60) {
+      // Mirrors the server rule so the admin gets a translated hint instead of
+      // an English 400 detail. The server stays the enforcer.
+      toast.error(t('sessionPolicy.idleExceedsToken'));
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const p = await updateAuthPolicy({
+        idle_timeout_minutes: idleMinutes,
+        idle_warning_seconds: warningSeconds,
+        access_token_minutes: tokenMinutes,
+      });
+      setIdleMinutes(p.idle_timeout_minutes);
+      setWarningSeconds(p.idle_warning_seconds);
+      setTokenMinutes(p.access_token_minutes);
+      toast.success(t('sessionPolicy.saved'));
+    } catch (err) {
+      handleApiError(err, t('sessionPolicy.saveError'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) return null;
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+      <h3 className="text-lg font-semibold text-slate-100">{t('sessionPolicy.title')}</h3>
+      <p className="mt-1 text-sm text-slate-400">{t('sessionPolicy.description')}</p>
+
+      <label className="mt-4 block text-sm text-slate-300">
+        {t('sessionPolicy.idleTimeout')}
+        <input
+          data-testid="session-idle-minutes"
+          type="number" min={0} max={1440} className="input mt-1" disabled={busy}
+          value={idleMinutes}
+          onChange={(e) => setIdleMinutes(Number(e.target.value))}
+        />
+        <span className="mt-1 block text-xs text-slate-500">
+          {idleMinutes === 0 ? t('sessionPolicy.idleDisabled') : t('sessionPolicy.idleHint')}
+        </span>
+      </label>
+
+      <label className="mt-4 block text-sm text-slate-300">
+        {t('sessionPolicy.warningSeconds')}
+        <input
+          data-testid="session-warning-seconds"
+          type="number" min={10} max={300} className="input mt-1"
+          disabled={busy || idleMinutes === 0}
+          value={warningSeconds}
+          onChange={(e) => setWarningSeconds(Number(e.target.value))}
+        />
+      </label>
+
+      <label className="mt-4 block text-sm text-slate-300">
+        {t('sessionPolicy.tokenMinutes')}
+        <input
+          data-testid="session-token-minutes"
+          type="number" min={5} max={1440} className="input mt-1" disabled={busy}
+          value={tokenMinutes}
+          onChange={(e) => setTokenMinutes(Number(e.target.value))}
+        />
+        <span data-testid="session-token-hint" className="mt-1 block text-xs text-amber-400/80">
+          {t('sessionPolicy.tokenHint')}
+        </span>
+      </label>
+
+      <button
+        data-testid="session-policy-save"
+        onClick={() => { void save(); }}
+        disabled={busy}
+        className="mt-5 rounded-xl border border-sky-500/40 bg-sky-500/15 px-4 py-2 text-sm font-medium text-sky-200 transition hover:border-sky-400 hover:bg-sky-500/25 disabled:opacity-50"
+      >
+        {busy ? t('sessionPolicy.saving') : t('sessionPolicy.save')}
+      </button>
+    </div>
+  );
+}

--- a/client/src/hooks/CLAUDE.md
+++ b/client/src/hooks/CLAUDE.md
@@ -56,7 +56,8 @@ Custom React hooks encapsulating data fetching, polling, and UI logic. Each hook
 | `useConfirmDialog.ts` | Confirmation dialog state management |
 | `useSortableTable.ts` | Table sorting state (column, direction) |
 | `useByteUnitMode.ts` | Binary (GiB) vs decimal (GB) byte unit preference |
-| `useIdleTimeout.ts` | Auto-logout after inactivity period |
+| `useIdleTimeout.ts` | Auto-logout after inactivity; durations come from `useSessionPolicy` and default to 4 min + 60 s |
+| `useSessionPolicy.ts` | Reads `auth_policy`'s idle timings once per login via `GET /api/auth/session-policy`; falls back to the hardcoded defaults on error, never disables the idle logout |
 | `useNotificationSocket.ts` | WebSocket connection for real-time notifications |
 | `useNextMaintenance.ts` | Next scheduled maintenance window |
 | `usePresenceHeartbeat.ts` | Presence heartbeat to `/api/system/sleep/presence` while tab visible (blocks auto true-suspend, #214); fire-and-forget, mounted once in `AppRoutes` (auth-gated via `enabled`); paused while the idle-logout warning is visible (#222) |

--- a/client/src/hooks/useIdleTimeout.ts
+++ b/client/src/hooks/useIdleTimeout.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { DEFAULT_IDLE_MS, DEFAULT_WARNING_SEC } from '../lib/sessionDefaults';
 
-const IDLE_MS = 4 * 60 * 1000;       // 4 min until warning
-const WARNING_SEC = 60;                // 60s countdown
 const STORAGE_KEY = 'baluhost-idle-ping';
 const ACTIVITY_EVENTS: (keyof DocumentEventMap)[] = [
   'mousemove', 'keydown', 'click', 'scroll', 'touchstart',
@@ -10,6 +9,10 @@ const ACTIVITY_EVENTS: (keyof DocumentEventMap)[] = [
 interface UseIdleTimeoutOptions {
   onLogout: () => void;
   enabled: boolean;
+  /** Inactivity before the warning appears. Defaults to 4 min. */
+  idleMs?: number;
+  /** Countdown length inside the warning dialog. Defaults to 60 s. */
+  warningSec?: number;
 }
 
 interface UseIdleTimeoutReturn {
@@ -18,9 +21,14 @@ interface UseIdleTimeoutReturn {
   resetTimer: () => void;
 }
 
-export function useIdleTimeout({ onLogout, enabled }: UseIdleTimeoutOptions): UseIdleTimeoutReturn {
+export function useIdleTimeout({
+  onLogout,
+  enabled,
+  idleMs = DEFAULT_IDLE_MS,
+  warningSec = DEFAULT_WARNING_SEC,
+}: UseIdleTimeoutOptions): UseIdleTimeoutReturn {
   const [warningVisible, setWarningVisible] = useState(false);
-  const [secondsRemaining, setSecondsRemaining] = useState(WARNING_SEC);
+  const [secondsRemaining, setSecondsRemaining] = useState(warningSec);
 
   // Stable refs to avoid re-creating callbacks when props change
   const onLogoutRef = useRef(onLogout);
@@ -28,6 +36,14 @@ export function useIdleTimeout({ onLogout, enabled }: UseIdleTimeoutOptions): Us
 
   const enabledRef = useRef(enabled);
   enabledRef.current = enabled;
+
+  // The durations arrive from the server one render after login, so callbacks
+  // read them through refs and stay stable; the effect below restarts the
+  // timers when they actually change.
+  const idleMsRef = useRef(idleMs);
+  idleMsRef.current = idleMs;
+  const warningSecRef = useRef(warningSec);
+  warningSecRef.current = warningSec;
 
   const idleTimer = useRef<ReturnType<typeof setTimeout>>();
   const countdownInterval = useRef<ReturnType<typeof setInterval>>();
@@ -60,14 +76,14 @@ export function useIdleTimeout({ onLogout, enabled }: UseIdleTimeoutOptions): Us
     clearTimers();
     warningActiveRef.current = false;
     setWarningVisible(false);
-    setSecondsRemaining(WARNING_SEC);
+    setSecondsRemaining(warningSecRef.current);
     lastActivityRef.current = Date.now();
 
     if (!enabledRef.current) return;
 
     idleTimer.current = setTimeout(() => {
-      startCountdown(WARNING_SEC);
-    }, IDLE_MS);
+      startCountdown(warningSecRef.current);
+    }, idleMsRef.current);
   }, [clearTimers, startCountdown]);
 
   // Activity handler — resets timer and pings other tabs
@@ -103,7 +119,10 @@ export function useIdleTimeout({ onLogout, enabled }: UseIdleTimeoutOptions): Us
         document.removeEventListener(event, handleActivity);
       }
     };
-  }, [enabled]); // eslint-disable-line react-hooks/exhaustive-deps
+    // idleMs/warningSec are in the deps on purpose: when the server-side policy
+    // arrives after login, the running timer must be replaced, not left at the
+    // fallback duration.
+  }, [enabled, idleMs, warningSec]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Cross-tab sync: listen for storage events from other tabs
   useEffect(() => {
@@ -128,14 +147,14 @@ export function useIdleTimeout({ onLogout, enabled }: UseIdleTimeoutOptions): Us
       if (document.visibilityState !== 'visible') return;
 
       const elapsed = Date.now() - lastActivityRef.current;
-      const totalMs = IDLE_MS + WARNING_SEC * 1000;
+      const totalMs = idleMsRef.current + warningSecRef.current * 1000;
 
       if (elapsed >= totalMs) {
         // Total timeout elapsed → immediate logout
         clearTimers();
         warningActiveRef.current = false;
         onLogoutRef.current();
-      } else if (elapsed >= IDLE_MS) {
+      } else if (elapsed >= idleMsRef.current) {
         // Idle time passed, still in countdown window → show warning with adjusted countdown
         clearTimers();
         const remaining = Math.ceil((totalMs - elapsed) / 1000);
@@ -144,9 +163,9 @@ export function useIdleTimeout({ onLogout, enabled }: UseIdleTimeoutOptions): Us
         // Not yet expired → restart timer with remaining idle time
         if (!warningActiveRef.current) {
           clearTimers();
-          const remainingIdle = IDLE_MS - elapsed;
+          const remainingIdle = idleMsRef.current - elapsed;
           idleTimer.current = setTimeout(() => {
-            startCountdown(WARNING_SEC);
+            startCountdown(warningSecRef.current);
           }, remainingIdle);
         }
       }

--- a/client/src/hooks/useSessionPolicy.ts
+++ b/client/src/hooks/useSessionPolicy.ts
@@ -1,0 +1,51 @@
+/**
+ * Reads the admin-configured session limits once per login.
+ *
+ * The idle logout used to be hardcoded at 4 min + 60 s. Those values now live
+ * in the `auth_policy` singleton and are served by `GET /api/auth/session-policy`.
+ * Until the answer arrives — and permanently if it never does — the hook
+ * reports the old hardcoded values: a failed read must not silently switch the
+ * idle logout off.
+ */
+import { useEffect, useState } from 'react';
+import { getSessionPolicy } from '../api/pin';
+import { DEFAULT_IDLE_MS, DEFAULT_WARNING_SEC } from '../lib/sessionDefaults';
+
+export interface SessionPolicyValues {
+  idleMs: number;
+  warningSec: number;
+  /** False when the admin set the idle timeout to 0 (no automatic logout). */
+  idleEnabled: boolean;
+}
+
+const FALLBACK: SessionPolicyValues = {
+  idleMs: DEFAULT_IDLE_MS,
+  warningSec: DEFAULT_WARNING_SEC,
+  idleEnabled: true,
+};
+
+export function useSessionPolicy(enabled: boolean): SessionPolicyValues {
+  const [values, setValues] = useState<SessionPolicyValues>(FALLBACK);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    getSessionPolicy()
+      .then((policy) => {
+        if (cancelled) return;
+        setValues({
+          idleMs: policy.idle_timeout_minutes * 60 * 1000,
+          warningSec: policy.idle_warning_seconds,
+          idleEnabled: policy.idle_timeout_minutes > 0,
+        });
+      })
+      .catch(() => {
+        // Keep the fallbacks. Never disable the idle logout on an error.
+      });
+
+    return () => { cancelled = true; };
+  }, [enabled]);
+
+  return values;
+}

--- a/client/src/i18n/locales/de/admin.json
+++ b/client/src/i18n/locales/de/admin.json
@@ -502,6 +502,21 @@
     },
     "processing": "Wird verarbeitet..."
   },
+  "sessionPolicy": {
+    "title": "Sitzungsdauer",
+    "description": "Wie lange eine angemeldete Sitzung lebt — Abmeldung bei Inaktivität und Laufzeit des Zugriffstokens.",
+    "idleTimeout": "Abmelden nach Inaktivität (Minuten)",
+    "idleHint": "Danach erscheint die Warnung mit Countdown.",
+    "idleDisabled": "0 = keine automatische Abmeldung bei Inaktivität.",
+    "warningSeconds": "Countdown im Warndialog (Sekunden)",
+    "tokenMinutes": "Laufzeit des Zugriffstokens (Minuten)",
+    "tokenHint": "Gilt ab der Anmeldung, unabhängig von Aktivität. Ein gestohlener Token bleibt so lange gültig — für Zugriffstokens gibt es keinen Widerruf.",
+    "idleExceedsToken": "Das Inaktivitätsfenster inklusive Countdown ist länger als die Tokenlaufzeit. Nutzer würden ohne Warndialog abgemeldet.",
+    "save": "Speichern",
+    "saving": "Speichert…",
+    "saved": "Sitzungsdauer gespeichert",
+    "saveError": "Sitzungsdauer konnte nicht gespeichert werden"
+  },
   "authPolicy": {
     "title": "PIN-Login-Richtlinie",
     "description": "Steuert das Gnadenfenster, in dem die Desktop-App-PIN ohne 2FA-Code genügt.",

--- a/client/src/i18n/locales/en/admin.json
+++ b/client/src/i18n/locales/en/admin.json
@@ -502,6 +502,21 @@
     },
     "processing": "Processing..."
   },
+  "sessionPolicy": {
+    "title": "Session duration",
+    "description": "How long a signed-in session lives — idle logout and access-token lifetime.",
+    "idleTimeout": "Log out after inactivity (minutes)",
+    "idleHint": "The warning with its countdown appears after this.",
+    "idleDisabled": "0 = no automatic logout on inactivity.",
+    "warningSeconds": "Countdown in the warning dialog (seconds)",
+    "tokenMinutes": "Access-token lifetime (minutes)",
+    "tokenHint": "Counts from sign-in, regardless of activity. A stolen token stays valid that long — access tokens cannot be revoked.",
+    "idleExceedsToken": "The idle window including the countdown outlives the token. Users would be logged out with no warning dialog.",
+    "save": "Save",
+    "saving": "Saving…",
+    "saved": "Session duration saved",
+    "saveError": "Could not save the session duration"
+  },
   "authPolicy": {
     "title": "PIN login policy",
     "description": "Controls the grace window in which the desktop-app PIN suffices without a 2FA code.",

--- a/client/src/lib/sessionDefaults.ts
+++ b/client/src/lib/sessionDefaults.ts
@@ -1,0 +1,14 @@
+/**
+ * Fallback session timings.
+ *
+ * These are the values `useIdleTimeout` had hardcoded before the timings became
+ * admin-configurable (`auth_policy.idle_*`). They apply until the server-side
+ * policy has been read — and permanently if that read fails, so a broken
+ * request degrades to the previous behavior instead of to no idle logout.
+ *
+ * They live in their own module rather than in the hook on purpose: a test that
+ * mocks `useIdleTimeout` would otherwise take the constants down with it and
+ * break every other module that reads them (it did — App.routing.test.tsx).
+ */
+export const DEFAULT_IDLE_MS = 4 * 60 * 1000;
+export const DEFAULT_WARNING_SEC = 60;

--- a/client/src/pages/SystemControlPage.tsx
+++ b/client/src/pages/SystemControlPage.tsx
@@ -19,6 +19,7 @@ import VCLSettings from '../components/vcl/VCLSettings';
 import { Link } from 'react-router-dom';
 import { RateLimitsTab } from '../components/rate-limits';
 import { AuthPolicySettings } from '../components/admin/AuthPolicySettings';
+import { SessionPolicySettings } from '../components/admin/SessionPolicySettings';
 import WebdavConnectionCard from '../components/webdav/WebdavConnectionCard';
 import SambaManagementCard from '../components/samba/SambaManagementCard';
 import NfsManagementCard from '../components/nfs/NfsManagementCard';
@@ -213,6 +214,7 @@ export default function SystemControlPage() {
           <div className="space-y-6">
             <RateLimitsTab />
             <AuthPolicySettings />
+            <SessionPolicySettings />
           </div>
         )}
         {activeTab === 'webdav' && <WebdavConnectionCard />}


### PR DESCRIPTION
## Problem

Man wird nach einer Weile abgemeldet, und nichts davon ließ sich einstellen. Der Status quo waren **zwei** unabhängige Mechanismen:

| | Grenze | einstellbar? |
|---|---|---|
| Idle-Logout (`useIdleTimeout.ts`) | 4 min + 60 s Warnung | nein, hartkodiert |
| Access-Token | 15 min ab **Login**, unabhängig von Aktivität | nur per Env |
| Refresh im Web-Client | existiert nicht — `/api/auth/login` gibt nur `access_token`, jede 401 → `fireAuthExpired()` | — |

Der Token war die härtere Grenze: wer durcharbeitet, fliegt nach 15 Minuten raus, ohne Dialog.

**Und der Regler dafür war tot.** `/opt/baluhost/.env.production` setzt `TOKEN_EXPIRE_MINUTES=720`. Das Settings-Feld heißt `ACCESS_TOKEN_EXPIRE_MINUTES`, es gibt keinen Alias, kein `env_prefix`, und `model_config` steht auf `extra="ignore"` — die Variable wurde still geschluckt. Gemessen:

```
$ TOKEN_EXPIRE_MINUTES=720 python -c "from app.core.config import Settings; print(Settings().ACCESS_TOKEN_EXPIRE_MINUTES)"
15
```

## Lösung

Beide Zahlen wandern in die bestehende `auth_policy`-Singleton-Tabelle, die schon Modell, Service, Route und Admin-UI mitbringt.

| Feld | Default | Grenzen |
|---|---|---|
| `idle_timeout_minutes` | 4 | `0` = kein Idle-Logout, sonst 1–1440 |
| `idle_warning_seconds` | 60 | 10–300 |
| `access_token_minutes` | 15 | 5–1440 |

Die Defaults reproduzieren exakt das bisherige Verhalten — **der Deploy ändert nichts**, bis jemand in der Oberfläche etwas verstellt. Auf 720 stellst du danach sichtbar und widerrufbar, nicht als stille Nebenwirkung einer Migration.

**Eine Ausgabestelle statt fünf.** `_issue_session_token()` in `auth.py`; `login`, `verify_2fa`, `login_pin`, `register` und `refresh_token` rufen nur noch das. Ein Test scannt `auth.py` und wird rot, sobald eine Route wieder direkt am Auth-Service hängt — sonst erbt die nächste hinzugefügte Route still den Config-Default und die Einstellung gilt für einen Login-Weg nicht mehr. Ein zweiter Test prüft, dass der Helfer die Policy wirklich liest, damit der Scan nicht grün bleibt, während nichts passiert.

**Der Lesepfad für alle Angemeldeten.** `GET /api/auth/session-policy` liefert nur die zwei Idle-Zahlen — der Idle-Hook läuft in jeder Sitzung, aber Token-Laufzeit und PIN-Richtlinie gehen ihn nichts an. Die Admin-Route bleibt admin-only.

**Die Kopplungsregel.** `idle_timeout_minutes * 60 + idle_warning_seconds` muss in `access_token_minutes * 60` passen, geprüft gegen den **zusammengeführten** Zustand — ein Teil-Update kann sie nicht umgehen, indem es die Felder einzeln schickt. Sonst stirbt die Sitzung an der Token-Grenze: eine 401 ohne Dialog und ohne Countdown. Genau der Zustand, in dem die Anlage steckte. Bei `idle_timeout_minutes = 0` entfällt die Prüfung — dann ist der Token ehrlicherweise die einzige Grenze.

**Frontend.** `useIdleTimeout` nimmt `idleMs`/`warningSec` als Optionen, `useSessionPolicy` holt sie einmal pro Anmeldung. Schlägt der Abruf fehl, bleibt es bei 4 min + 60 s — ein kaputter Lesepfad darf die Abmeldung nicht stillschweigend abschalten, das wäre eine Sicherheitsregression statt eines Ausfalls. Die Admin-Karte speichert alle drei Felder mit **einem** Knopf, weil die Kopplungsregel sonst an jedem Zwischenzustand scheitern würde.

## Sicherheit

Ein längerer Access-Token heißt: ein aus `localStorage` gestohlener Token bleibt entsprechend lange gültig, und **für Access-Tokens gibt es keinen Widerruf** — `logout` sperrt nur Refresh-Tokens, die der Web-Client gar nicht besitzt. Der Hinweis steht direkt neben dem Regler. Die Zeile in `.claude/rules/security-agent.md` ist nachgezogen.

## Tests

- Backend: 28 neue Tests (Round-Trip, alle Grenzwerte, Kopplungsregel in beide Richtungen inkl. Teil-Update, Lesepfad ohne Admin-Rechte, TTL aus den Token-Claims gemessen, Struktur-Guard). Regression: 449 auth-/token-/policy-/pin-Tests grün.
- Frontend: volle Vitest-Suite 270 Dateien / 1293 Tests grün, `eslint .` 0 Fehler, `npm run build` grün.

Die volle Suite hat dabei einen echten Fehler gefunden: `App.routing.test.tsx` mockt `useIdleTimeout`, und `useSessionPolicy` importierte die Default-Konstanten aus genau diesem Modul — der Mock riss sie mit. Die Konstanten liegen jetzt in `lib/sessionDefaults.ts`.

## Nach dem Deploy

Die tote Zeile `TOKEN_EXPIRE_MINUTES=720` gehört aus `/opt/baluhost/.env.production` entfernt, damit sie niemanden mehr in die Irre führt. Eingestellt wird das jetzt unter **System Control → Rate Limits → Sitzungsdauer**.

Bekannte Grenze: eine laufende Sitzung übernimmt geänderte Idle-Werte erst beim nächsten Laden der Seite, und eine bereits ausgestellte Token-Laufzeit ändert sich rückwirkend nicht.

## Nicht dabei

Der Refresh-Flow im Web-Client (bewusst verworfen zugunsten der einstellbaren Token-Laufzeit) und die hartkodierten englischen Strings im `IdleWarningDialog` (#406).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HT7gX6VGaYADnBqwQWyuND
