### PR TITLE
fix(fans): Luefterkurve wirkt wieder, RDNA3-PWM ehrlich melden (#517, #480)

### DIFF
--- a/backend/app/api/routes/fans.py
+++ b/backend/app/api/routes/fans.py
@@ -153,6 +153,17 @@ async def set_fan_pwm(
     Only works when fan is in manual mode.
     Requires admin role.
     """
+    backend = service._backend
+    cache = getattr(backend, "_fan_cache", None)
+    if cache and body.fan_id in cache:
+        from app.schemas.fans import PwmControl
+        if cache[body.fan_id].get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
+            raise HTTPException(
+                status_code=400,
+                detail=cache[body.fan_id].get("last_write_error")
+                or "This GPU manages its fan curve in firmware; PWM has no effect.",
+            )
+
     success, rpm = await service.set_fan_pwm(body.fan_id, body.pwm_percent)
 
     if not success:
@@ -1007,6 +1018,16 @@ async def set_gpu_manual_mode(
     hwmon_dir = info["pwm_path"].parent
 
     if body.enable:
+        from app.schemas.fans import PwmControl
+
+        if info.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "This GPU manages its fan curve in firmware (RDNA3+); manual "
+                    "PWM mode has no effect. See issue #516."
+                ),
+            )
         state = await enable_amd_manual(hwmon_dir=hwmon_dir, drm_root=None)
         _gpu_manual_state[fan_id] = state
     else:

--- a/backend/app/api/routes/fans.py
+++ b/backend/app/api/routes/fans.py
@@ -33,6 +33,7 @@ from app.schemas.fans import (
     ApplyPresetResponse,
     UpdateFanConfigRequest,
     UpdateFanConfigResponse,
+    PwmControl,
     FanCurvePoint,
     FanScheduleEntrySchema,
     CreateFanScheduleEntryRequest,
@@ -156,7 +157,6 @@ async def set_fan_pwm(
     backend = service._backend
     cache = getattr(backend, "_fan_cache", None)
     if cache and body.fan_id in cache:
-        from app.schemas.fans import PwmControl
         if cache[body.fan_id].get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
             raise HTTPException(
                 status_code=400,
@@ -1018,8 +1018,6 @@ async def set_gpu_manual_mode(
     hwmon_dir = info["pwm_path"].parent
 
     if body.enable:
-        from app.schemas.fans import PwmControl
-
         if info.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
             raise HTTPException(
                 status_code=400,

--- a/backend/app/schemas/fans.py
+++ b/backend/app/schemas/fans.py
@@ -15,6 +15,20 @@ class FanMode(str, Enum):
     SCHEDULED = "scheduled"
 
 
+class PwmControl(str, Enum):
+    """Ob PWM-Schreiben fuer einen Luefter moeglich ist — und wenn nicht, warum.
+
+    SUPPORTED:        Default. Schreiben wird versucht.
+    FIRMWARE_MANAGED: RDNA3+ (SMU13). Die Kurve liegt in der Firmware unter
+                      gpu_od/fan_ctrl; der Treiber lehnt PWM mit EINVAL ab (#480).
+    NO_PERMISSION:    EACCES beim Schreiben beobachtet. Laufzeit-Befund, kein
+                      Hardware-Merkmal — wird bei erfolgreichem Write zurueckgesetzt.
+    """
+    SUPPORTED = "supported"
+    FIRMWARE_MANAGED = "firmware_managed"
+    NO_PERMISSION = "no_permission"
+
+
 class CurvePreset(str, Enum):
     """Predefined fan curve presets."""
     SILENT = "silent"

--- a/backend/app/schemas/fans.py
+++ b/backend/app/schemas/fans.py
@@ -102,6 +102,7 @@ class FanInfo(BaseModel):
     is_gpu_fan: bool = False
     gpu_vendor: Optional[str] = None
     last_write_error: Optional[str] = None
+    pwm_control: PwmControl = PwmControl.SUPPORTED
     curve_type: str = "graph"
     flat_pwm_percent: Optional[int] = None
     target_temp_celsius: Optional[float] = None

--- a/backend/app/services/power/fan_backend_dev.py
+++ b/backend/app/services/power/fan_backend_dev.py
@@ -208,6 +208,10 @@ class DevFanControlBackend(FanControlBackend):
 
         # Update fan RPM with latency and fluctuation
         for fan_id, fan_data in self._fans.items():
+            # Skip firmware-managed fans (they don't respond to PWM changes)
+            if fan_data.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
+                continue
+
             elapsed = current_time - fan_data["last_update"]
 
             # Gradual RPM transition (2-3 second lag)

--- a/backend/app/services/power/fan_backend_dev.py
+++ b/backend/app/services/power/fan_backend_dev.py
@@ -7,7 +7,7 @@ import logging
 from typing import Dict, List, Optional
 
 from app.core.config import Settings
-from app.schemas.fans import FanMode, FanCurvePoint
+from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
 from app.services.power.fan_control import FanControlBackend, FanData, TempSensorData
 
 logger = logging.getLogger(__name__)
@@ -116,6 +116,7 @@ class DevFanControlBackend(FanControlBackend):
                 is_gpu_fan=fan_data.get("is_gpu_fan", False),
                 gpu_vendor=fan_data.get("gpu_vendor"),
                 device_driver=fan_data.get("device_driver"),
+                pwm_control=fan_data.get("pwm_control", PwmControl.SUPPORTED),
             ))
 
         return fans

--- a/backend/app/services/power/fan_backend_dev.py
+++ b/backend/app/services/power/fan_backend_dev.py
@@ -23,7 +23,7 @@ class DevFanControlBackend(FanControlBackend):
         self._initialize_simulated_fans()
 
     def _initialize_simulated_fans(self):
-        """Initialize 4 simulated PWM fans (3 CPU + 1 GPU)."""
+        """Initialize 5 simulated PWM fans (3 CPU + 2 GPU)."""
         self._fans = {
             "dev_cpu_fan": {
                 "name": "CPU Fan (Simulated)",
@@ -77,6 +77,20 @@ class DevFanControlBackend(FanControlBackend):
                 "gpu_vendor": "amd",
                 "device_driver": "amdgpu",
             },
+            "dev_gpu_rdna3_pwm1": {
+                "name": "AMD RDNA3 GPU Fan (sim, firmware-managed)",
+                "pwm_percent": 0,
+                "target_rpm": 0,
+                "current_rpm": 0,
+                "min_rpm": 0,
+                "max_rpm": 3000,
+                "temp_sensor_id": "dev_gpu_temp",
+                "last_update": time.time(),
+                "is_gpu_fan": True,
+                "gpu_vendor": "amd",
+                "device_driver": "amdgpu",
+                "pwm_control": PwmControl.FIRMWARE_MANAGED,
+            },
         }
 
         # Initialize simulated temperatures
@@ -125,6 +139,10 @@ class DevFanControlBackend(FanControlBackend):
         """Set simulated PWM value."""
         if fan_id not in self._fans:
             logger.warning(f"Fan {fan_id} not found")
+            return False
+
+        if self._fans[fan_id].get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
+            logger.debug(f"{fan_id}: firmware-managed, PWM write skipped")
             return False
 
         pwm_percent = max(0, min(100, pwm_percent))

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -8,8 +8,9 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from app.core.config import Settings
-from app.schemas.fans import FanMode, FanCurvePoint
+from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
 from app.services.power.fan_control import FanControlBackend, FanData, TempSensorData
+from app.services.power.fan_gpu_manual import probe_amd_pwm_control
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +108,7 @@ class LinuxFanControlBackend(FanControlBackend):
                 gpu_vendor=fan_info.get("gpu_vendor"),
                 device_driver=fan_info.get("device_driver"),
                 last_write_error=fan_info.get("last_write_error"),
+                pwm_control=fan_info.get("pwm_control", PwmControl.SUPPORTED),
             ))
 
         return fans
@@ -335,6 +337,13 @@ class LinuxFanControlBackend(FanControlBackend):
                         temp_path = temp_file
                         break
 
+                pwm_control = PwmControl.SUPPORTED
+                if gpu_vendor == "amd":
+                    try:
+                        pwm_control = probe_amd_pwm_control(hwmon_dir)
+                    except OSError as exc:
+                        logger.debug(f"pwm_control probe failed for {hwmon_dir}: {exc}")
+
                 new_cache[fan_id] = {
                     "name": f"{hwmon_name_value} PWM{pwm_num}",
                     "pwm_path": pwm_file,
@@ -345,6 +354,7 @@ class LinuxFanControlBackend(FanControlBackend):
                     "is_gpu_fan": is_gpu_fan,
                     "gpu_vendor": gpu_vendor,
                     "device_driver": hwmon_name_value,
+                    "pwm_control": pwm_control,
                 }
 
         if new_cache or not self._fan_cache:

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -1,6 +1,8 @@
 """
 Linux hardware backend for fan control using hwmon sysfs.
 """
+import errno
+import getpass
 import logging
 import os
 import subprocess
@@ -13,6 +15,13 @@ from app.services.power.fan_control import FanControlBackend, FanData, TempSenso
 from app.services.power.fan_gpu_manual import probe_amd_pwm_control
 
 logger = logging.getLogger(__name__)
+
+FIRMWARE_MANAGED_WRITE_ERROR = (
+    "This GPU manages its fan curve in firmware (RDNA3+). The amdgpu driver "
+    "does not support live PWM control on this card — setting "
+    "amdgpu.ppfeaturemask=0xffffffff does NOT change that. Control is only "
+    "possible through the firmware curve (gpu_od/fan_ctrl), see issue #516."
+)
 
 
 class LinuxFanControlBackend(FanControlBackend):
@@ -120,36 +129,54 @@ class LinuxFanControlBackend(FanControlBackend):
             return False
 
         fan_info = self._fan_cache[fan_id]
+
+        # Firmware besitzt die Kurve: sysfs gar nicht erst anfassen.
+        if fan_info.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
+            fan_info["last_write_error"] = FIRMWARE_MANAGED_WRITE_ERROR
+            logger.debug(f"{fan_id}: firmware-managed fan curve, PWM write skipped")
+            return False
+
         pwm_path = fan_info["pwm_path"]
         pwm_enable_path = fan_info.get("pwm_enable_path")
 
-        # Clamp to valid range
         pwm_percent = max(0, min(100, pwm_percent))
         pwm_value = self._percent_to_pwm(pwm_percent)
 
-        # First, set PWM enable to manual mode (1)
         if pwm_enable_path:
-            success = await self._write_hwmon_file(pwm_enable_path, "1")
-            if not success:
+            ok_enable, _ = await self._write_hwmon_file(pwm_enable_path, "1")
+            if not ok_enable:
                 logger.warning(f"Failed to set PWM enable for {fan_id}")
 
-        # Write PWM value
-        success = await self._write_hwmon_file(pwm_path, str(pwm_value))
+        success, err_code = await self._write_hwmon_file(pwm_path, str(pwm_value))
         if success:
             fan_info["last_write_error"] = None
+            if fan_info.get("pwm_control") is PwmControl.NO_PERMISSION:
+                # Rechte wurden zur Laufzeit korrigiert.
+                fan_info["pwm_control"] = PwmControl.SUPPORTED
             logger.debug(f"Set {fan_id} PWM to {pwm_percent}% ({pwm_value}/255)")
             return True
 
-        # Capture diagnostic
-        driver = fan_info.get("device_driver", "unknown")
-        enable_val = None
-        if pwm_enable_path:
-            v = await self._read_hwmon_file(pwm_enable_path)
-            enable_val = v if v is not None else "?"
-        fan_info["last_write_error"] = (
-            f"PWM write rejected by kernel (driver={driver}, pwm_enable={enable_val}). "
-            f"For AMD GPUs: enable manual mode in the UI."
-        )
+        if err_code in (errno.EACCES, errno.EPERM):
+            fan_info["pwm_control"] = PwmControl.NO_PERMISSION
+            try:
+                user = getpass.getuser()
+            except Exception:
+                user = "the service user"
+            fan_info["last_write_error"] = (
+                f"No write permission for {pwm_path} (EACCES). The backend runs as "
+                f"'{user}' and the udev rule does not cover hwmon PWM nodes."
+            )
+        else:
+            driver = fan_info.get("device_driver", "unknown")
+            enable_val = None
+            if pwm_enable_path:
+                v = await self._read_hwmon_file(pwm_enable_path)
+                enable_val = v if v is not None else "?"
+            fan_info["last_write_error"] = (
+                f"PWM write rejected by kernel (driver={driver}, "
+                f"pwm_enable={enable_val}, errno={err_code})."
+            )
+
         logger.error(f"Failed to write PWM for {fan_id}: {fan_info['last_write_error']}")
         return False
 
@@ -379,39 +406,48 @@ class LinuxFanControlBackend(FanControlBackend):
             logger.debug(f"Failed to read {path}: {e}")
             return None
 
-    async def _write_hwmon_file(self, path: Path, value: str) -> bool:
-        """Write value to hwmon sysfs file."""
+    async def _write_hwmon_file(self, path: Path, value: str) -> Tuple[bool, Optional[int]]:
+        """Write value to hwmon sysfs file.
+
+        Returns (ok, errno). errno ist der Code des letzten fehlgeschlagenen
+        Versuchs, damit der Aufrufer EACCES (fehlende Rechte) von EINVAL
+        (Treiber lehnt ab) unterscheiden kann — beide brauchen voellig
+        verschiedene Handlungsempfehlungen.
+        """
         if not path or not path.exists():
-            return False
+            return False, None
 
         try:
-            # Try direct write first
             path.write_text(value + "\n")
             self._has_write_permission = True
-            return True
-        except PermissionError:
-            # Try with sudo tee fallback
+            return True, None
+        except OSError as exc:
+            code = exc.errno
+            if code not in (errno.EACCES, errno.EPERM):
+                logger.debug(f"Write to {path} failed: {exc}")
+                return False, code
+
+            # Fehlende Rechte: sudo-tee-Fallback. -n, damit ein fehlender
+            # sudoers-Eintrag sofort scheitert statt in den Timeout zu laufen.
             try:
-                cmd = ["sudo", "tee", str(path)]
                 result = subprocess.run(
-                    cmd,
+                    ["sudo", "-n", "tee", str(path)],
                     input=value.encode(),
                     capture_output=True,
-                    timeout=5
+                    timeout=5,
                 )
                 if result.returncode == 0:
                     self._has_write_permission = True
                     logger.debug(f"Wrote to {path} via sudo tee")
-                    return True
-                else:
-                    logger.warning(f"sudo tee failed for {path}: {result.stderr.decode()}")
-                    return False
-            except Exception as e:
-                logger.error(f"Failed to write {path} with sudo: {e}")
-                return False
-        except Exception as e:
-            logger.error(f"Failed to write {path}: {e}")
-            return False
+                    return True, None
+                logger.warning(f"sudo tee failed for {path}: {result.stderr.decode()}")
+            except Exception as exc2:
+                logger.error(f"Failed to write {path} with sudo: {exc2}")
+            return False, errno.EACCES
+        except Exception as exc:
+            # Catch-all wie bisher: nichts Unerwartetes in den Loop propagieren.
+            logger.error(f"Failed to write {path}: {exc}")
+            return False, None
 
     def _pwm_to_percent(self, pwm_value: int) -> int:
         """Convert PWM value (0-255) to percentage (0-100)."""

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -163,8 +163,18 @@ class LinuxFanControlBackend(FanControlBackend):
             except Exception:
                 user = "the service user"
             fan_info["last_write_error"] = (
-                f"No write permission for {pwm_path} (EACCES). The backend runs as "
+                f"No write permission for {pwm_path} "
+                f"({errno.errorcode.get(err_code, err_code)}). The backend runs as "
                 f"'{user}' and the udev rule does not cover hwmon PWM nodes."
+            )
+        elif err_code is None:
+            # _write_hwmon_file() found the path missing before even attempting
+            # the write — the kernel rejected nothing, the sysfs node is gone
+            # (device removed or driver reloaded). Do not claim a kernel
+            # rejection that never happened.
+            fan_info["last_write_error"] = (
+                f"PWM sysfs node {pwm_path} no longer exists (device removed "
+                f"or driver reloaded)."
             )
         else:
             driver = fan_info.get("device_driver", "unknown")
@@ -174,7 +184,8 @@ class LinuxFanControlBackend(FanControlBackend):
                 enable_val = v if v is not None else "?"
             fan_info["last_write_error"] = (
                 f"PWM write rejected by kernel (driver={driver}, "
-                f"pwm_enable={enable_val}, errno={err_code})."
+                f"pwm_enable={enable_val}, "
+                f"errno={errno.errorcode.get(err_code, err_code)})."
             )
 
         logger.error(f"Failed to write PWM for {fan_id}: {fan_info['last_write_error']}")
@@ -443,7 +454,7 @@ class LinuxFanControlBackend(FanControlBackend):
                 logger.warning(f"sudo tee failed for {path}: {result.stderr.decode()}")
             except Exception as exc2:
                 logger.error(f"Failed to write {path} with sudo: {exc2}")
-            return False, errno.EACCES
+            return False, code
         except Exception as exc:
             # Catch-all wie bisher: nichts Unerwartetes in den Loop propagieren.
             logger.error(f"Failed to write {path}: {exc}")

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -530,6 +530,12 @@ class FanControlService:
                         target_pwm = evaluate_curve(
                             eval_cfg, temperature, prev, other_fan_pwms, _profile_loader, dt,
                         )
+                        if eval_cfg.curve_type == "graph" and temperature is None:
+                            # #517-Folgeschaden: _interpolate() liefert 0 fuer
+                            # temp=None (kein temp_sensor_id, oder der Sensor
+                            # liefert nicht). Ein ausgefallener Sensor darf die
+                            # Kuehlung nicht abstellen -> aktuellen PWM halten.
+                            target_pwm = fan.pwm_percent
                         # Hysteresis dampens the already-computed target (only for graph-like outputs)
                         target_pwm = self._apply_hysteresis(
                             fan.fan_id, temperature or 0.0,

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -530,9 +530,9 @@ class FanControlService:
                         target_pwm = evaluate_curve(
                             eval_cfg, temperature, prev, other_fan_pwms, _profile_loader, dt,
                         )
-                        # Hysteresis layered on top (existing helper, only for graph-like outputs)
-                        target_pwm = self._calculate_pwm_with_hysteresis(
-                            fan.fan_id, temperature or 0.0, [],
+                        # Hysteresis dampens the already-computed target (only for graph-like outputs)
+                        target_pwm = self._apply_hysteresis(
+                            fan.fan_id, temperature or 0.0,
                             getattr(config, "hysteresis_celsius", 3.0), target_pwm,
                         ) if eval_cfg.curve_type == "graph" else target_pwm
 
@@ -555,88 +555,51 @@ class FanControlService:
                     "mode": mode.value,
                 })
 
-    def _calculate_pwm_from_curve(self, temperature: float, curve_points: List[dict]) -> int:
-        """Calculate PWM from temperature using curve interpolation."""
-        if not curve_points or len(curve_points) < 2:
-            return 50  # Default
-
-        # Sort points by temperature
-        points = sorted(curve_points, key=lambda p: p["temp"])
-
-        # Below minimum temp
-        if temperature <= points[0]["temp"]:
-            return points[0]["pwm"]
-
-        # Above maximum temp
-        if temperature >= points[-1]["temp"]:
-            return points[-1]["pwm"]
-
-        # Linear interpolation
-        for i in range(len(points) - 1):
-            p1, p2 = points[i], points[i + 1]
-
-            if p1["temp"] <= temperature <= p2["temp"]:
-                # Linear interpolation
-                temp_ratio = (temperature - p1["temp"]) / (p2["temp"] - p1["temp"])
-                pwm = p1["pwm"] + (p2["pwm"] - p1["pwm"]) * temp_ratio
-                return round(pwm)
-
-        return 50  # Fallback
-
-    def _calculate_pwm_with_hysteresis(
+    def _apply_hysteresis(
         self,
         fan_id: str,
         temperature: float,
-        curve_points: List[dict],
         hysteresis: float,
-        current_pwm: int
+        target_pwm: int,
     ) -> int:
-        """
-        Calculate PWM with hysteresis to prevent oscillation.
+        """Daempft ein BEREITS BERECHNETES PWM-Ziel gegen Oszillation.
 
-        Args:
-            fan_id: Fan identifier for state tracking
-            temperature: Current temperature
-            curve_points: Fan curve definition
-            hysteresis: Hysteresis value in Celsius
-            current_pwm: Current PWM percentage
+        Steigende Ziele greifen sofort (Sicherheit); fallende erst, wenn die
+        Temperatur um `hysteresis` Grad unter den Wert gefallen ist, bei dem
+        zuletzt geregelt wurde.
 
-        Returns:
-            Target PWM percentage with hysteresis applied
+        #517: Der Vorgaenger rechnete das Ziel aus einer Kurve NEU — und bekam
+        vom einzigen Aufrufer eine leere Liste, was den Hardcode 50 lieferte und
+        das Ergebnis von evaluate_curve verwarf. Diese Funktion rechnet nichts
+        mehr aus; die Kurvenauswertung gehoert allein fan_curve_eval.py.
         """
-        target_pwm = self._calculate_pwm_from_curve(temperature, curve_points)
         current_time = time.time()
 
-        # Get or initialize hysteresis state
         if fan_id not in self._hysteresis_state:
             self._hysteresis_state[fan_id] = HysteresisState(
-                last_pwm=current_pwm,
+                last_pwm=target_pwm,
                 last_pwm_temp=temperature,
-                last_update=current_time
+                last_update=current_time,
             )
             return target_pwm
 
         state = self._hysteresis_state[fan_id]
 
         if target_pwm > state.last_pwm:
-            # Temperature rising - respond immediately for safety
+            # Temperatur steigt — sofort reagieren.
             state.last_pwm = target_pwm
             state.last_pwm_temp = temperature
             state.last_update = current_time
             return target_pwm
 
-        elif target_pwm < state.last_pwm:
-            # Temperature falling - only reduce PWM if temp dropped by hysteresis amount
+        if target_pwm < state.last_pwm:
             if temperature <= (state.last_pwm_temp - hysteresis):
                 state.last_pwm = target_pwm
                 state.last_pwm_temp = temperature
                 state.last_update = current_time
                 return target_pwm
-            else:
-                # Keep current PWM (within hysteresis deadband)
-                return state.last_pwm
+            return state.last_pwm
 
-        # PWM unchanged
         return state.last_pwm
 
     async def _persist_samples(self):

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -19,7 +19,7 @@ from sqlalchemy import select, desc, func
 
 from app.core.config import Settings
 from app.models.fans import FanConfig, FanSample
-from app.schemas.fans import FanMode, FanCurvePoint
+from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
 from app.services.power.fan_schedule import FanScheduleService
 from app.services.power.fan_profiles import FanProfileService
 from app.services.power.fan_sources import (
@@ -55,6 +55,7 @@ class FanData:
     gpu_vendor: Optional[str] = None
     device_driver: Optional[str] = None
     last_write_error: Optional[str] = None
+    pwm_control: PwmControl = PwmControl.SUPPORTED
 
 
 @dataclass
@@ -707,6 +708,7 @@ class FanControlService:
                         "is_gpu_fan": fan.is_gpu_fan,
                         "gpu_vendor": fan.gpu_vendor,
                         "last_write_error": fan.last_write_error,
+                        "pwm_control": fan.pwm_control,
                         "curve_type": getattr(config, "curve_type", "graph"),
                         "flat_pwm_percent": getattr(config, "flat_pwm_percent", None),
                         "target_temp_celsius": getattr(config, "target_temp_celsius", None),
@@ -755,6 +757,7 @@ class FanControlService:
                         "is_gpu_fan": fan.is_gpu_fan,
                         "gpu_vendor": fan.gpu_vendor,
                         "last_write_error": fan.last_write_error,
+                        "pwm_control": fan.pwm_control,
                         "curve_type": "graph",
                         "flat_pwm_percent": None,
                         "target_temp_celsius": None,

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -538,11 +538,23 @@ class FanControlService:
 
                 target_pwm = max(config.min_pwm_percent, min(config.max_pwm_percent, target_pwm))
 
+                if fan.pwm_control is PwmControl.FIRMWARE_MANAGED:
+                    # Die Firmware besitzt die Kurve (RDNA3+). Kein Write-Versuch,
+                    # und der Sample protokolliert den tatsaechlichen Wert.
+                    target_pwm = fan.pwm_percent
+
                 if target_pwm != fan.pwm_percent:
                     await self._backend.set_pwm(fan.fan_id, target_pwm)
                 self._last_pwm_by_fan[fan.fan_id] = target_pwm
 
-                if mode == FanMode.EMERGENCY and config.mode != FanMode.EMERGENCY.value:
+                if (
+                    mode == FanMode.EMERGENCY
+                    and config.mode != FanMode.EMERGENCY.value
+                    and fan.pwm_control is not PwmControl.FIRMWARE_MANAGED
+                ):
+                    # Bei firmware-verwalteten Lueftern brachte EMERGENCY nichts
+                    # ausser einem Zustand, aus dem nur der AUTO-Button wieder
+                    # herausfuehrt. Die Benachrichtigung oben bleibt erhalten.
                     config.mode = FanMode.EMERGENCY.value
                     db.commit()
 

--- a/backend/app/services/power/fan_gpu_manual.py
+++ b/backend/app/services/power/fan_gpu_manual.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from app.schemas.fans import PwmControl
+
 logger = logging.getLogger(__name__)
 
 AMD_VENDOR_ID = "0x1002"
@@ -68,9 +70,44 @@ async def disable_amd_manual(hwmon_dir: Path, drm_root: Optional[Path], state: A
                 state.previous_level, state.previous_pwm_enable)
 
 
-def _device_from_hwmon(hwmon_dir: Path, drm_root: Optional[Path]) -> Optional[Path]:
-    """Walk up from hwmon dir to find the amdgpu PCI device directory."""
-    # hwmon_dir typically looks like: <drm>/card0/device/hwmon/hwmonN
+def probe_amd_pwm_control(hwmon_dir: Path) -> PwmControl:
+    """Stellt fest, ob Live-PWM fuer diesen AMD-GPU-Luefter moeglich ist.
+
+    Ab RDNA3 (SMU13) liegt die Luefterkurve in der Firmware und wird ueber
+    <device>/gpu_od/fan_ctrl/ exponiert; pwm{n}-Writes lehnt der Treiber mit
+    EINVAL ab. Die Existenz von fan_curve ist der Marker.
+
+    WICHTIG: Aus einem fehlenden gpu_od/ darf NICHT auf ein fehlendes
+    Overdrive-Bit geschlossen werden. Auf der Referenzkarte (RX 7900 XT) war
+    amdgpu.ppfeaturemask=0xffffffff gesetzt und PWM trotzdem tot — die
+    gegenteilige Annahme war der urspruengliche Fehler in #480.
+    """
+    device = _device_from_hwmon(hwmon_dir)
+    if device is None:
+        return PwmControl.SUPPORTED
+    if (device / "gpu_od" / "fan_ctrl" / "fan_curve").exists():
+        return PwmControl.FIRMWARE_MANAGED
+    return PwmControl.SUPPORTED
+
+
+def _device_from_hwmon(hwmon_dir: Path, drm_root: Optional[Path] = None) -> Optional[Path]:
+    """Finde das amdgpu-PCI-Device zu einer hwmon-Directory.
+
+    Primaerweg: jede hwmon-Directory traegt einen 'device'-Symlink auf ihr
+    PCI-Geraet. An der Hardware verifiziert:
+        ls -d /sys/class/hwmon/hwmon2/device/gpu_od/fan_ctrl  -> existiert
+
+    Fallback: Aufwaertslauf ueber den aufgeloesten Pfad. Der funktioniert NUR
+    in synthetischen Baeumen — real enthaelt readlink -f keine Komponente
+    namens 'device'. Bleibt erhalten, damit bestehende Tests gueltig bleiben.
+    """
+    direct = hwmon_dir / "device"
+    try:
+        if (direct / "vendor").read_text().strip() == AMD_VENDOR_ID:
+            return direct
+    except OSError:
+        pass
+
     p = hwmon_dir.resolve()
     for parent in p.parents:
         if parent.name == "device" and (parent / "vendor").exists():

--- a/backend/app/services/power/fan_gpu_manual.py
+++ b/backend/app/services/power/fan_gpu_manual.py
@@ -48,7 +48,15 @@ async def enable_amd_manual(hwmon_dir: Path, drm_root: Optional[Path] = None) ->
 
     await asyncio.to_thread(level_path.write_text, "manual")
     if pwm_enable_path is not None:
-        await asyncio.to_thread(pwm_enable_path.write_text, "1")
+        try:
+            await asyncio.to_thread(pwm_enable_path.write_text, "1")
+        except OSError:
+            # Nichts halb angewendet zuruecklassen.
+            try:
+                await asyncio.to_thread(level_path.write_text, prev_level or "auto")
+            except OSError:
+                logger.error("Rollback of performance_level failed for %s", device)
+            raise
 
     logger.info("AMD GPU manual mode enabled (prev_level=%s, prev_enable=%s)", prev_level, prev_enable)
     return AmdManualState(previous_level=prev_level, previous_pwm_enable=prev_enable)

--- a/backend/tests/api/test_fans_routes.py
+++ b/backend/tests/api/test_fans_routes.py
@@ -11,11 +11,15 @@ Covers:
 - Auth checks (admin-only for write operations)
 """
 
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from fastapi.testclient import TestClient
 
 from app.api.routes.fans import get_fan_service
+from app.schemas.fans import PwmControl
 
 
 @pytest.fixture(autouse=True)
@@ -265,3 +269,97 @@ class TestFanScheduleRoutes:
 
         response = client.post("/api/fans/fan1/schedule", json={})
         assert response.status_code == 401
+
+
+# ============================================================================
+# Route Guards for Firmware-Managed AMD GPU Fans (#480, Task 7)
+# ============================================================================
+
+class TestFirmwareManagedGpuGuards:
+    """The two route-level guards that keep users from a no-op or a
+    misleading answer on RDNA3+ GPUs, whose fan curve lives in firmware
+    and cannot be driven by raw sysfs PWM writes.
+
+    Key invariant under test: the gpu-manual-mode guard blocks `enable=true`
+    only. `enable=false` must always succeed, or anyone who ever flipped the
+    toggle on such a GPU would be stuck with
+    power_dpm_force_performance_level=manual forever.
+    """
+
+    @staticmethod
+    def _configure_firmware_managed_fan(mock_service, fan_id, last_write_error=None):
+        pwm_path = MagicMock()
+        pwm_path.parent = Path("/fake/sys/class/hwmon/hwmon3")
+        mock_service._backend = SimpleNamespace(_fan_cache={
+            fan_id: {
+                "is_gpu_fan": True,
+                "gpu_vendor": "amd",
+                "pwm_control": PwmControl.FIRMWARE_MANAGED,
+                "pwm_path": pwm_path,
+                "last_write_error": last_write_error,
+            }
+        })
+
+    def test_gpu_manual_mode_disable_succeeds_on_firmware_managed_fan(
+        self, client: TestClient, admin_headers, mock_fan_service, monkeypatch
+    ):
+        """The regression guard: disabling must go through even though the
+        fan is firmware-managed. If the guard were ever hoisted above the
+        enable/disable branch, this would start returning 400."""
+        fan_id = "gpu_fan_disable"
+        self._configure_firmware_managed_fan(mock_fan_service, fan_id)
+
+        enable_mock = AsyncMock()
+        disable_mock = AsyncMock()
+        monkeypatch.setattr("app.services.power.fan_gpu_manual.enable_amd_manual", enable_mock)
+        monkeypatch.setattr("app.services.power.fan_gpu_manual.disable_amd_manual", disable_mock)
+
+        response = client.post(
+            f"/api/fans/{fan_id}/gpu-manual-mode",
+            json={"enable": False},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["enabled"] is False
+        disable_mock.assert_awaited_once()
+        enable_mock.assert_not_awaited()
+
+    def test_gpu_manual_mode_enable_returns_400_on_firmware_managed_fan(
+        self, client: TestClient, admin_headers, mock_fan_service, monkeypatch
+    ):
+        fan_id = "gpu_fan_enable"
+        self._configure_firmware_managed_fan(mock_fan_service, fan_id)
+
+        enable_mock = AsyncMock()
+        monkeypatch.setattr("app.services.power.fan_gpu_manual.enable_amd_manual", enable_mock)
+
+        response = client.post(
+            f"/api/fans/{fan_id}/gpu-manual-mode",
+            json={"enable": True},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 400
+        enable_mock.assert_not_awaited()
+
+    def test_set_fan_pwm_returns_400_with_firmware_hint_on_firmware_managed_fan(
+        self, client: TestClient, admin_headers, mock_fan_service
+    ):
+        fan_id = "gpu_fan_pwm"
+        last_write_error = (
+            "This GPU manages its fan curve in firmware (RDNA3+). The amdgpu "
+            "driver does not support live PWM control on this card — setting "
+            "amdgpu.ppfeaturemask=0xffffffff does NOT change that."
+        )
+        self._configure_firmware_managed_fan(mock_fan_service, fan_id, last_write_error)
+
+        response = client.post(
+            "/api/fans/pwm",
+            json={"fan_id": fan_id, "pwm_percent": 75},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 400
+        assert "ppfeaturemask" in response.json()["detail"]
+        mock_fan_service.set_fan_pwm.assert_not_awaited()

--- a/backend/tests/services/test_fan_control.py
+++ b/backend/tests/services/test_fan_control.py
@@ -42,7 +42,7 @@ class TestDevFanControlBackend:
         """Test backend initialization."""
         backend = DevFanControlBackend(mock_settings)
 
-        assert len(backend._fans) == 4
+        assert len(backend._fans) == 5
         assert "dev_cpu_fan" in backend._fans
         assert "dev_case_fan_1" in backend._fans
         assert "dev_case_fan_2" in backend._fans
@@ -70,7 +70,7 @@ class TestDevFanControlBackend:
 
         fans = await backend.get_fans()
 
-        assert len(fans) == 4
+        assert len(fans) == 5
         assert all(isinstance(fan, FanData) for fan in fans)
 
     @pytest.mark.asyncio
@@ -369,7 +369,7 @@ class TestSimulatedStateUpdate:
 
         # RPM values may fluctuate
         # Just verify we get data
-        assert len(fans1) == len(fans2) == 4
+        assert len(fans1) == len(fans2) == 5
 
 
 class TestFanDataStructure:

--- a/backend/tests/test_fan_curve_hysteresis.py
+++ b/backend/tests/test_fan_curve_hysteresis.py
@@ -136,3 +136,34 @@ async def test_monitor_loop_applies_the_curve_target_not_fifty(db_session):
         assert backend.set_pwm_calls[0][1] != 10  # min_pwm_percent
     finally:
         FanControlService._instance = None
+
+
+@pytest.mark.asyncio
+async def test_monitor_loop_holds_current_pwm_when_temperature_is_unavailable(db_session):
+    """Folgeschaden von #517: evaluate_curve()/_interpolate() liefert 0 fuer
+
+    temp=None (kein temp_sensor_id gesetzt, oder der Sensor liefert nicht). Vor
+    diesem Fix lief dieser Wert unveraendert durch die Klemmung auf
+    min_pwm_percent — bei min_pwm_percent=0 blieb ein Luefter mit ausgefallenem
+    Sensor komplett stehen. Das ist ein Sicherheitsrueckschritt gegenueber dem
+    alten (fehlerhaften) Verhalten, das wenigstens hartcodiert 50% lieferte.
+
+    Erwartung: der Loop haelt den aktuellen PWM-Wert, statt auf 0 zu regeln.
+    """
+    db_session.add(_config_row(min_pwm_percent=0, temp_sensor_id=None))
+    db_session.commit()
+
+    service = _monitor_service(db_session)
+    service._registry.get_temp = AsyncMock(return_value=None)
+    backend = _StubBackend(temperature=None, pwm_percent=45)
+    service._backend = backend
+    try:
+        await service._monitor_and_control_fans()
+
+        # Der Luefter darf nicht auf 0 geregelt werden, nur weil die Temperatur
+        # fehlt — und der Loop darf keinen abweichenden Wert an die Hardware
+        # schreiben (der aktuelle Wert bleibt bestehen).
+        assert backend.set_pwm_calls == []
+        assert service._last_pwm_by_fan["f1"] == 45
+    finally:
+        FanControlService._instance = None

--- a/backend/tests/test_fan_curve_hysteresis.py
+++ b/backend/tests/test_fan_curve_hysteresis.py
@@ -1,9 +1,12 @@
 """Die konfigurierte Kurve muss wirken, statt vom Hardcode 50 ersetzt zu werden (#517)."""
-from unittest.mock import MagicMock
+import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from app.services.power.fan_control import FanControlService
+from app.models.fans import FanConfig
+from app.schemas.fans import FanMode, PwmControl
+from app.services.power.fan_control import FanControlService, FanData
 
 
 def _service():
@@ -54,7 +57,82 @@ def test_hardcoded_fifty_is_gone():
     """Regression #517: kein Pfad darf mehr 50 aus dem Nichts liefern."""
     service = _service()
     try:
-        assert not hasattr(service, "_calculate_pwm_from_curve")
         assert service._apply_hysteresis("f1", 20.0, 3.0, 30) == 30
+    finally:
+        FanControlService._instance = None
+
+
+# ---------------------------------------------------------------------------
+# Integrationstest: deckt die eigentliche #517-Bruchstelle ab, die Aufrufstelle
+# in _monitor_and_control_fans. Ein reiner Unit-Test von _apply_hysteresis
+# haette den urspruenglichen Fehler (Ziel landete im falschen Parameter-Slot,
+# plus eine leere Kurvenliste) nie gefangen, weil er die Verdrahtung zwischen
+# evaluate_curve() und der Haemmpfung gar nicht ausuebt.
+# ---------------------------------------------------------------------------
+
+class _StubBackend:
+    """Minimaler FanControlBackend-Stub: eine Karte, PWM-Schreiben moeglich."""
+
+    def __init__(self, temperature: float, pwm_percent: int):
+        self.temperature = temperature
+        self.pwm_percent = pwm_percent
+        self.set_pwm_calls = []
+
+    async def get_fans(self):
+        return [FanData(
+            fan_id="f1", name="Test Fan", rpm=1000, pwm_percent=self.pwm_percent,
+            temperature_celsius=self.temperature, mode=FanMode.AUTO,
+            min_pwm_percent=10, max_pwm_percent=100, emergency_temp_celsius=95.0,
+            temp_sensor_id="hwmon:test", curve_points=[], is_active=True,
+            pwm_control=PwmControl.SUPPORTED,
+        )]
+
+    async def set_pwm(self, fan_id, pwm_percent):
+        self.set_pwm_calls.append((fan_id, pwm_percent))
+        return True
+
+
+def _config_row(**overrides):
+    # name ist NOT NULL ohne Default (models/fans.py).
+    base = dict(
+        fan_id="f1", name="Test Fan", mode=FanMode.AUTO.value, is_active=True,
+        min_pwm_percent=10, max_pwm_percent=100, emergency_temp_celsius=95.0,
+        curve_json=json.dumps([{"temp": 40, "pwm": 30}, {"temp": 80, "pwm": 100}]),
+        curve_type="graph", hysteresis_celsius=3.0, temp_sensor_id="hwmon:test",
+    )
+    base.update(overrides)
+    return FanConfig(**base)
+
+
+def _monitor_service(db_session):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = False
+    config.is_dev_mode = True
+    config.fan_sample_interval_seconds = 2
+    return FanControlService(config, lambda: db_session)
+
+
+@pytest.mark.asyncio
+async def test_monitor_loop_applies_the_curve_target_not_fifty(db_session):
+    """#517: _monitor_and_control_fans muss das Kurvenziel an set_pwm reichen.
+
+    Kurve: (40°C, 30%) -> (80°C, 100%). Bei 60°C interpoliert auf 65% — ein
+    Wert, der weder der Hardcode 50 noch min_pwm_percent (10) ist, damit der
+    Test die Verdrahtung tatsaechlich beweist.
+    """
+    db_session.add(_config_row())
+    db_session.commit()
+
+    service = _monitor_service(db_session)
+    service._registry.get_temp = AsyncMock(return_value=60.0)
+    backend = _StubBackend(temperature=60.0, pwm_percent=0)
+    service._backend = backend
+    try:
+        await service._monitor_and_control_fans()
+
+        assert backend.set_pwm_calls == [("f1", 65)]
+        assert backend.set_pwm_calls[0][1] != 50
+        assert backend.set_pwm_calls[0][1] != 10  # min_pwm_percent
     finally:
         FanControlService._instance = None

--- a/backend/tests/test_fan_curve_hysteresis.py
+++ b/backend/tests/test_fan_curve_hysteresis.py
@@ -1,0 +1,60 @@
+"""Die konfigurierte Kurve muss wirken, statt vom Hardcode 50 ersetzt zu werden (#517)."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.power.fan_control import FanControlService
+
+
+def _service():
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = False
+    config.is_dev_mode = True
+    return FanControlService(config, MagicMock())
+
+
+def test_hysteresis_returns_the_given_target_on_first_call():
+    service = _service()
+    try:
+        assert service._apply_hysteresis("f1", 50.0, 3.0, 42) == 42
+    finally:
+        FanControlService._instance = None
+
+
+def test_rising_target_takes_effect_immediately():
+    service = _service()
+    try:
+        service._apply_hysteresis("f1", 50.0, 3.0, 40)
+        assert service._apply_hysteresis("f1", 60.0, 3.0, 70) == 70
+    finally:
+        FanControlService._instance = None
+
+
+def test_falling_target_is_held_inside_the_deadband():
+    service = _service()
+    try:
+        service._apply_hysteresis("f1", 60.0, 3.0, 70)
+        # Nur 1 Grad gefallen, Hysterese ist 3 -> alter Wert wird gehalten
+        assert service._apply_hysteresis("f1", 59.0, 3.0, 40) == 70
+    finally:
+        FanControlService._instance = None
+
+
+def test_falling_target_applies_beyond_the_deadband():
+    service = _service()
+    try:
+        service._apply_hysteresis("f1", 60.0, 3.0, 70)
+        assert service._apply_hysteresis("f1", 55.0, 3.0, 40) == 40
+    finally:
+        FanControlService._instance = None
+
+
+def test_hardcoded_fifty_is_gone():
+    """Regression #517: kein Pfad darf mehr 50 aus dem Nichts liefern."""
+    service = _service()
+    try:
+        assert not hasattr(service, "_calculate_pwm_from_curve")
+        assert service._apply_hysteresis("f1", 20.0, 3.0, 30) == 30
+    finally:
+        FanControlService._instance = None

--- a/backend/tests/test_fan_einval_diagnostic.py
+++ b/backend/tests/test_fan_einval_diagnostic.py
@@ -37,3 +37,79 @@ async def test_write_failure_captures_diagnostic(tmp_path, monkeypatch):
     err = backend._fan_cache[fan_id]["last_write_error"]
     assert "amdgpu" in err
     assert "pwm_enable=2" in err
+
+
+from app.schemas.fans import PwmControl
+
+
+def _amd_hwmon(tmp_path, pwm="128", rpm="1200"):
+    d = tmp_path / "sys" / "class" / "hwmon" / "hwmon1"
+    d.mkdir(parents=True)
+    (d / "name").write_text("amdgpu\n")
+    (d / "pwm1").write_text(f"{pwm}\n")
+    (d / "fan1_input").write_text(f"{rpm}\n")
+    (d / "pwm1_enable").write_text("2\n")
+    return d
+
+
+@pytest.mark.asyncio
+async def test_firmware_managed_fan_is_not_written_at_all(tmp_path, monkeypatch):
+    d = _amd_hwmon(tmp_path, pwm="0", rpm="0")
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
+    await backend._scan_pwm_fans()
+    fan_id = next(iter(backend._fan_cache))
+    backend._fan_cache[fan_id]["pwm_control"] = PwmControl.FIRMWARE_MANAGED
+
+    writes = []
+    monkeypatch.setattr(Path, "write_text", lambda self_, v: writes.append(self_))
+
+    ok = await backend.set_pwm(fan_id, 80)
+
+    assert ok is False
+    assert writes == []
+    err = backend._fan_cache[fan_id]["last_write_error"]
+    assert "ppfeaturemask" in err
+    assert "enable manual mode in the UI" not in err
+
+
+@pytest.mark.asyncio
+async def test_eacces_reports_permission_not_kernel_rejection(tmp_path, monkeypatch):
+    d = _amd_hwmon(tmp_path)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
+    await backend._scan_pwm_fans()
+    fan_id = next(iter(backend._fan_cache))
+
+    def fail_eacces(self_, value):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(Path, "write_text", fail_eacces)
+    with patch("subprocess.run") as srun:
+        srun.return_value.returncode = 1
+        srun.return_value.stderr = b"a password is required"
+        ok = await backend.set_pwm(fan_id, 80)
+
+    assert ok is False
+    err = backend._fan_cache[fan_id]["last_write_error"]
+    assert "EACCES" in err
+    assert "rejected by kernel" not in err
+    assert backend._fan_cache[fan_id]["pwm_control"] is PwmControl.NO_PERMISSION
+
+
+@pytest.mark.asyncio
+async def test_successful_write_clears_no_permission(tmp_path, monkeypatch):
+    """Werden Rechte zur Laufzeit korrigiert, muss der Zustand zurueckgehen."""
+    d = _amd_hwmon(tmp_path)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
+    await backend._scan_pwm_fans()
+    fan_id = next(iter(backend._fan_cache))
+    backend._fan_cache[fan_id]["pwm_control"] = PwmControl.NO_PERMISSION
+    backend._fan_cache[fan_id]["last_write_error"] = "stale"
+
+    ok = await backend.set_pwm(fan_id, 60)
+
+    assert ok is True
+    assert backend._fan_cache[fan_id]["pwm_control"] is PwmControl.SUPPORTED
+    assert backend._fan_cache[fan_id]["last_write_error"] is None

--- a/backend/tests/test_fan_einval_diagnostic.py
+++ b/backend/tests/test_fan_einval_diagnostic.py
@@ -98,6 +98,56 @@ async def test_eacces_reports_permission_not_kernel_rejection(tmp_path, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_eperm_reports_eperm_not_eacces(tmp_path, monkeypatch):
+    """Fund 5: die Meldung darf nur den Code nennen, der tatsaechlich beobachtet
+    wurde. EPERM ist ein anderer Fehler als EACCES (z.B. immutable-Flag statt
+    fehlender Owner-Rechte) und darf nicht als EACCES ausgegeben werden."""
+    d = _amd_hwmon(tmp_path)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
+    await backend._scan_pwm_fans()
+    fan_id = next(iter(backend._fan_cache))
+
+    def fail_eperm(self_, value):
+        raise PermissionError(1, "Operation not permitted")  # errno.EPERM == 1
+
+    monkeypatch.setattr(Path, "write_text", fail_eperm)
+    with patch("subprocess.run") as srun:
+        srun.return_value.returncode = 1
+        srun.return_value.stderr = b"a password is required"
+        ok = await backend.set_pwm(fan_id, 80)
+
+    assert ok is False
+    err = backend._fan_cache[fan_id]["last_write_error"]
+    assert "EPERM" in err
+    assert "EACCES" not in err
+    assert backend._fan_cache[fan_id]["pwm_control"] is PwmControl.NO_PERMISSION
+
+
+@pytest.mark.asyncio
+async def test_missing_sysfs_node_is_not_reported_as_kernel_rejection(tmp_path, monkeypatch):
+    """Fund 4: existiert die sysfs-Node beim Eintritt nicht, liefert
+    _write_hwmon_file (False, None). Das ist keine Kernel-Ablehnung, sondern
+    eine verschwundene Node (Device entfernt / Treiber neu geladen)."""
+    d = _amd_hwmon(tmp_path)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
+    await backend._scan_pwm_fans()
+    fan_id = next(iter(backend._fan_cache))
+
+    # Node verschwindet, bevor set_pwm sie anfasst.
+    (d / "pwm1").unlink()
+
+    ok = await backend.set_pwm(fan_id, 80)
+
+    assert ok is False
+    err = backend._fan_cache[fan_id]["last_write_error"]
+    assert "no longer exists" in err
+    assert "errno=None" not in err
+    assert "rejected by kernel" not in err
+
+
+@pytest.mark.asyncio
 async def test_successful_write_clears_no_permission(tmp_path, monkeypatch):
     """Werden Rechte zur Laufzeit korrigiert, muss der Zustand zurueckgehen."""
     d = _amd_hwmon(tmp_path)

--- a/backend/tests/test_fan_firmware_managed_loop.py
+++ b/backend/tests/test_fan_firmware_managed_loop.py
@@ -1,0 +1,95 @@
+"""Der Regel-Loop schreibt firmware-verwaltete Luefter nicht an (#480)."""
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from app.models.fans import FanConfig
+from app.schemas.fans import FanMode, PwmControl
+from app.services.power.fan_control import FanControlService, FanData
+
+
+class _StubBackend:
+    def __init__(self, temperature=70.0):
+        self.set_pwm_calls = []
+        self.temperature = temperature
+
+    async def get_fans(self):
+        return [FanData(
+            fan_id="gpu_fw", name="RDNA3 GPU", rpm=0, pwm_percent=0,
+            temperature_celsius=self.temperature, mode=FanMode.AUTO,
+            min_pwm_percent=30, max_pwm_percent=100, emergency_temp_celsius=95.0,
+            temp_sensor_id=None, curve_points=[], is_active=True,
+            is_gpu_fan=True, gpu_vendor="amd",
+            pwm_control=PwmControl.FIRMWARE_MANAGED,
+        )]
+
+    async def set_pwm(self, fan_id, pwm_percent):
+        self.set_pwm_calls.append((fan_id, pwm_percent))
+        return True
+
+
+def _config_row(**overrides):
+    # name ist NOT NULL ohne Default (models/fans.py:77).
+    base = dict(
+        fan_id="gpu_fw", name="RDNA3 GPU", mode=FanMode.AUTO.value, is_active=True,
+        min_pwm_percent=30, max_pwm_percent=100, emergency_temp_celsius=95.0,
+        curve_json=json.dumps([{"temp": 35, "pwm": 30}, {"temp": 85, "pwm": 100}]),
+        curve_type="graph", hysteresis_celsius=3.0,
+    )
+    base.update(overrides)
+    return FanConfig(**base)
+
+
+def _service(db_session):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = False
+    config.is_dev_mode = True
+    config.fan_sample_interval_seconds = 2
+    return FanControlService(config, lambda: db_session)
+
+
+@pytest.mark.asyncio
+async def test_loop_does_not_write_firmware_managed_fan(db_session):
+    db_session.add(_config_row())
+    db_session.commit()
+
+    service = _service(db_session)
+    backend = _StubBackend()
+    service._backend = backend
+    try:
+        await service._monitor_and_control_fans()
+
+        assert backend.set_pwm_calls == []
+        # Der Sample traegt den TATSAECHLICHEN Wert, nicht den Wunsch.
+        assert service._sample_buffer[-1]["pwm_percent"] == 0
+    finally:
+        FanControlService._instance = None
+
+
+@pytest.mark.asyncio
+async def test_overtemp_does_not_persist_emergency_for_firmware_managed(db_session):
+    """Sonst haengt der Luefter dauerhaft in EMERGENCY, ohne dass es etwas nuetzt."""
+    # temp_sensor_id ist noetig, sonst bleibt die im Loop gelesene Temperatur
+    # None und der Emergency-Zweig wird gar nicht erst erreicht.
+    row = _config_row(temp_sensor_id="hwmon:gpu_fw")
+    db_session.add(row)
+    db_session.commit()
+
+    service = _service(db_session)
+    service._registry.get_temp = AsyncMock(return_value=99.0)  # ueber emergency_temp
+    service._backend = _StubBackend(temperature=99.0)
+    try:
+        await service._monitor_and_control_fans()
+        # _monitor_and_control_fans nutzt "with self.db_session_factory() as db:",
+        # was die (im Test geteilte) Session schliesst -> db_session.refresh(row)
+        # wuerde mit "not persistent within this Session" fehlschlagen. Frisch
+        # abfragen umgeht das.
+        updated = db_session.execute(
+            select(FanConfig).where(FanConfig.fan_id == "gpu_fw")
+        ).scalar_one()
+        assert updated.mode == FanMode.AUTO.value
+    finally:
+        FanControlService._instance = None

--- a/backend/tests/test_fan_gpu_manual_mode.py
+++ b/backend/tests/test_fan_gpu_manual_mode.py
@@ -43,3 +43,29 @@ async def test_disable_restores_previous(tmp_path):
 
     assert (device / "power_dpm_force_performance_level").read_text().strip() == "auto"
     assert (hwmon / "pwm1_enable").read_text().strip() == "2"
+
+
+@pytest.mark.asyncio
+async def test_enable_rolls_back_performance_level_when_pwm_enable_fails(tmp_path, monkeypatch):
+    device = tmp_path / "sys" / "class" / "drm" / "card0" / "device"
+    hwmon = device / "hwmon" / "hwmon3"
+    hwmon.mkdir(parents=True)
+    (device / "vendor").write_text("0x1002\n")
+    (device / "power_dpm_force_performance_level").write_text("auto\n")
+    (hwmon / "name").write_text("amdgpu\n")
+    (hwmon / "pwm1_enable").write_text("2\n")
+
+    real_write = Path.write_text
+
+    def fail_on_pwm_enable(self_, value, *a, **kw):
+        if self_.name == "pwm1_enable":
+            raise PermissionError(13, "Permission denied")
+        return real_write(self_, value, *a, **kw)
+
+    monkeypatch.setattr(Path, "write_text", fail_on_pwm_enable)
+
+    with pytest.raises(PermissionError):
+        await enable_amd_manual(hwmon_dir=hwmon, drm_root=None)
+
+    monkeypatch.undo()
+    assert (device / "power_dpm_force_performance_level").read_text().strip() == "auto"

--- a/backend/tests/test_fan_pwm_control_probe.py
+++ b/backend/tests/test_fan_pwm_control_probe.py
@@ -73,3 +73,42 @@ def test_board_sensor_without_device_is_supported(tmp_path):
     hwmon.mkdir(parents=True)
     (hwmon / "name").write_text("nct6798\n")
     assert probe_amd_pwm_control(hwmon) is PwmControl.SUPPORTED
+
+
+import pytest
+
+from app.core.config import get_settings
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+@pytest.mark.asyncio
+async def test_scan_marks_rdna3_fan_firmware_managed(tmp_path, monkeypatch):
+    hwmon = _hardware_shaped_tree(tmp_path, with_fan_curve=True)
+    (hwmon / "pwm1").write_text("0\n")
+    (hwmon / "fan1_input").write_text("0\n")
+    (hwmon / "pwm1_enable").write_text("2\n")
+
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", hwmon.parent)
+    await backend._scan_pwm_fans()
+
+    fan_id = next(iter(backend._fan_cache))
+    assert backend._fan_cache[fan_id]["pwm_control"] is PwmControl.FIRMWARE_MANAGED
+
+    fans = await backend.get_fans()
+    assert fans[0].pwm_control is PwmControl.FIRMWARE_MANAGED
+
+
+@pytest.mark.asyncio
+async def test_scan_marks_normal_fan_supported(tmp_path, monkeypatch):
+    hwmon = _hardware_shaped_tree(tmp_path, with_fan_curve=False)
+    (hwmon / "pwm1").write_text("128\n")
+    (hwmon / "fan1_input").write_text("1200\n")
+    (hwmon / "pwm1_enable").write_text("2\n")
+
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", hwmon.parent)
+    await backend._scan_pwm_fans()
+
+    fan_id = next(iter(backend._fan_cache))
+    assert backend._fan_cache[fan_id]["pwm_control"] is PwmControl.SUPPORTED

--- a/backend/tests/test_fan_pwm_control_probe.py
+++ b/backend/tests/test_fan_pwm_control_probe.py
@@ -1,0 +1,75 @@
+"""probe_amd_pwm_control: firmware-verwaltete Luefterkurven erkennen (RDNA3+, #480)."""
+from pathlib import Path
+
+from app.schemas.fans import PwmControl
+from app.services.power.fan_gpu_manual import probe_amd_pwm_control
+
+
+def _hardware_shaped_tree(tmp_path: Path, *, with_fan_curve: bool) -> Path:
+    """Bildet die ECHTE sysfs-Struktur nach.
+
+    Auf der Hardware liegt hwmon unter /sys/class/hwmon/hwmonN und traegt einen
+    'device'-Symlink auf das PCI-Geraet. KEIN Elternverzeichnis heisst 'device'
+    — genau daran ist der erste Entwurf gescheitert.
+    """
+    hwmon = tmp_path / "sys" / "class" / "hwmon" / "hwmon2"
+    device = hwmon / "device"
+    device.mkdir(parents=True)
+    (hwmon / "name").write_text("amdgpu\n")
+    (device / "vendor").write_text("0x1002\n")
+    if with_fan_curve:
+        fan_ctrl = device / "gpu_od" / "fan_ctrl"
+        fan_ctrl.mkdir(parents=True)
+        (fan_ctrl / "fan_curve").write_text("OD_FAN_CURVE:\n0: 0C 0%\n")
+    return hwmon
+
+
+def _drm_shaped_tree(tmp_path: Path, *, with_fan_curve: bool) -> Path:
+    """Die synthetische Struktur, die bestehende Tests verwenden."""
+    device = tmp_path / "sys" / "class" / "drm" / "card0" / "device"
+    hwmon = device / "hwmon" / "hwmon2"
+    hwmon.mkdir(parents=True)
+    (device / "vendor").write_text("0x1002\n")
+    (hwmon / "name").write_text("amdgpu\n")
+    if with_fan_curve:
+        fan_ctrl = device / "gpu_od" / "fan_ctrl"
+        fan_ctrl.mkdir(parents=True)
+        (fan_ctrl / "fan_curve").write_text("OD_FAN_CURVE:\n0: 0C 0%\n")
+    return hwmon
+
+
+def test_hardware_layout_detects_firmware_managed(tmp_path):
+    """Der Fall, der in Produktion zaehlt."""
+    hwmon = _hardware_shaped_tree(tmp_path, with_fan_curve=True)
+    assert probe_amd_pwm_control(hwmon) is PwmControl.FIRMWARE_MANAGED
+
+
+def test_hardware_layout_without_fan_curve_is_supported(tmp_path):
+    hwmon = _hardware_shaped_tree(tmp_path, with_fan_curve=False)
+    assert probe_amd_pwm_control(hwmon) is PwmControl.SUPPORTED
+
+
+def test_drm_layout_still_works(tmp_path):
+    """Der Aufwaertslauf bleibt als Fallback erhalten."""
+    hwmon = _drm_shaped_tree(tmp_path, with_fan_curve=True)
+    assert probe_amd_pwm_control(hwmon) is PwmControl.FIRMWARE_MANAGED
+
+
+def test_gpu_od_without_fan_curve_is_supported(tmp_path):
+    """gpu_od/ allein genuegt nicht — nur fan_curve ist der Marker."""
+    hwmon = _hardware_shaped_tree(tmp_path, with_fan_curve=False)
+    (hwmon / "device" / "gpu_od" / "fan_ctrl").mkdir(parents=True)
+    assert probe_amd_pwm_control(hwmon) is PwmControl.SUPPORTED
+
+
+def test_non_amd_vendor_is_supported(tmp_path):
+    hwmon = _hardware_shaped_tree(tmp_path, with_fan_curve=True)
+    (hwmon / "device" / "vendor").write_text("0x10de\n")
+    assert probe_amd_pwm_control(hwmon) is PwmControl.SUPPORTED
+
+
+def test_board_sensor_without_device_is_supported(tmp_path):
+    hwmon = tmp_path / "sys" / "class" / "hwmon" / "hwmon0"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nct6798\n")
+    assert probe_amd_pwm_control(hwmon) is PwmControl.SUPPORTED

--- a/backend/tests/test_fan_pwm_control_probe.py
+++ b/backend/tests/test_fan_pwm_control_probe.py
@@ -116,6 +116,7 @@ async def test_scan_marks_normal_fan_supported(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_dev_backend_exposes_a_firmware_managed_gpu_fan():
+    import asyncio
     from app.services.power.fan_backend_dev import DevFanControlBackend
 
     backend = DevFanControlBackend(get_settings())
@@ -123,4 +124,17 @@ async def test_dev_backend_exposes_a_firmware_managed_gpu_fan():
 
     assert fans["dev_gpu_pwm1"].pwm_control is PwmControl.SUPPORTED
     assert fans["dev_gpu_rdna3_pwm1"].pwm_control is PwmControl.FIRMWARE_MANAGED
+
+    # Verify set_pwm is rejected for firmware-managed fan
     assert await backend.set_pwm("dev_gpu_rdna3_pwm1", 80) is False
+
+    # Verify that pwm_percent and target_rpm remain unchanged after rejected set_pwm
+    assert backend._fans["dev_gpu_rdna3_pwm1"]["pwm_percent"] == 0
+    assert backend._fans["dev_gpu_rdna3_pwm1"]["target_rpm"] == 0
+
+    # Verify current_rpm stays at 0 across multiple get_fans() calls (no drift via fluctuation)
+    for _ in range(5):
+        fans = await backend.get_fans()
+        fan = next(f for f in fans if f.fan_id == "dev_gpu_rdna3_pwm1")
+        assert fan.rpm == 0, f"current_rpm drifted to {fan.rpm}"
+        await asyncio.sleep(0.05)  # Small delay between calls to test stability

--- a/backend/tests/test_fan_pwm_control_probe.py
+++ b/backend/tests/test_fan_pwm_control_probe.py
@@ -112,3 +112,15 @@ async def test_scan_marks_normal_fan_supported(tmp_path, monkeypatch):
 
     fan_id = next(iter(backend._fan_cache))
     assert backend._fan_cache[fan_id]["pwm_control"] is PwmControl.SUPPORTED
+
+
+@pytest.mark.asyncio
+async def test_dev_backend_exposes_a_firmware_managed_gpu_fan():
+    from app.services.power.fan_backend_dev import DevFanControlBackend
+
+    backend = DevFanControlBackend(get_settings())
+    fans = {f.fan_id: f for f in await backend.get_fans()}
+
+    assert fans["dev_gpu_pwm1"].pwm_control is PwmControl.SUPPORTED
+    assert fans["dev_gpu_rdna3_pwm1"].pwm_control is PwmControl.FIRMWARE_MANAGED
+    assert await backend.set_pwm("dev_gpu_rdna3_pwm1", 80) is False

--- a/client/src/__tests__/components/fan-control/FanCard.test.tsx
+++ b/client/src/__tests__/components/fan-control/FanCard.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import FanCard from '../../../components/fan-control/FanCard';
+import { FanMode } from '../../../api/fan-control';
+import type { FanInfo } from '../../../api/fan-control';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+function fan(overrides: Partial<FanInfo> = {}): FanInfo {
+  return {
+    fan_id: 'hwmon2_pwm1',
+    name: 'RDNA3 GPU',
+    rpm: 0,
+    pwm_percent: 0,
+    temperature_celsius: 55,
+    mode: FanMode.MANUAL,
+    is_active: true,
+    min_pwm_percent: 30,
+    max_pwm_percent: 100,
+    emergency_temp_celsius: 95,
+    temp_sensor_id: null,
+    curve_points: [],
+    hysteresis_celsius: 3,
+    is_gpu_fan: true,
+    gpu_vendor: 'amd',
+    pwm_control: 'supported',
+    ...overrides,
+  };
+}
+
+const noop = vi.fn();
+
+function renderCard(f: FanInfo) {
+  return render(
+    <FanCard
+      fan={f}
+      isSelected={false}
+      onSelect={noop}
+      onModeChange={noop}
+      onPWMChange={noop}
+      isReadOnly={false}
+      isLoading={false}
+      sensors={[]}
+    />
+  );
+}
+
+describe('FanCard bei firmware-verwalteter GPU', () => {
+  it('zeigt kein Firmware-Badge bei normalem Luefter', () => {
+    renderCard(fan());
+    expect(screen.queryByTestId('fan-firmware-badge')).toBeNull();
+  });
+
+  it('zeigt das Firmware-Badge', () => {
+    renderCard(fan({ pwm_control: 'firmware_managed' }));
+    expect(screen.getByTestId('fan-firmware-badge')).toBeTruthy();
+  });
+
+  it('sperrt den PWM-Slider', () => {
+    renderCard(fan({ pwm_control: 'firmware_managed' }));
+    const slider = screen.getByRole('slider') as HTMLInputElement;
+    expect(slider.disabled).toBe(true);
+  });
+
+  it('laesst die Modus-Buttons bedienbar — sonst sperrt sich der Nutzer aus', () => {
+    renderCard(fan({ pwm_control: 'firmware_managed' }));
+    const enabled = screen
+      .getAllByRole('button')
+      .filter((b) => !(b as HTMLButtonElement).disabled);
+    // AUTO und SCHEDULED sind klickbar (MANUAL ist der aktive Modus)
+    expect(enabled.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/client/src/__tests__/components/fan-control/FanDetails.test.tsx
+++ b/client/src/__tests__/components/fan-control/FanDetails.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FanDetails from '../../../components/fan-control/FanDetails';
+import { FanMode } from '../../../api/fan-control';
+import type { FanInfo, FanCurveProfile } from '../../../api/fan-control';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+function fan(overrides: Partial<FanInfo> = {}): FanInfo {
+  return {
+    fan_id: 'hwmon2_pwm1',
+    name: 'RDNA3 GPU',
+    rpm: 0,
+    pwm_percent: 0,
+    temperature_celsius: 55,
+    mode: FanMode.AUTO,
+    is_active: true,
+    min_pwm_percent: 30,
+    max_pwm_percent: 100,
+    emergency_temp_celsius: 95,
+    temp_sensor_id: null,
+    curve_points: [
+      { temp: 30, pwm: 30 },
+      { temp: 80, pwm: 100 },
+    ],
+    hysteresis_celsius: 3,
+    is_gpu_fan: true,
+    gpu_vendor: 'amd',
+    curve_type: 'graph',
+    pwm_control: 'supported',
+    ...overrides,
+  };
+}
+
+const profile: FanCurveProfile = {
+  id: 1,
+  name: 'silent',
+  is_system: true,
+  curve_points: [{ temp: 30, pwm: 30 }],
+};
+
+function renderDetails(f: FanInfo) {
+  return render(
+    <FanDetails
+      fan={f}
+      onCurveUpdate={vi.fn()}
+      isReadOnly={false}
+      profiles={[profile]}
+      allFans={[f]}
+    />
+  );
+}
+
+describe('FanDetails bei firmware-verwalteter GPU', () => {
+  it('zeigt Preset/Profil-Buttons bei normalem Luefter', () => {
+    renderDetails(fan());
+    expect(screen.getByText('Silent')).toBeTruthy();
+  });
+
+  it('versteckt Preset/Profil-Buttons, obwohl die Seite isReadOnly=false meldet', () => {
+    renderDetails(fan({ pwm_control: 'firmware_managed' }));
+    expect(screen.queryByText('Silent')).toBeNull();
+  });
+
+  it('sperrt den Kurventyp-Umschalter', () => {
+    renderDetails(fan({ pwm_control: 'firmware_managed' }));
+    const graphBtn = screen.getByText('system:fanControl.curveTypes.graph') as HTMLButtonElement;
+    expect(graphBtn.disabled).toBe(true);
+  });
+
+  it('sperrt die Tabellen-Kurvenbearbeitung ueber editor.canEdit (Hook bekommt editingLocked)', () => {
+    renderDetails(fan({ pwm_control: 'firmware_managed' }));
+    fireEvent.click(screen.getByText('system:fanControl.curve.table'));
+    expect(screen.queryByText('system:fanControl.curve.addPoint')).toBeNull();
+  });
+
+  it('zeigt das Firmware-Erklaerpanel statt des manuellen GPU-Toggles', () => {
+    renderDetails(fan({ pwm_control: 'firmware_managed' }));
+    expect(screen.getByText('system:fanControl.gpu.firmware.title')).toBeTruthy();
+    expect(screen.queryByText('system:fanControl.gpu.manualMode.title')).toBeNull();
+  });
+});

--- a/client/src/__tests__/components/fan-control/FirmwareFanNotice.test.tsx
+++ b/client/src/__tests__/components/fan-control/FirmwareFanNotice.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FirmwareFanNotice from '../../../components/fan-control/FirmwareFanNotice';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+const setGpuManualMode = vi.fn();
+vi.mock('../../../api/fan-control', () => ({
+  setGpuManualMode: (...args: unknown[]) => setGpuManualMode(...args),
+}));
+
+import toast from 'react-hot-toast';
+
+describe('FirmwareFanNotice: Ausstieg aus dem manuellen Modus bleibt erreichbar', () => {
+  it('bietet einen Reset-Button, der setGpuManualMode(fanId, false) aufruft', async () => {
+    setGpuManualMode.mockResolvedValueOnce(undefined);
+    render(<FirmwareFanNotice fanId="gpu_pwm1" />);
+
+    fireEvent.click(screen.getByText('system:fanControl.gpu.firmware.resetButton'));
+
+    await waitFor(() => {
+      expect(setGpuManualMode).toHaveBeenCalledWith('gpu_pwm1', false);
+    });
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('meldet einen Fehler ueber handleApiError, statt ihn zu verschlucken', async () => {
+    setGpuManualMode.mockRejectedValueOnce(new Error('boom'));
+    render(<FirmwareFanNotice fanId="gpu_pwm1" />);
+
+    fireEvent.click(screen.getByText('system:fanControl.gpu.firmware.resetButton'));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/__tests__/pages/FanControl.test.tsx
+++ b/client/src/__tests__/pages/FanControl.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithQueryClient } from '../helpers/queryClient';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('../../hooks/useFanControl', () => ({ useFanControl: vi.fn() }));
+
+// The page itself fetches profiles/sensors on mount (fire-and-forget, fails
+// silently by design) — stub those three so the test doesn't depend on a
+// real backend being reachable. Everything else in the module (FanMode, the
+// FanInfo type, etc.) stays real.
+vi.mock('../../api/fan-control', async () => {
+  const actual = await vi.importActual<typeof import('../../api/fan-control')>('../../api/fan-control');
+  return {
+    ...actual,
+    listProfiles: vi.fn().mockResolvedValue({ profiles: [], total_count: 0 }),
+    listTempSensors: vi.fn().mockResolvedValue({ sensors: [], total_count: 0 }),
+    listComposites: vi.fn().mockResolvedValue({ composites: [], total_count: 0 }),
+  };
+});
+
+// FanSchedulePanel is a real, fairly heavy component with its own API calls
+// on mount (schedule entries). Stub it down to a prop probe — this test is
+// only about which `isReadOnly` value FanControl.tsx computes and passes in,
+// not about FanSchedulePanel's own behavior (that's covered elsewhere).
+vi.mock('../../components/fan-control', async () => {
+  const actual = await vi.importActual<typeof import('../../components/fan-control')>('../../components/fan-control');
+  return {
+    ...actual,
+    FanSchedulePanel: (props: { isReadOnly: boolean }) => (
+      <div data-testid="schedule-panel-readonly">{String(props.isReadOnly)}</div>
+    ),
+  };
+});
+
+import { useFanControl } from '../../hooks/useFanControl';
+import { FanMode } from '../../api/fan-control';
+import type { FanInfo } from '../../api/fan-control';
+import FanControl from '../../pages/FanControl';
+
+function fan(overrides: Partial<FanInfo> = {}): FanInfo {
+  return {
+    fan_id: 'hwmon2_pwm1',
+    name: 'Fan',
+    rpm: 1200,
+    pwm_percent: 40,
+    temperature_celsius: 55,
+    mode: FanMode.SCHEDULED,
+    is_active: true,
+    min_pwm_percent: 30,
+    max_pwm_percent: 100,
+    emergency_temp_celsius: 95,
+    temp_sensor_id: null,
+    curve_points: [],
+    hysteresis_celsius: 3,
+    pwm_control: 'supported',
+    ...overrides,
+  };
+}
+
+function mockStatus(fans: FanInfo[]) {
+  (useFanControl as any).mockReturnValue({
+    status: {
+      fans,
+      is_dev_mode: true,
+      is_using_linux_backend: false,
+      permission_status: 'ok',
+      backend_available: true,
+    },
+    permissionStatus: { has_write_permission: true, status: 'ok', message: '', suggestions: [] },
+    loading: false,
+    refetch: vi.fn(),
+    isReadOnly: false,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('FanControl Seite: Zeitplan-Sperre folgt dem ausgewaehlten Luefter, nicht global', () => {
+  it('laesst den Zeitplan eines normalen Luefters editierbar', async () => {
+    mockStatus([fan({ fan_id: 'case_pwm1', name: 'Case Fan', pwm_control: 'supported' })]);
+    renderWithQueryClient(<FanControl />);
+    await waitFor(() => {
+      expect(screen.getByTestId('schedule-panel-readonly').textContent).toBe('false');
+    });
+  });
+
+  it('sperrt den Zeitplan eines firmware-verwalteten Luefters, obwohl die Seite isReadOnly=false meldet', async () => {
+    mockStatus([fan({ fan_id: 'gpu_pwm1', name: 'GPU Fan', pwm_control: 'firmware_managed' })]);
+    renderWithQueryClient(<FanControl />);
+    await waitFor(() => {
+      expect(screen.getByTestId('schedule-panel-readonly').textContent).toBe('true');
+    });
+  });
+
+  it('sperrt nur den ausgewaehlten firmware-verwalteten Luefter, nicht die ganze Box (per-Fan statt global)', async () => {
+    mockStatus([
+      fan({ fan_id: 'case_pwm1', name: 'Case Fan', mode: FanMode.SCHEDULED, pwm_control: 'supported' }),
+      fan({ fan_id: 'gpu_pwm1', name: 'GPU Fan', mode: FanMode.SCHEDULED, pwm_control: 'firmware_managed' }),
+    ]);
+    renderWithQueryClient(<FanControl />);
+
+    // Case Fan is auto-selected (first in the list) -> schedule stays editable.
+    await waitFor(() => {
+      expect(screen.getByTestId('schedule-panel-readonly').textContent).toBe('false');
+    });
+
+    // Selecting the GPU fan instead locks the panel for that fan specifically.
+    fireEvent.click(screen.getByText('GPU Fan'));
+    await waitFor(() => {
+      expect(screen.getByTestId('schedule-panel-readonly').textContent).toBe('true');
+    });
+  });
+});

--- a/client/src/__tests__/pages/FanControl.test.tsx
+++ b/client/src/__tests__/pages/FanControl.test.tsx
@@ -115,3 +115,25 @@ describe('FanControl Seite: Zeitplan-Sperre folgt dem ausgewaehlten Luefter, nic
     });
   });
 });
+
+describe('FanControl Seite: Profile-Panel fuer firmware-verwaltete Luefter gesperrt', () => {
+  it('zeigt den Profile Manager fuer einen normalen Luefter', async () => {
+    mockStatus([fan({ fan_id: 'case_pwm1', name: 'Case Fan', pwm_control: 'supported' })]);
+    renderWithQueryClient(<FanControl />);
+    await waitFor(() => {
+      expect(screen.getByText('system:fanControl.profiles.title')).toBeTruthy();
+    });
+  });
+
+  it('versteckt den Profile Manager fuer einen firmware-verwalteten Luefter, obwohl isReadOnly=false', async () => {
+    mockStatus([fan({ fan_id: 'gpu_pwm1', name: 'GPU Fan', pwm_control: 'firmware_managed' })]);
+    renderWithQueryClient(<FanControl />);
+    // Warten, bis die Seite fertig gerendert hat (Fan-Karte sichtbar), dann
+    // pruefen, dass der Profile Manager (der nachweislich nie an diesen
+    // Luefter schreiben kann) nicht erscheint.
+    await waitFor(() => {
+      expect(screen.getByText('GPU Fan')).toBeTruthy();
+    });
+    expect(screen.queryByText('system:fanControl.profiles.title')).toBeNull();
+  });
+});

--- a/client/src/api/fan-control.ts
+++ b/client/src/api/fan-control.ts
@@ -73,6 +73,7 @@ export interface FanInfo {
   is_gpu_fan?: boolean;
   gpu_vendor?: string | null;
   last_write_error?: string | null;
+  pwm_control?: 'supported' | 'firmware_managed' | 'no_permission';
   // Curve type and tuning fields (Task 15)
   curve_type?: 'graph' | 'flat' | 'target' | 'mix' | 'sync';
   flat_pwm_percent?: number | null;

--- a/client/src/components/fan-control/CurveEditorSync.tsx
+++ b/client/src/components/fan-control/CurveEditorSync.tsx
@@ -21,9 +21,12 @@ export default function CurveEditorSync({ allFans, currentFanId, syncFanId, onCh
         className="w-full bg-slate-900 border border-slate-700 rounded px-2 py-1 text-white"
       >
         <option value="">{t('system:fanControl.curveTypes.selectFan')}</option>
-        {allFans.filter((f) => f.fan_id !== currentFanId).map((f) => (
-          <option key={f.fan_id} value={f.fan_id}>{f.name}</option>
-        ))}
+        {allFans
+          .filter((f) => f.fan_id !== currentFanId)
+          .filter((f) => f.pwm_control !== 'firmware_managed')
+          .map((f) => (
+            <option key={f.fan_id} value={f.fan_id}>{f.name}</option>
+          ))}
       </select>
     </div>
   );

--- a/client/src/components/fan-control/FanCard.tsx
+++ b/client/src/components/fan-control/FanCard.tsx
@@ -80,6 +80,8 @@ export default function FanCard({
     }
   };
 
+  const isFirmwareManaged = fan.pwm_control === 'firmware_managed';
+
   return (
     <div
       onClick={onSelect}
@@ -97,6 +99,15 @@ export default function FanCard({
             {fan.is_gpu_fan && (
               <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs bg-purple-500/20 text-purple-300 rounded">
                 GPU{fan.gpu_vendor ? ` (${fan.gpu_vendor.toUpperCase()})` : ''}
+              </span>
+            )}
+            {isFirmwareManaged && (
+              <span
+                data-testid="fan-firmware-badge"
+                className="inline-flex items-center px-1.5 py-0.5 text-xs bg-sky-500/20 text-sky-300 rounded"
+                title={t('system:fanControl.gpu.firmware.badgeHint')}
+              >
+                {t('system:fanControl.gpu.firmware.badge')}
               </span>
             )}
             {fan.last_write_error && (
@@ -224,7 +235,7 @@ export default function FanCard({
             max={fan.max_pwm_percent}
             value={localPWM}
             onChange={(e) => handlePWMSliderChange(parseInt(e.target.value))}
-            disabled={isReadOnly}
+            disabled={isReadOnly || isFirmwareManaged}
             className="w-full h-2 bg-slate-700 rounded-lg appearance-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed accent-purple-500"
           />
         </div>

--- a/client/src/components/fan-control/FanDetails.tsx
+++ b/client/src/components/fan-control/FanDetails.tsx
@@ -152,7 +152,7 @@ export default function FanDetails({ fan, onCurveUpdate, isReadOnly, onEditingCh
       {fan.is_gpu_fan && fan.gpu_vendor === 'amd' && (
         <div className="mt-4">
           {isFirmwareManaged ? (
-            <FirmwareFanNotice />
+            <FirmwareFanNotice fanId={fan.fan_id} />
           ) : (
             <GpuManualModeToggle
               fanId={fan.fan_id}

--- a/client/src/components/fan-control/FanDetails.tsx
+++ b/client/src/components/fan-control/FanDetails.tsx
@@ -34,7 +34,7 @@ export default function FanDetails({ fan, onCurveUpdate, isReadOnly, onEditingCh
   const isFirmwareManaged = fan.pwm_control === 'firmware_managed';
   const editingLocked = isReadOnly || isFirmwareManaged;
   const editor = useFanCurveEditor(fan, {
-    isReadOnly, onCurveUpdate, onConfigUpdate, onEditingChange, onApplyProfile, profiles,
+    isReadOnly: editingLocked, onCurveUpdate, onConfigUpdate, onEditingChange, onApplyProfile, profiles,
   });
 
   return (
@@ -46,7 +46,7 @@ export default function FanDetails({ fan, onCurveUpdate, isReadOnly, onEditingCh
         </h2>
 
         <FanPresetProfileButtons
-          isReadOnly={isReadOnly}
+          isReadOnly={editingLocked}
           systemProfiles={editor.systemProfiles}
           userProfiles={editor.userProfiles}
           showMoreProfiles={editor.showMoreProfiles}
@@ -69,7 +69,7 @@ export default function FanDetails({ fan, onCurveUpdate, isReadOnly, onEditingCh
               viewMode={editor.viewMode}
               onViewModeChange={editor.setViewMode}
               hasUnsavedChanges={editor.hasUnsavedChanges}
-              isReadOnly={isReadOnly}
+              isReadOnly={editingLocked}
               onSave={editor.handleSaveCurve}
               onDiscard={editor.handleDiscardChanges}
             />

--- a/client/src/components/fan-control/FanDetails.tsx
+++ b/client/src/components/fan-control/FanDetails.tsx
@@ -7,6 +7,7 @@ import CurveEditorMix from './CurveEditorMix';
 import CurveEditorSync from './CurveEditorSync';
 import AdvancedFanSettings from './AdvancedFanSettings';
 import GpuManualModeToggle from './GpuManualModeToggle';
+import FirmwareFanNotice from './FirmwareFanNotice';
 import FanCurveChart from './FanCurveChart';
 import { useTranslation } from 'react-i18next';
 import { useFanCurveEditor } from '../../hooks/useFanCurveEditor';
@@ -30,6 +31,8 @@ interface FanDetailsProps {
 
 export default function FanDetails({ fan, onCurveUpdate, isReadOnly, onEditingChange, onConfigUpdate, profiles, onApplyProfile, allFans }: FanDetailsProps) {
   const { t } = useTranslation(['system', 'common']);
+  const isFirmwareManaged = fan.pwm_control === 'firmware_managed';
+  const editingLocked = isReadOnly || isFirmwareManaged;
   const editor = useFanCurveEditor(fan, {
     isReadOnly, onCurveUpdate, onConfigUpdate, onEditingChange, onApplyProfile, profiles,
   });
@@ -56,7 +59,7 @@ export default function FanDetails({ fan, onCurveUpdate, isReadOnly, onEditingCh
       {/* Curve Editor */}
       <div className="mb-4">
         <div className="mb-4">
-          <CurveTypeSelector value={editor.curveType} onChange={editor.handleCurveTypeChange} disabled={isReadOnly} />
+          <CurveTypeSelector value={editor.curveType} onChange={editor.handleCurveTypeChange} disabled={editingLocked} />
         </div>
 
         {/* Graph curve: original chart + table editor */}
@@ -82,7 +85,7 @@ export default function FanDetails({ fan, onCurveUpdate, isReadOnly, onEditingCh
                   maxPWM={fan.max_pwm_percent}
                   emergencyTemp={fan.emergency_temp_celsius}
                   isEditing={editor.canEdit}
-                  isReadOnly={isReadOnly}
+                  isReadOnly={editingLocked}
                 />
               </div>
             )}
@@ -105,7 +108,7 @@ export default function FanDetails({ fan, onCurveUpdate, isReadOnly, onEditingCh
           <CurveEditorFlat
             value={fan.flat_pwm_percent ?? 50}
             onChange={editor.handleFlatChange}
-            disabled={isReadOnly}
+            disabled={editingLocked}
           />
         )}
 
@@ -114,7 +117,7 @@ export default function FanDetails({ fan, onCurveUpdate, isReadOnly, onEditingCh
             targetTemp={fan.target_temp_celsius ?? 65}
             targetPwm={fan.target_pwm_percent ?? 80}
             onChange={editor.handleTargetChange}
-            disabled={isReadOnly}
+            disabled={editingLocked}
           />
         )}
 
@@ -125,7 +128,7 @@ export default function FanDetails({ fan, onCurveUpdate, isReadOnly, onEditingCh
             curveBId={fan.mix_curve_b_id ?? null}
             fn={(fan.mix_function as 'max' | 'sum') ?? 'max'}
             onChange={editor.handleMixChange}
-            disabled={isReadOnly}
+            disabled={editingLocked}
           />
         )}
 
@@ -135,24 +138,28 @@ export default function FanDetails({ fan, onCurveUpdate, isReadOnly, onEditingCh
             currentFanId={fan.fan_id}
             syncFanId={fan.sync_fan_id ?? null}
             onChange={editor.handleSyncChange}
-            disabled={isReadOnly}
+            disabled={editingLocked}
           />
         )}
       </div>
 
       {/* Advanced Settings */}
       <div className="mt-4">
-        <AdvancedFanSettings fan={fan} onChange={editor.handleAdvancedChange} disabled={isReadOnly} />
+        <AdvancedFanSettings fan={fan} onChange={editor.handleAdvancedChange} disabled={editingLocked} />
       </div>
 
       {/* GPU Manual Mode Toggle (AMD GPU fans only) */}
       {fan.is_gpu_fan && fan.gpu_vendor === 'amd' && (
         <div className="mt-4">
-          <GpuManualModeToggle
-            fanId={fan.fan_id}
-            enabled={editor.localGpuManualEnabled}
-            onChange={editor.setLocalGpuManualEnabled}
-          />
+          {isFirmwareManaged ? (
+            <FirmwareFanNotice />
+          ) : (
+            <GpuManualModeToggle
+              fanId={fan.fan_id}
+              enabled={editor.localGpuManualEnabled}
+              onChange={editor.setLocalGpuManualEnabled}
+            />
+          )}
         </div>
       )}
 

--- a/client/src/components/fan-control/FirmwareFanNotice.tsx
+++ b/client/src/components/fan-control/FirmwareFanNotice.tsx
@@ -1,8 +1,35 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
 import { Cpu } from 'lucide-react';
+import { setGpuManualMode } from '../../api/fan-control';
+import { handleApiError } from '../../lib/errorHandling';
 
-export default function FirmwareFanNotice() {
+interface Props {
+  fanId: string;
+}
+
+export default function FirmwareFanNotice({ fanId }: Props) {
   const { t } = useTranslation(['system']);
+  const [busy, setBusy] = useState(false);
+
+  // Der 400er-Guard auf gpu-manual-mode greift bewusst nur bei enable=true,
+  // damit ein Luefter, der einmal in den manuellen Modus geschaltet wurde,
+  // immer wieder herauskommt. Dieser Button ist der einzige UI-Weg dorthin —
+  // ohne ihn waere der Ausschalt-Pfad nur noch per curl erreichbar. Ein Aufruf
+  // auf einem Luefter, der nie manuell war, ist harmlos (stellt auto/pwm_enable=2
+  // wieder her, also genau den gewuenschten Zustand).
+  const resetManualMode = async () => {
+    setBusy(true);
+    try {
+      await setGpuManualMode(fanId, false);
+      toast.success(t('system:fanControl.gpu.firmware.resetSuccess'));
+    } catch (err) {
+      handleApiError(err, t('system:fanControl.gpu.firmware.resetButton'));
+    } finally {
+      setBusy(false);
+    }
+  };
 
   return (
     <div className="border border-sky-500/30 bg-sky-500/5 rounded p-3">
@@ -15,6 +42,13 @@ export default function FirmwareFanNotice() {
           <div className="text-xs text-slate-400 mt-1">
             {t('system:fanControl.gpu.firmware.explanation')}
           </div>
+          <button
+            onClick={resetManualMode}
+            disabled={busy}
+            className="mt-2 px-3 py-1 text-xs rounded bg-slate-700 text-slate-200 hover:bg-slate-600 disabled:opacity-50"
+          >
+            {t('system:fanControl.gpu.firmware.resetButton')}
+          </button>
         </div>
       </div>
     </div>

--- a/client/src/components/fan-control/FirmwareFanNotice.tsx
+++ b/client/src/components/fan-control/FirmwareFanNotice.tsx
@@ -1,0 +1,22 @@
+import { useTranslation } from 'react-i18next';
+import { Cpu } from 'lucide-react';
+
+export default function FirmwareFanNotice() {
+  const { t } = useTranslation(['system']);
+
+  return (
+    <div className="border border-sky-500/30 bg-sky-500/5 rounded p-3">
+      <div className="flex items-start gap-2">
+        <Cpu size={16} className="text-sky-400 mt-0.5" />
+        <div className="flex-1">
+          <div className="text-sm font-medium text-white">
+            {t('system:fanControl.gpu.firmware.title')}
+          </div>
+          <div className="text-xs text-slate-400 mt-1">
+            {t('system:fanControl.gpu.firmware.explanation')}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/fan-control/index.ts
+++ b/client/src/components/fan-control/index.ts
@@ -16,3 +16,4 @@ export { default as CurveEditorMix } from './CurveEditorMix';
 export { default as CurveEditorSync } from './CurveEditorSync';
 export { default as AdvancedFanSettings } from './AdvancedFanSettings';
 export { default as GpuManualModeToggle } from './GpuManualModeToggle';
+export { default as FirmwareFanNotice } from './FirmwareFanNotice';

--- a/client/src/i18n/locales/de/system.json
+++ b/client/src/i18n/locales/de/system.json
@@ -1019,6 +1019,12 @@
         "disable": "Deaktivieren",
         "enabled": "Manueller Modus aktiviert",
         "disabled": "Manueller Modus deaktiviert"
+      },
+      "firmware": {
+        "badge": "Firmware",
+        "badgeHint": "Die Lüfterkurve dieser GPU wird von der Firmware verwaltet und kann von BaluHost nicht gesetzt werden.",
+        "title": "Firmware-verwaltete Lüfterkurve",
+        "explanation": "Ab RDNA3 liegt die Lüfterkurve in der GPU-Firmware. Der amdgpu-Treiber lehnt direkte PWM-Steuerung ab — auch mit gesetztem Kernel-Parameter amdgpu.ppfeaturemask. Drehzahl und Temperatur werden weiter angezeigt."
       }
     }
   },

--- a/client/src/i18n/locales/de/system.json
+++ b/client/src/i18n/locales/de/system.json
@@ -1024,7 +1024,9 @@
         "badge": "Firmware",
         "badgeHint": "Die Lüfterkurve dieser GPU wird von der Firmware verwaltet und kann von BaluHost nicht gesetzt werden.",
         "title": "Firmware-verwaltete Lüfterkurve",
-        "explanation": "Ab RDNA3 liegt die Lüfterkurve in der GPU-Firmware. Der amdgpu-Treiber lehnt direkte PWM-Steuerung ab — auch mit gesetztem Kernel-Parameter amdgpu.ppfeaturemask. Drehzahl und Temperatur werden weiter angezeigt."
+        "explanation": "Ab RDNA3 liegt die Lüfterkurve in der GPU-Firmware. Der amdgpu-Treiber lehnt direkte PWM-Steuerung ab — auch mit gesetztem Kernel-Parameter amdgpu.ppfeaturemask. Drehzahl und Temperatur werden weiter angezeigt.",
+        "resetButton": "Manuellen Modus zurücksetzen",
+        "resetSuccess": "Manueller Modus zurückgesetzt — die GPU steht wieder unter Firmware-Kontrolle."
       }
     }
   },

--- a/client/src/i18n/locales/en/system.json
+++ b/client/src/i18n/locales/en/system.json
@@ -1029,7 +1029,9 @@
         "badge": "Firmware",
         "badgeHint": "This GPU's fan curve is managed by firmware and cannot be set by BaluHost.",
         "title": "Firmware-managed fan curve",
-        "explanation": "From RDNA3 onward the fan curve lives in the GPU firmware. The amdgpu driver rejects direct PWM control — even with the amdgpu.ppfeaturemask kernel parameter set. Speed and temperature are still shown."
+        "explanation": "From RDNA3 onward the fan curve lives in the GPU firmware. The amdgpu driver rejects direct PWM control — even with the amdgpu.ppfeaturemask kernel parameter set. Speed and temperature are still shown.",
+        "resetButton": "Reset manual mode",
+        "resetSuccess": "Manual mode reset — the GPU is back under firmware control."
       }
     }
   },

--- a/client/src/i18n/locales/en/system.json
+++ b/client/src/i18n/locales/en/system.json
@@ -1024,6 +1024,12 @@
         "disable": "Disable",
         "enabled": "Manual mode enabled",
         "disabled": "Manual mode disabled"
+      },
+      "firmware": {
+        "badge": "Firmware",
+        "badgeHint": "This GPU's fan curve is managed by firmware and cannot be set by BaluHost.",
+        "title": "Firmware-managed fan curve",
+        "explanation": "From RDNA3 onward the fan curve lives in the GPU firmware. The amdgpu driver rejects direct PWM control — even with the amdgpu.ppfeaturemask kernel parameter set. Speed and temperature are still shown."
       }
     }
   },

--- a/client/src/pages/FanControl.tsx
+++ b/client/src/pages/FanControl.tsx
@@ -59,6 +59,11 @@ export default function FanControl() {
     return status?.fans.find(f => f.fan_id === selectedFan);
   }, [status?.fans, selectedFan]);
 
+  // Firmware-managed fans (RDNA3 GPU) never accept a PWM write from BaluHost —
+  // a schedule for one would silently do nothing. Derived per-fan, not globally,
+  // so a normal fan's schedule stays editable while the GPU fan's is locked.
+  const isSelectedFanFirmwareManaged = selectedFanData?.pwm_control === 'firmware_managed';
+
   // Auto-select first fan if none selected
   useEffect(() => {
     if (!selectedFan && status?.fans && status.fans.length > 0) {
@@ -283,7 +288,7 @@ export default function FanControl() {
         <div className="mt-6">
           <FanSchedulePanel
             fan={selectedFanData}
-            isReadOnly={isReadOnly}
+            isReadOnly={isReadOnly || isSelectedFanFirmwareManaged}
             profiles={profiles}
           />
         </div>

--- a/client/src/pages/FanControl.tsx
+++ b/client/src/pages/FanControl.tsx
@@ -271,7 +271,7 @@ export default function FanControl() {
       </div>
 
       {/* Profile Manager */}
-      {selectedFanData && !isReadOnly && (
+      {selectedFanData && !isReadOnly && !isSelectedFanFirmwareManaged && (
         <div className="mt-6">
           <ProfileManager
             profiles={profiles}

--- a/docs/superpowers/plans/2026-08-07-rdna3-fan-capability.md
+++ b/docs/superpowers/plans/2026-08-07-rdna3-fan-capability.md
@@ -1,0 +1,1110 @@
+# RDNA3-Lüfter-Capability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** BaluHost erkennt firmware-verwaltete GPU-Lüfterkurven (RDNA3+), schreibt dort kein PWM mehr ins Leere und erklärt im UI und in der Fehlermeldung wahrheitsgemäß, warum.
+
+**Architecture:** Ein Enum-Feld `pwm_control` (`supported` / `firmware_managed` / `no_permission`) wird beim hwmon-Scan pro Lüfter bestimmt und über `_fan_cache` → `FanData` → `FanInfo` bis ins Frontend durchgereicht. Der Regel-Loop überspringt Schreibversuche bei `firmware_managed`, der Schreibpfad unterscheidet `EACCES` von `EINVAL` und stuft das Feld bei Rechteproblemen nachträglich herab.
+
+**Tech Stack:** Python 3.11, FastAPI, Pydantic v2, pytest + pytest-asyncio; React 18, TypeScript, Vitest, i18next.
+
+**Spec:** `docs/superpowers/specs/2026-08-06-rdna3-fan-capability-design.md`
+**Issue:** #480 — Folge-Issue für die eigentliche Firmware-Kurven-Steuerung: #516
+
+## Global Constraints
+
+- Der Erkennungsmarker ist **ausschließlich** die Existenz von `<device>/gpu_od/fan_ctrl/fan_curve`. Aus einem fehlenden `gpu_od/` darf **niemals** auf „Overdrive fehlt" geschlossen und daraus eine Handlungsempfehlung abgeleitet werden — genau dieser Fehlschluss ist der Inhalt von #480.
+- Die Meldung für `firmware_managed` muss explizit erwähnen, dass `amdgpu.ppfeaturemask` daran nichts ändert.
+- Backend-Meldungstexte (`last_write_error`) bleiben **englisch**, wie alle bestehenden. Nur Frontend-Strings werden übersetzt (`de` **und** `en`, Namespace `system`).
+- Kein Fix der fehlenden Schreibrechte auf hwmon-/`gpu_od`-Nodes. Kein Anfassen von `deploy/`. `NO_PERMISSION` wird nur **erkannt und benannt**.
+- Default für jeden Lüfter ohne Befund ist `PwmControl.SUPPORTED` — bestehendes Verhalten darf sich nirgends ändern.
+- Die volle Backend-Suite läuft auf Windows nicht durch. Lokal nur die genannten Testdateien gezielt aufrufen; die Gesamtsuite übernimmt CI.
+
+---
+
+## File Structure
+
+**Backend**
+
+| Datei | Verantwortung | Änderung |
+|---|---|---|
+| `backend/app/schemas/fans.py` | `PwmControl`-Enum, Feld in `FanInfo` | modify |
+| `backend/app/services/power/fan_gpu_manual.py` | `probe_amd_pwm_control()` — die Erkennung | modify |
+| `backend/app/services/power/fan_control.py` | `FanData`-Feld, `get_status()`-Ausgabe, Loop-Skip | modify |
+| `backend/app/services/power/fan_backend_linux.py` | Scan füllt das Feld, `set_pwm` bricht ab, errno-Unterscheidung | modify |
+| `backend/app/services/power/fan_backend_dev.py` | Default + simulierter Firmware-GPU-Lüfter | modify |
+| `backend/app/api/routes/fans.py` | Guard auf `gpu-manual-mode`, Rollback | modify |
+
+**Frontend**
+
+| Datei | Verantwortung | Änderung |
+|---|---|---|
+| `client/src/api/fan-control.ts` | `pwm_control` im `FanInfo`-Typ | modify |
+| `client/src/components/fan-control/FanCard.tsx` | Badge, Bedienelemente sperren | modify |
+| `client/src/components/fan-control/FanDetails.tsx` | Toggle ersetzen durch Erklärpanel | modify |
+| `client/src/components/fan-control/FirmwareFanNotice.tsx` | das Erklärpanel | create |
+| `client/src/i18n/locales/{de,en}/system.json` | Strings unter `fanControl.gpu.firmware.*` | modify |
+
+**Tests**
+
+| Datei | Deckt ab |
+|---|---|
+| `backend/tests/test_fan_pwm_control_probe.py` | Erkennung (create) |
+| `backend/tests/test_fan_einval_diagnostic.py` | die drei Meldungsvarianten (modify) |
+| `backend/tests/test_fan_firmware_managed_loop.py` | Loop schreibt nicht (create) |
+| `backend/tests/test_fan_gpu_manual_mode.py` | Route-Guard + Rollback (modify) |
+| `client/src/__tests__/components/fan-control/FanCard.test.tsx` | Badge + gesperrte Regler (create) |
+
+---
+
+## Task 1: `PwmControl`-Enum und Erkennungsfunktion
+
+**Files:**
+- Modify: `backend/app/schemas/fans.py:10` (bei den übrigen Enums)
+- Modify: `backend/app/services/power/fan_gpu_manual.py`
+- Test: `backend/tests/test_fan_pwm_control_probe.py` (create)
+
+**Interfaces:**
+- Produces: `PwmControl` (str-Enum mit `SUPPORTED`, `FIRMWARE_MANAGED`, `NO_PERMISSION`) aus `app.schemas.fans`; `probe_amd_pwm_control(hwmon_dir: Path, drm_root: Optional[Path] = None) -> PwmControl` aus `app.services.power.fan_gpu_manual`.
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_pwm_control_probe.py`:
+
+```python
+"""probe_amd_pwm_control: firmware-verwaltete Luefterkurven erkennen (RDNA3+, #480)."""
+from pathlib import Path
+
+from app.schemas.fans import PwmControl
+from app.services.power.fan_gpu_manual import probe_amd_pwm_control
+
+
+def _amd_tree(tmp_path: Path, *, with_fan_curve: bool) -> Path:
+    """Baut einen amdgpu-sysfs-Baum und gibt die hwmon-Directory zurueck."""
+    device = tmp_path / "sys" / "class" / "drm" / "card0" / "device"
+    hwmon = device / "hwmon" / "hwmon2"
+    hwmon.mkdir(parents=True)
+    (device / "vendor").write_text("0x1002\n")
+    (device / "power_dpm_force_performance_level").write_text("auto\n")
+    (hwmon / "name").write_text("amdgpu\n")
+    (hwmon / "pwm1_enable").write_text("2\n")
+    if with_fan_curve:
+        fan_ctrl = device / "gpu_od" / "fan_ctrl"
+        fan_ctrl.mkdir(parents=True)
+        (fan_ctrl / "fan_curve").write_text(
+            "OD_FAN_CURVE:\n0: 0C 0%\nOD_RANGE:\nFAN_CURVE(fan speed): 23% 100%\n"
+        )
+    return hwmon
+
+
+def test_rdna3_tree_reports_firmware_managed(tmp_path):
+    hwmon = _amd_tree(tmp_path, with_fan_curve=True)
+    assert probe_amd_pwm_control(hwmon) is PwmControl.FIRMWARE_MANAGED
+
+
+def test_pre_rdna3_tree_reports_supported(tmp_path):
+    hwmon = _amd_tree(tmp_path, with_fan_curve=False)
+    assert probe_amd_pwm_control(hwmon) is PwmControl.SUPPORTED
+
+
+def test_gpu_od_without_fan_curve_reports_supported(tmp_path):
+    """gpu_od/ allein genuegt nicht — nur fan_curve ist der Marker."""
+    hwmon = _amd_tree(tmp_path, with_fan_curve=False)
+    (hwmon.parent.parent / "gpu_od" / "fan_ctrl").mkdir(parents=True)
+    assert probe_amd_pwm_control(hwmon) is PwmControl.SUPPORTED
+
+
+def test_hwmon_without_device_parent_reports_supported(tmp_path):
+    """Board-Sensor ohne PCI-Device darueber: keine Aussage moeglich, Default."""
+    hwmon = tmp_path / "sys" / "class" / "hwmon" / "hwmon0"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nct6798\n")
+    assert probe_amd_pwm_control(hwmon) is PwmControl.SUPPORTED
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_pwm_control_probe.py -v`
+Expected: FAIL mit `ImportError: cannot import name 'PwmControl'`
+
+- [ ] **Step 3: Enum ergänzen**
+
+In `backend/app/schemas/fans.py`, direkt nach `class FanMode` (Zeile 10-15):
+
+```python
+class PwmControl(str, Enum):
+    """Ob PWM-Schreiben fuer einen Luefter moeglich ist — und wenn nicht, warum.
+
+    SUPPORTED:        Default. Schreiben wird versucht.
+    FIRMWARE_MANAGED: RDNA3+ (SMU13). Die Luefterkurve liegt in der Firmware
+                      unter gpu_od/fan_ctrl; der amdgpu-Treiber lehnt PWM-Writes
+                      mit EINVAL ab. Siehe Issue #480.
+    NO_PERMISSION:    Beim Schreiben wurde EACCES beobachtet. Anders als die
+                      beiden anderen Werte ist das ein Laufzeit-Befund, kein
+                      Hardware-Merkmal.
+    """
+    SUPPORTED = "supported"
+    FIRMWARE_MANAGED = "firmware_managed"
+    NO_PERMISSION = "no_permission"
+```
+
+- [ ] **Step 4: Erkennungsfunktion implementieren**
+
+In `backend/app/services/power/fan_gpu_manual.py` — Import oben ergänzen (`from app.schemas.fans import PwmControl`), dann ans Ende der öffentlichen Funktionen, vor `_device_from_hwmon`:
+
+```python
+def probe_amd_pwm_control(hwmon_dir: Path, drm_root: Optional[Path] = None) -> PwmControl:
+    """Stellt fest, ob Live-PWM fuer diesen AMD-GPU-Luefter moeglich ist.
+
+    Ab RDNA3 (SMU13) liegt die Luefterkurve in der Firmware und wird ueber
+    <device>/gpu_od/fan_ctrl/ exponiert; pwm{n}-Writes lehnt der Treiber mit
+    EINVAL ab. Die Existenz von fan_curve ist der Marker.
+
+    WICHTIG: Aus einem fehlenden gpu_od/ darf NICHT auf ein fehlendes
+    Overdrive-Bit geschlossen werden. Auf der vermessenen Referenzkarte
+    (RX 7900 XT) war amdgpu.ppfeaturemask=0xffffffff gesetzt und PWM trotzdem
+    tot — die gegenteilige Annahme war der urspruengliche Fehler in #480.
+    """
+    device = _device_from_hwmon(hwmon_dir, drm_root)
+    if device is None:
+        return PwmControl.SUPPORTED
+    if (device / "gpu_od" / "fan_ctrl" / "fan_curve").exists():
+        return PwmControl.FIRMWARE_MANAGED
+    return PwmControl.SUPPORTED
+```
+
+- [ ] **Step 5: Test laufen lassen, Erfolg bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_pwm_control_probe.py -v`
+Expected: 4 PASSED
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/schemas/fans.py backend/app/services/power/fan_gpu_manual.py backend/tests/test_fan_pwm_control_probe.py
+git commit -m "feat(fans): PwmControl-Enum und RDNA3-Erkennung ueber gpu_od/fan_ctrl (#480)"
+```
+
+---
+
+## Task 2: Feld durchreichen — Cache, `FanData`, `FanInfo`
+
+**Files:**
+- Modify: `backend/app/services/power/fan_control.py:37-57` (`FanData`), `:707-709` und `:755-757` (`get_status`)
+- Modify: `backend/app/services/power/fan_backend_linux.py:301-348` (`_scan_pwm_fans`), `:93-110` (`get_fans`)
+- Modify: `backend/app/services/power/fan_backend_dev.py:103-119` (`get_fans`)
+- Modify: `backend/app/schemas/fans.py:88-90` (`FanInfo`)
+- Test: `backend/tests/test_fan_pwm_control_probe.py` (erweitern)
+
+**Interfaces:**
+- Consumes: `PwmControl`, `probe_amd_pwm_control` aus Task 1.
+- Produces: `FanData.pwm_control: PwmControl`, `FanInfo.pwm_control: PwmControl`, Cache-Key `"pwm_control"`. Ab hier lesen Loop (Task 5), Schreibpfad (Task 4), Route (Task 6) und Frontend (Task 7) dieses Feld.
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+An `backend/tests/test_fan_pwm_control_probe.py` anhängen:
+
+```python
+import pytest
+
+from app.core.config import get_settings
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+@pytest.mark.asyncio
+async def test_scan_marks_rdna3_fan_firmware_managed(tmp_path, monkeypatch):
+    hwmon = _amd_tree(tmp_path, with_fan_curve=True)
+    (hwmon / "pwm1").write_text("0\n")
+    (hwmon / "fan1_input").write_text("0\n")
+
+    backend = LinuxFanControlBackend(get_settings())
+    # hwmon_base zeigt auf das hwmon-Verzeichnis IM Device-Baum, damit der
+    # Probe von dort zum PCI-Device hochlaufen kann.
+    monkeypatch.setattr(backend, "_hwmon_base", hwmon.parent)
+    await backend._scan_pwm_fans()
+
+    fan_id = next(iter(backend._fan_cache))
+    assert backend._fan_cache[fan_id]["pwm_control"] is PwmControl.FIRMWARE_MANAGED
+
+    fans = await backend.get_fans()
+    assert fans[0].pwm_control is PwmControl.FIRMWARE_MANAGED
+
+
+@pytest.mark.asyncio
+async def test_scan_marks_pre_rdna3_fan_supported(tmp_path, monkeypatch):
+    hwmon = _amd_tree(tmp_path, with_fan_curve=False)
+    (hwmon / "pwm1").write_text("128\n")
+    (hwmon / "fan1_input").write_text("1200\n")
+
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", hwmon.parent)
+    await backend._scan_pwm_fans()
+
+    fan_id = next(iter(backend._fan_cache))
+    assert backend._fan_cache[fan_id]["pwm_control"] is PwmControl.SUPPORTED
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_pwm_control_probe.py -v`
+Expected: FAIL mit `KeyError: 'pwm_control'`
+
+- [ ] **Step 3: `FanData` erweitern**
+
+`backend/app/services/power/fan_control.py`, im Import-Block oben `PwmControl` aus `app.schemas.fans` ergänzen (dort werden bereits `FanMode` und `FanCurvePoint` importiert), dann in der Dataclass nach Zeile 57:
+
+```python
+    last_write_error: Optional[str] = None
+    pwm_control: PwmControl = PwmControl.SUPPORTED
+```
+
+- [ ] **Step 4: Scan und `get_fans` im Linux-Backend füllen**
+
+In `fan_backend_linux.py` oben ergänzen:
+
+```python
+from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
+from app.services.power.fan_gpu_manual import probe_amd_pwm_control
+```
+
+In `_scan_pwm_fans`, direkt vor dem `new_cache[fan_id] = {...}`-Block (nach Zeile 336):
+
+```python
+                pwm_control = PwmControl.SUPPORTED
+                if gpu_vendor == "amd":
+                    try:
+                        pwm_control = probe_amd_pwm_control(hwmon_dir)
+                    except OSError as exc:
+                        logger.debug(f"pwm_control probe failed for {hwmon_dir}: {exc}")
+```
+
+und im Dict-Literal nach `"device_driver": hwmon_name_value,`:
+
+```python
+                    "pwm_control": pwm_control,
+```
+
+In `get_fans()` im `FanData(...)`-Aufruf nach `last_write_error=...`:
+
+```python
+                pwm_control=fan_info.get("pwm_control", PwmControl.SUPPORTED),
+```
+
+- [ ] **Step 5: Dev-Backend gleichziehen**
+
+In `fan_backend_dev.py` den Import auf `from app.schemas.fans import FanMode, FanCurvePoint, PwmControl` erweitern und im `FanData(...)`-Aufruf in `get_fans()` nach `device_driver=...`:
+
+```python
+                pwm_control=fan_data.get("pwm_control", PwmControl.SUPPORTED),
+```
+
+- [ ] **Step 6: Bis in die API durchreichen**
+
+In `backend/app/schemas/fans.py`, `FanInfo` nach Zeile 90 (`last_write_error`):
+
+```python
+    pwm_control: PwmControl = PwmControl.SUPPORTED
+```
+
+In `fan_control.py` an **beiden** Stellen in `get_status()` (nach Zeile 709 und nach Zeile 757) jeweils ergänzen:
+
+```python
+                        "pwm_control": fan.pwm_control,
+```
+
+Beide Vorkommen sind nötig — `get_status()` baut die Lüfterliste an zwei Stellen auf. Wird nur eine geändert, verschwindet das Feld je nach Codepfad aus der API-Antwort.
+
+- [ ] **Step 7: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_pwm_control_probe.py tests/test_fan_gpu_recognition.py -v`
+Expected: alle PASSED
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/app/schemas/fans.py backend/app/services/power/fan_control.py backend/app/services/power/fan_backend_linux.py backend/app/services/power/fan_backend_dev.py backend/tests/test_fan_pwm_control_probe.py
+git commit -m "feat(fans): pwm_control von Scan bis FanInfo durchreichen (#480)"
+```
+
+---
+
+## Task 3: Simulierter firmware-verwalteter GPU-Lüfter im Dev-Backend
+
+**Files:**
+- Modify: `backend/app/services/power/fan_backend_dev.py:27-88`
+
+**Interfaces:**
+- Consumes: `PwmControl` (Task 1), das `pwm_control`-Cache-Feld (Task 2).
+- Produces: Lüfter-ID `dev_gpu_rdna3_pwm1` mit `pwm_control=FIRMWARE_MANAGED`, an der der UI-Pfad aus Task 7 lokal sichtbar wird.
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_pwm_control_probe.py` anhängen:
+
+```python
+@pytest.mark.asyncio
+async def test_dev_backend_exposes_a_firmware_managed_gpu_fan():
+    from app.services.power.fan_backend_dev import DevFanControlBackend
+
+    backend = DevFanControlBackend(get_settings())
+    fans = {f.fan_id: f for f in await backend.get_fans()}
+
+    assert fans["dev_gpu_pwm1"].pwm_control is PwmControl.SUPPORTED
+    assert fans["dev_gpu_rdna3_pwm1"].pwm_control is PwmControl.FIRMWARE_MANAGED
+    assert fans["dev_gpu_rdna3_pwm1"].is_gpu_fan is True
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_pwm_control_probe.py::test_dev_backend_exposes_a_firmware_managed_gpu_fan -v`
+Expected: FAIL mit `KeyError: 'dev_gpu_rdna3_pwm1'`
+
+- [ ] **Step 3: Den simulierten Lüfter ergänzen**
+
+In `_initialize_simulated_fans()` nach dem `dev_gpu_pwm1`-Eintrag (Zeile 79) einfügen:
+
+```python
+            "dev_gpu_rdna3_pwm1": {
+                "name": "AMD RDNA3 GPU Fan (sim, firmware-managed)",
+                "pwm_percent": 0,
+                "target_rpm": 0,
+                "current_rpm": 0,
+                "min_rpm": 0,
+                "max_rpm": 3000,
+                "temp_sensor_id": "dev_gpu_temp",
+                "last_update": time.time(),
+                "is_gpu_fan": True,
+                "gpu_vendor": "amd",
+                "device_driver": "amdgpu",
+                "pwm_control": PwmControl.FIRMWARE_MANAGED,
+            },
+```
+
+Und in `set_pwm()` direkt nach der Existenzprüfung (nach Zeile 127), damit die Simulation dieselbe Wand hat wie die Hardware:
+
+```python
+        if self._fans[fan_id].get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
+            logger.debug(f"{fan_id}: firmware-managed, PWM write skipped")
+            return False
+```
+
+- [ ] **Step 4: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_pwm_control_probe.py -v`
+Expected: alle PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/power/fan_backend_dev.py backend/tests/test_fan_pwm_control_probe.py
+git commit -m "feat(fans): simulierter firmware-verwalteter GPU-Luefter im Dev-Backend (#480)"
+```
+
+---
+
+## Task 4: Schreibpfad — Frühabbruch, errno-Unterscheidung, ehrliche Meldungen
+
+**Files:**
+- Modify: `backend/app/services/power/fan_backend_linux.py:114-152` (`set_pwm`), `:372-404` (`_write_hwmon_file`)
+- Test: `backend/tests/test_fan_einval_diagnostic.py`
+
+**Interfaces:**
+- Consumes: `PwmControl`, Cache-Feld `pwm_control` (Tasks 1-2).
+- Produces: `_write_hwmon_file(path, value) -> Tuple[bool, Optional[int]]` (vorher `bool`); Modulkonstante `FIRMWARE_MANAGED_WRITE_ERROR: str`. Der Cache-Eintrag kann nach EACCES auf `PwmControl.NO_PERMISSION` stehen.
+
+- [ ] **Step 1: Die fehlschlagenden Tests schreiben**
+
+An `backend/tests/test_fan_einval_diagnostic.py` anhängen:
+
+```python
+from app.schemas.fans import PwmControl
+
+
+@pytest.mark.asyncio
+async def test_firmware_managed_fan_is_not_written_at_all(tmp_path, monkeypatch):
+    """Bei firmware-verwalteter Kurve wird sysfs gar nicht erst angefasst."""
+    d = tmp_path / "sys" / "class" / "hwmon" / "hwmon1"
+    d.mkdir(parents=True)
+    (d / "name").write_text("amdgpu\n")
+    (d / "pwm1").write_text("0\n")
+    (d / "fan1_input").write_text("0\n")
+    (d / "pwm1_enable").write_text("2\n")
+
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
+    await backend._scan_pwm_fans()
+    fan_id = next(iter(backend._fan_cache))
+    backend._fan_cache[fan_id]["pwm_control"] = PwmControl.FIRMWARE_MANAGED
+
+    writes = []
+    monkeypatch.setattr(Path, "write_text", lambda self_, v: writes.append(self_))
+
+    ok = await backend.set_pwm(fan_id, 80)
+
+    assert ok is False
+    assert writes == []
+    err = backend._fan_cache[fan_id]["last_write_error"]
+    assert "ppfeaturemask" in err
+    assert "enable manual mode in the UI" not in err
+
+
+@pytest.mark.asyncio
+async def test_eacces_reports_permission_not_kernel_rejection(tmp_path, monkeypatch):
+    """EACCES darf nicht als 'rejected by kernel' verkauft werden."""
+    d = tmp_path / "sys" / "class" / "hwmon" / "hwmon1"
+    d.mkdir(parents=True)
+    (d / "name").write_text("amdgpu\n")
+    (d / "pwm1").write_text("128\n")
+    (d / "fan1_input").write_text("1200\n")
+    (d / "pwm1_enable").write_text("2\n")
+
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
+    await backend._scan_pwm_fans()
+    fan_id = next(iter(backend._fan_cache))
+
+    def fail_eacces(self_, value):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(Path, "write_text", fail_eacces)
+    with patch("subprocess.run") as srun:
+        srun.return_value.returncode = 1
+        srun.return_value.stderr = b"a password is required"
+        ok = await backend.set_pwm(fan_id, 80)
+
+    assert ok is False
+    err = backend._fan_cache[fan_id]["last_write_error"]
+    assert "EACCES" in err
+    assert "rejected by kernel" not in err
+    assert backend._fan_cache[fan_id]["pwm_control"] is PwmControl.NO_PERMISSION
+```
+
+- [ ] **Step 2: Tests laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_einval_diagnostic.py -v`
+Expected: die zwei neuen Tests FAIL (der bestehende bleibt grün)
+
+- [ ] **Step 3: `_write_hwmon_file` auf `(ok, errno)` umstellen**
+
+In `fan_backend_linux.py` oben `import errno` und `import getpass` ergänzen sowie `Tuple` im `typing`-Import (bereits vorhanden). Dann `_write_hwmon_file` ersetzen:
+
+```python
+    async def _write_hwmon_file(self, path: Path, value: str) -> Tuple[bool, Optional[int]]:
+        """Write value to hwmon sysfs file.
+
+        Returns (ok, errno). errno ist der Fehlercode des letzten
+        fehlgeschlagenen Versuchs, damit der Aufrufer EACCES (fehlende Rechte)
+        von EINVAL (Treiber lehnt ab) unterscheiden kann — die beiden brauchen
+        voellig verschiedene Handlungsempfehlungen.
+        """
+        if not path or not path.exists():
+            return False, None
+
+        try:
+            path.write_text(value + "\n")
+            self._has_write_permission = True
+            return True, None
+        except OSError as exc:
+            code = exc.errno
+            if code not in (errno.EACCES, errno.EPERM):
+                logger.debug(f"Write to {path} failed: {exc}")
+                return False, code
+
+            # Fehlende Rechte: sudo-tee-Fallback. -n, damit ein fehlender
+            # sudoers-Eintrag sofort scheitert statt in den Timeout zu laufen.
+            try:
+                result = subprocess.run(
+                    ["sudo", "-n", "tee", str(path)],
+                    input=value.encode(),
+                    capture_output=True,
+                    timeout=5,
+                )
+                if result.returncode == 0:
+                    self._has_write_permission = True
+                    logger.debug(f"Wrote to {path} via sudo tee")
+                    return True, None
+                logger.warning(f"sudo tee failed for {path}: {result.stderr.decode()}")
+            except Exception as exc2:
+                logger.error(f"Failed to write {path} with sudo: {exc2}")
+            return False, errno.EACCES
+```
+
+- [ ] **Step 4: `set_pwm` umbauen**
+
+Modulkonstante oben in `fan_backend_linux.py`, nach `logger = logging.getLogger(__name__)`:
+
+```python
+FIRMWARE_MANAGED_WRITE_ERROR = (
+    "This GPU manages its fan curve in firmware (RDNA3+). The amdgpu driver "
+    "does not support live PWM control on this card — setting "
+    "amdgpu.ppfeaturemask=0xffffffff does NOT change that. Control is only "
+    "possible through the firmware curve (gpu_od/fan_ctrl), see issue #516."
+)
+```
+
+Dann `set_pwm` (Zeilen 114-152) ersetzen:
+
+```python
+    async def set_pwm(self, fan_id: str, pwm_percent: int) -> bool:
+        """Set hardware PWM value."""
+        if fan_id not in self._fan_cache:
+            logger.warning(f"Fan {fan_id} not found in cache")
+            return False
+
+        fan_info = self._fan_cache[fan_id]
+
+        # Firmware besitzt die Kurve: sysfs gar nicht erst anfassen.
+        if fan_info.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
+            fan_info["last_write_error"] = FIRMWARE_MANAGED_WRITE_ERROR
+            logger.debug(f"{fan_id}: firmware-managed fan curve, PWM write skipped")
+            return False
+
+        pwm_path = fan_info["pwm_path"]
+        pwm_enable_path = fan_info.get("pwm_enable_path")
+
+        pwm_percent = max(0, min(100, pwm_percent))
+        pwm_value = self._percent_to_pwm(pwm_percent)
+
+        if pwm_enable_path:
+            ok_enable, _ = await self._write_hwmon_file(pwm_enable_path, "1")
+            if not ok_enable:
+                logger.warning(f"Failed to set PWM enable for {fan_id}")
+
+        success, err_code = await self._write_hwmon_file(pwm_path, str(pwm_value))
+        if success:
+            fan_info["last_write_error"] = None
+            logger.debug(f"Set {fan_id} PWM to {pwm_percent}% ({pwm_value}/255)")
+            return True
+
+        if err_code in (errno.EACCES, errno.EPERM):
+            fan_info["pwm_control"] = PwmControl.NO_PERMISSION
+            try:
+                user = getpass.getuser()
+            except Exception:
+                user = "the service user"
+            fan_info["last_write_error"] = (
+                f"No write permission for {pwm_path} (EACCES). The backend runs as "
+                f"'{user}' and the udev rule does not cover hwmon PWM nodes."
+            )
+        else:
+            driver = fan_info.get("device_driver", "unknown")
+            enable_val = None
+            if pwm_enable_path:
+                v = await self._read_hwmon_file(pwm_enable_path)
+                enable_val = v if v is not None else "?"
+            fan_info["last_write_error"] = (
+                f"PWM write rejected by kernel (driver={driver}, "
+                f"pwm_enable={enable_val}, errno={err_code})."
+            )
+
+        logger.error(f"Failed to write PWM for {fan_id}: {fan_info['last_write_error']}")
+        return False
+```
+
+- [ ] **Step 5: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_einval_diagnostic.py tests/test_fan_pwm_control_probe.py -v`
+Expected: alle PASSED. Der bestehende `test_write_failure_captures_diagnostic` prüft `"amdgpu" in err` und `"pwm_enable=2" in err` — beides bleibt im EINVAL-Zweig erhalten.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/power/fan_backend_linux.py backend/tests/test_fan_einval_diagnostic.py
+git commit -m "fix(fans): EACCES von EINVAL trennen, firmware-verwaltete Luefter nicht schreiben (#480)"
+```
+
+---
+
+## Task 5: Regel-Loop überspringt firmware-verwaltete Lüfter
+
+**Files:**
+- Modify: `backend/app/services/power/fan_control.py:538-542`
+- Test: `backend/tests/test_fan_firmware_managed_loop.py` (create)
+
+**Interfaces:**
+- Consumes: `FanData.pwm_control` (Task 2).
+- Produces: keine neuen Symbole; Verhaltensänderung im Loop.
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_firmware_managed_loop.py`:
+
+```python
+"""Der Regel-Loop schreibt firmware-verwaltete Luefter nicht an (#480)."""
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models.fans import FanConfig
+from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
+from app.services.power.fan_control import FanControlService, FanData
+
+
+class _StubBackend:
+    """Backend mit genau einem firmware-verwalteten GPU-Luefter."""
+
+    def __init__(self):
+        self.set_pwm_calls = []
+
+    async def get_fans(self):
+        return [FanData(
+            fan_id="gpu_fw", name="RDNA3 GPU", rpm=0, pwm_percent=0,
+            temperature_celsius=70.0, mode=FanMode.AUTO,
+            min_pwm_percent=30, max_pwm_percent=100, emergency_temp_celsius=95.0,
+            temp_sensor_id=None, curve_points=[], is_active=True,
+            is_gpu_fan=True, gpu_vendor="amd",
+            pwm_control=PwmControl.FIRMWARE_MANAGED,
+        )]
+
+    async def set_pwm(self, fan_id, pwm_percent):
+        self.set_pwm_calls.append((fan_id, pwm_percent))
+        return True
+
+
+@pytest.mark.asyncio
+async def test_loop_does_not_write_firmware_managed_fan(db_session):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = False
+    config.is_dev_mode = True
+    config.fan_sample_interval_seconds = 2
+
+    # name ist NOT NULL ohne Default (models/fans.py:77) — weglassen bricht mit
+    # IntegrityError ab, bevor der Test ueberhaupt etwas prueft.
+    db_session.add(FanConfig(
+        fan_id="gpu_fw", name="RDNA3 GPU", mode=FanMode.AUTO.value, is_active=True,
+        min_pwm_percent=30, max_pwm_percent=100, emergency_temp_celsius=95.0,
+        curve_json=json.dumps([{"temp": 35, "pwm": 30}, {"temp": 85, "pwm": 100}]),
+        curve_type="graph", hysteresis_celsius=3.0,
+    ))
+    db_session.commit()
+
+    service = FanControlService(config, lambda: db_session)
+    backend = _StubBackend()
+    service._backend = backend
+    try:
+        await service._monitor_and_control_fans()
+
+        assert backend.set_pwm_calls == []
+        # Der gepufferte Sample traegt den TATSAECHLICHEN Wert, nicht den Wunsch.
+        assert service._sample_buffer[-1]["pwm_percent"] == 0
+    finally:
+        FanControlService._instance = None
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_firmware_managed_loop.py -v`
+Expected: FAIL — `set_pwm_calls` enthält einen Aufruf und der Sample trägt 30 statt 0.
+
+- [ ] **Step 3: Den Skip einbauen**
+
+In `fan_control.py` direkt nach dem Clamp (Zeile 538):
+
+```python
+                target_pwm = max(config.min_pwm_percent, min(config.max_pwm_percent, target_pwm))
+
+                if fan.pwm_control is PwmControl.FIRMWARE_MANAGED:
+                    # Die Firmware besitzt die Kurve (RDNA3+). Kein Write-Versuch,
+                    # und der Sample protokolliert den tatsaechlichen Wert statt
+                    # eines Wunschwerts, der die Hardware nie erreicht.
+                    target_pwm = fan.pwm_percent
+```
+
+Die bestehende Zeile `if target_pwm != fan.pwm_percent:` bleibt unverändert und greift dadurch nicht mehr.
+
+- [ ] **Step 4: Test laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_firmware_managed_loop.py tests/test_fan_schedule.py -v`
+Expected: alle PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/power/fan_control.py backend/tests/test_fan_firmware_managed_loop.py
+git commit -m "fix(fans): Regel-Loop schreibt firmware-verwaltete Luefter nicht mehr an (#480)"
+```
+
+---
+
+## Task 6: Route-Guard und Rollback in `enable_amd_manual`
+
+**Files:**
+- Modify: `backend/app/api/routes/fans.py:979-1018` (`set_gpu_manual_mode`)
+- Modify: `backend/app/services/power/fan_gpu_manual.py:30-52` (`enable_amd_manual`)
+- Test: `backend/tests/test_fan_gpu_manual_mode.py`
+
+**Interfaces:**
+- Consumes: `PwmControl` (Task 1), Cache-Feld `pwm_control` (Task 2).
+- Produces: `enable_amd_manual` lässt bei Fehlschlag des `pwm_enable`-Writes keinen halb angewendeten Zustand zurück.
+
+- [ ] **Step 1: Die fehlschlagenden Tests schreiben**
+
+An `backend/tests/test_fan_gpu_manual_mode.py` anhängen:
+
+```python
+from app.services.power.fan_gpu_manual import enable_amd_manual
+
+
+@pytest.mark.asyncio
+async def test_enable_rolls_back_performance_level_when_pwm_enable_fails(tmp_path, monkeypatch):
+    drm = tmp_path / "sys" / "class" / "drm" / "card0"
+    device = drm / "device"
+    hwmon = device / "hwmon" / "hwmon3"
+    hwmon.mkdir(parents=True)
+    (device / "vendor").write_text("0x1002\n")
+    (device / "power_dpm_force_performance_level").write_text("auto\n")
+    (hwmon / "name").write_text("amdgpu\n")
+    (hwmon / "pwm1_enable").write_text("2\n")
+
+    real_write = Path.write_text
+
+    def fail_on_pwm_enable(self_, value, *a, **kw):
+        if self_.name == "pwm1_enable":
+            raise PermissionError(13, "Permission denied")
+        return real_write(self_, value, *a, **kw)
+
+    monkeypatch.setattr(Path, "write_text", fail_on_pwm_enable)
+
+    with pytest.raises(PermissionError):
+        await enable_amd_manual(hwmon_dir=hwmon, drm_root=tmp_path / "sys" / "class" / "drm")
+
+    monkeypatch.undo()
+    # performance_level darf NICHT auf 'manual' stehengeblieben sein
+    assert (device / "power_dpm_force_performance_level").read_text().strip() == "auto"
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_gpu_manual_mode.py -v`
+Expected: der neue Test FAIL — `performance_level` steht auf `manual`.
+
+- [ ] **Step 3: Rollback implementieren**
+
+In `fan_gpu_manual.py`, `enable_amd_manual`, die Zeilen 47-49 ersetzen:
+
+```python
+    await asyncio.to_thread(level_path.write_text, "manual")
+    if pwm_enable_path is not None:
+        try:
+            await asyncio.to_thread(pwm_enable_path.write_text, "1")
+        except OSError:
+            # Nichts halb angewendet zuruecklassen: performance_level zurueckdrehen.
+            try:
+                await asyncio.to_thread(level_path.write_text, prev_level or "auto")
+            except OSError:
+                logger.error("Rollback of performance_level failed for %s", device)
+            raise
+```
+
+- [ ] **Step 4: Den Route-Guard einbauen**
+
+In `backend/app/api/routes/fans.py`, in `set_gpu_manual_mode` nach der bestehenden AMD-Prüfung (nach Zeile 1005):
+
+```python
+    from app.schemas.fans import PwmControl
+
+    if info.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "This GPU manages its fan curve in firmware (RDNA3+); manual PWM "
+                "mode has no effect. See issue #516."
+            ),
+        )
+```
+
+- [ ] **Step 5: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_gpu_manual_mode.py -v`
+Expected: alle PASSED
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/api/routes/fans.py backend/app/services/power/fan_gpu_manual.py backend/tests/test_fan_gpu_manual_mode.py
+git commit -m "fix(fans): gpu-manual-mode blockt firmware-verwaltete GPUs, Rollback bei Teilfehler (#480)"
+```
+
+---
+
+## Task 7: Frontend — Badge, gesperrte Regler, Erklärpanel
+
+**Files:**
+- Modify: `client/src/api/fan-control.ts:58-76` (`FanInfo`)
+- Modify: `client/src/components/fan-control/FanCard.tsx:83-232`
+- Modify: `client/src/components/fan-control/FanDetails.tsx:145-156`
+- Create: `client/src/components/fan-control/FirmwareFanNotice.tsx`
+- Modify: `client/src/i18n/locales/de/system.json:1014-1023`, `client/src/i18n/locales/en/system.json:1019-1028`
+- Test: `client/src/__tests__/components/fan-control/FanCard.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `FanInfo.pwm_control` aus der API (Task 2).
+- Produces: `FirmwareFanNotice` (default export, keine Props).
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`client/src/__tests__/components/fan-control/FanCard.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import FanCard from '../../../components/fan-control/FanCard';
+import { FanMode } from '../../../api/fan-control';
+import type { FanInfo } from '../../../api/fan-control';
+
+function fan(overrides: Partial<FanInfo> = {}): FanInfo {
+  return {
+    fan_id: 'hwmon2_pwm1',
+    name: 'RDNA3 GPU',
+    rpm: 0,
+    pwm_percent: 0,
+    temperature_celsius: 55,
+    mode: FanMode.AUTO,
+    is_active: true,
+    min_pwm_percent: 30,
+    max_pwm_percent: 100,
+    emergency_temp_celsius: 95,
+    temp_sensor_id: null,
+    curve_points: [],
+    is_gpu_fan: true,
+    gpu_vendor: 'amd',
+    pwm_control: 'supported',
+    ...overrides,
+  } as FanInfo;
+}
+
+const noop = vi.fn();
+
+function renderCard(f: FanInfo) {
+  return render(
+    <FanCard
+      fan={f}
+      isSelected={false}
+      onSelect={noop}
+      onModeChange={noop}
+      onPWMChange={noop}
+      isReadOnly={false}
+      isLoading={false}
+      sensors={[]}
+    />
+  );
+}
+
+describe('FanCard bei firmware-verwalteter GPU', () => {
+  it('zeigt kein Firmware-Badge bei normalem Luefter', () => {
+    renderCard(fan());
+    expect(screen.queryByTestId('fan-firmware-badge')).toBeNull();
+  });
+
+  it('zeigt das Firmware-Badge', () => {
+    renderCard(fan({ pwm_control: 'firmware_managed' }));
+    expect(screen.getByTestId('fan-firmware-badge')).toBeTruthy();
+  });
+
+  it('sperrt die Modus-Buttons', () => {
+    renderCard(fan({ pwm_control: 'firmware_managed' }));
+    for (const btn of screen.getAllByRole('button')) {
+      expect((btn as HTMLButtonElement).disabled).toBe(true);
+    }
+  });
+
+  it('laesst die Modus-Buttons bei supported bedienbar', () => {
+    renderCard(fan());
+    const enabled = screen.getAllByRole('button').filter((b) => !(b as HTMLButtonElement).disabled);
+    expect(enabled.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd client ; npx vitest run src/__tests__/components/fan-control/FanCard.test.tsx`
+Expected: FAIL — `pwm_control` existiert im Typ nicht, Badge fehlt.
+
+- [ ] **Step 3: Typ ergänzen**
+
+In `client/src/api/fan-control.ts`, im `FanInfo`-Interface nach `last_write_error` (Zeile 75):
+
+```ts
+  pwm_control?: 'supported' | 'firmware_managed' | 'no_permission';
+```
+
+- [ ] **Step 4: `FanCard` anpassen**
+
+In `FanCard.tsx` nach der `getModeColor`-Definition (Zeile 81):
+
+```tsx
+  const isFirmwareManaged = fan.pwm_control === 'firmware_managed';
+  const controlsDisabled = isReadOnly || isFirmwareManaged;
+```
+
+Badge im Kopfbereich nach dem GPU-Badge (nach Zeile 101):
+
+```tsx
+            {isFirmwareManaged && (
+              <span
+                data-testid="fan-firmware-badge"
+                className="inline-flex items-center px-1.5 py-0.5 text-xs bg-sky-500/20 text-sky-300 rounded"
+                title={t('system:fanControl.gpu.firmware.badgeHint')}
+              >
+                {t('system:fanControl.gpu.firmware.badge')}
+              </span>
+            )}
+```
+
+Danach in **allen drei** Modus-Buttons (Zeilen 164, 182, 200) und im PWM-Slider (Zeile 227) `isReadOnly` durch `controlsDisabled` ersetzen. Der `disabled`-Ausdruck der Buttons lautet danach z. B. `disabled={fan.mode === FanMode.AUTO || controlsDisabled || isLoading}`.
+
+- [ ] **Step 5: Erklärpanel anlegen**
+
+`client/src/components/fan-control/FirmwareFanNotice.tsx`:
+
+```tsx
+import { useTranslation } from 'react-i18next';
+import { Cpu } from 'lucide-react';
+
+export default function FirmwareFanNotice() {
+  const { t } = useTranslation(['system']);
+
+  return (
+    <div className="border border-sky-500/30 bg-sky-500/5 rounded p-3">
+      <div className="flex items-start gap-2">
+        <Cpu size={16} className="text-sky-400 mt-0.5" />
+        <div className="flex-1">
+          <div className="text-sm font-medium text-white">
+            {t('system:fanControl.gpu.firmware.title')}
+          </div>
+          <div className="text-xs text-slate-400 mt-1">
+            {t('system:fanControl.gpu.firmware.explanation')}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: `FanDetails` umstellen**
+
+In `FanDetails.tsx` den Import ergänzen (`import FirmwareFanNotice from './FirmwareFanNotice';`) und den `GpuManualModeToggle`-Block (Zeilen 150-156) ersetzen:
+
+```tsx
+        {fan.is_gpu_fan && fan.gpu_vendor === 'amd' && (
+          fan.pwm_control === 'firmware_managed' ? (
+            <FirmwareFanNotice />
+          ) : (
+            <GpuManualModeToggle
+              fanId={fan.fan_id}
+              enabled={editor.localGpuManualEnabled}
+              onChange={editor.setLocalGpuManualEnabled}
+            />
+          )
+        )}
+```
+
+In `client/src/components/fan-control/index.ts` ans Ende anhängen:
+
+```ts
+export { default as FirmwareFanNotice } from './FirmwareFanNotice';
+```
+
+- [ ] **Step 7: Übersetzungen ergänzen**
+
+In `client/src/i18n/locales/de/system.json`, im Block `fanControl.gpu` (Zeile 1014) nach dem `manualMode`-Objekt:
+
+```json
+      "firmware": {
+        "badge": "Firmware",
+        "badgeHint": "Die Lüfterkurve dieser GPU wird von der Firmware verwaltet und kann von BaluHost nicht gesetzt werden.",
+        "title": "Firmware-verwaltete Lüfterkurve",
+        "explanation": "Ab RDNA3 liegt die Lüfterkurve in der GPU-Firmware. Der amdgpu-Treiber lehnt direkte PWM-Steuerung ab — auch mit gesetztem Kernel-Parameter amdgpu.ppfeaturemask. Drehzahl und Temperatur werden weiter angezeigt."
+      }
+```
+
+In `client/src/i18n/locales/en/system.json` an derselben Stelle:
+
+```json
+      "firmware": {
+        "badge": "Firmware",
+        "badgeHint": "This GPU's fan curve is managed by firmware and cannot be set by BaluHost.",
+        "title": "Firmware-managed fan curve",
+        "explanation": "From RDNA3 onward the fan curve lives in the GPU firmware. The amdgpu driver rejects direct PWM control — even with the amdgpu.ppfeaturemask kernel parameter set. Speed and temperature are still shown."
+      }
+```
+
+Auf das Komma nach dem vorangehenden `manualMode`-Objekt achten; beide Dateien müssen gültiges JSON bleiben.
+
+- [ ] **Step 8: Tests und Gates laufen lassen**
+
+```bash
+cd client
+npx vitest run src/__tests__/components/fan-control/FanCard.test.tsx
+npx eslint .
+npm run build
+```
+
+Expected: Vitest PASSED, eslint 0 Fehler, Build erfolgreich.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add client/src/api/fan-control.ts client/src/components/fan-control/FanCard.tsx client/src/components/fan-control/FanDetails.tsx client/src/components/fan-control/FirmwareFanNotice.tsx client/src/components/fan-control/index.ts client/src/i18n/locales/de/system.json client/src/i18n/locales/en/system.json client/src/__tests__/components/fan-control/FanCard.test.tsx
+git commit -m "feat(client): firmware-verwaltete GPU-Luefter als read-only ausweisen (#480)"
+```
+
+---
+
+## Task 8: Abschluss-Verifikation
+
+**Files:** keine Änderungen — reiner Prüfschritt.
+
+- [ ] **Step 1: Betroffene Backend-Tests gebündelt**
+
+```bash
+cd backend
+python -m pytest tests/test_fan_pwm_control_probe.py tests/test_fan_einval_diagnostic.py tests/test_fan_firmware_managed_loop.py tests/test_fan_gpu_manual_mode.py tests/test_fan_gpu_recognition.py tests/test_fan_schedule.py -v
+```
+
+Expected: alle PASSED. Die vollstaendige Suite nicht lokal starten — sie haengt auf Windows; das übernimmt CI.
+
+- [ ] **Step 2: Frontend-Gates**
+
+```bash
+cd client
+npx vitest run
+npx eslint .
+npm run build
+```
+
+Expected: alle PASSED, 0 eslint-Fehler, Build erfolgreich.
+
+- [ ] **Step 3: Dev-Mode-Sichtprüfung**
+
+`python start_dev.py` starten, Fan Control öffnen. Erwartet: der Lüfter „AMD RDNA3 GPU Fan (sim, firmware-managed)" trägt das Firmware-Badge, seine Modus-Buttons sind ausgegraut, und in den Details erscheint das Erklärpanel statt des Manual-Mode-Toggles. Der bestehende „AMD GPU Fan (sim)" verhält sich unverändert.
+
+- [ ] **Step 4: Abschluss-Commit falls nötig**
+
+Nur wenn die Verifikation Korrekturen erzwungen hat:
+
+```bash
+git add -A
+git commit -m "fix(fans): Nacharbeiten aus der Abschluss-Verifikation (#480)"
+```
+
+---
+
+## Verifikation auf BaluNode (nach dem Deploy)
+
+Kein Plan-Schritt, sondern die Bestätigung am echten Gerät. Nach dem Merge auf `main` und dem Prod-Deploy:
+
+```bash
+# 1. Log-Rauschen muss verschwunden sein
+sudo journalctl -u baluhost-backend --since "10 min ago" | grep -c "Failed to write PWM"
+# Erwartet: 0 (vorher: ein Eintrag pro Monitoring-Tick)
+
+# 2. Das Feld muss in der API stehen
+curl -s -H "Authorization: Bearer <admin-jwt>" http://localhost:8000/api/fans/status \
+  | jq '.fans[] | select(.is_gpu_fan) | {fan_id, pwm_control, last_write_error}'
+# Erwartet: pwm_control == "firmware_managed"
+```

--- a/docs/superpowers/plans/2026-08-07-rdna3-fan-capability.md
+++ b/docs/superpowers/plans/2026-08-07-rdna3-fan-capability.md
@@ -2,23 +2,25 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** BaluHost erkennt firmware-verwaltete GPU-Lüfterkurven (RDNA3+), schreibt dort kein PWM mehr ins Leere und erklärt im UI und in der Fehlermeldung wahrheitsgemäß, warum.
+**Goal:** BaluHost erkennt firmware-verwaltete GPU-Lüfterkurven (RDNA3+), schreibt dort kein PWM mehr ins Leere, erklärt im UI und in der Fehlermeldung wahrheitsgemäß warum — und die konfigurierte Lüfterkurve wirkt wieder (#517).
 
-**Architecture:** Ein Enum-Feld `pwm_control` (`supported` / `firmware_managed` / `no_permission`) wird beim hwmon-Scan pro Lüfter bestimmt und über `_fan_cache` → `FanData` → `FanInfo` bis ins Frontend durchgereicht. Der Regel-Loop überspringt Schreibversuche bei `firmware_managed`, der Schreibpfad unterscheidet `EACCES` von `EINVAL` und stuft das Feld bei Rechteproblemen nachträglich herab.
+**Architecture:** Ein Enum-Feld `pwm_control` (`supported` / `firmware_managed` / `no_permission`) wird beim hwmon-Scan über den `device`-Symlink bestimmt und über `_fan_cache` → `FanData` → `FanInfo` bis ins Frontend durchgereicht. Der Regel-Loop überspringt aussichtslose Schreibversuche, der Schreibpfad unterscheidet `EACCES` von `EINVAL`.
 
 **Tech Stack:** Python 3.11, FastAPI, Pydantic v2, pytest + pytest-asyncio; React 18, TypeScript, Vitest, i18next.
 
 **Spec:** `docs/superpowers/specs/2026-08-06-rdna3-fan-capability-design.md`
-**Issue:** #480 — Folge-Issue für die eigentliche Firmware-Kurven-Steuerung: #516
+**Issues:** #480 (Hauptthema), #517 (Kurven-Bug, Task 7), #516 (Folge-Feature, nur referenziert)
 
 ## Global Constraints
 
-- Der Erkennungsmarker ist **ausschließlich** die Existenz von `<device>/gpu_od/fan_ctrl/fan_curve`. Aus einem fehlenden `gpu_od/` darf **niemals** auf „Overdrive fehlt" geschlossen und daraus eine Handlungsempfehlung abgeleitet werden — genau dieser Fehlschluss ist der Inhalt von #480.
+- **Der Erkennungspfad ist `hwmon_dir / "device" / "gpu_od" / "fan_ctrl" / "fan_curve"`.** An der Hardware verifiziert. `hwmon_dir.resolve()` mit Suche nach einer Pfadkomponente `device` funktioniert auf echter Hardware **nicht** (`readlink -f /sys/class/hwmon/hwmon2` enthält kein `/device/`) — nicht wieder einführen.
+- Aus einem fehlenden `gpu_od/` darf **niemals** auf ein fehlendes Overdrive-Bit geschlossen und daraus eine Handlungsempfehlung abgeleitet werden. Genau dieser Fehlschluss ist der Inhalt von #480.
 - Die Meldung für `firmware_managed` muss explizit erwähnen, dass `amdgpu.ppfeaturemask` daran nichts ändert.
-- Backend-Meldungstexte (`last_write_error`) bleiben **englisch**, wie alle bestehenden. Nur Frontend-Strings werden übersetzt (`de` **und** `en`, Namespace `system`).
-- Kein Fix der fehlenden Schreibrechte auf hwmon-/`gpu_od`-Nodes. Kein Anfassen von `deploy/`. `NO_PERMISSION` wird nur **erkannt und benannt**.
-- Default für jeden Lüfter ohne Befund ist `PwmControl.SUPPORTED` — bestehendes Verhalten darf sich nirgends ändern.
-- Die volle Backend-Suite läuft auf Windows nicht durch. Lokal nur die genannten Testdateien gezielt aufrufen; die Gesamtsuite übernimmt CI.
+- Backend-Meldungstexte (`last_write_error`) bleiben **englisch**. Frontend-Strings in `de` **und** `en`, Namespace `system`.
+- **Die Modus-Buttons AUTO/SCHEDULED/MANUAL werden nie gesperrt.** Der Modus ist DB-Konfiguration, kein Hardware-Write; der AUTO-Button ist der einzige Ausweg aus einem persistierten `emergency`-Zustand.
+- Kein Fix der fehlenden Schreibrechte, kein Anfassen von `deploy/`.
+- Default für jeden Lüfter ohne Befund ist `PwmControl.SUPPORTED`.
+- Die volle Backend-Suite läuft auf Windows nicht durch. Lokal nur die genannten Testdateien gezielt; die Gesamtsuite übernimmt CI.
 
 ---
 
@@ -29,45 +31,36 @@
 | Datei | Verantwortung | Änderung |
 |---|---|---|
 | `backend/app/schemas/fans.py` | `PwmControl`-Enum, Feld in `FanInfo` | modify |
-| `backend/app/services/power/fan_gpu_manual.py` | `probe_amd_pwm_control()` — die Erkennung | modify |
-| `backend/app/services/power/fan_control.py` | `FanData`-Feld, `get_status()`-Ausgabe, Loop-Skip | modify |
-| `backend/app/services/power/fan_backend_linux.py` | Scan füllt das Feld, `set_pwm` bricht ab, errno-Unterscheidung | modify |
+| `backend/app/services/power/fan_gpu_manual.py` | `probe_amd_pwm_control()`, reparierter `_device_from_hwmon()`, Rollback | modify |
+| `backend/app/services/power/fan_control.py` | `FanData`-Feld, `get_status()`, Loop-Skip, Hysterese-Fix (#517) | modify |
+| `backend/app/services/power/fan_backend_linux.py` | Scan füllt das Feld, `set_pwm`, errno-Trennung | modify |
 | `backend/app/services/power/fan_backend_dev.py` | Default + simulierter Firmware-GPU-Lüfter | modify |
-| `backend/app/api/routes/fans.py` | Guard auf `gpu-manual-mode`, Rollback | modify |
+| `backend/app/api/routes/fans.py` | Guards auf `gpu-manual-mode` und `/pwm` | modify |
 
 **Frontend**
 
 | Datei | Verantwortung | Änderung |
 |---|---|---|
 | `client/src/api/fan-control.ts` | `pwm_control` im `FanInfo`-Typ | modify |
-| `client/src/components/fan-control/FanCard.tsx` | Badge, Bedienelemente sperren | modify |
-| `client/src/components/fan-control/FanDetails.tsx` | Toggle ersetzen durch Erklärpanel | modify |
+| `client/src/components/fan-control/FanCard.tsx` | Badge, PWM-Slider sperren | modify |
+| `client/src/components/fan-control/FanDetails.tsx` | Erklärpanel, per-Lüfter-Read-only | modify |
 | `client/src/components/fan-control/FirmwareFanNotice.tsx` | das Erklärpanel | create |
-| `client/src/i18n/locales/{de,en}/system.json` | Strings unter `fanControl.gpu.firmware.*` | modify |
-
-**Tests**
-
-| Datei | Deckt ab |
-|---|---|
-| `backend/tests/test_fan_pwm_control_probe.py` | Erkennung (create) |
-| `backend/tests/test_fan_einval_diagnostic.py` | die drei Meldungsvarianten (modify) |
-| `backend/tests/test_fan_firmware_managed_loop.py` | Loop schreibt nicht (create) |
-| `backend/tests/test_fan_gpu_manual_mode.py` | Route-Guard + Rollback (modify) |
-| `client/src/__tests__/components/fan-control/FanCard.test.tsx` | Badge + gesperrte Regler (create) |
+| `client/src/components/fan-control/CurveEditorSync.tsx` | firmware-verwaltete Lüfter filtern | modify |
+| `client/src/i18n/locales/{de,en}/system.json` | `fanControl.gpu.firmware.*` | modify |
 
 ---
 
-## Task 1: `PwmControl`-Enum und Erkennungsfunktion
+## Task 1: Erkennung über den `device`-Symlink
 
 **Files:**
-- Modify: `backend/app/schemas/fans.py:10` (bei den übrigen Enums)
-- Modify: `backend/app/services/power/fan_gpu_manual.py`
+- Modify: `backend/app/schemas/fans.py` (nach `class FanMode`, Zeile 10-15)
+- Modify: `backend/app/services/power/fan_gpu_manual.py:71-82` (`_device_from_hwmon`) und neue Funktion
 - Test: `backend/tests/test_fan_pwm_control_probe.py` (create)
 
 **Interfaces:**
-- Produces: `PwmControl` (str-Enum mit `SUPPORTED`, `FIRMWARE_MANAGED`, `NO_PERMISSION`) aus `app.schemas.fans`; `probe_amd_pwm_control(hwmon_dir: Path, drm_root: Optional[Path] = None) -> PwmControl` aus `app.services.power.fan_gpu_manual`.
+- Produces: `PwmControl` (str-Enum: `SUPPORTED`, `FIRMWARE_MANAGED`, `NO_PERMISSION`) aus `app.schemas.fans`; `probe_amd_pwm_control(hwmon_dir: Path) -> PwmControl` aus `app.services.power.fan_gpu_manual`.
 
-- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+- [ ] **Step 1: Die fehlschlagenden Tests schreiben**
 
 `backend/tests/test_fan_pwm_control_probe.py`:
 
@@ -79,81 +72,140 @@ from app.schemas.fans import PwmControl
 from app.services.power.fan_gpu_manual import probe_amd_pwm_control
 
 
-def _amd_tree(tmp_path: Path, *, with_fan_curve: bool) -> Path:
-    """Baut einen amdgpu-sysfs-Baum und gibt die hwmon-Directory zurueck."""
+def _hardware_shaped_tree(tmp_path: Path, *, with_fan_curve: bool) -> Path:
+    """Bildet die ECHTE sysfs-Struktur nach.
+
+    Auf der Hardware liegt hwmon unter /sys/class/hwmon/hwmonN und traegt einen
+    'device'-Symlink auf das PCI-Geraet. KEIN Elternverzeichnis heisst 'device'
+    — genau daran ist der erste Entwurf gescheitert.
+    """
+    hwmon = tmp_path / "sys" / "class" / "hwmon" / "hwmon2"
+    device = hwmon / "device"
+    device.mkdir(parents=True)
+    (hwmon / "name").write_text("amdgpu\n")
+    (device / "vendor").write_text("0x1002\n")
+    if with_fan_curve:
+        fan_ctrl = device / "gpu_od" / "fan_ctrl"
+        fan_ctrl.mkdir(parents=True)
+        (fan_ctrl / "fan_curve").write_text("OD_FAN_CURVE:\n0: 0C 0%\n")
+    return hwmon
+
+
+def _drm_shaped_tree(tmp_path: Path, *, with_fan_curve: bool) -> Path:
+    """Die synthetische Struktur, die bestehende Tests verwenden."""
     device = tmp_path / "sys" / "class" / "drm" / "card0" / "device"
     hwmon = device / "hwmon" / "hwmon2"
     hwmon.mkdir(parents=True)
     (device / "vendor").write_text("0x1002\n")
-    (device / "power_dpm_force_performance_level").write_text("auto\n")
     (hwmon / "name").write_text("amdgpu\n")
-    (hwmon / "pwm1_enable").write_text("2\n")
     if with_fan_curve:
         fan_ctrl = device / "gpu_od" / "fan_ctrl"
         fan_ctrl.mkdir(parents=True)
-        (fan_ctrl / "fan_curve").write_text(
-            "OD_FAN_CURVE:\n0: 0C 0%\nOD_RANGE:\nFAN_CURVE(fan speed): 23% 100%\n"
-        )
+        (fan_ctrl / "fan_curve").write_text("OD_FAN_CURVE:\n0: 0C 0%\n")
     return hwmon
 
 
-def test_rdna3_tree_reports_firmware_managed(tmp_path):
-    hwmon = _amd_tree(tmp_path, with_fan_curve=True)
+def test_hardware_layout_detects_firmware_managed(tmp_path):
+    """Der Fall, der in Produktion zaehlt."""
+    hwmon = _hardware_shaped_tree(tmp_path, with_fan_curve=True)
     assert probe_amd_pwm_control(hwmon) is PwmControl.FIRMWARE_MANAGED
 
 
-def test_pre_rdna3_tree_reports_supported(tmp_path):
-    hwmon = _amd_tree(tmp_path, with_fan_curve=False)
+def test_hardware_layout_without_fan_curve_is_supported(tmp_path):
+    hwmon = _hardware_shaped_tree(tmp_path, with_fan_curve=False)
     assert probe_amd_pwm_control(hwmon) is PwmControl.SUPPORTED
 
 
-def test_gpu_od_without_fan_curve_reports_supported(tmp_path):
+def test_drm_layout_still_works(tmp_path):
+    """Der Aufwaertslauf bleibt als Fallback erhalten."""
+    hwmon = _drm_shaped_tree(tmp_path, with_fan_curve=True)
+    assert probe_amd_pwm_control(hwmon) is PwmControl.FIRMWARE_MANAGED
+
+
+def test_gpu_od_without_fan_curve_is_supported(tmp_path):
     """gpu_od/ allein genuegt nicht — nur fan_curve ist der Marker."""
-    hwmon = _amd_tree(tmp_path, with_fan_curve=False)
-    (hwmon.parent.parent / "gpu_od" / "fan_ctrl").mkdir(parents=True)
+    hwmon = _hardware_shaped_tree(tmp_path, with_fan_curve=False)
+    (hwmon / "device" / "gpu_od" / "fan_ctrl").mkdir(parents=True)
     assert probe_amd_pwm_control(hwmon) is PwmControl.SUPPORTED
 
 
-def test_hwmon_without_device_parent_reports_supported(tmp_path):
-    """Board-Sensor ohne PCI-Device darueber: keine Aussage moeglich, Default."""
+def test_non_amd_vendor_is_supported(tmp_path):
+    hwmon = _hardware_shaped_tree(tmp_path, with_fan_curve=True)
+    (hwmon / "device" / "vendor").write_text("0x10de\n")
+    assert probe_amd_pwm_control(hwmon) is PwmControl.SUPPORTED
+
+
+def test_board_sensor_without_device_is_supported(tmp_path):
     hwmon = tmp_path / "sys" / "class" / "hwmon" / "hwmon0"
     hwmon.mkdir(parents=True)
     (hwmon / "name").write_text("nct6798\n")
     assert probe_amd_pwm_control(hwmon) is PwmControl.SUPPORTED
 ```
 
-- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+- [ ] **Step 2: Tests laufen lassen, Fehlschlag bestätigen**
 
 Run: `cd backend ; python -m pytest tests/test_fan_pwm_control_probe.py -v`
 Expected: FAIL mit `ImportError: cannot import name 'PwmControl'`
 
 - [ ] **Step 3: Enum ergänzen**
 
-In `backend/app/schemas/fans.py`, direkt nach `class FanMode` (Zeile 10-15):
+In `backend/app/schemas/fans.py` nach `class FanMode` (Zeile 15):
 
 ```python
 class PwmControl(str, Enum):
     """Ob PWM-Schreiben fuer einen Luefter moeglich ist — und wenn nicht, warum.
 
     SUPPORTED:        Default. Schreiben wird versucht.
-    FIRMWARE_MANAGED: RDNA3+ (SMU13). Die Luefterkurve liegt in der Firmware
-                      unter gpu_od/fan_ctrl; der amdgpu-Treiber lehnt PWM-Writes
-                      mit EINVAL ab. Siehe Issue #480.
-    NO_PERMISSION:    Beim Schreiben wurde EACCES beobachtet. Anders als die
-                      beiden anderen Werte ist das ein Laufzeit-Befund, kein
-                      Hardware-Merkmal.
+    FIRMWARE_MANAGED: RDNA3+ (SMU13). Die Kurve liegt in der Firmware unter
+                      gpu_od/fan_ctrl; der Treiber lehnt PWM mit EINVAL ab (#480).
+    NO_PERMISSION:    EACCES beim Schreiben beobachtet. Laufzeit-Befund, kein
+                      Hardware-Merkmal — wird bei erfolgreichem Write zurueckgesetzt.
     """
     SUPPORTED = "supported"
     FIRMWARE_MANAGED = "firmware_managed"
     NO_PERMISSION = "no_permission"
 ```
 
-- [ ] **Step 4: Erkennungsfunktion implementieren**
+- [ ] **Step 4: `_device_from_hwmon` reparieren**
 
-In `backend/app/services/power/fan_gpu_manual.py` — Import oben ergänzen (`from app.schemas.fans import PwmControl`), dann ans Ende der öffentlichen Funktionen, vor `_device_from_hwmon`:
+In `fan_gpu_manual.py` die Funktion (Zeilen 71-82) ersetzen:
 
 ```python
-def probe_amd_pwm_control(hwmon_dir: Path, drm_root: Optional[Path] = None) -> PwmControl:
+def _device_from_hwmon(hwmon_dir: Path, drm_root: Optional[Path] = None) -> Optional[Path]:
+    """Finde das amdgpu-PCI-Device zu einer hwmon-Directory.
+
+    Primaerweg: jede hwmon-Directory traegt einen 'device'-Symlink auf ihr
+    PCI-Geraet. An der Hardware verifiziert:
+        ls -d /sys/class/hwmon/hwmon2/device/gpu_od/fan_ctrl  -> existiert
+
+    Fallback: Aufwaertslauf ueber den aufgeloesten Pfad. Der funktioniert NUR
+    in synthetischen Baeumen — real enthaelt readlink -f keine Komponente
+    namens 'device'. Bleibt erhalten, damit bestehende Tests gueltig bleiben.
+    """
+    direct = hwmon_dir / "device"
+    try:
+        if (direct / "vendor").read_text().strip() == AMD_VENDOR_ID:
+            return direct
+    except OSError:
+        pass
+
+    p = hwmon_dir.resolve()
+    for parent in p.parents:
+        if parent.name == "device" and (parent / "vendor").exists():
+            try:
+                if (parent / "vendor").read_text().strip() == AMD_VENDOR_ID:
+                    return parent
+            except OSError:
+                pass
+    return None
+```
+
+- [ ] **Step 5: Erkennungsfunktion ergänzen**
+
+Import oben in `fan_gpu_manual.py`: `from app.schemas.fans import PwmControl`. Dann vor `_device_from_hwmon`:
+
+```python
+def probe_amd_pwm_control(hwmon_dir: Path) -> PwmControl:
     """Stellt fest, ob Live-PWM fuer diesen AMD-GPU-Luefter moeglich ist.
 
     Ab RDNA3 (SMU13) liegt die Luefterkurve in der Firmware und wird ueber
@@ -161,11 +213,11 @@ def probe_amd_pwm_control(hwmon_dir: Path, drm_root: Optional[Path] = None) -> P
     EINVAL ab. Die Existenz von fan_curve ist der Marker.
 
     WICHTIG: Aus einem fehlenden gpu_od/ darf NICHT auf ein fehlendes
-    Overdrive-Bit geschlossen werden. Auf der vermessenen Referenzkarte
-    (RX 7900 XT) war amdgpu.ppfeaturemask=0xffffffff gesetzt und PWM trotzdem
-    tot — die gegenteilige Annahme war der urspruengliche Fehler in #480.
+    Overdrive-Bit geschlossen werden. Auf der Referenzkarte (RX 7900 XT) war
+    amdgpu.ppfeaturemask=0xffffffff gesetzt und PWM trotzdem tot — die
+    gegenteilige Annahme war der urspruengliche Fehler in #480.
     """
-    device = _device_from_hwmon(hwmon_dir, drm_root)
+    device = _device_from_hwmon(hwmon_dir)
     if device is None:
         return PwmControl.SUPPORTED
     if (device / "gpu_od" / "fan_ctrl" / "fan_curve").exists():
@@ -173,16 +225,16 @@ def probe_amd_pwm_control(hwmon_dir: Path, drm_root: Optional[Path] = None) -> P
     return PwmControl.SUPPORTED
 ```
 
-- [ ] **Step 5: Test laufen lassen, Erfolg bestätigen**
+- [ ] **Step 6: Tests laufen lassen**
 
-Run: `cd backend ; python -m pytest tests/test_fan_pwm_control_probe.py -v`
-Expected: 4 PASSED
+Run: `cd backend ; python -m pytest tests/test_fan_pwm_control_probe.py tests/test_fan_gpu_manual_mode.py -v`
+Expected: alle PASSED — die neuen sechs und die bestehenden Manual-Mode-Tests.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add backend/app/schemas/fans.py backend/app/services/power/fan_gpu_manual.py backend/tests/test_fan_pwm_control_probe.py
-git commit -m "feat(fans): PwmControl-Enum und RDNA3-Erkennung ueber gpu_od/fan_ctrl (#480)"
+git commit -m "feat(fans): RDNA3-Erkennung ueber den hwmon-device-Symlink (#480)"
 ```
 
 ---
@@ -190,15 +242,15 @@ git commit -m "feat(fans): PwmControl-Enum und RDNA3-Erkennung ueber gpu_od/fan_
 ## Task 2: Feld durchreichen — Cache, `FanData`, `FanInfo`
 
 **Files:**
-- Modify: `backend/app/services/power/fan_control.py:37-57` (`FanData`), `:707-709` und `:755-757` (`get_status`)
-- Modify: `backend/app/services/power/fan_backend_linux.py:301-348` (`_scan_pwm_fans`), `:93-110` (`get_fans`)
-- Modify: `backend/app/services/power/fan_backend_dev.py:103-119` (`get_fans`)
-- Modify: `backend/app/schemas/fans.py:88-90` (`FanInfo`)
+- Modify: `backend/app/services/power/fan_control.py:37-57`, `:707-709`, `:755-757`
+- Modify: `backend/app/services/power/fan_backend_linux.py:265-358` (`_scan_pwm_fans`), `:93-110` (`get_fans`)
+- Modify: `backend/app/services/power/fan_backend_dev.py:94-121` (`get_fans`)
+- Modify: `backend/app/schemas/fans.py` (`FanInfo`, nach `last_write_error`)
 - Test: `backend/tests/test_fan_pwm_control_probe.py` (erweitern)
 
 **Interfaces:**
-- Consumes: `PwmControl`, `probe_amd_pwm_control` aus Task 1.
-- Produces: `FanData.pwm_control: PwmControl`, `FanInfo.pwm_control: PwmControl`, Cache-Key `"pwm_control"`. Ab hier lesen Loop (Task 5), Schreibpfad (Task 4), Route (Task 6) und Frontend (Task 7) dieses Feld.
+- Consumes: `PwmControl`, `probe_amd_pwm_control` (Task 1).
+- Produces: `FanData.pwm_control: PwmControl`, `FanInfo.pwm_control: PwmControl`, Cache-Key `"pwm_control"`.
 
 - [ ] **Step 1: Den fehlschlagenden Test schreiben**
 
@@ -213,13 +265,12 @@ from app.services.power.fan_backend_linux import LinuxFanControlBackend
 
 @pytest.mark.asyncio
 async def test_scan_marks_rdna3_fan_firmware_managed(tmp_path, monkeypatch):
-    hwmon = _amd_tree(tmp_path, with_fan_curve=True)
+    hwmon = _hardware_shaped_tree(tmp_path, with_fan_curve=True)
     (hwmon / "pwm1").write_text("0\n")
     (hwmon / "fan1_input").write_text("0\n")
+    (hwmon / "pwm1_enable").write_text("2\n")
 
     backend = LinuxFanControlBackend(get_settings())
-    # hwmon_base zeigt auf das hwmon-Verzeichnis IM Device-Baum, damit der
-    # Probe von dort zum PCI-Device hochlaufen kann.
     monkeypatch.setattr(backend, "_hwmon_base", hwmon.parent)
     await backend._scan_pwm_fans()
 
@@ -231,10 +282,11 @@ async def test_scan_marks_rdna3_fan_firmware_managed(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_scan_marks_pre_rdna3_fan_supported(tmp_path, monkeypatch):
-    hwmon = _amd_tree(tmp_path, with_fan_curve=False)
+async def test_scan_marks_normal_fan_supported(tmp_path, monkeypatch):
+    hwmon = _hardware_shaped_tree(tmp_path, with_fan_curve=False)
     (hwmon / "pwm1").write_text("128\n")
     (hwmon / "fan1_input").write_text("1200\n")
+    (hwmon / "pwm1_enable").write_text("2\n")
 
     backend = LinuxFanControlBackend(get_settings())
     monkeypatch.setattr(backend, "_hwmon_base", hwmon.parent)
@@ -251,23 +303,22 @@ Expected: FAIL mit `KeyError: 'pwm_control'`
 
 - [ ] **Step 3: `FanData` erweitern**
 
-`backend/app/services/power/fan_control.py`, im Import-Block oben `PwmControl` aus `app.schemas.fans` ergänzen (dort werden bereits `FanMode` und `FanCurvePoint` importiert), dann in der Dataclass nach Zeile 57:
+`fan_control.py`: im Import-Block `PwmControl` aus `app.schemas.fans` ergänzen (dort stehen bereits `FanMode`, `FanCurvePoint`), dann in der Dataclass nach `last_write_error` (Zeile 57):
 
 ```python
-    last_write_error: Optional[str] = None
     pwm_control: PwmControl = PwmControl.SUPPORTED
 ```
 
-- [ ] **Step 4: Scan und `get_fans` im Linux-Backend füllen**
+- [ ] **Step 4: Linux-Backend füllen**
 
-In `fan_backend_linux.py` oben ergänzen:
+Imports oben in `fan_backend_linux.py`:
 
 ```python
 from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
 from app.services.power.fan_gpu_manual import probe_amd_pwm_control
 ```
 
-In `_scan_pwm_fans`, direkt vor dem `new_cache[fan_id] = {...}`-Block (nach Zeile 336):
+In `_scan_pwm_fans` vor dem `new_cache[fan_id] = {...}`-Block:
 
 ```python
                 pwm_control = PwmControl.SUPPORTED
@@ -278,7 +329,7 @@ In `_scan_pwm_fans`, direkt vor dem `new_cache[fan_id] = {...}`-Block (nach Zeil
                         logger.debug(f"pwm_control probe failed for {hwmon_dir}: {exc}")
 ```
 
-und im Dict-Literal nach `"device_driver": hwmon_name_value,`:
+Im Dict-Literal nach `"device_driver": hwmon_name_value,`:
 
 ```python
                     "pwm_control": pwm_control,
@@ -292,7 +343,7 @@ In `get_fans()` im `FanData(...)`-Aufruf nach `last_write_error=...`:
 
 - [ ] **Step 5: Dev-Backend gleichziehen**
 
-In `fan_backend_dev.py` den Import auf `from app.schemas.fans import FanMode, FanCurvePoint, PwmControl` erweitern und im `FanData(...)`-Aufruf in `get_fans()` nach `device_driver=...`:
+`fan_backend_dev.py`: Import auf `from app.schemas.fans import FanMode, FanCurvePoint, PwmControl` erweitern, im `FanData(...)`-Aufruf nach `device_driver=...`:
 
 ```python
                 pwm_control=fan_data.get("pwm_control", PwmControl.SUPPORTED),
@@ -300,19 +351,19 @@ In `fan_backend_dev.py` den Import auf `from app.schemas.fans import FanMode, Fa
 
 - [ ] **Step 6: Bis in die API durchreichen**
 
-In `backend/app/schemas/fans.py`, `FanInfo` nach Zeile 90 (`last_write_error`):
+`schemas/fans.py`, `FanInfo` nach `last_write_error`:
 
 ```python
     pwm_control: PwmControl = PwmControl.SUPPORTED
 ```
 
-In `fan_control.py` an **beiden** Stellen in `get_status()` (nach Zeile 709 und nach Zeile 757) jeweils ergänzen:
+`fan_control.py` an **beiden** Stellen in `get_status()` (nach Zeile 709 und nach Zeile 757):
 
 ```python
                         "pwm_control": fan.pwm_control,
 ```
 
-Beide Vorkommen sind nötig — `get_status()` baut die Lüfterliste an zwei Stellen auf. Wird nur eine geändert, verschwindet das Feld je nach Codepfad aus der API-Antwort.
+Beide Vorkommen sind nötig — wird nur eines geändert, verschwindet das Feld je nach Codepfad aus der API-Antwort.
 
 - [ ] **Step 7: Tests laufen lassen**
 
@@ -328,18 +379,19 @@ git commit -m "feat(fans): pwm_control von Scan bis FanInfo durchreichen (#480)"
 
 ---
 
-## Task 3: Simulierter firmware-verwalteter GPU-Lüfter im Dev-Backend
+## Task 3: Simulierter firmware-verwalteter GPU-Lüfter
 
 **Files:**
-- Modify: `backend/app/services/power/fan_backend_dev.py:27-88`
+- Modify: `backend/app/services/power/fan_backend_dev.py:25-88` (`_initialize_simulated_fans`), `:123-139` (`set_pwm`)
+- Modify: `backend/tests/services/test_fan_control.py:45`, `:73`, `:372`
+- Test: `backend/tests/test_fan_pwm_control_probe.py` (erweitern)
 
 **Interfaces:**
-- Consumes: `PwmControl` (Task 1), das `pwm_control`-Cache-Feld (Task 2).
-- Produces: Lüfter-ID `dev_gpu_rdna3_pwm1` mit `pwm_control=FIRMWARE_MANAGED`, an der der UI-Pfad aus Task 7 lokal sichtbar wird.
+- Produces: Lüfter-ID `dev_gpu_rdna3_pwm1` mit `pwm_control=FIRMWARE_MANAGED`.
 
 - [ ] **Step 1: Den fehlschlagenden Test schreiben**
 
-`backend/tests/test_fan_pwm_control_probe.py` anhängen:
+An `backend/tests/test_fan_pwm_control_probe.py` anhängen:
 
 ```python
 @pytest.mark.asyncio
@@ -351,7 +403,7 @@ async def test_dev_backend_exposes_a_firmware_managed_gpu_fan():
 
     assert fans["dev_gpu_pwm1"].pwm_control is PwmControl.SUPPORTED
     assert fans["dev_gpu_rdna3_pwm1"].pwm_control is PwmControl.FIRMWARE_MANAGED
-    assert fans["dev_gpu_rdna3_pwm1"].is_gpu_fan is True
+    assert await backend.set_pwm("dev_gpu_rdna3_pwm1", 80) is False
 ```
 
 - [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
@@ -361,7 +413,7 @@ Expected: FAIL mit `KeyError: 'dev_gpu_rdna3_pwm1'`
 
 - [ ] **Step 3: Den simulierten Lüfter ergänzen**
 
-In `_initialize_simulated_fans()` nach dem `dev_gpu_pwm1`-Eintrag (Zeile 79) einfügen:
+In `_initialize_simulated_fans()` nach dem `dev_gpu_pwm1`-Eintrag:
 
 ```python
             "dev_gpu_rdna3_pwm1": {
@@ -380,7 +432,9 @@ In `_initialize_simulated_fans()` nach dem `dev_gpu_pwm1`-Eintrag (Zeile 79) ein
             },
 ```
 
-Und in `set_pwm()` direkt nach der Existenzprüfung (nach Zeile 127), damit die Simulation dieselbe Wand hat wie die Hardware:
+Den Docstring in Zeile 26 auf `"""Initialize 5 simulated PWM fans (3 CPU + 2 GPU)."""` korrigieren.
+
+In `set_pwm()` nach der Existenzprüfung:
 
 ```python
         if self._fans[fan_id].get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
@@ -388,29 +442,35 @@ Und in `set_pwm()` direkt nach der Existenzprüfung (nach Zeile 127), damit die 
             return False
 ```
 
-- [ ] **Step 4: Tests laufen lassen**
+- [ ] **Step 4: Bestehende Erwartungen nachziehen**
 
-Run: `cd backend ; python -m pytest tests/test_fan_pwm_control_probe.py -v`
+In `backend/tests/services/test_fan_control.py` die drei Stellen von `4` auf `5` ändern:
+- Zeile 45: `assert len(backend._fans) == 5`
+- Zeile 73: `assert len(fans) == 5`
+- Zeile 372: `assert len(fans1) == len(fans2) == 5`
+
+- [ ] **Step 5: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_pwm_control_probe.py tests/services/test_fan_control.py -v`
 Expected: alle PASSED
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add backend/app/services/power/fan_backend_dev.py backend/tests/test_fan_pwm_control_probe.py
+git add backend/app/services/power/fan_backend_dev.py backend/tests/test_fan_pwm_control_probe.py backend/tests/services/test_fan_control.py
 git commit -m "feat(fans): simulierter firmware-verwalteter GPU-Luefter im Dev-Backend (#480)"
 ```
 
 ---
 
-## Task 4: Schreibpfad — Frühabbruch, errno-Unterscheidung, ehrliche Meldungen
+## Task 4: Schreibpfad — Frühabbruch, errno-Trennung, ehrliche Meldungen
 
 **Files:**
 - Modify: `backend/app/services/power/fan_backend_linux.py:114-152` (`set_pwm`), `:372-404` (`_write_hwmon_file`)
 - Test: `backend/tests/test_fan_einval_diagnostic.py`
 
 **Interfaces:**
-- Consumes: `PwmControl`, Cache-Feld `pwm_control` (Tasks 1-2).
-- Produces: `_write_hwmon_file(path, value) -> Tuple[bool, Optional[int]]` (vorher `bool`); Modulkonstante `FIRMWARE_MANAGED_WRITE_ERROR: str`. Der Cache-Eintrag kann nach EACCES auf `PwmControl.NO_PERMISSION` stehen.
+- Produces: `_write_hwmon_file(path, value) -> Tuple[bool, Optional[int]]`; Modulkonstante `FIRMWARE_MANAGED_WRITE_ERROR: str`.
 
 - [ ] **Step 1: Die fehlschlagenden Tests schreiben**
 
@@ -420,16 +480,19 @@ An `backend/tests/test_fan_einval_diagnostic.py` anhängen:
 from app.schemas.fans import PwmControl
 
 
-@pytest.mark.asyncio
-async def test_firmware_managed_fan_is_not_written_at_all(tmp_path, monkeypatch):
-    """Bei firmware-verwalteter Kurve wird sysfs gar nicht erst angefasst."""
+def _amd_hwmon(tmp_path, pwm="128", rpm="1200"):
     d = tmp_path / "sys" / "class" / "hwmon" / "hwmon1"
     d.mkdir(parents=True)
     (d / "name").write_text("amdgpu\n")
-    (d / "pwm1").write_text("0\n")
-    (d / "fan1_input").write_text("0\n")
+    (d / "pwm1").write_text(f"{pwm}\n")
+    (d / "fan1_input").write_text(f"{rpm}\n")
     (d / "pwm1_enable").write_text("2\n")
+    return d
 
+
+@pytest.mark.asyncio
+async def test_firmware_managed_fan_is_not_written_at_all(tmp_path, monkeypatch):
+    d = _amd_hwmon(tmp_path, pwm="0", rpm="0")
     backend = LinuxFanControlBackend(get_settings())
     monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
     await backend._scan_pwm_fans()
@@ -450,14 +513,7 @@ async def test_firmware_managed_fan_is_not_written_at_all(tmp_path, monkeypatch)
 
 @pytest.mark.asyncio
 async def test_eacces_reports_permission_not_kernel_rejection(tmp_path, monkeypatch):
-    """EACCES darf nicht als 'rejected by kernel' verkauft werden."""
-    d = tmp_path / "sys" / "class" / "hwmon" / "hwmon1"
-    d.mkdir(parents=True)
-    (d / "name").write_text("amdgpu\n")
-    (d / "pwm1").write_text("128\n")
-    (d / "fan1_input").write_text("1200\n")
-    (d / "pwm1_enable").write_text("2\n")
-
+    d = _amd_hwmon(tmp_path)
     backend = LinuxFanControlBackend(get_settings())
     monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
     await backend._scan_pwm_fans()
@@ -477,25 +533,43 @@ async def test_eacces_reports_permission_not_kernel_rejection(tmp_path, monkeypa
     assert "EACCES" in err
     assert "rejected by kernel" not in err
     assert backend._fan_cache[fan_id]["pwm_control"] is PwmControl.NO_PERMISSION
+
+
+@pytest.mark.asyncio
+async def test_successful_write_clears_no_permission(tmp_path, monkeypatch):
+    """Werden Rechte zur Laufzeit korrigiert, muss der Zustand zurueckgehen."""
+    d = _amd_hwmon(tmp_path)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
+    await backend._scan_pwm_fans()
+    fan_id = next(iter(backend._fan_cache))
+    backend._fan_cache[fan_id]["pwm_control"] = PwmControl.NO_PERMISSION
+    backend._fan_cache[fan_id]["last_write_error"] = "stale"
+
+    ok = await backend.set_pwm(fan_id, 60)
+
+    assert ok is True
+    assert backend._fan_cache[fan_id]["pwm_control"] is PwmControl.SUPPORTED
+    assert backend._fan_cache[fan_id]["last_write_error"] is None
 ```
 
 - [ ] **Step 2: Tests laufen lassen, Fehlschlag bestätigen**
 
 Run: `cd backend ; python -m pytest tests/test_fan_einval_diagnostic.py -v`
-Expected: die zwei neuen Tests FAIL (der bestehende bleibt grün)
+Expected: die drei neuen FAIL, der bestehende `test_write_failure_captures_diagnostic` bleibt grün.
 
 - [ ] **Step 3: `_write_hwmon_file` auf `(ok, errno)` umstellen**
 
-In `fan_backend_linux.py` oben `import errno` und `import getpass` ergänzen sowie `Tuple` im `typing`-Import (bereits vorhanden). Dann `_write_hwmon_file` ersetzen:
+Oben in `fan_backend_linux.py` `import errno` und `import getpass` ergänzen (`Tuple` ist im `typing`-Import bereits vorhanden). Dann ersetzen:
 
 ```python
     async def _write_hwmon_file(self, path: Path, value: str) -> Tuple[bool, Optional[int]]:
         """Write value to hwmon sysfs file.
 
-        Returns (ok, errno). errno ist der Fehlercode des letzten
-        fehlgeschlagenen Versuchs, damit der Aufrufer EACCES (fehlende Rechte)
-        von EINVAL (Treiber lehnt ab) unterscheiden kann — die beiden brauchen
-        voellig verschiedene Handlungsempfehlungen.
+        Returns (ok, errno). errno ist der Code des letzten fehlgeschlagenen
+        Versuchs, damit der Aufrufer EACCES (fehlende Rechte) von EINVAL
+        (Treiber lehnt ab) unterscheiden kann — beide brauchen voellig
+        verschiedene Handlungsempfehlungen.
         """
         if not path or not path.exists():
             return False, None
@@ -527,11 +601,15 @@ In `fan_backend_linux.py` oben `import errno` und `import getpass` ergänzen sow
             except Exception as exc2:
                 logger.error(f"Failed to write {path} with sudo: {exc2}")
             return False, errno.EACCES
+        except Exception as exc:
+            # Catch-all wie bisher: nichts Unerwartetes in den Loop propagieren.
+            logger.error(f"Failed to write {path}: {exc}")
+            return False, None
 ```
 
 - [ ] **Step 4: `set_pwm` umbauen**
 
-Modulkonstante oben in `fan_backend_linux.py`, nach `logger = logging.getLogger(__name__)`:
+Modulkonstante nach `logger = logging.getLogger(__name__)`:
 
 ```python
 FIRMWARE_MANAGED_WRITE_ERROR = (
@@ -542,7 +620,7 @@ FIRMWARE_MANAGED_WRITE_ERROR = (
 )
 ```
 
-Dann `set_pwm` (Zeilen 114-152) ersetzen:
+`set_pwm` (Zeilen 114-152) ersetzen:
 
 ```python
     async def set_pwm(self, fan_id: str, pwm_percent: int) -> bool:
@@ -573,6 +651,9 @@ Dann `set_pwm` (Zeilen 114-152) ersetzen:
         success, err_code = await self._write_hwmon_file(pwm_path, str(pwm_value))
         if success:
             fan_info["last_write_error"] = None
+            if fan_info.get("pwm_control") is PwmControl.NO_PERMISSION:
+                # Rechte wurden zur Laufzeit korrigiert.
+                fan_info["pwm_control"] = PwmControl.SUPPORTED
             logger.debug(f"Set {fan_id} PWM to {pwm_percent}% ({pwm_value}/255)")
             return True
 
@@ -604,7 +685,7 @@ Dann `set_pwm` (Zeilen 114-152) ersetzen:
 - [ ] **Step 5: Tests laufen lassen**
 
 Run: `cd backend ; python -m pytest tests/test_fan_einval_diagnostic.py tests/test_fan_pwm_control_probe.py -v`
-Expected: alle PASSED. Der bestehende `test_write_failure_captures_diagnostic` prüft `"amdgpu" in err` und `"pwm_enable=2" in err` — beides bleibt im EINVAL-Zweig erhalten.
+Expected: alle PASSED
 
 - [ ] **Step 6: Commit**
 
@@ -615,15 +696,177 @@ git commit -m "fix(fans): EACCES von EINVAL trennen, firmware-verwaltete Luefter
 
 ---
 
-## Task 5: Regel-Loop überspringt firmware-verwaltete Lüfter
+## Task 5: Kurven-Bug #517 — Hysterese dämpft statt neu zu rechnen
 
 **Files:**
-- Modify: `backend/app/services/power/fan_control.py:538-542`
+- Modify: `backend/app/services/power/fan_control.py:533-536` (Aufrufstelle), `:557-582` (`_calculate_pwm_from_curve` entfällt), `:585-639` (`_calculate_pwm_with_hysteresis` → `_apply_hysteresis`)
+- Test: `backend/tests/test_fan_curve_hysteresis.py` (create)
+
+**Interfaces:**
+- Produces: `_apply_hysteresis(fan_id: str, temperature: float, hysteresis: float, target_pwm: int) -> int`. Ersetzt `_calculate_pwm_with_hysteresis`; `_calculate_pwm_from_curve` wird gelöscht.
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_curve_hysteresis.py`:
+
+```python
+"""Die konfigurierte Kurve muss wirken, statt vom Hardcode 50 ersetzt zu werden (#517)."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.power.fan_control import FanControlService
+
+
+def _service():
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = False
+    config.is_dev_mode = True
+    return FanControlService(config, MagicMock())
+
+
+def test_hysteresis_returns_the_given_target_on_first_call():
+    service = _service()
+    try:
+        assert service._apply_hysteresis("f1", 50.0, 3.0, 42) == 42
+    finally:
+        FanControlService._instance = None
+
+
+def test_rising_target_takes_effect_immediately():
+    service = _service()
+    try:
+        service._apply_hysteresis("f1", 50.0, 3.0, 40)
+        assert service._apply_hysteresis("f1", 60.0, 3.0, 70) == 70
+    finally:
+        FanControlService._instance = None
+
+
+def test_falling_target_is_held_inside_the_deadband():
+    service = _service()
+    try:
+        service._apply_hysteresis("f1", 60.0, 3.0, 70)
+        # Nur 1 Grad gefallen, Hysterese ist 3 -> alter Wert wird gehalten
+        assert service._apply_hysteresis("f1", 59.0, 3.0, 40) == 70
+    finally:
+        FanControlService._instance = None
+
+
+def test_falling_target_applies_beyond_the_deadband():
+    service = _service()
+    try:
+        service._apply_hysteresis("f1", 60.0, 3.0, 70)
+        assert service._apply_hysteresis("f1", 55.0, 3.0, 40) == 40
+    finally:
+        FanControlService._instance = None
+
+
+def test_hardcoded_fifty_is_gone():
+    """Regression #517: kein Pfad darf mehr 50 aus dem Nichts liefern."""
+    service = _service()
+    try:
+        assert not hasattr(service, "_calculate_pwm_from_curve")
+        assert service._apply_hysteresis("f1", 20.0, 3.0, 30) == 30
+    finally:
+        FanControlService._instance = None
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_curve_hysteresis.py -v`
+Expected: FAIL mit `AttributeError: 'FanControlService' object has no attribute '_apply_hysteresis'`
+
+- [ ] **Step 3: `_calculate_pwm_from_curve` löschen**
+
+Die gesamte Methode `fan_control.py:557-582` entfernen. Sie hat nach Step 4 keinen Aufrufer mehr, und ihre Interpolation dupliziert `services/power/fan_curve_eval.py`.
+
+- [ ] **Step 4: `_calculate_pwm_with_hysteresis` durch `_apply_hysteresis` ersetzen**
+
+Die Methode (Zeilen 585-639) vollständig ersetzen:
+
+```python
+    def _apply_hysteresis(
+        self,
+        fan_id: str,
+        temperature: float,
+        hysteresis: float,
+        target_pwm: int,
+    ) -> int:
+        """Daempft ein BEREITS BERECHNETES PWM-Ziel gegen Oszillation.
+
+        Steigende Ziele greifen sofort (Sicherheit); fallende erst, wenn die
+        Temperatur um `hysteresis` Grad unter den Wert gefallen ist, bei dem
+        zuletzt geregelt wurde.
+
+        #517: Der Vorgaenger rechnete das Ziel aus einer Kurve NEU — und bekam
+        vom einzigen Aufrufer eine leere Liste, was den Hardcode 50 lieferte und
+        das Ergebnis von evaluate_curve verwarf. Diese Funktion rechnet nichts
+        mehr aus; die Kurvenauswertung gehoert allein fan_curve_eval.py.
+        """
+        current_time = time.time()
+
+        if fan_id not in self._hysteresis_state:
+            self._hysteresis_state[fan_id] = HysteresisState(
+                last_pwm=target_pwm,
+                last_pwm_temp=temperature,
+                last_update=current_time,
+            )
+            return target_pwm
+
+        state = self._hysteresis_state[fan_id]
+
+        if target_pwm > state.last_pwm:
+            # Temperatur steigt — sofort reagieren.
+            state.last_pwm = target_pwm
+            state.last_pwm_temp = temperature
+            state.last_update = current_time
+            return target_pwm
+
+        if target_pwm < state.last_pwm:
+            if temperature <= (state.last_pwm_temp - hysteresis):
+                state.last_pwm = target_pwm
+                state.last_pwm_temp = temperature
+                state.last_update = current_time
+                return target_pwm
+            return state.last_pwm
+
+        return state.last_pwm
+```
+
+- [ ] **Step 5: Die Aufrufstelle korrigieren**
+
+`fan_control.py:533-536` ersetzen:
+
+```python
+                        target_pwm = self._apply_hysteresis(
+                            fan.fan_id, temperature or 0.0,
+                            getattr(config, "hysteresis_celsius", 3.0), target_pwm,
+                        ) if eval_cfg.curve_type == "graph" else target_pwm
+```
+
+- [ ] **Step 6: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_curve_hysteresis.py tests/test_fan_curve_eval.py tests/test_fan_composite_api.py tests/test_fan_sensor_label_api.py -v`
+Expected: alle PASSED
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/power/fan_control.py backend/tests/test_fan_curve_hysteresis.py
+git commit -m "fix(fans): Luefterkurve wirkt wieder statt hartcodierter 50 Prozent (#517)"
+```
+
+---
+
+## Task 6: Regel-Loop — Skip und kein Emergency-Karteileichen-Zustand
+
+**Files:**
+- Modify: `backend/app/services/power/fan_control.py:538` (nach dem Clamp), `:544-546` (Emergency-Persist)
 - Test: `backend/tests/test_fan_firmware_managed_loop.py` (create)
 
 **Interfaces:**
-- Consumes: `FanData.pwm_control` (Task 2).
-- Produces: keine neuen Symbole; Verhaltensänderung im Loop.
+- Consumes: `FanData.pwm_control` (Task 2), `_apply_hysteresis` (Task 5).
 
 - [ ] **Step 1: Den fehlschlagenden Test schreiben**
 
@@ -637,20 +880,19 @@ from unittest.mock import MagicMock
 import pytest
 
 from app.models.fans import FanConfig
-from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
+from app.schemas.fans import FanMode, PwmControl
 from app.services.power.fan_control import FanControlService, FanData
 
 
 class _StubBackend:
-    """Backend mit genau einem firmware-verwalteten GPU-Luefter."""
-
-    def __init__(self):
+    def __init__(self, temperature=70.0):
         self.set_pwm_calls = []
+        self.temperature = temperature
 
     async def get_fans(self):
         return [FanData(
             fan_id="gpu_fw", name="RDNA3 GPU", rpm=0, pwm_percent=0,
-            temperature_celsius=70.0, mode=FanMode.AUTO,
+            temperature_celsius=self.temperature, mode=FanMode.AUTO,
             min_pwm_percent=30, max_pwm_percent=100, emergency_temp_celsius=95.0,
             temp_sensor_id=None, curve_points=[], is_active=True,
             is_gpu_fan=True, gpu_vendor="amd",
@@ -662,33 +904,58 @@ class _StubBackend:
         return True
 
 
-@pytest.mark.asyncio
-async def test_loop_does_not_write_firmware_managed_fan(db_session):
+def _config_row(**overrides):
+    # name ist NOT NULL ohne Default (models/fans.py:77).
+    base = dict(
+        fan_id="gpu_fw", name="RDNA3 GPU", mode=FanMode.AUTO.value, is_active=True,
+        min_pwm_percent=30, max_pwm_percent=100, emergency_temp_celsius=95.0,
+        curve_json=json.dumps([{"temp": 35, "pwm": 30}, {"temp": 85, "pwm": 100}]),
+        curve_type="graph", hysteresis_celsius=3.0,
+    )
+    base.update(overrides)
+    return FanConfig(**base)
+
+
+def _service(db_session):
     FanControlService._instance = None
     config = MagicMock()
     config.fan_control_enabled = False
     config.is_dev_mode = True
     config.fan_sample_interval_seconds = 2
+    return FanControlService(config, lambda: db_session)
 
-    # name ist NOT NULL ohne Default (models/fans.py:77) — weglassen bricht mit
-    # IntegrityError ab, bevor der Test ueberhaupt etwas prueft.
-    db_session.add(FanConfig(
-        fan_id="gpu_fw", name="RDNA3 GPU", mode=FanMode.AUTO.value, is_active=True,
-        min_pwm_percent=30, max_pwm_percent=100, emergency_temp_celsius=95.0,
-        curve_json=json.dumps([{"temp": 35, "pwm": 30}, {"temp": 85, "pwm": 100}]),
-        curve_type="graph", hysteresis_celsius=3.0,
-    ))
+
+@pytest.mark.asyncio
+async def test_loop_does_not_write_firmware_managed_fan(db_session):
+    db_session.add(_config_row())
     db_session.commit()
 
-    service = FanControlService(config, lambda: db_session)
+    service = _service(db_session)
     backend = _StubBackend()
     service._backend = backend
     try:
         await service._monitor_and_control_fans()
 
         assert backend.set_pwm_calls == []
-        # Der gepufferte Sample traegt den TATSAECHLICHEN Wert, nicht den Wunsch.
+        # Der Sample traegt den TATSAECHLICHEN Wert, nicht den Wunsch.
         assert service._sample_buffer[-1]["pwm_percent"] == 0
+    finally:
+        FanControlService._instance = None
+
+
+@pytest.mark.asyncio
+async def test_overtemp_does_not_persist_emergency_for_firmware_managed(db_session):
+    """Sonst haengt der Luefter dauerhaft in EMERGENCY, ohne dass es etwas nuetzt."""
+    row = _config_row()
+    db_session.add(row)
+    db_session.commit()
+
+    service = _service(db_session)
+    service._backend = _StubBackend(temperature=99.0)  # ueber emergency_temp
+    try:
+        await service._monitor_and_control_fans()
+        db_session.refresh(row)
+        assert row.mode == FanMode.AUTO.value
     finally:
         FanControlService._instance = None
 ```
@@ -696,48 +963,61 @@ async def test_loop_does_not_write_firmware_managed_fan(db_session):
 - [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
 
 Run: `cd backend ; python -m pytest tests/test_fan_firmware_managed_loop.py -v`
-Expected: FAIL — `set_pwm_calls` enthält einen Aufruf und der Sample trägt 30 statt 0.
+Expected: beide FAIL — `set_pwm_calls` enthält einen Aufruf, und `row.mode` steht auf `emergency`.
 
 - [ ] **Step 3: Den Skip einbauen**
 
-In `fan_control.py` direkt nach dem Clamp (Zeile 538):
+`fan_control.py` direkt nach dem Clamp (Zeile 538):
 
 ```python
                 target_pwm = max(config.min_pwm_percent, min(config.max_pwm_percent, target_pwm))
 
                 if fan.pwm_control is PwmControl.FIRMWARE_MANAGED:
                     # Die Firmware besitzt die Kurve (RDNA3+). Kein Write-Versuch,
-                    # und der Sample protokolliert den tatsaechlichen Wert statt
-                    # eines Wunschwerts, der die Hardware nie erreicht.
+                    # und der Sample protokolliert den tatsaechlichen Wert.
                     target_pwm = fan.pwm_percent
 ```
 
-Die bestehende Zeile `if target_pwm != fan.pwm_percent:` bleibt unverändert und greift dadurch nicht mehr.
+- [ ] **Step 4: Emergency-Persistierung überspringen**
 
-- [ ] **Step 4: Test laufen lassen**
+Den Block bei Zeile 544-546 ersetzen:
 
-Run: `cd backend ; python -m pytest tests/test_fan_firmware_managed_loop.py tests/test_fan_schedule.py -v`
+```python
+                if (
+                    mode == FanMode.EMERGENCY
+                    and config.mode != FanMode.EMERGENCY.value
+                    and fan.pwm_control is not PwmControl.FIRMWARE_MANAGED
+                ):
+                    # Bei firmware-verwalteten Lueftern brachte EMERGENCY nichts
+                    # ausser einem Zustand, aus dem nur der AUTO-Button wieder
+                    # herausfuehrt. Die Benachrichtigung oben bleibt erhalten.
+                    config.mode = FanMode.EMERGENCY.value
+                    db.commit()
+```
+
+- [ ] **Step 5: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_firmware_managed_loop.py tests/test_fan_schedule.py tests/test_fan_curve_hysteresis.py -v`
 Expected: alle PASSED
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add backend/app/services/power/fan_control.py backend/tests/test_fan_firmware_managed_loop.py
-git commit -m "fix(fans): Regel-Loop schreibt firmware-verwaltete Luefter nicht mehr an (#480)"
+git commit -m "fix(fans): Loop ueberspringt firmware-verwaltete Luefter ohne Emergency-Karteileiche (#480)"
 ```
 
 ---
 
-## Task 6: Route-Guard und Rollback in `enable_amd_manual`
+## Task 7: Route-Guards und Rollback
 
 **Files:**
-- Modify: `backend/app/api/routes/fans.py:979-1018` (`set_gpu_manual_mode`)
+- Modify: `backend/app/api/routes/fans.py:142-170` (`set_fan_pwm`), `:979-1018` (`set_gpu_manual_mode`)
 - Modify: `backend/app/services/power/fan_gpu_manual.py:30-52` (`enable_amd_manual`)
 - Test: `backend/tests/test_fan_gpu_manual_mode.py`
 
 **Interfaces:**
-- Consumes: `PwmControl` (Task 1), Cache-Feld `pwm_control` (Task 2).
-- Produces: `enable_amd_manual` lässt bei Fehlschlag des `pwm_enable`-Writes keinen halb angewendeten Zustand zurück.
+- Consumes: `PwmControl`, Cache-Feld `pwm_control`.
 
 - [ ] **Step 1: Die fehlschlagenden Tests schreiben**
 
@@ -749,8 +1029,7 @@ from app.services.power.fan_gpu_manual import enable_amd_manual
 
 @pytest.mark.asyncio
 async def test_enable_rolls_back_performance_level_when_pwm_enable_fails(tmp_path, monkeypatch):
-    drm = tmp_path / "sys" / "class" / "drm" / "card0"
-    device = drm / "device"
+    device = tmp_path / "sys" / "class" / "drm" / "card0" / "device"
     hwmon = device / "hwmon" / "hwmon3"
     hwmon.mkdir(parents=True)
     (device / "vendor").write_text("0x1002\n")
@@ -768,10 +1047,9 @@ async def test_enable_rolls_back_performance_level_when_pwm_enable_fails(tmp_pat
     monkeypatch.setattr(Path, "write_text", fail_on_pwm_enable)
 
     with pytest.raises(PermissionError):
-        await enable_amd_manual(hwmon_dir=hwmon, drm_root=tmp_path / "sys" / "class" / "drm")
+        await enable_amd_manual(hwmon_dir=hwmon, drm_root=None)
 
     monkeypatch.undo()
-    # performance_level darf NICHT auf 'manual' stehengeblieben sein
     assert (device / "power_dpm_force_performance_level").read_text().strip() == "auto"
 ```
 
@@ -790,7 +1068,7 @@ In `fan_gpu_manual.py`, `enable_amd_manual`, die Zeilen 47-49 ersetzen:
         try:
             await asyncio.to_thread(pwm_enable_path.write_text, "1")
         except OSError:
-            # Nichts halb angewendet zuruecklassen: performance_level zurueckdrehen.
+            # Nichts halb angewendet zuruecklassen.
             try:
                 await asyncio.to_thread(level_path.write_text, prev_level or "auto")
             except OSError:
@@ -798,50 +1076,77 @@ In `fan_gpu_manual.py`, `enable_amd_manual`, die Zeilen 47-49 ersetzen:
             raise
 ```
 
-- [ ] **Step 4: Den Route-Guard einbauen**
+- [ ] **Step 4: Guard auf `gpu-manual-mode` — nur beim Einschalten**
 
-In `backend/app/api/routes/fans.py`, in `set_gpu_manual_mode` nach der bestehenden AMD-Prüfung (nach Zeile 1005):
+In `set_gpu_manual_mode` den `if body.enable:`-Zweig um den Guard ergänzen; die Route sieht danach so aus:
 
 ```python
     from app.schemas.fans import PwmControl
 
-    if info.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "This GPU manages its fan curve in firmware (RDNA3+); manual PWM "
-                "mode has no effect. See issue #516."
-            ),
-        )
+    if body.enable:
+        if info.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "This GPU manages its fan curve in firmware (RDNA3+); manual "
+                    "PWM mode has no effect. See issue #516."
+                ),
+            )
+        state = await enable_amd_manual(hwmon_dir=hwmon_dir, drm_root=None)
+        _gpu_manual_state[fan_id] = state
+    else:
+        state = _gpu_manual_state.pop(fan_id, None)
+        if state is None:
+            state = AmdManualState(previous_level="auto", previous_pwm_enable=2)
+        await disable_amd_manual(hwmon_dir=hwmon_dir, drm_root=None, state=state)
 ```
 
-- [ ] **Step 5: Tests laufen lassen**
+Der Guard steht **im** `if body.enable:`-Zweig. Vor der Fallunterscheidung würde er auch das Abschalten blockieren — wer den Toggle je benutzt hat, käme dann nie wieder aus `performance_level=manual` heraus.
+
+- [ ] **Step 5: Guard auf `POST /api/fans/pwm`**
+
+In `set_fan_pwm` vor dem `service.set_fan_pwm`-Aufruf:
+
+```python
+    backend = service._backend
+    cache = getattr(backend, "_fan_cache", None)
+    if cache and body.fan_id in cache:
+        from app.schemas.fans import PwmControl
+        if cache[body.fan_id].get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
+            raise HTTPException(
+                status_code=400,
+                detail=cache[body.fan_id].get("last_write_error")
+                or "This GPU manages its fan curve in firmware; PWM has no effect.",
+            )
+```
+
+Ohne diesen Guard bliebe die generische Antwort „Failed to set PWM (fan not in manual mode or not found)" stehen — genau die Sorte irreführender Auskunft, die dieser PR abschafft.
+
+- [ ] **Step 6: Tests laufen lassen**
 
 Run: `cd backend ; python -m pytest tests/test_fan_gpu_manual_mode.py -v`
 Expected: alle PASSED
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add backend/app/api/routes/fans.py backend/app/services/power/fan_gpu_manual.py backend/tests/test_fan_gpu_manual_mode.py
-git commit -m "fix(fans): gpu-manual-mode blockt firmware-verwaltete GPUs, Rollback bei Teilfehler (#480)"
+git commit -m "fix(fans): Route-Guards fuer firmware-verwaltete GPUs, Rollback bei Teilfehler (#480)"
 ```
 
 ---
 
-## Task 7: Frontend — Badge, gesperrte Regler, Erklärpanel
+## Task 8: Frontend — Badge, gesperrter Slider, Erklärpanel
 
 **Files:**
-- Modify: `client/src/api/fan-control.ts:58-76` (`FanInfo`)
-- Modify: `client/src/components/fan-control/FanCard.tsx:83-232`
-- Modify: `client/src/components/fan-control/FanDetails.tsx:145-156`
+- Modify: `client/src/api/fan-control.ts` (`FanInfo`, nach `last_write_error`)
+- Modify: `client/src/components/fan-control/FanCard.tsx`
+- Modify: `client/src/components/fan-control/FanDetails.tsx:148-157`
+- Modify: `client/src/components/fan-control/CurveEditorSync.tsx:24`
 - Create: `client/src/components/fan-control/FirmwareFanNotice.tsx`
-- Modify: `client/src/i18n/locales/de/system.json:1014-1023`, `client/src/i18n/locales/en/system.json:1019-1028`
+- Modify: `client/src/components/fan-control/index.ts`
+- Modify: `client/src/i18n/locales/de/system.json:1014-1023`, `en/system.json:1019-1028`
 - Test: `client/src/__tests__/components/fan-control/FanCard.test.tsx` (create)
-
-**Interfaces:**
-- Consumes: `FanInfo.pwm_control` aus der API (Task 2).
-- Produces: `FirmwareFanNotice` (default export, keine Props).
 
 - [ ] **Step 1: Den fehlschlagenden Test schreiben**
 
@@ -854,6 +1159,10 @@ import FanCard from '../../../components/fan-control/FanCard';
 import { FanMode } from '../../../api/fan-control';
 import type { FanInfo } from '../../../api/fan-control';
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
 function fan(overrides: Partial<FanInfo> = {}): FanInfo {
   return {
     fan_id: 'hwmon2_pwm1',
@@ -861,18 +1170,19 @@ function fan(overrides: Partial<FanInfo> = {}): FanInfo {
     rpm: 0,
     pwm_percent: 0,
     temperature_celsius: 55,
-    mode: FanMode.AUTO,
+    mode: FanMode.MANUAL,
     is_active: true,
     min_pwm_percent: 30,
     max_pwm_percent: 100,
     emergency_temp_celsius: 95,
     temp_sensor_id: null,
     curve_points: [],
+    hysteresis_celsius: 3,
     is_gpu_fan: true,
     gpu_vendor: 'amd',
     pwm_control: 'supported',
     ...overrides,
-  } as FanInfo;
+  };
 }
 
 const noop = vi.fn();
@@ -903,17 +1213,19 @@ describe('FanCard bei firmware-verwalteter GPU', () => {
     expect(screen.getByTestId('fan-firmware-badge')).toBeTruthy();
   });
 
-  it('sperrt die Modus-Buttons', () => {
+  it('sperrt den PWM-Slider', () => {
     renderCard(fan({ pwm_control: 'firmware_managed' }));
-    for (const btn of screen.getAllByRole('button')) {
-      expect((btn as HTMLButtonElement).disabled).toBe(true);
-    }
+    const slider = screen.getByRole('slider') as HTMLInputElement;
+    expect(slider.disabled).toBe(true);
   });
 
-  it('laesst die Modus-Buttons bei supported bedienbar', () => {
-    renderCard(fan());
-    const enabled = screen.getAllByRole('button').filter((b) => !(b as HTMLButtonElement).disabled);
-    expect(enabled.length).toBeGreaterThan(0);
+  it('laesst die Modus-Buttons bedienbar — sonst sperrt sich der Nutzer aus', () => {
+    renderCard(fan({ pwm_control: 'firmware_managed' }));
+    const enabled = screen
+      .getAllByRole('button')
+      .filter((b) => !(b as HTMLButtonElement).disabled);
+    // AUTO und SCHEDULED sind klickbar (MANUAL ist der aktive Modus)
+    expect(enabled.length).toBeGreaterThanOrEqual(2);
   });
 });
 ```
@@ -925,7 +1237,7 @@ Expected: FAIL — `pwm_control` existiert im Typ nicht, Badge fehlt.
 
 - [ ] **Step 3: Typ ergänzen**
 
-In `client/src/api/fan-control.ts`, im `FanInfo`-Interface nach `last_write_error` (Zeile 75):
+`client/src/api/fan-control.ts`, im `FanInfo`-Interface nach `last_write_error`:
 
 ```ts
   pwm_control?: 'supported' | 'firmware_managed' | 'no_permission';
@@ -933,14 +1245,13 @@ In `client/src/api/fan-control.ts`, im `FanInfo`-Interface nach `last_write_erro
 
 - [ ] **Step 4: `FanCard` anpassen**
 
-In `FanCard.tsx` nach der `getModeColor`-Definition (Zeile 81):
+Nach der `getModeColor`-Definition:
 
 ```tsx
   const isFirmwareManaged = fan.pwm_control === 'firmware_managed';
-  const controlsDisabled = isReadOnly || isFirmwareManaged;
 ```
 
-Badge im Kopfbereich nach dem GPU-Badge (nach Zeile 101):
+Badge im Kopfbereich nach dem GPU-Badge:
 
 ```tsx
             {isFirmwareManaged && (
@@ -954,7 +1265,13 @@ Badge im Kopfbereich nach dem GPU-Badge (nach Zeile 101):
             )}
 ```
 
-Danach in **allen drei** Modus-Buttons (Zeilen 164, 182, 200) und im PWM-Slider (Zeile 227) `isReadOnly` durch `controlsDisabled` ersetzen. Der `disabled`-Ausdruck der Buttons lautet danach z. B. `disabled={fan.mode === FanMode.AUTO || controlsDisabled || isLoading}`.
+Im PWM-Slider `disabled={isReadOnly}` ersetzen durch:
+
+```tsx
+            disabled={isReadOnly || isFirmwareManaged}
+```
+
+**Die drei Modus-Buttons bleiben unverändert.** Ihr `disabled` darf `isFirmwareManaged` nicht enthalten — der AUTO-Button ist der einzige Ausweg aus einem persistierten `emergency`- oder `manual`-Zustand.
 
 - [ ] **Step 5: Erklärpanel anlegen**
 
@@ -985,13 +1302,32 @@ export default function FirmwareFanNotice() {
 }
 ```
 
+In `client/src/components/fan-control/index.ts` ans Ende anhängen:
+
+```ts
+export { default as FirmwareFanNotice } from './FirmwareFanNotice';
+```
+
 - [ ] **Step 6: `FanDetails` umstellen**
 
-In `FanDetails.tsx` den Import ergänzen (`import FirmwareFanNotice from './FirmwareFanNotice';`) und den `GpuManualModeToggle`-Block (Zeilen 150-156) ersetzen:
+Import ergänzen: `import FirmwareFanNotice from './FirmwareFanNotice';`
+
+Ganz oben in der Komponente, nach der Props-Destrukturierung:
 
 ```tsx
-        {fan.is_gpu_fan && fan.gpu_vendor === 'amd' && (
-          fan.pwm_control === 'firmware_managed' ? (
+  const isFirmwareManaged = fan.pwm_control === 'firmware_managed';
+  const editingLocked = isReadOnly || isFirmwareManaged;
+```
+
+Danach in den Kurven- und Einstellungs-Komponenten `isReadOnly` durch `editingLocked` ersetzen — betroffen sind `CurveTypeSelector`, die Kurveneditoren, die vier `disabled={isReadOnly}`-Felder und `AdvancedFanSettings`. Der `FanCurveChart`-Block (`isReadOnly`-Prop) zieht mit.
+
+Den GPU-Block (Zeilen 148-157) ersetzen — beachte, dass der bestehende Block eine äußere Bedingung, einen `<div className="mt-4">`-Wrapper und das schließende `)}` umfasst:
+
+```tsx
+      {/* GPU Manual Mode Toggle (AMD GPU fans only) */}
+      {fan.is_gpu_fan && fan.gpu_vendor === 'amd' && (
+        <div className="mt-4">
+          {isFirmwareManaged ? (
             <FirmwareFanNotice />
           ) : (
             <GpuManualModeToggle
@@ -999,19 +1335,24 @@ In `FanDetails.tsx` den Import ergänzen (`import FirmwareFanNotice from './Firm
               enabled={editor.localGpuManualEnabled}
               onChange={editor.setLocalGpuManualEnabled}
             />
-          )
-        )}
+          )}
+        </div>
+      )}
 ```
 
-In `client/src/components/fan-control/index.ts` ans Ende anhängen:
+- [ ] **Step 7: `CurveEditorSync` filtern**
 
-```ts
-export { default as FirmwareFanNotice } from './FirmwareFanNotice';
+In `CurveEditorSync.tsx:24` die Lüfterliste um firmware-verwaltete Einträge bereinigen. Ein Lüfter, der sich per `sync` an die GPU koppelt, würde sonst dauerhaft auf `min_pwm_percent` festgenagelt, weil `pwm1` auf RDNA3 konstant `0` liest:
+
+```tsx
+    .filter((f) => f.pwm_control !== 'firmware_managed')
 ```
 
-- [ ] **Step 7: Übersetzungen ergänzen**
+Der Filter gehört in die Kette, die die Auswahloptionen erzeugt, nach dem bestehenden Ausschluss des eigenen Lüfters.
 
-In `client/src/i18n/locales/de/system.json`, im Block `fanControl.gpu` (Zeile 1014) nach dem `manualMode`-Objekt:
+- [ ] **Step 8: Übersetzungen ergänzen**
+
+`client/src/i18n/locales/de/system.json`, im Block `fanControl.gpu` nach dem `manualMode`-Objekt (Komma nicht vergessen):
 
 ```json
       "firmware": {
@@ -1022,7 +1363,7 @@ In `client/src/i18n/locales/de/system.json`, im Block `fanControl.gpu` (Zeile 10
       }
 ```
 
-In `client/src/i18n/locales/en/system.json` an derselben Stelle:
+`client/src/i18n/locales/en/system.json` an derselben Stelle:
 
 ```json
       "firmware": {
@@ -1033,9 +1374,7 @@ In `client/src/i18n/locales/en/system.json` an derselben Stelle:
       }
 ```
 
-Auf das Komma nach dem vorangehenden `manualMode`-Objekt achten; beide Dateien müssen gültiges JSON bleiben.
-
-- [ ] **Step 8: Tests und Gates laufen lassen**
+- [ ] **Step 9: Tests und Gates**
 
 ```bash
 cd client
@@ -1046,16 +1385,16 @@ npm run build
 
 Expected: Vitest PASSED, eslint 0 Fehler, Build erfolgreich.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
-git add client/src/api/fan-control.ts client/src/components/fan-control/FanCard.tsx client/src/components/fan-control/FanDetails.tsx client/src/components/fan-control/FirmwareFanNotice.tsx client/src/components/fan-control/index.ts client/src/i18n/locales/de/system.json client/src/i18n/locales/en/system.json client/src/__tests__/components/fan-control/FanCard.test.tsx
+git add client/src/api/fan-control.ts client/src/components/fan-control/ client/src/i18n/locales/de/system.json client/src/i18n/locales/en/system.json client/src/__tests__/components/fan-control/FanCard.test.tsx
 git commit -m "feat(client): firmware-verwaltete GPU-Luefter als read-only ausweisen (#480)"
 ```
 
 ---
 
-## Task 8: Abschluss-Verifikation
+## Task 9: Abschluss-Verifikation
 
 **Files:** keine Änderungen — reiner Prüfschritt.
 
@@ -1063,10 +1402,10 @@ git commit -m "feat(client): firmware-verwaltete GPU-Luefter als read-only auswe
 
 ```bash
 cd backend
-python -m pytest tests/test_fan_pwm_control_probe.py tests/test_fan_einval_diagnostic.py tests/test_fan_firmware_managed_loop.py tests/test_fan_gpu_manual_mode.py tests/test_fan_gpu_recognition.py tests/test_fan_schedule.py -v
+python -m pytest tests/test_fan_pwm_control_probe.py tests/test_fan_einval_diagnostic.py tests/test_fan_firmware_managed_loop.py tests/test_fan_curve_hysteresis.py tests/test_fan_gpu_manual_mode.py tests/test_fan_gpu_recognition.py tests/test_fan_schedule.py tests/test_fan_curve_eval.py tests/test_fan_composite_api.py tests/test_fan_sensor_label_api.py tests/services/test_fan_control.py -v
 ```
 
-Expected: alle PASSED. Die vollstaendige Suite nicht lokal starten — sie haengt auf Windows; das übernimmt CI.
+Expected: alle PASSED. Die vollständige Suite nicht lokal starten — sie hängt auf Windows; das übernimmt CI.
 
 - [ ] **Step 2: Frontend-Gates**
 
@@ -1081,22 +1420,16 @@ Expected: alle PASSED, 0 eslint-Fehler, Build erfolgreich.
 
 - [ ] **Step 3: Dev-Mode-Sichtprüfung**
 
-`python start_dev.py` starten, Fan Control öffnen. Erwartet: der Lüfter „AMD RDNA3 GPU Fan (sim, firmware-managed)" trägt das Firmware-Badge, seine Modus-Buttons sind ausgegraut, und in den Details erscheint das Erklärpanel statt des Manual-Mode-Toggles. Der bestehende „AMD GPU Fan (sim)" verhält sich unverändert.
-
-- [ ] **Step 4: Abschluss-Commit falls nötig**
-
-Nur wenn die Verifikation Korrekturen erzwungen hat:
-
-```bash
-git add -A
-git commit -m "fix(fans): Nacharbeiten aus der Abschluss-Verifikation (#480)"
-```
+`python start_dev.py`, dann Fan Control öffnen. Erwartet:
+- „AMD RDNA3 GPU Fan (sim, firmware-managed)" trägt das Firmware-Badge
+- seine Modus-Buttons sind **bedienbar**, der PWM-Slider im MANUAL-Modus ist gesperrt
+- in den Details erscheint das Erklärpanel statt des Manual-Mode-Toggles
+- „AMD GPU Fan (sim)" verhält sich unverändert
+- ein Lüfter mit `sync`-Kurve bietet den RDNA3-Lüfter nicht mehr als Quelle an
 
 ---
 
 ## Verifikation auf BaluNode (nach dem Deploy)
-
-Kein Plan-Schritt, sondern die Bestätigung am echten Gerät. Nach dem Merge auf `main` und dem Prod-Deploy:
 
 ```bash
 # 1. Log-Rauschen muss verschwunden sein
@@ -1107,4 +1440,10 @@ sudo journalctl -u baluhost-backend --since "10 min ago" | grep -c "Failed to wr
 curl -s -H "Authorization: Bearer <admin-jwt>" http://localhost:8000/api/fans/status \
   | jq '.fans[] | select(.is_gpu_fan) | {fan_id, pwm_control, last_write_error}'
 # Erwartet: pwm_control == "firmware_managed"
+
+# 3. #517: die Kurve muss wirken
+# Gehaeuseluefter-PWM ueber die Zeit beobachten — vorher konstant ~50%,
+# jetzt der konfigurierten Kurve folgend.
+curl -s -H "Authorization: Bearer <admin-jwt>" http://localhost:8000/api/fans/status \
+  | jq '.fans[] | {fan_id, pwm_percent, temperature_celsius}'
 ```

--- a/docs/superpowers/specs/2026-08-06-rdna3-fan-capability-design.md
+++ b/docs/superpowers/specs/2026-08-06-rdna3-fan-capability-design.md
@@ -306,8 +306,23 @@ nicht durch und bleibt CI überlassen.
   vorhanden ⇒ PWM unmöglich" stammt von einer RX 7900 XT. Sie entspricht dem
   SMU13-Verhalten, ist aber nicht über die gesamte RDNA3-Reihe verifiziert.
   Fällt eine Karte auf, die beides kann, verliert sie die PWM-Steuerung —
-  sichtbar am Badge und über den Meldungstext zurückverfolgbar. Weil die
-  Modus-Buttons bedienbar bleiben, sperrt sich niemand dadurch aus.
+  sichtbar am Badge und über den Meldungstext zurückverfolgbar.
+
+  **Eine Fehlerkennung hat keinen Selbsthilfe-Weg.** Die Modus-Buttons retten
+  nur das DB-Feld `mode`. Bei einer fälschlich als `FIRMWARE_MANAGED`
+  erkannten Karte sind gleichzeitig zu: der Slider, Kurve/Zeitplan/Advanced,
+  `POST /api/fans/pwm` (400), `gpu-manual-mode enable` (400), und der Loop
+  schreibt nie. Es gibt keinen Config-Schalter und kein UI-Override. Erholung
+  hieße Dienst stoppen und sysfs von Hand schreiben. Ein Konfigurationsschalter
+  zum Abschalten der Erkennung ist als Folgearbeit vorgesehen (eigenes Issue).
+
+  **Zweiter Ordnungseffekt.** Stand ein solcher Lüfter zuvor auf
+  `pwm_enable=1`, hört der Loop einfach auf zu schreiben, und **nichts stellt
+  `pwm_enable=2` wieder her** — der Lüfter bleibt beim letzten PWM-Wert stehen,
+  während die Auto-Regelung des Treibers weiterhin deaktiviert ist. Auf echter
+  RDNA3-Hardware ist das gegenstandslos (der Treiber ignoriert `pwm_enable=1`
+  ohnehin, siehe Messtabelle oben); bei einer Fehlerkennung auf einer Karte,
+  die PWM tatsächlich unterstützt, ist das ein thermisches Risiko.
 - **Nicht gemessen:** ob `gpu_od/` ohne `amdgpu.ppfeaturemask=0xffffffff`
   verschwindet. Die Implementierung darf deshalb **nicht** aus einem fehlenden
   `gpu_od/` auf „Overdrive fehlt" schließen und daraus eine Handlungsempfehlung

--- a/docs/superpowers/specs/2026-08-06-rdna3-fan-capability-design.md
+++ b/docs/superpowers/specs/2026-08-06-rdna3-fan-capability-design.md
@@ -1,8 +1,8 @@
 # RDNA3-Lüfter: PWM-Fähigkeit erkennen statt ins Leere schreiben
 
-**Datum:** 2026-08-06
+**Datum:** 2026-08-06 (überarbeitet 2026-08-07 nach kritischem Review + Hardware-Verifikation)
 **Status:** Design freigegeben, Umsetzung ausstehend
-**Betrifft:** Issue #480; Fan-Overhaul (Plan 2026-05-24)
+**Betrifft:** Issue #480; Kurven-Bug #517 (im selben PR); Folge-Feature #516
 
 ---
 
@@ -12,7 +12,7 @@ Auf RDNA3-GPUs (gemessen: RX 7900 XT, `1002:744C`, Kernel 6.12.74, BaluNode)
 implementiert der amdgpu-Treiber keine manuelle PWM-Steuerung. BaluHost versucht
 sie trotzdem und gibt bei Misserfolg eine Empfehlung, die dort nicht greift.
 
-Messungen vom 2026-08-06, alle als `root` auf
+Messungen vom 2026-08-06, als `root` auf
 `/sys/class/drm/card0/device/hwmon/hwmon2/`:
 
 | Test | Ergebnis |
@@ -22,17 +22,16 @@ Messungen vom 2026-08-06, alle als `root` auf
 | `echo 1 > pwm1_enable` (lactd gestoppt) | `rc=0`, Readback bleibt `2` |
 | `echo 128 > pwm1` (lactd gestoppt) | `EINVAL`, `rc=1` |
 
-Daraus folgt dreierlei:
+Daraus folgt:
 
 1. **Der Boot-Parameter ist nicht die Ursache.** `amdgpu.ppfeaturemask=0xffffffff`
-   steht in `/proc/cmdline` und ist aktiv; PWM scheitert trotzdem. Die heutige
-   Meldung („For AMD GPUs: enable manual mode in the UI",
-   `fan_backend_linux.py:147-150`) und der ursprüngliche Fix-Vorschlag aus #480
-   („setz ppfeaturemask + Reboot") wären beide falsche Selbsthilfe.
+   ist gesetzt und aktiv; PWM scheitert trotzdem. Die heutige Meldung („For AMD
+   GPUs: enable manual mode in the UI", `fan_backend_linux.py:147-150`) und der
+   ursprüngliche Fix-Vorschlag aus #480 wären beide falsche Selbsthilfe.
 2. **Ein Fremd-Controller ist nicht die Ursache.** `lactd` läuft auf BaluNode,
    aber mit gestopptem Dienst ist das Verhalten bitgenau identisch.
-3. **`pwm{n}_enable` meldet Erfolg, ohne zu wirken.** Der Write gibt `rc=0`
-   zurück, der Wert bleibt `2`. Nur der `pwm{n}`-Write scheitert sichtbar.
+3. **`pwm{n}_enable` meldet Erfolg, ohne zu wirken** (`rc=0`, Wert bleibt `2`).
+   Nur der `pwm{n}`-Write scheitert sichtbar.
 
 Der einzige unterstützte Steuerpfad ist die firmware-verwaltete Kurve unter
 `<device>/gpu_od/fan_ctrl/` (`fan_curve`, `fan_minimum_pwm`,
@@ -42,38 +41,28 @@ Der einzige unterstützte Steuerpfad ist die firmware-verwaltete Kurve unter
 ### Folgeschaden im laufenden Betrieb
 
 `fan_control.py:540-541` ruft `set_pwm` in jedem Monitoring-Tick, sobald der
-Zielwert vom gelesenen abweicht. Auf BaluNode liest `pwm1` konstant `0`, die
-Kurve fordert mindestens `min_pwm_percent` — der Loop schreibt also dauerhaft,
-scheitert dauerhaft und schreibt bei jedem Fehlschlag ein `logger.error`
-(`fan_backend_linux.py:151`). Zusätzlich protokolliert `fan_sample` einen
-Wunsch-PWM, der die Hardware nie erreicht hat.
+Zielwert vom gelesenen abweicht. Auf BaluNode liest `pwm1` konstant `0` — der
+Loop schreibt dauerhaft, scheitert dauerhaft und schreibt bei jedem Fehlschlag
+ein `logger.error` (`fan_backend_linux.py:151`). Zusätzlich protokolliert
+`fan_sample` einen Wunsch-PWM, der die Hardware nie erreicht hat.
 
 ## Nicht-Ziele
-
-Bewusst ausgeklammert, jeweils mit Begründung:
 
 - **Fehlende Schreibrechte reparieren.** `pwm1`, `pwm1_enable` und
   `gpu_od/fan_ctrl/*` sind `root:root 0644`; die udev-Regel
   (`deploy/scripts/install-amd-gpu-permissions.sh:44-45`) erfasst nur
   `power_dpm_force_performance_level` und `pp_power_profile_mode`, und in keinem
-  sudoers-Template steht ein `tee`-Eintrag. Auf der einzigen vorhandenen
-  AMD-Karte ist PWM ohnehin tot, der Fix brächte dort also nichts messbares. Er
-  fasst `deploy/` an (CODEOWNERS) und braucht einen manuellen Skript-Re-Run auf
-  dem Server. Bleibt als Abschnitt in #480 dokumentiert.
+  sudoers-Template steht ein `tee`-Eintrag. Kein Anfassen von `deploy/`.
 
-  Nicht zu verwechseln mit `PwmControl.NO_PERMISSION` weiter unten: Dieses
-  Design **erkennt und benennt** den Rechtezustand, es **behebt** ihn nicht. Der
-  Unterschied ist der ganze Punkt — die heutige Meldung behauptet „rejected by
-  kernel", obwohl der Kernel in diesem Fall nie gefragt wurde.
-- **Die Firmware-Kurve tatsächlich steuern.** Eigenes Feature mit eigenem Design
-  (Schreibformat und Commit-Semantik von `fan_curve`, Zero-RPM-Verhalten,
-  Wertebereiche, Rücknahme beim Deaktivieren). Bekommt ein eigenes Issue, das
-  auf das hier eingeführte `pwm_control`-Feld aufsetzt.
+  Nicht zu verwechseln mit `PwmControl.NO_PERMISSION`: Dieses Design **erkennt
+  und benennt** den Rechtezustand, es **behebt** ihn nicht.
+- **Die Firmware-Kurve tatsächlich steuern.** Eigenes Feature, eigenes Design —
+  Issue #516.
 
 ## Lösung
 
-Ein neues Feld `pwm_control` beschreibt pro Lüfter, ob und warum PWM-Schreiben
-möglich ist. Loop, API und UI lesen dasselbe Feld.
+Ein Feld `pwm_control` beschreibt pro Lüfter, ob und warum PWM-Schreiben möglich
+ist. Loop, API und UI lesen dasselbe Feld.
 
 ```python
 class PwmControl(str, Enum):
@@ -82,58 +71,101 @@ class PwmControl(str, Enum):
     NO_PERMISSION    = "no_permission"      # EACCES beim Schreiben beobachtet
 ```
 
-Das Feld muss an **drei** Stellen getragen werden, die leicht zu verwechseln sind:
+Das Feld wird an drei leicht zu verwechselnden Stellen getragen:
 
 | Ort | Typ | Wer liest es |
 |---|---|---|
-| `_fan_cache[fan_id]["pwm_control"]` | `dict` in `fan_backend_linux.py` | `set_pwm()`, Route-Guard |
+| `_fan_cache[fan_id]["pwm_control"]` | `dict` in `fan_backend_linux.py` | `set_pwm()`, Route-Guards |
 | `FanData.pwm_control` | Dataclass, `fan_control.py:37-57` | der Regel-Loop (`get_fans()` liefert `FanData`, nicht `FanInfo`) |
 | `FanInfo.pwm_control` | Pydantic-Schema, `schemas/fans.py:72` | die API-Antwort und damit das Frontend |
 
-`get_fans()` in `fan_backend_linux.py:93-110` füllt `FanData` bereits aus dem
-Cache und wird um das Feld ergänzt; die Übersetzung `FanData` → `FanInfo` folgt
-dem Muster der bestehenden Felder `is_gpu_fan` / `last_write_error`. Der
-Dev-Backend baut `FanData` eigenständig und braucht denselben Default.
+`get_status()` baut die Lüfterliste an **zwei** Stellen auf (`fan_control.py:707`
+und `:755`); beide brauchen das Feld, sonst verschwindet es je nach Codepfad.
 
-### Erkennung
-
-Neue Funktion in `backend/app/services/power/fan_gpu_manual.py`:
+### Erkennung — an der Hardware verifiziert
 
 ```python
-def probe_amd_pwm_control(hwmon_dir: Path, drm_root: Optional[Path] = None) -> PwmControl
+(hwmon_dir / "device" / "gpu_od" / "fan_ctrl" / "fan_curve").exists()
 ```
 
-Sie nutzt das dort bereits vorhandene `_device_from_hwmon()`, das von der
-hwmon-Directory zum PCI-Device hochläuft — genau dort liegt `gpu_od/`.
-Existiert `<device>/gpu_od/fan_ctrl/fan_curve`, ist das Ergebnis
-`FIRMWARE_MANAGED`, sonst `SUPPORTED`.
+Jede hwmon-Directory hat einen `device`-Symlink auf ihr PCI-Gerät. Auf BaluNode
+verifiziert:
 
-Aufgerufen in `_scan_pwm_fans()` (`fan_backend_linux.py:301-348`), ausschließlich
-für `gpu_vendor == "amd"`. Das Ergebnis wird als `pwm_control` im
-`_fan_cache`-Eintrag abgelegt, neben `is_gpu_fan` und `gpu_vendor`. Kosten: ein
-Dateisystem-Check pro AMD-GPU je Scan.
+```
+$ ls -d /sys/class/hwmon/hwmon2/device/gpu_od/fan_ctrl
+/sys/class/hwmon/hwmon2/device/gpu_od/fan_ctrl
+```
 
-**Festlegung:** `NO_PERMISSION` wird bei der Erkennung *nicht* vergeben. Ein
-`os.access()`-Test würde ein falsches Urteil fällen, solange der
-`sudo tee`-Fallback theoretisch greifen könnte. Stattdessen stuft der
-Schreibpfad den Wert herab, sobald er tatsächlich `EACCES` beobachtet. Das Feld
-mischt damit statische Hardware-Eigenschaft und beobachteten Laufzeitzustand.
-Das ist gewollt: UI und Fehlermeldung stellen genau diese kombinierte Frage
-(„darf ich schreiben, und wenn nein, warum nicht?").
+**Verworfener Ansatz — nicht wieder einführen.** Der erste Entwurf wollte
+`_device_from_hwmon()` aus `fan_gpu_manual.py:71-82` wiederverwenden. Diese
+Funktion macht `hwmon_dir.resolve()` und sucht dann eine Pfadkomponente namens
+`device`. Auf echter Hardware gibt es die nicht:
+
+```
+$ readlink -f /sys/class/hwmon/hwmon2
+/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/0000:02:00.0/0000:03:00.0/hwmon/hwmon2
+```
+
+`_device_from_hwmon` liefert dort `None`. Die Erkennung hätte konstant
+`SUPPORTED` gemeldet und der gesamte Fix wäre wirkungslos in Produktion
+gegangen — unbemerkt, weil `tmp_path`-Tests `device` als echtes Verzeichnis
+anlegen.
+
+**Folgefehler gleicher Ursache, hier mitbehoben:** `enable_amd_manual()` und
+`disable_amd_manual()` nutzen denselben Resolver. Der „Manual Mode"-Toggle
+scheitert auf echter Hardware also seit jeher mit
+`RuntimeError: Could not locate amdgpu device` → HTTP 500. `_device_from_hwmon`
+wird auf den `device`-Symlink umgestellt, mit Rückfall auf den bisherigen
+Aufwärtslauf, damit vorhandene Tests mit synthetischen Bäumen grün bleiben.
+
+Aufgerufen wird die Erkennung in `_scan_pwm_fans()`, nur für
+`gpu_vendor == "amd"`. Kosten: ein `stat` pro AMD-GPU je Scan.
 
 ### Zustandstabelle
 
-| Lüfter | `gpu_od/fan_ctrl/fan_curve` | Beobachteter Fehler | `pwm_control` |
+| Lüfter | `device/gpu_od/fan_ctrl/fan_curve` | Beobachteter Fehler | `pwm_control` |
 |---|---|---|---|
 | CPU/Board-Lüfter | — (kein GPU-Lüfter) | keiner | `supported` |
 | AMD pre-RDNA3 | fehlt | keiner | `supported` |
 | AMD pre-RDNA3, Rechte fehlen | fehlt | `EACCES` | `no_permission` |
-| AMD RDNA3+ | vorhanden | — (wird nicht mehr versucht) | `firmware_managed` |
+| AMD RDNA3+ | vorhanden | — (wird nicht versucht) | `firmware_managed` |
 | nouveau / andere | nicht geprüft | keiner | `supported` |
+
+### Lebenszyklus von `NO_PERMISSION`
+
+`_scan_pwm_fans()` hat genau einen Aufrufer, `is_available()`, und der läuft nur
+bei `_initialize_backend()` (Start) und `switch_backend(use_linux=True)`. **Es
+gibt keinen periodischen Scan.** Daraus folgt:
+
+- Die Erkennung setzt nur `SUPPORTED` oder `FIRMWARE_MANAGED`. Ein
+  `os.access()`-Test würde lügen, solange der `sudo tee`-Fallback greifen könnte.
+- Der Schreibpfad stuft bei beobachtetem `EACCES` auf `NO_PERMISSION` **herab**
+  und bei einem später erfolgreichen Write wieder auf `SUPPORTED` **hoch**.
+  Ohne diesen Rückweg bliebe der Zustand bis zum Service-Neustart stehen, auch
+  wenn die Rechte zur Laufzeit korrigiert werden.
+- `FIRMWARE_MANAGED` wird nie herabgestuft — es ist eine Hardware-Eigenschaft.
+
+**Bekannte Einschränkung (Mehr-Worker):** Produktion läuft mit vier
+Uvicorn-Workern, jeder mit eigenem `_fan_cache`. `FIRMWARE_MANAGED` ist
+scan-abgeleitet und daher in allen Workern gleich. `NO_PERMISSION` und
+`last_write_error` entstehen nur im schreibenden Worker und flackern deshalb
+über die round-robin bediente Status-Route. Für `last_write_error` gilt das
+heute schon. Deshalb hängt **keine UI-Sperre an `NO_PERMISSION`** — der Wert
+informiert nur die Meldung.
+
+### Verhältnis zu `permission_status`
+
+`permission_status` (`fan_control.py:772-776`) ist global, wird nur am ersten
+Lüfter des Caches geprüft und ist monoton. Es beantwortet eine andere Frage als
+`pwm_control`. Festlegung, damit keine zweite Wahrheit entsteht:
+
+- Die UI sperrt Schreib-Bedienelemente bei `isReadOnly` (global) **oder**
+  `pwm_control === 'firmware_managed'` (pro Lüfter).
+- `no_permission` sperrt nichts, sondern liefert nur den Meldungstext.
 
 ## Regel-Loop
 
-In `_monitor_and_control_fans` direkt nach dem Clamp auf `min/max`
+In `_monitor_and_control_fans` nach dem Clamp auf `min/max`
 (`fan_control.py:538`):
 
 ```python
@@ -142,89 +174,127 @@ if fan.pwm_control is PwmControl.FIRMWARE_MANAGED:
 ```
 
 Die bestehende Bedingung `if target_pwm != fan.pwm_percent` greift dadurch von
-selbst nicht mehr — kein zusätzlicher Zweig an der Schreibstelle. Zwei
-gewünschte Nebeneffekte: `fan_sample` protokolliert den tatsächlichen statt
-eines nie angekommenen Wunschwerts, und das Error-Logging pro Tick verschwindet.
+selbst nicht mehr. `fan_sample` protokolliert den tatsächlichen statt eines nie
+angekommenen Wunschwerts, und das Error-Logging pro Tick verschwindet.
 
-Emergency-Benachrichtigungen bei GPU-Übertemperatur bleiben unverändert
-erhalten. Sie sind auch ohne Steuerhoheit wertvoll, und der Code-Pfad dorthin
-liegt vor der Änderung.
+**Emergency-Sonderfall.** Der Loop schreibt bei Übertemperatur
+`config.mode = "emergency"` in die DB (`:544-546`), und **nichts setzt das je
+zurück** — in `EMERGENCY` greift der `AUTO/SCHEDULED`-Zweig nicht mehr, und
+`POST /api/fans/mode` akzeptiert `emergency` nicht als Eingabe. Für einen
+firmware-verwalteten Lüfter wäre das ein Dauerzustand ohne jeden Nutzen: Die
+Regelung kann ohnehin nichts ausrichten. Deshalb wird für
+`FIRMWARE_MANAGED` die **Mode-Persistierung übersprungen**, die
+Temperatur-Benachrichtigung aber ausgelöst. Die Warnung bleibt, der
+Karteileichen-Zustand entsteht nicht.
 
 ## Schreibpfad und Meldungen
 
 In `fan_backend_linux.py`:
 
-1. `set_pwm()` bricht bei `FIRMWARE_MANAGED` sofort ab, ohne sysfs anzufassen,
-   und setzt `last_write_error` auf den Firmware-Text. Das deckt auch den
-   direkten API-Weg über `POST /api/fans/pwm` ab, der nicht durch den Loop geht.
+1. `set_pwm()` bricht bei `FIRMWARE_MANAGED` sofort ab, ohne sysfs anzufassen.
 2. `_write_hwmon_file()` gibt statt `bool` künftig `(ok, errno)` zurück. Es hat
-   genau zwei Aufrufstellen, beide in `set_pwm` (Zeilen 130 und 135) — die
-   Signaturänderung ist damit vollständig lokal. Heute verschluckt ein
-   gemeinsames `except` den Unterschied zwischen `EACCES` und `EINVAL`.
-3. Bei `EACCES` wird `pwm_control` im Cache auf `NO_PERMISSION` herabgestuft.
+   genau zwei Aufrufstellen, beide in `set_pwm` (`:130`, `:135`) — die
+   Signaturänderung bleibt lokal. Der bestehende Catch-all für Nicht-`OSError`
+   bleibt erhalten, damit nichts Neues in den Monitoring-Loop propagiert.
+3. Bei `EACCES` → `NO_PERMISSION`, bei erfolgreichem Write zurück auf
+   `SUPPORTED`.
 
-Die Meldungstexte bleiben englisch, wie alle bestehenden `last_write_error`-Texte:
+Der `sudo tee`-Fallback bekommt `-n`. Ohne das läuft jeder fehlgeschlagene Write
+in den Fünf-Sekunden-Timeout — bei einem Fehlschlag pro Tick ist das kein
+Detail. `_check_write_permission` nutzt `-n` bereits; die Schreibstelle war die
+Ausnahme.
+
+Meldungstexte bleiben englisch wie alle bestehenden:
 
 | Zustand | Aussage |
 |---|---|
-| `firmware_managed` | Firmware-verwaltete Kurve auf RDNA3+; Live-PWM wird vom Treiber nicht unterstützt — **ausdrücklich mit dem Zusatz, dass `amdgpu.ppfeaturemask` daran nichts ändert** |
+| `firmware_managed` | Firmware-verwaltete Kurve auf RDNA3+; Live-PWM vom Treiber nicht unterstützt — **mit dem ausdrücklichen Zusatz, dass `amdgpu.ppfeaturemask` daran nichts ändert** |
 | `no_permission` | Kein Schreibrecht auf den konkreten Pfad (`EACCES`), unter Nennung des Dienst-Users |
-| `EINVAL` sonst | Kernel lehnt den Wert ab, mit `driver=` und `pwm_enable=` wie bisher |
+| `EINVAL` sonst | Kernel lehnt ab, mit `driver=` und `pwm_enable=` wie bisher |
 
-Der Zusatz zu `ppfeaturemask` ist kein Beiwerk: Er ist der Grund, aus dem #480
-ursprünglich falsch diagnostiziert wurde, und verhindert, dass jemand denselben
-Weg noch einmal geht.
+Der `ppfeaturemask`-Zusatz ist der Grund, aus dem #480 ursprünglich falsch
+diagnostiziert wurde, und verhindert, dass jemand denselben Weg noch einmal geht.
 
 ## API
 
-`POST /api/fans/{fan_id}/gpu-manual-mode` antwortet bei `FIRMWARE_MANAGED` mit
-**400** und klarer Begründung, statt `enable_amd_manual()` aufzurufen.
+Zwei Routen brauchen einen Guard, nicht eine:
+
+- `POST /api/fans/{fan_id}/gpu-manual-mode` — 400 bei `FIRMWARE_MANAGED`,
+  **aber nur für `enable=true`**. Ein Guard vor der Fallunterscheidung würde
+  auch das Abschalten blockieren; wer den Toggle je benutzt hat, käme dann nie
+  wieder aus `performance_level=manual` heraus.
+- `POST /api/fans/pwm` — heute liefert die Route bei `success=False` pauschal
+  „Failed to set PWM (fan not in manual mode or not found)"
+  (`routes/fans.py:158-162`). Der frisch gesetzte `last_write_error` erreicht
+  die Antwort nie. Ohne eigenen Guard bliebe genau die Sorte irreführender
+  Auskunft bestehen, die dieses Design abschaffen soll.
 
 Zusätzlich wird `enable_amd_manual()` gegen halb angewendete Zustände
-abgesichert: Es schreibt erst `performance_level=manual` und dann `pwm_enable`.
-Scheitert der zweite Write, propagiert die Exception heute als 500, die GPU
-bleibt in `manual` stehen, und `_gpu_manual_state[fan_id]` wurde nie gesetzt.
-Künftig rollt ein `try/except` den ersten Write zurück und meldet den Fehler
-sauber.
+abgesichert: Scheitert der `pwm_enable`-Write, rollt ein `try/except` den
+`performance_level`-Write zurück.
 
 ## Frontend
 
-- `client/src/api/fan-control.ts` — `pwm_control` im Fan-Typ ergänzen.
-- `FanCard.tsx` — Badge „Firmware" neben dem bestehenden GPU-Badge, wenn
-  `pwm_control === 'firmware_managed'`.
-- `FanDetails.tsx` — `GpuManualModeToggle` wird in diesem Fall nicht gerendert;
-  Kurveneditor und PWM-Regler laufen über das vorhandene `isReadOnly`-Konzept
-  mit. An die Stelle des Toggles tritt ein Erklärpanel.
-- i18n `de` und `en`, Namespace `system`, unter `fanControl.gpu.*`.
+- `api/fan-control.ts` — `pwm_control` im `FanInfo`-Typ.
+- `FanCard.tsx` — Badge „Firmware"; der **PWM-Slider** wird gesperrt.
+- `FanDetails.tsx` — statt `GpuManualModeToggle` ein Erklärpanel; Kurveneditor,
+  `CurveTypeSelector`, `AdvancedFanSettings`, Profile und Zeitpläne werden über
+  ein per-Lüfter-Read-only gesperrt.
+- `CurveEditorSync.tsx` — firmware-verwaltete Lüfter aus der Auswahlliste
+  filtern. Ein Lüfter, der sich per `sync` an die GPU koppelt, würde sonst
+  dauerhaft auf `min_pwm_percent` festgenagelt, weil `pwm1` konstant `0` liest.
+- i18n `de` und `en`, Namespace `system`, unter `fanControl.gpu.firmware.*`.
 
-Die Karte bleibt sichtbar. Lesen funktioniert auf RDNA3 einwandfrei — Drehzahl
-und Temperatur sind weiterhin nützlich, nur Schreiben ist unmöglich.
+**Die Modus-Buttons (AUTO / SCHEDULED / MANUAL) bleiben bedienbar.** Der Modus
+ist reine DB-Konfiguration und kein Hardware-Write. Sie zu sperren würde einen
+Lüfter, der aus früherer Zeit in `MANUAL` oder `EMERGENCY` feststeckt,
+unrettbar machen — der AUTO-Button ist der einzige Ausweg aus `EMERGENCY`.
+
+Die Karte bleibt sichtbar: Lesen funktioniert auf RDNA3 einwandfrei, Drehzahl
+und Temperatur sind weiterhin nützlich.
 
 ## Dev-Mode
 
-`fan_backend_dev.py` meldet für alle simulierten Lüfter `SUPPORTED`, damit sich
-in der Dev-Umgebung nichts am bestehenden Verhalten ändert. Zusätzlich wird ein
-simulierter firmware-verwalteter GPU-Lüfter aufgenommen, sonst ist der neue
-UI-Pfad nur auf BaluNode prüfbar und auf der Windows-Entwicklungsmaschine
-unsichtbar.
+`fan_backend_dev.py` meldet für alle simulierten Lüfter `SUPPORTED` und bekommt
+zusätzlich einen simulierten firmware-verwalteten GPU-Lüfter, damit der neue
+UI-Pfad auf der Windows-Entwicklungsmaschine sichtbar ist.
+
+`backend/tests/services/test_fan_control.py:45`, `:73` und `:372` prüfen auf
+genau vier simulierte Lüfter und müssen mitgezogen werden.
+
+Der Route-Guard ist im Dev-Mode **nicht** erreichbar: `routes/fans.py:1001`
+prüft `hasattr(backend, "_fan_cache")`, und der Dev-Backend hat `_fans`. Die
+Sichtprüfung im Dev-Mode zeigt Badge, Sperren und Erklärpanel — den 400er
+bestätigt nur der Test.
+
+## Mitbehoben: Kurven-Bug #517
+
+Beim Nachrechnen einer Testerwartung aufgefallen und verifiziert:
+`fan_control.py:533-536` übergibt `_calculate_pwm_with_hysteresis` eine **leere**
+Kurvenliste. Die Funktion verwirft das von `evaluate_curve` berechnete Ziel und
+holt sich über `_calculate_pwm_from_curve` (`:557-560`) den Hardcode-Wert `50`.
+Für jeden Lüfter mit `curve_type="graph"` — dem Default — ist die konfigurierte
+Kurve damit wirkungslos.
+
+Fix: `_calculate_pwm_with_hysteresis` **dämpft** das bereits berechnete Ziel,
+statt es neu zu berechnen. Parameter `curve_points` und der Aufruf von
+`_calculate_pwm_from_curve` entfallen; letzteres wird tot und fällt weg (seine
+Interpolation dupliziert ohnehin `fan_curve_eval.py`). Beide Helfer haben je
+genau einen Aufrufer und werden von keinem Test direkt gerufen.
+
+Auf Wunsch im selben PR wie #480, obwohl inhaltlich unabhängig.
 
 ## Tests
 
-Backend, mit `tmp_path`-sysfs-Bäumen im Stil des vorhandenen
-`test_fan_gpu_manual_mode.py`:
-
-- **neu** `test_fan_pwm_control_probe.py` — Baum mit und ohne
-  `gpu_od/fan_ctrl/fan_curve`, plus Nicht-AMD-Fall und fehlendes Device.
-- **erweitern** `test_fan_einval_diagnostic.py` — die drei Meldungsvarianten;
-  explizit, dass „enable manual mode in the UI" bei `firmware_managed` **nicht**
-  mehr vorkommt und `ppfeaturemask` erwähnt wird.
-- **Loop** — firmware-verwalteter Lüfter, `set_pwm` wird nicht aufgerufen, und
-  der geschriebene Sample trägt den tatsächlichen PWM-Wert.
-- **Route** — `gpu-manual-mode` liefert 400 statt 500; Rollback-Pfad in
-  `enable_amd_manual` stellt `performance_level` wieder her.
-
-Frontend: unter `client/src/__tests__` existiert bisher kein Fan-Test. Es
-entsteht einer für Badge und ausgeblendeten Toggle.
+| Datei | Deckt ab |
+|---|---|
+| `test_fan_pwm_control_probe.py` (neu) | Erkennung über den `device`-Symlink, inkl. Nicht-AMD und fehlendem Symlink |
+| `test_fan_einval_diagnostic.py` | die drei Meldungsvarianten; `EACCES`-Herabstufung und Rückweg |
+| `test_fan_firmware_managed_loop.py` (neu) | Loop schreibt nicht, Sample trägt den echten Wert, kein `emergency`-Persist |
+| `test_fan_curve_hysteresis.py` (neu) | #517: Kurve wirkt, statt 50 zurückzugeben |
+| `test_fan_gpu_manual_mode.py` | Rollback; Guard nur bei `enable=true`; `device`-Symlink-Auflösung |
+| `tests/services/test_fan_control.py` | Lüfterzahl im Dev-Backend nachziehen |
+| `client/src/__tests__/components/fan-control/FanCard.test.tsx` (neu) | Badge, gesperrter Slider, **bedienbare** Modus-Buttons |
 
 Vor dem PR lokal: die betroffenen pytest-Dateien gezielt, dazu `npx vitest run`,
 `eslint .` und `npm run build`. Die vollständige Backend-Suite läuft auf Windows
@@ -232,20 +302,15 @@ nicht durch und bleibt CI überlassen.
 
 ## Risiken
 
-- **Cache-Aktualität.** `pwm_control` wird beim Scan bestimmt. Wechselt die
-  Hardware-Situation zur Laufzeit (Treiber-Reload, GPU-Hotplug), bleibt der Wert
-  bis zum nächsten Scan stehen. Für eine Eigenschaft, die sich faktisch nur mit
-  der Karte ändert, ist das vertretbar; der Fehlerpfad korrigiert
-  `NO_PERMISSION` ohnehin nachträglich.
-- **Erkennung nur über einen Pfad.** Die Zuordnung „`gpu_od/fan_ctrl/fan_curve`
-  vorhanden ⇒ PWM unmöglich" ist an einer Karte gemessen (RX 7900 XT). Sie
-  entspricht dem SMU13-Verhalten, ist aber nicht über die gesamte RDNA3-Reihe
-  verifiziert. Fällt eine Karte auf, die beides kann, verliert sie durch diese
-  Änderung die PWM-Steuerung — sichtbar am Badge, und über den
-  Fehlermeldungstext zurückverfolgbar.
+- **Erkennung an einer Karte gemessen.** Die Regel „`gpu_od/fan_ctrl/fan_curve`
+  vorhanden ⇒ PWM unmöglich" stammt von einer RX 7900 XT. Sie entspricht dem
+  SMU13-Verhalten, ist aber nicht über die gesamte RDNA3-Reihe verifiziert.
+  Fällt eine Karte auf, die beides kann, verliert sie die PWM-Steuerung —
+  sichtbar am Badge und über den Meldungstext zurückverfolgbar. Weil die
+  Modus-Buttons bedienbar bleiben, sperrt sich niemand dadurch aus.
 - **Nicht gemessen:** ob `gpu_od/` ohne `amdgpu.ppfeaturemask=0xffffffff`
-  verschwindet. Auf BaluNode ist der Parameter gesetzt; der Gegenfall ließe sich
-  nur mit einem Reboot ohne Parameter prüfen. Die Implementierung darf deshalb
-  **nicht** aus einem fehlenden `gpu_od/` auf „Overdrive fehlt" schließen und
-  daraus eine Handlungsempfehlung ableiten — das wäre exakt der Fehler, den
-  dieses Design behebt.
+  verschwindet. Die Implementierung darf deshalb **nicht** aus einem fehlenden
+  `gpu_od/` auf „Overdrive fehlt" schließen und daraus eine Handlungsempfehlung
+  ableiten — das wäre exakt der Fehler, den dieses Design behebt.
+- **Cache-Aktualität.** `pwm_control` wird beim Scan bestimmt; ein
+  Treiber-Reload zur Laufzeit wird erst beim nächsten Start berücksichtigt.

--- a/docs/superpowers/specs/2026-08-06-rdna3-fan-capability-design.md
+++ b/docs/superpowers/specs/2026-08-06-rdna3-fan-capability-design.md
@@ -1,0 +1,251 @@
+# RDNA3-Lüfter: PWM-Fähigkeit erkennen statt ins Leere schreiben
+
+**Datum:** 2026-08-06
+**Status:** Design freigegeben, Umsetzung ausstehend
+**Betrifft:** Issue #480; Fan-Overhaul (Plan 2026-05-24)
+
+---
+
+## Problem
+
+Auf RDNA3-GPUs (gemessen: RX 7900 XT, `1002:744C`, Kernel 6.12.74, BaluNode)
+implementiert der amdgpu-Treiber keine manuelle PWM-Steuerung. BaluHost versucht
+sie trotzdem und gibt bei Misserfolg eine Empfehlung, die dort nicht greift.
+
+Messungen vom 2026-08-06, alle als `root` auf
+`/sys/class/drm/card0/device/hwmon/hwmon2/`:
+
+| Test | Ergebnis |
+|---|---|
+| `cat /sys/module/amdgpu/parameters/ppfeaturemask` | `0xffffffff` — Overdrive ist aktiv |
+| `echo 1 > pwm1_enable` (lactd läuft) | `rc=0`, Readback bleibt `2` |
+| `echo 1 > pwm1_enable` (lactd gestoppt) | `rc=0`, Readback bleibt `2` |
+| `echo 128 > pwm1` (lactd gestoppt) | `EINVAL`, `rc=1` |
+
+Daraus folgt dreierlei:
+
+1. **Der Boot-Parameter ist nicht die Ursache.** `amdgpu.ppfeaturemask=0xffffffff`
+   steht in `/proc/cmdline` und ist aktiv; PWM scheitert trotzdem. Die heutige
+   Meldung („For AMD GPUs: enable manual mode in the UI",
+   `fan_backend_linux.py:147-150`) und der ursprüngliche Fix-Vorschlag aus #480
+   („setz ppfeaturemask + Reboot") wären beide falsche Selbsthilfe.
+2. **Ein Fremd-Controller ist nicht die Ursache.** `lactd` läuft auf BaluNode,
+   aber mit gestopptem Dienst ist das Verhalten bitgenau identisch.
+3. **`pwm{n}_enable` meldet Erfolg, ohne zu wirken.** Der Write gibt `rc=0`
+   zurück, der Wert bleibt `2`. Nur der `pwm{n}`-Write scheitert sichtbar.
+
+Der einzige unterstützte Steuerpfad ist die firmware-verwaltete Kurve unter
+`<device>/gpu_od/fan_ctrl/` (`fan_curve`, `fan_minimum_pwm`,
+`fan_target_temperature`, `acoustic_limit_rpm_threshold`,
+`acoustic_target_rpm_threshold`).
+
+### Folgeschaden im laufenden Betrieb
+
+`fan_control.py:540-541` ruft `set_pwm` in jedem Monitoring-Tick, sobald der
+Zielwert vom gelesenen abweicht. Auf BaluNode liest `pwm1` konstant `0`, die
+Kurve fordert mindestens `min_pwm_percent` — der Loop schreibt also dauerhaft,
+scheitert dauerhaft und schreibt bei jedem Fehlschlag ein `logger.error`
+(`fan_backend_linux.py:151`). Zusätzlich protokolliert `fan_sample` einen
+Wunsch-PWM, der die Hardware nie erreicht hat.
+
+## Nicht-Ziele
+
+Bewusst ausgeklammert, jeweils mit Begründung:
+
+- **Fehlende Schreibrechte reparieren.** `pwm1`, `pwm1_enable` und
+  `gpu_od/fan_ctrl/*` sind `root:root 0644`; die udev-Regel
+  (`deploy/scripts/install-amd-gpu-permissions.sh:44-45`) erfasst nur
+  `power_dpm_force_performance_level` und `pp_power_profile_mode`, und in keinem
+  sudoers-Template steht ein `tee`-Eintrag. Auf der einzigen vorhandenen
+  AMD-Karte ist PWM ohnehin tot, der Fix brächte dort also nichts messbares. Er
+  fasst `deploy/` an (CODEOWNERS) und braucht einen manuellen Skript-Re-Run auf
+  dem Server. Bleibt als Abschnitt in #480 dokumentiert.
+
+  Nicht zu verwechseln mit `PwmControl.NO_PERMISSION` weiter unten: Dieses
+  Design **erkennt und benennt** den Rechtezustand, es **behebt** ihn nicht. Der
+  Unterschied ist der ganze Punkt — die heutige Meldung behauptet „rejected by
+  kernel", obwohl der Kernel in diesem Fall nie gefragt wurde.
+- **Die Firmware-Kurve tatsächlich steuern.** Eigenes Feature mit eigenem Design
+  (Schreibformat und Commit-Semantik von `fan_curve`, Zero-RPM-Verhalten,
+  Wertebereiche, Rücknahme beim Deaktivieren). Bekommt ein eigenes Issue, das
+  auf das hier eingeführte `pwm_control`-Feld aufsetzt.
+
+## Lösung
+
+Ein neues Feld `pwm_control` beschreibt pro Lüfter, ob und warum PWM-Schreiben
+möglich ist. Loop, API und UI lesen dasselbe Feld.
+
+```python
+class PwmControl(str, Enum):
+    SUPPORTED        = "supported"          # Default für alle Lüfter
+    FIRMWARE_MANAGED = "firmware_managed"   # RDNA3+: Kurve liegt in der Firmware
+    NO_PERMISSION    = "no_permission"      # EACCES beim Schreiben beobachtet
+```
+
+Das Feld muss an **drei** Stellen getragen werden, die leicht zu verwechseln sind:
+
+| Ort | Typ | Wer liest es |
+|---|---|---|
+| `_fan_cache[fan_id]["pwm_control"]` | `dict` in `fan_backend_linux.py` | `set_pwm()`, Route-Guard |
+| `FanData.pwm_control` | Dataclass, `fan_control.py:37-57` | der Regel-Loop (`get_fans()` liefert `FanData`, nicht `FanInfo`) |
+| `FanInfo.pwm_control` | Pydantic-Schema, `schemas/fans.py:72` | die API-Antwort und damit das Frontend |
+
+`get_fans()` in `fan_backend_linux.py:93-110` füllt `FanData` bereits aus dem
+Cache und wird um das Feld ergänzt; die Übersetzung `FanData` → `FanInfo` folgt
+dem Muster der bestehenden Felder `is_gpu_fan` / `last_write_error`. Der
+Dev-Backend baut `FanData` eigenständig und braucht denselben Default.
+
+### Erkennung
+
+Neue Funktion in `backend/app/services/power/fan_gpu_manual.py`:
+
+```python
+def probe_amd_pwm_control(hwmon_dir: Path, drm_root: Optional[Path] = None) -> PwmControl
+```
+
+Sie nutzt das dort bereits vorhandene `_device_from_hwmon()`, das von der
+hwmon-Directory zum PCI-Device hochläuft — genau dort liegt `gpu_od/`.
+Existiert `<device>/gpu_od/fan_ctrl/fan_curve`, ist das Ergebnis
+`FIRMWARE_MANAGED`, sonst `SUPPORTED`.
+
+Aufgerufen in `_scan_pwm_fans()` (`fan_backend_linux.py:301-348`), ausschließlich
+für `gpu_vendor == "amd"`. Das Ergebnis wird als `pwm_control` im
+`_fan_cache`-Eintrag abgelegt, neben `is_gpu_fan` und `gpu_vendor`. Kosten: ein
+Dateisystem-Check pro AMD-GPU je Scan.
+
+**Festlegung:** `NO_PERMISSION` wird bei der Erkennung *nicht* vergeben. Ein
+`os.access()`-Test würde ein falsches Urteil fällen, solange der
+`sudo tee`-Fallback theoretisch greifen könnte. Stattdessen stuft der
+Schreibpfad den Wert herab, sobald er tatsächlich `EACCES` beobachtet. Das Feld
+mischt damit statische Hardware-Eigenschaft und beobachteten Laufzeitzustand.
+Das ist gewollt: UI und Fehlermeldung stellen genau diese kombinierte Frage
+(„darf ich schreiben, und wenn nein, warum nicht?").
+
+### Zustandstabelle
+
+| Lüfter | `gpu_od/fan_ctrl/fan_curve` | Beobachteter Fehler | `pwm_control` |
+|---|---|---|---|
+| CPU/Board-Lüfter | — (kein GPU-Lüfter) | keiner | `supported` |
+| AMD pre-RDNA3 | fehlt | keiner | `supported` |
+| AMD pre-RDNA3, Rechte fehlen | fehlt | `EACCES` | `no_permission` |
+| AMD RDNA3+ | vorhanden | — (wird nicht mehr versucht) | `firmware_managed` |
+| nouveau / andere | nicht geprüft | keiner | `supported` |
+
+## Regel-Loop
+
+In `_monitor_and_control_fans` direkt nach dem Clamp auf `min/max`
+(`fan_control.py:538`):
+
+```python
+if fan.pwm_control is PwmControl.FIRMWARE_MANAGED:
+    target_pwm = fan.pwm_percent   # Firmware besitzt die Kurve
+```
+
+Die bestehende Bedingung `if target_pwm != fan.pwm_percent` greift dadurch von
+selbst nicht mehr — kein zusätzlicher Zweig an der Schreibstelle. Zwei
+gewünschte Nebeneffekte: `fan_sample` protokolliert den tatsächlichen statt
+eines nie angekommenen Wunschwerts, und das Error-Logging pro Tick verschwindet.
+
+Emergency-Benachrichtigungen bei GPU-Übertemperatur bleiben unverändert
+erhalten. Sie sind auch ohne Steuerhoheit wertvoll, und der Code-Pfad dorthin
+liegt vor der Änderung.
+
+## Schreibpfad und Meldungen
+
+In `fan_backend_linux.py`:
+
+1. `set_pwm()` bricht bei `FIRMWARE_MANAGED` sofort ab, ohne sysfs anzufassen,
+   und setzt `last_write_error` auf den Firmware-Text. Das deckt auch den
+   direkten API-Weg über `POST /api/fans/pwm` ab, der nicht durch den Loop geht.
+2. `_write_hwmon_file()` gibt statt `bool` künftig `(ok, errno)` zurück. Es hat
+   genau zwei Aufrufstellen, beide in `set_pwm` (Zeilen 130 und 135) — die
+   Signaturänderung ist damit vollständig lokal. Heute verschluckt ein
+   gemeinsames `except` den Unterschied zwischen `EACCES` und `EINVAL`.
+3. Bei `EACCES` wird `pwm_control` im Cache auf `NO_PERMISSION` herabgestuft.
+
+Die Meldungstexte bleiben englisch, wie alle bestehenden `last_write_error`-Texte:
+
+| Zustand | Aussage |
+|---|---|
+| `firmware_managed` | Firmware-verwaltete Kurve auf RDNA3+; Live-PWM wird vom Treiber nicht unterstützt — **ausdrücklich mit dem Zusatz, dass `amdgpu.ppfeaturemask` daran nichts ändert** |
+| `no_permission` | Kein Schreibrecht auf den konkreten Pfad (`EACCES`), unter Nennung des Dienst-Users |
+| `EINVAL` sonst | Kernel lehnt den Wert ab, mit `driver=` und `pwm_enable=` wie bisher |
+
+Der Zusatz zu `ppfeaturemask` ist kein Beiwerk: Er ist der Grund, aus dem #480
+ursprünglich falsch diagnostiziert wurde, und verhindert, dass jemand denselben
+Weg noch einmal geht.
+
+## API
+
+`POST /api/fans/{fan_id}/gpu-manual-mode` antwortet bei `FIRMWARE_MANAGED` mit
+**400** und klarer Begründung, statt `enable_amd_manual()` aufzurufen.
+
+Zusätzlich wird `enable_amd_manual()` gegen halb angewendete Zustände
+abgesichert: Es schreibt erst `performance_level=manual` und dann `pwm_enable`.
+Scheitert der zweite Write, propagiert die Exception heute als 500, die GPU
+bleibt in `manual` stehen, und `_gpu_manual_state[fan_id]` wurde nie gesetzt.
+Künftig rollt ein `try/except` den ersten Write zurück und meldet den Fehler
+sauber.
+
+## Frontend
+
+- `client/src/api/fan-control.ts` — `pwm_control` im Fan-Typ ergänzen.
+- `FanCard.tsx` — Badge „Firmware" neben dem bestehenden GPU-Badge, wenn
+  `pwm_control === 'firmware_managed'`.
+- `FanDetails.tsx` — `GpuManualModeToggle` wird in diesem Fall nicht gerendert;
+  Kurveneditor und PWM-Regler laufen über das vorhandene `isReadOnly`-Konzept
+  mit. An die Stelle des Toggles tritt ein Erklärpanel.
+- i18n `de` und `en`, Namespace `system`, unter `fanControl.gpu.*`.
+
+Die Karte bleibt sichtbar. Lesen funktioniert auf RDNA3 einwandfrei — Drehzahl
+und Temperatur sind weiterhin nützlich, nur Schreiben ist unmöglich.
+
+## Dev-Mode
+
+`fan_backend_dev.py` meldet für alle simulierten Lüfter `SUPPORTED`, damit sich
+in der Dev-Umgebung nichts am bestehenden Verhalten ändert. Zusätzlich wird ein
+simulierter firmware-verwalteter GPU-Lüfter aufgenommen, sonst ist der neue
+UI-Pfad nur auf BaluNode prüfbar und auf der Windows-Entwicklungsmaschine
+unsichtbar.
+
+## Tests
+
+Backend, mit `tmp_path`-sysfs-Bäumen im Stil des vorhandenen
+`test_fan_gpu_manual_mode.py`:
+
+- **neu** `test_fan_pwm_control_probe.py` — Baum mit und ohne
+  `gpu_od/fan_ctrl/fan_curve`, plus Nicht-AMD-Fall und fehlendes Device.
+- **erweitern** `test_fan_einval_diagnostic.py` — die drei Meldungsvarianten;
+  explizit, dass „enable manual mode in the UI" bei `firmware_managed` **nicht**
+  mehr vorkommt und `ppfeaturemask` erwähnt wird.
+- **Loop** — firmware-verwalteter Lüfter, `set_pwm` wird nicht aufgerufen, und
+  der geschriebene Sample trägt den tatsächlichen PWM-Wert.
+- **Route** — `gpu-manual-mode` liefert 400 statt 500; Rollback-Pfad in
+  `enable_amd_manual` stellt `performance_level` wieder her.
+
+Frontend: unter `client/src/__tests__` existiert bisher kein Fan-Test. Es
+entsteht einer für Badge und ausgeblendeten Toggle.
+
+Vor dem PR lokal: die betroffenen pytest-Dateien gezielt, dazu `npx vitest run`,
+`eslint .` und `npm run build`. Die vollständige Backend-Suite läuft auf Windows
+nicht durch und bleibt CI überlassen.
+
+## Risiken
+
+- **Cache-Aktualität.** `pwm_control` wird beim Scan bestimmt. Wechselt die
+  Hardware-Situation zur Laufzeit (Treiber-Reload, GPU-Hotplug), bleibt der Wert
+  bis zum nächsten Scan stehen. Für eine Eigenschaft, die sich faktisch nur mit
+  der Karte ändert, ist das vertretbar; der Fehlerpfad korrigiert
+  `NO_PERMISSION` ohnehin nachträglich.
+- **Erkennung nur über einen Pfad.** Die Zuordnung „`gpu_od/fan_ctrl/fan_curve`
+  vorhanden ⇒ PWM unmöglich" ist an einer Karte gemessen (RX 7900 XT). Sie
+  entspricht dem SMU13-Verhalten, ist aber nicht über die gesamte RDNA3-Reihe
+  verifiziert. Fällt eine Karte auf, die beides kann, verliert sie durch diese
+  Änderung die PWM-Steuerung — sichtbar am Badge, und über den
+  Fehlermeldungstext zurückverfolgbar.
+- **Nicht gemessen:** ob `gpu_od/` ohne `amdgpu.ppfeaturemask=0xffffffff`
+  verschwindet. Auf BaluNode ist der Parameter gesetzt; der Gegenfall ließe sich
+  nur mit einem Reboot ohne Parameter prüfen. Die Implementierung darf deshalb
+  **nicht** aus einem fehlenden `gpu_od/` auf „Overdrive fehlt" schließen und
+  daraus eine Handlungsempfehlung ableiten — das wäre exakt der Fehler, den
+  dieses Design behebt.


### PR DESCRIPTION
Behebt zwei Befunde in der Lüftersteuerung, die sich am selben Codepfad treffen: die Kurve wirkt nicht (#517), und auf RDNA3-GPUs schreibt BaluHost gegen einen Knoten, den der Treiber strukturell nie annimmt (#480).

Die Arbeit lag seit dem 2026-08-07 unveröffentlicht lokal; dieser PR ist der unveränderte Stand, auf `main` rebased (keine Datei-Überschneidung, konfliktfrei).

## #517 — Lüfterkurve wirkt wieder

Für jeden Lüfter mit `curve_type="graph"` (dem Default) wurde das korrekt berechnete `target_pwm` an `_calculate_pwm_with_hysteresis` als *Ist*-Wert übergeben, dort verworfen und gegen eine **leere** Kurvenliste neu berechnet — was in `_calculate_pwm_from_curve` auf `return 50` lief. Ergebnis: temperaturunabhängig 50 %, still und ohne Fehlermeldung.

- `_apply_hysteresis` **dämpft** jetzt das bereits berechnete Ziel, statt es neu zu berechnen.
- `_calculate_pwm_from_curve` ist damit tot und entfällt; seine Interpolation war ohnehin eine Doppelung von `fan_curve_eval.py`.
- Folgeschaden mitbehandelt: `_interpolate()` liefert `0` für `temp=None`. Ein ausgefallener Sensor hätte nach dem Fix die Kühlung abgestellt — jetzt wird stattdessen der aktuelle PWM gehalten.

## #480 — RDNA3 ehrlich melden statt falsche Selbsthilfe

Gemessen auf BaluNode (RX 7900 XT, Kernel 6.12.74): `ppfeaturemask=0xffffffff` ist aktiv, `lactd` ist unbeteiligt — `pwm{n}_enable` nimmt den Write folgenlos an, `pwm{n}` lehnt mit `EINVAL` ab. Ab SMU13 implementiert der Treiber keine manuelle PWM-Steuerung; die Kurve liegt in der Firmware unter `gpu_od/fan_ctrl`.

- Neues Feld `pwm_control` (`supported` / `firmware_managed` / `no_permission`), erkannt über den hwmon-`device`-Symlink und von `scan` bis `FanInfo` durchgereicht.
- Firmware-verwaltete Lüfter werden im Regelkreis **übersprungen** statt beschrieben — inklusive des Emergency-Zweigs, der dort nur einen Zustand hinterließ, aus dem allein der AUTO-Button wieder herausführte.
- `EACCES` wird von `EINVAL` getrennt. Die bisherige Diagnose „PWM write rejected by kernel" war im Produktionspfad sachlich falsch: das Backend läuft als `sven`, der Kernel wird nie gefragt.
- Route-Guards mit Rollback bei Teilfehler; Frontend weist solche Lüfter als read-only aus (`FirmwareFanNotice`), Kurven-, Profil- und Zeitplan-Panels sind gesperrt.
- Dev-Backend simuliert einen firmware-verwalteten GPU-Lüfter, damit der Pfad ohne RDNA3-Hardware testbar ist.

## Nicht in diesem PR

- **#516** (Firmware-Kurve über `gpu_od/fan_ctrl` tatsächlich *schreiben*) — eigenes Design, braucht zusätzlich udev-/sudoers-Rechte unter `deploy/`.
- Die Schreibrechte-Lücke aus dem #480-Nebenbefund. Für RDNA3 wertlos (PWM geht ohnehin nicht), für pre-RDNA3 und #516 Voraussetzung.

## Verifikation

| Gate | Ergebnis |
|---|---|
| `pytest` über die 7 berührten Fan-Testdateien | 96 passed |
| `npx eslint .` | 0 errors (280 vorbestehende Warnings) |
| `npm run build` | ✓ built |
| `npx vitest run` | 274 Dateien / 1309 Tests passed |

Volle Backend-Suite bleibt der CI überlassen.

## Bezug

Entriegelt den nachgelagerten Lüfter-Stapel: #532, #533, #534 und #535 nennen #517 alle als Voraussetzung.

Closes #517
Closes #480

Design: `docs/superpowers/specs/2026-08-06-rdna3-fan-capability-design.md`
Plan: `docs/superpowers/plans/2026-08-07-rdna3-fan-capability.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184tK6o2QwQyBoU1oCHf7We
