### PR TITLE
fix(fans): Backoff gegen dauerhaft fehlschlagende PWM-Writes (#533)

### DIFF
--- a/backend/app/services/power/fan_backend_dev.py
+++ b/backend/app/services/power/fan_backend_dev.py
@@ -135,8 +135,13 @@ class DevFanControlBackend(FanControlBackend):
 
         return fans
 
-    async def set_pwm(self, fan_id: str, pwm_percent: int) -> bool:
-        """Set simulated PWM value."""
+    async def set_pwm(self, fan_id: str, pwm_percent: int, force: bool = False) -> bool:
+        """Set simulated PWM value.
+
+        force ist ohne Wirkung: das Dev-Backend schlaegt nie fehl, es gibt also
+        kein Backoff-Fenster zu umgehen. Der Parameter haelt nur die Signatur
+        mit FanControlBackend deckungsgleich.
+        """
         if fan_id not in self._fans:
             logger.warning(f"Fan {fan_id} not found")
             return False

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -6,6 +6,7 @@ import getpass
 import logging
 import os
 import subprocess
+import time
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -23,6 +24,15 @@ FIRMWARE_MANAGED_WRITE_ERROR = (
     "possible through the firmware curve (gpu_od/fan_ctrl), see issue #516."
 )
 
+# Backoff gegen Knoten, die den Write dauerhaft ablehnen (#533). Der Regelkreis
+# laeuft alle 5 s; ohne Deckelung ergab das 17k Logzeilen und 34k sudo-Aufrufe
+# pro Tag fuer einen einzigen Luefter.
+#
+# Die Basis ist BEWUSST groesser als ein Regelzyklus: mit 5 s waere das erste
+# Fenster genau einen Zyklus lang und wuerde nichts unterdruecken.
+PWM_BACKOFF_BASE_SECONDS = 10.0
+PWM_BACKOFF_MAX_SECONDS = 900.0  # 15 Minuten
+
 
 class LinuxFanControlBackend(FanControlBackend):
     """Linux hardware backend using hwmon sysfs."""
@@ -32,6 +42,11 @@ class LinuxFanControlBackend(FanControlBackend):
         self._hwmon_base = Path("/sys/class/hwmon")
         self._fan_cache: Dict[str, Dict] = {}
         self._has_write_permission = False
+        # fan_id -> (fail_count, naechster erlaubter Versuch als monotone Zeit).
+        # Bewusst NICHT in _fan_cache: der wird bei jedem Rescan neu gebaut,
+        # der Backoff muss das ueberleben.
+        self._write_backoff: Dict[str, Tuple[int, float]] = {}
+        self._monotonic = time.monotonic
 
     async def is_available(self) -> bool:
         """Check if hwmon is available."""
@@ -122,8 +137,13 @@ class LinuxFanControlBackend(FanControlBackend):
 
         return fans
 
-    async def set_pwm(self, fan_id: str, pwm_percent: int) -> bool:
-        """Set hardware PWM value."""
+    async def set_pwm(self, fan_id: str, pwm_percent: int, force: bool = False) -> bool:
+        """Set hardware PWM value.
+
+        force=True umgeht das Backoff-Fenster (#533) — fuer Nutzeraktionen und
+        den Notfallpfad, die einen echten Versuch und eine echte Fehlermeldung
+        verdienen statt eines stillen False.
+        """
         if fan_id not in self._fan_cache:
             logger.warning(f"Fan {fan_id} not found in cache")
             return False
@@ -136,6 +156,14 @@ class LinuxFanControlBackend(FanControlBackend):
             logger.debug(f"{fan_id}: firmware-managed fan curve, PWM write skipped")
             return False
 
+        backoff = self._write_backoff.get(fan_id)
+        if backoff is not None and not force and self._monotonic() < backoff[1]:
+            logger.debug(
+                f"{fan_id}: PWM write suppressed, {backoff[0]} consecutive failures, "
+                f"retry in {backoff[1] - self._monotonic():.0f}s"
+            )
+            return False
+
         pwm_path = fan_info["pwm_path"]
         pwm_enable_path = fan_info.get("pwm_enable_path")
 
@@ -145,11 +173,20 @@ class LinuxFanControlBackend(FanControlBackend):
         if pwm_enable_path:
             ok_enable, _ = await self._write_hwmon_file(pwm_enable_path, "1")
             if not ok_enable:
-                logger.warning(f"Failed to set PWM enable for {fan_id}")
+                # DEBUG statt WARNING (#533): schlaegt pwm_enable fehl, schlaegt
+                # gleich darauf auch der pwm-Write fehl und traegt die volle
+                # Diagnose. Eine Zeile pro Episode, nicht zwei pro Zyklus.
+                logger.debug(f"Failed to set PWM enable for {fan_id}")
 
         success, err_code = await self._write_hwmon_file(pwm_path, str(pwm_value))
         if success:
             fan_info["last_write_error"] = None
+            recovered = self._write_backoff.pop(fan_id, None)
+            if recovered is not None:
+                logger.info(
+                    f"{fan_id}: PWM write succeeded again after {recovered[0]} "
+                    f"consecutive failure(s)"
+                )
             if fan_info.get("pwm_control") is PwmControl.NO_PERMISSION:
                 # Rechte wurden zur Laufzeit korrigiert.
                 fan_info["pwm_control"] = PwmControl.SUPPORTED
@@ -188,7 +225,26 @@ class LinuxFanControlBackend(FanControlBackend):
                 f"errno={errno.errorcode.get(err_code, err_code)})."
             )
 
