### PR TITLE
fix(fans): Stabile Luefter- und Sensor-Identitaet statt hwmon-Index (#532)

### DIFF
--- a/backend/alembic/versions/193f03f94b4e_fan_identity_legacy_columns.py
+++ b/backend/alembic/versions/193f03f94b4e_fan_identity_legacy_columns.py
@@ -1,0 +1,33 @@
+"""fan identity legacy columns
+
+Revision ID: 193f03f94b4e
+Revises: c4b18e9a2f37
+Create Date: 2026-09-05 20:40:57.046699
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '193f03f94b4e'
+down_revision: Union[str, Sequence[str], None] = 'c4b18e9a2f37'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Herkunftsspalten fuer die Umstellung auf stabile Kennungen (#532).
+    # Reiner Nachweis, keine Datenmigration hier - die Zuordnung braucht die
+    # Hardware der Zielmaschine und laeuft deshalb beim Dienststart (Task 7).
+    op.add_column('fan_configs', sa.Column('legacy_fan_id', sa.String(length=100), nullable=True))
+    op.add_column('temp_sensor_labels', sa.Column('legacy_sensor_id', sa.String(length=120), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('temp_sensor_labels', 'legacy_sensor_id')
+    op.drop_column('fan_configs', 'legacy_fan_id')

--- a/backend/app/models/fans.py
+++ b/backend/app/models/fans.py
@@ -82,6 +82,9 @@ class FanConfig(Base):
     emergency_temp_celsius: Mapped[float] = mapped_column(Float, default=85.0, nullable=False)
     temp_sensor_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False, index=True)
+    # Herkunft der Zeile vor der Umstellung auf stabile Kennungen (#532).
+    # Reiner Nachweis: erlaubt, eine Fehlzuordnung nachtraeglich zu erkennen.
+    legacy_fan_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     hysteresis_celsius: Mapped[float] = mapped_column(Float, default=3.0, nullable=False)
     # --- Curve type & params ---
     curve_type: Mapped[str] = mapped_column(String(20), default="graph", nullable=False)
@@ -139,6 +142,7 @@ class TempSensorLabel(Base):
 
     sensor_id: Mapped[str] = mapped_column(String(120), primary_key=True)
     custom_label: Mapped[str] = mapped_column(String(100), nullable=False)
+    legacy_sensor_id: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/backend/app/schemas/fans.py
+++ b/backend/app/schemas/fans.py
@@ -85,7 +85,7 @@ class FanActiveSchedule(BaseModel):
 
 class FanInfo(BaseModel):
     """Information about a single fan."""
-    fan_id: str = Field(..., description="Unique fan identifier (e.g., hwmon0_pwm1)")
+    fan_id: str = Field(..., description="Unique fan identifier (e.g., nct6798-isa-0290:pwm1)")
     name: str = Field(..., description="Human-readable fan name")
     rpm: Optional[int] = Field(default=None, description="Current RPM (revolutions per minute)")
     pwm_percent: int = Field(..., ge=0, le=100, description="Current PWM percentage")
@@ -119,7 +119,7 @@ class FanInfo(BaseModel):
     class Config:
         json_schema_extra = {
             "example": {
-                "fan_id": "hwmon0_pwm1",
+                "fan_id": "nct6798-isa-0290:pwm1",
                 "name": "CPU Fan",
                 "rpm": 2400,
                 "pwm_percent": 65,
@@ -129,7 +129,7 @@ class FanInfo(BaseModel):
                 "min_pwm_percent": 30,
                 "max_pwm_percent": 100,
                 "emergency_temp_celsius": 85.0,
-                "temp_sensor_id": "hwmon0_temp1",
+                "temp_sensor_id": "hwmon:k10temp-pci-00c3:temp1",
                 "curve_points": [
                     {"temp": 35, "pwm": 30},
                     {"temp": 50, "pwm": 50},
@@ -169,7 +169,7 @@ class SetFanModeRequest(BaseModel):
     class Config:
         json_schema_extra = {
             "example": {
-                "fan_id": "hwmon0_pwm1",
+                "fan_id": "nct6798-isa-0290:pwm1",
                 "mode": "auto"
             }
         }
@@ -191,7 +191,7 @@ class SetFanPWMRequest(BaseModel):
     class Config:
         json_schema_extra = {
             "example": {
-                "fan_id": "hwmon0_pwm1",
+                "fan_id": "nct6798-isa-0290:pwm1",
                 "pwm_percent": 75
             }
         }
@@ -230,7 +230,7 @@ class UpdateFanCurveRequest(BaseModel):
     class Config:
         json_schema_extra = {
             "example": {
-                "fan_id": "hwmon0_pwm1",
+                "fan_id": "nct6798-isa-0290:pwm1",
                 "curve_points": [
                     {"temp": 35, "pwm": 30},
                     {"temp": 50, "pwm": 50},
@@ -343,7 +343,7 @@ class ApplyPresetRequest(BaseModel):
     class Config:
         json_schema_extra = {
             "example": {
-                "fan_id": "hwmon0_pwm1",
+                "fan_id": "nct6798-isa-0290:pwm1",
                 "preset": "balanced"
             }
         }
@@ -389,9 +389,9 @@ class UpdateFanConfigRequest(BaseModel):
     class Config:
         json_schema_extra = {
             "example": {
-                "fan_id": "hwmon0_pwm1",
+                "fan_id": "nct6798-isa-0290:pwm1",
                 "hysteresis_celsius": 5.0,
-                "temp_sensor_id": "hwmon2_temp1"
+                "temp_sensor_id": "hwmon:k10temp-pci-00c3:temp1"
             }
         }
 
@@ -410,7 +410,7 @@ class UpdateFanConfigResponse(BaseModel):
 
 class TempSensorInfo(BaseModel):
     """Information about a temperature sensor."""
-    sensor_id: str = Field(..., description="Sensor identifier (e.g., hwmon2_temp1)")
+    sensor_id: str = Field(..., description="Sensor identifier (e.g., hwmon:k10temp-pci-00c3:temp1)")
     device_name: str = Field(..., description="Hardware device name (e.g., k10temp)")
     label: Optional[str] = Field(default=None, description="Sensor label (e.g., Tctl)")
     custom_label: Optional[str] = Field(default=None, description="User-supplied custom label")

--- a/backend/app/services/CLAUDE.md
+++ b/backend/app/services/CLAUDE.md
@@ -87,6 +87,8 @@ Business logic layer. Routes delegate to services — services contain the actua
 **`power/`** — CPU frequency scaling, fan control, energy, sleep
 - `manager.py` — PowerManager: demand-based CPU profile selection
 - `fan_control.py` — Temperature-based fan speed control with curves
+- `fan_identity.py` — Derives stable chip-level fan/sensor identities (`<chip>-<bus>-<adresse>:pwm<N>`) that survive hwmon renumbering; ships with `get_stable_identity()`, `is_stable_backend()`, and hwmon-index fallback for unsupported buses (i2c, spi, scsi, hid, drivetemp)
+- `fan_reconcile.py` — One-time identity reconciliation at backend startup; matches legacy `fan_id` to stable equivalents, creates new configs for newly-visible fans (primary worker only), enforces fail-safe on mismatch (no default config creation)
 - `sleep.py` — Soft/hard sleep modes with idle detection
 - `presence.py` — user-presence tracker (heartbeats → presence_sessions table; blocks auto true-suspend, issue #214)
 - `energy.py` — Power consumption tracking and cost estimation

--- a/backend/app/services/CLAUDE.md
+++ b/backend/app/services/CLAUDE.md
@@ -87,8 +87,8 @@ Business logic layer. Routes delegate to services — services contain the actua
 **`power/`** — CPU frequency scaling, fan control, energy, sleep
 - `manager.py` — PowerManager: demand-based CPU profile selection
 - `fan_control.py` — Temperature-based fan speed control with curves
-- `fan_identity.py` — Derives stable chip-level fan/sensor identities (`<chip>-<bus>-<adresse>:pwm<N>`) that survive hwmon renumbering; ships with `get_stable_identity()`, `is_stable_backend()`, and hwmon-index fallback for unsupported buses (i2c, spi, scsi, hid, drivetemp)
-- `fan_reconcile.py` — One-time identity reconciliation at backend startup; matches legacy `fan_id` to stable equivalents, creates new configs for newly-visible fans (primary worker only), enforces fail-safe on mismatch (no default config creation)
+- `fan_identity.py` — Derives stable chip-level fan/sensor identities (`<chip>-<bus>-<adresse>:pwm<N>`) that survive hwmon renumbering; ships with `derive_chip_identity()`, `derive_all()`, `build_fan_id()`, `build_sensor_id()`, `encode_pci_address()`, `encode_platform_address()`, `format_chip_name()`, and hwmon-index fallback for unsupported buses (i2c, spi, scsi, hid, drivetemp)
+- `fan_reconcile.py` — One-time identity reconciliation at backend startup; matches legacy `fan_id`/sensor labels/composite sources to stable equivalents, enforces fail-safe on mismatch (no default config creation). Does NOT create configs for newly-visible fans — that anlage-loop lives in `fan_control.py:_load_fan_configs()` (primary worker only)
 - `sleep.py` — Soft/hard sleep modes with idle detection
 - `presence.py` — user-presence tracker (heartbeats → presence_sessions table; blocks auto true-suspend, issue #214)
 - `energy.py` — Power consumption tracking and cost estimation

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -260,23 +260,42 @@ class LinuxFanControlBackend(FanControlBackend):
     _CPU_SENSOR_DRIVERS = {"k10temp", "coretemp", "cpu_thermal", "acpi"}
 
     async def get_temperature(self, sensor_id: str) -> Optional[float]:
-        """Get temperature from hwmon sensor."""
+        """Get temperature from hwmon sensor.
+
+        Loest zuerst ueber die Rueckabbildung aus dem Scan auf (stabile
+        Kennungen, #532) und faellt danach auf die Altform hwmon<N>_temp<M>
+        zurueck, die waehrend der Umstellung noch in der Datenbank steht.
+        """
         if not sensor_id:
             return None
 
-        # sensor_id format: "hwmon0_temp1"
-        parts = sensor_id.split("_")
-        if len(parts) != 2:
-            return None
+        if sensor_id.startswith("hwmon:"):
+            sensor_id = sensor_id[len("hwmon:"):]
 
-        hwmon_name, temp_name = parts
-        temp_path = self._hwmon_base / hwmon_name / f"{temp_name}_input"
+        temp_path = self._temp_paths.get(sensor_id)
+        if temp_path is None:
+            temp_path = self._legacy_temp_path(sensor_id)
+        if temp_path is None:
+            return None
 
         temp_value = await self._read_hwmon_file(temp_path)
         if temp_value is not None:
             return float(temp_value) / 1000.0
-
         return None
+
+    def _legacy_temp_path(self, sensor_id: str) -> Optional[Path]:
+        """Altform "hwmon0_temp1" -> Pfad. Nur fuer noch nicht migrierte IDs."""
+        parts = sensor_id.split("_")
+        if len(parts) != 2:
+            return None
+        hwmon_name, temp_name = parts
+        if not hwmon_name.startswith("hwmon") or not temp_name.startswith("temp"):
+            return None
+        if "/" in hwmon_name or "\\" in hwmon_name or ".." in hwmon_name:
+            return None
+        if not temp_name[len("temp"):].isdigit():
+            return None
+        return self._hwmon_base / hwmon_name / f"{temp_name}_input"
 
     def _find_cpu_temp_sensor(self) -> Optional[Tuple[str, Path]]:
         """Find CPU temperature sensor across all hwmon directories.
@@ -289,6 +308,8 @@ class LinuxFanControlBackend(FanControlBackend):
         """
         if not self._hwmon_base.exists():
             return None
+
+        identities = derive_all(self._hwmon_base)
 
         for hwmon_dir in sorted(self._hwmon_base.iterdir()):
             if not hwmon_dir.is_dir() or not hwmon_dir.name.startswith("hwmon"):
@@ -306,10 +327,14 @@ class LinuxFanControlBackend(FanControlBackend):
             if driver_name not in self._CPU_SENSOR_DRIVERS:
                 continue
 
+            identity = identities.get(hwmon_dir.name)
+            if identity is None:
+                continue
+
             # Found a CPU sensor driver — use its first temp input
             for temp_file in sorted(hwmon_dir.glob("temp*_input")):
                 temp_num = temp_file.name.replace("temp", "").replace("_input", "")
-                sensor_id = f"{hwmon_dir.name}_temp{temp_num}"
+                sensor_id = build_sensor_id(identity, int(temp_num))
                 logger.info(
                     f"Found CPU temp sensor: {sensor_id} (driver={driver_name})"
                 )
@@ -324,8 +349,14 @@ class LinuxFanControlBackend(FanControlBackend):
         if not self._hwmon_base.exists():
             return sensors
 
+        identities = derive_all(self._hwmon_base)
+
         for hwmon_dir in sorted(self._hwmon_base.iterdir()):
             if not hwmon_dir.is_dir() or not hwmon_dir.name.startswith("hwmon"):
+                continue
+
+            identity = identities.get(hwmon_dir.name)
+            if identity is None:
                 continue
 
             name_file = hwmon_dir / "name"
@@ -340,7 +371,7 @@ class LinuxFanControlBackend(FanControlBackend):
 
             for temp_file in sorted(hwmon_dir.glob("temp*_input")):
                 temp_num = temp_file.name.replace("temp", "").replace("_input", "")
-                sensor_id = f"{hwmon_dir.name}_temp{temp_num}"
+                sensor_id = build_sensor_id(identity, int(temp_num))
 
                 # Try to read label
                 label = None

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -14,6 +14,11 @@ from app.core.config import Settings
 from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
 from app.services.power.fan_control import FanControlBackend, FanData, TempSensorData
 from app.services.power.fan_gpu_manual import probe_amd_pwm_control
+from app.services.power.fan_identity import (
+    build_fan_id,
+    build_sensor_id,
+    derive_all,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +51,10 @@ class LinuxFanControlBackend(FanControlBackend):
         # Bewusst NICHT in _fan_cache: der wird bei jedem Rescan neu gebaut,
         # der Backoff muss das ueberleben.
         self._write_backoff: Dict[str, Tuple[int, float]] = {}
+        # Rueckabbildung stabile Sensor-Kennung -> tempN_input-Pfad. Ohne sie
+        # kann get_temperature() die ID nicht mehr aufloesen, weil sie nicht
+        # mehr aus dem hwmon-Verzeichnisnamen besteht (#532).
+        self._temp_paths: Dict[str, Path] = {}
         self._monotonic = time.monotonic
 
     async def is_available(self) -> bool:
@@ -369,6 +378,8 @@ class LinuxFanControlBackend(FanControlBackend):
         board sensors for fan control.
         """
         new_cache: Dict[str, Dict] = {}
+        new_temp_paths: Dict[str, Path] = {}
+        identities = derive_all(self._hwmon_base)
 
         if not self._hwmon_base.exists():
             if not self._fan_cache:
@@ -384,6 +395,19 @@ class LinuxFanControlBackend(FanControlBackend):
         for hwmon_dir in self._hwmon_base.iterdir():
             if not hwmon_dir.is_dir() or not hwmon_dir.name.startswith("hwmon"):
                 continue
+
+            identity = identities.get(hwmon_dir.name)
+            if identity is None:
+                continue
+
+            # Rueckabbildung auf Ebene der hwmon-Schleife eintragen, nicht
+            # erst innerhalb der PWM-Schleife (R1, #532): Chips ohne Luefter
+            # (k10temp, NVMe) liefern Kurvenquellen fuer get_temperature()
+            # und muessten sonst aufloesbar bleiben, obwohl sie hier nie
+            # einen PWM-Kanal durchlaufen.
+            for temp_file in hwmon_dir.glob("temp[0-9]*_input"):
+                num = temp_file.name[len("temp"):-len("_input")]
+                new_temp_paths[build_sensor_id(identity, int(num))] = temp_file
 
             # Read hwmon name
             name_file = hwmon_dir / "name"
@@ -407,7 +431,7 @@ class LinuxFanControlBackend(FanControlBackend):
                     continue
 
                 pwm_num = pwm_file.name.replace("pwm", "")
-                fan_id = f"{hwmon_dir.name}_pwm{pwm_num}"
+                fan_id = build_fan_id(identity, int(pwm_num))
 
                 # Find corresponding fan input
                 fan_input_path = hwmon_dir / f"fan{pwm_num}_input"
@@ -427,7 +451,7 @@ class LinuxFanControlBackend(FanControlBackend):
                     temp_path = None
                     for temp_file in hwmon_dir.glob("temp*_input"):
                         temp_num = temp_file.name.replace("temp", "").replace("_input", "")
-                        temp_sensor_id = f"{hwmon_dir.name}_temp{temp_num}"
+                        temp_sensor_id = build_sensor_id(identity, int(temp_num))
                         temp_path = temp_file
                         break
 
@@ -449,10 +473,12 @@ class LinuxFanControlBackend(FanControlBackend):
                     "gpu_vendor": gpu_vendor,
                     "device_driver": hwmon_name_value,
                     "pwm_control": pwm_control,
+                    "identity_stable": identity.stable,
                 }
 
         if new_cache or not self._fan_cache:
             self._fan_cache = new_cache
+            self._temp_paths = new_temp_paths
             # Backoff-Eintraege verschwundener Luefter mitnehmen, sonst waechst
             # das Dict ueber Treiber-Reloads und hwmon-Renumbering hinweg (#533).
             for stale in set(self._write_backoff) - set(self._fan_cache):

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -332,9 +332,15 @@ class LinuxFanControlBackend(FanControlBackend):
                 continue
 
             # Found a CPU sensor driver — use its first temp input
-            for temp_file in sorted(hwmon_dir.glob("temp*_input")):
+            for temp_file in sorted(hwmon_dir.glob("temp[0-9]*_input")):
                 temp_num = temp_file.name.replace("temp", "").replace("_input", "")
                 sensor_id = build_sensor_id(identity, int(temp_num))
+                # I-3: ohne diesen Eintrag bliebe get_temperature() fuer einen
+                # Chip, der erst NACH dem Startscan erscheint (Treiber
+                # nachgeladen), dauerhaft None -- _temp_paths wird sonst
+                # ausschliesslich in _scan_pwm_fans gefuellt, das nur beim
+                # Start und in switch_backend laeuft.
+                self._temp_paths.setdefault(sensor_id, temp_file)
                 logger.info(
                     f"Found CPU temp sensor: {sensor_id} (driver={driver_name})"
                 )
@@ -369,9 +375,14 @@ class LinuxFanControlBackend(FanControlBackend):
 
             is_cpu = device_name in self._CPU_SENSOR_DRIVERS
 
-            for temp_file in sorted(hwmon_dir.glob("temp*_input")):
+            for temp_file in sorted(hwmon_dir.glob("temp[0-9]*_input")):
                 temp_num = temp_file.name.replace("temp", "").replace("_input", "")
                 sensor_id = build_sensor_id(identity, int(temp_num))
+                # I-3: gleicher Grund wie in _find_cpu_temp_sensor -- ohne
+                # diesen Eintrag ist ein erst nachtraeglich gelisteter Sensor
+                # zwar in der Auswahlliste sichtbar, aber get_temperature()
+                # findet ihn nie (kein Scan-Lauf hat ihn eingetragen).
+                self._temp_paths.setdefault(sensor_id, temp_file)
 
                 # Try to read label
                 label = None
@@ -480,7 +491,7 @@ class LinuxFanControlBackend(FanControlBackend):
                     # Fallback: use first temp sensor in same hwmon dir
                     temp_sensor_id = None
                     temp_path = None
-                    for temp_file in hwmon_dir.glob("temp*_input"):
+                    for temp_file in hwmon_dir.glob("temp[0-9]*_input"):
                         temp_num = temp_file.name.replace("temp", "").replace("_input", "")
                         temp_sensor_id = build_sensor_id(identity, int(temp_num))
                         temp_path = temp_file

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -349,7 +349,7 @@ class FanControlService:
                     # ein UNIQUE-Verstoss aus einem Rename wuerde sonst erst
                     # hier auftreten und aus dem try entkommen.
                     db.commit()
-                    if report.renamed or report.deactivated:
+                    if report.renamed or report.deactivated or report.unresolved_sensors:
                         try:
                             # Eigene Session (db=None): AuditLoggerDB.log_event
                             # committet die uebergebene Session selbst. Mit
@@ -363,11 +363,30 @@ class FanControlService:
                                     "renamed": report.renamed,
                                     "deactivated": report.deactivated,
                                     "skipped_absent": report.skipped_absent,
+                                    # M-3: eine nicht aufloesbare Sensor-Zuordnung
+                                    # tauscht die Nutzerwahl stillschweigend gegen
+                                    # den CPU-Default aus -- die einzige
+                                    # Nutzeraenderung dieses Laufs, die sonst
+                                    # nirgends revisionssicher gelandet waere.
+                                    "unresolved_sensors": report.unresolved_sensors,
                                 },
                                 db=None,
                             )
                         except Exception:
                             logger.debug("Audit-Eintrag zum Identitaets-Abgleich fehlgeschlagen")
+                    # M-6: _rebuild_registry() lief in start() VOR diesem Abgleich
+                    # und hat Labels/Composite-Quellen deshalb aus der noch
+                    # NICHT migrierten Datenbank gelesen. Ohne diesen zweiten
+                    # Aufruf gaelten im ersten Start nach dem Upgrade die alten
+                    # Schluessel bis zum naechsten Neustart. Eigenes try: der
+                    # Abgleich selbst ist zu diesem Zeitpunkt bereits committet
+                    # und erfolgreich -- ein Fehler beim Neuaufbau der Registry
+                    # darf nicht als Abgleichs-Fehlschlag geloggt werden und
+                    # nicht die Anlage-Schleife unten blockieren.
+                    try:
+                        await self._rebuild_registry()
+                    except Exception:
+                        logger.debug("Registry-Neuaufbau nach Abgleich fehlgeschlagen")
                 except Exception:
                     # Nicht weitermachen: die Scan-IDs liegen bereits in der
                     # neuen Form vor, die DB-Zeilen aber noch in der alten.
@@ -433,6 +452,16 @@ class FanControlService:
                         # mit sich (I3). Ein anderer Worker war schneller --
                         # die Zeile existiert, das ist der gewuenschte
                         # Endzustand.
+                        #
+                        # M-4: seit dem Primary-only-Gate direkt oberhalb (der
+                        # fruehe return bei nicht-Primary) ist dieser Zweig in
+                        # der Praxis kaum noch erreichbar -- ein weiterer
+                        # Uvicorn-Worker mit demselben Primary-Anspruch waere
+                        # der einzige verbleibende Weg zu einem Wettlauf um
+                        # dieselbe Zeile. Bewusst NICHT entfernen: der
+                        # Savepoint ist billig und die einzige Absicherung
+                        # gegen genau diesen (seltenen) Fall. Nicht als toten
+                        # Code streichen.
                         with db.begin_nested():
                             db.add(config)
                     except IntegrityError:

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -258,9 +258,13 @@ class FanControlService:
         by_prefix: Dict[str, Dict] = {}
         fan_cache = getattr(self._backend, "_fan_cache", None)
         if not isinstance(fan_cache, dict):
-            # Dev-Backend hat kein _fan_cache; ein Test-Double kann ein
-            # Attribut liefern, das kein echtes Dict ist. Beides bedeutet
-            # dasselbe wie ein leerer Scan: kein Chip, kein Abgleich.
+            # Schuetzt NICHT vor einer realen Produktionslage -- das echte
+            # LinuxFanControlBackend liefert hier immer ein dict. Der Fall
+            # tritt nur auf, wenn self._backend kein solches Attribut kennt
+            # (DevFanControlBackend) oder ein Test-Double (z. B. ein
+            # unspezifizierter AsyncMock()) ein Attribut liefert, das selbst
+            # wieder ein Mock statt eines dict ist. Beides wird wie ein
+            # leerer Scan behandelt: kein Chip, kein Abgleich.
             fan_cache = {}
         for fan_id, info in fan_cache.items():
             if not info.get("identity_stable"):
@@ -288,6 +292,10 @@ class FanControlService:
         mapping: Dict[str, str] = {}
         paths = getattr(self._backend, "_temp_paths", None)
         if not isinstance(paths, dict):
+            # Gleiche Absicherung wie in _collect_chip_facts oben: schuetzt
+            # vor Backend-Attributen, die kein dict sind (unspezifizierter
+            # Test-Mock, ein kuenftiges Backend ohne dieses Attribut) --
+            # nicht vor einer realen Produktionslage.
             paths = {}
         for stable_id, path in paths.items():
             hwmon_name = path.parent.name
@@ -321,12 +329,32 @@ class FanControlService:
         with self.db_session_factory() as db:
             chip_facts = self._collect_chip_facts()
             if self._should_reconcile(len(chip_facts)):
-                report = reconcile_fan_identities(
-                    db,
-                    chips=chip_facts,
-                    sensor_map=self._collect_sensor_map(),
-                    cpu_sensor_id=cpu_sensor_id,
-                )
+                try:
+                    report = reconcile_fan_identities(
+                        db,
+                        chips=chip_facts,
+                        sensor_map=self._collect_sensor_map(),
+                        cpu_sensor_id=cpu_sensor_id,
+                    )
+                except Exception:
+                    # Nicht weitermachen: die Scan-IDs liegen bereits in der
+                    # neuen Form vor, die DB-Zeilen aber noch in der alten.
+                    # Liefe die Anlage-Schleife trotzdem, legte sie frische
+                    # Default-Configs unter den neuen IDs an -- deren
+                    # updated_at ist "jetzt" und gewaenne beim naechsten
+                    # Abgleich gegen die echte Nutzerkurve. Das waere genau
+                    # der Datenverlust, den dieser Abgleich verhindern soll,
+                    # nur auf einem Umweg. Stattdessen: kein Commit, kein
+                    # neuer Fan-Datensatz -- die Luefter bleiben fuer diesen
+                    # einen Startzyklus ungeregelt (sichtbar: PWM bewegt sich
+                    # nicht, keine Kurve in der UI), aber keine Zeile geht
+                    # verloren. Der naechste Start versucht es erneut.
+                    logger.exception(
+                        "Identitaets-Abgleich fehlgeschlagen -- keine Configs "
+                        "angelegt, um die Altzeilen nicht zu ueberdecken. Die "
+                        "Luefter bleiben bis zum naechsten Start ungeregelt."
+                    )
+                    return
                 if report.renamed or report.deactivated:
                     try:
                         from app.services.audit import get_audit_logger_db

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -673,7 +673,7 @@ class FanControlService:
                     display_temp = fan.temperature_celsius
                     if config.temp_sensor_id:
                         try:
-                            sensor_temp = await self._backend.get_temperature(config.temp_sensor_id)
+                            sensor_temp = await self._registry.get_temp(config.temp_sensor_id)
                             if sensor_temp is not None:
                                 display_temp = sensor_temp
                         except Exception:

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -16,12 +16,15 @@ from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy import select, desc, func
+from sqlalchemy.exc import IntegrityError
 
+from app.core import lifespan
 from app.core.config import Settings
 from app.models.fans import FanConfig, FanSample
 from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
 from app.services.power.fan_schedule import FanScheduleService
 from app.services.power.fan_profiles import FanProfileService
+from app.services.power.fan_reconcile import ChipFacts, reconcile_fan_identities
 from app.services.power.fan_sources import (
     TempSourceRegistry, HwmonTempSource, GpuTempSource, DiskTempSource, MixTempSource,
 )
@@ -237,6 +240,61 @@ class FanControlService:
             self._backend = DevFanControlBackend(self.config)
             self._use_linux_backend = False
 
+    def _should_reconcile(self, chip_count: int) -> bool:
+        """Beide Vorbedingungen sind hart -- ihr Fehlen bedeutet Totalverlust.
+
+        Ohne Linux-Backend liefe der Abgleich gegen eine Chip-Menge ohne
+        einen einzigen hwmon-Chip; ohne gefundenen Chip gegen eine leere.
+        In beiden Faellen faende keine Altzeile ihren Chip wieder.
+        """
+        if not getattr(lifespan, "IS_PRIMARY_WORKER", False):
+            return False
+        if not self._use_linux_backend:
+            return False
+        return chip_count > 0
+
+    def _collect_chip_facts(self) -> Dict[str, ChipFacts]:
+        """Chipname -> Kennung, vorhandene PWM-Kanaele, Mehrdeutigkeit."""
+        by_prefix: Dict[str, Dict] = {}
+        fan_cache = getattr(self._backend, "_fan_cache", None)
+        if not isinstance(fan_cache, dict):
+            # Dev-Backend hat kein _fan_cache; ein Test-Double kann ein
+            # Attribut liefern, das kein echtes Dict ist. Beides bedeutet
+            # dasselbe wie ein leerer Scan: kein Chip, kein Abgleich.
+            fan_cache = {}
+        for fan_id, info in fan_cache.items():
+            if not info.get("identity_stable"):
+                continue
+            prefix = info.get("device_driver") or "Unknown"
+            key, _, channel = fan_id.rpartition(":pwm")
+            if not channel.isdigit():
+                continue
+            entry = by_prefix.setdefault(prefix, {"keys": set(), "channels": set()})
+            entry["keys"].add(key)
+            entry["channels"].add(int(channel))
+
+        facts: Dict[str, ChipFacts] = {}
+        for prefix, entry in by_prefix.items():
+            keys = entry["keys"]
+            facts[prefix] = ChipFacts(
+                key=next(iter(sorted(keys))),
+                pwm_channels=frozenset(entry["channels"]),
+                ambiguous=len(keys) > 1,
+            )
+        return facts
+
+    def _collect_sensor_map(self) -> Dict[str, str]:
+        """Alt-Sensor-ID (hwmon<N>_temp<M>) -> neue, praefixierte Kennung."""
+        mapping: Dict[str, str] = {}
+        paths = getattr(self._backend, "_temp_paths", None)
+        if not isinstance(paths, dict):
+            paths = {}
+        for stable_id, path in paths.items():
+            hwmon_name = path.parent.name
+            temp_num = path.name[len("temp"):-len("_input")]
+            mapping[f"{hwmon_name}_temp{temp_num}"] = f"hwmon:{stable_id}"
+        return mapping
+
     async def _load_fan_configs(self):
         """Load fan configurations from database.
 
@@ -261,6 +319,35 @@ class FanControlService:
             pass
 
         with self.db_session_factory() as db:
+            chip_facts = self._collect_chip_facts()
+            if self._should_reconcile(len(chip_facts)):
+                report = reconcile_fan_identities(
+                    db,
+                    chips=chip_facts,
+                    sensor_map=self._collect_sensor_map(),
+                    cpu_sensor_id=cpu_sensor_id,
+                )
+                if report.renamed or report.deactivated:
+                    try:
+                        from app.services.audit import get_audit_logger_db
+                        get_audit_logger_db().log_system_event(
+                            action="fan_identity_reconcile",
+                            details={
+                                "renamed": report.renamed,
+                                "deactivated": report.deactivated,
+                                "skipped_absent": report.skipped_absent,
+                            },
+                            db=db,
+                        )
+                    except Exception:
+                        logger.debug("Audit-Eintrag zum Identitaets-Abgleich fehlgeschlagen")
+
+                # Eigenstaendiger Commit: der Abgleich muss die Datenbank
+                # erreicht haben, BEVOR die Anlage-Schleife unten startet.
+                # Liefe er danach, waeren die Ziel-IDs bereits durch frische
+                # Default-Zeilen belegt und jede Altzeile verloere (R4).
+                db.commit()
+
             for fan in fans:
                 existing = db.execute(
                     select(FanConfig).where(FanConfig.fan_id == fan.fan_id)
@@ -276,10 +363,19 @@ class FanControlService:
                         min_pwm_percent=fan.min_pwm_percent,
                         max_pwm_percent=fan.max_pwm_percent,
                         emergency_temp_celsius=fan.emergency_temp_celsius,
-                        temp_sensor_id=cpu_sensor_id or fan.temp_sensor_id,
+                        temp_sensor_id=TempSourceRegistry._normalize_id(
+                            cpu_sensor_id or fan.temp_sensor_id
+                        ) if (cpu_sensor_id or fan.temp_sensor_id) else None,
                         is_active=True,
                     )
                     db.add(config)
+                    try:
+                        db.flush()
+                    except IntegrityError:
+                        # Ein anderer Worker war schneller. Die Zeile existiert,
+                        # das ist der gewuenschte Endzustand.
+                        db.rollback()
+                        logger.debug("Fan-Config %s wurde parallel angelegt", fan.fan_id)
 
             db.commit()
 

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -334,8 +334,40 @@ class FanControlService:
                         db,
                         chips=chip_facts,
                         sensor_map=self._collect_sensor_map(),
-                        cpu_sensor_id=cpu_sensor_id,
+                        cpu_sensor_id=TempSourceRegistry._normalize_id(cpu_sensor_id)
+                        if cpu_sensor_id else None,
                     )
+                    # Eigenstaendiger Commit VOR dem Audit-Eintrag: der
+                    # Abgleich muss die Datenbank erreicht haben, BEVOR die
+                    # Anlage-Schleife unten startet (R4) -- und bevor der
+                    # Audit-Aufruf unten laeuft, damit dessen eigene Session
+                    # (db=None, siehe unten) nicht ueber unsere entscheidet,
+                    # ob unser Commit stattfand. db.commit() steht bewusst
+                    # noch IM try: die eigentlichen ORM-Schreibzugriffe des
+                    # Abgleichs (Umbenennung, Deaktivierung) erreichen die
+                    # Datenbank erst beim Flush, das der Commit ausloest --
+                    # ein UNIQUE-Verstoss aus einem Rename wuerde sonst erst
+                    # hier auftreten und aus dem try entkommen.
+                    db.commit()
+                    if report.renamed or report.deactivated:
+                        try:
+                            # Eigene Session (db=None): AuditLoggerDB.log_event
+                            # committet die uebergebene Session selbst. Mit
+                            # unserer db haette ein fehlschlagender Audit-Commit
+                            # unsere bereits erfolgreiche Transaktion getroffen
+                            # und den echten Fehler als Audit-Problem maskiert.
+                            from app.services.audit import get_audit_logger_db
+                            get_audit_logger_db().log_system_event(
+                                action="fan_identity_reconcile",
+                                details={
+                                    "renamed": report.renamed,
+                                    "deactivated": report.deactivated,
+                                    "skipped_absent": report.skipped_absent,
+                                },
+                                db=None,
+                            )
+                        except Exception:
+                            logger.debug("Audit-Eintrag zum Identitaets-Abgleich fehlgeschlagen")
                 except Exception:
                     # Nicht weitermachen: die Scan-IDs liegen bereits in der
                     # neuen Form vor, die DB-Zeilen aber noch in der alten.
@@ -344,37 +376,35 @@ class FanControlService:
                     # updated_at ist "jetzt" und gewaenne beim naechsten
                     # Abgleich gegen die echte Nutzerkurve. Das waere genau
                     # der Datenverlust, den dieser Abgleich verhindern soll,
-                    # nur auf einem Umweg. Stattdessen: kein Commit, kein
-                    # neuer Fan-Datensatz -- die Luefter bleiben fuer diesen
-                    # einen Startzyklus ungeregelt (sichtbar: PWM bewegt sich
-                    # nicht, keine Kurve in der UI), aber keine Zeile geht
-                    # verloren. Der naechste Start versucht es erneut.
+                    # nur auf einem Umweg. Stattdessen: kein neuer
+                    # Fan-Datensatz -- die Luefter bleiben fuer diesen einen
+                    # Startzyklus ungeregelt (sichtbar: PWM bewegt sich nicht,
+                    # keine Kurve in der UI), aber keine Zeile geht verloren.
+                    # Der naechste Start versucht es erneut.
                     logger.exception(
                         "Identitaets-Abgleich fehlgeschlagen -- keine Configs "
                         "angelegt, um die Altzeilen nicht zu ueberdecken. Die "
                         "Luefter bleiben bis zum naechsten Start ungeregelt."
                     )
                     return
-                if report.renamed or report.deactivated:
-                    try:
-                        from app.services.audit import get_audit_logger_db
-                        get_audit_logger_db().log_system_event(
-                            action="fan_identity_reconcile",
-                            details={
-                                "renamed": report.renamed,
-                                "deactivated": report.deactivated,
-                                "skipped_absent": report.skipped_absent,
-                            },
-                            db=db,
-                        )
-                    except Exception:
-                        logger.debug("Audit-Eintrag zum Identitaets-Abgleich fehlgeschlagen")
 
-                # Eigenstaendiger Commit: der Abgleich muss die Datenbank
-                # erreicht haben, BEVOR die Anlage-Schleife unten startet.
-                # Liefe er danach, waeren die Ziel-IDs bereits durch frische
-                # Default-Zeilen belegt und jede Altzeile verloere (R4).
-                db.commit()
+            if not getattr(lifespan, "IS_PRIMARY_WORKER", False):
+                # Die Anlage-Schleife ist ebenso primary-only wie der Abgleich
+                # oben (C1): der Sekundaer-Worker durchlaeuft beim Start KEINE
+                # start_power_manager(primary=True)/check_and_notify_permissions()
+                # zwischen Primary-Flag und Fan-Start (siehe lifespan.py) und
+                # erreicht diese Stelle deshalb plausibel VOR dem Primary.
+                # Legte er hier eine Default-Config unter einer (noch) neuen
+                # Scan-ID an, traegt sie updated_at="jetzt" und gewinnt beim
+                # spaeteren Abgleich des Primary gegen die echte Nutzerkurve
+                # -- genau die Zeile, die der Abgleich schuetzen soll, ginge
+                # ueber den Sekundaer-Worker doch noch verloren. Sekundaer-
+                # Worker lesen daher nur; die Configs liegen in der
+                # gemeinsamen Datenbank, der Primary legt sie an. Ein
+                # Sekundaer, der kurz davor eine Anfrage bedient, zeigt einen
+                # Luefter ohne Config -- transient und harmlos.
+                logger.debug("Sekundaer-Worker: Anlage-Schleife uebersprungen")
+                return
 
             for fan in fans:
                 existing = db.execute(
@@ -396,13 +426,16 @@ class FanControlService:
                         ) if (cpu_sensor_id or fan.temp_sensor_id) else None,
                         is_active=True,
                     )
-                    db.add(config)
                     try:
-                        db.flush()
+                        # Savepoint statt db.rollback() auf der ganzen
+                        # Transaktion: sonst risse eine kollidierende fuenfte
+                        # Zeile die vier zuvor erfolgreich geflushten wieder
+                        # mit sich (I3). Ein anderer Worker war schneller --
+                        # die Zeile existiert, das ist der gewuenschte
+                        # Endzustand.
+                        with db.begin_nested():
+                            db.add(config)
                     except IntegrityError:
-                        # Ein anderer Worker war schneller. Die Zeile existiert,
-                        # das ist der gewuenschte Endzustand.
-                        db.rollback()
                         logger.debug("Fan-Config %s wurde parallel angelegt", fan.fan_id)
 
             db.commit()

--- a/backend/app/services/power/fan_identity.py
+++ b/backend/app/services/power/fan_identity.py
@@ -7,8 +7,12 @@ nicht.
 """
 from __future__ import annotations
 
