### PR TITLE
feat(scripts): Repo-Map — LOC je Verzeichnis und Refactor-Score je Datei

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ scripts/fix_umlauts.py
 
 # Superpowers subagent-driven-development scratch (briefs, reports, diffs)
 .superpowers/
+
+# Repo map report (regenerate with: python scripts/repo_map.py)
+repo-map*.html

--- a/scripts/repo_map.py
+++ b/scripts/repo_map.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Map the BaluHost repo: LOC per directory plus per-file refactor signals.
+
+Counts only files reported by `git ls-files`, so .gitignore is respected by
+definition. No third-party dependencies.
+
+Usage:
+    python scripts/repo_map.py                  # writes repo-map.html
+    python scripts/repo_map.py -o /tmp/map.html # custom output path
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from repo_map_metrics import FileEntry, Thresholds, analyze_file
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass
+class DirNode:
+    """A directory in the map, carrying the totals of everything beneath it."""
+
+    name: str
+    path: str
+    loc: int = 0
+    files: int = 0
+    children: dict[str, DirNode] = field(default_factory=dict)
+    entries: list[FileEntry] = field(default_factory=list)
+
+
+def build_tree(entries: Iterable[FileEntry]) -> DirNode:
+    """Aggregate file entries into a directory tree with rolled-up totals."""
+    root = DirNode(name="", path="")
+    for entry in entries:
+        parts = entry.path.split("/")
+        node = root
+        node.loc += entry.loc
+        node.files += 1
+        for index, part in enumerate(parts[:-1]):
+            child = node.children.get(part)
+            if child is None:
+                child = DirNode(name=part, path="/".join(parts[: index + 1]))
+                node.children[part] = child
+            child.loc += entry.loc
+            child.files += 1
+            node = child
+        node.entries.append(entry)
+    return root
+
+
+@dataclass(frozen=True)
+class Report:
+    """Everything one run produces, ready to be rendered."""
+
+    commit: str
+    generated_at: str
+    thresholds: Thresholds
+    entries: list[FileEntry]
+    tree: DirNode
+
+
+def tracked_files(root: Path) -> list[str]:
+    """List repo files tracked by git. Respects .gitignore by definition."""
+    out = subprocess.check_output(
+        ["git", "ls-files"], cwd=root, text=True, encoding="utf-8"
+    )
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def git_commit(root: Path) -> str:
+    """Short SHA of HEAD, or 'unknown' outside a repository."""
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=root,
+            text=True,
+            encoding="utf-8",
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return "unknown"
+    return out.strip() or "unknown"
+
+
+def _read_text(path: Path) -> str | None:
+    """Decode a file as UTF-8, or None when it is missing or not text."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    return None if "\x00" in text else text
+
+
+def build_report(
+    root: Path,
+    paths: Iterable[str],
+    *,
+    thresholds: Thresholds,
+    commit: str,
+    include_generated: bool = False,
+    generated_at: str | None = None,
+) -> Report:
+    """Analyse every readable path under root and assemble the report.
+
+    Unreadable and binary files are skipped rather than raising: a repo map
+    that dies on one stray blob is useless.
+    """
+    entries: list[FileEntry] = []
+    for rel in paths:
+        text = _read_text(root / rel)
+        if text is None:
+            continue
+        entries.append(
+            analyze_file(
+                rel,
+                text,
+                thresholds=thresholds,
+                include_generated=include_generated,
+            )
+        )
+
+    return Report(
+        commit=commit,
+        generated_at=generated_at or datetime.now().strftime("%Y-%m-%d %H:%M"),
+        thresholds=thresholds,
+        entries=entries,
+        tree=build_tree(entries),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    # Imported here, not at module level: the renderer imports this module back
+    # for its dataclasses, and a top-level import would close that cycle.
+    import repo_map_html
+
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=str(ROOT / "repo-map.html"),
+        help="output path (default: repo-map.html in the repo root)",
+    )
+    parser.add_argument("--max-loc", type=int, default=Thresholds.max_loc)
+    parser.add_argument("--max-fn-loc", type=int, default=Thresholds.max_fn_loc)
+    parser.add_argument("--max-depth", type=int, default=Thresholds.max_depth)
+    parser.add_argument(
+        "--include-generated",
+        action="store_true",
+        help="score generated files like hand-written ones",
+    )
+    args = parser.parse_args(argv)
+
+    thresholds = Thresholds(
+        max_loc=args.max_loc,
+        max_fn_loc=args.max_fn_loc,
+        max_depth=args.max_depth,
+    )
+    report = build_report(
+        ROOT,
+        tracked_files(ROOT),
+        thresholds=thresholds,
+        commit=git_commit(ROOT),
+        include_generated=args.include_generated,
+    )
+
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(repo_map_html.render(report), encoding="utf-8")
+
+    flagged = sum(1 for e in report.entries if e.score > 0)
+    print(
+        f"{len(report.entries)} files, {report.tree.loc:,} lines, "
+        f"{flagged} flagged -> {out}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repo_map_html.py
+++ b/scripts/repo_map_html.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Render a repo_map.Report into one self-contained HTML page.
+
+No CDN, no external stylesheet, no network access at view time: the data is
+embedded as JSON and the page builds itself from it. That keeps the report
+usable offline and makes it safe to open straight from disk.
+"""
+from __future__ import annotations
+
+import json
+
+from repo_map import DirNode, Report
+from repo_map_metrics import FileEntry
+
+# Score at which a file is called out as a split candidate.
+CANDIDATE_SCORE = 1
+
+
+def build_payload(report: Report) -> dict:
+    """Turn a report into the plain-data structure the page renders from.
+
+    Files come out ordered by score, then by size - that ordering IS the work
+    list, so it belongs in the data rather than in the browser.
+    """
+    files = sorted(report.entries, key=lambda e: (-e.score, -e.loc, e.path))
+    return {
+        "commit": report.commit,
+        "generatedAt": report.generated_at,
+        "thresholds": {
+            "max_loc": report.thresholds.max_loc,
+            "max_fn_loc": report.thresholds.max_fn_loc,
+            "max_depth": report.thresholds.max_depth,
+        },
+        "totals": _totals(report.entries),
+        "tree": _tree_payload(report.tree),
+        "files": [_file_payload(entry) for entry in files],
+    }
+
+
+def _totals(entries: list[FileEntry]) -> dict:
+    return {
+        "files": len(entries),
+        "loc": sum(e.loc for e in entries),
+        "code": sum(e.code for e in entries),
+        "comment": sum(e.comment for e in entries),
+        "blank": sum(e.blank for e in entries),
+        "candidates": sum(1 for e in entries if e.score >= CANDIDATE_SCORE),
+    }
+
+
+def _file_payload(entry: FileEntry) -> dict:
+    return {
+        "p": entry.path,
+        "e": entry.ext,
+        "k": entry.kind,
+        "loc": entry.loc,
+        "code": entry.code,
+        "cm": entry.comment,
+        "bl": entry.blank,
+        "sym": entry.symbols,
+        "cls": entry.classes,
+        "fn": entry.functions,
+        "hk": entry.hooks,
+        "ln": entry.longest_name,
+        "ll": entry.longest_loc,
+        "d": entry.max_depth,
+        "est": entry.estimated,
+        "gen": entry.generated,
+        "s": entry.score,
+        "r": list(entry.reasons),
+    }
+
+
+def _tree_payload(node: DirNode) -> dict:
+    children = sorted(node.children.values(), key=lambda c: (-c.loc, c.name))
+    return {
+        "name": node.name,
+        "path": node.path,
+        "loc": node.loc,
+        "files": node.files,
+        "children": [_tree_payload(child) for child in children],
+    }
+
+
+def _embed(payload: dict) -> str:
+    """Serialise the payload so it cannot terminate its own script element.
+
+    Escaping the angle brackets keeps a path like `weird/</script>` from
+    closing the tag early - the browser still parses it as valid JSON.
+    """
+    return (
+        json.dumps(payload, ensure_ascii=False)
+        .replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+    )
+
+
+def render(report: Report) -> str:
+    """Render the full HTML document for a report."""
+    return _TEMPLATE.replace("__PAYLOAD__", _embed(build_payload(report)))
+
+
+_STYLE = """
+:root {
+  color-scheme: dark;
+  --bg: #14161a; --panel: #1c1f26; --line: #2c313b;
+  --fg: #e6e8ec; --muted: #8d95a5; --accent: #6fa8ff;
+  --warn: #f0b429; --hot: #f2686b; --ok: #4fbf7f;
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--fg);
+  font: 14px/1.5 "Segoe UI", system-ui, sans-serif; }
+header { padding: 24px 28px 16px; border-bottom: 1px solid var(--line); }
+h1 { margin: 0 0 4px; font-size: 20px; font-weight: 600; }
+h2 { margin: 0 0 12px; font-size: 15px; font-weight: 600; color: var(--muted);
+  text-transform: uppercase; letter-spacing: .06em; }
+.meta { color: var(--muted); font-size: 12px; }
+.cards { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 16px; }
+.card { background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
+  padding: 10px 14px; min-width: 120px; }
+.card b { display: block; font-size: 19px; font-weight: 600; }
+.card span { color: var(--muted); font-size: 11px; text-transform: uppercase;
+  letter-spacing: .05em; }
+main { padding: 20px 28px 60px; display: grid; gap: 28px; }
+section { min-width: 0; }
+.tree { font-family: Consolas, "Cascadia Mono", monospace; font-size: 13px; }
+.tree details { margin-left: 14px; }
+.tree > details { margin-left: 0; }
+.tree summary { cursor: pointer; padding: 1px 0; list-style: none;
+  display: grid; grid-template-columns: 1fr 90px 70px 160px; gap: 8px;
+  align-items: center; }
+.tree summary::-webkit-details-marker { display: none; }
+.tree summary:hover { background: var(--panel); }
+.tree .nm::before { content: "\\25B8 "; color: var(--muted); }
+.tree details[open] > summary .nm::before { content: "\\25BE "; }
+.tree .num { text-align: right; color: var(--muted); }
+.bar { height: 7px; background: var(--line); border-radius: 4px; overflow: hidden; }
+.bar > i { display: block; height: 100%; background: var(--accent); }
+.leaf { display: grid; grid-template-columns: 1fr 90px 70px 160px; gap: 8px;
+  margin-left: 28px; padding: 1px 0; }
+.leaf .nm { color: var(--fg); opacity: .8; }
+table { width: 100%; border-collapse: collapse; font-size: 13px; }
+th, td { text-align: left; padding: 5px 8px; border-bottom: 1px solid var(--line);
+  white-space: nowrap; }
+th { position: sticky; top: 0; background: var(--bg); cursor: pointer;
+  color: var(--muted); font-weight: 600; user-select: none; }
+th.num, td.num { text-align: right; }
+th:hover { color: var(--fg); }
+td.path { font-family: Consolas, "Cascadia Mono", monospace; white-space: nowrap;
+  max-width: 520px; overflow: hidden; text-overflow: ellipsis; }
+td.why { white-space: normal; color: var(--muted); font-size: 12px;
+  min-width: 260px; }
+.wrap { overflow-x: auto; max-height: 70vh; overflow-y: auto;
+  border: 1px solid var(--line); border-radius: 8px; }
+.pill { display: inline-block; padding: 0 6px; border-radius: 10px;
+  font-size: 11px; font-weight: 600; }
+.s-hot { background: rgba(242,104,107,.18); color: var(--hot); }
+.s-warn { background: rgba(240,180,41,.18); color: var(--warn); }
+.s-ok { background: rgba(79,191,127,.15); color: var(--ok); }
+.tag { color: var(--muted); font-size: 11px; margin-left: 6px; }
+.filters { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 10px; }
+input, select { background: var(--panel); border: 1px solid var(--line);
+  color: var(--fg); border-radius: 6px; padding: 5px 9px; font: inherit; }
+input:focus, select:focus { outline: 1px solid var(--accent); }
+label.chk { display: flex; align-items: center; gap: 6px; color: var(--muted); }
+"""
+
+_SCRIPT = """
+const DATA = JSON.parse(document.getElementById("repo-map-data").textContent);
+const nf = new Intl.NumberFormat("de-DE");
+const el = (t, cls, txt) => {
+  const n = document.createElement(t);
+  if (cls) n.className = cls;
+  if (txt !== undefined) n.textContent = txt;
+  return n;
+};
+const scoreClass = (s) => (s >= 60 ? "s-hot" : s >= 25 ? "s-warn" : "s-ok");
+
+function head() {
+  const t = DATA.totals, th = DATA.thresholds;
+  document.getElementById("meta").textContent =
+    `commit ${DATA.commit} \\u00b7 ${DATA.generatedAt} \\u00b7 limits: ` +
+    `${th.max_loc} LOC / ${th.max_fn_loc} LOC per function / depth ${th.max_depth}`;
+  const cards = [
+    ["Files", nf.format(t.files)], ["Lines", nf.format(t.loc)],
+    ["Code", nf.format(t.code)], ["Comments", nf.format(t.comment)],
+    ["Blank", nf.format(t.blank)], ["Flagged", nf.format(t.candidates)],
+  ];
+  const box = document.getElementById("cards");
+  for (const [label, value] of cards) {
+    const c = el("div", "card");
+    c.append(el("b", null, value), el("span", null, label));
+    box.append(c);
+  }
+}
+
+function treeRow(name, loc, files, share, isLeaf) {
+  const frag = document.createDocumentFragment();
+  frag.append(el("span", "nm", name));
+  frag.append(el("span", "num", nf.format(loc)));
+  frag.append(el("span", "num", files === null ? "" : nf.format(files)));
+  const bar = el("div", "bar");
+  const fill = el("i");
+  fill.style.width = Math.max(1, Math.round(share * 100)) + "%";
+  if (isLeaf) fill.style.background = "var(--muted)";
+  bar.append(fill);
+  frag.append(bar);
+  return frag;
+}
+
+function renderTree(node, parent, total, depth) {
+  const build = (n, host, lvl) => {
+    const d = el("details");
+    if (lvl < 1) d.open = true;
+    const s = el("summary");
+    s.append(treeRow(n.name || "/", n.loc, n.files, total ? n.loc / total : 0, false));
+    d.append(s);
+    for (const child of n.children) build(child, d, lvl + 1);
+    const own = DATA.files.filter((f) => {
+      const cut = f.p.lastIndexOf("/");
+      return (cut === -1 ? "" : f.p.slice(0, cut)) === n.path;
+    }).sort((a, b) => b.loc - a.loc);
+    for (const f of own) {
+      const row = el("div", "leaf");
+      row.append(treeRow(f.p.split("/").pop(), f.loc, null,
+        total ? f.loc / total : 0, true));
+      d.append(row);
+    }
+    host.append(d);
+  };
+  build(node, parent, depth);
+}
+
+const COLUMNS = [
+  { key: "p", label: "File", cls: "path" },
+  { key: "s", label: "Score", num: true },
+  { key: "loc", label: "LOC", num: true },
+  { key: "code", label: "Code", num: true },
+  { key: "sym", label: "Symbols", num: true },
+  { key: "ll", label: "Longest", num: true },
+  { key: "d", label: "Depth", num: true },
+  { key: "r", label: "Why", cls: "why" },
+];
+let sortKey = "s", sortDir = -1;
+
+function cell(f, col) {
+  if (col.key === "p") {
+    const td = el("td", "path");
+    td.append(document.createTextNode(f.p));
+    if (f.est) td.append(el("span", "tag", "est."));
+    if (f.gen) td.append(el("span", "tag", "generated"));
+    return td;
+  }
+  if (col.key === "s") {
+    const td = el("td", "num");
+    td.append(el("span", "pill " + scoreClass(f.s), String(f.s)));
+    return td;
+  }
+  if (col.key === "r") {
+    const parts = f.r.slice();
+    if (f.ln && f.ll) parts.push(`longest: ${f.ln}`);
+    return el("td", "why", parts.join(" \\u00b7 "));
+  }
+  return el("td", "num", nf.format(f[col.key] || 0));
+}
+
+function renderTable() {
+  const q = document.getElementById("q").value.trim().toLowerCase();
+  const ext = document.getElementById("ext").value;
+  const onlyFlagged = document.getElementById("flagged").checked;
+  const hideGen = document.getElementById("hidegen").checked;
+
+  const rows = DATA.files.filter((f) =>
+    (!q || f.p.toLowerCase().includes(q)) &&
+    (!ext || f.e === ext) &&
+    (!onlyFlagged || f.s > 0) &&
+    (!hideGen || !f.gen)
+  ).sort((a, b) => {
+    const x = a[sortKey], y = b[sortKey];
+    if (typeof x === "string") return x.localeCompare(y) * sortDir;
+    return ((x || 0) - (y || 0)) * sortDir;
+  });
+
+  const body = document.getElementById("rows");
+  body.textContent = "";
+  document.getElementById("count").textContent =
+    `${nf.format(rows.length)} of ${nf.format(DATA.files.length)} files`;
+  const frag = document.createDocumentFragment();
+  for (const f of rows) {
+    const tr = el("tr");
+    for (const col of COLUMNS) tr.append(cell(f, col));
+    frag.append(tr);
+  }
+  body.append(frag);
+}
+
+function buildTable() {
+  const tr = document.getElementById("headrow");
+  for (const col of COLUMNS) {
+    const th = el("th", col.num ? "num" : null, col.label);
+    th.onclick = () => {
+      sortDir = sortKey === col.key ? -sortDir : (col.key === "p" ? 1 : -1);
+      sortKey = col.key;
+      renderTable();
+    };
+    tr.append(th);
+  }
+  const exts = [...new Set(DATA.files.map((f) => f.e))].sort();
+  const sel = document.getElementById("ext");
+  for (const e of exts) sel.append(new Option(e || "(none)", e));
+  for (const id of ["q", "ext", "flagged", "hidegen"]) {
+    document.getElementById(id).addEventListener("input", renderTable);
+  }
+  renderTable();
+}
+
+head();
+renderTree(DATA.tree, document.getElementById("tree"), DATA.totals.loc, 0);
+buildTable();
+"""
+
+_TEMPLATE = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BaluHost Repo Map</title>
+<style>{_STYLE}</style>
+</head>
+<body>
+<header>
+  <h1>BaluHost Repo Map</h1>
+  <div class="meta" id="meta"></div>
+  <div class="cards" id="cards"></div>
+</header>
+<main>
+  <section>
+    <h2>Directories</h2>
+    <div class="tree" id="tree"></div>
+  </section>
+  <section>
+    <h2>Files &mdash; sorted by refactor score</h2>
+    <div class="filters">
+      <input id="q" type="search" placeholder="filter by path…" size="34">
+      <select id="ext"><option value="">all extensions</option></select>
+      <label class="chk"><input id="flagged" type="checkbox"> only flagged</label>
+      <label class="chk"><input id="hidegen" type="checkbox"> hide generated</label>
+      <span class="meta" id="count"></span>
+    </div>
+    <div class="wrap">
+      <table>
+        <thead><tr id="headrow"></tr></thead>
+        <tbody id="rows"></tbody>
+      </table>
+    </div>
+  </section>
+</main>
+<script type="application/json" id="repo-map-data">__PAYLOAD__</script>
+<script>{_SCRIPT}</script>
+</body>
+</html>
+"""

--- a/scripts/repo_map_metrics.py
+++ b/scripts/repo_map_metrics.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Per-file metrics for the repo map: line counts, structure signals, score.
+
+Split out from repo_map.py so neither module outgrows the 500-line convention
+this tool exists to police.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from pathlib import PurePosixPath
+
+
+# Line-comment prefixes per file extension. Extensions absent from this map get
+# no comment detection at all - every non-blank line counts as code.
+LINE_COMMENT_PREFIXES: dict[str, tuple[str, ...]] = {
+    ".py": ("#",),
+    ".sh": ("#",),
+    ".yml": ("#",),
+    ".yaml": ("#",),
+    ".conf": ("#",),
+    ".ps1": ("#",),
+    ".toml": ("#",),
+    ".ts": ("//",),
+    ".tsx": ("//",),
+    ".js": ("//",),
+    ".jsx": ("//",),
+    ".css": ("//",),
+    ".rs": ("//",),
+    ".sql": ("--",),
+}
+
+# Extensions using C-style /* ... */ block comments.
+BLOCK_COMMENT_EXTS = frozenset({".ts", ".tsx", ".js", ".jsx", ".css", ".rs"})
+
+
+@dataclass(frozen=True)
+class LineCounts:
+    total: int
+    blank: int
+    comment: int
+    code: int
+
+
+def count_lines(text: str, ext: str) -> LineCounts:
+    """Split text into blank, comment-only and code lines.
+
+    A line counts as a comment only when the comment marker starts the line;
+    trailing comments stay code, because the line still carries logic.
+    """
+    if not text:
+        return LineCounts(total=0, blank=0, comment=0, code=0)
+
+    prefixes = LINE_COMMENT_PREFIXES.get(ext, ())
+    has_blocks = ext in BLOCK_COMMENT_EXTS
+    lines = text.splitlines()
+
+    blank = comment = code = 0
+    in_block = False
+    for raw in lines:
+        stripped = raw.strip()
+        if in_block:
+            comment += 1
+            if "*/" in stripped:
+                in_block = False
+                # Code trailing the block close makes the line count as code.
+                if stripped.split("*/", 1)[1].strip():
+                    comment -= 1
+                    code += 1
+            continue
+        if not stripped:
+            blank += 1
+        elif has_blocks and stripped.startswith("/*"):
+            if "*/" in stripped:
+                if stripped.split("*/", 1)[1].strip():
+                    code += 1
+                else:
+                    comment += 1
+            else:
+                comment += 1
+                in_block = True
+        elif prefixes and stripped.startswith(prefixes):
+            comment += 1
+        else:
+            code += 1
+
+    return LineCounts(total=len(lines), blank=blank, comment=comment, code=code)
+
+
+# AST nodes that open an indented block. Nesting these is what makes a function
+# hard to follow, so they define the depth metric.
+_BLOCK_NODES: tuple[type[ast.AST], ...] = (
+    ast.FunctionDef,
+    ast.AsyncFunctionDef,
+    ast.ClassDef,
+    ast.If,
+    ast.For,
+    ast.AsyncFor,
+    ast.While,
+    ast.With,
+    ast.AsyncWith,
+    ast.Try,
+    ast.ExceptHandler,
+    ast.Match,
+    ast.match_case,
+)
+
+_FUNCTION_NODES = (ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+@dataclass(frozen=True)
+class PythonMetrics:
+    classes: int
+    functions: int
+    longest_fn: str | None
+    longest_fn_loc: int
+    max_depth: int
+
+
+def analyze_python(text: str) -> PythonMetrics | None:
+    """Extract structure metrics from Python source, or None if it won't parse.
+
+    Functions include methods and nested definitions - a 900-line module built
+    from many small helpers reads very differently from one built from three
+    monsters, and only the per-function span tells them apart.
+    """
+    try:
+        tree = ast.parse(text)
+    except (SyntaxError, ValueError):
+        return None
+
+    classes = functions = 0
+    longest_fn: str | None = None
+    longest_fn_loc = 0
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            classes += 1
+        elif isinstance(node, _FUNCTION_NODES):
+            functions += 1
+            span = (node.end_lineno or node.lineno) - node.lineno + 1
+            if span > longest_fn_loc:
+                longest_fn_loc = span
+                longest_fn = node.name
+
+    return PythonMetrics(
+        classes=classes,
+        functions=functions,
+        longest_fn=longest_fn,
+        longest_fn_loc=longest_fn_loc,
+        max_depth=_max_block_depth(tree, 0),
+    )
+
+
+def _max_block_depth(node: ast.AST, depth: int) -> int:
+    """Deepest chain of nested block statements below node. Module level is 0."""
+    deepest = depth
+    for child in ast.iter_child_nodes(node):
+        child_depth = depth + 1 if isinstance(child, _BLOCK_NODES) else depth
+        deepest = max(deepest, _max_block_depth(child, child_depth))
+    return deepest
+
+
+# A top-level declaration that may open a block: `function x`, `const X = () => {`,
+# `class X {`, each optionally exported. Anchored at column 0 on purpose - indented
+# matches are members, not the outer block we want to measure.
+_TS_DECL_RE = re.compile(
+    r"^(?:export\s+)?(?:default\s+)?(?:async\s+)?"
+    r"(?:function|const|let|var|class)\s+(\w+)"
+)
+_TS_HOOK_RE = re.compile(r"\buse[A-Z]\w*\s*\(")
+
+
+@dataclass(frozen=True)
+class TypescriptMetrics:
+    exports: int
+    hooks: int
+    longest_block: str | None
+    longest_block_loc: int
+
+
+def analyze_typescript(text: str) -> TypescriptMetrics:
+    """Estimate structure metrics for TS/TSX by counting braces.
+
+    This is deliberately not a parser. Braces inside string literals, template
+    literals, regexes or comments are counted like real ones, so block spans are
+    an estimate - the report labels them as such. It is accurate enough to rank
+    a 1400-line page component against a 90-line hook, which is all it is for.
+    """
+    exports = hooks = 0
+    longest_block: str | None = None
+    longest_block_loc = 0
+
+    depth = 0
+    open_line = 0
+    open_name: str | None = None
+
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.strip()
+        if stripped.startswith("export "):
+            exports += 1
+        hooks += len(_TS_HOOK_RE.findall(raw))
+
+        delta = raw.count("{") - raw.count("}")
+        if depth == 0 and delta > 0:
+            match = _TS_DECL_RE.match(raw)
+            if match:
+                open_name = match.group(1)
+                open_line = lineno
+            else:
+                open_name = None
+        depth += delta
+        if depth <= 0:
+            if open_name is not None:
+                span = lineno - open_line + 1
+                if span > longest_block_loc:
+                    longest_block_loc = span
+                    longest_block = open_name
+                open_name = None
+            depth = 0
+
+    return TypescriptMetrics(
+        exports=exports,
+        hooks=hooks,
+        longest_block=longest_block,
+        longest_block_loc=longest_block_loc,
+    )
+
+
+# Machine-written files. They are still mapped and still counted in the LOC
+# totals, but their score is damped so migrations and locale bundles cannot
+# crowd the split-candidate list. Kept visible here rather than hidden inside
+# the scoring maths - see --include-generated to switch the damping off.
+GENERATED_PATTERNS: tuple[str, ...] = (
+    "backend/alembic/versions/*",
+    "client/src/i18n/locales/*",
+    "*package-lock.json",
+    "*.lock",
+    "*.min.js",
+    "*.min.css",
+)
+GENERATED_DAMPING = 0.1
+
+# Weights: how many score points each signal contributes at most.
+SIZE_WEIGHT = 50
+FUNCTION_WEIGHT = 30
+DEPTH_WEIGHT = 20
+DEPTH_POINTS_PER_LEVEL = 10
+
+
+@dataclass(frozen=True)
+class Thresholds:
+    max_loc: int = 500
+    max_fn_loc: int = 80
+    max_depth: int = 5
+
+
+@dataclass(frozen=True)
+class ScoreResult:
+    score: int
+    reasons: tuple[str, ...]
+
+
+def is_generated(path: str) -> bool:
+    """True when a repo-relative path matches a known machine-written pattern."""
+    return any(fnmatch(path, pattern) for pattern in GENERATED_PATTERNS)
+
+
+def compute_score(
+    *,
+    loc: int,
+    longest_fn_loc: int,
+    max_depth: int,
+    generated: bool,
+    thresholds: Thresholds,
+) -> ScoreResult:
+    """Rank a file's need for a split on a 0-100 scale, with its reasons.
+
+    Each signal only contributes once it passes its threshold, and every
+    contribution is spelled out in reasons - a bare number would be a verdict
+    nobody can check.
+    """
+    points = 0
+    reasons: list[str] = []
+
+    size = _overshoot_points(loc, thresholds.max_loc, SIZE_WEIGHT)
+    if size:
+        points += size
+        reasons.append(f"{loc} LOC (limit {thresholds.max_loc})")
+
+    fn = _overshoot_points(longest_fn_loc, thresholds.max_fn_loc, FUNCTION_WEIGHT)
+    if fn:
+        points += fn
+        reasons.append(
+            f"longest function {longest_fn_loc} LOC (limit {thresholds.max_fn_loc})"
+        )
+
+    if max_depth > thresholds.max_depth:
+        levels = max_depth - thresholds.max_depth
+        points += min(DEPTH_WEIGHT, levels * DEPTH_POINTS_PER_LEVEL)
+        reasons.append(f"nesting depth {max_depth} (limit {thresholds.max_depth})")
+
+    score = min(100, points)
+    if generated and score:
+        score = round(score * GENERATED_DAMPING)
+        reasons.append("generated - score damped")
+
+    return ScoreResult(score=score, reasons=tuple(reasons))
+
+
+def _overshoot_points(value: int, limit: int, weight: int) -> int:
+    """Award the full weight at twice the limit, nothing at or below it."""
+    if limit <= 0 or value <= limit:
+        return 0
+    return min(weight, round(weight * (value / limit - 1)))
+
+
+TYPESCRIPT_EXTS = frozenset({".ts", ".tsx", ".js", ".jsx"})
+
+
+@dataclass(frozen=True)
+class FileEntry:
+    """One tracked file with its line counts, structure metrics and score."""
+
+    path: str
+    ext: str
+    kind: str
+    loc: int
+    blank: int
+    comment: int
+    code: int
+    symbols: int
+    classes: int
+    functions: int
+    hooks: int
+    longest_name: str | None
+    longest_loc: int
+    max_depth: int
+    estimated: bool
+    generated: bool
+    score: int
+    reasons: tuple[str, ...]
+
+
+def analyze_file(
+    path: str,
+    text: str,
+    *,
+    thresholds: Thresholds,
+    include_generated: bool = False,
+) -> FileEntry:
+    """Build the full record for one repo-relative path and its content.
+
+    Python that fails to parse degrades to kind "other" rather than raising:
+    a file we cannot read structurally still belongs on the LOC map.
+    """
+    path = path.replace("\\", "/")
+    ext = PurePosixPath(path).suffix
+    lines = count_lines(text, ext)
+    generated = is_generated(path)
+
+    kind = "other"
+    symbols = classes = functions = hooks = 0
+    longest_name: str | None = None
+    longest_loc = max_depth = 0
+    estimated = False
+
+    if ext == ".py":
+        py = analyze_python(text)
+        if py is not None:
+            kind = "python"
+            classes, functions = py.classes, py.functions
+            symbols = py.classes + py.functions
+            longest_name, longest_loc = py.longest_fn, py.longest_fn_loc
+            max_depth = py.max_depth
+    elif ext in TYPESCRIPT_EXTS:
+        ts = analyze_typescript(text)
+        kind = "typescript"
+        estimated = True
+        symbols = ts.exports
+        hooks = ts.hooks
+        longest_name, longest_loc = ts.longest_block, ts.longest_block_loc
+
+    result = compute_score(
+        loc=lines.total,
+        longest_fn_loc=longest_loc,
+        max_depth=max_depth,
+        generated=generated and not include_generated,
+        thresholds=thresholds,
+    )
+
+    return FileEntry(
+        path=path,
+        ext=ext,
+        kind=kind,
+        loc=lines.total,
+        blank=lines.blank,
+        comment=lines.comment,
+        code=lines.code,
+        symbols=symbols,
+        classes=classes,
+        functions=functions,
+        hooks=hooks,
+        longest_name=longest_name,
+        longest_loc=longest_loc,
+        max_depth=max_depth,
+        estimated=estimated,
+        generated=generated,
+        score=result.score,
+        reasons=result.reasons,
+    )
+

--- a/scripts/test_repo_map.py
+++ b/scripts/test_repo_map.py
@@ -1,0 +1,418 @@
+"""Tests for scripts/repo_map.py and scripts/repo_map_html.py."""
+from __future__ import annotations
+
+import repo_map
+import repo_map_html
+import repo_map_metrics as metrics
+
+
+class TestCountLines:
+    def test_counts_every_line(self):
+        counts = metrics.count_lines("a = 1\nb = 2\n", ".py")
+        assert counts.total == 2
+
+    def test_counts_final_line_without_trailing_newline(self):
+        counts = metrics.count_lines("a = 1\nb = 2", ".py")
+        assert counts.total == 2
+
+    def test_empty_text_has_no_lines(self):
+        counts = metrics.count_lines("", ".py")
+        assert counts.total == 0
+        assert counts.code == 0
+
+    def test_separates_blank_comment_and_code_in_python(self):
+        text = "# header\n\nvalue = 1\n"
+        counts = metrics.count_lines(text, ".py")
+        assert (counts.total, counts.blank, counts.comment, counts.code) == (3, 1, 1, 1)
+
+    def test_trailing_comment_is_code_not_comment(self):
+        counts = metrics.count_lines("value = 1  # why\n", ".py")
+        assert counts.comment == 0
+        assert counts.code == 1
+
+    def test_counts_typescript_line_comments(self):
+        counts = metrics.count_lines("// note\nconst a = 1;\n", ".ts")
+        assert (counts.comment, counts.code) == (1, 1)
+
+    def test_counts_typescript_block_comments(self):
+        text = "/*\n * doc\n */\nconst a = 1;\n"
+        counts = metrics.count_lines(text, ".tsx")
+        assert (counts.comment, counts.code) == (3, 1)
+
+    def test_code_after_block_comment_close_counts_as_code(self):
+        counts = metrics.count_lines("/* doc */ const a = 1;\n", ".ts")
+        assert counts.code == 1
+
+    def test_unknown_extension_counts_no_comments(self):
+        counts = metrics.count_lines("# not a comment here\n", ".bin")
+        assert (counts.comment, counts.code) == (0, 1)
+
+
+class TestAnalyzePython:
+    def test_counts_top_level_classes_and_functions(self):
+        m = metrics.analyze_python("class A:\n    pass\n\n\ndef f():\n    pass\n")
+        assert (m.classes, m.functions) == (1, 1)
+
+    def test_counts_methods_as_functions(self):
+        text = (
+            "class A:\n"
+            "    def one(self):\n"
+            "        pass\n"
+            "\n"
+            "    def two(self):\n"
+            "        pass\n"
+        )
+        m = metrics.analyze_python(text)
+        assert (m.classes, m.functions) == (1, 2)
+
+    def test_counts_async_functions(self):
+        m = metrics.analyze_python("async def f():\n    pass\n")
+        assert m.functions == 1
+
+    def test_reports_longest_function_name_and_span(self):
+        text = "def small():\n    pass\n\n\ndef big():\n    a = 1\n    b = 2\n    c = 3\n"
+        m = metrics.analyze_python(text)
+        assert m.longest_fn == "big"
+        assert m.longest_fn_loc == 4
+
+    def test_module_without_functions_has_no_longest(self):
+        m = metrics.analyze_python("VALUE = 1\n")
+        assert m.longest_fn is None
+        assert m.longest_fn_loc == 0
+
+    def test_top_level_function_body_is_depth_one(self):
+        m = metrics.analyze_python("def f():\n    return 1\n")
+        assert m.max_depth == 1
+
+    def test_nested_blocks_increase_depth(self):
+        text = "def f():\n    if x:\n        for i in y:\n            pass\n"
+        m = metrics.analyze_python(text)
+        assert m.max_depth == 3
+
+    def test_flat_module_has_depth_zero(self):
+        m = metrics.analyze_python("A = 1\nB = 2\n")
+        assert m.max_depth == 0
+
+    def test_unparseable_source_returns_none(self):
+        assert metrics.analyze_python("def (:\n") is None
+
+
+class TestAnalyzeTypescript:
+    def test_counts_export_statements(self):
+        text = "const a = 1;\nexport const b = 2;\nexport default function C() {}\n"
+        m = metrics.analyze_typescript(text)
+        assert m.exports == 2
+
+    def test_counts_react_hook_call_sites(self):
+        text = "const [a, b] = useState(0);\nuseEffect(() => {}, []);\nuser.name;\n"
+        m = metrics.analyze_typescript(text)
+        assert m.hooks == 2
+
+    def test_measures_top_level_block_span_by_brace_balance(self):
+        text = "function big() {\n  const a = 1;\n  const b = 2;\n}\n"
+        m = metrics.analyze_typescript(text)
+        assert m.longest_block == "big"
+        assert m.longest_block_loc == 4
+
+    def test_nested_braces_do_not_close_the_block_early(self):
+        text = (
+            "export function outer() {\n"
+            "  if (x) {\n"
+            "    run();\n"
+            "  }\n"
+            "  return 1;\n"
+            "}\n"
+        )
+        m = metrics.analyze_typescript(text)
+        assert m.longest_block_loc == 6
+
+    def test_picks_the_largest_of_several_blocks(self):
+        text = (
+            "function small() {\n"
+            "  return 1;\n"
+            "}\n"
+            "const Big = () => {\n"
+            "  const a = 1;\n"
+            "  const b = 2;\n"
+            "  return a + b;\n"
+            "};\n"
+        )
+        m = metrics.analyze_typescript(text)
+        assert m.longest_block == "Big"
+        assert m.longest_block_loc == 5
+
+    def test_module_without_blocks_reports_nothing(self):
+        m = metrics.analyze_typescript("export const A = 1;\n")
+        assert m.longest_block is None
+        assert m.longest_block_loc == 0
+
+
+class TestIsGenerated:
+    def test_alembic_revisions_are_generated(self):
+        assert metrics.is_generated("backend/alembic/versions/a1b2c3_add_fan.py")
+
+    def test_i18n_locale_bundles_are_generated(self):
+        assert metrics.is_generated("client/src/i18n/locales/de/common.json")
+
+    def test_lockfiles_are_generated(self):
+        assert metrics.is_generated("client/package-lock.json")
+
+    def test_hand_written_service_is_not_generated(self):
+        assert not metrics.is_generated("backend/app/services/power/manager.py")
+
+
+class TestComputeScore:
+    def score(self, **kwargs):
+        params = {"loc": 0, "longest_fn_loc": 0, "max_depth": 0, "generated": False}
+        params.update(kwargs)
+        return metrics.compute_score(thresholds=metrics.Thresholds(), **params)
+
+    def test_file_below_every_threshold_scores_zero(self):
+        result = self.score(loc=200, longest_fn_loc=40, max_depth=3)
+        assert result.score == 0
+        assert result.reasons == ()
+
+    def test_double_the_line_limit_costs_the_full_size_budget(self):
+        assert self.score(loc=1000).score == 50
+
+    def test_size_points_are_capped(self):
+        assert self.score(loc=50_000).score == 50
+
+    def test_long_function_adds_points(self):
+        assert self.score(loc=100, longest_fn_loc=160).score == 30
+
+    def test_deep_nesting_adds_points(self):
+        assert self.score(loc=100, max_depth=7).score == 20
+
+    def test_score_never_exceeds_one_hundred(self):
+        assert self.score(loc=50_000, longest_fn_loc=5_000, max_depth=20).score == 100
+
+    def test_generated_files_are_damped(self):
+        assert self.score(loc=1000, generated=True).score == 5
+
+    def test_reasons_name_each_exceeded_metric(self):
+        result = self.score(loc=1000, longest_fn_loc=160, max_depth=7)
+        joined = " | ".join(result.reasons)
+        assert "1000 LOC" in joined
+        assert "longest function 160" in joined
+        assert "nesting depth 7" in joined
+
+    def test_generated_file_below_thresholds_gets_no_damping_note(self):
+        result = self.score(loc=100, generated=True)
+        assert result.score == 0
+        assert result.reasons == ()
+
+    def test_thresholds_are_configurable(self):
+        result = metrics.compute_score(
+            loc=1000,
+            longest_fn_loc=0,
+            max_depth=0,
+            generated=False,
+            thresholds=metrics.Thresholds(max_loc=1000),
+        )
+        assert result.score == 0
+
+
+def make_entry(path: str, text: str, **kwargs):
+    kwargs.setdefault("thresholds", metrics.Thresholds())
+    return metrics.analyze_file(path, text, **kwargs)
+
+
+class TestAnalyzeFile:
+    def test_python_file_carries_ast_metrics(self):
+        entry = make_entry("backend/app/x.py", "def f():\n    if a:\n        pass\n")
+        assert entry.kind == "python"
+        assert entry.functions == 1
+        assert entry.max_depth == 2
+        assert entry.estimated is False
+
+    def test_typescript_metrics_are_flagged_as_estimated(self):
+        entry = make_entry("client/src/X.tsx", "export function A() {\n  return 1;\n}\n")
+        assert entry.kind == "typescript"
+        assert entry.symbols == 1
+        assert entry.estimated is True
+
+    def test_other_extensions_get_line_counts_only(self):
+        entry = make_entry("docs/guide.md", "# Title\n\ntext\n")
+        assert entry.kind == "other"
+        assert entry.loc == 3
+        assert entry.symbols == 0
+        assert entry.longest_loc == 0
+
+    def test_unparseable_python_falls_back_to_line_counts(self):
+        entry = make_entry("backend/broken.py", "def (:\n" + "x\n" * 700)
+        assert entry.kind == "other"
+        assert entry.loc == 701
+
+    def test_generated_python_is_damped_by_default(self):
+        text = "x = 1\n" * 1000
+        assert make_entry("backend/alembic/versions/a1.py", text).score == 5
+
+    def test_include_generated_disables_the_damping(self):
+        text = "x = 1\n" * 1000
+        entry = make_entry(
+            "backend/alembic/versions/a1.py", text, include_generated=True
+        )
+        assert entry.score == 50
+
+    def test_windows_separators_are_normalised(self):
+        entry = make_entry("backend\\app\\x.py", "a = 1\n")
+        assert entry.path == "backend/app/x.py"
+
+
+class TestBuildTree:
+    def entries(self):
+        return [
+            make_entry("a/b/deep.py", "x = 1\n" * 10),
+            make_entry("a/shallow.py", "x = 1\n" * 5),
+            make_entry("root.md", "text\n" * 2),
+        ]
+
+    def test_root_totals_cover_every_file(self):
+        tree = repo_map.build_tree(self.entries())
+        assert (tree.loc, tree.files) == (17, 3)
+
+    def test_directory_totals_include_nested_directories(self):
+        tree = repo_map.build_tree(self.entries())
+        assert tree.children["a"].loc == 15
+        assert tree.children["a"].files == 2
+
+    def test_leaf_directory_holds_only_its_own_files(self):
+        tree = repo_map.build_tree(self.entries())
+        assert tree.children["a"].children["b"].loc == 10
+        assert tree.children["a"].children["b"].files == 1
+
+    def test_directory_knows_its_repo_relative_path(self):
+        tree = repo_map.build_tree(self.entries())
+        assert tree.children["a"].children["b"].path == "a/b"
+
+    def test_empty_input_yields_an_empty_root(self):
+        tree = repo_map.build_tree([])
+        assert (tree.loc, tree.files, tree.children) == (0, 0, {})
+
+
+def make_report(entries=None, commit="abc1234"):
+    entries = list(entries or [])
+    return repo_map.Report(
+        commit=commit,
+        generated_at="2026-09-05T10:00:00",
+        thresholds=metrics.Thresholds(),
+        entries=entries,
+        tree=repo_map.build_tree(entries),
+    )
+
+
+class TestBuildPayload:
+    def test_files_are_ordered_by_score_descending(self):
+        entries = [
+            make_entry("small.py", "x = 1\n"),
+            make_entry("huge.py", "x = 1\n" * 2000),
+            make_entry("medium.py", "x = 1\n" * 700),
+        ]
+        payload = repo_map_html.build_payload(make_report(entries))
+        assert [f["p"] for f in payload["files"]] == ["huge.py", "medium.py", "small.py"]
+
+    def test_equal_scores_fall_back_to_size(self):
+        entries = [
+            make_entry("tiny.py", "x = 1\n" * 10),
+            make_entry("bigger.py", "x = 1\n" * 200),
+        ]
+        payload = repo_map_html.build_payload(make_report(entries))
+        assert [f["p"] for f in payload["files"]] == ["bigger.py", "tiny.py"]
+
+    def test_totals_sum_every_file(self):
+        entries = [make_entry("a.py", "x = 1\n" * 3), make_entry("b.md", "t\n" * 4)]
+        payload = repo_map_html.build_payload(make_report(entries))
+        assert payload["totals"]["files"] == 2
+        assert payload["totals"]["loc"] == 7
+
+    def test_tree_is_nested_by_directory(self):
+        entries = [make_entry("a/b/x.py", "x = 1\n" * 6)]
+        payload = repo_map_html.build_payload(make_report(entries))
+        assert payload["tree"]["children"][0]["name"] == "a"
+        assert payload["tree"]["children"][0]["children"][0]["loc"] == 6
+
+    def test_commit_and_thresholds_travel_with_the_payload(self):
+        payload = repo_map_html.build_payload(make_report(commit="deadbee"))
+        assert payload["commit"] == "deadbee"
+        assert payload["thresholds"]["max_loc"] == 500
+
+
+class TestRender:
+    def test_report_makes_no_external_requests(self):
+        html = repo_map_html.render(make_report([make_entry("a.py", "x = 1\n")]))
+        assert "http://" not in html
+        assert "https://" not in html
+        assert "<script src=" not in html
+        assert "<link rel=\"stylesheet\"" not in html
+
+    def test_script_terminator_in_a_path_cannot_break_out_of_the_payload(self):
+        entry = make_entry("weird/</script><b>x.py", "x = 1\n")
+        html = repo_map_html.render(make_report([entry]))
+        assert "</script><b>x.py" not in html
+
+    def test_every_file_reaches_the_document(self):
+        entries = [make_entry("a/one.py", "x = 1\n"), make_entry("b/two.tsx", "const a=1;\n")]
+        html = repo_map_html.render(make_report(entries))
+        assert "a/one.py" in html
+        assert "b/two.tsx" in html
+
+    def test_document_is_a_complete_html_page(self):
+        html = repo_map_html.render(make_report())
+        assert html.startswith("<!doctype html>")
+        assert html.rstrip().endswith("</html>")
+
+
+class TestBuildReport:
+    def test_reads_each_listed_file_from_disk(self, tmp_path):
+        (tmp_path / "pkg").mkdir()
+        (tmp_path / "pkg" / "a.py").write_text("x = 1\ny = 2\n", encoding="utf-8")
+        report = repo_map.build_report(
+            tmp_path, ["pkg/a.py"], thresholds=metrics.Thresholds(), commit="c0ffee"
+        )
+        assert [e.path for e in report.entries] == ["pkg/a.py"]
+        assert report.entries[0].loc == 2
+        assert report.tree.loc == 2
+
+    def test_missing_file_is_skipped_not_fatal(self, tmp_path):
+        (tmp_path / "there.py").write_text("x = 1\n", encoding="utf-8")
+        report = repo_map.build_report(
+            tmp_path,
+            ["there.py", "gone.py"],
+            thresholds=metrics.Thresholds(),
+            commit="c0ffee",
+        )
+        assert [e.path for e in report.entries] == ["there.py"]
+
+    def test_binary_file_is_skipped(self, tmp_path):
+        (tmp_path / "blob.bin").write_bytes(b"\xff\xfe\x00\x01\x80")
+        (tmp_path / "ok.py").write_text("x = 1\n", encoding="utf-8")
+        report = repo_map.build_report(
+            tmp_path,
+            ["blob.bin", "ok.py"],
+            thresholds=metrics.Thresholds(),
+            commit="c0ffee",
+        )
+        assert [e.path for e in report.entries] == ["ok.py"]
+
+    def test_commit_travels_into_the_report(self, tmp_path):
+        report = repo_map.build_report(
+            tmp_path, [], thresholds=metrics.Thresholds(), commit="c0ffee"
+        )
+        assert report.commit == "c0ffee"
+
+
+class TestMain:
+    def test_writes_a_report_for_the_real_repository(self, tmp_path):
+        out = tmp_path / "map.html"
+        assert repo_map.main(["-o", str(out)]) == 0
+        html = out.read_text(encoding="utf-8")
+        tracked = repo_map.tracked_files(repo_map.ROOT)
+        first_module = next(p for p in tracked if p.endswith(".py"))
+        assert first_module in html
+        assert "https://" not in html
+
+    def test_threshold_flags_reach_the_report(self, tmp_path):
+        out = tmp_path / "map.html"
+        assert repo_map.main(["-o", str(out), "--max-loc", "1234"]) == 0
+        assert '"max_loc": 1234' in out.read_text(encoding="utf-8")


### PR DESCRIPTION
Ein Entwickler-Werkzeug, das die Frage „welche Datei gehört als nächstes zerlegt?" mit Zahlen beantwortet statt mit Bauchgefühl — die fehlende Grundlage für die 500-Zeilen-Konvention (#301).

## Was es tut

`python scripts/repo_map.py` schreibt eine HTML-Seite: LOC je Verzeichnis als aufklappbarer Baum, darunter eine nach Refactor-Score sortierte Dateiliste. Die Sortierung *ist* die Arbeitsliste und steckt deshalb in den Daten, nicht im Browser.

Gemessen über dieses Repo: **2.678 Dateien, 598.658 Zeilen, 599 markiert.**

## Drei Module, nicht eines

| Datei | Zeilen | Aufgabe |
|---|---|---|
| `scripts/repo_map.py` | 185 | Scan + Verzeichnisbaum mit Roll-up-Summen |
| `scripts/repo_map_metrics.py` | 413 | Zeilenklassifikation, Strukturmetriken, Score |
| `scripts/repo_map_html.py` | 363 | Renderer |

Der Split ist kein Zufall: ein Werkzeug, das 500-Zeilen-Dateien anprangert, sollte selbst keine sein.

## Entscheidungen, die nicht offensichtlich sind

**Dateiauswahl über `git ls-files`.** Damit ist `.gitignore` per Definition respektiert — kein zweiter, driftender Ignore-Mechanismus, und `node_modules/` taucht nie auf.

**Ein nachgestelltes Kommentar zählt als Code.** `value = 1  # warum` trägt weiterhin Logik; nur eine Zeile, die *mit* dem Kommentarzeichen beginnt, ist ein Kommentar.

**Tiefe je Sprache unterschiedlich gemessen.** Python über `ast` (verlässlich), TS/JS über Klammertiefe (Heuristik). Für Extensions ohne Eintrag in der Kommentartabelle gibt es gar keine Kommentarerkennung, statt eine falsche zu raten.

**Die HTML-Seite ist autark.** Kein CDN, kein externes Stylesheet, kein Netzzugriff beim Öffnen — die Daten stecken als JSON in der Seite. So bleibt der Report offline nutzbar und direkt von Platte gefahrlos zu öffnen.

## Bewusst nicht enthalten

Der Import-/Kopplungsgraph. Der Score sagt, dass `services/power/manager.py` zu groß ist — er sagt nicht, **entlang welcher Naht** zu schneiden wäre, und ein Split quer zur Architektur macht die Kopplung schlimmer. Diese zweite Dimension hält **#538** fest, damit die Rangliste erst einmal steht (YAGNI).

## Risiko

Kein Produktionscode berührt, reines Werkzeug unter `scripts/`, Ausgabe gitignored. Kein Deploy-Pfad, keine neue Abhängigkeit.

## Gates

| Gate | Ergebnis |
|---|---|
| `python -m pytest scripts/test_repo_map.py` | 65 passed |
| `ruff check scripts/repo_map*.py scripts/test_repo_map.py` | All checks passed |
| Lauf über das echte Repo | 2.678 Dateien, HTML gerendert |

**Einschränkung:** die Tests liegen in `scripts/`, nicht in `backend/tests/`, und laufen deshalb **nicht** im `backend-tests`-Job mit. Sie sind lokal auszuführen (aus dem `scripts/`-Verzeichnis heraus, die Module importieren sich flach untereinander). Eine CI-Anbindung wäre eigene Arbeit und ist hier nicht dabei.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yrHzUD98edGYVz4yABy9m