-        logger.error(f"Failed to write PWM for {fan_id}: {fan_info['last_write_error']}")
+        fail_count = self._write_backoff.get(fan_id, (0, 0.0))[0] + 1
+        delay = min(
+            PWM_BACKOFF_BASE_SECONDS * (2 ** (fail_count - 1)),
+            PWM_BACKOFF_MAX_SECONDS,
+        )
+        self._write_backoff[fan_id] = (fail_count, self._monotonic() + delay)
+
+        if fail_count == 1:
+            # Erster Fehlschlag einer Episode: eine ERROR-Zeile mit der vollen
+            # Diagnose. Wiederholungen laufen auf DEBUG, damit Fehler-Metrik und
+            # Log-Alerting brauchbar bleiben.
+            logger.error(
+                f"Failed to write PWM for {fan_id}: {fan_info['last_write_error']} "
+                f"Further attempts suppressed, next retry in {delay:.0f}s."
+            )
+        else:
+            logger.debug(
+                f"Failed to write PWM for {fan_id} ({fail_count} consecutive), "
+                f"next retry in {delay:.0f}s"
+            )
         return False
 
     # CPU temperature driver names (same keywords as hardware/sensors.py)
@@ -397,6 +453,10 @@ class LinuxFanControlBackend(FanControlBackend):
 
         if new_cache or not self._fan_cache:
             self._fan_cache = new_cache