+import logging
+import os
 import re
-from typing import Optional
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
 
 # "0000:03:00.0" -- Domain, Bus, Slot, Funktion
 _PCI_BDF = re.compile(
@@ -63,3 +67,130 @@ def encode_platform_address(dev_name: str) -> Optional[int]:
 def format_chip_name(prefix: str, bus: str, addr: int) -> str:
     """lib/data.c: "%s-isa-%04x" bzw. "%s-pci-%04x" -- Mindestbreite, nicht fix."""
     return f"{prefix}-{bus}-{addr:04x}"
+
+
+logger = logging.getLogger(__name__)
+
+# Bustypen, deren Adressformat wir bilden koennen.
+_SUPPORTED_BUSES = {"pci": "pci", "platform": "isa", "of_platform": "isa"}
+# Bustypen, die libsensors kennt und wir NICHT bilden. Wird einer davon
+# getroffen, brechen wir sofort ab statt weiterzuklettern: bei drivetemp
+# (scsi) landete man sonst auf dem AHCI-Controller und gaebe allen Platten
+# desselben Controllers dieselbe Kennung.
+_FALLBACK_BUSES = {"i2c", "spi", "scsi", "hid", "acpi", "mdio_bus", "sdio"}
+_MAX_CLIMB = 12
+
+
+@dataclass(frozen=True)
+class ChipIdentity:
+    key: str
+    prefix: str
+    stable: bool
+    hwmon_name: str
+    reason: Optional[str]
+
+
+def _read_name(hwmon_dir: Path) -> Optional[str]:
+    try:
+        value = (hwmon_dir / "name").read_text().strip()
+    except OSError:
+        return None
+    return value or None
+
+
+def _subsystem_of(device: Path) -> Optional[str]:
+    link = device / "subsystem"
+    try:
+        if not link.exists():
+            return None
+        return os.path.basename(os.path.realpath(link))
+    except OSError:
+        return None
+
+
+def _unstable(hwmon_name: str, prefix: Optional[str], reason: str) -> ChipIdentity:
+    logger.warning("hwmon %s: keine stabile Kennung (%s)", hwmon_name, reason)
+    return ChipIdentity(key=hwmon_name, prefix=prefix or "Unknown",
+                        stable=False, hwmon_name=hwmon_name, reason=reason)
+
+
+def derive_chip_identity(hwmon_link: Path) -> ChipIdentity:
+    """Leitet die stabile Kennung eines hwmon-Knotens ab.
+
+    hwmon_link ist der Eintrag unter /sys/class/hwmon -- ein Symlink. Der
+    Aufstieg laeuft ueber den AUFGELOESTEN Pfad; ein lexikalisches
+    Path.parent landete bei /sys/class und faende nie ein subsystem
+    (dieselbe Falle wie in fan_gpu_manual.py:101-127).
+    """
+    hwmon_name = hwmon_link.name
+    hwmon_dir = Path(os.path.realpath(hwmon_link))
+    prefix = _read_name(hwmon_dir)
+    if prefix is None:
+        return _unstable(hwmon_name, None, "hwmon/name fehlt oder ist unlesbar")
+
+    device_link = hwmon_dir / "device"
+    if not device_link.exists():
+        return _unstable(hwmon_name, prefix, "kein device-Symlink (virtueller Chip)")
+
+    current = Path(os.path.realpath(device_link))
+    for _ in range(_MAX_CLIMB):
+        subsystem = _subsystem_of(current)
+        if subsystem in _SUPPORTED_BUSES:
+            bus = _SUPPORTED_BUSES[subsystem]
+            addr = (encode_pci_address(current.name) if subsystem == "pci"
+                    else encode_platform_address(current.name))
+            if addr is None:
+                # Kein extrahierbarer Suffix: Geraetename ist innerhalb
+                # seines Busses eindeutig und damit selbst ein tauglicher Anker.
+                key = f"{prefix}@{current.name}"
+            else:
+                key = format_chip_name(prefix, bus, addr)
+            return ChipIdentity(key=key, prefix=prefix, stable=True,
+                                hwmon_name=hwmon_name, reason=None)
+        if subsystem in _FALLBACK_BUSES:
+            return _unstable(hwmon_name, prefix, f"Bustyp {subsystem} nicht unterstuetzt")
+        parent = current.parent
+        if parent == current or current.name == "devices":
+            break
+        current = parent
+
+    return _unstable(hwmon_name, prefix, "kein pci/platform-Elter gefunden")
+
+
+def derive_all(hwmon_base: Path) -> Dict[str, ChipIdentity]:
+    """Kennungen aller hwmon-Knoten, mit Duplikaterkennung."""
+    identities: Dict[str, ChipIdentity] = {}
+    try:
+        entries = sorted(hwmon_base.iterdir())
+    except OSError:
+        return identities
+
+    for entry in entries:
+        if not entry.name.startswith("hwmon"):
+            continue
+        identities[entry.name] = derive_chip_identity(entry)
+
+    by_key: Dict[str, list] = {}
+    for name, identity in identities.items():
+        if identity.stable:
+            by_key.setdefault(identity.key, []).append(name)
+    for key, names in by_key.items():
+        if len(names) > 1:
+            for name in names:
+                identities[name] = _unstable(
+                    name, identities[name].prefix,
+                    f"Kennung {key} nicht eindeutig ({len(names)} hwmon-Knoten)",
+                )
+    return identities
+
+
+def build_fan_id(identity: ChipIdentity, pwm_num: int) -> str:
+    if identity.stable:
+        return f"{identity.key}:pwm{pwm_num}"
+    return f"{identity.hwmon_name}_pwm{pwm_num}"
+
+
+def build_sensor_id(identity: ChipIdentity, temp_num: int) -> str:
+    if identity.stable:
+        return f"{identity.key}:temp{temp_num}"
+    return f"{identity.hwmon_name}_temp{temp_num}"

--- a/backend/app/services/power/fan_identity.py
+++ b/backend/app/services/power/fan_identity.py
@@ -109,7 +109,15 @@ def _subsystem_of(device: Path) -> Optional[str]:
 
 
 def _unstable(hwmon_name: str, prefix: Optional[str], reason: str) -> ChipIdentity:
-    logger.warning("hwmon %s: keine stabile Kennung (%s)", hwmon_name, reason)
+    # M-2: DEBUG statt WARNING. derive_all() laeuft nicht nur beim Start,
+    # sondern bei jedem Sensor-Listing-Request (get_available_temp_sensors(),
+    # _find_cpu_temp_sensor()) -- eine WARNING pro instabilem Chip UND
+    # Request waere die Log-Flut aus #533 im Kleinen. Ein Chip, der instabil
+    # ist, bleibt es fuer die Laufzeit des Prozesses; ein modulweiter Merker
+    # gegen wiederholtes Loggen waere komplexer als der Nutzen hier
+    # rechtfertigt -- DEBUG ist die einfachere Variante mit demselben Effekt
+    # (bei Bedarf im Log sichtbar, aber ohne Dauerrauschen auf WARNING).
+    logger.debug("hwmon %s: keine stabile Kennung (%s)", hwmon_name, reason)
     return ChipIdentity(key=hwmon_name, prefix=prefix or "Unknown",
                         stable=False, hwmon_name=hwmon_name, reason=reason)
 

--- a/backend/app/services/power/fan_identity.py
+++ b/backend/app/services/power/fan_identity.py
@@ -37,17 +37,19 @@ def encode_platform_address(dev_name: str) -> Optional[int]:
     auch wenn der Punkt danach nie matcht. Daraus werden asus-nb-wmi -> 0x0a
     und eeepc-wmi -> 0xeee: stabil, aber bedeutungslos. _PLATFORM_HEX
     verlangt den Punkt tatsaechlich und bildet damit den gemeinten
-    Device-Tree-Fall ab statt des Parser-Unfalls.
+    Device-Tree-Fall ab statt des Parser-Unfalls. Betroffen sind nur Chips,
+    die `sensors` ohnehin nicht listet.
 
-    Zweite bewusste Abweichung: sscanf ("%d") traegt dem Fehlen des
-    Stringende-Ankers Rechnung -- "nct6775.656.1" liefert 656. Libsensors'
-    "%*[a-zA-Z0-9_]%*1[.:]%d" haette das gleiche Ergebnis.
+    Technische Anmerkung zu _PLATFORM_DECIMAL: sscanf ("%d") liest den
+    fuehrenden Ziffernlauf und ignoriert den Rest. Das Muster verzichtet
+    bewusst auf einen Stringende-Anker ($), um dieses Verhalten nachzubilden.
+    Ein Anker waere eine Abweichung -- "nct6775.656.1" wuerde dann None
+    liefern statt 656. Keinen Anker zu setzen ist die Paritaet.
 
-    Dritte bewusste Abweichung: Zeichenklasse enthaelt Bindestrich,
+    Zweite bewusste Abweichung: Zeichenklasse enthaelt Bindestrich,
     normatives Scanset %*[a-zA-Z0-9_] nicht. Ohne Bindestrich fiele
     "abc-def.5" in den Hex-Parser-Unfall (sscanf "%x" liest "abc" -> 0xabc).
-    Stattdessen lesen wir den Suffix. Betroffen sind nur Chips, die `sensors`
-    ohnehin nicht listet.
+    Stattdessen lesen wir den Suffix.
     """
     match = _PLATFORM_DECIMAL.match(dev_name)
     if match:

--- a/backend/app/services/power/fan_identity.py
+++ b/backend/app/services/power/fan_identity.py
@@ -15,9 +15,9 @@ _PCI_BDF = re.compile(
     r"^([0-9a-fA-F]{4}):([0-9a-fA-F]{2}):([0-9a-fA-F]{2})\.([0-9a-fA-F])$"
 )
 # "nct6775.656" / "foo:42" -- Suffix wird DEZIMAL gelesen
-_PLATFORM_DECIMAL = re.compile(r"^[A-Za-z0-9_-]+[.:](\d+)$")
+_PLATFORM_DECIMAL = re.compile(r"^[A-Za-z0-9_-]+[.:](\d+)")
 # "f0000000.hwmon" -- Device-Tree-Adresse, hexadezimal
-_PLATFORM_HEX = re.compile(r"^([0-9a-f]+)\.")
+_PLATFORM_HEX = re.compile(r"^([0-9a-fA-F]+)\.")
 
 
 def encode_pci_address(dev_name: str) -> Optional[int]:
@@ -32,12 +32,14 @@ def encode_pci_address(dev_name: str) -> Optional[int]:
 def encode_platform_address(dev_name: str) -> Optional[int]:
     """Platform-Adresse: dezimaler Suffix, sonst Device-Tree-Hex, sonst None.
 
-    libsensors' zweiter sscanf ("%x.%*s") liefert bereits 1, wenn %x etwas
-    konsumiert hat -- auch wenn der Punkt danach nie matcht. Daraus werden
-    asus-nb-wmi -> 0x0a und eeepc-wmi -> 0xeee: stabil, aber bedeutungslos.
-    _PLATFORM_HEX verlangt den Punkt tatsaechlich und bildet damit den
-    gemeinten Device-Tree-Fall ab statt des Parser-Unfalls. Betroffen sind nur
-    Chips, die `sensors` ohnehin nicht listet.
+    Erste bewusste Abweichung von libsensors 3.6.2: sscanf ("%d") traegt dem
+    Eintritt ohne Stringende-Anker Rechnung -- "nct6775.656.1" liefert 656.
+    Libsensors' "%*[a-zA-Z0-9_]%*1[.:]%d" haette das gleiche Ergebnis.
+
+    Zweite bewusste Abweichung: Zeichenklasse enthaelt Bindestrich, normatives
+    Scanset %*[a-zA-Z0-9_] nicht. Ohne Bindestrich fiele "abc-def.5" in den
+    Hex-Parser-Unfall (sscanf "%x" liest "abc" -> 0xabc). Stattdessen lesen
+    wir den Suffix. Betroffen sind nur Chips, die `sensors` ohnehin nicht listet.
     """
     match = _PLATFORM_DECIMAL.match(dev_name)
     if match:

--- a/backend/app/services/power/fan_identity.py
+++ b/backend/app/services/power/fan_identity.py
@@ -1,0 +1,53 @@
+"""Stabile Chip-Identitaet fuer hwmon-Knoten (#532).
+
+Bildet die libsensors-Kennung <prefix>-<bus>-<adresse>, damit Luefter- und
+Sensor-IDs ein hwmon-Renumbering ueberleben. Normativ ist lm-sensors 3.6.2
+(lib/sysfs.c, lib/data.c); Regeln aus master gelten fuer diese Zielhardware
+nicht.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# "0000:03:00.0" -- Domain, Bus, Slot, Funktion
+_PCI_BDF = re.compile(
+    r"^([0-9a-fA-F]{4}):([0-9a-fA-F]{2}):([0-9a-fA-F]{2})\.([0-9a-fA-F])$"
+)
+# "nct6775.656" / "foo:42" -- Suffix wird DEZIMAL gelesen
+_PLATFORM_DECIMAL = re.compile(r"^[A-Za-z0-9_-]+[.:](\d+)$")
+# "f0000000.hwmon" -- Device-Tree-Adresse, hexadezimal
+_PLATFORM_HEX = re.compile(r"^([0-9a-f]+)\.")
+
+
+def encode_pci_address(dev_name: str) -> Optional[int]:
+    """PCI-Adresse nach lib/sysfs.c: (domain<<16)+(bus<<8)+(slot<<3)+fn."""
+    match = _PCI_BDF.match(dev_name)
+    if not match:
+        return None
+    domain, bus, slot, fn = (int(group, 16) for group in match.groups())
+    return (domain << 16) + (bus << 8) + (slot << 3) + fn
+
+
+def encode_platform_address(dev_name: str) -> Optional[int]:
+    """Platform-Adresse: dezimaler Suffix, sonst Device-Tree-Hex, sonst None.
+
+    libsensors' zweiter sscanf ("%x.%*s") liefert bereits 1, wenn %x etwas
+    konsumiert hat -- auch wenn der Punkt danach nie matcht. Daraus werden
+    asus-nb-wmi -> 0x0a und eeepc-wmi -> 0xeee: stabil, aber bedeutungslos.
+    _PLATFORM_HEX verlangt den Punkt tatsaechlich und bildet damit den
+    gemeinten Device-Tree-Fall ab statt des Parser-Unfalls. Betroffen sind nur
+    Chips, die `sensors` ohnehin nicht listet.
+    """
+    match = _PLATFORM_DECIMAL.match(dev_name)
+    if match:
+        return int(match.group(1), 10)
+    match = _PLATFORM_HEX.match(dev_name)
+    if match:
+        return int(match.group(1), 16)
+    return None
+
+
+def format_chip_name(prefix: str, bus: str, addr: int) -> str:
+    """lib/data.c: "%s-isa-%04x" bzw. "%s-pci-%04x" -- Mindestbreite, nicht fix."""
+    return f"{prefix}-{bus}-{addr:04x}"

--- a/backend/app/services/power/fan_identity.py
+++ b/backend/app/services/power/fan_identity.py
@@ -32,14 +32,22 @@ def encode_pci_address(dev_name: str) -> Optional[int]:
 def encode_platform_address(dev_name: str) -> Optional[int]:
     """Platform-Adresse: dezimaler Suffix, sonst Device-Tree-Hex, sonst None.
 
-    Erste bewusste Abweichung von libsensors 3.6.2: sscanf ("%d") traegt dem
-    Eintritt ohne Stringende-Anker Rechnung -- "nct6775.656.1" liefert 656.
-    Libsensors' "%*[a-zA-Z0-9_]%*1[.:]%d" haette das gleiche Ergebnis.
+    Erste bewusste Abweichung von libsensors 3.6.2: libsensors' zweiter
+    sscanf ("%x.%*s") liefert bereits 1, wenn %x etwas konsumiert hat --
+    auch wenn der Punkt danach nie matcht. Daraus werden asus-nb-wmi -> 0x0a
+    und eeepc-wmi -> 0xeee: stabil, aber bedeutungslos. _PLATFORM_HEX
+    verlangt den Punkt tatsaechlich und bildet damit den gemeinten
+    Device-Tree-Fall ab statt des Parser-Unfalls.
 
-    Zweite bewusste Abweichung: Zeichenklasse enthaelt Bindestrich, normatives
-    Scanset %*[a-zA-Z0-9_] nicht. Ohne Bindestrich fiele "abc-def.5" in den
-    Hex-Parser-Unfall (sscanf "%x" liest "abc" -> 0xabc). Stattdessen lesen
-    wir den Suffix. Betroffen sind nur Chips, die `sensors` ohnehin nicht listet.
+    Zweite bewusste Abweichung: sscanf ("%d") traegt dem Fehlen des
+    Stringende-Ankers Rechnung -- "nct6775.656.1" liefert 656. Libsensors'
+    "%*[a-zA-Z0-9_]%*1[.:]%d" haette das gleiche Ergebnis.
+
+    Dritte bewusste Abweichung: Zeichenklasse enthaelt Bindestrich,
+    normatives Scanset %*[a-zA-Z0-9_] nicht. Ohne Bindestrich fiele
+    "abc-def.5" in den Hex-Parser-Unfall (sscanf "%x" liest "abc" -> 0xabc).
+    Stattdessen lesen wir den Suffix. Betroffen sind nur Chips, die `sensors`
+    ohnehin nicht listet.
     """
     match = _PLATFORM_DECIMAL.match(dev_name)
     if match:

--- a/backend/app/services/power/fan_reconcile.py
+++ b/backend/app/services/power/fan_reconcile.py
@@ -156,15 +156,21 @@ def reconcile_fan_identities(
                 row.is_active = False
                 report.deactivated.append(row.fan_id)
             if row.fan_id == new_id:
-                # I-2: Ein Inkumbent (bereits in Neuform), der den Rangvergleich
+                # Ein Inkumbent (bereits in Neuform), der den Rangvergleich
                 # verliert, behielte sonst fan_id == new_id. Der Gewinner wird
                 # gleich darunter auf denselben Wert umbenannt -- zwei Zeilen mit
                 # identischem fan_id verletzen den Unique-Index beim Flush. Die
-                # ID freimachen, BEVOR der Gewinner sie uebernimmt. legacy_fan_id
-                # ist der natuerliche Rueckfall (die urspruengliche Altform, aus
-                # einem frueheren Lauf); ohne den erzeugt die id einen
-                # garantiert eindeutigen Ersatz.
-                row.fan_id = row.legacy_fan_id or f"{new_id}#legacy{row.id}"
+                # ID freimachen, BEVOR der Gewinner sie uebernimmt.
+                #
+                # Bewusst NICHT legacy_fan_id als Ersatz: nach einem Rollback auf
+                # Code vor #532 legt die alte Anlage-Schleife eine Zeile unter
+                # exakt der Altform an, die dieser Inkumbent als legacy_fan_id
+                # fuehrt. Beim Roll-forward gewinnt sie (juenger), und der
+                # Inkumbent bekaeme "seine" Altform zurueck -- die die Gewinnerin
+                # noch haelt. Das ist derselbe Unique-Verstoss, nur eine Zeile
+                # weiter. row.id ist Primaerschluessel und damit ohne Rueckfrage
+                # eindeutig; die Herkunft steht ohnehin in legacy_fan_id.
+                row.fan_id = f"{new_id}#legacy{row.id}"
 
         if winner.fan_id != new_id:
             # session.dirty ist ein Set ohne Reihenfolgegarantie: ohne

--- a/backend/app/services/power/fan_reconcile.py
+++ b/backend/app/services/power/fan_reconcile.py
@@ -155,8 +155,26 @@ def reconcile_fan_identities(
             if row.is_active:
                 row.is_active = False
                 report.deactivated.append(row.fan_id)
+            if row.fan_id == new_id:
+                # I-2: Ein Inkumbent (bereits in Neuform), der den Rangvergleich
+                # verliert, behielte sonst fan_id == new_id. Der Gewinner wird
+                # gleich darunter auf denselben Wert umbenannt -- zwei Zeilen mit
+                # identischem fan_id verletzen den Unique-Index beim Flush. Die
+                # ID freimachen, BEVOR der Gewinner sie uebernimmt. legacy_fan_id
+                # ist der natuerliche Rueckfall (die urspruengliche Altform, aus
+                # einem frueheren Lauf); ohne den erzeugt die id einen
+                # garantiert eindeutigen Ersatz.
+                row.fan_id = row.legacy_fan_id or f"{new_id}#legacy{row.id}"
 
         if winner.fan_id != new_id:
+            # session.dirty ist ein Set ohne Reihenfolgegarantie: ohne
+            # diesen Flush kann SQLAlchemy die Umbenennung des Gewinners
+            # (unten) VOR dem Freimachen des Inkumbenten (oben) herausschreiben
+            # und denselben Unique-Verstoss ausloesen, den die I-2-Aenderung
+            # gerade beheben soll -- nur verschoben vom Python- ins DB-Timing.
+            # Der Flush erzwingt: erst der befreite Inkumbent, dann der
+            # Gewinner.
+            db.flush()
             old_id = winner.fan_id
             winner.legacy_fan_id = old_id
             winner.fan_id = new_id
@@ -199,42 +217,50 @@ def _reconcile_sensor_labels(db: Session, sensor_map: Dict[str, str],
     ihrem alten Schluessel liegen und wird ignoriert. Kein Loeschen -- das
     ist ein ausdrueckliches Nicht-Ziel der Spec.
 
-    Praefix-Asymmetrie ist Absicht: sensor_id (Primaerschluessel dieser
-    Tabelle) wird OHNE "hwmon:"-Praefix abgelegt -- das ist die interne Form
-    der Registry. FanConfig.temp_sensor_id und die Quell-IDs in
-    composite_temp_sensors behalten das Praefix, weil sie dort die
-    oeffentliche, praefixierte Sensor-Kennung referenzieren. Keine
-    Vereinheitlichung vorgesehen.
+    I-1: Real gespeichert wird sensor_id IMMER praefixiert ("hwmon:hwmon4_temp1")
+    -- die Route persistiert dieselbe Kennung, die die Registry vergibt
+    (HwmonTempSource.id = "hwmon:"+sensor_id), und PUT/DELETE
+    /api/fans/sensors/{sensor_id}/label suchen spaeter exakt danach. Ein
+    Regex-Test ohne vorheriges Abstreifen des Praefix traf keine einzige
+    reale Zeile -- die Migration lief still ins Leere. Deshalb: Praefix vor
+    dem Regex-Test optional abstreifen (wie _map_sensor es bereits tut),
+    und die neue Kennung MIT Praefix zurueckschreiben -- sensor_map liefert
+    sie ohnehin schon praefixiert (siehe FanControlService._collect_sensor_map),
+    und nur so bleibt die Zeile fuer PUT/DELETE wiederauffindbar. Keine
+    Praefix-Asymmetrie mehr: sensor_id traegt jetzt durchgehend "hwmon:",
+    genau wie FanConfig.temp_sensor_id und die Quell-IDs in
+    composite_temp_sensors.
     """
     rows = list(db.execute(select(TempSensorLabel)).scalars())
     existing = {row.sensor_id for row in rows}
     claimed: Dict[str, TempSensorLabel] = {}
 
     for row in rows:
-        if not _LEGACY_SENSOR_ID.match(row.sensor_id or ""):
-            continue
-        new_id = sensor_map.get(row.sensor_id)
+        raw = row.sensor_id or ""
+        bare = raw[len("hwmon:"):] if raw.startswith("hwmon:") else raw
+        if not _LEGACY_SENSOR_ID.match(bare):
+            continue                                   # bereits stabil oder unbekannt
+        new_id = sensor_map.get(bare)
         if not new_id:
             report.unresolved_sensors.append(row.sensor_id)
             continue
-        bare_new = new_id[len("hwmon:"):] if new_id.startswith("hwmon:") else new_id
-        if bare_new in existing:
+        if new_id in existing:
             continue
-        rival = claimed.get(bare_new)
+        rival = claimed.get(new_id)
         if rival is not None:
             loser = min((rival, row), key=lambda r: r.updated_at or _EPOCH)
             logger.warning(
                 "Sensor-Label %s verworfen: %s ist bereits vergeben",
-                loser.sensor_id, bare_new,
+                loser.sensor_id, new_id,
             )
             if loser is row:
                 continue
-        claimed[bare_new] = row
+        claimed[new_id] = row
 
-    for bare_new, row in claimed.items():
+    for new_id, row in claimed.items():
         row.legacy_sensor_id = row.sensor_id
-        row.sensor_id = bare_new
-        logger.info("Sensor-Label: %s -> %s", row.legacy_sensor_id, bare_new)
+        row.sensor_id = new_id
+        logger.info("Sensor-Label: %s -> %s", row.legacy_sensor_id, new_id)
 
 
 def _reconcile_composites(db: Session, sensor_map: Dict[str, str]) -> None:

--- a/backend/app/services/power/fan_reconcile.py
+++ b/backend/app/services/power/fan_reconcile.py
@@ -1,0 +1,250 @@
+"""Ueberfuehrt hwmon-indizierte fan_configs auf stabile Kennungen (#532).
+
+Reines Modul: es bekommt die Scan-Fakten uebergeben und fasst kein sysfs an.
+Der Aufrufer haelt die Transaktion.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.fans import (
+    CompositeTempSensor,
+    FanConfig,
+    FanScheduleEntry,
+    TempSensorLabel,
+)
+
+logger = logging.getLogger(__name__)
+
+_LEGACY_FAN_ID = re.compile(r"^hwmon(\d+)_pwm(\d+)$")
+_LEGACY_SENSOR_ID = re.compile(r"^hwmon(\d+)_temp(\d+)$")
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class ChipFacts:
+    """Was der Scan ueber einen heute vorhandenen Chip weiss."""
+    key: str
+    pwm_channels: frozenset
+    ambiguous: bool
+
+
+@dataclass
+class ReconcileReport:
+    renamed: List[Tuple[str, str]] = field(default_factory=list)
+    deactivated: List[str] = field(default_factory=list)
+    skipped_absent: List[str] = field(default_factory=list)
+    unresolved_sensors: List[str] = field(default_factory=list)
+
+
+def _chip_from_name(name: Optional[str]) -> Optional[str]:
+    """"nct6798 PWM1" -> "nct6798". Ohne " PWM" kein Kandidat.
+
+    Der Dev-Backend erzeugt Namen wie "CPU Fan (Simulated)"; ein naives
+    rsplit gaebe dort den ganzen Namen als Chip-Namen zurueck.
+    """
+    if not name:
+        return None
+    index = name.rfind(" PWM")
+    if index <= 0:
+        return None
+    return name[:index]
+
+
+def _map_sensor(sensor_id: Optional[str], sensor_map: Dict[str, str],
+                cpu_sensor_id: Optional[str],
+                report: ReconcileReport) -> Optional[str]:
+    """Bildet eine Alt-Sensor-ID ueber sensor_map auf die stabile Form ab.
+
+    Regel R2: nur die nackte Alt-Form (nach optionalem "hwmon:"-Praefix)
+    im Muster "hwmonX_tempY" ist ueberhaupt ein Abbildungskandidat. Ohne
+    diese Einschraenkung wuerde ein zweiter Lauf jede bereits stabile ID
+    (z. B. "hwmon:k10temp-pci-00c3:temp1") erneut durch die Map schicken,
+    dort nicht finden und faelschlich als unaufloesbar melden -- bei
+    jedem Dienststart eine WARNING, obwohl nichts falsch ist.
+    """
+    if not sensor_id:
+        return cpu_sensor_id
+    bare = sensor_id[len("hwmon:"):] if sensor_id.startswith("hwmon:") else sensor_id
+    if not _LEGACY_SENSOR_ID.match(bare):
+        return sensor_id                               # bereits stabil oder unbekanntes Format
+    mapped = sensor_map.get(bare)
+    if mapped:
+        return mapped
+    report.unresolved_sensors.append(bare)
+    logger.warning(
+        "Sensor %s nicht aufloesbar, Rueckfall auf den CPU-Default %s",
+        sensor_id, cpu_sensor_id,
+    )
+    return cpu_sensor_id
+
+
+def reconcile_fan_identities(
+    db: Session,
+    *,
+    chips: Dict[str, ChipFacts],
+    sensor_map: Dict[str, str],
+    cpu_sensor_id: Optional[str],
+) -> ReconcileReport:
+    """Ordnet Altzeilen stabilen Kennungen zu. Committet NICHT."""
+    report = ReconcileReport()
+    rows = list(db.execute(select(FanConfig)).scalars())
+
+    # Rangfolge VOR dem ersten Schreibzugriff festhalten: updated_at traegt
+    # ein onupdate=func.now() und aendert sich sonst waehrend des Laufs.
+    order = {row.id: row.updated_at for row in rows}
+
+    candidates: Dict[str, List[FanConfig]] = {}
+    for row in rows:
+        match = _LEGACY_FAN_ID.match(row.fan_id or "")
+        if not match:
+            continue                                   # Regel 1
+        if not row.is_active:
+            # Bereits in einem frueheren Lauf final entschieden (verloren
+            # oder wegen fehlendem Kanal deaktiviert). Ohne diese Sperre
+            # traete die Zeile bei jedem weiteren Lauf erneut gegen den
+            # laengst gekuerten Gewinner an -- mit demselben fan_id-Wert
+            # wie zuvor, also ohne neue Information, aber mit der Chance,
+            # den Wettbewerb per Ranggleichstand zu gewinnen und so den
+            # Unique-Index auf fan_id zu verletzen.
+            continue
+        chip = _chip_from_name(row.name)
+        if chip is None:
+            continue                                   # kein " PWM" im Namen
+        facts = chips.get(chip)
+        if facts is None:                              # Regel 4: Chip abwesend
+            report.skipped_absent.append(row.fan_id)
+            continue
+        if facts.ambiguous:
+            continue                                   # Regel 2
+        channel = int(match.group(2))
+        if channel not in facts.pwm_channels:
+            row.is_active = False                      # Chip da, Kanal weg
+            report.deactivated.append(row.fan_id)
+            continue
+        candidates.setdefault(f"{facts.key}:pwm{channel}", []).append(row)
+
+    # Bereits in Neuform vorliegende Zeilen treten mit an, sonst laeuft ein
+    # nach einem Abbruch wiederholter Lauf in den Unique-Index.
+    existing = {row.fan_id: row for row in rows}
+    for new_id, group in candidates.items():
+        incumbent = existing.get(new_id)
+        if incumbent is not None and incumbent not in group:
+            group.append(incumbent)
+
+        # Kein None in den Sortierschluessel: zwei Zeilen ohne updated_at
+        # liefen sonst in einen TypeError beim Vergleich None < None.
+        winner = max(group, key=lambda r: order.get(r.id) or _EPOCH)
+        for row in group:
+            if row is winner:
+                continue
+            if row.is_active:
+                row.is_active = False
+                report.deactivated.append(row.fan_id)
+
+        if winner.fan_id != new_id:
+            old_id = winner.fan_id
+            winner.legacy_fan_id = old_id
+            winner.fan_id = new_id
+            report.renamed.append((old_id, new_id))
+            logger.info("Fan-Identitaet: %s -> %s", old_id, new_id)
+            _rewrite_references(db, old_id, new_id)
+
+        winner.temp_sensor_id = _map_sensor(
+            winner.temp_sensor_id, sensor_map, cpu_sensor_id, report
+        )
+
+    _reconcile_sensor_labels(db, sensor_map, report)
+    _reconcile_composites(db, sensor_map)
+
+    logger.info(
+        "Identitaets-Abgleich: %d uebernommen, %d deaktiviert, %d ohne Chip",
+        len(report.renamed), len(report.deactivated), len(report.skipped_absent),
+    )
+    return report
+
+
+def _rewrite_references(db: Session, old_id: str, new_id: str) -> None:
+    """sync_fan_id und Zeitplaneintraege ziehen mit."""
+    for row in db.execute(
+        select(FanConfig).where(FanConfig.sync_fan_id == old_id)
+    ).scalars():
+        row.sync_fan_id = new_id
+    for entry in db.execute(
+        select(FanScheduleEntry).where(FanScheduleEntry.fan_id == old_id)
+    ).scalars():
+        entry.fan_id = new_id
+
+
+def _reconcile_sensor_labels(db: Session, sensor_map: Dict[str, str],
+                             report: ReconcileReport) -> None:
+    """Nutzer-Labels auf die neuen Sensor-Kennungen umschluesseln.
+
+    sensor_id ist Primaerschluessel und die Tabelle hat kein is_active. Bei
+    einer Kollision gewinnt die juengste Zeile; die verworfene BLEIBT unter
+    ihrem alten Schluessel liegen und wird ignoriert. Kein Loeschen -- das
+    ist ein ausdrueckliches Nicht-Ziel der Spec.
+    """
+    rows = list(db.execute(select(TempSensorLabel)).scalars())
+    existing = {row.sensor_id for row in rows}
+    claimed: Dict[str, TempSensorLabel] = {}
+
+    for row in rows:
+        if not _LEGACY_SENSOR_ID.match(row.sensor_id or ""):
+            continue
+        new_id = sensor_map.get(row.sensor_id)
+        if not new_id:
+            report.unresolved_sensors.append(row.sensor_id)
+            continue
+        bare_new = new_id[len("hwmon:"):] if new_id.startswith("hwmon:") else new_id
+        if bare_new in existing:
+            continue
+        rival = claimed.get(bare_new)
+        if rival is not None:
+            loser = min((rival, row), key=lambda r: r.updated_at or _EPOCH)
+            logger.warning(
+                "Sensor-Label %s verworfen: %s ist bereits vergeben",
+                loser.sensor_id, bare_new,
+            )
+            if loser is row:
+                continue
+        claimed[bare_new] = row
+
+    for bare_new, row in claimed.items():
+        row.legacy_sensor_id = row.sensor_id
+        row.sensor_id = bare_new
+        logger.info("Sensor-Label: %s -> %s", row.legacy_sensor_id, bare_new)
+
+
+def _reconcile_composites(db: Session, sensor_map: Dict[str, str]) -> None:
+    """Quell-IDs in composite_temp_sensors mit derselben Abbildung umschreiben."""
+    for composite in db.execute(select(CompositeTempSensor)).scalars():
+        try:
+            sources = json.loads(composite.source_ids_json)
+        except (TypeError, ValueError):
+            logger.warning("Composite %s: source_ids_json unlesbar", composite.id)
+            continue
+        if not isinstance(sources, list):
+            continue
+
+        changed = False
+        rewritten = []
+        for source in sources:
+            bare = source[len("hwmon:"):] if isinstance(source, str) and source.startswith("hwmon:") else source
+            mapped = sensor_map.get(bare) if isinstance(bare, str) else None
+            if mapped:
+                rewritten.append(mapped)
+                changed = True
+            else:
+                rewritten.append(source)
+        if changed:
+            composite.source_ids_json = json.dumps(rewritten)
+            logger.info("Composite %s: Quell-IDs umgeschrieben", composite.id)

--- a/backend/app/services/power/fan_reconcile.py
+++ b/backend/app/services/power/fan_reconcile.py
@@ -142,7 +142,13 @@ def reconcile_fan_identities(
 
         # Kein None in den Sortierschluessel: zwei Zeilen ohne updated_at
         # liefen sonst in einen TypeError beim Vergleich None < None.
-        winner = max(group, key=lambda r: order.get(r.id) or _EPOCH)
+        # Zweites Kriterium id: bei exaktem Zeitgleichstand (SQLite-Aufloesung,
+        # oder ein Restore/Bulk-Update, das mehrere Zeilen in derselben Sekunde
+        # anfasst) entscheidet sonst die zufaellige Query-Reihenfolge -- genau
+        # das hat den urspruenglichen IntegrityError mitverursacht. Die hoehere
+        # id ist die zuletzt angelegte Zeile und bildet die aktuellere
+        # Hardware-Sicht ab.
+        winner = max(group, key=lambda r: (order.get(r.id) or _EPOCH, r.id or 0))
         for row in group:
             if row is winner:
                 continue
@@ -192,6 +198,13 @@ def _reconcile_sensor_labels(db: Session, sensor_map: Dict[str, str],
     einer Kollision gewinnt die juengste Zeile; die verworfene BLEIBT unter
     ihrem alten Schluessel liegen und wird ignoriert. Kein Loeschen -- das
     ist ein ausdrueckliches Nicht-Ziel der Spec.
+
+    Praefix-Asymmetrie ist Absicht: sensor_id (Primaerschluessel dieser
+    Tabelle) wird OHNE "hwmon:"-Praefix abgelegt -- das ist die interne Form
+    der Registry. FanConfig.temp_sensor_id und die Quell-IDs in
+    composite_temp_sensors behalten das Praefix, weil sie dort die
+    oeffentliche, praefixierte Sensor-Kennung referenzieren. Keine
+    Vereinheitlichung vorgesehen.
     """
     rows = list(db.execute(select(TempSensorLabel)).scalars())
     existing = {row.sensor_id for row in rows}

--- a/backend/app/services/power/fan_sources.py
+++ b/backend/app/services/power/fan_sources.py
@@ -13,6 +13,9 @@ logger = logging.getLogger(__name__)
 
 SourceKind = Literal["hwmon", "gpu", "disk", "mix"]
 
+# Namespace-Praefix-Whitelist fuer _normalize_id()
+_NAMESPACES = ("hwmon:", "gpu:", "disk:", "mix:")
+
 
 @runtime_checkable
 class TempSource(Protocol):
@@ -100,8 +103,12 @@ class TempSourceRegistry:
 
     @staticmethod
     def _normalize_id(sensor_id: str) -> str:
-        """Accept both namespaced (hwmon:foo) and legacy (foo) IDs."""
-        if ":" in sensor_id:
+        """Accept both namespaced (hwmon:foo) and legacy (foo) IDs.
+
+        Geprueft wird der Namespace-Praefix, nicht das blosse Vorkommen eines
+        Doppelpunkts: stabile Kennungen (#532) tragen selbst einen.
+        """
+        if sensor_id.startswith(_NAMESPACES):
             return sensor_id
         return f"hwmon:{sensor_id}"
 

--- a/backend/tests/services/test_fan_control.py
+++ b/backend/tests/services/test_fan_control.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.core import lifespan
 from app.schemas.fans import FanCurvePoint, FanMode
 from app.services.power.fan_control import (
     DevFanControlBackend,
@@ -578,10 +579,18 @@ class TestDbAutoCorrection:
 
     The auto-correction was removed in Task 9 (Step 3b): user-chosen sensors
     must survive service restarts unchanged, including composite sensors.
+
+    I-4: the config-creation loop in _load_fan_configs is primary-worker-only
+    since the reconcile gate was added. Without IS_PRIMARY_WORKER=True the
+    method returns before ever reaching that loop, so these tests exercised
+    nothing. monkeypatch forces the flag for the duration of each test;
+    _use_linux_backend=False keeps _should_reconcile() from touching the
+    (unbuilt) reconcile path on this bare, __new__-constructed service.
     """
 
     @pytest.mark.asyncio
-    async def test_user_chosen_non_cpu_sensor_survives_reload(self, mock_settings):
+    async def test_user_chosen_non_cpu_sensor_survives_reload(self, mock_settings, monkeypatch):
+        monkeypatch.setattr(lifespan, "IS_PRIMARY_WORKER", True, raising=False)
         """User's non-CPU sensor must NOT be overwritten even when a CPU sensor is present."""
         from unittest.mock import MagicMock, patch
         from app.models.fans import FanConfig
@@ -635,6 +644,7 @@ class TestDbAutoCorrection:
             service.config = mock_settings
             service.db_session_factory = mock_session_factory
             service._backend = mock_backend
+            service._use_linux_backend = False
 
             await service._load_fan_configs()
 
@@ -644,8 +654,9 @@ class TestDbAutoCorrection:
         )
 
     @pytest.mark.asyncio
-    async def test_composite_sensor_survives_reload(self, mock_settings):
+    async def test_composite_sensor_survives_reload(self, mock_settings, monkeypatch):
         """A composite (mix:) sensor ID must survive service reload unchanged."""
+        monkeypatch.setattr(lifespan, "IS_PRIMARY_WORKER", True, raising=False)
         from unittest.mock import MagicMock, patch
         from app.models.fans import FanConfig
 
@@ -693,6 +704,7 @@ class TestDbAutoCorrection:
             service.config = mock_settings
             service.db_session_factory = mock_session_factory
             service._backend = mock_backend
+            service._use_linux_backend = False
 
             await service._load_fan_configs()
 
@@ -702,8 +714,9 @@ class TestDbAutoCorrection:
         )
 
     @pytest.mark.asyncio
-    async def test_no_change_when_already_cpu_sensor(self, mock_settings):
+    async def test_no_change_when_already_cpu_sensor(self, mock_settings, monkeypatch):
         """Existing CPU-sensor config also stays untouched on reload."""
+        monkeypatch.setattr(lifespan, "IS_PRIMARY_WORKER", True, raising=False)
         from unittest.mock import MagicMock, patch
         from app.models.fans import FanConfig
 
@@ -750,6 +763,7 @@ class TestDbAutoCorrection:
             service.config = mock_settings
             service.db_session_factory = mock_session_factory
             service._backend = mock_backend
+            service._use_linux_backend = False
 
             await service._load_fan_configs()
 

--- a/backend/tests/test_fan_einval_diagnostic.py
+++ b/backend/tests/test_fan_einval_diagnostic.py
@@ -1,4 +1,5 @@
 """When pwm write fails, capture driver name + pwm_enable in last_write_error."""
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,18 +11,17 @@ from app.core.config import get_settings
 
 @pytest.mark.asyncio
 async def test_write_failure_captures_diagnostic(tmp_path, monkeypatch):
-    d = tmp_path / "sys" / "class" / "hwmon" / "hwmon1"
-    d.mkdir(parents=True)
-    (d / "name").write_text("amdgpu\n")
-    (d / "pwm1").write_text("128\n")
-    (d / "fan1_input").write_text("1200\n")
-    (d / "pwm1_enable").write_text("2\n")
+    d = _amd_hwmon(tmp_path)
 
     backend = LinuxFanControlBackend(get_settings())
     monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
     await backend._scan_pwm_fans()
 
     fan_id = next(iter(backend._fan_cache))
+    # Beweis, dass der Scan den stabilen Zweig trifft (device/subsystem-Symlink
+    # in _amd_hwmon), nicht den Fallback "hwmon1_pwm1".
+    assert fan_id == "amdgpu-isa-0001:pwm1"
+    assert backend._fan_cache[fan_id]["identity_stable"] is True
 
     # Force direct write to fail with OSError(EINVAL) and sudo path to also fail
     def fail_write(self_, value):
@@ -43,12 +43,22 @@ from app.schemas.fans import PwmControl
 
 
 def _amd_hwmon(tmp_path, pwm="128", rpm="1200"):
-    d = tmp_path / "sys" / "class" / "hwmon" / "hwmon1"
+    """Platform-foermiger Baum (#532): device+subsystem-Symlink, damit die
+    Identitaetsableitung stabile IDs bildet statt in den Fallback zu fallen."""
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "amdgpu-sim.1"
+    device.mkdir(parents=True)
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus, device / "subsystem", target_is_directory=True)
+
+    d = sysfs / "class" / "hwmon" / "hwmon1"
     d.mkdir(parents=True)
     (d / "name").write_text("amdgpu\n")
     (d / "pwm1").write_text(f"{pwm}\n")
     (d / "fan1_input").write_text(f"{rpm}\n")
     (d / "pwm1_enable").write_text("2\n")
+    os.symlink(device, d / "device", target_is_directory=True)
     return d
 
 
@@ -80,6 +90,7 @@ async def test_eacces_reports_permission_not_kernel_rejection(tmp_path, monkeypa
     monkeypatch.setattr(backend, "_hwmon_base", tmp_path / "sys" / "class" / "hwmon")
     await backend._scan_pwm_fans()
     fan_id = next(iter(backend._fan_cache))
+    assert fan_id == "amdgpu-isa-0001:pwm1"
 
     def fail_eacces(self_, value):
         raise PermissionError(13, "Permission denied")

--- a/backend/tests/test_fan_identity_encoding.py
+++ b/backend/tests/test_fan_identity_encoding.py
@@ -47,6 +47,22 @@ def test_platform_address_without_suffix_is_none():
     assert encode_platform_address("eeepc-wmi") is None
 
 
+def test_platform_address_ignores_trailing_garbage_after_the_number():
+    # sscanf' %d liest den fuehrenden Ziffernlauf und stoppt; alles danach
+    # ist ihm gleich. Ein Endanker im Muster waere hier falsch.
+    assert encode_platform_address("nct6775.656.1") == 656
+
+
+def test_platform_address_accepts_hyphen_before_the_suffix():
+    # Zweite bewusste Abweichung: libsensors' Scanset kennt kein "-" und
+    # fiele in den Hex-Unfall (0xabc). Wir lesen den Suffix.
+    assert encode_platform_address("abc-def.5") == 5
+
+
+def test_device_tree_prefix_is_case_insensitive():
+    assert encode_platform_address("F0000000.hwmon") == 0xf0000000
+
+
 @pytest.mark.parametrize("prefix,bus,addr,expected", [
     ("nct6798", "isa", 656, "nct6798-isa-0290"),
     ("amdgpu", "pci", 0x0300, "amdgpu-pci-0300"),

--- a/backend/tests/test_fan_identity_encoding.py
+++ b/backend/tests/test_fan_identity_encoding.py
@@ -1,0 +1,58 @@
+"""Adressbildung der stabilen Chip-Kennung (#532).
+
+Sollwerte sind die Chip-Ueberschriften, die `sensors` auf BaluNode ausgibt --
+also eine unabhaengige Implementierung derselben Regeln auf derselben Hardware.
+"""
+import pytest
+
+from app.services.power.fan_identity import (
+    encode_pci_address,
+    encode_platform_address,
+    format_chip_name,
+)
+
+
+@pytest.mark.parametrize("dev_name,expected", [
+    ("0000:03:00.0", 0x0300),   # amdgpu
+    ("0000:00:18.3", 0x00c3),   # k10temp: (0x18 << 3) | 3
+    ("0000:0d:00.0", 0x0d00),   # nvme
+    ("0000:0a:00.0", 0x0a00),   # nvme
+    ("0001:0d:00.0", 0x10d00),  # Domain != 0 geht mit <<16 ein
+])
+def test_pci_address(dev_name, expected):
+    assert encode_pci_address(dev_name) == expected
+
+
+def test_pci_address_rejects_non_bdf():
+    assert encode_pci_address("nct6775.656") is None
+
+
+def test_platform_address_reads_suffix_as_decimal():
+    # 656 dezimal == 0x290 -- der Wert, den `sensors` als nct6798-isa-0290 zeigt
+    assert encode_platform_address("nct6775.656") == 656
+
+
+def test_platform_address_accepts_colon_separator():
+    assert encode_platform_address("foo:42") == 42
+
+
+def test_platform_address_reads_device_tree_prefix_as_hex():
+    assert encode_platform_address("f0000000.hwmon") == 0xf0000000
+
+
+def test_platform_address_without_suffix_is_none():
+    # Bewusste Abweichung von libsensors 3.6.2: dessen "%x.%*s" liefert hier
+    # 0x0a bzw. 0xeee, weil sscanf schon zaehlt, bevor der Punkt scheitert.
+    assert encode_platform_address("asus-nb-wmi") is None
+    assert encode_platform_address("eeepc-wmi") is None
+
+
+@pytest.mark.parametrize("prefix,bus,addr,expected", [
+    ("nct6798", "isa", 656, "nct6798-isa-0290"),
+    ("amdgpu", "pci", 0x0300, "amdgpu-pci-0300"),
+    ("k10temp", "pci", 0x00c3, "k10temp-pci-00c3"),
+    ("nvme", "pci", 0x0d00, "nvme-pci-0d00"),
+    ("nvme", "pci", 0x10d00, "nvme-pci-10d00"),  # %04x ist Mindestbreite
+])
+def test_format_chip_name(prefix, bus, addr, expected):
+    assert format_chip_name(prefix, bus, addr) == expected

--- a/backend/tests/test_fan_identity_resolve.py
+++ b/backend/tests/test_fan_identity_resolve.py
@@ -97,11 +97,10 @@ def test_platform_without_numeric_suffix_uses_device_name(tmp_path):
     assert identity.key == "asus@asus-nb-wmi"
 
 
-@requires_colon_paths
 def test_unsupported_bus_falls_back(tmp_path):
-    # drivetemp haengt am scsi-Bus. Weiterklettern landete auf dem
-    # AHCI-Controller und gaebe allen Platten dieselbe Kennung.
-    link = _tree(tmp_path, "hwmon7", "pci0000:00/0000:00:17.0/ata1/host0",
+    # drivetemp haengt am scsi-Bus. Die Schleife bricht sofort ab, wenn
+    # subsystem=scsi erkannt wird; der PCI-Baum darueber wird nicht betreten.
+    link = _tree(tmp_path, "hwmon7", "platform/ahci-sim/ata1/host0",
                  "drivetemp", subsystem="scsi")
     identity = derive_chip_identity(link)
     assert identity.stable is False
@@ -121,9 +120,11 @@ def test_missing_device_link_falls_back(tmp_path):
     assert derive_chip_identity(link).stable is False
 
 
-@requires_colon_paths
 def test_missing_name_falls_back(tmp_path):
-    link = _tree(tmp_path, "hwmon4", "pci0000:00/0000:00:18.3", "k10temp")
+    # Namensprüfung läuft vor dem Gerätelauf. Ein vollständiger Baum
+    # mit fehlender name ist trotzdem instabil.
+    link = _tree(tmp_path, "hwmon4", "platform/k10temp-sim.1", "k10temp",
+                 subsystem="platform")
     (link.resolve() / "name").unlink()
     assert derive_chip_identity(link).stable is False
 

--- a/backend/tests/test_fan_identity_resolve.py
+++ b/backend/tests/test_fan_identity_resolve.py
@@ -121,8 +121,9 @@ def test_missing_device_link_falls_back(tmp_path):
 
 
 def test_missing_name_falls_back(tmp_path):
-    # Namensprüfung läuft vor dem Gerätelauf. Ein vollständiger Baum
-    # mit fehlender name ist trotzdem instabil.
+    # Die Namenspruefung laeuft vor dem Aufstieg durch den Geraetebaum: ein
+    # ansonsten vollstaendiger Baum ohne lesbare "name"-Datei ist trotzdem
+    # instabil.
     link = _tree(tmp_path, "hwmon4", "platform/k10temp-sim.1", "k10temp",
                  subsystem="platform")
     (link.resolve() / "name").unlink()

--- a/backend/tests/test_fan_identity_resolve.py
+++ b/backend/tests/test_fan_identity_resolve.py
@@ -17,6 +17,13 @@ from app.services.power.fan_identity import (
     derive_chip_identity,
 )
 
+requires_colon_paths = pytest.mark.skipif(
+    os.name == "nt",
+    reason="NTFS erlaubt keine Doppelpunkte in Verzeichnisnamen; PCI-Pfade "
+           "wie pci0000:00/0000:03:00.0 sind unter Windows nicht anlegbar. "
+           "Die CI (Linux) fuehrt diesen Test aus.",
+)
+
 
 def _tree(tmp_path: Path, hwmon_name: str, device_rel: str, chip: str,
           subsystem: str = "pci") -> Path:
@@ -51,11 +58,13 @@ def test_platform_chip_uses_decimal_suffix(tmp_path):
     assert identity.key == "nct6798-isa-0290"
 
 
+@requires_colon_paths
 def test_pci_chip(tmp_path):
     link = _tree(tmp_path, "hwmon2", "pci0000:00/0000:03:00.0", "amdgpu")
     assert derive_chip_identity(link).key == "amdgpu-pci-0300"
 
 
+@requires_colon_paths
 def test_climbs_past_intermediate_class_to_pci_parent(tmp_path):
     # NVMe: der device-Link zeigt auf nvme1, dessen subsystem die Klasse
     # "nvme" ist -- weder pci noch platform, also weiterklettern.
@@ -88,6 +97,7 @@ def test_platform_without_numeric_suffix_uses_device_name(tmp_path):
     assert identity.key == "asus@asus-nb-wmi"
 
 
+@requires_colon_paths
 def test_unsupported_bus_falls_back(tmp_path):
     # drivetemp haengt am scsi-Bus. Weiterklettern landete auf dem
     # AHCI-Controller und gaebe allen Platten dieselbe Kennung.
@@ -111,6 +121,7 @@ def test_missing_device_link_falls_back(tmp_path):
     assert derive_chip_identity(link).stable is False
 
 
+@requires_colon_paths
 def test_missing_name_falls_back(tmp_path):
     link = _tree(tmp_path, "hwmon4", "pci0000:00/0000:00:18.3", "k10temp")
     (link.resolve() / "name").unlink()

--- a/backend/tests/test_fan_identity_resolve.py
+++ b/backend/tests/test_fan_identity_resolve.py
@@ -1,0 +1,153 @@
+"""Aufloesung der Chip-Kennung aus dem sysfs-Baum (#532).
+
+Die Baeume bilden die auf BaluNode gemessenen Pfade nach, inklusive echter
+device- und subsystem-Symlinks -- ohne die laeuft die Ableitung in den
+Fallback und der Test prueft das Falsche.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from app.services.power.fan_identity import (
+    ChipIdentity,
+    build_fan_id,
+    build_sensor_id,
+    derive_all,
+    derive_chip_identity,
+)
+
+
+def _tree(tmp_path: Path, hwmon_name: str, device_rel: str, chip: str,
+          subsystem: str = "pci") -> Path:
+    """Legt /sys/devices/<device_rel> an und haengt <hwmon_name> daran.
+
+    device_rel ist relativ zu sys/devices, z. B. "platform/nct6775.656".
+    subsystem wird an das TIEFSTE Verzeichnis von device_rel gehaengt.
+    """
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / device_rel
+    hwmon = device / "hwmon" / hwmon_name
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text(chip + "\n")
+
+    bus_dir = sysfs / "bus" / subsystem
+    bus_dir.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus_dir, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    link = klass / hwmon_name
+    os.symlink(hwmon, link, target_is_directory=True)
+    return link
+
+
+def test_platform_chip_uses_decimal_suffix(tmp_path):
+    link = _tree(tmp_path, "hwmon3", "platform/nct6775.656", "nct6798",
+                 subsystem="platform")
+    identity = derive_chip_identity(link)
+    assert identity.stable is True
+    assert identity.key == "nct6798-isa-0290"
+
+
+def test_pci_chip(tmp_path):
+    link = _tree(tmp_path, "hwmon2", "pci0000:00/0000:03:00.0", "amdgpu")
+    assert derive_chip_identity(link).key == "amdgpu-pci-0300"
+
+
+def test_climbs_past_intermediate_class_to_pci_parent(tmp_path):
+    # NVMe: der device-Link zeigt auf nvme1, dessen subsystem die Klasse
+    # "nvme" ist -- weder pci noch platform, also weiterklettern.
+    sysfs = tmp_path / "sys"
+    pci = sysfs / "devices" / "pci0000:00" / "0000:0d:00.0"
+    nvme = pci / "nvme" / "nvme1"
+    hwmon = nvme / "hwmon" / "hwmon0"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nvme\n")
+    for bus, target in (("pci", pci), ("nvme", nvme)):
+        bus_dir = sysfs / "bus" / bus
+        bus_dir.mkdir(parents=True, exist_ok=True)
+        os.symlink(bus_dir, target / "subsystem", target_is_directory=True)
+    os.symlink(nvme, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True)
+    link = klass / "hwmon0"
+    os.symlink(hwmon, link, target_is_directory=True)
+
+    identity = derive_chip_identity(link)
+    assert identity.stable is True
+    assert identity.key == "nvme-pci-0d00"   # ohne den instabilen nvme1
+
+
+def test_platform_without_numeric_suffix_uses_device_name(tmp_path):
+    link = _tree(tmp_path, "hwmon5", "platform/asus-nb-wmi", "asus",
+                 subsystem="platform")
+    identity = derive_chip_identity(link)
+    assert identity.stable is True
+    assert identity.key == "asus@asus-nb-wmi"
+
+
+def test_unsupported_bus_falls_back(tmp_path):
+    # drivetemp haengt am scsi-Bus. Weiterklettern landete auf dem
+    # AHCI-Controller und gaebe allen Platten dieselbe Kennung.
+    link = _tree(tmp_path, "hwmon7", "pci0000:00/0000:00:17.0/ata1/host0",
+                 "drivetemp", subsystem="scsi")
+    identity = derive_chip_identity(link)
+    assert identity.stable is False
+    assert "scsi" in (identity.reason or "")
+
+
+def test_missing_device_link_falls_back(tmp_path):
+    sysfs = tmp_path / "sys"
+    hwmon = sysfs / "devices" / "virtual" / "hwmon" / "hwmon9"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("acpitz\n")
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True)
+    link = klass / "hwmon9"
+    os.symlink(hwmon, link, target_is_directory=True)
+
+    assert derive_chip_identity(link).stable is False
+
+
+def test_missing_name_falls_back(tmp_path):
+    link = _tree(tmp_path, "hwmon4", "pci0000:00/0000:00:18.3", "k10temp")
+    (link.resolve() / "name").unlink()
+    assert derive_chip_identity(link).stable is False
+
+
+def test_duplicate_keys_both_fall_back(tmp_path):
+    # Zwei hwmon-Knoten am selben Geraet erzeugen dieselbe Kennung. Ohne
+    # Erkennung ueberschriebe der zweite den ersten still im Scan-Cache.
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "twin.1"
+    bus_dir = sysfs / "bus" / "platform"
+    bus_dir.mkdir(parents=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True)
+    device.mkdir(parents=True)
+    os.symlink(bus_dir, device / "subsystem", target_is_directory=True)
+    for name in ("hwmon0", "hwmon1"):
+        hwmon = device / "hwmon" / name
+        hwmon.mkdir(parents=True)
+        (hwmon / "name").write_text("twin\n")
+        os.symlink(device, hwmon / "device", target_is_directory=True)
+        os.symlink(hwmon, klass / name, target_is_directory=True)
+
+    identities = derive_all(klass)
+    assert identities["hwmon0"].stable is False
+    assert identities["hwmon1"].stable is False
+
+
+def test_id_builders_use_legacy_form_when_unstable():
+    stable = ChipIdentity(key="nct6798-isa-0290", prefix="nct6798",
+                          stable=True, hwmon_name="hwmon3", reason=None)
+    unstable = ChipIdentity(key="hwmon3", prefix="Unknown",
+                            stable=False, hwmon_name="hwmon3", reason="x")
+    assert build_fan_id(stable, 1) == "nct6798-isa-0290:pwm1"
+    assert build_sensor_id(stable, 6) == "nct6798-isa-0290:temp6"
+    # Fallback behaelt exakt die Altform -- sonst waere die Zeile bei jedem
+    # Start erneut ein Migrationskandidat.
+    assert build_fan_id(unstable, 1) == "hwmon3_pwm1"
+    assert build_sensor_id(unstable, 6) == "hwmon3_temp6"

--- a/backend/tests/test_fan_pwm_backoff.py
+++ b/backend/tests/test_fan_pwm_backoff.py
@@ -11,6 +11,7 @@ reproduzierbar sind und die tatsaechlichen Schreibversuche zaehlbar bleiben.
 """
 import json
 import logging
+import os
 import shutil
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -25,13 +26,29 @@ from app.services.power.fan_control import FanControlService, FanData
 
 
 def _hwmon(tmp_path: Path) -> Path:
-    d = tmp_path / "sys" / "class" / "hwmon" / "hwmon1"
-    d.mkdir(parents=True)
-    (d / "name").write_text("nct6798\n")
-    (d / "pwm1").write_text("128\n")
-    (d / "fan1_input").write_text("1200\n")
-    (d / "pwm1_enable").write_text("1\n")
-    return d
+    """nct6798 an platform/nct6775.656 -- platform-foermiger Baum (#532).
+
+    Die frueher flache Variante ohne device-Symlink liess die Chip-Identitaet
+    als "virtuellen Chip" durchfallen: seit die Identitaetsableitung in
+    _scan_pwm_fans() haengt (#532), loggt das bei jedem Scan eine WARNING und
+    haette test_failure_episode_emits_no_warning_lines faelschlich rot gemacht.
+    """
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "nct6775.656"
+    hwmon = device / "hwmon" / "hwmon1"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nct6798\n")
+    (hwmon / "pwm1").write_text("128\n")
+    (hwmon / "fan1_input").write_text("1200\n")
+    (hwmon / "pwm1_enable").write_text("1\n")
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / "hwmon1", target_is_directory=True)
+    return hwmon
 
 
 async def _backend(tmp_path, monkeypatch) -> tuple[LinuxFanControlBackend, str]:
@@ -424,9 +441,11 @@ async def test_rescan_prunes_backoff_of_vanished_fans(tmp_path, monkeypatch):
     assert len(backend._write_backoff) == 2
 
     # Ein Kanal verschwindet (Treiber-Reload, Geraet weg)
-    gone = "hwmon1_pwm2"
+    gone = "nct6798-isa-0290:pwm2"
     (d / "pwm2").unlink()
     await backend._scan_pwm_fans()
 
     assert gone not in backend._write_backoff, "verwaister Backoff-Eintrag"
-    assert "hwmon1_pwm1" in backend._write_backoff, "der verbliebene Luefter behaelt sein Fenster"
+    assert "nct6798-isa-0290:pwm1" in backend._write_backoff, (
+        "der verbliebene Luefter behaelt sein Fenster"
+    )

--- a/backend/tests/test_fan_pwm_control_probe.py
+++ b/backend/tests/test_fan_pwm_control_probe.py
@@ -1,4 +1,5 @@
 """probe_amd_pwm_control: firmware-verwaltete Luefterkurven erkennen (RDNA3+, #480)."""
+import os
 from pathlib import Path
 
 from app.schemas.fans import PwmControl
@@ -11,16 +12,27 @@ def _hardware_shaped_tree(tmp_path: Path, *, with_fan_curve: bool) -> Path:
     Auf der Hardware liegt hwmon unter /sys/class/hwmon/hwmonN und traegt einen
     'device'-Symlink auf das PCI-Geraet. KEIN Elternverzeichnis heisst 'device'
     — genau daran ist der erste Entwurf gescheitert.
+
+    Platform-foermig (kein PCI-Doppelpunkt, #532) mit device/subsystem-Symlink,
+    damit die stabile Identitaetsableitung greift statt in den Fallback zu
+    fallen -- die zwei Scan-Tests unten pruefen genau das.
     """
-    hwmon = tmp_path / "sys" / "class" / "hwmon" / "hwmon2"
-    device = hwmon / "device"
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "amdgpu-sim.1"
     device.mkdir(parents=True)
-    (hwmon / "name").write_text("amdgpu\n")
     (device / "vendor").write_text("0x1002\n")
     if with_fan_curve:
         fan_ctrl = device / "gpu_od" / "fan_ctrl"
         fan_ctrl.mkdir(parents=True)
         (fan_ctrl / "fan_curve").write_text("OD_FAN_CURVE:\n0: 0C 0%\n")
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus, device / "subsystem", target_is_directory=True)
+
+    hwmon = sysfs / "class" / "hwmon" / "hwmon2"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("amdgpu\n")
+    os.symlink(device, hwmon / "device", target_is_directory=True)
     return hwmon
 
 
@@ -93,6 +105,10 @@ async def test_scan_marks_rdna3_fan_firmware_managed(tmp_path, monkeypatch):
     await backend._scan_pwm_fans()
 
     fan_id = next(iter(backend._fan_cache))
+    # Beweis, dass der Scan den stabilen Zweig trifft, nicht den Fallback
+    # ("hwmon2_pwm1"): ohne device/subsystem-Symlink waere die ID instabil.
+    assert fan_id == "amdgpu-isa-0001:pwm1"
+    assert backend._fan_cache[fan_id]["identity_stable"] is True
     assert backend._fan_cache[fan_id]["pwm_control"] is PwmControl.FIRMWARE_MANAGED
 
     fans = await backend.get_fans()
@@ -111,6 +127,8 @@ async def test_scan_marks_normal_fan_supported(tmp_path, monkeypatch):
     await backend._scan_pwm_fans()
 
     fan_id = next(iter(backend._fan_cache))
+    assert fan_id == "amdgpu-isa-0001:pwm1"
+    assert backend._fan_cache[fan_id]["identity_stable"] is True
     assert backend._fan_cache[fan_id]["pwm_control"] is PwmControl.SUPPORTED
 
 

--- a/backend/tests/test_fan_reconcile.py
+++ b/backend/tests/test_fan_reconcile.py
@@ -14,6 +14,8 @@ from app.models.base import Base
 from app.models.fans import CompositeTempSensor, FanConfig, TempSensorLabel
 from app.services.power.fan_reconcile import (
     ChipFacts,
+    ReconcileReport,
+    _map_sensor,
     reconcile_fan_identities,
 )
 
@@ -234,3 +236,56 @@ def test_unmappable_composite_source_is_left_alone(db):
 
     composite = db.query(CompositeTempSensor).one()
     assert json.loads(composite.source_ids_json) == ["gpu:junction", "hwmon9_temp1"]
+
+
+def test_map_sensor_leaves_already_stable_id_untouched():
+    """R2: eine bereits migrierte Sensor-ID wird nicht erneut abgebildet
+    und erzeugt keinen Fehlalarm."""
+    report = ReconcileReport()
+    result = _map_sensor("hwmon:k10temp-pci-00c3:temp1", SENSOR_MAP,
+                         CPU_DEFAULT, report)
+    assert result == "hwmon:k10temp-pci-00c3:temp1"
+    assert report.unresolved_sensors == []
+
+
+def test_map_sensor_leaves_unknown_form_untouched():
+    """R2: was nicht wie eine Alt-ID aussieht, wird nicht angefasst."""
+    report = ReconcileReport()
+    result = _map_sensor("gpu:junction", SENSOR_MAP, CPU_DEFAULT, report)
+    assert result == "gpu:junction"
+    assert report.unresolved_sensors == []
+
+
+def test_tie_break_on_identical_updated_at_is_deterministic(db):
+    """F2: bei exakt gleichem updated_at entscheidet die hoehere id (die
+    zuletzt angelegte, also aktuellere Zeile) -- nicht die Query-Reihenfolge.
+    """
+    same_ts = _dt("2026-07-06T23:38:15")
+    db.add(FanConfig(fan_id="hwmon6_pwm1", name="amdgpu PWM1", mode="auto",
+                     temp_sensor_id="hwmon3_temp1", is_active=True,
+                     updated_at=same_ts))
+    db.commit()
+
+    newer_row = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "hwmon6_pwm1")).scalar_one()
+    older_row = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "hwmon1_pwm1")).scalar_one()
+    assert newer_row.updated_at == older_row.updated_at   # echter Gleichstand
+    assert newer_row.id > older_row.id
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    winner = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "amdgpu-pci-0300:pwm1")).scalar_one()
+    assert winner.legacy_fan_id == "hwmon6_pwm1"
+
+    # Wiederholter Lauf liefert dasselbe Ergebnis -- kein Ranggleichstands-Flackern.
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    winner_again = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "amdgpu-pci-0300:pwm1")).scalar_one()
+    assert winner_again.legacy_fan_id == "hwmon6_pwm1"

--- a/backend/tests/test_fan_reconcile.py
+++ b/backend/tests/test_fan_reconcile.py
@@ -143,6 +143,35 @@ def test_resumes_after_abort_between_rename_and_deactivate(db):
     assert "nct6798-isa-0290:pwm1" in _active(db)
 
 
+def test_losing_incumbent_frees_its_id_for_the_winner(db):
+    """I-2: Traegt der Inkumbent (bereits in Neuform) das AELTERE updated_at
+    und eine Altzeile das juengere, verliert der Inkumbent den Rangvergleich.
+    Ohne Freimachen wuerde die anschliessende Umbenennung des Gewinners auf
+    denselben fan_id-Wert den Unique-Index verletzen -- reproduzierbar ueber
+    Rollback+Roll-forward (siehe Review)."""
+    incumbent = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "hwmon3_pwm1")).scalar_one()
+    incumbent.fan_id = "nct6798-isa-0290:pwm1"
+    incumbent.legacy_fan_id = "hwmon3_pwm1"
+    incumbent.updated_at = _dt("2026-01-01T00:00:00")   # aelter als alle Rivalen
+    db.commit()
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()   # darf keinen IntegrityError werfen
+
+    winner = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "nct6798-isa-0290:pwm1")).scalar_one()
+    assert winner.legacy_fan_id == "hwmon2_pwm1"        # juengste Altzeile gewinnt
+
+    incumbent_after = db.execute(select(FanConfig).where(
+        FanConfig.id == incumbent.id)).scalar_one()
+    assert incumbent_after.is_active is False
+    assert incumbent_after.fan_id != "nct6798-isa-0290:pwm1"
+
+    assert db.query(FanConfig).count() == 16            # nichts geloescht
+
+
 def test_unknown_name_is_neither_candidate_nor_deactivated(db):
     db.add(FanConfig(fan_id="hwmon9_pwm1", name="Unknown PWM1", mode="auto",
                      temp_sensor_id=None, is_active=True,
@@ -192,7 +221,11 @@ def test_unresolvable_sensor_falls_back_to_cpu_default(db):
 
 
 def test_sensor_label_is_rekeyed_and_keeps_provenance(db):
-    db.add(TempSensorLabel(sensor_id="hwmon4_temp1", custom_label="RAID-Platten"))
+    """I-1: real gespeicherte Label-sensor_id traegt IMMER das 'hwmon:'-Praefix
+    (die Route persistiert die Registry-Kennung, siehe HwmonTempSource.id).
+    Ohne Praefix-Abstreifen vor dem Regex-Test traf die Migration keine
+    einzige echte Zeile."""
+    db.add(TempSensorLabel(sensor_id="hwmon:hwmon4_temp1", custom_label="RAID-Platten"))
     db.commit()
 
     reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
@@ -200,9 +233,36 @@ def test_sensor_label_is_rekeyed_and_keeps_provenance(db):
     db.commit()
 
     labels = {row.sensor_id: row for row in db.query(TempSensorLabel).all()}
-    assert "k10temp-pci-00c3:temp1" in labels
-    assert labels["k10temp-pci-00c3:temp1"].custom_label == "RAID-Platten"
-    assert labels["k10temp-pci-00c3:temp1"].legacy_sensor_id == "hwmon4_temp1"
+    assert "hwmon:k10temp-pci-00c3:temp1" in labels
+    assert labels["hwmon:k10temp-pci-00c3:temp1"].custom_label == "RAID-Platten"
+    assert labels["hwmon:k10temp-pci-00c3:temp1"].legacy_sensor_id == "hwmon:hwmon4_temp1"
+
+
+def test_sensor_label_collision_keeps_older_row_under_its_own_key(db):
+    """Zwei Altzeilen zielen auf denselben neuen Schluessel -- die juengere
+    gewinnt und traegt ihn, die aeltere bleibt unter ihrem alten Schluessel
+    liegen (kein Loeschen, kein Primaerschluessel-Konflikt)."""
+    older = TempSensorLabel(sensor_id="hwmon:hwmon4_temp1", custom_label="Alt",
+                            updated_at=_dt("2026-01-01T00:00:00"))
+    newer = TempSensorLabel(sensor_id="hwmon:hwmon6_temp1", custom_label="Neu",
+                            updated_at=_dt("2026-08-01T00:00:00"))
+    db.add(older)
+    db.add(newer)
+    db.commit()
+
+    sensor_map = dict(SENSOR_MAP)
+    sensor_map["hwmon6_temp1"] = "hwmon:k10temp-pci-00c3:temp1"
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=sensor_map,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()   # darf keinen Primaerschluessel-Konflikt werfen
+
+    labels = {row.sensor_id: row for row in db.query(TempSensorLabel).all()}
+    assert "hwmon:k10temp-pci-00c3:temp1" in labels
+    assert labels["hwmon:k10temp-pci-00c3:temp1"].custom_label == "Neu"
+    assert "hwmon:hwmon4_temp1" in labels           # aeltere bleibt liegen
+    assert labels["hwmon:hwmon4_temp1"].custom_label == "Alt"
+    assert len(labels) == 2
 
 
 def test_composite_sources_are_rewritten(db):

--- a/backend/tests/test_fan_reconcile.py
+++ b/backend/tests/test_fan_reconcile.py
@@ -1,0 +1,236 @@
+"""Zuordnung der Altzeilen auf stabile Kennungen (#532).
+
+Das Fixture ist die auf BaluNode gemessene Datenlage: 16 Zeilen, davon 13
+hwmon-indiziert in vier Generationen fuer 5 physische Luefter, plus 3 dev_*.
+"""
+import json
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import Base
+from app.models.fans import CompositeTempSensor, FanConfig, TempSensorLabel
+from app.services.power.fan_reconcile import (
+    ChipFacts,
+    reconcile_fan_identities,
+)
+
+NCT = ChipFacts(key="nct6798-isa-0290",
+                pwm_channels=frozenset({1, 2, 3, 7}), ambiguous=False)
+AMD = ChipFacts(key="amdgpu-pci-0300",
+                pwm_channels=frozenset({1}), ambiguous=False)
+CHIPS = {"nct6798": NCT, "amdgpu": AMD}
+
+SENSOR_MAP = {
+    "hwmon4_temp1": "hwmon:k10temp-pci-00c3:temp1",
+    "hwmon3_temp1": "hwmon:nct6798-isa-0290:temp1",
+}
+CPU_DEFAULT = "hwmon:k10temp-pci-00c3:temp1"
+
+
+def _dt(text: str) -> datetime:
+    return datetime.fromisoformat(text).replace(tzinfo=timezone.utc)
+
+
+ROWS = [
+    # (fan_id, name, temp_sensor_id, updated_at)
+    ("hwmon5_pwm1", "nct6798 PWM1", "hwmon5_temp6", "2026-01-25T22:51:59"),
+    ("hwmon5_pwm2", "nct6798 PWM2", "hwmon5_temp6", "2026-01-25T22:51:59"),
+    ("hwmon5_pwm3", "nct6798 PWM3", "hwmon5_temp6", "2026-01-25T22:51:59"),
+    ("hwmon5_pwm7", "nct6798 PWM7", "hwmon5_temp6", "2026-01-25T22:51:59"),
+    ("dev_case_fan_1", "Case Fan 1 (Simulated)", "dev_package_temp", "2026-01-27T22:48:27"),
+    ("dev_cpu_fan", "CPU Fan (Simulated)", "dev_cpu_temp", "2026-02-17T21:48:42"),
+    ("dev_case_fan_2", "Case Fan 2 (Simulated)", "dev_cpu_temp", "2026-02-25T19:57:42"),
+    ("hwmon1_pwm1", "amdgpu PWM1", "hwmon3_temp1", "2026-07-06T23:38:15"),
+    ("hwmon2_pwm1", "nct6798 PWM1", "hwmon3_temp1", "2026-07-20T22:59:55"),
+    ("hwmon2_pwm2", "nct6798 PWM2", "hwmon3_temp1", "2026-07-20T22:59:55"),
+    ("hwmon2_pwm3", "nct6798 PWM3", "hwmon3_temp1", "2026-07-20T22:59:55"),
+    ("hwmon2_pwm7", "nct6798 PWM7", "hwmon3_temp1", "2026-07-20T22:59:55"),
+    ("hwmon3_pwm1", "nct6798 PWM1", "hwmon4_temp1", "2026-08-07T00:32:04"),
+    ("hwmon3_pwm2", "nct6798 PWM2", "hwmon4_temp1", "2026-08-07T00:32:04"),
+    ("hwmon3_pwm3", "nct6798 PWM3", "hwmon4_temp1", "2026-08-07T00:32:04"),
+    ("hwmon3_pwm7", "nct6798 PWM7", "hwmon4_temp1", "2026-08-07T00:32:04"),
+]
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    for fan_id, name, sensor, updated in ROWS:
+        session.add(FanConfig(fan_id=fan_id, name=name, mode="auto",
+                              temp_sensor_id=sensor, is_active=True,
+                              updated_at=_dt(updated)))
+    session.commit()
+    yield session
+    session.close()
+
+
+def _active(db):
+    return {r.fan_id for r in db.execute(
+        select(FanConfig).where(FanConfig.is_active.is_(True))).scalars()}
+
+
+def test_newest_generation_wins_and_nothing_is_deleted(db):
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    assert _active(db) == {
+        "nct6798-isa-0290:pwm1", "nct6798-isa-0290:pwm2",
+        "nct6798-isa-0290:pwm3", "nct6798-isa-0290:pwm7",
+        "amdgpu-pci-0300:pwm1",
+        "dev_case_fan_1", "dev_cpu_fan", "dev_case_fan_2",
+    }
+    assert db.query(FanConfig).count() == 16   # nichts geloescht
+
+
+def test_july_row_named_nct6798_does_not_become_the_gpu(db):
+    """Die Falle: hwmon2 ist heute die GPU, war im Juli aber der nct6798."""
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    gpu = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "amdgpu-pci-0300:pwm1")).scalar_one()
+    assert gpu.legacy_fan_id == "hwmon1_pwm1"
+    assert gpu.name == "amdgpu PWM1"
+
+
+def test_absent_chip_is_never_deactivated(db):
+    """Treiber beim Start noch nicht geladen -- Kurven muessen bleiben."""
+    reconcile_fan_identities(db, chips={"amdgpu": AMD}, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    for fan_id in ("hwmon3_pwm1", "hwmon2_pwm1", "hwmon5_pwm1"):
+        row = db.execute(select(FanConfig).where(
+            FanConfig.fan_id == fan_id)).scalar_one()
+        assert row.is_active is True
+
+
+def test_second_run_is_a_noop(db):
+    first = reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                                     cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+    second = reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                                      cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    assert len(first.renamed) == 5
+    assert second.renamed == []
+    assert second.deactivated == []
+
+
+def test_resumes_after_abort_between_rename_and_deactivate(db):
+    """Gewinner schon umbenannt, Verlierer noch aktiv -- kein Unique-Fehler."""
+    row = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "hwmon3_pwm1")).scalar_one()
+    row.fan_id = "nct6798-isa-0290:pwm1"
+    row.legacy_fan_id = "hwmon3_pwm1"
+    db.commit()
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    assert "hwmon2_pwm1" not in _active(db)
+    assert "nct6798-isa-0290:pwm1" in _active(db)
+
+
+def test_unknown_name_is_neither_candidate_nor_deactivated(db):
+    db.add(FanConfig(fan_id="hwmon9_pwm1", name="Unknown PWM1", mode="auto",
+                     temp_sensor_id=None, is_active=True,
+                     updated_at=_dt("2026-08-08T00:00:00")))
+    db.commit()
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    row = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "hwmon9_pwm1")).scalar_one()
+    assert row.is_active is True
+
+
+def test_ambiguous_chip_name_is_no_candidate(db):
+    chips = {"nct6798": ChipFacts(key="nct6798-isa-0290",
+                                  pwm_channels=frozenset({1, 2, 3, 7}),
+                                  ambiguous=True),
+             "amdgpu": AMD}
+    reconcile_fan_identities(db, chips=chips, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    assert "hwmon3_pwm1" in _active(db)
+
+
+def test_winner_sensor_is_rewritten_prefixed(db):
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    row = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "nct6798-isa-0290:pwm1")).scalar_one()
+    assert row.temp_sensor_id == "hwmon:k10temp-pci-00c3:temp1"
+
+
+def test_unresolvable_sensor_falls_back_to_cpu_default(db):
+    report = reconcile_fan_identities(db, chips=CHIPS, sensor_map={},
+                                      cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    row = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "nct6798-isa-0290:pwm1")).scalar_one()
+    assert row.temp_sensor_id == CPU_DEFAULT
+    assert "hwmon4_temp1" in report.unresolved_sensors
+
+
+def test_sensor_label_is_rekeyed_and_keeps_provenance(db):
+    db.add(TempSensorLabel(sensor_id="hwmon4_temp1", custom_label="RAID-Platten"))
+    db.commit()
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    labels = {row.sensor_id: row for row in db.query(TempSensorLabel).all()}
+    assert "k10temp-pci-00c3:temp1" in labels
+    assert labels["k10temp-pci-00c3:temp1"].custom_label == "RAID-Platten"
+    assert labels["k10temp-pci-00c3:temp1"].legacy_sensor_id == "hwmon4_temp1"
+
+
+def test_composite_sources_are_rewritten(db):
+    db.add(CompositeTempSensor(
+        id="mix:abc", name="CPU und Board", function="max",
+        source_ids_json='["hwmon:hwmon4_temp1", "hwmon3_temp1"]',
+    ))
+    db.commit()
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    composite = db.query(CompositeTempSensor).one()
+    assert json.loads(composite.source_ids_json) == [
+        "hwmon:k10temp-pci-00c3:temp1",
+        "hwmon:nct6798-isa-0290:temp1",
+    ]
+
+
+def test_unmappable_composite_source_is_left_alone(db):
+    db.add(CompositeTempSensor(
+        id="mix:def", name="Mit Luecke", function="max",
+        source_ids_json='["gpu:junction", "hwmon9_temp1"]',
+    ))
+    db.commit()
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    composite = db.query(CompositeTempSensor).one()
+    assert json.loads(composite.source_ids_json) == ["gpu:junction", "hwmon9_temp1"]

--- a/backend/tests/test_fan_reconcile.py
+++ b/backend/tests/test_fan_reconcile.py
@@ -172,6 +172,41 @@ def test_losing_incumbent_frees_its_id_for_the_winner(db):
     assert db.query(FanConfig).count() == 16            # nichts geloescht
 
 
+def test_losing_incumbent_does_not_reuse_an_id_the_winner_still_holds(db):
+    """Der Rollback+Roll-forward-Fall: die Altform, die der Inkumbent als
+    legacy_fan_id fuehrt, ist von der Gewinnerin noch belegt.
+
+    Nach einem Rollback auf Code vor #532 legt die alte Anlage-Schleife eine
+    Zeile unter genau dieser Altform an; beim Roll-forward gewinnt sie, weil
+    sie juenger ist. Wuerde legacy_fan_id als Ersatz-ID wiederverwendet, traefe
+    derselbe Unique-Verstoss eine Zeile weiter -- und der Dienst kaeme bei
+    JEDEM folgenden Start ohne Luefter-Configs hoch.
+    """
+    incumbent = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "hwmon3_pwm1")).scalar_one()
+    incumbent.fan_id = "nct6798-isa-0290:pwm1"
+    incumbent.legacy_fan_id = "hwmon2_pwm1"   # genau die ID der spaeteren Gewinnerin
+    incumbent.updated_at = _dt("2026-01-01T00:00:00")
+    db.commit()
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()   # darf keinen IntegrityError werfen
+
+    winner = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "nct6798-isa-0290:pwm1")).scalar_one()
+    assert winner.legacy_fan_id == "hwmon2_pwm1"
+
+    incumbent_after = db.execute(select(FanConfig).where(
+        FanConfig.id == incumbent.id)).scalar_one()
+    assert incumbent_after.is_active is False
+    # Ersatz-ID aus dem Primaerschluessel, nicht aus legacy_fan_id
+    assert incumbent_after.fan_id == f"nct6798-isa-0290:pwm1#legacy{incumbent.id}"
+    assert incumbent_after.legacy_fan_id == "hwmon2_pwm1"   # Herkunft bleibt
+
+    assert db.query(FanConfig).count() == 16
+
+
 def test_unknown_name_is_neither_candidate_nor_deactivated(db):
     db.add(FanConfig(fan_id="hwmon9_pwm1", name="Unknown PWM1", mode="auto",
                      temp_sensor_id=None, is_active=True,

--- a/backend/tests/test_fan_reconcile_wiring.py
+++ b/backend/tests/test_fan_reconcile_wiring.py
@@ -1,0 +1,42 @@
+"""Vorbedingungen und Gate des Identitaets-Abgleichs (#532)."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_control import FanControlService
+
+
+def _service(monkeypatch, *, primary: bool, linux: bool):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = True
+    config.is_dev_mode = False
+    service = FanControlService(config, MagicMock())
+    service._use_linux_backend = linux
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        primary, raising=False)
+    return service
+
+
+def test_skips_when_not_primary_worker(monkeypatch):
+    service = _service(monkeypatch, primary=False, linux=True)
+    assert service._should_reconcile(chip_count=3) is False
+
+
+def test_skips_on_dev_backend(monkeypatch):
+    # is_available() faellt bei 0 gefundenen Lueftern auch in Produktion auf
+    # das Dev-Backend zurueck. Liefe der Abgleich dann, deaktivierte er in
+    # einem Rutsch alle hwmon-Zeilen.
+    service = _service(monkeypatch, primary=True, linux=False)
+    assert service._should_reconcile(chip_count=3) is False
+
+
+def test_skips_when_scan_found_no_chip(monkeypatch):
+    service = _service(monkeypatch, primary=True, linux=True)
+    assert service._should_reconcile(chip_count=0) is False
+
+
+def test_runs_when_all_preconditions_hold(monkeypatch):
+    service = _service(monkeypatch, primary=True, linux=True)
+    assert service._should_reconcile(chip_count=3) is True

--- a/backend/tests/test_fan_reconcile_wiring.py
+++ b/backend/tests/test_fan_reconcile_wiring.py
@@ -1,10 +1,12 @@
 """Vorbedingungen und Gate des Identitaets-Abgleichs (#532)."""
-from unittest.mock import MagicMock
+import logging
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from app.schemas.fans import FanCurvePoint, FanMode
 from app.services.power import fan_control as fan_control_module
-from app.services.power.fan_control import FanControlService
+from app.services.power.fan_control import FanControlService, FanData
 
 
 def _service(monkeypatch, *, primary: bool, linux: bool):
@@ -40,3 +42,75 @@ def test_skips_when_scan_found_no_chip(monkeypatch):
 def test_runs_when_all_preconditions_hold(monkeypatch):
     service = _service(monkeypatch, primary=True, linux=True)
     assert service._should_reconcile(chip_count=3) is True
+
+
+@pytest.mark.asyncio
+async def test_reconcile_failure_does_not_create_configs(monkeypatch, caplog):
+    """Wirft reconcile_fan_identities, darf die Anlage-Schleife NICHT laufen.
+
+    Sonst legte sie eine frische Default-Config unter der bereits neuen
+    Scan-ID an, deren updated_at "jetzt" ist -- die schluege beim naechsten
+    Abgleich jede echte Nutzerkurve. Genau das soll dieser Abgleich
+    verhindern; ihn bei einem eigenen Fehler trotzdem durchlaufen zu lassen,
+    waere derselbe Datenverlust auf einem Umweg.
+    """
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = True
+    config.is_dev_mode = False
+
+    service = FanControlService(config, MagicMock())
+    service._use_linux_backend = True
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        True, raising=False)
+
+    fan = FanData(
+        fan_id="nct6798-isa-0290:pwm1",
+        name="nct6798 PWM1",
+        rpm=900,
+        pwm_percent=40,
+        temperature_celsius=None,
+        mode=FanMode.AUTO,
+        min_pwm_percent=0,
+        max_pwm_percent=100,
+        emergency_temp_celsius=85.0,
+        temp_sensor_id=None,
+        curve_points=[FanCurvePoint(temp=35, pwm=30)],
+        is_active=True,
+    )
+
+    backend = AsyncMock()
+    backend.get_fans.return_value = [fan]
+    backend.get_available_temp_sensors.return_value = []
+    backend._fan_cache = {
+        "nct6798-isa-0290:pwm1": {
+            "identity_stable": True,
+            "device_driver": "nct6798",
+        },
+    }
+    backend._temp_paths = {}
+    service._backend = backend
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None  # keine Altzeile vorhanden
+    mock_db = MagicMock()
+    mock_db.execute.return_value = mock_result
+
+    mock_session_factory = MagicMock()
+    mock_session_factory.return_value.__enter__ = MagicMock(return_value=mock_db)
+    mock_session_factory.return_value.__exit__ = MagicMock(return_value=False)
+    service.db_session_factory = mock_session_factory
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("Abgleich kaputt")
+
+    monkeypatch.setattr(fan_control_module, "reconcile_fan_identities", _boom)
+
+    with caplog.at_level(logging.ERROR, logger="app.services.power.fan_control"):
+        await service._load_fan_configs()  # darf NICHT werfen
+
+    assert mock_db.add.call_count == 0, "Anlage-Schleife durfte nicht laufen"
+    assert mock_db.commit.call_count == 0, "kein Commit nach fehlgeschlagenem Abgleich"
+    assert any(r.levelno == logging.ERROR for r in caplog.records), (
+        "Fehlschlag muss als ERROR mit Traceback geloggt werden"
+    )

--- a/backend/tests/test_fan_reconcile_wiring.py
+++ b/backend/tests/test_fan_reconcile_wiring.py
@@ -1,12 +1,45 @@
 """Vorbedingungen und Gate des Identitaets-Abgleichs (#532)."""
 import logging
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
 
+from app.models.base import Base
+from app.models.fans import FanConfig
 from app.schemas.fans import FanCurvePoint, FanMode
 from app.services.power import fan_control as fan_control_module
 from app.services.power.fan_control import FanControlService, FanData
+
+
+class _FakeLinuxBackend:
+    """Schlankes Double fuer LinuxFanControlBackend, mit echten dict-Attributen
+    statt Mock-Kindern -- fuer die beiden Tests unten, die eine echte
+    SQLite-Session gegen die tatsaechliche Transaktionsreihenfolge pruefen.
+    """
+
+    def __init__(self, fan_cache, temp_paths, fans, cpu_sensor_id=None):
+        self._fan_cache = fan_cache
+        self._temp_paths = temp_paths
+        self._fans = fans
+        self._cpu_sensor_id = cpu_sensor_id
+
+    async def get_fans(self):
+        return self._fans
+
+    async def get_available_temp_sensors(self):
+        if self._cpu_sensor_id is None:
+            return []
+        from app.services.power.fan_control import TempSensorData
+        return [TempSensorData(
+            sensor_id=self._cpu_sensor_id,
+            device_name="k10temp",
+            label="Tctl",
+            is_cpu_sensor=True,
+            current_temp=50.0,
+        )]
 
 
 def _service(monkeypatch, *, primary: bool, linux: bool):
@@ -114,3 +147,129 @@ async def test_reconcile_failure_does_not_create_configs(monkeypatch, caplog):
     assert any(r.levelno == logging.ERROR for r in caplog.records), (
         "Fehlschlag muss als ERROR mit Traceback geloggt werden"
     )
+
+
+@pytest.mark.asyncio
+async def test_secondary_worker_creates_no_configs(monkeypatch):
+    """C1: der Sekundaer-Worker darf die Anlage-Schleife nicht ausfuehren.
+
+    Legte er hier eine Default-Config unter der (bereits neuen) Scan-ID an,
+    truege sie updated_at="jetzt" und gewaenne beim spaeteren Abgleich des
+    Primary gegen die echte Nutzerkurve -- der Datenverlust, den der
+    Abgleich verhindern soll, nur ueber den Sekundaer-Worker eingeschleust.
+    Echte In-Memory-SQLite-Session, kein MagicMock: die Zeilenzahl wird
+    tatsaechlich gezaehlt, nicht an einem Call-Count abgelesen.
+    """
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine)
+
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = True
+    config.is_dev_mode = False
+
+    service = FanControlService(config, session_factory)
+    service._use_linux_backend = True
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        False, raising=False)
+
+    fan = FanData(
+        fan_id="nct6798-isa-0290:pwm1",
+        name="nct6798 PWM1",
+        rpm=900,
+        pwm_percent=40,
+        temperature_celsius=None,
+        mode=FanMode.AUTO,
+        min_pwm_percent=0,
+        max_pwm_percent=100,
+        emergency_temp_celsius=85.0,
+        temp_sensor_id=None,
+        curve_points=[FanCurvePoint(temp=35, pwm=30)],
+        is_active=True,
+    )
+    service._backend = _FakeLinuxBackend(fan_cache={}, temp_paths={}, fans=[fan])
+
+    await service._load_fan_configs()
+
+    with session_factory() as check:
+        assert check.execute(select(FanConfig)).scalars().all() == [], (
+            "Sekundaer-Worker hat eine Config angelegt -- C1-Regression"
+        )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_runs_before_anlage_and_no_duplicate_row(monkeypatch):
+    """Reihenfolge: Abgleich vor Anlage-Schleife, keine zusaetzliche Zeile.
+
+    Eine Altzeile liegt unter der frueheren hwmon-indizierten ID in der DB.
+    Der Scan liefert dieselbe physische PWM-Leitung bereits unter der neuen,
+    stabilen ID. Lief der Abgleich VOR der Anlage-Schleife (wie vorgesehen),
+    traegt die migrierte Zeile danach die neue ID plus legacy_fan_id, und
+    die Anlage-Schleife findet unter der neuen ID bereits eine "existing"
+    Zeile vor -- es entsteht KEINE zweite, zusaetzliche Default-Zeile. Liefe
+    der Abgleich stattdessen nach der Anlage-Schleife (die Regression, die
+    R4 verhindern soll), gaebe es zwei Zeilen: die frische Default-Zeile
+    unter der neuen ID und die unveraenderte Altzeile.
+    """
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine)
+
+    with session_factory() as seed:
+        seed.add(FanConfig(
+            fan_id="hwmon5_pwm1",
+            name="nct6798 PWM1",
+            mode="auto",
+            temp_sensor_id="hwmon5_temp6",
+            is_active=True,
+            updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ))
+        seed.commit()
+
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = True
+    config.is_dev_mode = False
+
+    service = FanControlService(config, session_factory)
+    service._use_linux_backend = True
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        True, raising=False)
+
+    fan = FanData(
+        fan_id="nct6798-isa-0290:pwm1",
+        name="nct6798 PWM1",
+        rpm=900,
+        pwm_percent=40,
+        temperature_celsius=None,
+        mode=FanMode.AUTO,
+        min_pwm_percent=0,
+        max_pwm_percent=100,
+        emergency_temp_celsius=85.0,
+        temp_sensor_id=None,
+        curve_points=[FanCurvePoint(temp=35, pwm=30)],
+        is_active=True,
+    )
+    service._backend = _FakeLinuxBackend(
+        fan_cache={
+            "nct6798-isa-0290:pwm1": {
+                "identity_stable": True,
+                "device_driver": "nct6798",
+            },
+        },
+        temp_paths={},
+        fans=[fan],
+    )
+
+    await service._load_fan_configs()
+
+    with session_factory() as check:
+        rows = list(check.execute(select(FanConfig)).scalars())
+        assert len(rows) == 1, (
+            f"erwartet genau eine Zeile (migriert, keine zusaetzliche "
+            f"Default-Zeile), gefunden: {[r.fan_id for r in rows]}"
+        )
+        row = rows[0]
+        assert row.fan_id == "nct6798-isa-0290:pwm1"
+        assert row.legacy_fan_id == "hwmon5_pwm1"

--- a/backend/tests/test_fan_scan_stable_ids.py
+++ b/backend/tests/test_fan_scan_stable_ids.py
@@ -1,0 +1,71 @@
+"""Der Scan bildet stabile IDs und ueberlebt ein Renumbering (#532)."""
+import os
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+def _nct_tree(tmp_path: Path, hwmon_name: str) -> Path:
+    """nct6798 an platform/nct6775.656, mit pwm1 + fan1_input + temp1_input."""
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "nct6775.656"
+    hwmon = device / "hwmon" / hwmon_name
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nct6798\n")
+    (hwmon / "pwm1").write_text("128\n")
+    (hwmon / "pwm1_enable").write_text("1\n")
+    (hwmon / "fan1_input").write_text("900\n")
+    (hwmon / "temp1_input").write_text("42000\n")
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    if not (device / "subsystem").exists():
+        os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / hwmon_name, target_is_directory=True)
+    return klass
+
+
+@pytest.mark.asyncio
+async def test_scan_builds_stable_fan_id(tmp_path, monkeypatch):
+    klass = _nct_tree(tmp_path, "hwmon3")
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+
+    cache = await backend._scan_pwm_fans()
+
+    assert "nct6798-isa-0290:pwm1" in cache
+    assert cache["nct6798-isa-0290:pwm1"]["identity_stable"] is True
+
+
+@pytest.mark.asyncio
+async def test_same_device_under_other_hwmon_index_keeps_id(tmp_path, monkeypatch):
+    """Das Akzeptanzkriterium des Issues: Renumbering aendert die ID nicht."""
+    first = _nct_tree(tmp_path / "boot_a", "hwmon3")
+    second = _nct_tree(tmp_path / "boot_b", "hwmon5")
+
+    backend_a = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend_a, "_hwmon_base", first)
+    cache_a = await backend_a._scan_pwm_fans()
+
+    backend_b = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend_b, "_hwmon_base", second)
+    cache_b = await backend_b._scan_pwm_fans()
+
+    assert set(cache_a) == set(cache_b) == {"nct6798-isa-0290:pwm1"}
+
+
+@pytest.mark.asyncio
+async def test_scan_registers_reverse_path_for_sensor(tmp_path, monkeypatch):
+    klass = _nct_tree(tmp_path, "hwmon3")
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+    await backend._scan_pwm_fans()
+
+    sensor_id = "nct6798-isa-0290:temp1"
+    assert sensor_id in backend._temp_paths
+    assert backend._temp_paths[sensor_id].name == "temp1_input"

--- a/backend/tests/test_fan_sensor_assignment.py
+++ b/backend/tests/test_fan_sensor_assignment.py
@@ -4,11 +4,19 @@ Regression test: user-chosen sensor must not be overwritten on service restart.
 This test would FAIL if the auto-correction branch were re-added to
 _load_fan_configs (the branch that changes existing.temp_sensor_id to the CPU
 sensor when it points anywhere else).
+
+I-4: die Anlage-Schleife in _load_fan_configs ist seit dem Primary-Gate
+(fan_control.py) primary-only. Ohne IS_PRIMARY_WORKER=True kehrt die Methode
+vor der bewachten Schleife zurueck und diese Tests pruefen gar nichts mehr --
+sie waren gruen, auch wenn die entfernte Auto-Korrektur wieder eingebaut
+worden waere. monkeypatch.setattr auf app.core.lifespan.IS_PRIMARY_WORKER
+schaltet die Schleife fuer den Testlauf frei.
 """
 import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from app.core import lifespan
 from app.models.fans import FanConfig
 from app.schemas.fans import FanMode, FanCurvePoint
 from app.services.power.fan_control import FanControlService, FanData, TempSensorData
@@ -43,6 +51,10 @@ def _make_service(mock_backend, existing_sensor_id: str) -> FanControlService:
     service.config = MockSettings()
     service.db_session_factory = mock_session_factory
     service._backend = mock_backend
+    # _should_reconcile() prueft dies vor dem hwmon-Chipcount; False haelt
+    # den (hier nicht aufgebauten) Abgleichspfad zu, ohne die
+    # primary-only-Gate der Anlage-Schleife weiter unten zu beeinflussen.
+    service._use_linux_backend = False
     return service, mock_config
 
 
@@ -85,8 +97,9 @@ def _make_backend_with_cpu_sensor():
 
 
 @pytest.mark.asyncio
-async def test_non_cpu_sensor_survives_reload():
+async def test_non_cpu_sensor_survives_reload(monkeypatch):
     """Non-CPU sensor chosen by user must not be overwritten by CPU sensor on reload."""
+    monkeypatch.setattr(lifespan, "IS_PRIMARY_WORKER", True, raising=False)
     mock_backend = _make_backend_with_cpu_sensor()
 
     with patch.object(FanControlService, "_instance", None):
@@ -101,8 +114,9 @@ async def test_non_cpu_sensor_survives_reload():
 
 
 @pytest.mark.asyncio
-async def test_composite_sensor_survives_reload():
+async def test_composite_sensor_survives_reload(monkeypatch):
     """A composite (mix:) sensor ID must survive service reload even when CPU sensor is available."""
+    monkeypatch.setattr(lifespan, "IS_PRIMARY_WORKER", True, raising=False)
     mock_backend = _make_backend_with_cpu_sensor()
 
     with patch.object(FanControlService, "_instance", None):
@@ -116,8 +130,9 @@ async def test_composite_sensor_survives_reload():
 
 
 @pytest.mark.asyncio
-async def test_gpu_sensor_survives_reload():
+async def test_gpu_sensor_survives_reload(monkeypatch):
     """A GPU sensor (gpu:edge) must survive service reload unchanged."""
+    monkeypatch.setattr(lifespan, "IS_PRIMARY_WORKER", True, raising=False)
     mock_backend = _make_backend_with_cpu_sensor()
 
     with patch.object(FanControlService, "_instance", None):
@@ -131,8 +146,9 @@ async def test_gpu_sensor_survives_reload():
 
 
 @pytest.mark.asyncio
-async def test_disk_sensor_survives_reload():
+async def test_disk_sensor_survives_reload(monkeypatch):
     """A disk sensor (disk:sda) must survive service reload unchanged."""
+    monkeypatch.setattr(lifespan, "IS_PRIMARY_WORKER", True, raising=False)
     mock_backend = _make_backend_with_cpu_sensor()
 
     with patch.object(FanControlService, "_instance", None):
@@ -146,8 +162,9 @@ async def test_disk_sensor_survives_reload():
 
 
 @pytest.mark.asyncio
-async def test_cpu_sensor_assignment_unchanged_on_reload():
+async def test_cpu_sensor_assignment_unchanged_on_reload(monkeypatch):
     """A fan already using the CPU sensor must continue using it after reload."""
+    monkeypatch.setattr(lifespan, "IS_PRIMARY_WORKER", True, raising=False)
     mock_backend = _make_backend_with_cpu_sensor()
 
     with patch.object(FanControlService, "_instance", None):

--- a/backend/tests/test_fan_sources_normalize.py
+++ b/backend/tests/test_fan_sources_normalize.py
@@ -1,0 +1,19 @@
+"""Namespace-Erkennung darf nicht am blossen Doppelpunkt haengen (#532)."""
+from app.services.power.fan_sources import TempSourceRegistry
+
+
+def test_legacy_bare_id_gets_hwmon_namespace():
+    assert TempSourceRegistry._normalize_id("hwmon3_temp1") == "hwmon:hwmon3_temp1"
+
+
+def test_stable_bare_id_gets_hwmon_namespace():
+    # Enthaelt selbst einen Doppelpunkt -- die alte Heuristik ":" in id"
+    # haette die ID unveraendert durchgereicht und die Quelle nicht gefunden.
+    assert (TempSourceRegistry._normalize_id("k10temp-pci-00c3:temp1")
+            == "hwmon:k10temp-pci-00c3:temp1")
+
+
+def test_already_namespaced_ids_pass_through():
+    for sid in ("hwmon:k10temp-pci-00c3:temp1", "gpu:edge",
+                "disk:sda", "mix:abc123"):
+        assert TempSourceRegistry._normalize_id(sid) == sid

--- a/backend/tests/test_fan_temp_resolution.py
+++ b/backend/tests/test_fan_temp_resolution.py
@@ -1,0 +1,39 @@
+"""get_temperature loest stabile, praefixierte und Alt-IDs auf (#532)."""
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+@pytest.fixture
+def backend(tmp_path):
+    hwmon = tmp_path / "hwmon3"
+    hwmon.mkdir()
+    (hwmon / "temp1_input").write_text("42000\n")
+    be = LinuxFanControlBackend(get_settings())
+    be._hwmon_base = tmp_path
+    be._temp_paths = {"nct6798-isa-0290:temp1": hwmon / "temp1_input"}
+    return be
+
+
+@pytest.mark.asyncio
+async def test_resolves_stable_id(backend):
+    assert await backend.get_temperature("nct6798-isa-0290:temp1") == 42.0
+
+
+@pytest.mark.asyncio
+async def test_strips_hwmon_namespace_prefix(backend):
+    assert await backend.get_temperature("hwmon:nct6798-isa-0290:temp1") == 42.0
+
+
+@pytest.mark.asyncio
+async def test_still_resolves_legacy_id(backend):
+    # Waehrend der Umstellung stehen Alt-IDs noch in der Datenbank.
+    assert await backend.get_temperature("hwmon3_temp1") == 42.0
+
+
+@pytest.mark.asyncio
+async def test_unknown_id_is_none(backend):
+    assert await backend.get_temperature("nope-isa-0000:temp9") is None

--- a/backend/tests/test_fan_temp_resolution.py
+++ b/backend/tests/test_fan_temp_resolution.py
@@ -94,3 +94,27 @@ async def test_cpu_sensor_id_agrees_between_lookup_and_scan(tmp_path):
     assert backend._temp_paths.get(sensor_id) == temp_path
 
     assert await backend.get_temperature(sensor_id) == 55.0
+
+
+@pytest.mark.asyncio
+async def test_sensor_discovered_after_scan_is_still_resolvable(tmp_path):
+    """I-3: ein hwmon-Chip, der erst NACH dem Startscan erscheint (Treiber
+    nachgeladen), muss trotzdem lesbar bleiben. _temp_paths wurde bisher
+    ausschliesslich in _scan_pwm_fans() gefuellt -- get_available_temp_sensors()
+    und _find_cpu_temp_sensor() bildeten zwar eine stabile ID, trugen sie
+    aber nie ein. Ohne Unterstrich in der Kennung greift auch der
+    Alt-Format-Rueckfall (_legacy_temp_path) nicht -- get_temperature()
+    lieferte fuer einen solchen Sensor dauerhaft None."""
+    klass = tmp_path / "sys" / "class" / "hwmon"
+    klass.mkdir(parents=True)
+    backend = LinuxFanControlBackend(get_settings())
+    backend._hwmon_base = klass
+
+    await backend._scan_pwm_fans()   # Startscan: der Chip existiert noch nicht
+
+    _k10temp_tree(tmp_path)          # Chip erscheint erst jetzt (Treiber nachgeladen)
+
+    sensors = await backend.get_available_temp_sensors()
+    assert any(s.sensor_id == "k10temp-isa-0001:temp1" for s in sensors)
+
+    assert await backend.get_temperature("k10temp-isa-0001:temp1") == 55.0

--- a/backend/tests/test_fan_temp_resolution.py
+++ b/backend/tests/test_fan_temp_resolution.py
@@ -1,4 +1,5 @@
 """get_temperature loest stabile, praefixierte und Alt-IDs auf (#532)."""
+import os
 from pathlib import Path
 
 import pytest
@@ -37,3 +38,59 @@ async def test_still_resolves_legacy_id(backend):
 @pytest.mark.asyncio
 async def test_unknown_id_is_none(backend):
     assert await backend.get_temperature("nope-isa-0000:temp9") is None
+
+
+def _k10temp_tree(tmp_path: Path) -> Path:
+    """k10temp an platform/k10temp-sim.1 mit echtem device/subsystem-Symlink.
+
+    Doppelpunktfreier Geraetename (kein "0000:00:18.3"), damit der Baum auch
+    unter Windows/NTFS anlegbar ist. k10temp steht in _CPU_SENSOR_DRIVERS
+    und ist der CPU-Sensor der Zielmaschine -- damit durchlaeuft dieser
+    Baum, anders als die Treiber-losen Faelle in test_fan_scan_stable_ids.py
+    (nct6798) und die device-losen Faelle in test_fan_control.py, tatsaechlich
+    den stabilen derive_all()+build_sensor_id()-Pfad in
+    _find_cpu_temp_sensor().
+    """
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "k10temp-sim.1"
+    hwmon = device / "hwmon" / "hwmon1"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("k10temp\n")
+    (hwmon / "temp1_input").write_text("55000\n")
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    if not (device / "subsystem").exists():
+        os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / "hwmon1", target_is_directory=True)
+    return klass
+
+
+@pytest.mark.asyncio
+async def test_cpu_sensor_id_agrees_between_lookup_and_scan(tmp_path):
+    """Kern von #532: _find_cpu_temp_sensor() und die Rueckabbildung aus
+    _scan_pwm_fans() duerfen fuer denselben physischen Sensor NIE
+    auseinanderlaufen -- sonst findet get_temperature() die Quelle des per
+    _find_cpu_temp_sensor() gewaehlten Default-Sensors nicht mehr, und die
+    Kurve regelt lautlos nicht (das Symptom von #517).
+    """
+    klass = _k10temp_tree(tmp_path)
+    backend = LinuxFanControlBackend(get_settings())
+    backend._hwmon_base = klass
+
+    found = backend._find_cpu_temp_sensor()
+    assert found is not None
+    sensor_id, temp_path = found
+
+    # Stabile Form, nicht die Altform "hwmon1_temp1".
+    assert sensor_id == "k10temp-isa-0001:temp1"
+    assert temp_path.name == "temp1_input"
+
+    await backend._scan_pwm_fans()
+
+    # Kern der Garantie: dieselbe ID zeigt in beiden Wegen auf dieselbe Datei.
+    assert backend._temp_paths.get(sensor_id) == temp_path
+
+    assert await backend.get_temperature(sensor_id) == 55.0

--- a/client/src/components/fan-control/FanCard.tsx
+++ b/client/src/components/fan-control/FanCard.tsx
@@ -4,9 +4,17 @@ import { FanMode } from '../../api/fan-control';
 import type { FanInfo, TempSensorInfo } from '../../api/fan-control';
 import { formatNumber } from '../../lib/formatters';
 
+// Namespace-Praefixe wie im Backend (app/services/power/fan_sources.py).
+const SENSOR_ID_NAMESPACES = ['hwmon:', 'gpu:', 'disk:', 'mix:'];
+
 function sensorDisplayName(sensorId: string, sensors: TempSensorInfo[]): string {
-  // Accept both namespaced and legacy unprefixed IDs
-  const found = sensors.find((s) => s.sensor_id === sensorId || s.sensor_id === `hwmon:${sensorId}`);
+  // Accept both namespaced and legacy unprefixed IDs. Die stabile Kennung
+  // (#532) traegt bereits einen Namespace -- ein zweites Praefix ergaebe
+  // "hwmon:hwmon:...", daher nur praefixieren, wenn noch keiner vorhanden ist.
+  const namespacedSensorId = SENSOR_ID_NAMESPACES.some((n) => sensorId.startsWith(n))
+    ? sensorId
+    : `hwmon:${sensorId}`;
+  const found = sensors.find((s) => s.sensor_id === sensorId || s.sensor_id === namespacedSensorId);
   if (!found) return sensorId;
   return found.custom_label || found.label || found.device_name;
 }

--- a/docs/TECHNICAL_DOCUMENTATION.md
+++ b/docs/TECHNICAL_DOCUMENTATION.md
@@ -1236,6 +1236,37 @@ CREATE TABLE fan_sample (
 );
 ```
 
+#### Stable Fan & Sensor Identities (v1.38+)
+
+As of version 1.38, fan and sensor identities are no longer tied to `hwmon` device indices, which can shift during hardware re-enumeration or driver reload. Instead, they are anchored to a **stable chip-level identifier** derived from the hardware bus and address.
+
+**Identity Format:**
+- **Fans:** `<chip>-<bus>-<adresse>:pwm<N>` (e.g., `nct6798-isa-0290:pwm1`)
+- **Sensors:** `hwmon:<chip>-<bus>-<adresse>:temp<M>` (e.g., `hwmon:k10temp-pci-00c3:temp1`)
+
+These identities survive kernel driver reloads and hwmon renumbering.
+
+**Important Limitation:**  
+Chips without a discoverable `pci` or `platform` parent (i.e., on `i2c`, `spi`, `scsi`, `hid` or other buses) continue to use the hwmon-indexed form (`hwmon0_pwm1`, etc.) and behave as before. This notably affects **`drivetemp`** (SATA disk temperature sensors), which retain their legacy identities.
+
+**Migration Behavior:**  
+When the backend starts after a code upgrade that includes this refactoring:
+1. All existing `fan_configs` rows are analyzed to derive their new stable identities.
+2. Rows are **matched and renamed** to the new identity if a stable identity can be determined; orphaned configs (i.e., matching no currently-visible hardware) are preserved but marked inactive.
+3. Newly-visible fans (e.g., after a hardware addition or back after a driver reload) get a new row if on the primary worker.
+
+**Prerequisite after Restore from Pre-Refactoring Backup:**  
+If you restore a database snapshot taken before this refactoring, a backend restart is required. The reconciliation logic runs only at startup and will not run again mid-session.
+
+**Fan History:**  
+After the refactoring, the fan history graph is empty for **all** fans. Existing `fan_sample` rows retain their old identity and gradually expire according to the configured retention policy. This is a one-time effect; ongoing samples use the new stable identities and accumulate normally.
+
+**Fan Regulation During Identity Mismatch:**  
+If the identity-matching logic fails at startup (e.g., due to an unexpected hardware topology), the backend will **not** create default fan configurations as a fail-safe. During this cycle, fans remain unregulated (PWM is unmodified, no automatic curve adjustment). This prevents erasing legitimate user configurations with synthetic defaults. The error is logged with a traceback; a subsequent backend restart after the mismatch is resolved will complete the reconciliation.
+
+**Secondary Worker Behavior:**  
+The configuration-creation logic runs only on the primary Uvicorn worker. A backend-switching request (e.g., switching from `dev` to `prod` mode via HTTP) landing on a secondary worker will not create configs for newly-visible fans; these configs are created on the next primary-worker startup cycle (either an immediate restart or the next service restart). This is transparent to the user but introduces a brief window where newly-visible fans lack a configuration row.
+
 ---
 
 ### 17. Monitoring Orchestrator

--- a/docs/TECHNICAL_DOCUMENTATION.md
+++ b/docs/TECHNICAL_DOCUMENTATION.md
@@ -1252,7 +1252,7 @@ Chips without a discoverable `pci` or `platform` parent (i.e., on `i2c`, `spi`, 
 **Migration Behavior:**  
 When the backend starts after a code upgrade that includes this refactoring:
 1. All existing `fan_configs` rows are analyzed to derive their new stable identities.
-2. Rows are **matched and renamed** to the new identity if a stable identity can be determined; orphaned configs (i.e., matching no currently-visible hardware) are preserved but marked inactive.
+2. Rows are **matched and renamed** to the new identity if a stable identity can be determined. A row whose chip is **not currently visible** (e.g., a driver not yet loaded at this particular startup) is preserved **untouched and still active** — this is the core safeguard against curve loss: a chip that simply hasn't been re-enumerated yet must not have its curve invalidated. A row is only marked **inactive** when it loses a rank comparison against a newer row targeting the same stable identity, or when its chip is present but the specific PWM channel is gone.
 3. Newly-visible fans (e.g., after a hardware addition or back after a driver reload) get a new row if on the primary worker.
 
 **Prerequisite after Restore from Pre-Refactoring Backup:**  

--- a/docs/superpowers/plans/2026-09-05-stable-fan-identity.md
+++ b/docs/superpowers/plans/2026-09-05-stable-fan-identity.md
@@ -1,0 +1,1790 @@
+# Stabile Lüfter- und Sensor-Identität — Implementierungsplan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lüfter- und Sensor-IDs vom hwmon-Index lösen, damit eine eingestellte Lüfterkurve ein Renumbering überlebt.
+
+**Architecture:** Eine neue, reine Modul-Einheit `fan_identity.py` leitet aus dem sysfs-Baum die libsensors-Kennung `<prefix>-<bus>-<adresse>` ab. Das Linux-Backend bildet daraus `fan_id`/`temp_sensor_id` und führt eine Rückabbildung Kennung → hwmon-Pfad mit. Ein zweites Modul `fan_reconcile.py` überführt bestehende Datenbankzeilen anhand des Chip-Namens in `fan_configs.name`; es läuft beim Dienststart vor der Anlage-Schleife, im Primary-Worker, in einer Transaktion.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLAlchemy 2.0, Alembic, pytest. Keine neuen Abhängigkeiten.
+
+**Spec:** `docs/superpowers/specs/2026-09-05-stable-fan-identity-design.md`
+
+## Global Constraints
+
+- **Normative libsensors-Version: 3.6.2** (`1:3.6.2-2` auf BaluNode). Regeln aus `master` gelten hier nicht.
+- **Keine neuen Abhängigkeiten.**
+- **Nichts wird gelöscht.** Verwaiste Zeilen werden ausschließlich auf `is_active=False` gesetzt.
+- **Abwesenheit darf niemals schreiben.** Eine Zeile, deren Chip beim Scan nicht auftaucht, bleibt unangetastet und aktiv.
+- **`dev_*`-Zeilen bleiben unberührt.** Nur `^hwmon\d+_pwm\d+$` wird angefasst.
+- Kommentare und Log-Meldungen auf Deutsch, wie im umgebenden Fan-Code (`fan_backend_linux.py` verwendet Umlaut-freie deutsche Kommentare — dieser Konvention folgen).
+- Die volle Backend-Suite läuft in der CI, nicht lokal (hängt auf Windows). Lokal gilt `python -m pytest -k "fan or power"`.
+- Alembic-Elternrevision ist `c4b18e9a2f37` (verifizierter einziger Head).
+
+---
+
+### Task 1: `fan_identity.py` — Adressbildung und Namensformat
+
+Reine Funktionen ohne Dateisystemzugriff. Sie sind der Kern, an dem die selbstgebaute Kodierung hängt, und deshalb zuerst und isoliert.
+
+**Files:**
+- Create: `backend/app/services/power/fan_identity.py`
+- Test: `backend/tests/test_fan_identity_encoding.py`
+
+**Interfaces:**
+- Produces: `encode_pci_address(dev_name: str) -> Optional[int]`, `encode_platform_address(dev_name: str) -> Optional[int]`, `format_chip_name(prefix: str, bus: str, addr: int) -> str`
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_identity_encoding.py`:
+
+```python
+"""Adressbildung der stabilen Chip-Kennung (#532).
+
+Sollwerte sind die Chip-Ueberschriften, die `sensors` auf BaluNode ausgibt --
+also eine unabhaengige Implementierung derselben Regeln auf derselben Hardware.
+"""
+import pytest
+
+from app.services.power.fan_identity import (
+    encode_pci_address,
+    encode_platform_address,
+    format_chip_name,
+)
+
+
+@pytest.mark.parametrize("dev_name,expected", [
+    ("0000:03:00.0", 0x0300),   # amdgpu
+    ("0000:00:18.3", 0x00c3),   # k10temp: (0x18 << 3) | 3
+    ("0000:0d:00.0", 0x0d00),   # nvme
+    ("0000:0a:00.0", 0x0a00),   # nvme
+    ("0001:0d:00.0", 0x10d00),  # Domain != 0 geht mit <<16 ein
+])
+def test_pci_address(dev_name, expected):
+    assert encode_pci_address(dev_name) == expected
+
+
+def test_pci_address_rejects_non_bdf():
+    assert encode_pci_address("nct6775.656") is None
+
+
+def test_platform_address_reads_suffix_as_decimal():
+    # 656 dezimal == 0x290 -- der Wert, den `sensors` als nct6798-isa-0290 zeigt
+    assert encode_platform_address("nct6775.656") == 656
+
+
+def test_platform_address_accepts_colon_separator():
+    assert encode_platform_address("foo:42") == 42
+
+
+def test_platform_address_reads_device_tree_prefix_as_hex():
+    assert encode_platform_address("f0000000.hwmon") == 0xf0000000
+
+
+def test_platform_address_without_suffix_is_none():
+    # Bewusste Abweichung von libsensors 3.6.2: dessen "%x.%*s" liefert hier
+    # 0x0a bzw. 0xeee, weil sscanf schon zaehlt, bevor der Punkt scheitert.
+    assert encode_platform_address("asus-nb-wmi") is None
+    assert encode_platform_address("eeepc-wmi") is None
+
+
+@pytest.mark.parametrize("prefix,bus,addr,expected", [
+    ("nct6798", "isa", 656, "nct6798-isa-0290"),
+    ("amdgpu", "pci", 0x0300, "amdgpu-pci-0300"),
+    ("k10temp", "pci", 0x00c3, "k10temp-pci-00c3"),
+    ("nvme", "pci", 0x0d00, "nvme-pci-0d00"),
+    ("nvme", "pci", 0x10d00, "nvme-pci-10d00"),  # %04x ist Mindestbreite
+])
+def test_format_chip_name(prefix, bus, addr, expected):
+    assert format_chip_name(prefix, bus, addr) == expected
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_identity_encoding.py -v`
+Expected: FAIL mit `ModuleNotFoundError: No module named 'app.services.power.fan_identity'`
+
+- [ ] **Step 3: Modul anlegen**
+
+`backend/app/services/power/fan_identity.py`:
+
+```python
+"""Stabile Chip-Identitaet fuer hwmon-Knoten (#532).
+
+Bildet die libsensors-Kennung <prefix>-<bus>-<adresse>, damit Luefter- und
+Sensor-IDs ein hwmon-Renumbering ueberleben. Normativ ist lm-sensors 3.6.2
+(lib/sysfs.c, lib/data.c); Regeln aus master gelten fuer diese Zielhardware
+nicht.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# "0000:03:00.0" -- Domain, Bus, Slot, Funktion
+_PCI_BDF = re.compile(
+    r"^([0-9a-fA-F]{4}):([0-9a-fA-F]{2}):([0-9a-fA-F]{2})\.([0-9a-fA-F])$"
+)
+# "nct6775.656" / "foo:42" -- Suffix wird DEZIMAL gelesen
+_PLATFORM_DECIMAL = re.compile(r"^[A-Za-z0-9_-]+[.:](\d+)$")
+# "f0000000.hwmon" -- Device-Tree-Adresse, hexadezimal
+_PLATFORM_HEX = re.compile(r"^([0-9a-f]+)\.")
+
+
+def encode_pci_address(dev_name: str) -> Optional[int]:
+    """PCI-Adresse nach lib/sysfs.c: (domain<<16)+(bus<<8)+(slot<<3)+fn."""
+    match = _PCI_BDF.match(dev_name)
+    if not match:
+        return None
+    domain, bus, slot, fn = (int(group, 16) for group in match.groups())
+    return (domain << 16) + (bus << 8) + (slot << 3) + fn
+
+
+def encode_platform_address(dev_name: str) -> Optional[int]:
+    """Platform-Adresse: dezimaler Suffix, sonst Device-Tree-Hex, sonst None.
+
+    libsensors' zweiter sscanf ("%x.%*s") liefert bereits 1, wenn %x etwas
+    konsumiert hat -- auch wenn der Punkt danach nie matcht. Daraus werden
+    asus-nb-wmi -> 0x0a und eeepc-wmi -> 0xeee: stabil, aber bedeutungslos.
+    _PLATFORM_HEX verlangt den Punkt tatsaechlich und bildet damit den
+    gemeinten Device-Tree-Fall ab statt des Parser-Unfalls. Betroffen sind nur
+    Chips, die `sensors` ohnehin nicht listet.
+    """
+    match = _PLATFORM_DECIMAL.match(dev_name)
+    if match:
+        return int(match.group(1), 10)
+    match = _PLATFORM_HEX.match(dev_name)
+    if match:
+        return int(match.group(1), 16)
+    return None
+
+
+def format_chip_name(prefix: str, bus: str, addr: int) -> str:
+    """lib/data.c: "%s-isa-%04x" bzw. "%s-pci-%04x" -- Mindestbreite, nicht fix."""
+    return f"{prefix}-{bus}-{addr:04x}"
+```
+
+- [ ] **Step 4: Test laufen lassen, Erfolg bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_identity_encoding.py -v`
+Expected: PASS (alle 14 Fälle)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/power/fan_identity.py backend/tests/test_fan_identity_encoding.py
+git commit -m "feat(fans): Adressbildung der stabilen Chip-Kennung (#532)"
+```
+
+---
+
+### Task 2: `fan_identity.py` — Auflösung aus dem sysfs-Baum
+
+**Files:**
+- Modify: `backend/app/services/power/fan_identity.py`
+- Test: `backend/tests/test_fan_identity_resolve.py`
+
+**Interfaces:**
+- Consumes: `encode_pci_address`, `encode_platform_address`, `format_chip_name` aus Task 1
+- Produces: `ChipIdentity` (Felder `key: str`, `prefix: str`, `stable: bool`, `hwmon_name: str`, `reason: Optional[str]`), `derive_chip_identity(hwmon_dir: Path) -> ChipIdentity`, `derive_all(hwmon_base: Path) -> Dict[str, ChipIdentity]` (Schlüssel: `hwmon_dir.name`), `build_fan_id(identity, pwm_num: int) -> str`, `build_sensor_id(identity, temp_num: int) -> str`
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_identity_resolve.py`:
+
+```python
+"""Aufloesung der Chip-Kennung aus dem sysfs-Baum (#532).
+
+Die Baeume bilden die auf BaluNode gemessenen Pfade nach, inklusive echter
+device- und subsystem-Symlinks -- ohne die laeuft die Ableitung in den
+Fallback und der Test prueft das Falsche.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from app.services.power.fan_identity import (
+    ChipIdentity,
+    build_fan_id,
+    build_sensor_id,
+    derive_all,
+    derive_chip_identity,
+)
+
+
+def _tree(tmp_path: Path, hwmon_name: str, device_rel: str, chip: str,
+          subsystem: str = "pci") -> Path:
+    """Legt /sys/devices/<device_rel> an und haengt <hwmon_name> daran.
+
+    device_rel ist relativ zu sys/devices, z. B. "platform/nct6775.656".
+    subsystem wird an das TIEFSTE Verzeichnis von device_rel gehaengt.
+    """
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / device_rel
+    hwmon = device / "hwmon" / hwmon_name
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text(chip + "\n")
+
+    bus_dir = sysfs / "bus" / subsystem
+    bus_dir.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus_dir, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    link = klass / hwmon_name
+    os.symlink(hwmon, link, target_is_directory=True)
+    return link
+
+
+def test_platform_chip_uses_decimal_suffix(tmp_path):
+    link = _tree(tmp_path, "hwmon3", "platform/nct6775.656", "nct6798",
+                 subsystem="platform")
+    identity = derive_chip_identity(link)
+    assert identity.stable is True
+    assert identity.key == "nct6798-isa-0290"
+
+
+def test_pci_chip(tmp_path):
+    link = _tree(tmp_path, "hwmon2", "pci0000:00/0000:03:00.0", "amdgpu")
+    assert derive_chip_identity(link).key == "amdgpu-pci-0300"
+
+
+def test_climbs_past_intermediate_class_to_pci_parent(tmp_path):
+    # NVMe: der device-Link zeigt auf nvme1, dessen subsystem die Klasse
+    # "nvme" ist -- weder pci noch platform, also weiterklettern.
+    sysfs = tmp_path / "sys"
+    pci = sysfs / "devices" / "pci0000:00" / "0000:0d:00.0"
+    nvme = pci / "nvme" / "nvme1"
+    hwmon = nvme / "hwmon" / "hwmon0"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nvme\n")
+    for bus, target in (("pci", pci), ("nvme", nvme)):
+        bus_dir = sysfs / "bus" / bus
+        bus_dir.mkdir(parents=True, exist_ok=True)
+        os.symlink(bus_dir, target / "subsystem", target_is_directory=True)
+    os.symlink(nvme, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True)
+    link = klass / "hwmon0"
+    os.symlink(hwmon, link, target_is_directory=True)
+
+    identity = derive_chip_identity(link)
+    assert identity.stable is True
+    assert identity.key == "nvme-pci-0d00"   # ohne den instabilen nvme1
+
+
+def test_platform_without_numeric_suffix_uses_device_name(tmp_path):
+    link = _tree(tmp_path, "hwmon5", "platform/asus-nb-wmi", "asus",
+                 subsystem="platform")
+    identity = derive_chip_identity(link)
+    assert identity.stable is True
+    assert identity.key == "asus@asus-nb-wmi"
+
+
+def test_unsupported_bus_falls_back(tmp_path):
+    # drivetemp haengt am scsi-Bus. Weiterklettern landete auf dem
+    # AHCI-Controller und gaebe allen Platten dieselbe Kennung.
+    link = _tree(tmp_path, "hwmon7", "pci0000:00/0000:00:17.0/ata1/host0",
+                 "drivetemp", subsystem="scsi")
+    identity = derive_chip_identity(link)
+    assert identity.stable is False
+    assert "scsi" in (identity.reason or "")
+
+
+def test_missing_device_link_falls_back(tmp_path):
+    sysfs = tmp_path / "sys"
+    hwmon = sysfs / "devices" / "virtual" / "hwmon" / "hwmon9"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("acpitz\n")
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True)
+    link = klass / "hwmon9"
+    os.symlink(hwmon, link, target_is_directory=True)
+
+    assert derive_chip_identity(link).stable is False
+
+
+def test_missing_name_falls_back(tmp_path):
+    link = _tree(tmp_path, "hwmon4", "pci0000:00/0000:00:18.3", "k10temp")
+    (link.resolve() / "name").unlink()
+    assert derive_chip_identity(link).stable is False
+
+
+def test_duplicate_keys_both_fall_back(tmp_path):
+    # Zwei hwmon-Knoten am selben Geraet erzeugen dieselbe Kennung. Ohne
+    # Erkennung ueberschriebe der zweite den ersten still im Scan-Cache.
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "twin.1"
+    bus_dir = sysfs / "bus" / "platform"
+    bus_dir.mkdir(parents=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True)
+    device.mkdir(parents=True)
+    os.symlink(bus_dir, device / "subsystem", target_is_directory=True)
+    for name in ("hwmon0", "hwmon1"):
+        hwmon = device / "hwmon" / name
+        hwmon.mkdir(parents=True)
+        (hwmon / "name").write_text("twin\n")
+        os.symlink(device, hwmon / "device", target_is_directory=True)
+        os.symlink(hwmon, klass / name, target_is_directory=True)
+
+    identities = derive_all(klass)
+    assert identities["hwmon0"].stable is False
+    assert identities["hwmon1"].stable is False
+
+
+def test_id_builders_use_legacy_form_when_unstable():
+    stable = ChipIdentity(key="nct6798-isa-0290", prefix="nct6798",
+                          stable=True, hwmon_name="hwmon3", reason=None)
+    unstable = ChipIdentity(key="hwmon3", prefix="Unknown",
+                            stable=False, hwmon_name="hwmon3", reason="x")
+    assert build_fan_id(stable, 1) == "nct6798-isa-0290:pwm1"
+    assert build_sensor_id(stable, 6) == "nct6798-isa-0290:temp6"
+    # Fallback behaelt exakt die Altform -- sonst waere die Zeile bei jedem
+    # Start erneut ein Migrationskandidat.
+    assert build_fan_id(unstable, 1) == "hwmon3_pwm1"
+    assert build_sensor_id(unstable, 6) == "hwmon3_temp6"
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_identity_resolve.py -v`
+Expected: FAIL mit `ImportError: cannot import name 'ChipIdentity'`
+
+- [ ] **Step 3: Auflösung implementieren**
+
+An `backend/app/services/power/fan_identity.py` anhängen (Importblock oben um `os`, `logging`, `dataclass`, `Path`, `Dict` ergänzen):
+
+```python
+logger = logging.getLogger(__name__)
+
+# Bustypen, deren Adressformat wir bilden koennen.
+_SUPPORTED_BUSES = {"pci": "pci", "platform": "isa", "of_platform": "isa"}
+# Bustypen, die libsensors kennt und wir NICHT bilden. Wird einer davon
+# getroffen, brechen wir sofort ab statt weiterzuklettern: bei drivetemp
+# (scsi) landete man sonst auf dem AHCI-Controller und gaebe allen Platten
+# desselben Controllers dieselbe Kennung.
+_FALLBACK_BUSES = {"i2c", "spi", "scsi", "hid", "acpi", "mdio_bus", "sdio"}
+_MAX_CLIMB = 12
+
+
+@dataclass(frozen=True)
+class ChipIdentity:
+    key: str
+    prefix: str
+    stable: bool
+    hwmon_name: str
+    reason: Optional[str]
+
+
+def _read_name(hwmon_dir: Path) -> Optional[str]:
+    try:
+        value = (hwmon_dir / "name").read_text().strip()
+    except OSError:
+        return None
+    return value or None
+
+
+def _subsystem_of(device: Path) -> Optional[str]:
+    link = device / "subsystem"
+    try:
+        if not link.exists():
+            return None
+        return os.path.basename(os.path.realpath(link))
+    except OSError:
+        return None
+
+
+def _unstable(hwmon_name: str, prefix: Optional[str], reason: str) -> ChipIdentity:
+    logger.warning("hwmon %s: keine stabile Kennung (%s)", hwmon_name, reason)
+    return ChipIdentity(key=hwmon_name, prefix=prefix or "Unknown",
+                        stable=False, hwmon_name=hwmon_name, reason=reason)
+
+
+def derive_chip_identity(hwmon_link: Path) -> ChipIdentity:
+    """Leitet die stabile Kennung eines hwmon-Knotens ab.
+
+    hwmon_link ist der Eintrag unter /sys/class/hwmon -- ein Symlink. Der
+    Aufstieg laeuft ueber den AUFGELOESTEN Pfad; ein lexikalisches
+    Path.parent landete bei /sys/class und faende nie ein subsystem
+    (dieselbe Falle wie in fan_gpu_manual.py:101-127).
+    """
+    hwmon_name = hwmon_link.name
+    hwmon_dir = Path(os.path.realpath(hwmon_link))
+    prefix = _read_name(hwmon_dir)
+    if prefix is None:
+        return _unstable(hwmon_name, None, "hwmon/name fehlt oder ist unlesbar")
+
+    device_link = hwmon_dir / "device"
+    if not device_link.exists():
+        return _unstable(hwmon_name, prefix, "kein device-Symlink (virtueller Chip)")
+
+    current = Path(os.path.realpath(device_link))
+    for _ in range(_MAX_CLIMB):
+        subsystem = _subsystem_of(current)
+        if subsystem in _SUPPORTED_BUSES:
+            bus = _SUPPORTED_BUSES[subsystem]
+            addr = (encode_pci_address(current.name) if subsystem == "pci"
+                    else encode_platform_address(current.name))
+            if addr is None:
+                # Kein extrahierbarer Suffix: Geraetename ist innerhalb
+                # seines Busses eindeutig und damit selbst ein tauglicher Anker.
+                key = f"{prefix}@{current.name}"
+            else:
+                key = format_chip_name(prefix, bus, addr)
+            return ChipIdentity(key=key, prefix=prefix, stable=True,
+                                hwmon_name=hwmon_name, reason=None)
+        if subsystem in _FALLBACK_BUSES:
+            return _unstable(hwmon_name, prefix, f"Bustyp {subsystem} nicht unterstuetzt")
+        parent = current.parent
+        if parent == current or current.name == "devices":
+            break
+        current = parent
+
+    return _unstable(hwmon_name, prefix, "kein pci/platform-Elter gefunden")
+
+
+def derive_all(hwmon_base: Path) -> Dict[str, ChipIdentity]:
+    """Kennungen aller hwmon-Knoten, mit Duplikaterkennung."""
+    identities: Dict[str, ChipIdentity] = {}
+    try:
+        entries = sorted(hwmon_base.iterdir())
+    except OSError:
+        return identities
+
+    for entry in entries:
+        if not entry.name.startswith("hwmon"):
+            continue
+        identities[entry.name] = derive_chip_identity(entry)
+
+    by_key: Dict[str, list] = {}
+    for name, identity in identities.items():
+        if identity.stable:
+            by_key.setdefault(identity.key, []).append(name)
+    for key, names in by_key.items():
+        if len(names) > 1:
+            for name in names:
+                identities[name] = _unstable(
+                    name, identities[name].prefix,
+                    f"Kennung {key} nicht eindeutig ({len(names)} hwmon-Knoten)",
+                )
+    return identities
+
+
+def build_fan_id(identity: ChipIdentity, pwm_num: int) -> str:
+    if identity.stable:
+        return f"{identity.key}:pwm{pwm_num}"
+    return f"{identity.hwmon_name}_pwm{pwm_num}"
+
+
+def build_sensor_id(identity: ChipIdentity, temp_num: int) -> str:
+    if identity.stable:
+        return f"{identity.key}:temp{temp_num}"
+    return f"{identity.hwmon_name}_temp{temp_num}"
+```
+
+- [ ] **Step 4: Test laufen lassen, Erfolg bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_identity_resolve.py -v`
+Expected: PASS (9 Tests)
+
+Hinweis: `os.symlink` auf Verzeichnisse braucht unter Windows entweder Entwicklermodus oder Adminrechte. Schlägt der Test lokal mit `OSError: symbolic link privilege not held` fehl, ist das eine Umgebungs-, keine Codefrage — die CI läuft unter Linux. In dem Fall Task 3 fortsetzen und diesen Test der CI überlassen.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/power/fan_identity.py backend/tests/test_fan_identity_resolve.py
+git commit -m "feat(fans): Chip-Kennung aus dem sysfs-Baum ableiten (#532)"
+```
+
+---
+
+### Task 3: Scan auf stabile IDs umstellen, Rückabbildung mitführen
+
+**Files:**
+- Modify: `backend/app/services/power/fan_backend_linux.py:361-466` (`_scan_pwm_fans`), `:48` (Konstruktor)
+- Test: `backend/tests/test_fan_scan_stable_ids.py`
+
+**Interfaces:**
+- Consumes: `derive_all`, `build_fan_id`, `build_sensor_id`, `ChipIdentity` aus Task 2
+- Produces: `LinuxFanControlBackend._temp_paths: Dict[str, Path]` (Sensor-ID → `tempN_input`-Pfad), `_fan_cache[fan_id]["identity_stable"]: bool`
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_scan_stable_ids.py`:
+
+```python
+"""Der Scan bildet stabile IDs und ueberlebt ein Renumbering (#532)."""
+import os
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+def _nct_tree(tmp_path: Path, hwmon_name: str) -> Path:
+    """nct6798 an platform/nct6775.656, mit pwm1 + fan1_input + temp1_input."""
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "nct6775.656"
+    hwmon = device / "hwmon" / hwmon_name
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nct6798\n")
+    (hwmon / "pwm1").write_text("128\n")
+    (hwmon / "pwm1_enable").write_text("1\n")
+    (hwmon / "fan1_input").write_text("900\n")
+    (hwmon / "temp1_input").write_text("42000\n")
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    if not (device / "subsystem").exists():
+        os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / hwmon_name, target_is_directory=True)
+    return klass
+
+
+@pytest.mark.asyncio
+async def test_scan_builds_stable_fan_id(tmp_path, monkeypatch):
+    klass = _nct_tree(tmp_path, "hwmon3")
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+
+    cache = await backend._scan_pwm_fans()
+
+    assert "nct6798-isa-0290:pwm1" in cache
+    assert cache["nct6798-isa-0290:pwm1"]["identity_stable"] is True
+
+
+@pytest.mark.asyncio
+async def test_same_device_under_other_hwmon_index_keeps_id(tmp_path, monkeypatch):
+    """Das Akzeptanzkriterium des Issues: Renumbering aendert die ID nicht."""
+    first = _nct_tree(tmp_path / "boot_a", "hwmon3")
+    second = _nct_tree(tmp_path / "boot_b", "hwmon5")
+
+    backend_a = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend_a, "_hwmon_base", first)
+    cache_a = await backend_a._scan_pwm_fans()
+
+    backend_b = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend_b, "_hwmon_base", second)
+    cache_b = await backend_b._scan_pwm_fans()
+
+    assert set(cache_a) == set(cache_b) == {"nct6798-isa-0290:pwm1"}
+
+
+@pytest.mark.asyncio
+async def test_scan_registers_reverse_path_for_sensor(tmp_path, monkeypatch):
+    klass = _nct_tree(tmp_path, "hwmon3")
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+    await backend._scan_pwm_fans()
+
+    sensor_id = "nct6798-isa-0290:temp1"
+    assert sensor_id in backend._temp_paths
+    assert backend._temp_paths[sensor_id].name == "temp1_input"
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_scan_stable_ids.py -v`
+Expected: FAIL — der Cache enthält `hwmon3_pwm1`, `_temp_paths` existiert nicht.
+
+- [ ] **Step 3: Konstruktor und Scan umbauen**
+
+In `fan_backend_linux.py` den Importblock ergänzen:
+
+```python
+from app.services.power.fan_identity import (
+    build_fan_id,
+    build_sensor_id,
+    derive_all,
+)
+```
+
+Im Konstruktor nach `self._write_backoff: Dict[str, Tuple[int, float]] = {}`:
+
+```python
+        # Rueckabbildung stabile Sensor-Kennung -> tempN_input-Pfad. Ohne sie
+        # kann get_temperature() die ID nicht mehr aufloesen, weil sie nicht
+        # mehr aus dem hwmon-Verzeichnisnamen besteht (#532).
+        self._temp_paths: Dict[str, Path] = {}
+```
+
+In `_scan_pwm_fans` direkt nach `new_cache: Dict[str, Dict] = {}`:
+
+```python
+        new_temp_paths: Dict[str, Path] = {}
+        identities = derive_all(self._hwmon_base)
+```
+
+Die Zeile `fan_id = f"{hwmon_dir.name}_pwm{pwm_num}"` ersetzen durch:
+
+```python
+                identity = identities.get(hwmon_dir.name)
+                if identity is None:
+                    continue
+                fan_id = build_fan_id(identity, int(pwm_num))
+```
+
+Den Fallback-Zweig für den lokalen Temperatursensor (`temp_sensor_id = f"{hwmon_dir.name}_temp{temp_num}"`) ersetzen durch:
+
+```python
+                        temp_sensor_id = build_sensor_id(identity, int(temp_num))
+```
+
+Im Dict-Literal `new_cache[fan_id] = {...}` nach `"pwm_control": pwm_control,` ergänzen:
+
+```python
+                    "identity_stable": identity.stable,
+```
+
+Und direkt vor `new_cache[fan_id] = {...}` alle Temperaturkanäle des Chips in die Rückabbildung eintragen:
+
+```python
+                for temp_file in hwmon_dir.glob("temp[0-9]*_input"):
+                    num = temp_file.name[len("temp"):-len("_input")]
+                    new_temp_paths[build_sensor_id(identity, int(num))] = temp_file
+```
+
+Im Block, der den Cache ersetzt (`if new_cache or not self._fan_cache:`), nach der Zuweisung `self._fan_cache = new_cache`:
+
+```python
+            self._temp_paths = new_temp_paths
+```
+
+- [ ] **Step 4: Test laufen lassen, Erfolg bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_scan_stable_ids.py -v`
+Expected: PASS (3 Tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/power/fan_backend_linux.py backend/tests/test_fan_scan_stable_ids.py
+git commit -m "feat(fans): Scan bildet stabile IDs und fuehrt die Rueckabbildung mit (#532)"
+```
+
+---
+
+### Task 4: `get_temperature()` und `_find_cpu_temp_sensor()` über die Rückabbildung
+
+Ohne diesen Schritt liefert nach Task 3 **jeder** hwmon-Sensor `None`, weil `get_temperature` die ID mit `split("_")` zerlegt.
+
+**Files:**
+- Modify: `backend/app/services/power/fan_backend_linux.py:253-309`
+- Test: `backend/tests/test_fan_temp_resolution.py`
+
+**Interfaces:**
+- Consumes: `_temp_paths` aus Task 3
+- Produces: `get_temperature(sensor_id)` akzeptiert stabile IDs, `hwmon:`-präfixierte IDs und Alt-IDs
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_temp_resolution.py`:
+
+```python
+"""get_temperature loest stabile, praefixierte und Alt-IDs auf (#532)."""
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+@pytest.fixture
+def backend(tmp_path):
+    hwmon = tmp_path / "hwmon3"
+    hwmon.mkdir()
+    (hwmon / "temp1_input").write_text("42000\n")
+    be = LinuxFanControlBackend(get_settings())
+    be._hwmon_base = tmp_path
+    be._temp_paths = {"nct6798-isa-0290:temp1": hwmon / "temp1_input"}
+    return be
+
+
+@pytest.mark.asyncio
+async def test_resolves_stable_id(backend):
+    assert await backend.get_temperature("nct6798-isa-0290:temp1") == 42.0
+
+
+@pytest.mark.asyncio
+async def test_strips_hwmon_namespace_prefix(backend):
+    assert await backend.get_temperature("hwmon:nct6798-isa-0290:temp1") == 42.0
+
+
+@pytest.mark.asyncio
+async def test_still_resolves_legacy_id(backend):
+    # Waehrend der Umstellung stehen Alt-IDs noch in der Datenbank.
+    assert await backend.get_temperature("hwmon3_temp1") == 42.0
+
+
+@pytest.mark.asyncio
+async def test_unknown_id_is_none(backend):
+    assert await backend.get_temperature("nope-isa-0000:temp9") is None
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_temp_resolution.py -v`
+Expected: FAIL — die ersten beiden geben `None` zurück.
+
+- [ ] **Step 3: `get_temperature` umbauen**
+
+`fan_backend_linux.py`, die Methode ab Zeile 253 ersetzen:
+
+```python
+    async def get_temperature(self, sensor_id: str) -> Optional[float]:
+        """Get temperature from hwmon sensor.
+
+        Loest zuerst ueber die Rueckabbildung aus dem Scan auf (stabile
+        Kennungen, #532) und faellt danach auf die Altform hwmon<N>_temp<M>
+        zurueck, die waehrend der Umstellung noch in der Datenbank steht.
+        """
+        if not sensor_id:
+            return None
+
+        if sensor_id.startswith("hwmon:"):
+            sensor_id = sensor_id[len("hwmon:"):]
+
+        temp_path = self._temp_paths.get(sensor_id)
+        if temp_path is None:
+            temp_path = self._legacy_temp_path(sensor_id)
+        if temp_path is None:
+            return None
+
+        temp_value = await self._read_hwmon_file(temp_path)
+        if temp_value is not None:
+            return float(temp_value) / 1000.0
+        return None
+
+    def _legacy_temp_path(self, sensor_id: str) -> Optional[Path]:
+        """Altform "hwmon0_temp1" -> Pfad. Nur fuer noch nicht migrierte IDs."""
+        parts = sensor_id.split("_")
+        if len(parts) != 2:
+            return None
+        hwmon_name, temp_name = parts
+        return self._hwmon_base / hwmon_name / f"{temp_name}_input"
+```
+
+- [ ] **Step 4: `_find_cpu_temp_sensor` und `get_available_temp_sensors` auf die Kennung umstellen**
+
+Beide bilden Sensor-IDs heute aus dem hwmon-Verzeichnisnamen. Sie müssen dieselbe Ableitung benutzen wie der Scan, sonst weichen die IDs voneinander ab. Dafür in beiden Methoden einmal `identities = derive_all(self._hwmon_base)` holen und pro Temperaturkanal so bilden:
+
+```python
+                identity = identities.get(hwmon_dir.name)
+                if identity is None:
+                    continue
+                sensor_id = build_sensor_id(identity, int(temp_num))
+                # Auch Sensoren ohne zugehoerigen PWM-Kanal muessen aufloesbar
+                # sein -- der Scan traegt nur Chips mit Luefter ein.
+                self._temp_paths[sensor_id] = temp_file
+```
+
+Die bisherige Bildung `f"{hwmon_dir.name}_temp{temp_num}"` entfällt an beiden Stellen. `_find_cpu_temp_sensor` gibt weiterhin `(sensor_id, path)` zurück, nur mit der neuen ID-Form.
+
+- [ ] **Step 5: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_temp_resolution.py tests/test_fan_scan_stable_ids.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/power/fan_backend_linux.py backend/tests/test_fan_temp_resolution.py
+git commit -m "fix(fans): Temperaturaufloesung ueber die Rueckabbildung statt String-Zerlegung (#532)"
+```
+
+---
+
+### Task 5: `_normalize_id` auf eine Namespace-Whitelist, `get_status` über die Registry
+
+**Files:**
+- Modify: `backend/app/services/power/fan_sources.py:101-106`
+- Modify: `backend/app/services/power/fan_control.py:670-680` (`get_status`)
+- Test: `backend/tests/test_fan_sources_normalize.py`
+
+**Interfaces:**
+- Produces: `TempSourceRegistry._normalize_id` erkennt Namespaces am Präfix statt am Doppelpunkt
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_sources_normalize.py`:
+
+```python
+"""Namespace-Erkennung darf nicht am blossen Doppelpunkt haengen (#532)."""
+from app.services.power.fan_sources import TempSourceRegistry
+
+
+def test_legacy_bare_id_gets_hwmon_namespace():
+    assert TempSourceRegistry._normalize_id("hwmon3_temp1") == "hwmon:hwmon3_temp1"
+
+
+def test_stable_bare_id_gets_hwmon_namespace():
+    # Enthaelt selbst einen Doppelpunkt -- die alte Heuristik "":" in id"
+    # haette die ID unveraendert durchgereicht und die Quelle nicht gefunden.
+    assert (TempSourceRegistry._normalize_id("k10temp-pci-00c3:temp1")
+            == "hwmon:k10temp-pci-00c3:temp1")
+
+
+def test_already_namespaced_ids_pass_through():
+    for sid in ("hwmon:k10temp-pci-00c3:temp1", "gpu:edge",
+                "disk:sda", "mix:abc123"):
+        assert TempSourceRegistry._normalize_id(sid) == sid
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_sources_normalize.py -v`
+Expected: FAIL bei `test_stable_bare_id_gets_hwmon_namespace`
+
+- [ ] **Step 3: `_normalize_id` ersetzen**
+
+`fan_sources.py`, oberhalb der Klasse:
+
+```python
+_NAMESPACES = ("hwmon:", "gpu:", "disk:", "mix:")
+```
+
+Die Methode ersetzen:
+
+```python
+    @staticmethod
+    def _normalize_id(sensor_id: str) -> str:
+        """Accept both namespaced (hwmon:foo) and legacy (foo) IDs.
+
+        Geprueft wird der Namespace-Praefix, nicht das blosse Vorkommen eines
+        Doppelpunkts: stabile Kennungen (#532) tragen selbst einen.
+        """
+        if sensor_id.startswith(_NAMESPACES):
+            return sensor_id
+        return f"hwmon:{sensor_id}"
+```
+
+- [ ] **Step 4: `get_status` auf die Registry umstellen**
+
+`fan_control.py:676` liest die Anzeigetemperatur am Registry vorbei über `self._backend.get_temperature(...)` und verschluckt jeden Fehler. Die Zeile ersetzen:
+
+```python
+                            sensor_temp = await self._registry.get_temp(config.temp_sensor_id)
+```
+
+Damit gilt für die Anzeige dieselbe Auflösung wie für die Regelung (`fan_control.py:482`); sonst zeigt die UI für jeden Lüfter mit abweichend gewähltem Sensor eine andere Temperatur als die, nach der geregelt wird.
+
+- [ ] **Step 5: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_sources_normalize.py tests/test_fan_sources.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/power/fan_sources.py backend/app/services/power/fan_control.py backend/tests/test_fan_sources_normalize.py
+git commit -m "fix(fans): Namespace-Erkennung am Praefix, Anzeigetemperatur ueber die Registry (#532)"
+```
+
+---
+
+### Task 6: Alembic-Migration für die Herkunftsspalten
+
+**Files:**
+- Create: `backend/alembic/versions/<rev>_fan_identity_legacy_columns.py`
+- Modify: `backend/app/models/fans.py` (`FanConfig`, `TempSensorLabel`)
+
+**Interfaces:**
+- Produces: `FanConfig.legacy_fan_id: Optional[str]`, `TempSensorLabel.legacy_sensor_id: Optional[str]`
+
+- [ ] **Step 1: Aktuellen Head bestätigen**
+
+Run: `cd backend ; python -m alembic heads`
+Expected: genau eine Zeile, `c4b18e9a2f37 (head)`. Weicht das ab, **hier stoppen** und melden — das Projekt hatte bereits einen Multi-Head-Deployfehler.
+
+- [ ] **Step 2: Modelle erweitern**
+
+`backend/app/models/fans.py`, in `FanConfig` nach `is_active`:
+
+```python
+    # Herkunft der Zeile vor der Umstellung auf stabile Kennungen (#532).
+    # Reiner Nachweis: erlaubt, eine Fehlzuordnung nachtraeglich zu erkennen.
+    legacy_fan_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+```
+
+In `TempSensorLabel` nach `custom_label`:
+
+```python
+    legacy_sensor_id: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
+```
+
+- [ ] **Step 3: Migration erzeugen**
+
+Run: `cd backend ; python -m alembic revision --autogenerate -m "fan identity legacy columns"`
+
+In der erzeugten Datei prüfen, dass `down_revision = "c4b18e9a2f37"` steht und **nur** die beiden `add_column`-Aufrufe enthalten sind. Autogenerate nimmt gern Unbeteiligtes mit — alles andere entfernen.
+
+- [ ] **Step 4: Migration anwenden und zurückrollen**
+
+```bash
+cd backend
+python -m alembic upgrade head
+python -m alembic downgrade -1
+python -m alembic upgrade head
+```
+Expected: alle drei Läufe ohne Fehler; `python -m alembic heads` zeigt wieder genau einen Head.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/models/fans.py backend/alembic/versions/
+git commit -m "feat(fans): Herkunftsspalten fuer die Identitaets-Umstellung (#532)"
+```
+
+---
+
+### Task 7: `fan_reconcile.py` — die Zuordnungsregeln
+
+Reines Modul ohne sysfs-Zugriff: es bekommt die Scan-Fakten als Datenstruktur. Dadurch ist die gesamte Regelmenge gegen die echte Datenlage testbar.
+
+**Files:**
+- Create: `backend/app/services/power/fan_reconcile.py`
+- Test: `backend/tests/test_fan_reconcile.py`
+
+**Interfaces:**
+- Produces: `ChipFacts(key: str, pwm_channels: frozenset[int], ambiguous: bool)`, `ReconcileReport(renamed: list[tuple[str, str]], deactivated: list[str], skipped_absent: list[str], unresolved_sensors: list[str])`, `reconcile_fan_identities(db, chips: Dict[str, ChipFacts], sensor_map: Dict[str, str], cpu_sensor_id: Optional[str]) -> ReconcileReport`
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_reconcile.py`:
+
+```python
+"""Zuordnung der Altzeilen auf stabile Kennungen (#532).
+
+Das Fixture ist die auf BaluNode gemessene Datenlage: 16 Zeilen, davon 13
+hwmon-indiziert in vier Generationen fuer 5 physische Luefter, plus 3 dev_*.
+"""
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import Base
+from app.models.fans import FanConfig
+from app.services.power.fan_reconcile import (
+    ChipFacts,
+    reconcile_fan_identities,
+)
+
+NCT = ChipFacts(key="nct6798-isa-0290",
+                pwm_channels=frozenset({1, 2, 3, 7}), ambiguous=False)
+AMD = ChipFacts(key="amdgpu-pci-0300",
+                pwm_channels=frozenset({1}), ambiguous=False)
+CHIPS = {"nct6798": NCT, "amdgpu": AMD}
+
+SENSOR_MAP = {
+    "hwmon4_temp1": "hwmon:k10temp-pci-00c3:temp1",
+    "hwmon3_temp1": "hwmon:nct6798-isa-0290:temp1",
+}
+CPU_DEFAULT = "hwmon:k10temp-pci-00c3:temp1"
+
+
+def _dt(text: str) -> datetime:
+    return datetime.fromisoformat(text).replace(tzinfo=timezone.utc)
+
+
+ROWS = [
+    # (fan_id, name, temp_sensor_id, updated_at)
+    ("hwmon5_pwm1", "nct6798 PWM1", "hwmon5_temp6", "2026-01-25T22:51:59"),
+    ("hwmon5_pwm2", "nct6798 PWM2", "hwmon5_temp6", "2026-01-25T22:51:59"),
+    ("hwmon5_pwm3", "nct6798 PWM3", "hwmon5_temp6", "2026-01-25T22:51:59"),
+    ("hwmon5_pwm7", "nct6798 PWM7", "hwmon5_temp6", "2026-01-25T22:51:59"),
+    ("dev_case_fan_1", "Case Fan 1 (Simulated)", "dev_package_temp", "2026-01-27T22:48:27"),
+    ("dev_cpu_fan", "CPU Fan (Simulated)", "dev_cpu_temp", "2026-02-17T21:48:42"),
+    ("dev_case_fan_2", "Case Fan 2 (Simulated)", "dev_cpu_temp", "2026-02-25T19:57:42"),
+    ("hwmon1_pwm1", "amdgpu PWM1", "hwmon3_temp1", "2026-07-06T23:38:15"),
+    ("hwmon2_pwm1", "nct6798 PWM1", "hwmon3_temp1", "2026-07-20T22:59:55"),
+    ("hwmon2_pwm2", "nct6798 PWM2", "hwmon3_temp1", "2026-07-20T22:59:55"),
+    ("hwmon2_pwm3", "nct6798 PWM3", "hwmon3_temp1", "2026-07-20T22:59:55"),
+    ("hwmon2_pwm7", "nct6798 PWM7", "hwmon3_temp1", "2026-07-20T22:59:55"),
+    ("hwmon3_pwm1", "nct6798 PWM1", "hwmon4_temp1", "2026-08-07T00:32:04"),
+    ("hwmon3_pwm2", "nct6798 PWM2", "hwmon4_temp1", "2026-08-07T00:32:04"),
+    ("hwmon3_pwm3", "nct6798 PWM3", "hwmon4_temp1", "2026-08-07T00:32:04"),
+    ("hwmon3_pwm7", "nct6798 PWM7", "hwmon4_temp1", "2026-08-07T00:32:04"),
+]
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    for fan_id, name, sensor, updated in ROWS:
+        session.add(FanConfig(fan_id=fan_id, name=name, mode="auto",
+                              temp_sensor_id=sensor, is_active=True,
+                              updated_at=_dt(updated)))
+    session.commit()
+    yield session
+    session.close()
+
+
+def _active(db):
+    return {r.fan_id for r in db.execute(
+        select(FanConfig).where(FanConfig.is_active.is_(True))).scalars()}
+
+
+def test_newest_generation_wins_and_nothing_is_deleted(db):
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    assert _active(db) == {
+        "nct6798-isa-0290:pwm1", "nct6798-isa-0290:pwm2",
+        "nct6798-isa-0290:pwm3", "nct6798-isa-0290:pwm7",
+        "amdgpu-pci-0300:pwm1",
+        "dev_case_fan_1", "dev_cpu_fan", "dev_case_fan_2",
+    }
+    assert db.query(FanConfig).count() == 16   # nichts geloescht
+
+
+def test_july_row_named_nct6798_does_not_become_the_gpu(db):
+    """Die Falle: hwmon2 ist heute die GPU, war im Juli aber der nct6798."""
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    gpu = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "amdgpu-pci-0300:pwm1")).scalar_one()
+    assert gpu.legacy_fan_id == "hwmon1_pwm1"
+    assert gpu.name == "amdgpu PWM1"
+
+
+def test_absent_chip_is_never_deactivated(db):
+    """Treiber beim Start noch nicht geladen -- Kurven muessen bleiben."""
+    reconcile_fan_identities(db, chips={"amdgpu": AMD}, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    for fan_id in ("hwmon3_pwm1", "hwmon2_pwm1", "hwmon5_pwm1"):
+        row = db.execute(select(FanConfig).where(
+            FanConfig.fan_id == fan_id)).scalar_one()
+        assert row.is_active is True
+
+
+def test_second_run_is_a_noop(db):
+    first = reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                                     cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+    second = reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                                      cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    assert len(first.renamed) == 5
+    assert second.renamed == []
+    assert second.deactivated == []
+
+
+def test_resumes_after_abort_between_rename_and_deactivate(db):
+    """Gewinner schon umbenannt, Verlierer noch aktiv -- kein Unique-Fehler."""
+    row = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "hwmon3_pwm1")).scalar_one()
+    row.fan_id = "nct6798-isa-0290:pwm1"
+    row.legacy_fan_id = "hwmon3_pwm1"
+    db.commit()
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    assert "hwmon2_pwm1" not in _active(db)
+    assert "nct6798-isa-0290:pwm1" in _active(db)
+
+
+def test_unknown_name_is_neither_candidate_nor_deactivated(db):
+    db.add(FanConfig(fan_id="hwmon9_pwm1", name="Unknown PWM1", mode="auto",
+                     temp_sensor_id=None, is_active=True,
+                     updated_at=_dt("2026-08-08T00:00:00")))
+    db.commit()
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    row = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "hwmon9_pwm1")).scalar_one()
+    assert row.is_active is True
+
+
+def test_ambiguous_chip_name_is_no_candidate(db):
+    chips = {"nct6798": ChipFacts(key="nct6798-isa-0290",
+                                  pwm_channels=frozenset({1, 2, 3, 7}),
+                                  ambiguous=True),
+             "amdgpu": AMD}
+    reconcile_fan_identities(db, chips=chips, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    assert "hwmon3_pwm1" in _active(db)
+
+
+def test_winner_sensor_is_rewritten_prefixed(db):
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    row = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "nct6798-isa-0290:pwm1")).scalar_one()
+    assert row.temp_sensor_id == "hwmon:k10temp-pci-00c3:temp1"
+
+
+def test_unresolvable_sensor_falls_back_to_cpu_default(db):
+    report = reconcile_fan_identities(db, chips=CHIPS, sensor_map={},
+                                      cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    row = db.execute(select(FanConfig).where(
+        FanConfig.fan_id == "nct6798-isa-0290:pwm1")).scalar_one()
+    assert row.temp_sensor_id == CPU_DEFAULT
+    assert "hwmon4_temp1" in report.unresolved_sensors
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_reconcile.py -v`
+Expected: FAIL mit `ModuleNotFoundError: No module named 'app.services.power.fan_reconcile'`
+
+- [ ] **Step 3: Modul implementieren**
+
+`backend/app/services/power/fan_reconcile.py`:
+
+```python
+"""Ueberfuehrt hwmon-indizierte fan_configs auf stabile Kennungen (#532).
+
+Reines Modul: es bekommt die Scan-Fakten uebergeben und fasst kein sysfs an.
+Der Aufrufer haelt die Transaktion.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.fans import (
+    CompositeTempSensor,
+    FanConfig,
+    FanScheduleEntry,
+    TempSensorLabel,
+)
+
+logger = logging.getLogger(__name__)
+
+_LEGACY_FAN_ID = re.compile(r"^hwmon(\d+)_pwm(\d+)$")
+_LEGACY_SENSOR_ID = re.compile(r"^hwmon(\d+)_temp(\d+)$")
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class ChipFacts:
+    """Was der Scan ueber einen heute vorhandenen Chip weiss."""
+    key: str
+    pwm_channels: frozenset
+    ambiguous: bool
+
+
+@dataclass
+class ReconcileReport:
+    renamed: List[Tuple[str, str]] = field(default_factory=list)
+    deactivated: List[str] = field(default_factory=list)
+    skipped_absent: List[str] = field(default_factory=list)
+    unresolved_sensors: List[str] = field(default_factory=list)
+
+
+def _chip_from_name(name: Optional[str]) -> Optional[str]:
+    """"nct6798 PWM1" -> "nct6798". Ohne " PWM" kein Kandidat.
+
+    Der Dev-Backend erzeugt Namen wie "CPU Fan (Simulated)"; ein naives
+    rsplit gaebe dort den ganzen Namen als Chip-Namen zurueck.
+    """
+    if not name:
+        return None
+    index = name.rfind(" PWM")
+    if index <= 0:
+        return None
+    return name[:index]
+
+
+def _map_sensor(sensor_id: Optional[str], sensor_map: Dict[str, str],
+                cpu_sensor_id: Optional[str],
+                report: ReconcileReport) -> Optional[str]:
+    if not sensor_id:
+        return cpu_sensor_id
+    bare = sensor_id[len("hwmon:"):] if sensor_id.startswith("hwmon:") else sensor_id
+    mapped = sensor_map.get(bare)
+    if mapped:
+        return mapped
+    report.unresolved_sensors.append(bare)
+    logger.warning(
+        "Sensor %s nicht aufloesbar, Rueckfall auf den CPU-Default %s",
+        sensor_id, cpu_sensor_id,
+    )
+    return cpu_sensor_id
+
+
+def reconcile_fan_identities(
+    db: Session,
+    *,
+    chips: Dict[str, ChipFacts],
+    sensor_map: Dict[str, str],
+    cpu_sensor_id: Optional[str],
+) -> ReconcileReport:
+    """Ordnet Altzeilen stabilen Kennungen zu. Committet NICHT."""
+    report = ReconcileReport()
+    rows = list(db.execute(select(FanConfig)).scalars())
+
+    # Rangfolge VOR dem ersten Schreibzugriff festhalten: updated_at traegt
+    # ein onupdate=func.now() und aendert sich sonst waehrend des Laufs.
+    order = {row.id: row.updated_at for row in rows}
+
+    candidates: Dict[str, List[FanConfig]] = {}
+    for row in rows:
+        match = _LEGACY_FAN_ID.match(row.fan_id or "")
+        if not match:
+            continue                                   # Regel 1
+        chip = _chip_from_name(row.name)
+        if chip is None:
+            continue                                   # kein " PWM" im Namen
+        facts = chips.get(chip)
+        if facts is None:                              # Regel 4: Chip abwesend
+            report.skipped_absent.append(row.fan_id)
+            continue
+        if facts.ambiguous:
+            continue                                   # Regel 2
+        channel = int(match.group(2))
+        if channel not in facts.pwm_channels:
+            row.is_active = False                      # Chip da, Kanal weg
+            report.deactivated.append(row.fan_id)
+            continue
+        candidates.setdefault(f"{facts.key}:pwm{channel}", []).append(row)
+
+    # Bereits in Neuform vorliegende Zeilen treten mit an, sonst laeuft ein
+    # nach einem Abbruch wiederholter Lauf in den Unique-Index.
+    existing = {row.fan_id: row for row in rows}
+    for new_id, group in candidates.items():
+        incumbent = existing.get(new_id)
+        if incumbent is not None and incumbent not in group:
+            group.append(incumbent)
+
+        # Kein None in den Sortierschluessel: zwei Zeilen ohne updated_at
+        # liefen sonst in einen TypeError beim Vergleich None < None.
+        winner = max(group, key=lambda r: order.get(r.id) or _EPOCH)
+        for row in group:
+            if row is winner:
+                continue
+            row.is_active = False
+            report.deactivated.append(row.fan_id)
+
+        if winner.fan_id != new_id:
+            old_id = winner.fan_id
+            winner.legacy_fan_id = old_id
+            winner.fan_id = new_id
+            report.renamed.append((old_id, new_id))
+            logger.info("Fan-Identitaet: %s -> %s", old_id, new_id)
+            _rewrite_references(db, old_id, new_id)
+
+        winner.temp_sensor_id = _map_sensor(
+            winner.temp_sensor_id, sensor_map, cpu_sensor_id, report
+        )
+
+    _reconcile_sensor_labels(db, sensor_map, report)
+    _reconcile_composites(db, sensor_map)
+
+    logger.info(
+        "Identitaets-Abgleich: %d uebernommen, %d deaktiviert, %d ohne Chip",
+        len(report.renamed), len(report.deactivated), len(report.skipped_absent),
+    )
+    return report
+
+
+def _rewrite_references(db: Session, old_id: str, new_id: str) -> None:
+    """sync_fan_id und Zeitplaneintraege ziehen mit."""
+    for row in db.execute(
+        select(FanConfig).where(FanConfig.sync_fan_id == old_id)
+    ).scalars():
+        row.sync_fan_id = new_id
+    for entry in db.execute(
+        select(FanScheduleEntry).where(FanScheduleEntry.fan_id == old_id)
+    ).scalars():
+        entry.fan_id = new_id
+
+
+def _reconcile_sensor_labels(db: Session, sensor_map: Dict[str, str],
+                             report: ReconcileReport) -> None:
+    """Nutzer-Labels auf die neuen Sensor-Kennungen umschluesseln.
+
+    sensor_id ist Primaerschluessel und die Tabelle hat kein is_active. Bei
+    einer Kollision gewinnt die juengste Zeile; die verworfene BLEIBT unter
+    ihrem alten Schluessel liegen und wird ignoriert. Kein Loeschen -- das
+    ist ein ausdrueckliches Nicht-Ziel der Spec.
+    """
+    rows = list(db.execute(select(TempSensorLabel)).scalars())
+    existing = {row.sensor_id for row in rows}
+    claimed: Dict[str, TempSensorLabel] = {}
+
+    for row in rows:
+        if not _LEGACY_SENSOR_ID.match(row.sensor_id or ""):
+            continue
+        new_id = sensor_map.get(row.sensor_id)
+        if not new_id:
+            report.unresolved_sensors.append(row.sensor_id)
+            continue
+        bare_new = new_id[len("hwmon:"):] if new_id.startswith("hwmon:") else new_id
+        if bare_new in existing:
+            continue
+        rival = claimed.get(bare_new)
+        if rival is not None:
+            loser = min((rival, row), key=lambda r: r.updated_at or _EPOCH)
+            logger.warning(
+                "Sensor-Label %s verworfen: %s ist bereits vergeben",
+                loser.sensor_id, bare_new,
+            )
+            if loser is row:
+                continue
+        claimed[bare_new] = row
+
+    for bare_new, row in claimed.items():
+        row.legacy_sensor_id = row.sensor_id
+        row.sensor_id = bare_new
+        logger.info("Sensor-Label: %s -> %s", row.legacy_sensor_id, bare_new)
+
+
+def _reconcile_composites(db: Session, sensor_map: Dict[str, str]) -> None:
+    """Quell-IDs in composite_temp_sensors mit derselben Abbildung umschreiben."""
+    for composite in db.execute(select(CompositeTempSensor)).scalars():
+        try:
+            sources = json.loads(composite.source_ids_json)
+        except (TypeError, ValueError):
+            logger.warning("Composite %s: source_ids_json unlesbar", composite.id)
+            continue
+        if not isinstance(sources, list):
+            continue
+
+        changed = False
+        rewritten = []
+        for source in sources:
+            bare = source[len("hwmon:"):] if isinstance(source, str) and source.startswith("hwmon:") else source
+            mapped = sensor_map.get(bare) if isinstance(bare, str) else None
+            if mapped:
+                rewritten.append(mapped)
+                changed = True
+            else:
+                rewritten.append(source)
+        if changed:
+            composite.source_ids_json = json.dumps(rewritten)
+            logger.info("Composite %s: Quell-IDs umgeschrieben", composite.id)
+```
+
+- [ ] **Step 4: Test laufen lassen, Erfolg bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_reconcile.py -v`
+Expected: PASS (10 Tests)
+
+- [ ] **Step 5: Test für Labels und Composite-Sensoren schreiben**
+
+An `backend/tests/test_fan_reconcile.py` anhängen:
+
+```python
+from app.models.fans import CompositeTempSensor, TempSensorLabel
+
+
+def test_sensor_label_is_rekeyed_and_keeps_provenance(db):
+    db.add(TempSensorLabel(sensor_id="hwmon4_temp1", custom_label="RAID-Platten"))
+    db.commit()
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    labels = {row.sensor_id: row for row in db.query(TempSensorLabel).all()}
+    assert "k10temp-pci-00c3:temp1" in labels
+    assert labels["k10temp-pci-00c3:temp1"].custom_label == "RAID-Platten"
+    assert labels["k10temp-pci-00c3:temp1"].legacy_sensor_id == "hwmon4_temp1"
+
+
+def test_composite_sources_are_rewritten(db):
+    db.add(CompositeTempSensor(
+        id="mix:abc", name="CPU und Board", function="max",
+        source_ids_json='["hwmon:hwmon4_temp1", "hwmon3_temp1"]',
+    ))
+    db.commit()
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    composite = db.query(CompositeTempSensor).one()
+    assert json.loads(composite.source_ids_json) == [
+        "hwmon:k10temp-pci-00c3:temp1",
+        "hwmon:nct6798-isa-0290:temp1",
+    ]
+
+
+def test_unmappable_composite_source_is_left_alone(db):
+    db.add(CompositeTempSensor(
+        id="mix:def", name="Mit Luecke", function="max",
+        source_ids_json='["gpu:junction", "hwmon9_temp1"]',
+    ))
+    db.commit()
+
+    reconcile_fan_identities(db, chips=CHIPS, sensor_map=SENSOR_MAP,
+                             cpu_sensor_id=CPU_DEFAULT)
+    db.commit()
+
+    composite = db.query(CompositeTempSensor).one()
+    assert json.loads(composite.source_ids_json) == ["gpu:junction", "hwmon9_temp1"]
+```
+
+`import json` oben in der Testdatei ergänzen.
+
+- [ ] **Step 6: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_reconcile.py -v`
+Expected: PASS (13 Tests)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/power/fan_reconcile.py backend/tests/test_fan_reconcile.py
+git commit -m "feat(fans): Zuordnungsregeln fuer die Identitaets-Umstellung (#532)"
+```
+
+---
+
+### Task 8: Verdrahtung in `_load_fan_configs` — Vorbedingungen, Reihenfolge, Primary-Gate
+
+Der gefährlichste Task des Plans: hier entscheidet sich, ob der Abgleich in einer der beiden Fehlkonstellationen produktive Kurven zerstört.
+
+**Files:**
+- Modify: `backend/app/services/power/fan_control.py:240-284` (`_load_fan_configs`)
+- Test: `backend/tests/test_fan_reconcile_wiring.py`
+
+**Interfaces:**
+- Consumes: `reconcile_fan_identities`, `ChipFacts` aus Task 7; `_fan_cache`, `_temp_paths` aus Task 3
+- Produces: `FanControlService._collect_chip_facts() -> Dict[str, ChipFacts]`, `_collect_sensor_map() -> Dict[str, str]`
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_reconcile_wiring.py`:
+
+```python
+"""Vorbedingungen und Gate des Identitaets-Abgleichs (#532)."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_control import FanControlService
+
+
+def _service(monkeypatch, *, primary: bool, linux: bool):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = True
+    config.is_dev_mode = False
+    service = FanControlService(config, MagicMock())
+    service._use_linux_backend = linux
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        primary, raising=False)
+    return service
+
+
+def test_skips_when_not_primary_worker(monkeypatch):
+    service = _service(monkeypatch, primary=False, linux=True)
+    assert service._should_reconcile(chip_count=3) is False
+
+
+def test_skips_on_dev_backend(monkeypatch):
+    # is_available() faellt bei 0 gefundenen Lueftern auch in Produktion auf
+    # das Dev-Backend zurueck. Liefe der Abgleich dann, deaktivierte er in
+    # einem Rutsch alle hwmon-Zeilen.
+    service = _service(monkeypatch, primary=True, linux=False)
+    assert service._should_reconcile(chip_count=3) is False
+
+
+def test_skips_when_scan_found_no_chip(monkeypatch):
+    service = _service(monkeypatch, primary=True, linux=True)
+    assert service._should_reconcile(chip_count=0) is False
+
+
+def test_runs_when_all_preconditions_hold(monkeypatch):
+    service = _service(monkeypatch, primary=True, linux=True)
+    assert service._should_reconcile(chip_count=3) is True
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_reconcile_wiring.py -v`
+Expected: FAIL mit `AttributeError: 'FanControlService' object has no attribute '_should_reconcile'`
+
+- [ ] **Step 3: Gate und Fakten-Sammler implementieren**
+
+In `fan_control.py` im Importblock:
+
+```python
+from app.core import lifespan
+from app.services.power.fan_reconcile import ChipFacts, reconcile_fan_identities
+```
+
+`lifespan` wird als **Modul** importiert. Ein `from app.core.lifespan import IS_PRIMARY_WORKER` friert den Importwert `False` ein, weil das Flag erst in `_lifespan()` gesetzt wird — der Abgleich liefe dann nie. Einziges funktionierendes Muster im Repo: `plugin_enablement.py:191`.
+
+Methoden auf `FanControlService`:
+
+```python
+    def _should_reconcile(self, chip_count: int) -> bool:
+        """Beide Vorbedingungen sind hart -- ihr Fehlen bedeutet Totalverlust.
+
+        Ohne Linux-Backend liefe der Abgleich gegen eine Chip-Menge ohne
+        einen einzigen hwmon-Chip; ohne gefundenen Chip gegen eine leere.
+        In beiden Faellen faende keine Altzeile ihren Chip wieder.
+        """
+        if not getattr(lifespan, "IS_PRIMARY_WORKER", False):
+            return False
+        if not self._use_linux_backend:
+            return False
+        return chip_count > 0
+
+    def _collect_chip_facts(self) -> Dict[str, ChipFacts]:
+        """Chipname -> Kennung, vorhandene PWM-Kanaele, Mehrdeutigkeit."""
+        by_prefix: Dict[str, Dict] = {}
+        for fan_id, info in (self._backend._fan_cache or {}).items():
+            if not info.get("identity_stable"):
+                continue
+            prefix = info.get("device_driver") or "Unknown"
+            key, _, channel = fan_id.rpartition(":pwm")
+            if not channel.isdigit():
+                continue
+            entry = by_prefix.setdefault(prefix, {"keys": set(), "channels": set()})
+            entry["keys"].add(key)
+            entry["channels"].add(int(channel))
+
+        facts: Dict[str, ChipFacts] = {}
+        for prefix, entry in by_prefix.items():
+            keys = entry["keys"]
+            facts[prefix] = ChipFacts(
+                key=next(iter(sorted(keys))),
+                pwm_channels=frozenset(entry["channels"]),
+                ambiguous=len(keys) > 1,
+            )
+        return facts
+
+    def _collect_sensor_map(self) -> Dict[str, str]:
+        """Alt-Sensor-ID (hwmon<N>_temp<M>) -> neue, praefixierte Kennung."""
+        mapping: Dict[str, str] = {}
+        paths = getattr(self._backend, "_temp_paths", {}) or {}
+        for stable_id, path in paths.items():
+            hwmon_name = path.parent.name
+            temp_num = path.name[len("temp"):-len("_input")]
+            mapping[f"{hwmon_name}_temp{temp_num}"] = f"hwmon:{stable_id}"
+        return mapping
+```
+
+- [ ] **Step 4: Abgleich vor die Anlage-Schleife hängen**
+
+In `_load_fan_configs`, innerhalb des bestehenden `with self.db_session_factory() as db:`-Blocks, **vor** der `for fan in fans:`-Schleife:
+
+```python
+            chip_facts = self._collect_chip_facts()
+            if self._should_reconcile(len(chip_facts)):
+                report = reconcile_fan_identities(
+                    db,
+                    chips=chip_facts,
+                    sensor_map=self._collect_sensor_map(),
+                    cpu_sensor_id=cpu_sensor_id,
+                )
+                if report.renamed or report.deactivated:
+                    try:
+                        from app.services.audit import get_audit_logger_db
+                        get_audit_logger_db().log_system_event(
+                            action="fan_identity_reconcile",
+                            details={
+                                "renamed": report.renamed,
+                                "deactivated": report.deactivated,
+                                "skipped_absent": report.skipped_absent,
+                            },
+                            db=db,
+                        )
+                    except Exception:
+                        logger.debug("Audit-Eintrag zum Identitaets-Abgleich fehlgeschlagen")
+```
+
+Reihenfolge und Transaktion sind wesentlich: der Abgleich läuft **vor** der Anlage-Schleife und im selben `db`-Kontext, sodass ein einziges `db.commit()` am Ende beides trägt. Liefe er danach, wären die Ziel-IDs bereits durch frische Default-Zeilen belegt und jede Altzeile verlöre.
+
+Der Aufruf der Audit-Fassade muss an die im Repo vorhandene Signatur angepasst werden — die exakte Form ist `backend/app/services/audit/` zu entnehmen. Fällt der Audit-Eintrag aus, darf das den Abgleich **nicht** abbrechen; deshalb der `try`.
+
+- [ ] **Step 5: Neuanlage gegen das Worker-Rennen absichern**
+
+In derselben Methode die Anlage-Schleife (`if not existing:`) so umbauen, dass ein paralleler Worker keinen Unique-Fehler auslöst:
+
+```python
+                if not existing:
+                    config = FanConfig(...)     # bestehender Aufbau, unveraendert
+                    db.add(config)
+                    try:
+                        db.flush()
+                    except IntegrityError:
+                        # Ein anderer Worker war schneller. Die Zeile existiert,
+                        # das ist der gewuenschte Endzustand.
+                        db.rollback()
+                        logger.debug("Fan-Config %s wurde parallel angelegt", fan.fan_id)
+```
+
+`from sqlalchemy.exc import IntegrityError` im Importblock ergänzen. Der `db.rollback()` verwirft auch den Abgleich — deshalb steht dieser Zweig **nach** einem eigenen `db.commit()` des Abgleichs. Diesen Commit direkt nach dem Reconcile-Block einfügen:
+
+```python
+                db.commit()
+```
+
+- [ ] **Step 6: Den Default-Sensor präfixiert speichern**
+
+In der Anlage-Schleife `temp_sensor_id=cpu_sensor_id or fan.temp_sensor_id` ersetzen durch:
+
+```python
+                        temp_sensor_id=TempSourceRegistry._normalize_id(
+                            cpu_sensor_id or fan.temp_sensor_id
+                        ) if (cpu_sensor_id or fan.temp_sensor_id) else None,
+```
+
+Damit steht in der Spalte durchgehend die präfixierte Form — dieselbe, die die API ausgibt und unter der die Registry registriert.
+
+- [ ] **Step 7: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_reconcile_wiring.py tests/test_fan_reconcile.py -v`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/app/services/power/fan_control.py backend/tests/test_fan_reconcile_wiring.py
+git commit -m "feat(fans): Identitaets-Abgleich beim Start, primary-only und fail-safe (#532)"
+```
+
+---
+
+### Task 9: Bestand mitziehen — Swagger-Beispiele, Testliterale, Frontend
+
+**Files:**
+- Modify: `backend/app/schemas/fans.py` (Zeilen 88, 122, 132, 172, 194, 233, 346, 392, 394, 413)
+- Modify: `backend/tests/services/test_fan_control.py`, `tests/test_fan_composite_api.py`, `tests/test_fan_sensor_assignment.py`, `tests/services/power/test_fan_gpu_hwmon_dedup.py`, `tests/test_fan_sensor_label_api.py`, `tests/test_fan_sources.py`, `tests/test_fan_curve_eval.py`, `tests/test_fan_pwm_backoff.py`
+- Modify: `backend/tests/test_fan_pwm_control_probe.py`, `tests/test_fan_gpu_manual_mode.py`, `tests/test_fan_einval_diagnostic.py`
+- Modify: `client/src/components/fan-control/FanCard.tsx:9`
+- Modify: `client/src/__tests__/pages/FanControl.test.tsx`, `__tests__/components/fan-control/FanCard.test.tsx`, `FanDetails.test.tsx`, `fan-details/FanStatsGrid.test.tsx`
+
+- [ ] **Step 1: Die drei Testdateien mit synthetischen Bäumen reparieren**
+
+`test_fan_pwm_control_probe.py`, `test_fan_gpu_manual_mode.py` und `test_fan_einval_diagnostic.py` bauen hwmon-Bäume **ohne** `device`- und `subsystem`-Symlinks. Nach Task 3 laufen sie stillschweigend in den Fallback und bleiben grün, ohne die neue Ableitung abzudecken.
+
+In jeder der drei Dateien die Baum-Hilfsfunktion um den Elternbaum ergänzen — dasselbe Muster wie `_nct_tree` aus Task 3: Gerät unter `sys/devices/<bus>/<name>` anlegen, `subsystem`-Symlink auf `sys/bus/<bus>` setzen, `device`-Symlink vom hwmon-Verzeichnis dorthin, und `_hwmon_base` auf `sys/class/hwmon` zeigen lassen.
+
+- [ ] **Step 2: Tests laufen lassen, echte Fehlschläge sichtbar machen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_pwm_control_probe.py tests/test_fan_gpu_manual_mode.py tests/test_fan_einval_diagnostic.py -v`
+Expected: Fehlschläge dort, wo Tests die alte ID-Form behaupten. Diese Behauptungen auf die neue Form umstellen — nicht die Bäume wieder vereinfachen.
+
+- [ ] **Step 3: Die übrigen Testliterale nachziehen**
+
+74 Vorkommen von `hwmon<N>_pwm<M>` / `hwmon<N>_temp<M>` in den acht oben genannten Backend-Dateien. Die meisten sind reine Fixture-Strings und laufen unverändert weiter; anzupassen sind nur die Stellen, die die **gebildete** ID behaupten.
+
+Run: `cd backend ; python -m pytest -k "fan or power" -v`
+Expected: 559 passed plus die neuen Tests.
+
+- [ ] **Step 4: Swagger-Beispiele aktualisieren**
+
+In `backend/app/schemas/fans.py` an den zehn genannten Zeilen `"hwmon0_pwm1"` durch `"nct6798-isa-0290:pwm1"` ersetzen und `"hwmon0_temp1"` durch `"hwmon:k10temp-pci-00c3:temp1"`. Bleiben sie stehen, bringt die API-Doku Nutzern die tote Form bei.
+
+- [ ] **Step 5: Frontend-Formatannahme entschärfen**
+
+`client/src/components/fan-control/FanCard.tsx:9` baut `` `hwmon:${sensorId}` ``. Nach der Umstellung liegt die präfixierte Form bereits vor; ein zweites Präfix ergäbe `hwmon:hwmon:…`. Die Stelle so ändern, dass sie nur präfixiert, wenn noch kein Namespace vorhanden ist:
+
+```tsx
+const NAMESPACES = ['hwmon:', 'gpu:', 'disk:', 'mix:'];
+const namespacedSensorId = NAMESPACES.some((n) => sensorId.startsWith(n))
+  ? sensorId
+  : `hwmon:${sensorId}`;
+```
+
+- [ ] **Step 6: Frontend-Gates**
+
+```bash
+cd client
+npx eslint .
+npm run build
+npx vitest run
+```
+Expected: 0 eslint-Fehler, Build grün, Vitest grün.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/schemas/fans.py backend/tests/ client/src/components/fan-control/FanCard.tsx client/src/__tests__/
+git commit -m "chore(fans): Beispiele, Testliterale und Sensor-Praefix auf stabile IDs (#532)"
+```
+
+---
+
+### Task 10: Dokumentation und Abschluss-Gates
+
+**Files:**
+- Modify: `docs/TECHNICAL_DOCUMENTATION.md` (Abschnitt Lüftersteuerung)
+- Modify: `backend/app/services/CLAUDE.md` (Hinweis auf `fan_identity.py` / `fan_reconcile.py`)
+
+- [ ] **Step 1: Die ehrliche Einschränkung dokumentieren**
+
+In `docs/TECHNICAL_DOCUMENTATION.md` im Lüfter-Abschnitt festhalten:
+
+- Lüfter- und Sensor-IDs haben die Form `<chip>-<bus>-<adresse>:pwm<N>` bzw. `hwmon:<chip>-<bus>-<adresse>:temp<M>` und überleben ein hwmon-Renumbering.
+- **Nicht uneingeschränkt:** Chips ohne `pci`/`platform`-Elter (u. a. i2c-, spi-, scsi-, hid-Busse) behalten die hwmon-indizierte Form und verhalten sich wie bisher. Das betrifft insbesondere `drivetemp` (SATA-Plattentemperaturen).
+- Nach einem Restore eines Vor-Umstellungs-Backups ist ein Neustart des Backends erforderlich, weil der Abgleich nur beim Dienststart läuft.
+- Der Lüfter-Verlaufsgraph ist nach der Umstellung für alle Lüfter leer; alte `fan_sample`-Zeilen behalten ihre alte ID und laufen über die Retention aus.
+
+- [ ] **Step 2: Modulhinweise ergänzen**
+
+In `backend/app/services/CLAUDE.md` bei den `power/`-Modulen `fan_identity.py` (Ableitung der stabilen Chip-Kennung) und `fan_reconcile.py` (einmaliger Abgleich beim Start) aufnehmen.
+
+- [ ] **Step 3: Alle Gates**
+
+```bash
+cd backend
+python -m pytest -k "fan or power" -v
+python -m ruff check app/services/power/ tests/
+cd ../client
+npx eslint .
+npm run build
+npx vitest run
+```
+Expected: alles grün. Die volle Backend-Suite bleibt der CI überlassen.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/TECHNICAL_DOCUMENTATION.md backend/app/services/CLAUDE.md
+git commit -m "docs(fans): Stabile Luefter-Identitaet und ihre Grenzen dokumentieren (#532)"
+```
+
+---
+
+## Feldverifikation nach dem Deploy
+
+Kein Task — der Nachweis am lebenden Objekt, den nur die Zielhardware liefern kann.
+
+1. **Kennungen gegen `sensors` prüfen.** Die abgeleiteten Chip-Kennungen müssen für die fünf dort gelisteten Chips zeichengleich sein: `nct6798-isa-0290`, `amdgpu-pci-0300`, `k10temp-pci-00c3`, `nvme-pci-0d00`, `nvme-pci-0a00`.
+2. **Zeilenbilanz.** `SELECT count(*) FROM fan_configs WHERE is_active` vor und nach dem ersten Start: **16 → 8** (5 neue plus 3 `dev_*`). Gesamtzahl bleibt 16.
+3. **Fehlzuordnung aufgelöst.** `SELECT fan_id, name, legacy_fan_id FROM fan_configs WHERE is_active` — `amdgpu-pci-0300:pwm1` muss `name = "amdgpu PWM1"` und `legacy_fan_id = "hwmon1_pwm1"` tragen. Heute läuft der GPU-Lüfter auf der Config eines Gehäuselüfters.
+4. **Renumbering ohne Reboot.** `modprobe -r nct6775 ; modprobe nct6775`, danach Backend neu starten: `fan_configs` muss gleich viele Zeilen haben wie davor. Beim Entladen verliert BaluHost kurzzeitig die Lüfter und `pwm_enable` fällt auf den Board-Default zurück — bei Leerlauftemperaturen ungefährlich, aber ein Eingriff. Ein regulärer Reboot leistet dasselbe.

--- a/docs/superpowers/specs/2026-09-05-stable-fan-identity-design.md
+++ b/docs/superpowers/specs/2026-09-05-stable-fan-identity-design.md
@@ -1,0 +1,370 @@
+# Stabile Lüfter- und Sensor-Identität statt hwmon-Index
+
+**Status:** Design freigegeben (2026-09-05)
+**Issue:** #532
+**Branch:** `feat/stable-fan-identity-532` (von `main`)
+**Voraussetzung:** #517/#480 (PR #537) und #533 (PR #539) sind gemergt.
+
+## Kontext
+
+`fan_id` wird heute aus dem hwmon-Index gebildet (`fan_backend_linux.py`:
+`fan_id = f"{hwmon_dir.name}_pwm{pwm_num}"`), `temp_sensor_id` analog
+(`hwmon<N>_temp<M>`). Der hwmon-Index ist über Reboots, Kernel-Updates und
+Änderungen der Modul-Ladereihenfolge nicht stabil. Bei jeder Umnummerierung
+erkennt BaluHost dieselben physischen Lüfter als neue, legt einen frischen Satz
+`fan_configs` an, und die vorher eingestellte Kurve ist für den Nutzer verloren.
+
+Auf BaluNode liegen dadurch **16 Config-Zeilen für 4 physische Lüfter** vor, alle
+`is_active=True`, in vier Generationen:
+
+```
+2026-01-25   hwmon5_pwm{1,2,3,7}   temp_sensor_id=hwmon5_temp6
+2026-07-06   hwmon1_pwm1           temp_sensor_id=hwmon3_temp1
+2026-07-20   hwmon2_pwm{1,2,3,7}   temp_sensor_id=hwmon3_temp1
+2026-08-07   hwmon3_pwm{1,2,3,7}   temp_sensor_id=hwmon4_temp1   <- aktuell live
+```
+
+Dazu drei `dev_*`-Zeilen aus Dev-Läufen. Einen Aufräummechanismus gibt es nicht.
+
+Bis #517 war der Verlust folgenlos, weil die Kurve ohnehin nicht wirkte. Seit dem
+Deploy von PR #537 regelt sie nachweislich (gemessen 2026-09-05: `pwm` bewegt
+sich bei 76–79 statt starr auf 128) — damit ist eine vom Nutzer eingestellte
+Kurve zum ersten Mal etwas wert, und ihr Verlust ein echter Schaden.
+
+## Ziele
+
+- Lüfter- und Sensor-Identität so bilden, dass sie ein Renumbering überlebt.
+- Bestehende Konfigurationen auf die neue Identität überführen, ohne eine Kurve
+  dem falschen Lüfter zuzuordnen.
+- Verwaiste Generationen deaktivieren statt sie unbegrenzt als `is_active`
+  liegen zu lassen.
+
+## Nicht-Ziele
+
+- Kein Löschen von Altzeilen. Deaktivieren genügt; eine falsch zugeordnete Kurve
+  muss nachvollziehbar bleiben.
+- Keine Erhaltung der Lüfter-Historie (`fan_sample`). Bewusst akzeptiert: alte
+  Samples behalten ihre alte ID und laufen über die bestehende Retention aus,
+  der Verlaufsgraph beginnt zum Umstellungszeitpunkt neu.
+- Keine Änderung an Kurvenauswertung, Zeitplänen, Profilen oder Presets.
+- Keine UI-Änderung (siehe Abschnitt 4 — es ist keine nötig).
+
+---
+
+## 1. Identität und ihre Ableitung
+
+### Gewählter Anker: der libsensors-Chipname
+
+`sensors.conf(5)` definiert Chip-Namen als `<prefix>-<bus>-<adresse>`. Das ist
+eine dokumentierte, außerhalb von BaluHost gültige Konvention, und sie ist auf
+der Zielhardware bereits sichtbar — es sind exakt die Überschriften, die
+`sensors` ausgibt.
+
+```
+Lüfter:  nct6798-isa-0290:pwm1
+Sensor:  hwmon:k10temp-pci-00c3:temp1
+```
+
+Der `hwmon:`-Präfix bei Sensoren bleibt, weil `fan_sources.py` die Namensräume
+`hwmon:` / `gpu:` / `disk:` / `mix:` bereits so führt; ersetzt wird nur der Teil
+dahinter.
+
+**Warum nicht der Gerätepfad (fancontrol-Stil).** `fancontrol` speichert
+`DEVPATH`/`DEVNAME` aus `readlink -f /sys/class/hwmon/hwmonN/device`. Das ist
+einfacher zu bilden, hat aber zwei Nachteile: bei PCI steckt die ganze
+Bridge-Kette drin (`0000:00:01.1/0000:01:00.0/0000:02:00.0/0000:03:00.0`), und
+für NVMe enthält der Pfad den Instanzindex `nvmeN` — selbst wieder instabil, auf
+BaluNode sogar gekreuzt (`hwmon0 → nvme1`, `hwmon1 → nvme0`). libsensors löst
+beides bereits, indem es zum Bus-Gerät aufsteigt.
+
+**Warum keine Indirektionstabelle.** Eine `fan_identity`-Tabelle (stabile Kennung
+↔ aktueller hwmon-Pfad) würde die Datenmigration sparen, aber zwei Wahrheiten
+über dieselbe Sache schaffen und das Aufräumproblem nur verschieben.
+
+### Ableitungsregeln
+
+Verifiziert gegen `lm-sensors/lib/sysfs.c` (nicht aus den beobachteten Werten
+zurückgeschlossen):
+
+```c
+/* PCI */
+entry.chip.addr = (domain << 16) + (bus << 8) + (slot << 3) + fn;
+/* platform / of_platform -> ISA */
+if (sscanf(dev_name, "%*[a-zA-Z0-9_-]%*1[.:]%d", &entry.chip.addr) == 1);
+else if (sscanf(dev_name, "%x.%*s", &entry.chip.addr) == 1);
+else entry.chip.addr = 0;
+```
+
+Zwei Details, die man sonst falsch rät: die PCI-Domain geht mit `<<16` **in** die
+Adresse ein, und der Platform-Suffix wird **dezimal** gelesen (`nct6775.656` →
+656 → als Hex ausgegeben `0290`).
+
+Ableitung in dieser Reihenfolge:
+
+1. Vom hwmon-Verzeichnis über `..` aufwärts bis zum ersten Elter, dessen
+   `subsystem`-Symlink auf `pci` oder `platform` zeigt.
+2. Präfix = Inhalt von `hwmon<N>/name`.
+3. Adresse und Bus-Typ nach den zitierten Regeln.
+
+### Kollisionsregel
+
+Der libsensors-Name ist **nicht garantiert eindeutig**, und auf BaluNode
+kollidiert er: `asus-nb-wmi` und `eeepc-wmi` haben beide keinen numerischen
+Suffix (`addr = 0`) und melden beide `name = asus` — beide ergäben
+`asus-isa-0000`.
+
+Regel: liefert Schritt 3 die Adresse `0`, lautet die Kennung stattdessen
+`<name>@<geräteverzeichnis>`, also `asus@asus-nb-wmi` und `asus@eeepc-wmi`.
+Geräteverzeichnisnamen sind innerhalb ihres Busses eindeutig.
+
+Die Regel hängt bewusst **nicht** davon ab, welche anderen Chips vorhanden sind —
+sonst bekäme dieselbe Hardware je nach Nachbarn eine andere ID.
+
+### Fallback
+
+Findet Schritt 1 keinen `pci`/`platform`-Elter (rein virtuelle Chips), bleibt die
+hwmon-indizierte Kennung stehen und wird als instabil markiert. Kein Erfinden
+einer Pseudo-Identität: eine ID, die stabil aussieht und es nicht ist, wäre
+schlimmer als der ehrliche Status quo. Auf BaluNode betrifft das keinen Chip;
+die Aussage „Fan-IDs sind jetzt stabil" gilt trotzdem nicht unbedingt und ist so
+zu dokumentieren.
+
+---
+
+## 2. Datenmodell und Migration
+
+### Warum Zuordnung über den hwmon-Index falsch ist
+
+Die naheliegende Migration — nimm `hwmonN_pwmM`, schau nach, was heute an
+`hwmonN` hängt — geht auf den echten Daten schief:
+
+```
+2026-07-20   hwmon2_pwm1   <- war damals der nct6798 (Gehäuselüfter)
+heute        hwmon2        =  amdgpu (GPU)
+```
+
+Blindes Index-Mapping klebte eine Gehäuselüfter-Kurve vom Juli auf den
+GPU-Lüfter. Still, plausibel aussehend, Monate später bemerkt.
+
+### Der Schlüssel ist `fan_configs.name`
+
+`name` wird genau einmal bei der Entdeckung gesetzt, als
+`f"{hwmon_name_value} PWM{pwm_num}"`, und ist **nicht über die API änderbar** —
+`UpdateFanConfigRequest` (`backend/app/schemas/fans.py`) hat kein `name`-Feld.
+Jede Altzeile trägt damit den Chip-Namen aus dem Moment ihrer Entstehung. Die
+Juli-Zeile heißt `"nct6798 PWM1"`, heute ist `hwmon2` der `amdgpu` — Widerspruch,
+also kein Kandidat.
+
+### Zuordnungsregeln
+
+1. Nur Zeilen der Form `^hwmon\d+_` werden angefasst. `dev_*`-Zeilen und bereits
+   stabile IDs bleiben unberührt; damit ist der Lauf idempotent.
+2. Kandidat ist eine Zeile, wenn der Chip-Name aus `name` heute genau einen Chip
+   trifft **und** der Kanal auf diesem Chip existiert. Der Chip-Name ist der
+   Teil von `name` vor dem letzten `" PWM"` (Format `"<chip> PWM<n>"`); die
+   Kanalnummer stammt aus dem `pwm<M>`-Teil der alten `fan_id`. Trifft der
+   Chip-Name heute mehrere Chips (zwei baugleiche Karten), ist die Zeile kein
+   Kandidat — Raten wäre hier schlimmer als Nichtstun.
+3. Konkurrieren mehrere Zeilen um dieselbe neue ID, gewinnt die mit dem jüngsten
+   `updated_at`.
+4. Alles Übrige: `is_active=False`. Nichts wird gelöscht.
+5. Jede Übernahme als INFO-Zeile `alt → neu`, dazu eine Zusammenfassung.
+
+Ergebnis auf BaluNode: alle Generationen der Gehäuselüfter tragen
+`"nct6798 PWM…"` und zielen auf dieselben vier neuen IDs; die Generation vom
+2026-08-07 gewinnt und die Kurven überleben. Von den 16 Zeilen bleiben damit
+4 aktiv, **9** werden inaktiv, und die 3 `dev_*`-Zeilen bleiben nach Regel 1
+unberührt.
+
+### Schema
+
+Eine Alembic-Migration, **nur Struktur**:
+
+```
+fan_configs        + legacy_fan_id     String(100) NULL
+temp_sensor_labels + legacy_sensor_id  String(120) NULL
+```
+
+Keine Spaltenverbreiterung nötig — die längste neue ID
+(`hwmon:asus@asus-nb-wmi:temp1`, 28 Zeichen) passt in die bestehenden Breiten.
+
+### Wo die Umschreibung läuft
+
+Beim **Dienststart** in `_load_fan_configs`, nicht in der Migration. Eine
+Migration, die sysfs der Zielmaschine liest, verhielte sich in CI, auf einem
+Dev-Rechner und bei einem DB-Restore jeweils anders — dort existiert die
+Hardware nicht. Zur Startzeit ist der hwmon-Scan ohnehin gelaufen.
+
+Bei vier Uvicorn-Workern läuft der Abgleich nur im Primary-Worker (Muster aus
+#465).
+
+Mitzuziehen mit derselben Abbildung: `fan_configs.sync_fan_id`,
+`fan_schedule_entries.fan_id`.
+
+### Sensor-IDs: die schwächere Stelle
+
+Für Sensoren gibt es kein Gegenstück zu `name`. `fan_configs.temp_sensor_id` ist
+ein nackter String; `temp_sensor_labels.sensor_id` ist ein Primärschlüssel mit
+einem Nutzer-Label, aber ohne Chip-Herkunft.
+
+Deshalb: Sensor-IDs werden über den **heutigen Index** aufgelöst. Löst der Index
+nicht auf, fällt der Lüfter auf den CPU-Sensor-Default zurück. Beide Fälle werden
+als WARNING geloggt, nicht still ausgeführt. Der Schaden im Fehlerfall ist „der
+Lüfter folgt dem falschen Sensor" — in der UI sichtbar und mit einem Klick
+korrigierbar.
+
+`composite_temp_sensors.source_ids_json` wird mit derselben Abbildung
+umgeschrieben (auf BaluNode leer). Kollidieren zwei Altzeilen auf denselben neuen
+`temp_sensor_labels`-Primärschlüssel, gewinnt die jüngste; die verworfene wird
+geloggt.
+
+Eine Chip-Namensspalte für `temp_sensor_labels` wurde erwogen und **verworfen**:
+sie hülfe nur künftigen Index-Migrationen, die es nach dieser Umstellung per
+Konstruktion nicht mehr gibt.
+
+---
+
+## 3. Auflösung zur Laufzeit
+
+Der Scan in `_scan_pwm_fans` bildet die neue Form direkt; `_fan_cache` ist damit
+auf stabile Schlüssel umgestellt. Als Nebeneffekt überlebt der Write-Backoff aus
+#533 ein Renumbering — heute verliert er seinen Eintrag, weil der Schlüssel
+wechselt.
+
+**Abwesenheit darf niemals schreiben.** Beim Dienststart kann ein Treiber noch
+nicht geladen sein; ein Lüfter fehlt dann im Scan, ohne dass die Hardware weg
+wäre.
+
+- Lüfter im Scan, ohne Config → Config mit Defaults anlegen (heutiges Verhalten).
+- Config ohne Lüfter im Scan → nichts tun. Kein `is_active=False`, kein Löschen,
+  keine Neuanlage.
+
+Die bestehende Schutzregel in `_scan_pwm_fans` („found 0 fans, keeping cached
+fans") bleibt und deckt denselben Gedanken eine Ebene tiefer ab.
+
+Der Abgleich läuft genau einmal pro Start, im Primary-Worker, und fasst
+ausschließlich Zeilen der Altform an. Zeilen in neuer Form sind für ihn
+unsichtbar — ein zweiter Lauf ist folgenlos, auch wenn der erste abbrach.
+
+**Akzeptanzkriterium:** Ein Reboot, der `nct6798` von `hwmon3` nach `hwmon5`
+verschiebt, verändert die Kennung `nct6798-isa-0290:pwm1` nicht. Es entsteht
+keine neue Config, die Kurve gilt weiter, es sammelt sich keine Generation an.
+
+Sensor-Auflösung braucht keine neue Kompatibilitätsschicht: `TempSourceRegistry`
+akzeptiert unpräfixierte Alt-IDs bereits, und nach dem Abgleich hält keine
+aktive Config mehr eine Alt-ID.
+
+---
+
+## 4. API, Frontend, Konsumenten
+
+**Das Frontend braucht keine Änderung.** Nachgeprüft: in `client/src/` gibt es
+keine Stelle, die `fan_id`/`fanId` zerlegt (`split`, `slice`, `startsWith`,
+`match`), und keine, die eine Lüfter-Auswahl in `localStorage` ablegt. Die ID ist
+durchgehend ein undurchsichtiger Handle.
+
+**Pfadparameter tragen die neue Form ohne Kodierungsarbeit.** Sechs Routen nehmen
+`{fan_id}` (`/{fan_id}/schedule`, `/{fan_id}/gpu-manual-mode`, …). `:` und `@`
+sind laut RFC 3986 gültige `pchar` in einem Pfadsegment; die Sensor-Routen
+transportieren mit `hwmon:hwmon4_temp1` heute schon Doppelpunkte im Pfad und
+funktionieren in Produktion.
+
+**Mitzuziehen:**
+
+- `backend/app/schemas/fans.py` — zehn Swagger-Beispiele auf `hwmon0_pwm1`.
+- Rund 75 fest verdrahtete Vorkommen in neun Backend- und vier
+  Frontend-Testdateien; betroffen sind die Stellen, die die gebildete ID
+  *behaupten*.
+
+**Kein API-Versionssprung.** Die ID war nie ein dokumentiertes Format, sondern
+ein Handle; BaluApp und BaluDesk sprechen die Fan-Endpunkte nicht an. Ein Client
+mit zwischengespeicherter Fan-ID bekommt eine 404 und lädt neu — bestehender
+Fehlerpfad, kein neuer.
+
+---
+
+## 5. Tests und Verifikation
+
+### Der Test, der das Issue beantwortet
+
+Ein hwmon-Baum unter `tmp_path`, zweimal aufgebaut: derselbe Gerätepfad einmal
+als `hwmon3`, einmal als `hwmon5`. Erwartung: identische Kennung, und
+`_load_fan_configs` legt beim zweiten Durchlauf keine neue Zeile an.
+
+### Kodierung gegen echte Pfade
+
+Sollwerte sind die von `sensors` auf BaluNode gemeldeten Chip-Namen — also eine
+unabhängige Implementierung derselben Regeln auf derselben Hardware:
+
+| Gerätepfad | erwartete Kennung |
+|---|---|
+| `platform/nct6775.656` | `nct6798-isa-0290` |
+| `pci…/0000:03:00.0` | `amdgpu-pci-0300` |
+| `pci0000:00/0000:00:18.3` | `k10temp-pci-00c3` |
+| `…/0000:0d:00.0/nvme/nvme1` | `nvme-pci-0d00` |
+| `…/0000:0a:00.0/nvme/nvme0` | `nvme-pci-0a00` |
+| `platform/asus-nb-wmi` | `asus@asus-nb-wmi` |
+| `platform/eeepc-wmi` | `asus@eeepc-wmi` |
+
+Die NVMe-Fälle sichern ab, dass der Aufstieg den instabilen `nvmeN` überspringt;
+die letzten beiden die Kollisionsregel.
+
+### Reconciliation
+
+- Vier Generationen wie auf BaluNode (16 Zeilen) → jüngste gewinnt: 4 aktiv,
+  9 inaktiv, 3 `dev_*` unberührt, null Löschungen.
+- Die Falle: Zeile `hwmon2_pwm1` mit `name="nct6798 PWM1"`, während `hwmon2`
+  heute der `amdgpu` ist → darf **nicht** zugeordnet werden.
+- Zweiter Lauf folgenlos (Idempotenz).
+- `dev_*`-Zeilen unberührt.
+- Lüfter fehlt im Scan → keine Schreiboperation.
+- Chip ohne `pci`/`platform`-Elter → Altform bleibt, als instabil markiert.
+
+### Gates
+
+`pytest -k "fan or power"` steht seit #539 bei 559 passed — das ist die Messlatte
+plus die neuen Tests. Dazu `ruff check`, `eslint .`, `npm run build`,
+`vitest run`. Die volle Backend-Suite bleibt der CI überlassen (hängt auf
+Windows).
+
+### Feldverifikation nach dem Deploy
+
+1. Abgeleitete Kennungen gegen die `sensors`-Überschriften vergleichen — muss
+   zeichengleich sein.
+2. `modprobe -r nct6775 ; modprobe nct6775` erzwingt ein Renumbering ohne Reboot.
+   Danach muss `fan_configs` gleich viele Zeilen haben wie davor.
+
+Zu Schritt 2: beim Entladen verliert BaluHost kurzzeitig die Lüfter, und
+`pwm_enable` fällt auf den Board-Default zurück. Bei Leerlauftemperaturen
+ungefährlich, aber ein Eingriff — ein regulärer Reboot leistet dasselbe, nur ohne
+Kontrolle über den Zeitpunkt.
+
+---
+
+## Risiken
+
+- **Selbstgebaute Kodierung.** Die Adressbildung ist aus dem libsensors-Quelltext
+  übernommen, nicht aus Beobachtungen zurückgeschlossen. Der Vergleich gegen die
+  `sensors`-Ausgabe ist die Absicherung; für Bus-Typen jenseits `pci`/`platform`
+  gibt es keine Testdaten auf dieser Hardware.
+- **i2c-Busnummern sind laut lm-sensors selbst nicht reboot-stabil** (daher die
+  `bus`-Statements und `sensors --bus-list`). Auf BaluNode ist alles `isa` oder
+  `pci`, die Kennung darf sich aber nicht darauf verlassen, dass das so bleibt.
+- **Sensor-Zuordnung bleibt heuristisch** (siehe Abschnitt 2). Fehlerbild ist ein
+  falscher Sensor am Lüfter, sichtbar und korrigierbar, nicht stumm.
+- **Einmaliger Vorgang mit Datenwirkung.** Der Abgleich läuft auf produktiven
+  Zeilen. Absicherung: nichts wird gelöscht, `legacy_fan_id` hält die Herkunft
+  fest, jede Übernahme wird geloggt.
+
+## Quellen
+
+- [sensors.conf(5)](https://manpages.debian.org/testing/lm-sensors/sensors.conf.5.en.html)
+  — Chip-Namensformat `<prefix>-<bus>-<adresse>`
+- [lm-sensors `lib/sysfs.c`](https://github.com/lm-sensors/lm-sensors/blob/master/lib/sysfs.c)
+  — Adressbildung für PCI und platform/ISA
+- [fancontrol(8)](https://www.systutorials.com/docs/linux/man/8-fancontrol/) —
+  `DEVPATH`/`DEVNAME`, der Stand der Technik: Drift erkennen statt automatisch
+  zuordnen
+- [lm-sensors#227](https://github.com/lm-sensors/lm-sensors/issues/227) —
+  „fancontrol: use sensors' stable names"
+- [Fan speed control — ArchWiki](https://wiki.archlinux.org/title/Fan_speed_control)

--- a/docs/superpowers/specs/2026-09-05-stable-fan-identity-design.md
+++ b/docs/superpowers/specs/2026-09-05-stable-fan-identity-design.md
@@ -1,9 +1,12 @@
 # Stabile Lüfter- und Sensor-Identität statt hwmon-Index
 
-**Status:** Design freigegeben (2026-09-05)
+**Status:** Design freigegeben (2026-09-05), überarbeitet nach kritischer Review
 **Issue:** #532
 **Branch:** `feat/stable-fan-identity-532` (von `main`)
 **Voraussetzung:** #517/#480 (PR #537) und #533 (PR #539) sind gemergt.
+**Normative libsensors-Version:** 3.6.2 (`dpkg -l lm-sensors` auf BaluNode:
+`1:3.6.2-2`). Die Parsing-Regeln haben sich zwischen 3.6.0, 3.6.1/3.6.2 und
+`master` verändert — Aussagen gegen `master` sind für diese Box nicht gültig.
 
 ## Kontext
 
@@ -14,40 +17,66 @@
 erkennt BaluHost dieselben physischen Lüfter als neue, legt einen frischen Satz
 `fan_configs` an, und die vorher eingestellte Kurve ist für den Nutzer verloren.
 
-Auf BaluNode liegen dadurch **16 Config-Zeilen für 4 physische Lüfter** vor, alle
-`is_active=True`, in vier Generationen:
+### Gemessener Ist-Zustand auf BaluNode (2026-09-05)
+
+`SELECT fan_id, name, temp_sensor_id, updated_at FROM fan_configs ORDER BY updated_at`
+liefert **16 Zeilen: 13 hwmon-indizierte für 5 physische Lüfter, plus 3 `dev_*`**,
+alle `is_active=True`:
 
 ```
-2026-01-25   hwmon5_pwm{1,2,3,7}   temp_sensor_id=hwmon5_temp6
-2026-07-06   hwmon1_pwm1           temp_sensor_id=hwmon3_temp1
-2026-07-20   hwmon2_pwm{1,2,3,7}   temp_sensor_id=hwmon3_temp1
-2026-08-07   hwmon3_pwm{1,2,3,7}   temp_sensor_id=hwmon4_temp1   <- aktuell live
+hwmon5_pwm1/2/3/7 | nct6798 PWM1/2/3/7 | hwmon5_temp6 | 2026-01-25
+dev_case_fan_1    | Case Fan 1 (Simulated) | dev_package_temp | 2026-01-27
+dev_cpu_fan       | CPU Fan (Simulated)    | dev_cpu_temp     | 2026-02-17
+dev_case_fan_2    | Case Fan 2 (Simulated) | dev_cpu_temp     | 2026-02-25
+hwmon1_pwm1       | amdgpu PWM1        | hwmon3_temp1 | 2026-07-06
+hwmon2_pwm1/2/3/7 | nct6798 PWM1/2/3/7 | hwmon3_temp1 | 2026-07-20
+hwmon3_pwm1/2/3/7 | nct6798 PWM1/2/3/7 | hwmon4_temp1 | 2026-08-07
 ```
 
-Dazu drei `dev_*`-Zeilen aus Dev-Läufen. Einen Aufräummechanismus gibt es nicht.
+Alle `temp_sensor_id` liegen **unpräfixiert** vor — es sind durchweg Defaults aus
+`_load_fan_configs`, keine vom Nutzer über die UI gesetzten (die kämen
+präfixiert als `hwmon:…` an, siehe `routes/fans.py:349`).
+
+### Der Schaden ist nicht nur zukünftig — er ist bereits eingetreten
+
+Heute ist `hwmon2` der `amdgpu`, die GPU-Lüfter-ID lautet also `hwmon2_pwm1`.
+Unter genau dieser ID liegt die **Juli-Zeile eines Gehäuselüfters**
+(`name = "nct6798 PWM1"`, `temp_sensor_id = hwmon3_temp1`). `_load_fan_configs`
+sucht ausschließlich über `fan_id` und findet sie. Der GPU-Lüfter läuft damit
+auf der Konfiguration eines Gehäuselüfters.
+
+Folgenlos ist das nur, weil die RDNA3-GPU firmware-verwaltet ist und `set_pwm()`
+seit #480 dort ohnehin aussteigt. Die Migration behebt diese Fehlzuordnung als
+Nebeneffekt: `hwmon2_pwm1` trägt den Chip-Namen `nct6798` und wird korrekt dem
+nct6798 zugeordnet, die GPU erhält über `hwmon1_pwm1` (`amdgpu PWM1`) ihre eigene
+Zeile zurück.
 
 Bis #517 war der Verlust folgenlos, weil die Kurve ohnehin nicht wirkte. Seit dem
 Deploy von PR #537 regelt sie nachweislich (gemessen 2026-09-05: `pwm` bewegt
-sich bei 76–79 statt starr auf 128) — damit ist eine vom Nutzer eingestellte
-Kurve zum ersten Mal etwas wert, und ihr Verlust ein echter Schaden.
+sich bei 76–79 statt starr auf 128) — damit ist eine Konfiguration zum ersten Mal
+etwas wert.
 
 ## Ziele
 
 - Lüfter- und Sensor-Identität so bilden, dass sie ein Renumbering überlebt.
-- Bestehende Konfigurationen auf die neue Identität überführen, ohne eine Kurve
-  dem falschen Lüfter zuzuordnen.
-- Verwaiste Generationen deaktivieren statt sie unbegrenzt als `is_active`
-  liegen zu lassen.
+- Bestehende Konfigurationen überführen, ohne eine Kurve dem falschen Lüfter
+  zuzuordnen — und die bereits bestehende Fehlzuordnung dabei auflösen.
+- Verwaiste **hwmon-Generationen** deaktivieren statt sie unbegrenzt als
+  `is_active` liegen zu lassen.
 
 ## Nicht-Ziele
 
-- Kein Löschen von Altzeilen. Deaktivieren genügt; eine falsch zugeordnete Kurve
-  muss nachvollziehbar bleiben.
-- Keine Erhaltung der Lüfter-Historie (`fan_sample`). Bewusst akzeptiert: alte
-  Samples behalten ihre alte ID und laufen über die bestehende Retention aus,
-  der Verlaufsgraph beginnt zum Umstellungszeitpunkt neu.
+- Kein Löschen von Zeilen. Deaktivieren genügt.
+- Keine Aufräumarbeit an den `dev_*`-Zeilen. Sie fallen nicht unter Regel 1 und
+  bleiben unberührt und aktiv — bewusst, weil ein Eingriff dort den Dev-Betrieb
+  auf derselben Datenbank beschädigen könnte und der Nutzen kosmetisch ist.
+  Das Ziel „verwaiste Generationen deaktivieren" bezieht sich auf
+  hwmon-Generationen.
+- Keine Erhaltung der Lüfter-Historie (`fan_sample`). **Wirkung explizit:**
+  `get_history` filtert nach `fan_id` (`fan_control.py:854-877`) — der
+  Verlaufsgraph ist nach der Umstellung für **alle** Lüfter schlagartig leer,
+  nicht „beginnt neu". Alte Samples laufen über die bestehende Retention aus.
 - Keine Änderung an Kurvenauswertung, Zeitplänen, Profilen oder Presets.
-- Keine UI-Änderung (siehe Abschnitt 4 — es ist keine nötig).
 
 ---
 
@@ -57,8 +86,7 @@ Kurve zum ersten Mal etwas wert, und ihr Verlust ein echter Schaden.
 
 `sensors.conf(5)` definiert Chip-Namen als `<prefix>-<bus>-<adresse>`. Das ist
 eine dokumentierte, außerhalb von BaluHost gültige Konvention, und sie ist auf
-der Zielhardware bereits sichtbar — es sind exakt die Überschriften, die
-`sensors` ausgibt.
+der Zielhardware bereits sichtbar — es sind exakt die Überschriften von `sensors`.
 
 ```
 Lüfter:  nct6798-isa-0290:pwm1
@@ -66,224 +94,380 @@ Sensor:  hwmon:k10temp-pci-00c3:temp1
 ```
 
 Der `hwmon:`-Präfix bei Sensoren bleibt, weil `fan_sources.py` die Namensräume
-`hwmon:` / `gpu:` / `disk:` / `mix:` bereits so führt; ersetzt wird nur der Teil
-dahinter.
+`hwmon:` / `gpu:` / `disk:` / `mix:` bereits so führt.
 
 **Warum nicht der Gerätepfad (fancontrol-Stil).** `fancontrol` speichert
-`DEVPATH`/`DEVNAME` aus `readlink -f /sys/class/hwmon/hwmonN/device`. Das ist
-einfacher zu bilden, hat aber zwei Nachteile: bei PCI steckt die ganze
-Bridge-Kette drin (`0000:00:01.1/0000:01:00.0/0000:02:00.0/0000:03:00.0`), und
-für NVMe enthält der Pfad den Instanzindex `nvmeN` — selbst wieder instabil, auf
-BaluNode sogar gekreuzt (`hwmon0 → nvme1`, `hwmon1 → nvme0`). libsensors löst
-beides bereits, indem es zum Bus-Gerät aufsteigt.
+`DEVPATH`/`DEVNAME` aus `readlink -f /sys/class/hwmon/hwmonN/device`. Einfacher
+zu bilden, aber bei PCI steckt die Bridge-Kette drin, und für NVMe enthält der
+Pfad den Instanzindex `nvmeN` — selbst instabil, auf BaluNode sogar gekreuzt
+(`hwmon0 → nvme1`, `hwmon1 → nvme0`).
 
-**Warum keine Indirektionstabelle.** Eine `fan_identity`-Tabelle (stabile Kennung
-↔ aktueller hwmon-Pfad) würde die Datenmigration sparen, aber zwei Wahrheiten
-über dieselbe Sache schaffen und das Aufräumproblem nur verschieben.
+**Warum keine Indirektionstabelle.** Eine `fan_identity`-Tabelle würde die
+Datenmigration sparen, aber zwei Wahrheiten schaffen und das Aufräumproblem nur
+verschieben.
 
 ### Ableitungsregeln
 
-Verifiziert gegen `lm-sensors/lib/sysfs.c` (nicht aus den beobachteten Werten
-zurückgeschlossen):
+libsensors steigt **nicht** lexikalisch über `..` auf, sondern folgt dem
+`device`-Symlink und klassifiziert auf jeder Ebene (`lib/sysfs.c`,
+`find_bus_type` / `classify_device`). Es kennt neun Bustypen: `i2c`, `spi`,
+`pci`, `platform`, `of_platform`, `acpi`, `hid`, `mdio_bus`, `scsi`, `sdio` — und
+bricht beim **ersten klassifizierbaren** Elter ab, nicht beim ersten
+pci-/platform-Elter.
+
+Ableitung:
+
+1. Startpunkt ist `realpath(/sys/class/hwmon/hwmonN/device)`. **Kein lexikalischer
+   `Path.parent`/`dirname`** — `/sys/class/hwmon/hwmonN` ist ein Symlink, ein
+   lexikalischer Aufstieg landet bei `/sys/class` und findet nie ein
+   `subsystem`. Das Repo dokumentiert die Falle bereits in
+   `fan_gpu_manual.py:101-127`.
+2. Auf jeder Ebene das `subsystem`-Symlink auflösen und klassifizieren, dann
+   aufwärts über den aufgelösten Pfad.
+3. Unterstützt werden `pci` und `platform`/`of_platform`. Wird ein **anderer**
+   bekannter Bustyp getroffen (`i2c`, `spi`, `scsi`, `hid`, `acpi`, `mdio_bus`,
+   `sdio`), wird **sofort** in den instabilen Fallback gefallen — nicht
+   weitergeklettert. Fehlt der `device`-Link ganz, ist der Chip virtuell,
+   ebenfalls Fallback.
+4. Präfix = Inhalt von `hwmon<N>/name`. Fehlt oder ist unlesbar (`"Unknown"`,
+   `fan_backend_linux.py:390`), greift ebenfalls der Fallback.
+
+**Warum Schritt 3 so scharf ist:** `drivetemp` (SATA-Plattentemperaturen, für ein
+NAS hochrelevant) hängt am `scsi`-Bus. Ein Weiterklettern landete auf dem
+AHCI-Controller und gäbe **allen Platten desselben Controllers dieselbe
+Kennung**; `:tempN` unterscheidet sie nicht, jede hat `temp1`. Dasselbe gilt für
+USB/HID-Lüftersteuerungen (`corsair-cpro`, `nzxt-*`, `aquacomputer_d5next`).
+Weitere Bustypen zu unterstützen ist möglich, aber eigene Arbeit mit eigenen
+Testdaten — nicht in diesem Scope.
+
+### Adressbildung
+
+Aus `lm-sensors 3.6.2`, `lib/sysfs.c`:
 
 ```c
 /* PCI */
-entry.chip.addr = (domain << 16) + (bus << 8) + (slot << 3) + fn;
+addr = (domain << 16) + (bus << 8) + (slot << 3) + fn;
 /* platform / of_platform -> ISA */
-if (sscanf(dev_name, "%*[a-zA-Z0-9_-]%*1[.:]%d", &entry.chip.addr) == 1);
-else if (sscanf(dev_name, "%x.%*s", &entry.chip.addr) == 1);
-else entry.chip.addr = 0;
+if (sscanf(dev_name, "%*[a-zA-Z0-9_]%*1[.:]%d", &addr) == 1);
+else if (sscanf(dev_name, "%x.%*s", &addr) == 1);
+else addr = 0;
 ```
 
 Zwei Details, die man sonst falsch rät: die PCI-Domain geht mit `<<16` **in** die
 Adresse ein, und der Platform-Suffix wird **dezimal** gelesen (`nct6775.656` →
 656 → als Hex ausgegeben `0290`).
 
-Ableitung in dieser Reihenfolge:
+**Formatierung** (`lib/data.c:sensors_snprintf_chip_name`): `"%s-isa-%04x"`,
+`"%s-pci-%04x"`. `%04x` ist eine **Mindest**breite — bei PCI-Domain ≠ 0 sind es
+fünf Hexziffern (`nvme-pci-10d00`). Wer auf vier Stellen abschneidet, baut eine
+stille Kollision zwischen Domain 0 und Domain 1.
 
-1. Vom hwmon-Verzeichnis über `..` aufwärts bis zum ersten Elter, dessen
-   `subsystem`-Symlink auf `pci` oder `platform` zeigt.
-2. Präfix = Inhalt von `hwmon<N>/name`.
-3. Adresse und Bus-Typ nach den zitierten Regeln.
+**Bewusste Abweichung beim Hex-Fallback.** libsensors' zweiter `sscanf` gibt
+bereits `1` zurück, wenn `%x` etwas konsumiert hat, auch wenn der Literal-Punkt
+danach nie matcht. Daraus werden `asus-nb-wmi` → `0x0a` und `eeepc-wmi` →
+`0xeee` — stabil, aber bedeutungslos. Wir bilden stattdessen:
 
-### Kollisionsregel
+```
+Regel A:  ^[A-Za-z0-9_-]+[.:](\d+)$   ->  addr = int(gruppe, 10)     # nct6775.656 -> 0290
+Regel B:  ^([0-9a-f]+)\.               ->  addr = int(gruppe, 16)     # f0000000.hwmon (Device-Tree)
+sonst:    Kennung = "<präfix>@<gerätename>"                           # asus@asus-nb-wmi
+```
 
-Der libsensors-Name ist **nicht garantiert eindeutig**, und auf BaluNode
-kollidiert er: `asus-nb-wmi` und `eeepc-wmi` haben beide keinen numerischen
-Suffix (`addr = 0`) und melden beide `name = asus` — beide ergäben
-`asus-isa-0000`.
+Regel B verlangt den Punkt tatsächlich und reproduziert damit den *gemeinten*
+Device-Tree-Fall (relevant für die ARM-Box mit Rock Pi), nicht den Parser-Unfall.
+Die Abweichung betrifft ausschließlich Chips, die `sensors` auf BaluNode
+**überhaupt nicht listet** — die asus-WMI-Knoten erscheinen in der Ausgabe nicht,
+haben keine PWM-Kanäle und sind für die Lüftersteuerung ohne Belang. Die
+Verifikation „zeichengleich mit `sensors`" gilt entsprechend nur für Chips, die
+`sensors` auch ausgibt.
 
-Regel: liefert Schritt 3 die Adresse `0`, lautet die Kennung stattdessen
-`<name>@<geräteverzeichnis>`, also `asus@asus-nb-wmi` und `asus@eeepc-wmi`.
-Geräteverzeichnisnamen sind innerhalb ihres Busses eindeutig.
+### Eindeutigkeit
 
-Die Regel hängt bewusst **nicht** davon ab, welche anderen Chips vorhanden sind —
-sonst bekäme dieselbe Hardware je nach Nachbarn eine andere ID.
+Der Chipname ist **nicht garantiert eindeutig**. Zwei Fälle:
+
+- Zwei Geräte ohne numerischen Suffix → durch die `@`-Regel getrennt
+  (Gerätenamen sind innerhalb ihres Busses eindeutig).
+- **Zwei hwmon-Knoten am selben Gerät** (kernelseitig zulässig) → erzeugen
+  dieselbe Kennung, und `_scan_pwm_fans` baut `new_cache` als Dict über `fan_id`
+  (`fan_backend_linux.py:410`, `:441`): der zweite überschriebe den ersten
+  **still**, ein Lüfter verschwände. Der `:pwmN`-Suffix hilft nicht, weil beide
+  Knoten bei 1 zu zählen anfangen.
+
+Deshalb: der Scan erkennt Duplikate der abgeleiteten Kennung und lässt **alle
+betroffenen** Knoten in den instabilen Fallback fallen, mit WARNING. Lieber
+ehrlich instabil als scheinstabil.
 
 ### Fallback
 
-Findet Schritt 1 keinen `pci`/`platform`-Elter (rein virtuelle Chips), bleibt die
-hwmon-indizierte Kennung stehen und wird als instabil markiert. Kein Erfinden
-einer Pseudo-Identität: eine ID, die stabil aussieht und es nicht ist, wäre
-schlimmer als der ehrliche Status quo. Auf BaluNode betrifft das keinen Chip;
-die Aussage „Fan-IDs sind jetzt stabil" gilt trotzdem nicht unbedingt und ist so
-zu dokumentieren.
+Betroffen sind: unbekannter/nicht unterstützter Bustyp, fehlender `device`-Link,
+fehlender `name`, doppelte abgeleitete Kennung. In allen Fällen bleibt die
+hwmon-indizierte Kennung stehen und wird als instabil markiert (Feld im
+Fan-Cache, WARNING beim Scan). Kein Erfinden einer Pseudo-Identität.
+
+Auf BaluNode betrifft das keinen für die Lüftersteuerung relevanten Chip; die
+Aussage „Fan-IDs sind jetzt stabil" gilt trotzdem nicht unbedingt und ist so zu
+dokumentieren.
 
 ---
 
-## 2. Datenmodell und Migration
+## 2. Die Rückabbildung (fehlte in der ersten Fassung vollständig)
+
+Der Scan muss eine Map **stabile Kennung → aktuelles hwmon-Verzeichnis**
+mitführen. Ohne sie kann nach der Umstellung weder eine Temperatur gelesen noch
+ein PWM geschrieben werden. Betroffene Stellen:
+
+| Fundort | Problem |
+|---|---|
+| `fan_backend_linux.py:253-270` `get_temperature()` | `sensor_id.split("_")`, `if len(parts) != 2: return None`. `k10temp-pci-00c3:temp1` hat keinen Unterstrich → ein Element → `None`. **Jede** hwmon-Temperatur wäre `None` |
+| `fan_backend_linux.py:272-309` `_find_cpu_temp_sensor()` | bildet Sensor-IDs aus dem hwmon-Verzeichnisnamen |
+| `fan_control.py:336-342` `_make_hwmon_reader()` | legt jede `HwmonTempSource` genau auf `get_temperature` |
+| `fan_control.py:676` `get_status()` | liest die Temperatur am Registry **vorbei** über `_backend.get_temperature`; scheitert das, fällt die Anzeige stumm auf den Scan-Sensor zurück und die UI zeigt für jeden Lüfter mit abweichendem Sensor die falsche Temperatur |
+| `fan_sources.py:101-106` `_normalize_id()` | `if ":" in sensor_id: return sensor_id` — die neue nackte Form enthält selbst einen Doppelpunkt, wird nicht zu `hwmon:…` normalisiert, Registry-Miss |
+
+Umsetzung: `_scan_pwm_fans` und `get_available_temp_sensors` legen die
+aufgelösten Pfade in einen Cache; `get_temperature` löst darüber auf statt per
+String-Zerlegung. `_normalize_id` bekommt eine echte Namespace-Whitelist
+(`hwmon:`, `gpu:`, `disk:`, `mix:`) statt der `":" in`-Heuristik.
+
+**Speicherform von `temp_sensor_id`: künftig präfixiert** (`hwmon:<chip>:<kanal>`).
+Das ist die Form, die die API ohnehin ausgibt (`routes/fans.py:349`) und unter
+der die Registry registriert (`fan_sources.py:43`). Der Default in
+`_load_fan_configs` (`fan_control.py:279`, heute unpräfixiert) wird entsprechend
+mitgezogen. Die Migration akzeptiert beide Altformen und streift ein optionales
+`hwmon:` vor der Abbildung ab.
+
+---
+
+## 3. Datenmodell und Migration
 
 ### Warum Zuordnung über den hwmon-Index falsch ist
-
-Die naheliegende Migration — nimm `hwmonN_pwmM`, schau nach, was heute an
-`hwmonN` hängt — geht auf den echten Daten schief:
 
 ```
 2026-07-20   hwmon2_pwm1   <- war damals der nct6798 (Gehäuselüfter)
 heute        hwmon2        =  amdgpu (GPU)
 ```
 
-Blindes Index-Mapping klebte eine Gehäuselüfter-Kurve vom Juli auf den
-GPU-Lüfter. Still, plausibel aussehend, Monate später bemerkt.
+Blindes Index-Mapping klebte eine Gehäuselüfter-Kurve auf den GPU-Lüfter — und
+genau das ist über die `fan_id`-Gleichheit heute schon passiert (siehe Kontext).
 
 ### Der Schlüssel ist `fan_configs.name`
 
 `name` wird genau einmal bei der Entdeckung gesetzt, als
-`f"{hwmon_name_value} PWM{pwm_num}"`, und ist **nicht über die API änderbar** —
-`UpdateFanConfigRequest` (`backend/app/schemas/fans.py`) hat kein `name`-Feld.
-Jede Altzeile trägt damit den Chip-Namen aus dem Moment ihrer Entstehung. Die
-Juli-Zeile heißt `"nct6798 PWM1"`, heute ist `hwmon2` der `amdgpu` — Widerspruch,
-also kein Kandidat.
+`f"{hwmon_name_value} PWM{pwm_num}"`, und ist **nicht über die API änderbar**.
+Beide Reviewer haben das unabhängig erschöpfend verifiziert: einziger
+Schreibpfad ist die Neuanlage (`fan_control.py:271-282`);
+`UpdateFanConfigRequest` hat kein `name`-Feld; `apply_preset`,
+`update_fan_curve`, `set_fan_mode`, `set_fan_pwm` fassen es nicht an; keiner der
+`setattr()`-Aufrufe im Backend zielt auf `FanConfig`.
+
+Chip-Name = Teil von `name` vor dem letzten `" PWM"`. Enthält `name` kein
+`" PWM"` (Dev-Backend erzeugt `"CPU Fan (Simulated)"` u. ä.), ist die Zeile kein
+Kandidat — ein naives `rsplit(" PWM", 1)` gäbe sonst den ganzen Namen als
+Chip-Namen zurück. Kanalnummer = `pwm<M>`-Teil der alten `fan_id`.
+
+### Vorbedingungen — ohne die läuft der Abgleich nicht
+
+Beide sind hart, weil ihr Fehlen einen Totalverlust bedeutet:
+
+1. `self._use_linux_backend` ist wahr. `is_available()` gibt `False` zurück,
+   sobald der Scan **0 PWM-Lüfter** findet, und `_initialize_backend` schaltet
+   dann **auch in Produktion** auf `DevFanControlBackend`
+   (`fan_backend_linux.py:51-65`, `fan_control.py:220-238`). Der Abgleich liefe
+   dann gegen eine Chip-Menge ohne einen einzigen hwmon-Chip. Genau so sind die
+   drei `dev_*`-Zeilen auf BaluNode entstanden.
+2. Der Scan hat mindestens einen Chip geliefert.
 
 ### Zuordnungsregeln
 
 1. Nur Zeilen der Form `^hwmon\d+_` werden angefasst. `dev_*`-Zeilen und bereits
-   stabile IDs bleiben unberührt; damit ist der Lauf idempotent.
-2. Kandidat ist eine Zeile, wenn der Chip-Name aus `name` heute genau einen Chip
-   trifft **und** der Kanal auf diesem Chip existiert. Der Chip-Name ist der
-   Teil von `name` vor dem letzten `" PWM"` (Format `"<chip> PWM<n>"`); die
-   Kanalnummer stammt aus dem `pwm<M>`-Teil der alten `fan_id`. Trifft der
-   Chip-Name heute mehrere Chips (zwei baugleiche Karten), ist die Zeile kein
-   Kandidat — Raten wäre hier schlimmer als Nichtstun.
+   stabile IDs bleiben unberührt.
+2. Kandidat ist eine Zeile, wenn der Chip-Name aus `name` heute **genau einen**
+   Chip trifft und der Kanal auf diesem Chip existiert. Mehrere Treffer (zwei
+   baugleiche Karten) → kein Kandidat; Raten wäre schlimmer als Nichtstun.
+   `"Unknown …"`-Zeilen sind nie Kandidat.
 3. Konkurrieren mehrere Zeilen um dieselbe neue ID, gewinnt die mit dem jüngsten
-   `updated_at`.
-4. Alles Übrige: `is_active=False`. Nichts wird gelöscht.
-5. Jede Übernahme als INFO-Zeile `alt → neu`, dazu eine Zusammenfassung.
+   `updated_at`. Die Konkurrenzmenge schließt eine **bereits in Neuform
+   vorliegende** Zeile ein — sonst läuft ein nach einem Abbruch wiederholter Lauf
+   in den Unique-Index. Die Rangfolge wird als Snapshot **vor** dem ersten
+   Schreibzugriff festgehalten, weil `FanConfig.updated_at` ein
+   `onupdate=func.now()` trägt (`models/fans.py:104-109`).
+4. Deaktiviert wird **nur**, wessen Chip heute präsent ist und der entweder den
+   Vergleich aus Regel 3 verloren hat oder dessen Kanal auf dem Chip fehlt.
+   Zeilen, deren Chip heute **nicht** auftaucht, bleiben unangetastet und aktiv.
+   Fallback-Zeilen (neue ID = alte ID) sind ein No-op, nie eine Deaktivierung.
+5. Jede Übernahme als INFO-Zeile `alt → neu`, dazu eine Zusammenfassung und ein
+   Audit-Eintrag über `get_audit_logger_db()` — der Lauf verändert
+   Nutzerkonfiguration und gehört in die Revisionsspur.
 
-Ergebnis auf BaluNode: alle Generationen der Gehäuselüfter tragen
-`"nct6798 PWM…"` und zielen auf dieselben vier neuen IDs; die Generation vom
-2026-08-07 gewinnt und die Kurven überleben. Von den 16 Zeilen bleiben damit
-4 aktiv, **9** werden inaktiv, und die 3 `dev_*`-Zeilen bleiben nach Regel 1
-unberührt.
+**Regel 4 ist die Korrektur des schwersten Fehlers der ersten Fassung.** Dort
+hieß es „alles Übrige `is_active=False`". Ist `nct6775` beim Dienststart noch
+nicht geladen, wären alle vier Gehäuselüfter-Zeilen keine Kandidaten gewesen und
+deaktiviert worden — `fan_control.py:478` (`if not config or not
+config.is_active: continue`) schaltet die Regelung für sie ab, und beim
+Nachladen legt `_load_fan_configs` Default-Configs an. Die Nutzerkurven wären
+still weg gewesen: exakt der Schaden, den dieses Issue verhindern soll.
+
+### Erwartetes Ergebnis auf BaluNode
+
+| Neue ID | Quelle | |
+|---|---|---|
+| `nct6798-isa-0290:pwm1/2/3/7` | `hwmon3_pwm*` (2026-08-07) | aktiv |
+| `amdgpu-pci-0300:pwm1` | `hwmon1_pwm1` (2026-07-06, `amdgpu PWM1`) | aktiv |
+
+**5 aktiv, 8 inaktiv** (4× Januar `hwmon5_*`, 4× Juli `hwmon2_*`), 3 `dev_*`
+unberührt, 0 Löschungen. Nebeneffekt: die heutige Fehlzuordnung des GPU-Lüfters
+auf eine Gehäuselüfter-Config ist danach aufgelöst.
 
 ### Schema
 
-Eine Alembic-Migration, **nur Struktur**:
+Eine Alembic-Migration, **nur Struktur**, Elternrevision `c4b18e9a2f37`
+(aktueller einziger Head; die Kette lautet
+`dcabe4cc2ebc → 16ea14ef13bb → a7d3c9f18e42 → c4b18e9a2f37`). Explizit genannt,
+weil das Projekt einen Multi-Head-Deployfehler in seiner Geschichte hat.
 
 ```
 fan_configs        + legacy_fan_id     String(100) NULL
 temp_sensor_labels + legacy_sensor_id  String(120) NULL
 ```
 
-Keine Spaltenverbreiterung nötig — die längste neue ID
-(`hwmon:asus@asus-nb-wmi:temp1`, 28 Zeichen) passt in die bestehenden Breiten.
+Keine Spaltenverbreiterung nötig — verifiziert: `fan_configs.fan_id`/`name`/
+`temp_sensor_id` `String(100)`, `fan_schedule_entries.fan_id` `String(100)`,
+`temp_sensor_labels.sensor_id` `String(120)`; längste neue ID 28 Zeichen.
 
-### Wo die Umschreibung läuft
+### Ausführungsort, Reihenfolge, Nebenläufigkeit
 
-Beim **Dienststart** in `_load_fan_configs`, nicht in der Migration. Eine
-Migration, die sysfs der Zielmaschine liest, verhielte sich in CI, auf einem
-Dev-Rechner und bei einem DB-Restore jeweils anders — dort existiert die
-Hardware nicht. Zur Startzeit ist der hwmon-Scan ohnehin gelaufen.
+Der Abgleich läuft **beim Dienststart in `_load_fan_configs`, vor der
+Anlage-Schleife, in derselben Transaktion**. Eine Migration, die sysfs der
+Zielmaschine liest, verhielte sich in CI, auf einem Dev-Rechner und bei einem
+DB-Restore jeweils anders.
 
-Bei vier Uvicorn-Workern läuft der Abgleich nur im Primary-Worker (Muster aus
-#465).
+Nebenläufigkeit ist der zweite schwere Fehler der ersten Fassung. Tatsächlicher
+Ist-Zustand:
+
+- `start()` ruft `_load_fan_configs()` **vor** dem `if monitoring:`-Gate auf
+  (`fan_control.py:199`) — also in **allen vier Workern**. Der `monitoring`-
+  Schalter steuert nur die Loop.
+- `_load_fan_configs` legt für jeden gescannten Lüfter ohne Config eine
+  Default-Zeile an (`fan_control.py:265-284`). Ein Sekundär-Worker, der zuerst
+  durchläuft, belegt damit die neuen Ziel-IDs; der Primary läuft beim
+  `UPDATE fan_id` in den UNIQUE-Index (`models/fans.py:76`). Die `IntegrityError`
+  fliegt aus `start()` und wird in `lifespan.py:531-532` nur als Warning
+  geschluckt — Fan-Control startet auf dem Primary gar nicht.
+- `start_fan_control` ist zusätzlich über `service_registry.py:208` aus
+  `restart_service` (`services/service_status.py:233-292`, Route
+  `routes/service_status.py:91-118`) und über `switch_backend()`
+  (`fan_control.py:879-904`) erreichbar — beides aus einem HTTP-Request in einem
+  **beliebigen** Worker.
+
+Daraus folgt:
+
+- Der Primary-Gate liegt **im Abgleich selbst**, nicht im Startpfad — sonst
+  umgehen ihn `restart_service` und `switch_backend`.
+- Gelesen wird `lifespan.IS_PRIMARY_WORKER` als Attributzugriff. Ein
+  `from app.core.lifespan import IS_PRIMARY_WORKER` friert den Importwert `False`
+  ein und der Abgleich liefe **nie**. Einziges funktionierendes Muster im Repo:
+  `plugin_enablement.py:191`.
+- Die Neuanlage wird ebenfalls serialisiert (Primary-only oder
+  `ON CONFLICT DO NOTHING` mit Re-Select). Regel 1 allein genügt **nicht** als
+  Schutz: die konkurrierende Zeile entsteht in *Neuform* und ist für Regel 1
+  unsichtbar.
+- Ist die Ziel-ID trotz allem belegt, wird der Verlierer deaktiviert statt in die
+  `IntegrityError` zu laufen.
 
 Mitzuziehen mit derselben Abbildung: `fan_configs.sync_fan_id`,
 `fan_schedule_entries.fan_id`.
 
 ### Sensor-IDs: die schwächere Stelle
 
-Für Sensoren gibt es kein Gegenstück zu `name`. `fan_configs.temp_sensor_id` ist
-ein nackter String; `temp_sensor_labels.sensor_id` ist ein Primärschlüssel mit
-einem Nutzer-Label, aber ohne Chip-Herkunft.
-
-Deshalb: Sensor-IDs werden über den **heutigen Index** aufgelöst. Löst der Index
-nicht auf, fällt der Lüfter auf den CPU-Sensor-Default zurück. Beide Fälle werden
-als WARNING geloggt, nicht still ausgeführt. Der Schaden im Fehlerfall ist „der
-Lüfter folgt dem falschen Sensor" — in der UI sichtbar und mit einem Klick
+Für Sensoren gibt es kein Gegenstück zu `name`. Sensor-IDs werden über den
+**heutigen Index** aufgelöst; löst er nicht auf, fällt der Lüfter auf den
+CPU-Sensor-Default zurück. Beide Fälle als WARNING, nicht still. Fehlerbild:
+„der Lüfter folgt dem falschen Sensor" — sichtbar und mit einem Klick
 korrigierbar.
 
 `composite_temp_sensors.source_ids_json` wird mit derselben Abbildung
-umgeschrieben (auf BaluNode leer). Kollidieren zwei Altzeilen auf denselben neuen
-`temp_sensor_labels`-Primärschlüssel, gewinnt die jüngste; die verworfene wird
-geloggt.
+umgeschrieben (auf BaluNode leer).
 
-Eine Chip-Namensspalte für `temp_sensor_labels` wurde erwogen und **verworfen**:
-sie hülfe nur künftigen Index-Migrationen, die es nach dieser Umstellung per
+`temp_sensor_labels.sensor_id` ist Primärschlüssel ohne `is_active`-Spalte.
+Kollidieren zwei Altzeilen auf denselben neuen Schlüssel, gewinnt die jüngste;
+die verworfene **bleibt unter ihrem alten Schlüssel liegen** und wird ignoriert.
+Kein Löschen (Nicht-Ziel), keine neue Spalte.
+
+Eine Chip-Namensspalte für `temp_sensor_labels` wurde erwogen und verworfen: sie
+hülfe nur künftigen Index-Migrationen, die es nach dieser Umstellung per
 Konstruktion nicht mehr gibt.
 
 ---
 
-## 3. Auflösung zur Laufzeit
+## 4. Auflösung zur Laufzeit
 
-Der Scan in `_scan_pwm_fans` bildet die neue Form direkt; `_fan_cache` ist damit
-auf stabile Schlüssel umgestellt. Als Nebeneffekt überlebt der Write-Backoff aus
-#533 ein Renumbering — heute verliert er seinen Eintrag, weil der Schlüssel
-wechselt.
+Der Scan in `_scan_pwm_fans` bildet die neue Form direkt; `_fan_cache` ist auf
+stabile Schlüssel umgestellt. Nebeneffekt: der Write-Backoff aus #533 überlebt
+ein Renumbering — heute verliert er seinen Eintrag, weil der Schlüssel wechselt
+(`fan_backend_linux.py:458`).
 
-**Abwesenheit darf niemals schreiben.** Beim Dienststart kann ein Treiber noch
-nicht geladen sein; ein Lüfter fehlt dann im Scan, ohne dass die Hardware weg
-wäre.
+**Abwesenheit darf niemals schreiben.**
 
 - Lüfter im Scan, ohne Config → Config mit Defaults anlegen (heutiges Verhalten).
 - Config ohne Lüfter im Scan → nichts tun. Kein `is_active=False`, kein Löschen,
-  keine Neuanlage.
+  keine Neuanlage. Deckungsgleich mit Regel 4 aus Abschnitt 3.
 
-Die bestehende Schutzregel in `_scan_pwm_fans` („found 0 fans, keeping cached
-fans") bleibt und deckt denselben Gedanken eine Ebene tiefer ab.
+Der `„found 0 fans, keeping cached fans"`-Schutz in `_scan_pwm_fans`
+(`fan_backend_linux.py:454-464`) greift **nur bei null** gefundenen Lüftern und
+deckt den Teilfall (amdgpu da, nct6775 noch nicht) *nicht* ab — die Aussage der
+ersten Fassung, er decke „denselben Gedanken eine Ebene tiefer" ab, war falsch.
+Der Schutz liegt allein in Regel 4.
 
-Der Abgleich läuft genau einmal pro Start, im Primary-Worker, und fasst
-ausschließlich Zeilen der Altform an. Zeilen in neuer Form sind für ihn
-unsichtbar — ein zweiter Lauf ist folgenlos, auch wenn der erste abbrach.
+**Es gibt keinen periodischen Rescan.** `_scan_pwm_fans` läuft nur über
+`is_available()` beim Start und in `switch_backend`. Ein später geladener Treiber
+bleibt bis zum Neustart unsichtbar — das bestimmt die Halbwertszeit des Zustands
+„Lüfter fehlt" und ist ein bestehender Zustand, den diese Arbeit nicht ändert.
 
 **Akzeptanzkriterium:** Ein Reboot, der `nct6798` von `hwmon3` nach `hwmon5`
-verschiebt, verändert die Kennung `nct6798-isa-0290:pwm1` nicht. Es entsteht
-keine neue Config, die Kurve gilt weiter, es sammelt sich keine Generation an.
-
-Sensor-Auflösung braucht keine neue Kompatibilitätsschicht: `TempSourceRegistry`
-akzeptiert unpräfixierte Alt-IDs bereits, und nach dem Abgleich hält keine
-aktive Config mehr eine Alt-ID.
+verschiebt, verändert `nct6798-isa-0290:pwm1` nicht. Keine neue Config, die Kurve
+gilt weiter, keine neue Generation.
 
 ---
 
-## 4. API, Frontend, Konsumenten
+## 5. API, Frontend, Konsumenten
 
-**Das Frontend braucht keine Änderung.** Nachgeprüft: in `client/src/` gibt es
-keine Stelle, die `fan_id`/`fanId` zerlegt (`split`, `slice`, `startsWith`,
-`match`), und keine, die eine Lüfter-Auswahl in `localStorage` ablegt. Die ID ist
-durchgehend ein undurchsichtiger Handle.
+**Das Frontend braucht keine funktionale Änderung.** Unabhängig von beiden
+Reviewern verifiziert: keine Stelle in `client/src/` zerlegt `fan_id`/`fanId`,
+keine legt eine Lüfterauswahl in `localStorage` ab, keine Router-/URL-Parameter,
+React-Query-Keys ohne fan_id (`hooks/useFanControl.ts:37`), E2E-Fixture
+`MOCK_FAN_STATUS = { fans: [] }`.
 
-**Pfadparameter tragen die neue Form ohne Kodierungsarbeit.** Sechs Routen nehmen
-`{fan_id}` (`/{fan_id}/schedule`, `/{fan_id}/gpu-manual-mode`, …). `:` und `@`
-sind laut RFC 3986 gültige `pchar` in einem Pfadsegment; die Sensor-Routen
-transportieren mit `hwmon:hwmon4_temp1` heute schon Doppelpunkte im Pfad und
-funktionieren in Produktion.
+Eine Ausnahme: `client/src/components/fan-control/FanCard.tsx:9` baut
+`` `hwmon:${sensorId}` `` und setzt damit eine Formatannahme über Sensor-IDs
+voraus. Funktioniert nach der Umstellung weiter, gehört aber auf die
+Mitzuziehen-Liste.
 
-**Mitzuziehen:**
+**Pfadparameter** tragen die neue Form ohne Arbeit: der Client kodiert mit
+`encodeURIComponent` (`api/fan-control.ts`, neun Stellen), uvicorn entquotet vor
+dem Routing, und die Sensor-Label-Routen transportieren `hwmon:…` bereits
+produktiv. Weder `fan_id` noch `sensor_id` noch `sync_fan_id` haben ein
+`pattern=` in den Pydantic-Schemas.
 
-- `backend/app/schemas/fans.py` — zehn Swagger-Beispiele auf `hwmon0_pwm1`.
-- Rund 75 fest verdrahtete Vorkommen in neun Backend- und vier
-  Frontend-Testdateien; betroffen sind die Stellen, die die gebildete ID
-  *behaupten*.
+**Keine weitere Spalte speichert eine Fan- oder Sensor-ID.** Repo-weit
+verifiziert: Notifications tragen nur `action_url="/fans"`, die Status-Bar liest
+nur `fan["name"]`, Monitoring speichert nur `fan_rpm`, Scheduler/Presets/
+Profile/Audit-Logs führen keine fan_id. Die TUI (`backend/baluhost_tui/`) hat
+null Treffer für „fan" oder „hwmon" und ist kein Konsument.
 
-**Kein API-Versionssprung.** Die ID war nie ein dokumentiertes Format, sondern
-ein Handle; BaluApp und BaluDesk sprechen die Fan-Endpunkte nicht an. Ein Client
-mit zwischengespeicherter Fan-ID bekommt eine 404 und lädt neu — bestehender
-Fehlerpfad, kein neuer.
+**Mitzuziehen:** zehn Swagger-Beispiele in `backend/app/schemas/fans.py`
+(Z. 88, 122, 132, 172, 194, 233, 346, 392, 394, 413).
+
+**Kein API-Versionssprung.** Die ID war nie ein dokumentiertes Format. Ein Client
+mit zwischengespeicherter Fan-ID bekommt eine 404 und lädt neu.
+
+**Restore:** `fan_configs` steckt im DB-Backup
+(`services/backup/service.py:30`). Das Zurückspielen eines
+Vor-Umstellungs-Backups bringt Altzeilen zurück; der Abgleich läuft nur beim
+Dienststart — **nach einem Restore ist ein Neustart erforderlich.**
 
 ---
 
-## 5. Tests und Verifikation
+## 6. Tests und Verifikation
 
 ### Der Test, der das Issue beantwortet
 
@@ -291,9 +475,17 @@ Ein hwmon-Baum unter `tmp_path`, zweimal aufgebaut: derselbe Gerätepfad einmal
 als `hwmon3`, einmal als `hwmon5`. Erwartung: identische Kennung, und
 `_load_fan_configs` legt beim zweiten Durchlauf keine neue Zeile an.
 
+**Der Testbaum muss echte `device`- und `subsystem`-Symlinks enthalten.** Sonst
+läuft er in den Fallback und prüft die neue Ableitung gerade nicht. Das betrifft
+auch drei bestehende Dateien, die synthetische Bäume ohne Elternstruktur bauen —
+`test_fan_pwm_control_probe.py` (35 hwmon-Vorkommen),
+`test_fan_gpu_manual_mode.py` (17), `test_fan_einval_diagnostic.py` (15): sie
+würden nach der Umstellung stillschweigend den Fallback testen und grün bleiben,
+ohne die Umstellung abzudecken.
+
 ### Kodierung gegen echte Pfade
 
-Sollwerte sind die von `sensors` auf BaluNode gemeldeten Chip-Namen — also eine
+Sollwerte sind die von `sensors` auf BaluNode gemeldeten Chip-Namen — eine
 unabhängige Implementierung derselben Regeln auf derselben Hardware:
 
 | Gerätepfad | erwartete Kennung |
@@ -303,68 +495,78 @@ unabhängige Implementierung derselben Regeln auf derselben Hardware:
 | `pci0000:00/0000:00:18.3` | `k10temp-pci-00c3` |
 | `…/0000:0d:00.0/nvme/nvme1` | `nvme-pci-0d00` |
 | `…/0000:0a:00.0/nvme/nvme0` | `nvme-pci-0a00` |
-| `platform/asus-nb-wmi` | `asus@asus-nb-wmi` |
-| `platform/eeepc-wmi` | `asus@eeepc-wmi` |
 
-Die NVMe-Fälle sichern ab, dass der Aufstieg den instabilen `nvmeN` überspringt;
-die letzten beiden die Kollisionsregel.
+Ergänzend, ohne `sensors`-Sollwert (die Chips erscheinen dort nicht):
+`platform/asus-nb-wmi` → `asus@asus-nb-wmi`, `platform/eeepc-wmi` →
+`asus@eeepc-wmi`. Dazu je ein Fall für PCI-Domain ≠ 0 (fünf Hexziffern), einen
+`scsi`-Elter (→ Fallback), einen fehlenden `device`-Link (→ Fallback) und zwei
+hwmon-Knoten am selben Gerät (→ beide Fallback, WARNING).
 
 ### Reconciliation
 
-- Vier Generationen wie auf BaluNode (16 Zeilen) → jüngste gewinnt: 4 aktiv,
-  9 inaktiv, 3 `dev_*` unberührt, null Löschungen.
-- Die Falle: Zeile `hwmon2_pwm1` mit `name="nct6798 PWM1"`, während `hwmon2`
-  heute der `amdgpu` ist → darf **nicht** zugeordnet werden.
-- Zweiter Lauf folgenlos (Idempotenz).
-- `dev_*`-Zeilen unberührt.
-- Lüfter fehlt im Scan → keine Schreiboperation.
-- Chip ohne `pci`/`platform`-Elter → Altform bleibt, als instabil markiert.
+Fixture ist die echte Datenlage (16 Zeilen, oben vollständig abgedruckt).
+
+- Erwartung: **5 aktiv, 8 inaktiv, 3 `dev_*` unberührt, 0 Löschungen.**
+- Die Falle: `hwmon2_pwm1` mit `name="nct6798 PWM1"` darf **nicht** dem heutigen
+  `hwmon2` (amdgpu) zugeordnet werden, sondern muss gegen die August-Generation
+  des nct6798 verlieren.
+- `hwmon1_pwm1` mit `name="amdgpu PWM1"` gewinnt `amdgpu-pci-0300:pwm1`.
+- Chip nicht präsent (Treiber nicht geladen) → **keine** Deaktivierung.
+- Dev-Backend aktiv → Abgleich läuft gar nicht.
+- Zweiter Lauf folgenlos, auch nach Abbruch zwischen Umbenennung und
+  Deaktivierung.
+- `"Unknown PWM1"` → weder Kandidat noch Deaktivierung.
+- Zwei Sekundär-Worker parallel → keine `IntegrityError`.
 
 ### Gates
 
-`pytest -k "fan or power"` steht seit #539 bei 559 passed — das ist die Messlatte
-plus die neuen Tests. Dazu `ruff check`, `eslint .`, `npm run build`,
-`vitest run`. Die volle Backend-Suite bleibt der CI überlassen (hängt auf
-Windows).
+`pytest -k "fan or power"` steht seit #539 bei 559 passed — Messlatte plus die
+neuen Tests. Dazu `ruff check`, `eslint .`, `npm run build`, `vitest run`. Die
+volle Backend-Suite bleibt der CI überlassen (hängt auf Windows).
+
+Mitzuziehen: 74 hwmon-ID-Literale in 8 Backend-Testdateien und 4
+Frontend-Testdateien.
 
 ### Feldverifikation nach dem Deploy
 
-1. Abgeleitete Kennungen gegen die `sensors`-Überschriften vergleichen — muss
-   zeichengleich sein.
-2. `modprobe -r nct6775 ; modprobe nct6775` erzwingt ein Renumbering ohne Reboot.
+1. Abgeleitete Kennungen gegen die `sensors`-Überschriften vergleichen — für die
+   fünf dort gelisteten Chips zeichengleich.
+2. `SELECT count(*) FROM fan_configs WHERE is_active` vor und nach dem ersten
+   Start: 16 → 8 (5 neue + 3 `dev_*`).
+3. `modprobe -r nct6775 ; modprobe nct6775` erzwingt ein Renumbering ohne Reboot.
    Danach muss `fan_configs` gleich viele Zeilen haben wie davor.
 
-Zu Schritt 2: beim Entladen verliert BaluHost kurzzeitig die Lüfter, und
+Zu Schritt 3: beim Entladen verliert BaluHost kurzzeitig die Lüfter, und
 `pwm_enable` fällt auf den Board-Default zurück. Bei Leerlauftemperaturen
-ungefährlich, aber ein Eingriff — ein regulärer Reboot leistet dasselbe, nur ohne
-Kontrolle über den Zeitpunkt.
+ungefährlich, aber ein Eingriff — ein regulärer Reboot leistet dasselbe.
 
 ---
 
 ## Risiken
 
-- **Selbstgebaute Kodierung.** Die Adressbildung ist aus dem libsensors-Quelltext
-  übernommen, nicht aus Beobachtungen zurückgeschlossen. Der Vergleich gegen die
-  `sensors`-Ausgabe ist die Absicherung; für Bus-Typen jenseits `pci`/`platform`
-  gibt es keine Testdaten auf dieser Hardware.
-- **i2c-Busnummern sind laut lm-sensors selbst nicht reboot-stabil** (daher die
-  `bus`-Statements und `sensors --bus-list`). Auf BaluNode ist alles `isa` oder
-  `pci`, die Kennung darf sich aber nicht darauf verlassen, dass das so bleibt.
-- **Sensor-Zuordnung bleibt heuristisch** (siehe Abschnitt 2). Fehlerbild ist ein
-  falscher Sensor am Lüfter, sichtbar und korrigierbar, nicht stumm.
-- **Einmaliger Vorgang mit Datenwirkung.** Der Abgleich läuft auf produktiven
-  Zeilen. Absicherung: nichts wird gelöscht, `legacy_fan_id` hält die Herkunft
-  fest, jede Übernahme wird geloggt.
+- **Selbstgebaute Kodierung.** Aus dem libsensors-Quelltext übernommen, nicht aus
+  Beobachtungen zurückgeschlossen — mit einer dokumentierten bewussten Abweichung
+  beim Hex-Fallback. Für Bustypen jenseits `pci`/`platform` gibt es auf dieser
+  Hardware keine Testdaten; sie fallen deshalb in den ehrlichen Fallback.
+- **i2c-Busnummern sind laut lm-sensors selbst nicht reboot-stabil.** Auf
+  BaluNode ist alles `isa` oder `pci`; die Kennung darf sich nicht darauf
+  verlassen, dass das so bleibt — deshalb Fallback statt Rateversuch.
+- **Sensor-Zuordnung bleibt heuristisch.** Fehlerbild ist ein falscher Sensor am
+  Lüfter, sichtbar und korrigierbar, nicht stumm.
+- **`is_active=False` ist keine Buchhaltung, sondern eine Funktionsabschaltung**
+  (`fan_control.py:478` überspringt inaktive Configs in der Regelschleife). Das
+  bestimmt die Kosten eines Fehlurteils in Regel 4 und ist der Grund für die
+  beiden harten Vorbedingungen.
+- **Einmaliger Vorgang mit Datenwirkung** auf produktiven Zeilen. Absicherung:
+  nichts wird gelöscht, `legacy_fan_id` hält die Herkunft fest, jede Übernahme
+  wird geloggt und auditiert.
 
 ## Quellen
 
 - [sensors.conf(5)](https://manpages.debian.org/testing/lm-sensors/sensors.conf.5.en.html)
-  — Chip-Namensformat `<prefix>-<bus>-<adresse>`
 - [lm-sensors `lib/sysfs.c`](https://github.com/lm-sensors/lm-sensors/blob/master/lib/sysfs.c)
-  — Adressbildung für PCI und platform/ISA
+  — `find_bus_type`, `classify_device`, Adressbildung
 - [fancontrol(8)](https://www.systutorials.com/docs/linux/man/8-fancontrol/) —
-  `DEVPATH`/`DEVNAME`, der Stand der Technik: Drift erkennen statt automatisch
-  zuordnen
-- [lm-sensors#227](https://github.com/lm-sensors/lm-sensors/issues/227) —
-  „fancontrol: use sensors' stable names"
+  `DEVPATH`/`DEVNAME`: Drift erkennen statt automatisch zuordnen
+- [lm-sensors#227](https://github.com/lm-sensors/lm-sensors/issues/227)
 - [Fan speed control — ArchWiki](https://wiki.archlinux.org/title/Fan_speed_control)


### PR DESCRIPTION
`fan_id` wurde aus dem hwmon-Index gebildet (`hwmon3_pwm1`). Der Index ist über Reboots und Änderungen der Modul-Ladereihenfolge nicht stabil — bei jeder Umnummerierung erkennt BaluHost dieselben physischen Lüfter als neue, legt frische Configs an, und die eingestellte Kurve ist weg.

## Der Schaden ist nicht nur zukünftig

Auf BaluNode liegen **16 Config-Zeilen in vier Generationen für 5 physische Lüfter**, alle `is_active=True`:

```
hwmon5_pwm1/2/3/7 | nct6798 PWM1/2/3/7 | 2026-01-25
hwmon1_pwm1       | amdgpu PWM1        | 2026-07-06
hwmon2_pwm1/2/3/7 | nct6798 PWM1/2/3/7 | 2026-07-20
hwmon3_pwm1/2/3/7 | nct6798 PWM1/2/3/7 | 2026-08-07   <- aktiv genutzt
```

Beim Vermessen fiel auf: **der GPU-Lüfter läuft heute auf der Konfiguration eines Gehäuselüfters.** Heute ist `hwmon2` der amdgpu, die GPU-ID lautet also `hwmon2_pwm1` — und unter genau dieser ID liegt die Juli-Zeile eines nct6798-Kanals. `_load_fan_configs` sucht nur über `fan_id` und findet sie. Folgenlos war das bisher nur, weil die RDNA3-GPU firmware-verwaltet ist und `set_pwm()` seit #480 dort ohnehin aussteigt.

Bis #517 war der Verlust einer Kurve egal, weil die Regelung ohnehin nicht wirkte. Seit dem Deploy von #537 regelt sie nachweislich (gemessen: `pwm` bewegt sich bei 76–79 statt starr auf 128) — damit ist eine Nutzerkonfiguration zum ersten Mal etwas wert.

## Lösung

Die Kennung ist der libsensors-Chipname, `<prefix>-<bus>-<adresse>`:

```
Lüfter:  nct6798-isa-0290:pwm1
Sensor:  hwmon:k10temp-pci-00c3:temp1
```

Das ist eine dokumentierte, außerhalb von BaluHost gültige Konvention ([`sensors.conf(5)`](https://manpages.debian.org/testing/lm-sensors/sensors.conf.5.en.html)) — es sind exakt die Überschriften, die `sensors` auf der Box ausgibt. Die Adressbildung ist aus `lm-sensors 3.6.2` (`lib/sysfs.c`, `lib/data.c`) übernommen, nicht aus beobachteten Werten zurückgeschlossen. Zwei Details, die man sonst falsch rät: die PCI-Domain geht mit `<<16` **in** die Adresse ein, und der Platform-Suffix wird **dezimal** gelesen (`nct6775.656` → 656 → hex `0290`).

Zwei bewusste Abweichungen von libsensors sind im Docstring benannt und je mit einem Test belegt.

## Migration

Beim Dienststart, nicht in der Alembic-Migration — eine Migration, die sysfs der Zielmaschine liest, verhielte sich in CI, auf einem Dev-Rechner und bei einem DB-Restore jeweils anders.

**Zugeordnet wird über den Chip-Namen in `fan_configs.name`, nicht über den hwmon-Index.** Der Index ist genau der unzuverlässige Teil: die Juli-Zeile `hwmon2_pwm1` heißt `"nct6798 PWM1"` und gehört zum nct6798, während `hwmon2` heute die GPU ist. Index-Mapping klebte diese Kurve auf den GPU-Lüfter. `name` ist nicht über die API änderbar (`UpdateFanConfigRequest` hat kein `name`-Feld) und trägt den Chip aus dem Moment der Entdeckung.

Erwartetes Ergebnis auf BaluNode: **5 aktiv, 8 inaktiv, 3 `dev_*` unberührt, 0 gelöscht.** Die Fehlzuordnung des GPU-Lüfters ist danach aufgelöst.

### Die Regel, an der alles hängt

**Abwesenheit schreibt nie.** Eine Zeile, deren Chip im Scan nicht auftaucht, bleibt unangetastet und aktiv. Ohne diese Regel deaktivierte ein beim Start noch nicht geladener Treiber sämtliche Nutzerkurven — genau der Schaden, den dieses Issue verhindern soll. Dazu zwei harte Vorbedingungen: der Abgleich läuft nur im Primary-Worker, nur mit aktivem Linux-Backend, und nur wenn der Scan mindestens einen Chip gefunden hat.

Die zweite Vorbedingung ist nicht theoretisch: `is_available()` liefert `False`, sobald der Scan 0 PWM-Lüfter findet, und `_initialize_backend` schaltet dann **auch in Produktion** auf das Dev-Backend. Genau so sind die drei `dev_*`-Zeilen auf BaluNode entstanden.

## Was die Lösung nicht kann

Chips ohne `pci`/`platform`-Elter behalten die hwmon-indizierte Altform und verhalten sich wie bisher. Das betrifft `i2c`, `spi`, `scsi`, `hid` — darunter **`drivetemp`** für SATA-Plattentemperaturen. Die Regel bricht dort bewusst sofort ab, statt weiterzuklettern: ein Aufstieg zum AHCI-Controller gäbe allen Platten desselben Controllers dieselbe Kennung. Lieber ehrlich instabil als scheinstabil.

Weitere dokumentierte Folgen: nach einem Restore eines Vor-Umstellungs-Backups ist ein Neustart nötig; `switch_backend()` auf einem Sekundär-Worker legt keine Configs mehr an; der Lüfter-Verlaufsgraph ist nach der Umstellung leer (alte `fan_sample`-Zeilen laufen über die Retention aus).

## Umfang

25 Commits. Neu: `fan_identity.py` (Ableitung), `fan_reconcile.py` (Zuordnung), eine Alembic-Migration mit zwei Herkunftsspalten. Geändert: Scan, Temperaturauflösung, Namespace-Erkennung, Anzeigepfad, `_load_fan_configs`.

| Gate | Ergebnis |
|---|---|
| `pytest -k "fan or power"` | 621 passed, 2 skipped |
| `ruff check app/services/power/ tests/` | All checks passed |
| `eslint .` | 0 Fehler |
| `npm run build` | grün |
| `vitest run` | 1309 Tests grün |

Volle Backend-Suite bleibt der CI überlassen.

### Vier Tests, die den Ausschlag geben

- `test_july_row_named_nct6798_does_not_become_the_gpu` — die Falle, die oben real eingetreten ist.
- `test_absent_chip_is_never_deactivated` — die Schutzregel.
- `test_secondary_worker_creates_no_configs` — verhindert, dass ein Sekundär-Worker die Ziel-ID belegt und der Abgleich danach die Nutzerkurve als Verlierer deaktiviert.
- `test_losing_incumbent_does_not_reuse_an_id_the_winner_still_holds` — der Rollback-plus-Roll-forward-Fall.

Die drei bestehenden Testdateien mit synthetischen hwmon-Bäumen wurden um echte `device`/`subsystem`-Symlinks ergänzt **und** um eine Behauptung auf die stabile ID. Ohne sie wären sie grün geblieben, ohne die neue Ableitung je zu berühren.

## Bekannte, bewusst offene Punkte

- Der Audit-Eintrag kann bei jedem Start feuern, wenn ein Sensor-Label dauerhaft unauflösbar ist (die Abbildung kennt nur die aktuelle hwmon-Nummerierung).
- Der Fehlerpfad des Abgleichs setzt keinen Health-Marker; ein dauerhaft scheiternder Abgleich steht nur als ERROR mit Traceback im Journal.
- In `test_fan_control.py` steht in einem Test eine `monkeypatch`-Zeile vor der Docstring, die dadurch wirkungslos wird.
- Die WARNING für nicht ableitbare Kennungen wurde pauschal auf DEBUG gesenkt; damit ist auch der echte Anomaliefall „Kennung nicht eindeutig" still.

## Nach dem Deploy zu prüfen

1. Abgeleitete Kennungen gegen die `sensors`-Überschriften — für die fünf dort gelisteten Chips zeichengleich.
2. `SELECT count(*) FROM fan_configs WHERE is_active` vor und nach dem ersten Start: **16 → 8** (5 neue plus 3 `dev_*`), Gesamtzahl bleibt 16.
3. `SELECT fan_id, name, legacy_fan_id FROM fan_configs WHERE is_active` — `amdgpu-pci-0300:pwm1` muss `name = "amdgpu PWM1"` und `legacy_fan_id = "hwmon1_pwm1"` tragen.
4. `modprobe -r nct6775 ; modprobe nct6775`, dann Backend neu starten: die Zeilenzahl muss gleich bleiben. Beim Entladen fällt `pwm_enable` kurz auf den Board-Default zurück — bei Leerlauftemperaturen ungefährlich, aber ein Eingriff.

Closes #532
Nebenbefund als #549 festgehalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yrHzUD98edGYVz4yABy9m