+            # Backoff-Eintraege verschwundener Luefter mitnehmen, sonst waechst
+            # das Dict ueber Treiber-Reloads und hwmon-Renumbering hinweg (#533).
+            for stale in set(self._write_backoff) - set(self._fan_cache):
+                del self._write_backoff[stale]
             logger.info(f"Scanned hwmon: found {len(self._fan_cache)} PWM fan(s)")
         else:
             logger.warning(
@@ -451,7 +511,10 @@ class LinuxFanControlBackend(FanControlBackend):
                     self._has_write_permission = True
                     logger.debug(f"Wrote to {path} via sudo tee")
                     return True, None
-                logger.warning(f"sudo tee failed for {path}: {result.stderr.decode()}")
+                # DEBUG statt WARNING (#533): der Aufrufer meldet die Episode
+                # bereits mit einer ERROR-Zeile; hier wuerde sie pro Zyklus
+                # ein zweites Mal auflaufen.
+                logger.debug(f"sudo tee failed for {path}: {result.stderr.decode()}")
             except Exception as exc2:
                 logger.error(f"Failed to write {path} with sudo: {exc2}")
             return False, code

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -94,13 +94,15 @@ class FanControlBackend(ABC):
         pass
 
     @abstractmethod
-    async def set_pwm(self, fan_id: str, pwm_percent: int) -> bool:
+    async def set_pwm(self, fan_id: str, pwm_percent: int, force: bool = False) -> bool:
         """
         Set PWM value for a fan.
 
         Args:
             fan_id: Fan identifier
             pwm_percent: PWM percentage (0-100)
+            force: Ein etwaiges Backoff-Fenster uebergehen (#533). Fuer
+                Nutzeraktionen und den Notfallpfad.
 
         Returns:
             True if successful, False otherwise
@@ -550,7 +552,12 @@ class FanControlService:
                     target_pwm = fan.pwm_percent
 
                 if target_pwm != fan.pwm_percent:
-                    await self._backend.set_pwm(fan.fan_id, target_pwm)
+                    # Im Notfall das Backoff-Fenster umgehen (#533): ein
+                    # Ueberhitzungsfall ist per Definition kein Dauerzustand,
+                    # und thermische Sicherheit schlaegt Log-Hygiene.
+                    await self._backend.set_pwm(
+                        fan.fan_id, target_pwm, force=(mode == FanMode.EMERGENCY)
+                    )
                 self._last_pwm_by_fan[fan.fan_id] = target_pwm
 
                 if (
@@ -805,8 +812,9 @@ class FanControlService:
             # Apply min/max limits
             pwm_percent = max(config.min_pwm_percent, min(config.max_pwm_percent, pwm_percent))
 
-        # Set PWM
-        success = await self._backend.set_pwm(fan_id, pwm_percent)
+        # Set PWM. Nutzeraktion: das Backoff-Fenster umgehen (#533), damit der
+        # Klick einen echten Versuch und eine echte Fehlermeldung bekommt.
+        success = await self._backend.set_pwm(fan_id, pwm_percent, force=True)
 
         # Read back RPM
         rpm = None

--- a/backend/tests/test_fan_curve_hysteresis.py
+++ b/backend/tests/test_fan_curve_hysteresis.py
@@ -87,7 +87,7 @@ class _StubBackend:
             pwm_control=PwmControl.SUPPORTED,
         )]
 
-    async def set_pwm(self, fan_id, pwm_percent):
+    async def set_pwm(self, fan_id, pwm_percent, force=False):
         self.set_pwm_calls.append((fan_id, pwm_percent))
         return True
 

--- a/backend/tests/test_fan_firmware_managed_loop.py
+++ b/backend/tests/test_fan_firmware_managed_loop.py
@@ -25,7 +25,7 @@ class _StubBackend:
             pwm_control=PwmControl.FIRMWARE_MANAGED,
         )]
 
-    async def set_pwm(self, fan_id, pwm_percent):
+    async def set_pwm(self, fan_id, pwm_percent, force=False):
         self.set_pwm_calls.append((fan_id, pwm_percent))
         return True
 

--- a/backend/tests/test_fan_pwm_backoff.py
+++ b/backend/tests/test_fan_pwm_backoff.py
@@ -1,0 +1,432 @@
+"""Backoff gegen dauerhaft fehlschlagende PWM-Writes (#533).
+
+Der Regelkreis schreibt alle 5 s. Gegen einen Knoten, den der Treiber nie
+annimmt, ergab das 17k Logzeilen und 34k sudo-Aufrufe pro Tag. Die Tests hier
+messen, dass nach einem Fehlschlag *nicht mehr geschrieben* wird, bis das
+Backoff-Fenster abgelaufen ist.
+
+Muster wie in test_fan_einval_diagnostic.py: echter tmp-sysfs-Baum, und
+Path.write_text wird als I/O-Grenze ersetzt, damit die Fehlschlaege
+reproduzierbar sind und die tatsaechlichen Schreibversuche zaehlbar bleiben.
+"""
+import json
+import logging
+import shutil
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.config import get_settings
+from app.models.fans import FanConfig
+from app.schemas.fans import FanMode, PwmControl
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+from app.services.power.fan_control import FanControlService, FanData
+
+
+def _hwmon(tmp_path: Path) -> Path:
+    d = tmp_path / "sys" / "class" / "hwmon" / "hwmon1"
+    d.mkdir(parents=True)
+    (d / "name").write_text("nct6798\n")
+    (d / "pwm1").write_text("128\n")
+    (d / "fan1_input").write_text("1200\n")
+    (d / "pwm1_enable").write_text("1\n")
+    return d
+
+
+async def _backend(tmp_path, monkeypatch) -> tuple[LinuxFanControlBackend, str]:
+    _hwmon(tmp_path)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
+    await backend._scan_pwm_fans()
+    return backend, next(iter(backend._fan_cache))
+
+
+class _Clock:
+    """Steuerbare monotone Uhr."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _fail_writes(monkeypatch) -> list[Path]:
+    """Laesst jeden sysfs-Write mit EINVAL scheitern und zaehlt die Versuche."""
+    attempts: list[Path] = []
+
+    def failing_write(self_, _value, *_a, **_kw):
+        attempts.append(self_)
+        raise OSError(22, "Invalid argument")
+
+    monkeypatch.setattr(Path, "write_text", failing_write)
+    return attempts
+
+
+@pytest.mark.asyncio
+async def test_second_write_within_backoff_window_is_suppressed(tmp_path, monkeypatch):
+    """Nach einem Fehlschlag darf der naechste Zyklus die Hardware nicht anfassen."""
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(backend, "_monotonic", clock, raising=False)
+
+    attempts = _fail_writes(monkeypatch)
+
+    assert await backend.set_pwm(fan_id, 80) is False
+    attempts_after_first = len(attempts)
+    assert attempts_after_first > 0, "der erste Versuch muss die Hardware anfassen"
+
+    clock.advance(5.0)  # ein Regelzyklus
+    assert await backend.set_pwm(fan_id, 81) is False
+
+    assert len(attempts) == attempts_after_first, (
+        "innerhalb des Backoff-Fensters darf kein weiterer Write erfolgen"
+    )
+
+
+@pytest.mark.asyncio
+async def test_backoff_window_doubles_with_each_failure(tmp_path, monkeypatch):
+    """Zweiter Fehlschlag sperrt doppelt so lange wie der erste."""
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(backend, "_monotonic", clock, raising=False)
+    attempts = _fail_writes(monkeypatch)
+
+    await backend.set_pwm(fan_id, 80)  # Fehlschlag 1 -> 10 s Sperre
+
+    clock.advance(10.0)
+    await backend.set_pwm(fan_id, 81)  # Fehlschlag 2 -> 20 s Sperre
+    attempts_after_second = len(attempts)
+
+    clock.advance(10.0)  # erst die Haelfte des neuen Fensters
+    await backend.set_pwm(fan_id, 82)
+    assert len(attempts) == attempts_after_second, (
+        "nach dem zweiten Fehlschlag muss das Fenster 20 s betragen, nicht wieder 10 s"
+    )
+
+    clock.advance(10.0)  # jetzt sind die 20 s um
+    await backend.set_pwm(fan_id, 83)
+    assert len(attempts) > attempts_after_second, "nach Fensterablauf muss neu versucht werden"
+
+
+@pytest.mark.asyncio
+async def test_backoff_window_is_capped_at_fifteen_minutes(tmp_path, monkeypatch):
+    """Ohne Deckel waere das Fenster nach 10 Fehlschlaegen bei ueber 85 Minuten."""
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(backend, "_monotonic", clock, raising=False)
+    attempts = _fail_writes(monkeypatch)
+
+    for _ in range(10):
+        await backend.set_pwm(fan_id, 80)
+        clock.advance(100_000.0)  # jedes Fenster sicher ueberspringen
+
+    await backend.set_pwm(fan_id, 80)  # Fehlschlag 11 setzt das Fenster neu
+    attempts_before = len(attempts)
+
+    clock.advance(900.0)  # exakt der Deckel
+    await backend.set_pwm(fan_id, 81)
+
+    assert len(attempts) > attempts_before, (
+        "nach 15 Minuten muss wieder versucht werden, egal wie viele Fehlschlaege vorlagen"
+    )
+
+
+class _Writer:
+    """sysfs-Write, der zwischen Erfolg und EINVAL umgeschaltet werden kann."""
+
+    def __init__(self, monkeypatch) -> None:
+        self.attempts: list[Path] = []
+        self.fail = True
+        real_write = Path.write_text
+
+        def write(self_, value, *a, **kw):
+            self.attempts.append(self_)
+            if self.fail:
+                raise OSError(22, "Invalid argument")
+            return real_write(self_, value, *a, **kw)
+
+        monkeypatch.setattr(Path, "write_text", write)
+
+
+@pytest.mark.asyncio
+async def test_successful_write_clears_the_backoff(tmp_path, monkeypatch):
+    """Nach einem erfolgreichen Write faengt die Zaehlung wieder bei null an."""
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(backend, "_monotonic", clock, raising=False)
+    writer = _Writer(monkeypatch)
+
+    await backend.set_pwm(fan_id, 80)  # Fehlschlag 1
+    clock.advance(10.0)
+    await backend.set_pwm(fan_id, 81)  # Fehlschlag 2 -> 20 s
+
+    clock.advance(20.0)
+    writer.fail = False
+    assert await backend.set_pwm(fan_id, 82) is True
+    assert fan_id not in backend._write_backoff
+
+    # Ein neuer Fehlschlag beginnt wieder mit dem Basisfenster (10 s), nicht 40 s.
+    writer.fail = True
+    await backend.set_pwm(fan_id, 83)
+    before = len(writer.attempts)
+    clock.advance(10.0)
+    await backend.set_pwm(fan_id, 84)
+    assert len(writer.attempts) > before, (
+        "nach dem Erfolg muss die Eskalation zurueckgesetzt sein"
+    )
+
+
+@pytest.mark.asyncio
+async def test_force_bypasses_the_backoff_window(tmp_path, monkeypatch):
+    """Ein Nutzer-Klick bekommt einen echten Versuch, kein stilles False."""
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(backend, "_monotonic", clock, raising=False)
+    attempts = _fail_writes(monkeypatch)
+
+    await backend.set_pwm(fan_id, 80)  # Fehlschlag -> Fenster steht
+    before = len(attempts)
+
+    await backend.set_pwm(fan_id, 90, force=True)
+
+    assert len(attempts) > before, "force muss die Hardware trotz Fenster anfassen"
+
+
+@pytest.mark.asyncio
+async def test_forced_success_clears_the_backoff(tmp_path, monkeypatch):
+    """Wenn der erzwungene Versuch klappt, ist die Episode vorbei."""
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(backend, "_monotonic", clock, raising=False)
+    writer = _Writer(monkeypatch)
+
+    await backend.set_pwm(fan_id, 80)
+    assert fan_id in backend._write_backoff
+
+    writer.fail = False
+    assert await backend.set_pwm(fan_id, 90, force=True) is True
+    assert fan_id not in backend._write_backoff
+
+
+# --- Aufrufer-Verdrahtung: wer darf das Fenster umgehen? ---------------------
+
+
+class _RecordingBackend:
+    """Merkt sich, ob der Aufrufer force gesetzt hat."""
+
+    def __init__(self, temperature=70.0, pwm_percent=40):
+        self.calls: list[tuple[str, int, bool]] = []
+        self.temperature = temperature
+        self.pwm_percent = pwm_percent
+
+    async def get_fans(self):
+        return [FanData(
+            fan_id="case1", name="Gehaeuse", rpm=800, pwm_percent=self.pwm_percent,
+            temperature_celsius=self.temperature, mode=FanMode.AUTO,
+            min_pwm_percent=20, max_pwm_percent=100, emergency_temp_celsius=85.0,
+            temp_sensor_id="hwmon:case1", curve_points=[], is_active=True,
+            pwm_control=PwmControl.SUPPORTED,
+        )]
+
+    async def set_pwm(self, fan_id, pwm_percent, force=False):
+        self.calls.append((fan_id, pwm_percent, force))
+        return True
+
+
+def _row(**overrides):
+    base = dict(
+        fan_id="case1", name="Gehaeuse", mode=FanMode.AUTO.value, is_active=True,
+        min_pwm_percent=20, max_pwm_percent=100, emergency_temp_celsius=85.0,
+        curve_json=json.dumps([{"temp": 35, "pwm": 30}, {"temp": 85, "pwm": 100}]),
+        curve_type="graph", hysteresis_celsius=3.0, temp_sensor_id="hwmon:case1",
+    )
+    base.update(overrides)
+    return FanConfig(**base)
+
+
+def _service(db_session):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = False
+    config.is_dev_mode = True
+    config.fan_sample_interval_seconds = 2
+    return FanControlService(config, lambda: db_session)
+
+
+@pytest.mark.asyncio
+async def test_regular_loop_respects_the_backoff(db_session):
+    """Der 5-s-Takt ist genau der Aufrufer, der gedaempft werden soll."""
+    db_session.add(_row())
+    db_session.commit()
+    service = _service(db_session)
+    service._registry.get_temp = AsyncMock(return_value=60.0)
+    service._backend = _RecordingBackend(temperature=60.0)
+    try:
+        await service._monitor_and_control_fans()
+        assert service._backend.calls, "der Loop sollte in diesem Aufbau schreiben"
+        assert all(force is False for _, _, force in service._backend.calls)
+    finally:
+        FanControlService._instance = None
+
+
+@pytest.mark.asyncio
+async def test_emergency_bypasses_the_backoff(db_session):
+    """Thermische Sicherheit schlaegt Log-Hygiene."""
+    db_session.add(_row())
+    db_session.commit()
+    service = _service(db_session)
+    service._registry.get_temp = AsyncMock(return_value=99.0)  # ueber emergency_temp
+    service._backend = _RecordingBackend(temperature=99.0)
+    try:
+        await service._monitor_and_control_fans()
+        assert service._backend.calls, "im Notfall muss geschrieben werden"
+        assert all(force is True for _, _, force in service._backend.calls)
+    finally:
+        FanControlService._instance = None
+
+
+@pytest.mark.asyncio
+async def test_manual_set_bypasses_the_backoff(db_session):
+    """Der Nutzer hat geklickt: echter Versuch, echte Fehlermeldung."""
+    db_session.add(_row(mode=FanMode.MANUAL.value))
+    db_session.commit()
+    service = _service(db_session)
+    service._backend = _RecordingBackend()
+    try:
+        ok, _ = await service.set_fan_pwm("case1", 70)
+        assert ok is True
+        assert service._backend.calls == [("case1", 70, True)]
+    finally:
+        FanControlService._instance = None
+
+
+# --- Log-Hygiene: der eigentliche Zweck von #533 -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_repeated_failures_produce_exactly_one_error_line(tmp_path, monkeypatch, caplog):
+    """17k identische ERROR-Zeilen machten jedes Alerting unbrauchbar."""
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(backend, "_monotonic", clock, raising=False)
+    _fail_writes(monkeypatch)
+
+    with caplog.at_level(logging.DEBUG, logger="app.services.power.fan_backend_linux"):
+        for _ in range(20):
+            await backend.set_pwm(fan_id, 80)
+            clock.advance(100_000.0)  # jedes Fenster ueberspringen -> 20 Fehlschlaege
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert len(errors) == 1, (
+        f"eine Fehler-Episode darf genau eine ERROR-Zeile erzeugen, waren {len(errors)}"
+    )
+    assert "next retry in" in errors[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_recovery_is_logged_once_at_info(tmp_path, monkeypatch, caplog):
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(backend, "_monotonic", clock, raising=False)
+    writer = _Writer(monkeypatch)
+
+    await backend.set_pwm(fan_id, 80)
+    clock.advance(100_000.0)
+
+    with caplog.at_level(logging.INFO, logger="app.services.power.fan_backend_linux"):
+        writer.fail = False
+        await backend.set_pwm(fan_id, 81)
+
+    infos = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+    assert any("succeeded again" in m for m in infos), infos
+
+
+@pytest.mark.asyncio
+async def test_failure_episode_emits_no_warning_lines(tmp_path, monkeypatch, caplog):
+    """Die WARNING-Zeilen verdoppelten die Diagnose, die die ERROR-Zeile schon traegt."""
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(backend, "_monotonic", clock, raising=False)
+
+    # EACCES: hier greift zusaetzlich der sudo-tee-Fallback.
+    def eacces_write(self_, value, *a, **kw):
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(Path, "write_text", eacces_write)
+
+    class _Result:
+        returncode = 1
+        stderr = b"tee: Permission denied"
+
+    monkeypatch.setattr(
+        "app.services.power.fan_backend_linux.subprocess.run",
+        lambda *a, **kw: _Result(),
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="app.services.power.fan_backend_linux"):
+        await backend.set_pwm(fan_id, 80)
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings == [], f"unerwartete WARNING-Zeilen: {warnings}"
+
+
+# --- Rescan: der Backoff darf nicht mit dem Cache verschwinden ---------------
+
+
+@pytest.mark.asyncio
+async def test_backoff_survives_a_rescan(tmp_path, monkeypatch):
+    """_fan_cache wird beim Rescan neu gebaut — der Backoff-Zustand nicht."""
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(backend, "_monotonic", clock, raising=False)
+    writer = _Writer(monkeypatch)
+
+    await backend.set_pwm(fan_id, 80)
+    assert fan_id in backend._write_backoff
+
+    await backend._scan_pwm_fans()
+
+    assert fan_id in backend._write_backoff, "der Rescan darf den Backoff nicht loeschen"
+    before = len(writer.attempts)
+    clock.advance(5.0)
+    await backend.set_pwm(fan_id, 81)
+    assert len(writer.attempts) == before, "das Fenster muss den Rescan ueberdauern"
+
+
+@pytest.mark.asyncio
+async def test_rescan_prunes_backoff_of_vanished_fans(tmp_path, monkeypatch):
+    """Sonst waechst das Dict ueber Treiber-Reloads und Renumbering hinweg (#532).
+
+    Bewusst mit ZWEI Lueftern: verschwindet der einzige, behaelt _scan_pwm_fans()
+    absichtlich den alten Cache ("found 0 fans, keeping cached"). Der Fall, der
+    hier zaehlt, ist der Teilverlust.
+    """
+    d = _hwmon(tmp_path)
+    (d / "pwm2").write_text("140\n")
+    (d / "fan2_input").write_text("900\n")
+    (d / "pwm2_enable").write_text("1\n")
+
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
+    await backend._scan_pwm_fans()
+    assert len(backend._fan_cache) == 2, sorted(backend._fan_cache)
+
+    monkeypatch.setattr(backend, "_monotonic", _Clock(), raising=False)
+    _Writer(monkeypatch)
+
+    for fan_id in list(backend._fan_cache):
+        await backend.set_pwm(fan_id, 80)
+    assert len(backend._write_backoff) == 2
+
+    # Ein Kanal verschwindet (Treiber-Reload, Geraet weg)
+    gone = "hwmon1_pwm2"
+    (d / "pwm2").unlink()
+    await backend._scan_pwm_fans()
+
+    assert gone not in backend._write_backoff, "verwaister Backoff-Eintrag"
+    assert "hwmon1_pwm1" in backend._write_backoff, "der verbliebene Luefter behaelt sein Fenster"


### PR DESCRIPTION
Der Regelkreis schrieb im 5-Sekunden-Takt gegen sysfs-Knoten, die der Treiber strukturell nie annimmt — ohne Backoff, ohne Aufgeben. Gemessen auf BaluNode: 17.378 Logzeilen pro Tag für einen einzigen Lüfter, ~34.500 sudo-Aufrufe, 4 GB Journal.

## Was #480 bereits erledigt hat

Beim Lesen des gemergten Codes (#537) zeigte sich, dass die Hälfte von #533 schon steht:

- `set_pwm()` steigt bei `FIRMWARE_MANAGED` als Erstes aus — der Pfad, der die 17k Zeilen erzeugte, ist tot.
- `_write_hwmon_file()` nutzt bereits `sudo -n`.
- Der `sudo tee`-Fallback läuft nur noch bei EACCES/EPERM; bei EINVAL wird `sudo` gar nicht mehr angefasst.

**Nicht** erledigt war das Netz für alles Übrige: EACCES, EINVAL auf nicht erkannten Karten, künftige Treiber. Ein Lüfter mit `NO_PERMISSION` wird weiterhin jeden Zyklus neu beschrieben, weil `target_pwm != fan.pwm_percent` dauerhaft wahr bleibt. Genau das schließt dieser PR.

## Backoff

Nach einem Fehlschlag sperrt ein Fenster den nächsten Versuch: **10 s**, dann Verdopplung, gedeckelt bei **15 min**. Ein erfolgreicher Write räumt die Episode ab.

Die Basis ist bewusst größer als ein Regelzyklus. Mit den im Issue genannten 5 s wäre das erste Fenster exakt einen Zyklus lang und würde nichts unterdrücken — der erste Test ist genau daran gescheitert.

Der Zustand liegt in einem eigenen Dict, **nicht** in `_fan_cache`: der wird bei jedem `_scan_pwm_fans()` neu gebaut, der Backoff muss das überdauern. Beim Rescan fallen Einträge verschwundener Lüfter weg, damit über Treiber-Reloads und hwmon-Renumbering (#532) hinweg nichts leckt.

## Log-Hygiene — der eigentliche Zweck

Genau **eine ERROR-Zeile pro Fehler-Episode**, mit voller Diagnose und dem nächsten Versuchszeitpunkt. Wiederholungen auf DEBUG, Wiederanlauf als INFO. Vorher war der bekannte Dauerzustand als ERROR geloggt und machte damit jede Fehler-Metrik und jedes Log-Alerting unbrauchbar.

Die beiden WARNING-Zeilen zu `pwm_enable` und `sudo tee` gehen auf DEBUG — sie verdoppelten pro Zyklus, was die ERROR-Zeile ohnehin trägt.

## Wer darf das Fenster umgehen

`set_pwm()` bekommt `force: bool = False`:

| Aufrufer | force | Warum |
|---|---|---|
| `_monitor_and_control_fans()` (5-s-Takt) | nein | genau der Aufrufer, der gedämpft werden soll |
| `set_fan_pwm()` (Nutzer-Klick) | **ja** | wer klickt, verdient einen echten Versuch und eine echte Fehlermeldung statt eines stillen False |
| Notfallpfad (`FanMode.EMERGENCY`) | **ja** | thermische Sicherheit schlägt Log-Hygiene; ein Überhitzungsfall ist kein Dauerzustand |

Der Emergency-Bypass ist eine Abwägung, keine Notwendigkeit: hält der Notfall auf einem toten Knoten an, kommt der 5-s-Takt für diesen einen Lüfter zurück. Umkehrbar in einer Zeile, falls unerwünscht.

## Tests

14 neue Tests in `backend/tests/test_fan_pwm_backoff.py`: Fenster, Verdopplung, 15-min-Deckel, Reset nach Erfolg, `force` in beiden Richtungen, Log-Level pro Episode, Rescan-Überleben und Prune. Zwei bestehende Test-Stubs ziehen die Signatur nach.

Der Prune-Test prüft bewusst **Teilverlust** (einer von zwei Lüftern fällt weg): verschwindet der einzige, behält `_scan_pwm_fans()` absichtlich den alten Cache („found 0 fans, keeping cached").

| Gate | Ergebnis |
|---|---|
| `pytest -k "power or fan"` | 559 passed |
| `ruff check app/services/power/ tests/test_fan_pwm_backoff.py` | All checks passed |

Volle Backend-Suite bleibt der CI überlassen. Frontend unberührt.

## Nicht in diesem Scope

- UI-Ausweisung „nicht steuerbar / Board regelt" → #534
- Erweiterung der Capability-Erkennung → steht durch #480

## Ehrliche Erwartung

Auf BaluNode dürfte der Sofort-Effekt klein sein, weil #480 den bekannten Auslöser bereits entfernt hat. Der Wert liegt darin, dass das Netz überhaupt existiert.

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184tK6o2QwQyBoU1oCHf7We
