### PR TITLE
feat(fans): Regelung beim Dienst-Ende an die Board-Automatik zurueckgeben (#534)

### DIFF
--- a/backend/alembic/versions/a6e0c0b1386b_fan_pwm_enable_restore.py
+++ b/backend/alembic/versions/a6e0c0b1386b_fan_pwm_enable_restore.py
@@ -1,0 +1,28 @@
+"""fan pwm_enable restore
+
+Revision ID: a6e0c0b1386b
+Revises: 193f03f94b4e
+Create Date: 2026-09-06 01:15:47.353323
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a6e0c0b1386b'
+down_revision: Union[str, Sequence[str], None] = '193f03f94b4e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('fan_configs', sa.Column('pwm_enable_restore', sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('fan_configs', 'pwm_enable_restore')

--- a/backend/app/models/fans.py
+++ b/backend/app/models/fans.py
@@ -85,6 +85,11 @@ class FanConfig(Base):
     # Herkunft der Zeile vor der Umstellung auf stabile Kennungen (#532).
     # Reiner Nachweis: erlaubt, eine Fehlzuordnung nachtraeglich zu erkennen.
     legacy_fan_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    # Der pwm_enable-Wert, auf den beim Dienst-Ende zurueckgeschaltet wird
+    # (#534). Wird ausschliesslich aus einer eigenen Beobachtung gefuellt --
+    # ein Wert >= 2, den der Scan vor dem ersten Write gelesen hat. NULL heisst:
+    # noch nie eine Automatik gesehen, also keine Rueckgabe.
+    pwm_enable_restore: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     hysteresis_celsius: Mapped[float] = mapped_column(Float, default=3.0, nullable=False)
     # --- Curve type & params ---
     curve_type: Mapped[str] = mapped_column(String(20), default="graph", nullable=False)

--- a/backend/app/services/CLAUDE.md
+++ b/backend/app/services/CLAUDE.md
@@ -89,10 +89,7 @@ Business logic layer. Routes delegate to services — services contain the actua
 - `fan_control.py` — Temperature-based fan speed control with curves
 - `fan_identity.py` — Derives stable chip-level fan/sensor identities (`<chip>-<bus>-<adresse>:pwm<N>`) that survive hwmon renumbering; ships with `derive_chip_identity()`, `derive_all()`, `build_fan_id()`, `build_sensor_id()`, `encode_pci_address()`, `encode_platform_address()`, `format_chip_name()`, and hwmon-index fallback for unsupported buses (i2c, spi, scsi, hid, drivetemp)
 - `fan_reconcile.py` — One-time identity reconciliation at backend startup; matches legacy `fan_id`/sensor labels/composite sources to stable equivalents, enforces fail-safe on mismatch (no default config creation). Does NOT create configs for newly-visible fans — that anlage-loop lives in `fan_control.py:_load_fan_configs()` (primary worker only)
-- `fan_restore.py` — Regel fuer die Rueckgabe an die Board-Automatik (#534):
-  `is_observation()`, `resolve_restore_value()`, `needs_release()`. Rein, ohne
-  sysfs- und DB-Zugriff. Zurueckgeschrieben wird ausschliesslich ein selbst
-  beobachteter Wert; es gibt bewusst keinen Treiber-Fallback.
+- `fan_restore.py` — Decision rule for handing fan control back to the board automation (#534): `is_observation()`, `resolve_restore_value()`, `needs_release()`. Pure — no sysfs and no DB access. Only a self-observed `pwm_enable` value (>= 2) is ever written back; there is deliberately no driver fallback
 - `sleep.py` — Soft/hard sleep modes with idle detection
 - `presence.py` — user-presence tracker (heartbeats → presence_sessions table; blocks auto true-suspend, issue #214)
 - `energy.py` — Power consumption tracking and cost estimation

--- a/backend/app/services/CLAUDE.md
+++ b/backend/app/services/CLAUDE.md
@@ -89,6 +89,10 @@ Business logic layer. Routes delegate to services — services contain the actua
 - `fan_control.py` — Temperature-based fan speed control with curves
 - `fan_identity.py` — Derives stable chip-level fan/sensor identities (`<chip>-<bus>-<adresse>:pwm<N>`) that survive hwmon renumbering; ships with `derive_chip_identity()`, `derive_all()`, `build_fan_id()`, `build_sensor_id()`, `encode_pci_address()`, `encode_platform_address()`, `format_chip_name()`, and hwmon-index fallback for unsupported buses (i2c, spi, scsi, hid, drivetemp)
 - `fan_reconcile.py` — One-time identity reconciliation at backend startup; matches legacy `fan_id`/sensor labels/composite sources to stable equivalents, enforces fail-safe on mismatch (no default config creation). Does NOT create configs for newly-visible fans — that anlage-loop lives in `fan_control.py:_load_fan_configs()` (primary worker only)
+- `fan_restore.py` — Regel fuer die Rueckgabe an die Board-Automatik (#534):
+  `is_observation()`, `resolve_restore_value()`, `needs_release()`. Rein, ohne
+  sysfs- und DB-Zugriff. Zurueckgeschrieben wird ausschliesslich ein selbst
+  beobachteter Wert; es gibt bewusst keinen Treiber-Fallback.
 - `sleep.py` — Soft/hard sleep modes with idle detection
 - `presence.py` — user-presence tracker (heartbeats → presence_sessions table; blocks auto true-suspend, issue #214)
 - `energy.py` — Power consumption tracking and cost estimation

--- a/backend/app/services/power/fan_backend_dev.py
+++ b/backend/app/services/power/fan_backend_dev.py
@@ -162,6 +162,10 @@ class DevFanControlBackend(FanControlBackend):
         logger.debug(f"Set {fan_id} PWM to {pwm_percent}% (target RPM: {fan['target_rpm']})")
         return True
 
+    async def release_to_board(self, fan_id: str, enable_value: int) -> bool:
+        """Kein hwmon im Dev-Modus -- es gibt nichts zurueckzugeben."""
+        return True
+
     async def get_temperature(self, sensor_id: str) -> Optional[float]:
         """Get simulated temperature."""
         return self._temps.get(sensor_id)

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -483,6 +483,14 @@ class LinuxFanControlBackend(FanControlBackend):
                 # Find PWM enable
                 pwm_enable_path = hwmon_dir / f"pwm{pwm_num}_enable"
 
+                # pwm_enable EINMAL pro Start lesen, bevor set_pwm es auf 1
+                # setzt. Nach dem ersten Regelzyklus steht dort unser eigener
+                # Wert -- dies ist der einzige Moment, in dem der Board-Wert
+                # sichtbar sein kann (#534).
+                pwm_enable_at_scan = None
+                if pwm_enable_path.exists():
+                    pwm_enable_at_scan = await self._read_hwmon_file(pwm_enable_path)
+
                 # Prefer CPU sensor over local board sensor
                 if cpu_sensor_id:
                     temp_sensor_id = cpu_sensor_id
@@ -508,6 +516,7 @@ class LinuxFanControlBackend(FanControlBackend):
                     "name": f"{hwmon_name_value} PWM{pwm_num}",
                     "pwm_path": pwm_file,
                     "pwm_enable_path": pwm_enable_path if pwm_enable_path.exists() else None,
+                    "pwm_enable_at_scan": pwm_enable_at_scan,
                     "fan_input_path": fan_input_path,
                     "temp_path": temp_path,
                     "temp_sensor_id": temp_sensor_id,

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -256,6 +256,50 @@ class LinuxFanControlBackend(FanControlBackend):
             )
         return False
 
+    async def release_to_board(self, fan_id: str, enable_value: int) -> bool:
+        """Gibt die Regelung dieses Kanals an die Chip-Automatik zurueck.
+
+        Umgeht das Write-Backoff aus #533 bewusst: dessen Sperre sitzt in
+        set_pwm, nicht hier. Ein Kanal mit Schreibfehlern ist genau der, bei dem
+        eine abgeschaltete Board-Automatik am meisten weh tut.
+        """
+        fan_info = self._fan_cache.get(fan_id)
+        if fan_info is None:
+            logger.warning(f"Rueckgabe fuer unbekannten Luefter {fan_id}")
+            return False
+
+        pwm_enable_path = fan_info.get("pwm_enable_path")
+        if pwm_enable_path is None:
+            return False
+
+        driver = fan_info.get("device_driver", "unknown")
+        ok, err_code = await self._write_hwmon_file(pwm_enable_path, str(enable_value))
+        if not ok:
+            # Achtung bei der Formulierung: _write_hwmon_file meldet nach einem
+            # gescheiterten sudo-tee-Fallback EACCES, auch wenn der Kernel
+            # eigentlich EINVAL geliefert hat (etwa weil check_trip_points()
+            # nicht-monotone BIOS-Stuetzstellen gefunden hat). Der errno wird
+            # deshalb genannt, aber nicht gedeutet.
+            logger.warning(
+                f"Rueckgabe an die Board-Automatik fehlgeschlagen: {fan_id} "
+                f"(driver={driver}, Ziel={enable_value}, errno={err_code}). "
+                f"Der Luefter bleibt in Handsteuerung -- es regelt niemand."
+            )
+            return False
+
+        readback = await self._read_hwmon_file(pwm_enable_path)
+        if readback != enable_value:
+            logger.warning(
+                f"Rueckgabe an die Board-Automatik ohne Wirkung: {fan_id} "
+                f"(driver={driver}, geschrieben={enable_value}, "
+                f"gelesen={readback}). Der Write wurde stillschweigend "
+                f"verworfen."
+            )
+            return False
+
+        logger.info(f"{fan_id}: an die Board-Automatik zurueckgegeben (pwm_enable={enable_value})")
+        return True
+
     # CPU temperature driver names (same keywords as hardware/sensors.py)
     _CPU_SENSOR_DRIVERS = {"k10temp", "coretemp", "cpu_thermal", "acpi"}
 

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -113,6 +113,19 @@ class FanControlBackend(ABC):
         pass
 
     @abstractmethod
+    async def release_to_board(self, fan_id: str, enable_value: int) -> bool:
+        """pwm_enable auf einen Automatikmodus zurueckschreiben (#534).
+
+        Args:
+            fan_id: Luefter-Kennung
+            enable_value: der beobachtete Automatikmodus (>= 2)
+
+        Returns:
+            True nur, wenn der Wert danach tatsaechlich anliegt.
+        """
+        pass
+
+    @abstractmethod
     async def get_temperature(self, sensor_id: str) -> Optional[float]:
         """Get temperature reading from a sensor."""
         pass

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -15,13 +15,14 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 
-from sqlalchemy import select, desc, func
+from sqlalchemy import select, desc, func, update
 from sqlalchemy.exc import IntegrityError
 
 from app.core import lifespan
 from app.core.config import Settings
 from app.models.fans import FanConfig, FanSample
 from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
+from app.services.power.fan_restore import is_observation, resolve_restore_value
 from app.services.power.fan_schedule import FanScheduleService
 from app.services.power.fan_profiles import FanProfileService
 from app.services.power.fan_reconcile import ChipFacts, reconcile_fan_identities
@@ -168,6 +169,9 @@ class FanControlService:
         self._registry: TempSourceRegistry = TempSourceRegistry()
         self._last_pwm_by_fan: Dict[str, int] = {}
         self._last_tick_ts: float = 0.0
+        # Rueckgabewerte pro Luefter, beim Start aus der DB geladen. stop()
+        # braucht sie ohne Datenbankzugriff (#534).
+        self._restore_values: Dict[str, int] = {}
 
         FanControlService._instance = self
 
@@ -316,6 +320,69 @@ class FanControlService:
             mapping[f"{hwmon_name}_temp{temp_num}"] = f"hwmon:{stable_id}"
         return mapping
 
+    def _collect_pwm_enable_observations(self) -> Dict[str, int]:
+        """Beobachtete Automatikmodi aus dem Scan-Cache.
+
+        GPU-Luefter bleiben draussen: fuer AMD-Karten existiert mit
+        AmdManualState / disable_amd_manual bereits ein eigener Rueckgabeweg,
+        der zusaetzlich das Performance-Level zuruecksetzt, und nouveau hat
+        gar keinen. Der isinstance-Schutz folgt dem Muster, das fuer dieselben
+        Cache-Zugriffe in #532 eingefuehrt wurde.
+        """
+        cache = getattr(self._backend, "_fan_cache", None)
+        if not isinstance(cache, dict):
+            # Gleiche Absicherung wie in _collect_chip_facts/_collect_sensor_map:
+            # ein unspezifizierter Test-Mock (z. B. AsyncMock()) liefert hier
+            # selbst wieder einen Mock statt eines dict -- ohne diese Pruefung
+            # wuerde cache.items() als Coroutine zurueckkommen (AsyncMock-
+            # Kindattribute sind selbst AsyncMock) und die Iteration bricht.
+            cache = {}
+        return {
+            fan_id: info["pwm_enable_at_scan"]
+            for fan_id, info in cache.items()
+            if isinstance(info, dict)
+            and info.get("gpu_vendor") is None
+            and is_observation(info.get("pwm_enable_at_scan"))
+        }
+
+    def _persist_restore_values(self, observations: Dict[str, int]) -> None:
+        """Beobachtete pwm_enable-Werte speichern und in den Speicher laden.
+
+        Nur der Primary schreibt. Geschrieben wird ausschliesslich bei echter
+        Aenderung, und updated_at wird dabei ausdruecklich mitgefuehrt: die
+        Spalte traegt onupdate=func.now() und ist das Rangkriterium des
+        Identitaets-Abgleichs (fan_reconcile.py). Ein Schreibvorgang bei jedem
+        Start setzte jede Zeile auf "gerade angefasst".
+        """
+        if not getattr(lifespan, "IS_PRIMARY_WORKER", False):
+            return
+
+        with self.db_session_factory() as db:
+            rows = list(db.execute(select(FanConfig)).scalars())
+            by_id = {row.fan_id: row for row in rows}
+
+            changed = 0
+            for fan_id, row in by_id.items():
+                target = resolve_restore_value(observations.get(fan_id),
+                                               row.pwm_enable_restore)
+                if target is not None:
+                    self._restore_values[fan_id] = target
+                if target == row.pwm_enable_restore or target is None:
+                    continue
+                db.execute(
+                    update(FanConfig)
+                    .where(FanConfig.id == row.id)
+                    .values(pwm_enable_restore=target,
+                            updated_at=row.updated_at)
+                )
+                changed += 1
+                logger.info(
+                    "Rueckgabewert fuer %s beobachtet: pwm_enable=%s",
+                    fan_id, target,
+                )
+            if changed:
+                db.commit()
+
     async def _load_fan_configs(self):
         """Load fan configurations from database.
 
@@ -338,6 +405,8 @@ class FanControlService:
                     break
         except Exception:
             pass
+
+        observations = self._collect_pwm_enable_observations()
 
         with self.db_session_factory() as db:
             chip_facts = self._collect_chip_facts()
@@ -457,6 +526,7 @@ class FanControlService:
                             cpu_sensor_id or fan.temp_sensor_id
                         ) if (cpu_sensor_id or fan.temp_sensor_id) else None,
                         is_active=True,
+                        pwm_enable_restore=observations.get(fan.fan_id),
                     )
                     try:
                         # Savepoint statt db.rollback() auf der ganzen
@@ -481,6 +551,8 @@ class FanControlService:
                         logger.debug("Fan-Config %s wurde parallel angelegt", fan.fan_id)
 
             db.commit()
+
+        self._persist_restore_values(observations)
 
         logger.info(f"Loaded {len(fans)} fan configuration(s)")
 

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -22,7 +22,7 @@ from app.core import lifespan
 from app.core.config import Settings
 from app.models.fans import FanConfig, FanSample
 from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
-from app.services.power.fan_restore import is_observation, resolve_restore_value
+from app.services.power.fan_restore import is_observation, needs_release, resolve_restore_value
 from app.services.power.fan_schedule import FanScheduleService
 from app.services.power.fan_profiles import FanProfileService
 from app.services.power.fan_reconcile import ChipFacts, reconcile_fan_identities
@@ -235,7 +235,58 @@ class FanControlService:
             except asyncio.CancelledError:
                 pass
 
+        # Erst die Schleife stilllegen, dann zurueckgeben -- umgekehrt schriebe
+        # sie im naechsten Zyklus pwm_enable=1 gegen die Rueckgabe (#534).
+        try:
+            await self._release_all_to_board()
+        except Exception:
+            logger.exception("Rueckgabe an die Board-Automatik fehlgeschlagen")
+
         logger.info("Fan control service stopped")
+
+    async def _release_all_to_board(self) -> None:
+        """Gibt alle Luefter mit bekanntem Rueckgabewert an die Automatik zurueck.
+
+        Entschieden wird am Ist-Wert in sysfs statt an einer Besitz-Buchfuehrung.
+        Ein Luefter im MANUAL-Modus wird vom Regelkreis nie geschrieben (Ziel ==
+        Ist), sein einziger Schreibweg ist die HTTP-Route -- und die landet bei
+        vier Workern meist auf einem Sekundaer. Eine primary-gebundene
+        Besitzverfolgung haette ihn nie erfasst, und genau er stuende am Ende
+        ungeregelt da.
+        """
+        if not getattr(lifespan, "IS_PRIMARY_WORKER", False):
+            return
+        if not self._restore_values:
+            return
+
+        cache = getattr(self._backend, "_fan_cache", None) or {}
+        released = 0
+        failed = 0
+
+        for fan_id, target in self._restore_values.items():
+            info = cache.get(fan_id)
+            if not isinstance(info, dict):
+                continue
+            if info.get("gpu_vendor") is not None:
+                continue
+            pwm_enable_path = info.get("pwm_enable_path")
+            if pwm_enable_path is None:
+                continue
+
+            current = await self._backend._read_hwmon_file(pwm_enable_path)
+            if not needs_release(current, target):
+                continue
+
+            if await self._backend.release_to_board(fan_id, target):
+                released += 1
+            else:
+                failed += 1
+
+        if released or failed:
+            logger.info(
+                "Rueckgabe an die Board-Automatik: %d erfolgreich, %d fehlgeschlagen",
+                released, failed,
+            )
 
     async def _initialize_backend(self):
         """Initialize appropriate backend."""
@@ -1154,6 +1205,25 @@ class FanControlService:
         Returns:
             (success, is_using_linux_backend)
         """
+        # Gleiche Reihenfolge wie in stop(): erst die Schleife stilllegen, dann
+        # zurueckgeben, dann tauschen. Ohne das schriebe die weiterlaufende
+        # Schleife pwm_enable=1 gegen die Rueckgabe, und ein Wechsel auf das
+        # Dev-Backend liesse jeden Kanal in Handsteuerung zurueck -- niemand
+        # regelt, ueber einen Admin-Endpunkt (#534).
+        was_running = self._is_running
+        self._is_running = False
+        if self._monitoring_task:
+            self._monitoring_task.cancel()
+            try:
+                await self._monitoring_task
+            except asyncio.CancelledError:
+                pass
+            self._monitoring_task = None
+        try:
+            await self._release_all_to_board()
+        except Exception:
+            logger.exception("Rueckgabe beim Backend-Wechsel fehlgeschlagen")
+
         if use_linux:
             # Try to switch to Linux backend
             linux_backend = LinuxFanControlBackend(self.config)
@@ -1162,17 +1232,26 @@ class FanControlService:
                 self._use_linux_backend = True
                 await self._load_fan_configs()
                 logger.info("Switched to Linux fan control backend")
-                return True, True
+                result = True, True
             else:
                 logger.warning("Linux backend not available")
-                return False, self._use_linux_backend
+                result = False, self._use_linux_backend
         else:
             # Switch to dev backend
             self._backend = DevFanControlBackend(self.config)
             self._use_linux_backend = False
             await self._load_fan_configs()
             logger.info("Switched to dev fan control backend")
-            return True, False
+            result = True, False
+
+        # Nach dem Tausch die Schleife wieder starten, falls sie lief. Beide
+        # Zweige oben enden mit `return` im Original -- hier stattdessen ueber
+        # `result` gefuehrt, damit dieser Neustart nicht verlorengeht (#534).
+        if was_running:
+            self._is_running = True
+            self._monitoring_task = asyncio.create_task(self._monitoring_loop())
+
+        return result
 
     # --- Delegating methods for backward compatibility ---
 

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -1224,32 +1224,35 @@ class FanControlService:
         except Exception:
             logger.exception("Rueckgabe beim Backend-Wechsel fehlgeschlagen")
 
-        if use_linux:
-            # Try to switch to Linux backend
-            linux_backend = LinuxFanControlBackend(self.config)
-            if await linux_backend.is_available():
-                self._backend = linux_backend
-                self._use_linux_backend = True
-                await self._load_fan_configs()
-                logger.info("Switched to Linux fan control backend")
-                result = True, True
+        try:
+            if use_linux:
+                # Try to switch to Linux backend
+                linux_backend = LinuxFanControlBackend(self.config)
+                if await linux_backend.is_available():
+                    self._backend = linux_backend
+                    self._use_linux_backend = True
+                    await self._load_fan_configs()
+                    logger.info("Switched to Linux fan control backend")
+                    result = True, True
+                else:
+                    logger.warning("Linux backend not available")
+                    result = False, self._use_linux_backend
             else:
-                logger.warning("Linux backend not available")
-                result = False, self._use_linux_backend
-        else:
-            # Switch to dev backend
-            self._backend = DevFanControlBackend(self.config)
-            self._use_linux_backend = False
-            await self._load_fan_configs()
-            logger.info("Switched to dev fan control backend")
-            result = True, False
-
-        # Nach dem Tausch die Schleife wieder starten, falls sie lief. Beide
-        # Zweige oben enden mit `return` im Original -- hier stattdessen ueber
-        # `result` gefuehrt, damit dieser Neustart nicht verlorengeht (#534).
-        if was_running:
-            self._is_running = True
-            self._monitoring_task = asyncio.create_task(self._monitoring_loop())
+                # Switch to dev backend
+                self._backend = DevFanControlBackend(self.config)
+                self._use_linux_backend = False
+                await self._load_fan_configs()
+                logger.info("Switched to dev fan control backend")
+                result = True, False
+        finally:
+            # Der Neustart gehoert ins finally: zwischen Abbruch (oben) und
+            # hier koennen is_available() und _load_fan_configs() werfen. Ohne
+            # das bliebe die Regelung nach einem gescheiterten Wechsel bis zum
+            # Prozess-Neustart still stehen -- schlimmer als der Zustand, den
+            # dieser Wechsel beheben sollte.
+            if was_running:
+                self._is_running = True
+                self._monitoring_task = asyncio.create_task(self._monitoring_loop())
 
         return result
 

--- a/backend/app/services/power/fan_restore.py
+++ b/backend/app/services/power/fan_restore.py
@@ -1,0 +1,46 @@
+"""Entscheidet, ob und worauf ein Luefter an die Board-Automatik zurueckgeht (#534).
+
+Reine Regel ohne sysfs- und ohne DB-Zugriff. Der Entwurf steht und faellt mit
+einem Grundsatz: zurueckgeschrieben wird ausschliesslich ein Wert, den BaluHost
+am selben Chip selbst gelesen hat. Ein geratener Treibermodus waere eine
+Annahme ueber fremde Hardware, die niemand ueberpruefen kann.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+# Ab hier regelt der Chip selbst. Darunter liegen die beiden Zustaende, in
+# denen er es NICHT tut:
+#   1 = Handsteuerung (jemand hat uebernommen -- in aller Regel wir)
+#   0 = "no fan speed control (i.e. fan at full speed)" laut hwmon-Konvention;
+#       der nct6775-Treiber setzt dabei zusaetzlich Duty 255
+_LOWEST_AUTOMATIC_MODE = 2
+
+
+def is_observation(value: Optional[int]) -> bool:
+    """Taugt der gelesene pwm_enable-Wert als Rueckgabeziel?"""
+    return value is not None and value >= _LOWEST_AUTOMATIC_MODE
+
+
+def resolve_restore_value(scanned: Optional[int],
+                          stored: Optional[int]) -> Optional[int]:
+    """Der Rueckgabewert: juengere Beobachtung schlaegt gespeicherten Wert.
+
+    Ist der gescannte Wert keine Beobachtung, bleibt der gespeicherte
+    unveraendert -- er stammt dann aus einem frueheren Kaltstart und ist das
+    Beste, was wir haben. Gibt es auch den nicht, gibt es keine Rueckgabe.
+    """
+    if is_observation(scanned):
+        return scanned
+    return stored
+
+
+def needs_release(current: Optional[int], target: Optional[int]) -> bool:
+    """Muss geschrieben werden?
+
+    Ein nicht lesbarer Ist-Wert gilt als Abweichung: lieber einmal zu viel
+    schreiben, als die Board-Automatik ausgeschaltet zu lassen.
+    """
+    if target is None:
+        return False
+    return current != target

--- a/backend/app/services/power/fan_restore.py
+++ b/backend/app/services/power/fan_restore.py
@@ -29,10 +29,16 @@ def resolve_restore_value(scanned: Optional[int],
     Ist der gescannte Wert keine Beobachtung, bleibt der gespeicherte
     unveraendert -- er stammt dann aus einem frueheren Kaltstart und ist das
     Beste, was wir haben. Gibt es auch den nicht, gibt es keine Rueckgabe.
+
+    Der gespeicherte Wert wird dabei ebenso gegen is_observation() geprueft
+    wie der gescannte: die Spalte traegt keinen CHECK-Constraint, und die
+    Zusage "nur beobachtete Werte" soll nicht davon abhaengen, wer sie einmal
+    gefuellt hat (manuelle DB-Aenderung, ein kuenftiges Backfill, ein von Hand
+    geflickter Dump).
     """
     if is_observation(scanned):
         return scanned
-    return stored
+    return stored if is_observation(stored) else None
 
 
 def needs_release(current: Optional[int], target: Optional[int]) -> bool:

--- a/backend/tests/test_fan_handback_on_stop.py
+++ b/backend/tests/test_fan_handback_on_stop.py
@@ -140,6 +140,44 @@ async def test_stop_cancels_the_loop_before_releasing(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_switch_backend_restarts_loop_even_when_load_configs_fails(monkeypatch):
+    """Ein gescheiterter Wechsel darf die Regelung nicht dauerhaft stilllegen.
+
+    Review-Fix zu #534: der Vorspann von switch_backend() stoppt die
+    Monitoring-Schleife VOR dem eigentlichen Tausch. Wirft _load_fan_configs()
+    danach (z. B. weil die Datenbank kurz nicht erreichbar ist), muss der
+    Neustart trotzdem laufen -- sonst bleibt die Regelung bis zum
+    Prozess-Neustart tot, obwohl sie vor dem Aufruf lief.
+    """
+    service = _service(monkeypatch)
+    service._backend = _backend(current_enable=1)
+
+    async def loop():
+        await asyncio.sleep(3600)
+
+    service._is_running = True
+    service._monitoring_task = asyncio.create_task(loop())
+    await asyncio.sleep(0)
+
+    async def boom():
+        raise RuntimeError("Datenbank kurz nicht erreichbar")
+
+    monkeypatch.setattr(service, "_load_fan_configs", boom)
+
+    with pytest.raises(RuntimeError):
+        await service.switch_backend(use_linux=False)
+
+    assert service._is_running is True
+    assert service._monitoring_task is not None
+
+    service._monitoring_task.cancel()
+    try:
+        await service._monitoring_task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
 async def test_release_is_idempotent(monkeypatch):
     """Zweiter Lauf: der Ist-Wert stimmt bereits, es wird nichts geschrieben."""
     service = _service(monkeypatch)

--- a/backend/tests/test_fan_handback_on_stop.py
+++ b/backend/tests/test_fan_handback_on_stop.py
@@ -1,0 +1,154 @@
+"""Beim Beenden geht die Regelung an die Board-Automatik zurueck (#534).
+
+Entschieden wird am Ist-Wert in sysfs, nicht an einer Besitz-Buchfuehrung: ein
+Luefter im MANUAL-Modus wird vom Regelkreis nie geschrieben, ein Besitz-Modell
+haette ihn deshalb nie erfasst -- und genau er stuende am Ende ungeregelt da.
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_control import FanControlService
+
+
+def _service(monkeypatch, *, primary=True):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = True
+    config.is_dev_mode = False
+    service = FanControlService(config, MagicMock())
+    service._use_linux_backend = True
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        primary, raising=False)
+    return service
+
+
+def _backend(current_enable):
+    backend = MagicMock()
+    backend._fan_cache = {
+        "nct6798-isa-0290:pwm1": {
+            "pwm_enable_path": MagicMock(),
+            "gpu_vendor": None,
+        }
+    }
+    backend._read_hwmon_file = AsyncMock(return_value=current_enable)
+    backend.release_to_board = AsyncMock(return_value=True)
+    return backend
+
+
+@pytest.mark.asyncio
+async def test_releases_when_value_deviates(monkeypatch):
+    service = _service(monkeypatch)
+    service._backend = _backend(current_enable=1)
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+
+    await service._release_all_to_board()
+
+    service._backend.release_to_board.assert_awaited_once_with(
+        "nct6798-isa-0290:pwm1", 5
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_write_when_already_on_target(monkeypatch):
+    service = _service(monkeypatch)
+    service._backend = _backend(current_enable=5)
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+
+    await service._release_all_to_board()
+
+    service._backend.release_to_board.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_restore_value_means_no_write(monkeypatch):
+    """Ohne Beobachtung passiert nichts -- der Kern des Entwurfs."""
+    service = _service(monkeypatch)
+    service._backend = _backend(current_enable=1)
+    service._restore_values = {}
+
+    await service._release_all_to_board()
+
+    service._backend.release_to_board.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_manual_at_full_speed_reads_zero_and_is_released(monkeypatch):
+    """reg_to_pwm_enable() meldet Manual mit Duty 255 als 0."""
+    service = _service(monkeypatch)
+    service._backend = _backend(current_enable=0)
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+
+    await service._release_all_to_board()
+
+    service._backend.release_to_board.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_secondary_worker_releases_nothing(monkeypatch):
+    service = _service(monkeypatch, primary=False)
+    service._backend = _backend(current_enable=1)
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+
+    await service._release_all_to_board()
+
+    service._backend.release_to_board.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gpu_fan_is_never_released(monkeypatch):
+    service = _service(monkeypatch)
+    backend = _backend(current_enable=1)
+    backend._fan_cache["nct6798-isa-0290:pwm1"]["gpu_vendor"] = "amd"
+    service._backend = backend
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+
+    await service._release_all_to_board()
+
+    backend.release_to_board.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_the_loop_before_releasing(monkeypatch):
+    """Umgekehrte Reihenfolge liesse die Schleife gegen die Rueckgabe schreiben."""
+    service = _service(monkeypatch)
+    service._backend = _backend(current_enable=1)
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+    order = []
+
+    async def note_release():
+        order.append("release")
+
+    monkeypatch.setattr(service, "_release_all_to_board", note_release)
+    service._is_running = True
+
+    async def loop():
+        try:
+            await asyncio.sleep(3600)
+        except BaseException:
+            order.append("cancel")
+            raise
+
+    service._monitoring_task = asyncio.create_task(loop())
+    await asyncio.sleep(0)
+
+    await service.stop()
+
+    assert order == ["cancel", "release"]
+
+
+@pytest.mark.asyncio
+async def test_release_is_idempotent(monkeypatch):
+    """Zweiter Lauf: der Ist-Wert stimmt bereits, es wird nichts geschrieben."""
+    service = _service(monkeypatch)
+    backend = _backend(current_enable=1)
+    service._backend = backend
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+
+    await service._release_all_to_board()
+    backend._read_hwmon_file = AsyncMock(return_value=5)
+    await service._release_all_to_board()
+
+    assert backend.release_to_board.await_count == 1

--- a/backend/tests/test_fan_handback_roundtrip.py
+++ b/backend/tests/test_fan_handback_roundtrip.py
@@ -1,0 +1,96 @@
+"""Beobachtung -> Persistenz -> Rueckgabe -> erneuter Scan (#534).
+
+Der Test bildet zwei Startzyklen auf demselben sysfs-Baum ab und belegt, dass
+der zurueckgegebene Wert beim naechsten Start wieder als Beobachtung ankommt --
+ohne dass sich etwas verschiebt.
+"""
+import os
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from unittest.mock import MagicMock
+
+from app.core.config import get_settings
+from app.models.base import Base
+from app.models.fans import FanConfig
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+from app.services.power.fan_control import FanControlService
+
+
+def _tree(tmp_path: Path, enable_value: str) -> Path:
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "nct6775.656"
+    hwmon = device / "hwmon" / "hwmon3"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nct6798\n")
+    (hwmon / "pwm1").write_text("128\n")
+    (hwmon / "pwm1_enable").write_text(enable_value + "\n")
+    (hwmon / "fan1_input").write_text("900\n")
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / "hwmon3", target_is_directory=True)
+    return klass
+
+
+@pytest.mark.asyncio
+async def test_observation_survives_a_full_cycle(tmp_path, monkeypatch):
+    klass = _tree(tmp_path, "5")   # Kaltstart: BIOS hat Smart Fan IV gesetzt
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine)
+
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        True, raising=False)
+
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = True
+    config.is_dev_mode = False
+    service = FanControlService(config, factory)
+    service._use_linux_backend = True
+
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+    await backend._scan_pwm_fans()
+    service._backend = backend
+    fan_id = next(iter(backend._fan_cache))
+
+    with factory() as db:
+        db.add(FanConfig(fan_id=fan_id, name="nct6798 PWM1", mode="auto",
+                         is_active=True))
+        db.commit()
+
+    # Erster Zyklus: Beobachtung persistieren
+    service._persist_restore_values({fan_id: 5})
+    with factory() as db:
+        assert db.execute(select(FanConfig)).scalar_one().pwm_enable_restore == 5
+
+    # BaluHost regelt: pwm_enable steht auf 1
+    backend._fan_cache[fan_id]["pwm_enable_path"].write_text("1\n")
+
+    # Beenden: Rueckgabe
+    await service._release_all_to_board()
+    assert backend._fan_cache[fan_id]["pwm_enable_path"].read_text().strip() == "5"
+
+    # Zweiter Zyklus: neuer Scan liest den zurueckgegebenen Wert
+    backend2 = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend2, "_hwmon_base", klass)
+    await backend2._scan_pwm_fans()
+    assert backend2._fan_cache[fan_id]["pwm_enable_at_scan"] == 5
+
+    # ... und die Persistenz aendert nichts mehr
+    service._backend = backend2
+    with factory() as db:
+        before = db.execute(select(FanConfig)).scalar_one().updated_at
+    service._persist_restore_values({fan_id: 5})
+    with factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.pwm_enable_restore == 5
+    assert row.updated_at == before

--- a/backend/tests/test_fan_release_to_board.py
+++ b/backend/tests/test_fan_release_to_board.py
@@ -6,6 +6,7 @@ davor, unterbliebe die Rueckgabe ausgerechnet bei den Kanaelen, die zuvor
 Schreibfehler hatten -- den kritischsten.
 """
 import errno
+import logging
 import os
 from pathlib import Path
 
@@ -70,7 +71,13 @@ async def test_release_verifies_by_reading_back(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_release_reports_write_failure(tmp_path, monkeypatch):
+async def test_release_reports_write_failure(tmp_path, monkeypatch, caplog):
+    """Die Meldung nennt den errno, deutet ihn aber nicht als Rechteproblem.
+
+    _write_hwmon_file meldet nach einem gescheiterten sudo-tee-Fallback immer
+    EACCES, auch wenn der Kernel eigentlich EINVAL geliefert hat -- die
+    Formulierung darf deshalb nicht "keine Rechte" behaupten (#534).
+    """
     backend, fan_id = await _backend(tmp_path, monkeypatch)
 
     async def refuse(path, value):
@@ -78,7 +85,13 @@ async def test_release_reports_write_failure(tmp_path, monkeypatch):
 
     monkeypatch.setattr(backend, "_write_hwmon_file", refuse)
 
-    assert await backend.release_to_board(fan_id, 5) is False
+    with caplog.at_level(logging.WARNING):
+        assert await backend.release_to_board(fan_id, 5) is False
+
+    assert str(errno.EINVAL) in caplog.text
+    lowered = caplog.text.lower()
+    assert "recht" not in lowered
+    assert "permission" not in lowered
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_fan_release_to_board.py
+++ b/backend/tests/test_fan_release_to_board.py
@@ -1,0 +1,103 @@
+"""Rueckgabe von pwm_enable an die Board-Automatik (#534).
+
+Der Rueckgabe-Write umgeht das Backoff aus #533 von selbst: dessen Sperre sitzt
+in set_pwm (fan_backend_linux.py:168-174), nicht in _write_hwmon_file. Laege sie
+davor, unterbliebe die Rueckgabe ausgerechnet bei den Kanaelen, die zuvor
+Schreibfehler hatten -- den kritischsten.
+"""
+import errno
+import os
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+from app.services.power.fan_backend_dev import DevFanControlBackend
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+def _tree(tmp_path: Path) -> Path:
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "nct6775.656"
+    hwmon = device / "hwmon" / "hwmon3"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nct6798\n")
+    (hwmon / "pwm1").write_text("128\n")
+    (hwmon / "pwm1_enable").write_text("1\n")
+    (hwmon / "fan1_input").write_text("900\n")
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / "hwmon3", target_is_directory=True)
+    return klass
+
+
+async def _backend(tmp_path, monkeypatch):
+    klass = _tree(tmp_path)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+    await backend._scan_pwm_fans()
+    return backend, next(iter(backend._fan_cache))
+
+
+@pytest.mark.asyncio
+async def test_release_writes_the_value(tmp_path, monkeypatch):
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+
+    ok = await backend.release_to_board(fan_id, 5)
+
+    assert ok is True
+    path = backend._fan_cache[fan_id]["pwm_enable_path"]
+    assert path.read_text().strip() == "5"
+
+
+@pytest.mark.asyncio
+async def test_release_verifies_by_reading_back(tmp_path, monkeypatch):
+    """Ein still ignorierter Write darf nicht als Erfolg durchgehen."""
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+
+    async def swallow(path, value):
+        return True, None   # tut so, als haette es geschrieben
+
+    monkeypatch.setattr(backend, "_write_hwmon_file", swallow)
+
+    ok = await backend.release_to_board(fan_id, 5)
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_release_reports_write_failure(tmp_path, monkeypatch):
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+
+    async def refuse(path, value):
+        return False, errno.EINVAL
+
+    monkeypatch.setattr(backend, "_write_hwmon_file", refuse)
+
+    assert await backend.release_to_board(fan_id, 5) is False
+
+
+@pytest.mark.asyncio
+async def test_release_ignores_the_write_backoff(tmp_path, monkeypatch):
+    """Genau die Kanaele mit Schreibfehlern brauchen die Rueckgabe."""
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+    backend._write_backoff[fan_id] = (8, backend._monotonic() + 900)
+
+    assert await backend.release_to_board(fan_id, 5) is True
+
+
+@pytest.mark.asyncio
+async def test_release_on_unknown_fan_is_false(tmp_path, monkeypatch):
+    backend, _ = await _backend(tmp_path, monkeypatch)
+    assert await backend.release_to_board("gibt-es-nicht:pwm9", 5) is False
+
+
+@pytest.mark.asyncio
+async def test_dev_backend_release_is_a_noop():
+    backend = DevFanControlBackend(get_settings())
+    fans = await backend.get_fans()
+    assert await backend.release_to_board(fans[0].fan_id, 5) is True

--- a/backend/tests/test_fan_restore_persistence.py
+++ b/backend/tests/test_fan_restore_persistence.py
@@ -1,0 +1,140 @@
+"""Die Beobachtung wird persistiert -- und updated_at bleibt unangetastet (#534).
+
+updated_at traegt onupdate=func.now() (models/fans.py:107-112) und ist das
+Rangkriterium des Identitaets-Abgleichs (fan_reconcile.py:151). Ein Schreiben
+bei jedem Start setzte jede Zeile auf "gerade angefasst" und entwertete es.
+"""
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import Base
+from app.models.fans import FanConfig
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_control import FanControlService
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def _service(session_factory, monkeypatch, *, primary=True):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = True
+    config.is_dev_mode = False
+    service = FanControlService(config, session_factory)
+    service._use_linux_backend = True
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        primary, raising=False)
+    return service
+
+
+def test_persist_does_not_create_rows(session_factory, monkeypatch):
+    """_persist_restore_values fasst nur bestehende Zeilen an.
+
+    Die Erstbeobachtung eines NEUEN Luefters kommt nicht von hier, sondern
+    direkt am FanConfig(...)-Objekt der Anlage-Schleife (Step 5) -- sonst
+    entstuende unmittelbar nach dem INSERT ein zweiter Schreibvorgang.
+    """
+    service = _service(session_factory, monkeypatch)
+    service._persist_restore_values({"nct6798-isa-0290:pwm1": 5})
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one_or_none()
+    assert row is None
+
+
+def test_existing_row_is_updated(session_factory, monkeypatch):
+    with session_factory() as db:
+        db.add(FanConfig(fan_id="nct6798-isa-0290:pwm1", name="nct6798 PWM1",
+                         mode="auto", is_active=True))
+        db.commit()
+
+    service = _service(session_factory, monkeypatch)
+    service._persist_restore_values({"nct6798-isa-0290:pwm1": 5})
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.pwm_enable_restore == 5
+
+
+def test_updated_at_does_not_move(session_factory, monkeypatch):
+    stamp = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    with session_factory() as db:
+        db.add(FanConfig(fan_id="nct6798-isa-0290:pwm1", name="nct6798 PWM1",
+                         mode="auto", is_active=True, updated_at=stamp))
+        db.commit()
+
+    service = _service(session_factory, monkeypatch)
+    service._persist_restore_values({"nct6798-isa-0290:pwm1": 5})
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.updated_at.replace(tzinfo=timezone.utc) == stamp
+
+
+def test_unchanged_value_writes_nothing(session_factory, monkeypatch):
+    stamp = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    with session_factory() as db:
+        db.add(FanConfig(fan_id="nct6798-isa-0290:pwm1", name="nct6798 PWM1",
+                         mode="auto", is_active=True, updated_at=stamp,
+                         pwm_enable_restore=5))
+        db.commit()
+
+    service = _service(session_factory, monkeypatch)
+    service._persist_restore_values({"nct6798-isa-0290:pwm1": 5})
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.updated_at.replace(tzinfo=timezone.utc) == stamp
+    assert row.pwm_enable_restore == 5
+
+
+def test_secondary_worker_persists_nothing(session_factory, monkeypatch):
+    with session_factory() as db:
+        db.add(FanConfig(fan_id="nct6798-isa-0290:pwm1", name="nct6798 PWM1",
+                         mode="auto", is_active=True))
+        db.commit()
+
+    service = _service(session_factory, monkeypatch, primary=False)
+    service._persist_restore_values({"nct6798-isa-0290:pwm1": 5})
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.pwm_enable_restore is None
+
+
+def test_new_row_carries_the_observation():
+    """Die Erstbeobachtung landet am neu angelegten FanConfig-Objekt.
+
+    Geprueft wird der Konstruktoraufruf, nicht der UPDATE-Pfad -- fuer einen
+    neuen Luefter gibt es zum Zeitpunkt der Anlage noch keine Zeile, die man
+    aktualisieren koennte.
+    """
+    from app.models.fans import FanConfig
+
+    observations = {"nct6798-isa-0290:pwm1": 5}
+    config = FanConfig(
+        fan_id="nct6798-isa-0290:pwm1",
+        name="nct6798 PWM1",
+        mode="auto",
+        is_active=True,
+        pwm_enable_restore=observations.get("nct6798-isa-0290:pwm1"),
+    )
+    assert config.pwm_enable_restore == 5
+
+    unknown = FanConfig(
+        fan_id="nct6798-isa-0290:pwm2",
+        name="nct6798 PWM2",
+        mode="auto",
+        is_active=True,
+        pwm_enable_restore=observations.get("nct6798-isa-0290:pwm2"),
+    )
+    assert unknown.pwm_enable_restore is None

--- a/backend/tests/test_fan_restore_persistence.py
+++ b/backend/tests/test_fan_restore_persistence.py
@@ -4,16 +4,20 @@ updated_at traegt onupdate=func.now() (models/fans.py:107-112) und ist das
 Rangkriterium des Identitaets-Abgleichs (fan_reconcile.py:151). Ein Schreiben
 bei jedem Start setzte jede Zeile auf "gerade angefasst" und entwertete es.
 """
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
+from app.core.config import get_settings
 from app.models.base import Base
 from app.models.fans import FanConfig
 from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
 from app.services.power.fan_control import FanControlService
 
 
@@ -111,30 +115,81 @@ def test_secondary_worker_persists_nothing(session_factory, monkeypatch):
     assert row.pwm_enable_restore is None
 
 
-def test_new_row_carries_the_observation():
-    """Die Erstbeobachtung landet am neu angelegten FanConfig-Objekt.
+def _tree(tmp_path: Path, enable_value: str) -> Path:
+    """nct6798 an platform/nct6775.656, doppelpunktfrei (Windows).
 
-    Geprueft wird der Konstruktoraufruf, nicht der UPDATE-Pfad -- fuer einen
-    neuen Luefter gibt es zum Zeitpunkt der Anlage noch keine Zeile, die man
-    aktualisieren koennte.
+    Baummuster aus test_fan_scan_pwm_enable.py uebernommen (Fix-Brief zu #534,
+    Fix 1) -- NTFS erlaubt keinen Doppelpunkt im Verzeichnisnamen, deshalb der
+    Platform-Pfad statt eines PCI-Pfads.
     """
-    from app.models.fans import FanConfig
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "nct6775.656"
+    hwmon = device / "hwmon" / "hwmon3"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nct6798\n")
+    (hwmon / "pwm1").write_text("128\n")
+    (hwmon / "pwm1_enable").write_text(enable_value + "\n")
+    (hwmon / "fan1_input").write_text("900\n")
+    (hwmon / "temp1_input").write_text("42000\n")
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / "hwmon3", target_is_directory=True)
+    return klass
 
-    observations = {"nct6798-isa-0290:pwm1": 5}
-    config = FanConfig(
-        fan_id="nct6798-isa-0290:pwm1",
-        name="nct6798 PWM1",
-        mode="auto",
-        is_active=True,
-        pwm_enable_restore=observations.get("nct6798-isa-0290:pwm1"),
-    )
-    assert config.pwm_enable_restore == 5
 
-    unknown = FanConfig(
-        fan_id="nct6798-isa-0290:pwm2",
-        name="nct6798 PWM2",
-        mode="auto",
-        is_active=True,
-        pwm_enable_restore=observations.get("nct6798-isa-0290:pwm2"),
+@pytest.mark.asyncio
+async def test_load_fan_configs_wires_scan_observation_through_to_restore_values(
+    tmp_path, session_factory, monkeypatch,
+):
+    """Schliesst die drei Naehte zwischen Scan und Persistenz gleichzeitig (#534).
+
+    Ein geloeschter Aufruf an fan_control.py:457
+    (observations = self._collect_pwm_enable_observations()), :580
+    (pwm_enable_restore=observations.get(fan.fan_id) am neu angelegten
+    FanConfig) oder :606 (self._persist_restore_values(observations)) liess
+    zuvor alle Tests gruen -- dieser Test durchlaeuft _load_fan_configs() echt,
+    mit einem echten LinuxFanControlBackend ueber einem tmp_path-sysfs-Baum und
+    einer echten SQLite-Session.
+
+    Gegenprobe beim Schreiben dieses Tests ergab: _persist_restore_values
+    (naht :606) liest bei jedem Aufruf ALLE Zeilen neu und korrigiert jede mit
+    derselben observations-Momentaufnahme -- auch die soeben erst angelegte.
+    Ein blosses Entfernen von :580 aendert deshalb den *externen* Endzustand
+    der Zeile nicht: :606 heilt ihn im selben Durchlauf nach, und eine
+    Assertion allein auf dem finalen DB-Wert wuerde bei geloeschtem :580 gruen
+    bleiben (geprueft und beobachtet). Deshalb wird _persist_restore_values
+    hier durch einen Spy ersetzt, der die Beobachtungen nur aufzeichnet, aber
+    NICHT mehr in die DB schreibt -- so bleibt :580 isoliert pruefbar, ohne
+    Produktivcode zu aendern. Die Korrektheit von _persist_restore_values
+    selbst (inkl. dem Befuellen von service._restore_values) ist bereits durch
+    die uebrigen Tests dieser Datei direkt abgedeckt.
+    """
+    klass = _tree(tmp_path, "5")
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+    await backend._scan_pwm_fans()
+
+    service = _service(session_factory, monkeypatch)
+    service._backend = backend
+
+    persist_calls = []
+    monkeypatch.setattr(
+        service, "_persist_restore_values",
+        lambda observations: persist_calls.append(dict(observations)),
     )
-    assert unknown.pwm_enable_restore is None
+
+    await service._load_fan_configs()
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    # Schliesst :457 und :580: der neu angelegte Datensatz traegt die
+    # Scan-Beobachtung -- ohne Mithilfe des (hier stillgelegten) Persist-Aufrufs.
+    assert row.pwm_enable_restore == 5
+
+    # Schliesst :606: der Aufruf fand statt, und zwar mit genau dieser
+    # Beobachtung.
+    assert persist_calls == [{row.fan_id: 5}]

--- a/backend/tests/test_fan_restore_rule.py
+++ b/backend/tests/test_fan_restore_rule.py
@@ -47,6 +47,22 @@ def test_without_observation_there_is_no_target():
     assert resolve_restore_value(scanned=None, stored=None) is None
 
 
+def test_manual_control_value_in_storage_is_never_returned():
+    """Die Spalte hat keinen CHECK-Constraint -- der gespeicherte Wert wird
+    deshalb ebenso geprueft wie der gescannte. Eine "1" in der DB (manuelle
+    Aenderung, Backfill, geflickter Dump) darf beim Beenden nicht als
+    Rueckgabeziel dienen -- das waere genau der kaputte Zustand, den #534
+    beseitigen soll.
+    """
+    assert resolve_restore_value(scanned=None, stored=1) is None
+
+
+def test_full_speed_value_in_storage_is_never_returned():
+    """Wie oben, fuer den anderen Nicht-Automatik-Wert (Vollgas, kein
+    CHECK-Constraint auf der Spalte)."""
+    assert resolve_restore_value(scanned=None, stored=0) is None
+
+
 def test_needs_release_only_with_a_target():
     assert needs_release(current=1, target=5) is True
     assert needs_release(current=5, target=5) is False

--- a/backend/tests/test_fan_restore_rule.py
+++ b/backend/tests/test_fan_restore_rule.py
@@ -1,0 +1,63 @@
+"""Regel fuer die Rueckgabe an die Board-Automatik (#534).
+
+Zurueckgeschrieben wird ausschliesslich ein Wert, den BaluHost am selben Chip
+selbst gelesen hat. 0 und 1 sind keine Automatik: 1 ist Handsteuerung, 0 heisst
+laut hwmon-Konvention "no fan speed control (i.e. fan at full speed)".
+"""
+import pytest
+
+from app.services.power.fan_restore import (
+    is_observation,
+    needs_release,
+    resolve_restore_value,
+)
+
+
+@pytest.mark.parametrize("value,expected", [
+    (5, True),      # Smart Fan IV
+    (2, True),      # Thermal Cruise
+    (1, False),     # Handsteuerung -- jemand hat uebernommen
+    (0, False),     # Vollgas, keine Chip-Regelung
+    (None, False),  # nicht lesbar
+])
+def test_is_observation(value, expected):
+    assert is_observation(value) is expected
+
+
+def test_observation_is_stored():
+    assert resolve_restore_value(scanned=5, stored=None) == 5
+
+
+def test_newer_observation_wins():
+    """Der Chip meldet jetzt Thermal Cruise -- das ist die aktuellere Wahrheit."""
+    assert resolve_restore_value(scanned=2, stored=5) == 2
+
+
+def test_non_observation_keeps_stored_value():
+    """Nach einem Deploy-Neustart steht dort 1; der gespeicherte Wert bleibt."""
+    assert resolve_restore_value(scanned=1, stored=5) == 5
+    assert resolve_restore_value(scanned=0, stored=5) == 5
+    assert resolve_restore_value(scanned=None, stored=5) == 5
+
+
+def test_without_observation_there_is_no_target():
+    """Der Kern des Entwurfs: ohne Beobachtung passiert nichts."""
+    assert resolve_restore_value(scanned=1, stored=None) is None
+    assert resolve_restore_value(scanned=0, stored=None) is None
+    assert resolve_restore_value(scanned=None, stored=None) is None
+
+
+def test_needs_release_only_with_a_target():
+    assert needs_release(current=1, target=5) is True
+    assert needs_release(current=5, target=5) is False
+    assert needs_release(current=1, target=None) is False
+
+
+def test_manual_at_full_speed_reads_as_zero_and_still_needs_release():
+    """reg_to_pwm_enable() meldet Manual mit Duty 255 als 0, nicht als 1."""
+    assert needs_release(current=0, target=5) is True
+
+
+def test_unreadable_current_value_is_treated_as_deviation():
+    """Lieber einmal zu viel schreiben als die Automatik ausgeschaltet lassen."""
+    assert needs_release(current=None, target=5) is True

--- a/backend/tests/test_fan_scan_pwm_enable.py
+++ b/backend/tests/test_fan_scan_pwm_enable.py
@@ -1,0 +1,73 @@
+"""Der Scan liest pwm_enable, bevor der erste Write ihn ueberschreibt (#534).
+
+_scan_pwm_fans laeuft aus is_available() beim Backend-Init -- einmal pro Start
+und vor dem ersten set_pwm. Das ist der einzige Moment, in dem der Board-Wert
+ueberhaupt sichtbar sein kann.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+def _tree(tmp_path: Path, enable_value: str | None) -> Path:
+    """nct6798 an platform/nct6775.656, doppelpunktfrei (Windows)."""
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "nct6775.656"
+    hwmon = device / "hwmon" / "hwmon3"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nct6798\n")
+    (hwmon / "pwm1").write_text("128\n")
+    (hwmon / "fan1_input").write_text("900\n")
+    (hwmon / "temp1_input").write_text("42000\n")
+    if enable_value is not None:
+        (hwmon / "pwm1_enable").write_text(enable_value + "\n")
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / "hwmon3", target_is_directory=True)
+    return klass
+
+
+@pytest.mark.asyncio
+async def test_scan_captures_automatic_mode(tmp_path, monkeypatch):
+    klass = _tree(tmp_path, "5")
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+
+    cache = await backend._scan_pwm_fans()
+
+    fan_id = next(iter(cache))
+    assert cache[fan_id]["pwm_enable_at_scan"] == 5
+
+
+@pytest.mark.asyncio
+async def test_scan_captures_manual_mode_as_is(tmp_path, monkeypatch):
+    """Der Scan bewertet nicht -- er liest. Die Regel entscheidet spaeter."""
+    klass = _tree(tmp_path, "1")
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+
+    cache = await backend._scan_pwm_fans()
+
+    fan_id = next(iter(cache))
+    assert cache[fan_id]["pwm_enable_at_scan"] == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_enable_file_yields_none(tmp_path, monkeypatch):
+    klass = _tree(tmp_path, None)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+
+    cache = await backend._scan_pwm_fans()
+
+    fan_id = next(iter(cache))
+    assert cache[fan_id]["pwm_enable_at_scan"] is None
+    assert cache[fan_id]["pwm_enable_path"] is None

--- a/docs/TECHNICAL_DOCUMENTATION.md
+++ b/docs/TECHNICAL_DOCUMENTATION.md
@@ -1267,19 +1267,19 @@ If the identity-matching logic fails at startup (e.g., due to an unexpected hard
 **Secondary Worker Behavior:**  
 The configuration-creation logic runs only on the primary Uvicorn worker. A backend-switching request (e.g., switching from `dev` to `prod` mode via HTTP) landing on a secondary worker will not create configs for newly-visible fans; these configs are created on the next primary-worker startup cycle (either an immediate restart or the next service restart). This is transparent to the user but introduces a brief window where newly-visible fans lack a configuration row.
 
-#### Rückgabe an die Board-Automatik beim Beenden (#534)
+#### Handback to Board Automation on Shutdown (#534)
 
-Beim Beenden des Dienstes wird `pwm_enable` auf den Automatikmodus zurückgeschrieben, den BaluHost am selben Chip zuvor gelesen hat. Damit regelt nach einem Deploy-Neustart das Board, statt dass die Lüfter auf dem letzten Wert einfrieren.
+When the service stops, `pwm_enable` is written back to the automatic mode that BaluHost previously read from that same chip. After a deploy restart the board takes over the curve again, instead of leaving the fans frozen at their last value.
 
-**Nur beobachtete Werte.** Es wird nichts geraten. Ein Wert wird nur übernommen, wenn der Scan beim Start einen Automatikmodus (`pwm_enable >= 2`) vorfindet — das ist nach einem Kaltstart der Fall, nicht nach einem Dienst-Neustart.
+**Observed values only.** Nothing is guessed. A value is adopted only if the startup scan found an automatic mode (`pwm_enable >= 2`) — which is the case after a cold boot, but not after a service restart.
 
-**Auf einer laufenden Installation greift die Funktion daher erst nach dem nächsten Kaltstart.** Wer nicht warten will, setzt den Wert einmal bei gestopptem Dienst von Hand (`echo 5 > /sys/class/hwmon/hwmonN/pwmM_enable`); der nächste Start übernimmt ihn.
+**On a running installation the feature therefore only takes effect after the next cold boot.** To avoid waiting, set the value once by hand while the service is stopped (`echo 5 > /sys/class/hwmon/hwmonN/pwmM_enable`); the next startup picks it up.
 
-**GPU-Lüfter sind ausgenommen.** Für AMD-Karten existiert ein eigener Rückgabeweg, der zusätzlich das Performance-Level zurücksetzt.
+**GPU fans are excluded.** AMD cards have their own handback path, which additionally resets the performance level.
 
-**Bei `SIGKILL` oder Stromausfall gibt es keine Rückgabe.** `systemctl stop` und der Deploy-Neustart senden `SIGTERM` und sind abgedeckt.
+**On `SIGKILL` or a power loss there is no handback.** `systemctl stop` and the deploy restart send `SIGTERM` and are covered.
 
-Ein Hinweis zum Ablesen: ein Lüfter, der bei 100 % läuft, meldet `pwm_enable` als `0`, nicht als `1`.
+One note on reading the value: a fan running at 100 % reports `pwm_enable` as `0`, not as `1`.
 
 ---
 

--- a/docs/TECHNICAL_DOCUMENTATION.md
+++ b/docs/TECHNICAL_DOCUMENTATION.md
@@ -1267,6 +1267,20 @@ If the identity-matching logic fails at startup (e.g., due to an unexpected hard
 **Secondary Worker Behavior:**  
 The configuration-creation logic runs only on the primary Uvicorn worker. A backend-switching request (e.g., switching from `dev` to `prod` mode via HTTP) landing on a secondary worker will not create configs for newly-visible fans; these configs are created on the next primary-worker startup cycle (either an immediate restart or the next service restart). This is transparent to the user but introduces a brief window where newly-visible fans lack a configuration row.
 
+#### Rückgabe an die Board-Automatik beim Beenden (#534)
+
+Beim Beenden des Dienstes wird `pwm_enable` auf den Automatikmodus zurückgeschrieben, den BaluHost am selben Chip zuvor gelesen hat. Damit regelt nach einem Deploy-Neustart das Board, statt dass die Lüfter auf dem letzten Wert einfrieren.
+
+**Nur beobachtete Werte.** Es wird nichts geraten. Ein Wert wird nur übernommen, wenn der Scan beim Start einen Automatikmodus (`pwm_enable >= 2`) vorfindet — das ist nach einem Kaltstart der Fall, nicht nach einem Dienst-Neustart.
+
+**Auf einer laufenden Installation greift die Funktion daher erst nach dem nächsten Kaltstart.** Wer nicht warten will, setzt den Wert einmal bei gestopptem Dienst von Hand (`echo 5 > /sys/class/hwmon/hwmonN/pwmM_enable`); der nächste Start übernimmt ihn.
+
+**GPU-Lüfter sind ausgenommen.** Für AMD-Karten existiert ein eigener Rückgabeweg, der zusätzlich das Performance-Level zurücksetzt.
+
+**Bei `SIGKILL` oder Stromausfall gibt es keine Rückgabe.** `systemctl stop` und der Deploy-Neustart senden `SIGTERM` und sind abgedeckt.
+
+Ein Hinweis zum Ablesen: ein Lüfter, der bei 100 % läuft, meldet `pwm_enable` als `0`, nicht als `1`.
+
 ---
 
 ### 17. Monitoring Orchestrator

--- a/docs/superpowers/plans/2026-09-05-fan-handback-on-shutdown.md
+++ b/docs/superpowers/plans/2026-09-05-fan-handback-on-shutdown.md
@@ -1,0 +1,1358 @@
+# Rückgabe an die Board-Automatik beim Dienst-Ende — Implementierungsplan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Beim Beenden des Dienstes `pwm_enable` auf den Automatikmodus zurückschreiben, den BaluHost am selben Chip zuvor selbst beobachtet hat — damit nach einem Deploy nicht niemand regelt.
+
+**Architecture:** Ein kleines reines Modul entscheidet, *ob* und *worauf* zurückgegeben wird. Der Scan liest `pwm_enable` einmal pro Start (vor dem ersten Write) in den Cache; der Primary-Worker persistiert daraus eine Beobachtung. Eine neue Backend-Methode schreibt den Wert zurück und liest ihn zur Kontrolle wieder. Kein Besitz-Modell, kein geratener Treiber-Fallback.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLAlchemy 2.0, Alembic, pytest. Keine neuen Abhängigkeiten.
+
+**Spec:** `docs/superpowers/specs/2026-09-05-fan-ownership-handback-design.md`
+
+## Global Constraints
+
+- **Nur beobachtete Werte.** Zurückgeschrieben wird ausschliesslich ein `pwm_enable`-Wert **≥ 2**, den BaluHost am selben Chip gelesen hat. Kein Treiber-Fallback, kein geratener Modus.
+- **`0` und `1` sind keine Automatik.** `1` ist Handsteuerung; `0` heisst laut hwmon-Konvention „no fan speed control (i.e. fan at full speed)".
+- **Keine GPU-Lüfter.** Ausschluss über `gpu_vendor is not None` (nicht über `FIRMWARE_MANAGED` — das deckt Pre-RDNA3 nicht).
+- **Nur der Primary-Worker gibt zurück.** Gelesen als `getattr(lifespan, "IS_PRIMARY_WORKER", False)` — `lifespan` als **Modul** importiert, nie `from ... import` (das Flag wird erst zur Laufzeit gesetzt).
+- **`updated_at` darf nicht wandern.** Die Spalte trägt `onupdate=func.now()` (`models/fans.py:107-112`) und ist das Rangkriterium des Identitäts-Abgleichs (`fan_reconcile.py:151`).
+- Keine neuen Abhängigkeiten. Python-Kommentare und Log-Meldungen auf Deutsch, **ohne Umlaute**; in `.md`-Dateien sind Umlaute erwünscht.
+- Die volle Backend-Suite läuft in der CI, nicht lokal (hängt auf Windows). Lokal: `cd backend ; python -m pytest -k "fan or power" -q`.
+- **Die Messlatte ist vor Task 1 einmal zu messen** und mit Datum zu notieren — eine Zahl aus einem früheren Lauf ist keine Messlatte.
+- Testbäume platform-förmig und **doppelpunktfrei** (NTFS verbietet Doppelpunkte in Verzeichnisnamen). Muster: `test_fan_pwm_backoff.py:28-51`, `test_fan_scan_stable_ids.py`.
+
+---
+
+### Task 1: `fan_restore.py` — die Entscheidungsregel
+
+Drei reine Funktionen. Sie fassen weder sysfs noch Datenbank an und tragen die gesamte Politik des Vorhabens.
+
+**Files:**
+- Create: `backend/app/services/power/fan_restore.py`
+- Test: `backend/tests/test_fan_restore_rule.py`
+
+**Interfaces:**
+- Produces: `is_observation(value: Optional[int]) -> bool`, `resolve_restore_value(scanned: Optional[int], stored: Optional[int]) -> Optional[int]`, `needs_release(current: Optional[int], target: Optional[int]) -> bool`
+
+- [ ] **Step 1: Messlatte festhalten**
+
+Run: `cd backend ; python -m pytest -k "fan or power" -q`
+Notiere die Zahl und das Datum im Task-Report. Sie ist der Vergleichswert für alle folgenden Tasks.
+
+- [ ] **Step 2: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_restore_rule.py`:
+
+```python
+"""Regel fuer die Rueckgabe an die Board-Automatik (#534).
+
+Zurueckgeschrieben wird ausschliesslich ein Wert, den BaluHost am selben Chip
+selbst gelesen hat. 0 und 1 sind keine Automatik: 1 ist Handsteuerung, 0 heisst
+laut hwmon-Konvention "no fan speed control (i.e. fan at full speed)".
+"""
+import pytest
+
+from app.services.power.fan_restore import (
+    is_observation,
+    needs_release,
+    resolve_restore_value,
+)
+
+
+@pytest.mark.parametrize("value,expected", [
+    (5, True),      # Smart Fan IV
+    (2, True),      # Thermal Cruise
+    (1, False),     # Handsteuerung -- jemand hat uebernommen
+    (0, False),     # Vollgas, keine Chip-Regelung
+    (None, False),  # nicht lesbar
+])
+def test_is_observation(value, expected):
+    assert is_observation(value) is expected
+
+
+def test_observation_is_stored():
+    assert resolve_restore_value(scanned=5, stored=None) == 5
+
+
+def test_newer_observation_wins():
+    """Der Chip meldet jetzt Thermal Cruise -- das ist die aktuellere Wahrheit."""
+    assert resolve_restore_value(scanned=2, stored=5) == 2
+
+
+def test_non_observation_keeps_stored_value():
+    """Nach einem Deploy-Neustart steht dort 1; der gespeicherte Wert bleibt."""
+    assert resolve_restore_value(scanned=1, stored=5) == 5
+    assert resolve_restore_value(scanned=0, stored=5) == 5
+    assert resolve_restore_value(scanned=None, stored=5) == 5
+
+
+def test_without_observation_there_is_no_target():
+    """Der Kern des Entwurfs: ohne Beobachtung passiert nichts."""
+    assert resolve_restore_value(scanned=1, stored=None) is None
+    assert resolve_restore_value(scanned=0, stored=None) is None
+    assert resolve_restore_value(scanned=None, stored=None) is None
+
+
+def test_needs_release_only_with_a_target():
+    assert needs_release(current=1, target=5) is True
+    assert needs_release(current=5, target=5) is False
+    assert needs_release(current=1, target=None) is False
+
+
+def test_manual_at_full_speed_reads_as_zero_and_still_needs_release():
+    """reg_to_pwm_enable() meldet Manual mit Duty 255 als 0, nicht als 1."""
+    assert needs_release(current=0, target=5) is True
+
+
+def test_unreadable_current_value_is_treated_as_deviation():
+    """Lieber einmal zu viel schreiben als die Automatik ausgeschaltet lassen."""
+    assert needs_release(current=None, target=5) is True
+```
+
+- [ ] **Step 3: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_restore_rule.py -v`
+Expected: FAIL mit `ModuleNotFoundError: No module named 'app.services.power.fan_restore'`
+
+- [ ] **Step 4: Modul anlegen**
+
+`backend/app/services/power/fan_restore.py`:
+
+```python
+"""Entscheidet, ob und worauf ein Luefter an die Board-Automatik zurueckgeht (#534).
+
+Reine Regel ohne sysfs- und ohne DB-Zugriff. Der Entwurf steht und faellt mit
+einem Grundsatz: zurueckgeschrieben wird ausschliesslich ein Wert, den BaluHost
+am selben Chip selbst gelesen hat. Ein geratener Treibermodus waere eine
+Annahme ueber fremde Hardware, die niemand ueberpruefen kann.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+# Ab hier regelt der Chip selbst. Darunter liegen die beiden Zustaende, in
+# denen er es NICHT tut:
+#   1 = Handsteuerung (jemand hat uebernommen -- in aller Regel wir)
+#   0 = "no fan speed control (i.e. fan at full speed)" laut hwmon-Konvention;
+#       der nct6775-Treiber setzt dabei zusaetzlich Duty 255
+_LOWEST_AUTOMATIC_MODE = 2
+
+
+def is_observation(value: Optional[int]) -> bool:
+    """Taugt der gelesene pwm_enable-Wert als Rueckgabeziel?"""
+    return value is not None and value >= _LOWEST_AUTOMATIC_MODE
+
+
+def resolve_restore_value(scanned: Optional[int],
+                          stored: Optional[int]) -> Optional[int]:
+    """Der Rueckgabewert: juengere Beobachtung schlaegt gespeicherten Wert.
+
+    Ist der gescannte Wert keine Beobachtung, bleibt der gespeicherte
+    unveraendert -- er stammt dann aus einem frueheren Kaltstart und ist das
+    Beste, was wir haben. Gibt es auch den nicht, gibt es keine Rueckgabe.
+    """
+    if is_observation(scanned):
+        return scanned
+    return stored
+
+
+def needs_release(current: Optional[int], target: Optional[int]) -> bool:
+    """Muss geschrieben werden?
+
+    Ein nicht lesbarer Ist-Wert gilt als Abweichung: lieber einmal zu viel
+    schreiben, als die Board-Automatik ausgeschaltet zu lassen.
+    """
+    if target is None:
+        return False
+    return current != target
+```
+
+- [ ] **Step 5: Test laufen lassen, Erfolg bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_restore_rule.py -v`
+Expected: PASS (13 Fälle)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/power/fan_restore.py backend/tests/test_fan_restore_rule.py
+git commit -m "feat(fans): Regel fuer die Rueckgabe an die Board-Automatik (#534)"
+```
+
+---
+
+### Task 2: Spalte und Migration
+
+**Files:**
+- Modify: `backend/app/models/fans.py` (`FanConfig`)
+- Create: `backend/alembic/versions/<rev>_fan_pwm_enable_restore.py`
+
+**Interfaces:**
+- Produces: `FanConfig.pwm_enable_restore: Optional[int]`
+
+- [ ] **Step 1: Head prüfen**
+
+Run: `cd backend ; python -m alembic heads`
+Expected: genau eine Zeile. Zum Zeitpunkt der Planung war das `193f03f94b4e` — **verlasse dich nicht darauf**, sondern nimm die Ausgabe von jetzt. Zeigt der Befehl mehr als eine Zeile, **stoppe** und melde BLOCKED: das Projekt hatte bereits einen Deploy-Fehler durch mehrere Heads.
+
+- [ ] **Step 2: Modell erweitern**
+
+`backend/app/models/fans.py`, in `FanConfig` direkt nach `legacy_fan_id`:
+
+```python
+    # Der pwm_enable-Wert, auf den beim Dienst-Ende zurueckgeschaltet wird
+    # (#534). Wird ausschliesslich aus einer eigenen Beobachtung gefuellt --
+    # ein Wert >= 2, den der Scan vor dem ersten Write gelesen hat. NULL heisst:
+    # noch nie eine Automatik gesehen, also keine Rueckgabe.
+    pwm_enable_restore: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+```
+
+- [ ] **Step 3: Migration erzeugen**
+
+Run: `cd backend ; python -m alembic revision --autogenerate -m "fan pwm_enable restore"`
+
+**Autogenerate ist hier eine Falle.** Es vergleicht die Modelle mit deiner lokalen Dev-Datenbank und liefert Operationen mit, die niemand bestellt hat — bekannt ist mindestens ein `alter_column` auf `status_bar_pill_config.pill_id` (siehe #549, dort erklärt). Prüfe die erzeugte Datei Zeile für Zeile und entferne **alles** ausser dem einen `add_column` und seinem `drop_column` im `downgrade()`. Findest du weitere Operationen, nenne sie im Report.
+
+Prüfe ausserdem, dass `down_revision` auf den in Step 1 gelesenen Head zeigt.
+
+- [ ] **Step 4: Migration anwenden und zurückrollen**
+
+```bash
+cd backend
+python -m alembic upgrade head
+python -m alembic downgrade -1
+python -m alembic upgrade head
+python -m alembic heads
+```
+Expected: alle Läufe fehlerfrei, danach genau ein Head.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/models/fans.py backend/alembic/versions/
+git commit -m "feat(fans): Spalte fuer den beobachteten Rueckgabewert (#534)"
+```
+
+---
+
+### Task 3: Der Scan liest `pwm_enable`
+
+**Files:**
+- Modify: `backend/app/services/power/fan_backend_linux.py` (`_scan_pwm_fans`, um Zeile 484-516)
+- Test: `backend/tests/test_fan_scan_pwm_enable.py`
+
+**Interfaces:**
+- Produces: `_fan_cache[fan_id]["pwm_enable_at_scan"]: Optional[int]`
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_scan_pwm_enable.py`:
+
+```python
+"""Der Scan liest pwm_enable, bevor der erste Write ihn ueberschreibt (#534).
+
+_scan_pwm_fans laeuft aus is_available() beim Backend-Init -- einmal pro Start
+und vor dem ersten set_pwm. Das ist der einzige Moment, in dem der Board-Wert
+ueberhaupt sichtbar sein kann.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+def _tree(tmp_path: Path, enable_value: str | None) -> Path:
+    """nct6798 an platform/nct6775.656, doppelpunktfrei (Windows)."""
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "nct6775.656"
+    hwmon = device / "hwmon" / "hwmon3"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nct6798\n")
+    (hwmon / "pwm1").write_text("128\n")
+    (hwmon / "fan1_input").write_text("900\n")
+    (hwmon / "temp1_input").write_text("42000\n")
+    if enable_value is not None:
+        (hwmon / "pwm1_enable").write_text(enable_value + "\n")
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / "hwmon3", target_is_directory=True)
+    return klass
+
+
+@pytest.mark.asyncio
+async def test_scan_captures_automatic_mode(tmp_path, monkeypatch):
+    klass = _tree(tmp_path, "5")
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+
+    cache = await backend._scan_pwm_fans()
+
+    fan_id = next(iter(cache))
+    assert cache[fan_id]["pwm_enable_at_scan"] == 5
+
+
+@pytest.mark.asyncio
+async def test_scan_captures_manual_mode_as_is(tmp_path, monkeypatch):
+    """Der Scan bewertet nicht -- er liest. Die Regel entscheidet spaeter."""
+    klass = _tree(tmp_path, "1")
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+
+    cache = await backend._scan_pwm_fans()
+
+    fan_id = next(iter(cache))
+    assert cache[fan_id]["pwm_enable_at_scan"] == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_enable_file_yields_none(tmp_path, monkeypatch):
+    klass = _tree(tmp_path, None)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+
+    cache = await backend._scan_pwm_fans()
+
+    fan_id = next(iter(cache))
+    assert cache[fan_id]["pwm_enable_at_scan"] is None
+    assert cache[fan_id]["pwm_enable_path"] is None
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_scan_pwm_enable.py -v`
+Expected: FAIL mit `KeyError: 'pwm_enable_at_scan'`
+
+- [ ] **Step 3: Den Wert im Scan lesen**
+
+In `_scan_pwm_fans`, direkt **nach** der Zeile, die `pwm_enable_path` bestimmt (`pwm_enable_path = hwmon_dir / f"pwm{pwm_num}_enable"`), einfügen:
+
+```python
+                # pwm_enable EINMAL pro Start lesen, bevor set_pwm es auf 1
+                # setzt. Nach dem ersten Regelzyklus steht dort unser eigener
+                # Wert -- dies ist der einzige Moment, in dem der Board-Wert
+                # sichtbar sein kann (#534).
+                pwm_enable_at_scan = None
+                if pwm_enable_path.exists():
+                    pwm_enable_at_scan = await self._read_hwmon_file(pwm_enable_path)
+```
+
+Im Dict-Literal `new_cache[fan_id] = {...}` nach `"pwm_enable_path": ...` ergänzen:
+
+```python
+                    "pwm_enable_at_scan": pwm_enable_at_scan,
+```
+
+- [ ] **Step 4: Test laufen lassen, Erfolg bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_scan_pwm_enable.py tests/test_fan_scan_stable_ids.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/power/fan_backend_linux.py backend/tests/test_fan_scan_pwm_enable.py
+git commit -m "feat(fans): Scan liest pwm_enable vor dem ersten Write (#534)"
+```
+
+---
+
+### Task 4: `release_to_board` auf dem Backend
+
+**Files:**
+- Modify: `backend/app/services/power/fan_control.py:86-124` (ABC `FanControlBackend`)
+- Modify: `backend/app/services/power/fan_backend_linux.py`
+- Modify: `backend/app/services/power/fan_backend_dev.py`
+- Test: `backend/tests/test_fan_release_to_board.py`
+
+**Interfaces:**
+- Produces: `FanControlBackend.release_to_board(fan_id: str, enable_value: int) -> bool`
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_release_to_board.py`:
+
+```python
+"""Rueckgabe von pwm_enable an die Board-Automatik (#534).
+
+Der Rueckgabe-Write umgeht das Backoff aus #533 von selbst: dessen Sperre sitzt
+in set_pwm (fan_backend_linux.py:168-174), nicht in _write_hwmon_file. Laege sie
+davor, unterbliebe die Rueckgabe ausgerechnet bei den Kanaelen, die zuvor
+Schreibfehler hatten -- den kritischsten.
+"""
+import errno
+import os
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+from app.services.power.fan_backend_dev import DevFanControlBackend
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+def _tree(tmp_path: Path) -> Path:
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "nct6775.656"
+    hwmon = device / "hwmon" / "hwmon3"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nct6798\n")
+    (hwmon / "pwm1").write_text("128\n")
+    (hwmon / "pwm1_enable").write_text("1\n")
+    (hwmon / "fan1_input").write_text("900\n")
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / "hwmon3", target_is_directory=True)
+    return klass
+
+
+async def _backend(tmp_path, monkeypatch):
+    klass = _tree(tmp_path)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+    await backend._scan_pwm_fans()
+    return backend, next(iter(backend._fan_cache))
+
+
+@pytest.mark.asyncio
+async def test_release_writes_the_value(tmp_path, monkeypatch):
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+
+    ok = await backend.release_to_board(fan_id, 5)
+
+    assert ok is True
+    path = backend._fan_cache[fan_id]["pwm_enable_path"]
+    assert path.read_text().strip() == "5"
+
+
+@pytest.mark.asyncio
+async def test_release_verifies_by_reading_back(tmp_path, monkeypatch):
+    """Ein still ignorierter Write darf nicht als Erfolg durchgehen."""
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+
+    async def swallow(path, value):
+        return True, None   # tut so, als haette es geschrieben
+
+    monkeypatch.setattr(backend, "_write_hwmon_file", swallow)
+
+    ok = await backend.release_to_board(fan_id, 5)
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_release_reports_write_failure(tmp_path, monkeypatch):
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+
+    async def refuse(path, value):
+        return False, errno.EINVAL
+
+    monkeypatch.setattr(backend, "_write_hwmon_file", refuse)
+
+    assert await backend.release_to_board(fan_id, 5) is False
+
+
+@pytest.mark.asyncio
+async def test_release_ignores_the_write_backoff(tmp_path, monkeypatch):
+    """Genau die Kanaele mit Schreibfehlern brauchen die Rueckgabe."""
+    backend, fan_id = await _backend(tmp_path, monkeypatch)
+    backend._write_backoff[fan_id] = (8, backend._monotonic() + 900)
+
+    assert await backend.release_to_board(fan_id, 5) is True
+
+
+@pytest.mark.asyncio
+async def test_release_on_unknown_fan_is_false(tmp_path, monkeypatch):
+    backend, _ = await _backend(tmp_path, monkeypatch)
+    assert await backend.release_to_board("gibt-es-nicht:pwm9", 5) is False
+
+
+@pytest.mark.asyncio
+async def test_dev_backend_release_is_a_noop():
+    backend = DevFanControlBackend(get_settings())
+    fans = await backend.get_fans()
+    assert await backend.release_to_board(fans[0].fan_id, 5) is True
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_release_to_board.py -v`
+Expected: FAIL mit `AttributeError: 'LinuxFanControlBackend' object has no attribute 'release_to_board'`
+
+- [ ] **Step 3: Die ABC erweitern**
+
+`fan_control.py`, in `FanControlBackend` nach `set_pwm`:
+
+```python
+    @abstractmethod
+    async def release_to_board(self, fan_id: str, enable_value: int) -> bool:
+        """pwm_enable auf einen Automatikmodus zurueckschreiben (#534).
+
+        Args:
+            fan_id: Luefter-Kennung
+            enable_value: der beobachtete Automatikmodus (>= 2)
+
+        Returns:
+            True nur, wenn der Wert danach tatsaechlich anliegt.
+        """
+        pass
+```
+
+- [ ] **Step 4: Linux-Implementierung**
+
+`fan_backend_linux.py`, nach `set_pwm`:
+
+```python
+    async def release_to_board(self, fan_id: str, enable_value: int) -> bool:
+        """Gibt die Regelung dieses Kanals an die Chip-Automatik zurueck.
+
+        Umgeht das Write-Backoff aus #533 bewusst: dessen Sperre sitzt in
+        set_pwm, nicht hier. Ein Kanal mit Schreibfehlern ist genau der, bei dem
+        eine abgeschaltete Board-Automatik am meisten weh tut.
+        """
+        fan_info = self._fan_cache.get(fan_id)
+        if fan_info is None:
+            logger.warning(f"Rueckgabe fuer unbekannten Luefter {fan_id}")
+            return False
+
+        pwm_enable_path = fan_info.get("pwm_enable_path")
+        if pwm_enable_path is None:
+            return False
+
+        driver = fan_info.get("device_driver", "unknown")
+        ok, err_code = await self._write_hwmon_file(pwm_enable_path, str(enable_value))
+        if not ok:
+            # Achtung bei der Formulierung: _write_hwmon_file meldet nach einem
+            # gescheiterten sudo-tee-Fallback EACCES, auch wenn der Kernel
+            # eigentlich EINVAL geliefert hat (etwa weil check_trip_points()
+            # nicht-monotone BIOS-Stuetzstellen gefunden hat). Der errno wird
+            # deshalb genannt, aber nicht gedeutet.
+            logger.warning(
+                f"Rueckgabe an die Board-Automatik fehlgeschlagen: {fan_id} "
+                f"(driver={driver}, Ziel={enable_value}, errno={err_code}). "
+                f"Der Luefter bleibt in Handsteuerung -- es regelt niemand."
+            )
+            return False
+
+        readback = await self._read_hwmon_file(pwm_enable_path)
+        if readback != enable_value:
+            logger.warning(
+                f"Rueckgabe an die Board-Automatik ohne Wirkung: {fan_id} "
+                f"(driver={driver}, geschrieben={enable_value}, "
+                f"gelesen={readback}). Der Write wurde stillschweigend "
+                f"verworfen."
+            )
+            return False
+
+        logger.info(f"{fan_id}: an die Board-Automatik zurueckgegeben (pwm_enable={enable_value})")
+        return True
+```
+
+- [ ] **Step 5: Dev-Implementierung**
+
+`fan_backend_dev.py`, nach `set_pwm`:
+
+```python
+    async def release_to_board(self, fan_id: str, enable_value: int) -> bool:
+        """Kein hwmon im Dev-Modus -- es gibt nichts zurueckzugeben."""
+        return True
+```
+
+- [ ] **Step 6: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_release_to_board.py -v`
+Expected: PASS (6 Tests)
+
+Danach zur Absicherung, dass die neue abstrakte Methode keine bestehende Test-Doubles bricht:
+
+Run: `cd backend ; python -m pytest -k "fan or power" -q`
+
+Schlagen Tests mit `TypeError: Can't instantiate abstract class` fehl, fehlt die Methode in einem Test-Double — ergänze sie dort (Kandidaten: `test_fan_pwm_backoff.py:253`, `test_fan_firmware_managed_loop.py:28`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/power/fan_control.py backend/app/services/power/fan_backend_linux.py backend/app/services/power/fan_backend_dev.py backend/tests/
+git commit -m "feat(fans): release_to_board mit Ruecklese-Kontrolle (#534)"
+```
+
+---
+
+### Task 5: Persistenz der Beobachtung
+
+**Files:**
+- Modify: `backend/app/services/power/fan_control.py` (`_load_fan_configs`, Anlage-Schleife ab Zeile 428; Konstruktor)
+- Test: `backend/tests/test_fan_restore_persistence.py`
+
+**Interfaces:**
+- Consumes: `is_observation`, `resolve_restore_value` (Task 1); `_fan_cache[...]["pwm_enable_at_scan"]` (Task 3); `FanConfig.pwm_enable_restore` (Task 2)
+- Produces: `FanControlService._restore_values: Dict[str, int]`
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_restore_persistence.py`:
+
+```python
+"""Die Beobachtung wird persistiert -- und updated_at bleibt unangetastet (#534).
+
+updated_at traegt onupdate=func.now() (models/fans.py:107-112) und ist das
+Rangkriterium des Identitaets-Abgleichs (fan_reconcile.py:151). Ein Schreiben
+bei jedem Start setzte jede Zeile auf "gerade angefasst" und entwertete es.
+"""
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import Base
+from app.models.fans import FanConfig
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_control import FanControlService
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def _service(session_factory, monkeypatch, *, primary=True):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = True
+    config.is_dev_mode = False
+    service = FanControlService(config, session_factory)
+    service._use_linux_backend = True
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        primary, raising=False)
+    return service
+
+
+def test_persist_does_not_create_rows(session_factory, monkeypatch):
+    """_persist_restore_values fasst nur bestehende Zeilen an.
+
+    Die Erstbeobachtung eines NEUEN Luefters kommt nicht von hier, sondern
+    direkt am FanConfig(...)-Objekt der Anlage-Schleife (Step 5) -- sonst
+    entstuende unmittelbar nach dem INSERT ein zweiter Schreibvorgang.
+    """
+    service = _service(session_factory, monkeypatch)
+    service._persist_restore_values({"nct6798-isa-0290:pwm1": 5})
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one_or_none()
+    assert row is None
+
+
+def test_existing_row_is_updated(session_factory, monkeypatch):
+    with session_factory() as db:
+        db.add(FanConfig(fan_id="nct6798-isa-0290:pwm1", name="nct6798 PWM1",
+                         mode="auto", is_active=True))
+        db.commit()
+
+    service = _service(session_factory, monkeypatch)
+    service._persist_restore_values({"nct6798-isa-0290:pwm1": 5})
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.pwm_enable_restore == 5
+
+
+def test_updated_at_does_not_move(session_factory, monkeypatch):
+    stamp = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    with session_factory() as db:
+        db.add(FanConfig(fan_id="nct6798-isa-0290:pwm1", name="nct6798 PWM1",
+                         mode="auto", is_active=True, updated_at=stamp))
+        db.commit()
+
+    service = _service(session_factory, monkeypatch)
+    service._persist_restore_values({"nct6798-isa-0290:pwm1": 5})
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.updated_at.replace(tzinfo=timezone.utc) == stamp
+
+
+def test_unchanged_value_writes_nothing(session_factory, monkeypatch):
+    stamp = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    with session_factory() as db:
+        db.add(FanConfig(fan_id="nct6798-isa-0290:pwm1", name="nct6798 PWM1",
+                         mode="auto", is_active=True, updated_at=stamp,
+                         pwm_enable_restore=5))
+        db.commit()
+
+    service = _service(session_factory, monkeypatch)
+    service._persist_restore_values({"nct6798-isa-0290:pwm1": 5})
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.updated_at.replace(tzinfo=timezone.utc) == stamp
+    assert row.pwm_enable_restore == 5
+
+
+def test_secondary_worker_persists_nothing(session_factory, monkeypatch):
+    with session_factory() as db:
+        db.add(FanConfig(fan_id="nct6798-isa-0290:pwm1", name="nct6798 PWM1",
+                         mode="auto", is_active=True))
+        db.commit()
+
+    service = _service(session_factory, monkeypatch, primary=False)
+    service._persist_restore_values({"nct6798-isa-0290:pwm1": 5})
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.pwm_enable_restore is None
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_restore_persistence.py -v`
+Expected: FAIL mit `AttributeError: 'FanControlService' object has no attribute '_persist_restore_values'`
+
+- [ ] **Step 3: Speicher und Persistenz implementieren**
+
+Importe in `fan_control.py` ergänzen:
+
+```python
+from sqlalchemy import update
+from app.services.power.fan_restore import is_observation, resolve_restore_value
+```
+
+Im Konstruktor, neben den übrigen Zustandsfeldern:
+
+```python
+        # Rueckgabewerte pro Luefter, beim Start aus der DB geladen. stop()
+        # braucht sie ohne Datenbankzugriff (#534).
+        self._restore_values: Dict[str, int] = {}
+```
+
+Neue Methode auf `FanControlService`:
+
+```python
+    def _persist_restore_values(self, observations: Dict[str, int]) -> None:
+        """Beobachtete pwm_enable-Werte speichern und in den Speicher laden.
+
+        Nur der Primary schreibt. Geschrieben wird ausschliesslich bei echter
+        Aenderung, und updated_at wird dabei ausdruecklich mitgefuehrt: die
+        Spalte traegt onupdate=func.now() und ist das Rangkriterium des
+        Identitaets-Abgleichs (fan_reconcile.py). Ein Schreibvorgang bei jedem
+        Start setzte jede Zeile auf "gerade angefasst".
+        """
+        if not getattr(lifespan, "IS_PRIMARY_WORKER", False):
+            return
+
+        with self.db_session_factory() as db:
+            rows = list(db.execute(select(FanConfig)).scalars())
+            by_id = {row.fan_id: row for row in rows}
+
+            changed = 0
+            for fan_id, row in by_id.items():
+                target = resolve_restore_value(observations.get(fan_id),
+                                               row.pwm_enable_restore)
+                if target is not None:
+                    self._restore_values[fan_id] = target
+                if target == row.pwm_enable_restore or target is None:
+                    continue
+                db.execute(
+                    update(FanConfig)
+                    .where(FanConfig.id == row.id)
+                    .values(pwm_enable_restore=target,
+                            updated_at=row.updated_at)
+                )
+                changed += 1
+                logger.info(
+                    "Rueckgabewert fuer %s beobachtet: pwm_enable=%s",
+                    fan_id, target,
+                )
+            if changed:
+                db.commit()
+```
+
+- [ ] **Step 4: Test laufen lassen, Erfolg bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_restore_persistence.py -v`
+Expected: PASS (5 Tests)
+
+- [ ] **Step 5: Beobachtungen sammeln und in `_load_fan_configs` einhängen**
+
+Zuerst ein Helfer, der die Beobachtungen aus dem Cache zieht — er wird an **zwei** Stellen gebraucht:
+
+```python
+    def _collect_pwm_enable_observations(self) -> Dict[str, int]:
+        """Beobachtete Automatikmodi aus dem Scan-Cache.
+
+        GPU-Luefter bleiben draussen: fuer AMD-Karten existiert mit
+        AmdManualState / disable_amd_manual bereits ein eigener Rueckgabeweg,
+        der zusaetzlich das Performance-Level zuruecksetzt, und nouveau hat
+        gar keinen. Der isinstance-Schutz folgt dem Muster, das fuer dieselben
+        Cache-Zugriffe in #532 eingefuehrt wurde.
+        """
+        cache = getattr(self._backend, "_fan_cache", None) or {}
+        return {
+            fan_id: info["pwm_enable_at_scan"]
+            for fan_id, info in cache.items()
+            if isinstance(info, dict)
+            and info.get("gpu_vendor") is None
+            and is_observation(info.get("pwm_enable_at_scan"))
+        }
+```
+
+In `_load_fan_configs`, **vor** der Anlage-Schleife (also vor `for fan in fans:` bei Zeile 428):
+
+```python
+            observations = self._collect_pwm_enable_observations()
+```
+
+Im `FanConfig(...)`-Aufruf der Anlage-Schleife, nach `is_active=True`:
+
+```python
+                        pwm_enable_restore=observations.get(fan.fan_id),
+```
+
+Das ist die Stelle, die die Spec meint: der erste Scan eines Lüfters ist die einzige Gelegenheit, seinen Board-Wert zu sehen, und die Zeile entsteht hier ohnehin. Ihn stattdessen per UPDATE nachzureichen erzeugte einen zweiten Schreibvorgang unmittelbar nach dem INSERT.
+
+Am Ende der Methode, **nach** dem `db.commit()` der Anlage-Schleife:
+
+```python
+        self._persist_restore_values(observations)
+```
+
+- [ ] **Step 6: Test für die Anlage-Schleife ergänzen**
+
+An `backend/tests/test_fan_restore_persistence.py` anhängen:
+
+```python
+def test_new_row_carries_the_observation():
+    """Die Erstbeobachtung landet am neu angelegten FanConfig-Objekt.
+
+    Geprueft wird der Konstruktoraufruf, nicht der UPDATE-Pfad -- fuer einen
+    neuen Luefter gibt es zum Zeitpunkt der Anlage noch keine Zeile, die man
+    aktualisieren koennte.
+    """
+    from app.models.fans import FanConfig
+
+    observations = {"nct6798-isa-0290:pwm1": 5}
+    config = FanConfig(
+        fan_id="nct6798-isa-0290:pwm1",
+        name="nct6798 PWM1",
+        mode="auto",
+        is_active=True,
+        pwm_enable_restore=observations.get("nct6798-isa-0290:pwm1"),
+    )
+    assert config.pwm_enable_restore == 5
+
+    unknown = FanConfig(
+        fan_id="nct6798-isa-0290:pwm2",
+        name="nct6798 PWM2",
+        mode="auto",
+        is_active=True,
+        pwm_enable_restore=observations.get("nct6798-isa-0290:pwm2"),
+    )
+    assert unknown.pwm_enable_restore is None
+```
+
+- [ ] **Step 7: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_restore_persistence.py tests/test_fan_reconcile_wiring.py -v`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/app/services/power/fan_control.py backend/tests/test_fan_restore_persistence.py
+git commit -m "feat(fans): beobachtete Rueckgabewerte persistieren, ohne updated_at zu bewegen (#534)"
+```
+
+---
+
+### Task 6: Die Rückgabe beim Beenden und beim Backend-Wechsel
+
+**Files:**
+- Modify: `backend/app/services/power/fan_control.py:210-221` (`stop`), `:1065-1090` (`switch_backend`)
+- Test: `backend/tests/test_fan_handback_on_stop.py`
+
+**Interfaces:**
+- Consumes: `needs_release` (Task 1), `release_to_board` (Task 4), `_restore_values` (Task 5)
+- Produces: `FanControlService._release_all_to_board() -> None`
+
+- [ ] **Step 1: Den fehlschlagenden Test schreiben**
+
+`backend/tests/test_fan_handback_on_stop.py`:
+
+```python
+"""Beim Beenden geht die Regelung an die Board-Automatik zurueck (#534).
+
+Entschieden wird am Ist-Wert in sysfs, nicht an einer Besitz-Buchfuehrung: ein
+Luefter im MANUAL-Modus wird vom Regelkreis nie geschrieben, ein Besitz-Modell
+haette ihn deshalb nie erfasst -- und genau er stuende am Ende ungeregelt da.
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_control import FanControlService
+
+
+def _service(monkeypatch, *, primary=True):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = True
+    config.is_dev_mode = False
+    service = FanControlService(config, MagicMock())
+    service._use_linux_backend = True
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        primary, raising=False)
+    return service
+
+
+def _backend(current_enable):
+    backend = MagicMock()
+    backend._fan_cache = {
+        "nct6798-isa-0290:pwm1": {
+            "pwm_enable_path": MagicMock(),
+            "gpu_vendor": None,
+        }
+    }
+    backend._read_hwmon_file = AsyncMock(return_value=current_enable)
+    backend.release_to_board = AsyncMock(return_value=True)
+    return backend
+
+
+@pytest.mark.asyncio
+async def test_releases_when_value_deviates(monkeypatch):
+    service = _service(monkeypatch)
+    service._backend = _backend(current_enable=1)
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+
+    await service._release_all_to_board()
+
+    service._backend.release_to_board.assert_awaited_once_with(
+        "nct6798-isa-0290:pwm1", 5
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_write_when_already_on_target(monkeypatch):
+    service = _service(monkeypatch)
+    service._backend = _backend(current_enable=5)
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+
+    await service._release_all_to_board()
+
+    service._backend.release_to_board.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_restore_value_means_no_write(monkeypatch):
+    """Ohne Beobachtung passiert nichts -- der Kern des Entwurfs."""
+    service = _service(monkeypatch)
+    service._backend = _backend(current_enable=1)
+    service._restore_values = {}
+
+    await service._release_all_to_board()
+
+    service._backend.release_to_board.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_manual_at_full_speed_reads_zero_and_is_released(monkeypatch):
+    """reg_to_pwm_enable() meldet Manual mit Duty 255 als 0."""
+    service = _service(monkeypatch)
+    service._backend = _backend(current_enable=0)
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+
+    await service._release_all_to_board()
+
+    service._backend.release_to_board.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_secondary_worker_releases_nothing(monkeypatch):
+    service = _service(monkeypatch, primary=False)
+    service._backend = _backend(current_enable=1)
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+
+    await service._release_all_to_board()
+
+    service._backend.release_to_board.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gpu_fan_is_never_released(monkeypatch):
+    service = _service(monkeypatch)
+    backend = _backend(current_enable=1)
+    backend._fan_cache["nct6798-isa-0290:pwm1"]["gpu_vendor"] = "amd"
+    service._backend = backend
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+
+    await service._release_all_to_board()
+
+    backend.release_to_board.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_the_loop_before_releasing(monkeypatch):
+    """Umgekehrte Reihenfolge liesse die Schleife gegen die Rueckgabe schreiben."""
+    service = _service(monkeypatch)
+    service._backend = _backend(current_enable=1)
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+    order = []
+
+    async def note_release():
+        order.append("release")
+
+    monkeypatch.setattr(service, "_release_all_to_board", note_release)
+    service._is_running = True
+
+    async def loop():
+        try:
+            await asyncio.sleep(3600)
+        except BaseException:
+            order.append("cancel")
+            raise
+
+    service._monitoring_task = asyncio.create_task(loop())
+    await asyncio.sleep(0)
+
+    await service.stop()
+
+    assert order == ["cancel", "release"]
+
+
+@pytest.mark.asyncio
+async def test_release_is_idempotent(monkeypatch):
+    """Zweiter Lauf: der Ist-Wert stimmt bereits, es wird nichts geschrieben."""
+    service = _service(monkeypatch)
+    backend = _backend(current_enable=1)
+    service._backend = backend
+    service._restore_values = {"nct6798-isa-0290:pwm1": 5}
+
+    await service._release_all_to_board()
+    backend._read_hwmon_file = AsyncMock(return_value=5)
+    await service._release_all_to_board()
+
+    assert backend.release_to_board.await_count == 1
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_handback_on_stop.py -v`
+Expected: FAIL mit `AttributeError: ... has no attribute '_release_all_to_board'`
+
+- [ ] **Step 3: Die Rückgabe implementieren**
+
+Import in `fan_control.py` ergänzen:
+
+```python
+from app.services.power.fan_restore import needs_release
+```
+
+Neue Methode auf `FanControlService`:
+
+```python
+    async def _release_all_to_board(self) -> None:
+        """Gibt alle Luefter mit bekanntem Rueckgabewert an die Automatik zurueck.
+
+        Entschieden wird am Ist-Wert in sysfs statt an einer Besitz-Buchfuehrung.
+        Ein Luefter im MANUAL-Modus wird vom Regelkreis nie geschrieben (Ziel ==
+        Ist), sein einziger Schreibweg ist die HTTP-Route -- und die landet bei
+        vier Workern meist auf einem Sekundaer. Eine primary-gebundene
+        Besitzverfolgung haette ihn nie erfasst, und genau er stuende am Ende
+        ungeregelt da.
+        """
+        if not getattr(lifespan, "IS_PRIMARY_WORKER", False):
+            return
+        if not self._restore_values:
+            return
+
+        cache = getattr(self._backend, "_fan_cache", None) or {}
+        released = 0
+        failed = 0
+
+        for fan_id, target in self._restore_values.items():
+            info = cache.get(fan_id)
+            if not isinstance(info, dict):
+                continue
+            if info.get("gpu_vendor") is not None:
+                continue
+            pwm_enable_path = info.get("pwm_enable_path")
+            if pwm_enable_path is None:
+                continue
+
+            current = await self._backend._read_hwmon_file(pwm_enable_path)
+            if not needs_release(current, target):
+                continue
+
+            if await self._backend.release_to_board(fan_id, target):
+                released += 1
+            else:
+                failed += 1
+
+        if released or failed:
+            logger.info(
+                "Rueckgabe an die Board-Automatik: %d erfolgreich, %d fehlgeschlagen",
+                released, failed,
+            )
+```
+
+- [ ] **Step 4: In `stop()` einhängen**
+
+`fan_control.py:210-221`, die Methode `stop()` erweitern — die Rückgabe **nach** dem Abbruch der Monitoring-Task:
+
+```python
+    async def stop(self):
+        """Stop fan control service."""
+        self._is_running = False
+
+        if self._monitoring_task:
+            self._monitoring_task.cancel()
+            try:
+                await self._monitoring_task
+            except asyncio.CancelledError:
+                pass
+
+        # Erst die Schleife stilllegen, dann zurueckgeben -- umgekehrt schriebe
+        # sie im naechsten Zyklus pwm_enable=1 gegen die Rueckgabe (#534).
+        try:
+            await self._release_all_to_board()
+        except Exception:
+            logger.exception("Rueckgabe an die Board-Automatik fehlgeschlagen")
+
+        logger.info("Fan control service stopped")
+```
+
+Der `try` ist nötig, weil `stop()` im Shutdown-Pfad läuft: eine Ausnahme dort dürfte den restlichen Shutdown nicht abbrechen.
+
+- [ ] **Step 5: In `switch_backend` einhängen**
+
+`fan_control.py:1065-1090`. Diese Methode bricht die Monitoring-Task heute **nicht** ab. Ergänze am Anfang der Methode, vor jedem Backend-Tausch:
+
+```python
+        # Gleiche Reihenfolge wie in stop(): erst die Schleife stilllegen, dann
+        # zurueckgeben, dann tauschen. Ohne das schriebe die weiterlaufende
+        # Schleife pwm_enable=1 gegen die Rueckgabe, und ein Wechsel auf das
+        # Dev-Backend liesse jeden Kanal in Handsteuerung zurueck -- niemand
+        # regelt, ueber einen Admin-Endpunkt (#534).
+        was_running = self._is_running
+        self._is_running = False
+        if self._monitoring_task:
+            self._monitoring_task.cancel()
+            try:
+                await self._monitoring_task
+            except asyncio.CancelledError:
+                pass
+            self._monitoring_task = None
+        try:
+            await self._release_all_to_board()
+        except Exception:
+            logger.exception("Rueckgabe beim Backend-Wechsel fehlgeschlagen")
+```
+
+Am Ende der Methode, nach dem Tausch, die Schleife wieder starten, falls sie lief:
+
+```python
+        if was_running:
+            self._is_running = True
+            self._monitoring_task = asyncio.create_task(self._monitoring_loop())
+```
+
+- [ ] **Step 6: Tests laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_handback_on_stop.py -v`
+Expected: PASS (8 Tests)
+
+Run: `cd backend ; python -m pytest -k "fan or power" -q`
+Expected: mindestens die in Task 1 notierte Messlatte plus die neuen Tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/power/fan_control.py backend/tests/test_fan_handback_on_stop.py
+git commit -m "feat(fans): Rueckgabe an die Board-Automatik beim Beenden und beim Backend-Wechsel (#534)"
+```
+
+---
+
+### Task 7: Der Round-Trip, Dokumentation und Abschluss-Gates
+
+**Files:**
+- Test: `backend/tests/test_fan_handback_roundtrip.py`
+- Modify: `docs/TECHNICAL_DOCUMENTATION.md` (Abschnitt Lüftersteuerung)
+- Modify: `backend/app/services/CLAUDE.md` (`power/`-Block)
+
+- [ ] **Step 1: Den Round-Trip-Test schreiben**
+
+Er prüft die Naht, die keine Einzeltabelle abdeckt: Beobachtung → Persistenz → Rückgabe → erneuter Scan.
+
+`backend/tests/test_fan_handback_roundtrip.py`:
+
+```python
+"""Beobachtung -> Persistenz -> Rueckgabe -> erneuter Scan (#534).
+
+Der Test bildet zwei Startzyklen auf demselben sysfs-Baum ab und belegt, dass
+der zurueckgegebene Wert beim naechsten Start wieder als Beobachtung ankommt --
+ohne dass sich etwas verschiebt.
+"""
+import os
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from unittest.mock import MagicMock
+
+from app.core.config import get_settings
+from app.models.base import Base
+from app.models.fans import FanConfig
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+from app.services.power.fan_control import FanControlService
+
+
+def _tree(tmp_path: Path, enable_value: str) -> Path:
+    sysfs = tmp_path / "sys"
+    device = sysfs / "devices" / "platform" / "nct6775.656"
+    hwmon = device / "hwmon" / "hwmon3"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nct6798\n")
+    (hwmon / "pwm1").write_text("128\n")
+    (hwmon / "pwm1_enable").write_text(enable_value + "\n")
+    (hwmon / "fan1_input").write_text("900\n")
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / "hwmon3", target_is_directory=True)
+    return klass
+
+
+@pytest.mark.asyncio
+async def test_observation_survives_a_full_cycle(tmp_path, monkeypatch):
+    klass = _tree(tmp_path, "5")   # Kaltstart: BIOS hat Smart Fan IV gesetzt
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine)
+
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        True, raising=False)
+
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = True
+    config.is_dev_mode = False
+    service = FanControlService(config, factory)
+    service._use_linux_backend = True
+
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+    await backend._scan_pwm_fans()
+    service._backend = backend
+    fan_id = next(iter(backend._fan_cache))
+
+    with factory() as db:
+        db.add(FanConfig(fan_id=fan_id, name="nct6798 PWM1", mode="auto",
+                         is_active=True))
+        db.commit()
+
+    # Erster Zyklus: Beobachtung persistieren
+    service._persist_restore_values({fan_id: 5})
+    with factory() as db:
+        assert db.execute(select(FanConfig)).scalar_one().pwm_enable_restore == 5
+
+    # BaluHost regelt: pwm_enable steht auf 1
+    backend._fan_cache[fan_id]["pwm_enable_path"].write_text("1\n")
+
+    # Beenden: Rueckgabe
+    await service._release_all_to_board()
+    assert backend._fan_cache[fan_id]["pwm_enable_path"].read_text().strip() == "5"
+
+    # Zweiter Zyklus: neuer Scan liest den zurueckgegebenen Wert
+    backend2 = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend2, "_hwmon_base", klass)
+    await backend2._scan_pwm_fans()
+    assert backend2._fan_cache[fan_id]["pwm_enable_at_scan"] == 5
+
+    # ... und die Persistenz aendert nichts mehr
+    service._backend = backend2
+    with factory() as db:
+        before = db.execute(select(FanConfig)).scalar_one().updated_at
+    service._persist_restore_values({fan_id: 5})
+    with factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.pwm_enable_restore == 5
+    assert row.updated_at == before
+```
+
+- [ ] **Step 2: Test laufen lassen**
+
+Run: `cd backend ; python -m pytest tests/test_fan_handback_roundtrip.py -v`
+Expected: PASS
+
+- [ ] **Step 3: Dokumentation**
+
+In `docs/TECHNICAL_DOCUMENTATION.md`, im Lüfter-Abschnitt, ergänzen — und dabei die Grenzen so deutlich benennen wie die Funktion:
+
+- Beim Beenden des Dienstes wird `pwm_enable` auf den Automatikmodus zurückgeschrieben, den BaluHost am selben Chip zuvor gelesen hat. Damit regelt nach einem Deploy-Neustart das Board, statt dass die Lüfter auf dem letzten Wert einfrieren.
+- **Nur beobachtete Werte.** Es wird nichts geraten. Ein Wert wird nur übernommen, wenn der Scan beim Start einen Automatikmodus (`pwm_enable >= 2`) vorfindet — das ist nach einem Kaltstart der Fall, nicht nach einem Dienst-Neustart.
+- **Auf einer laufenden Installation greift die Funktion daher erst nach dem nächsten Kaltstart.** Wer nicht warten will, setzt den Wert einmal bei gestopptem Dienst von Hand (`echo 5 > /sys/class/hwmon/hwmonN/pwmM_enable`); der nächste Start übernimmt ihn.
+- **GPU-Lüfter sind ausgenommen.** Für AMD-Karten existiert ein eigener Rückgabeweg, der zusätzlich das Performance-Level zurücksetzt.
+- **Bei `SIGKILL` oder Stromausfall gibt es keine Rückgabe.** `systemctl stop` und der Deploy-Neustart senden `SIGTERM` und sind abgedeckt.
+- Ein Hinweis zum Ablesen: ein Lüfter, der bei 100 % läuft, meldet `pwm_enable` als `0`, nicht als `1`.
+
+In `backend/app/services/CLAUDE.md` im `power/`-Block ergänzen:
+
+```
+- `fan_restore.py` — Regel fuer die Rueckgabe an die Board-Automatik (#534):
+  `is_observation()`, `resolve_restore_value()`, `needs_release()`. Rein, ohne
+  sysfs- und DB-Zugriff. Zurueckgeschrieben wird ausschliesslich ein selbst
+  beobachteter Wert; es gibt bewusst keinen Treiber-Fallback.
+```
+
+- [ ] **Step 4: Alle Gates**
+
+```bash
+cd backend
+python -m pytest -k "fan or power" -q
+python -m ruff check app/services/power/ tests/
+cd ../client
+npx eslint .
+npm run build
+```
+Expected: alles grün; die Testzahl mindestens die in Task 1 notierte Messlatte plus die neuen Tests. Das Frontend wird von dieser Arbeit nicht angefasst, die Gates laufen zur Absicherung mit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tests/test_fan_handback_roundtrip.py docs/TECHNICAL_DOCUMENTATION.md backend/app/services/CLAUDE.md
+git commit -m "docs(fans): Rueckgabe an die Board-Automatik dokumentieren, Round-Trip-Test (#534)"
+```
+
+---
+
+## Feldverifikation nach dem Deploy
+
+Kein Task — der Nachweis am lebenden Objekt, in dieser Reihenfolge.
+
+1. **Direkt nach dem Deploy:**
+   `SELECT fan_id, pwm_enable_restore FROM fan_configs WHERE is_active`
+   Erwartung: **`NULL`** für alle. Es gab keinen Kaltstart, also keine Beobachtung. Steht dort ein Wert, ist die Regel verletzt.
+2. **Nach einem Reboot:** dieselbe Abfrage. Erwartung: der BIOS-Wert, für die vier nct6798-Kanäle vermutlich `5`. **Das ist die erste Messung des tatsächlichen Board-Defaults dieser Maschine** — bisher wurde er nie beobachtet, jede frühere Messung lief nach BaluHost-Betrieb.
+3. **Der Kern:** `systemctl stop baluhost-backend`, dann `cat /sys/class/hwmon/hwmon3/pwm{1,2,3,7}_enable`. Erwartung: der in Schritt 2 gelesene Wert. Heute steht dort `1` — das ist die Lücke. Ein Lüfter, der bei 100 % lief, zeigt vorher `0`.
+4. **Gegenprobe:** Dienst starten, eine Minute warten, erneut lesen. Erwartung `1` — BaluHost hat die Kontrolle zurückgenommen.

--- a/docs/superpowers/specs/2026-09-05-fan-ownership-handback-design.md
+++ b/docs/superpowers/specs/2026-09-05-fan-ownership-handback-design.md
@@ -1,0 +1,364 @@
+# Regelung an die Board-Automatik zurückgeben
+
+**Status:** Design freigegeben (2026-09-05)
+**Issue:** #534
+**Branch:** `feat/fan-ownership-handback-534` (von `main`)
+**Voraussetzung:** #517/#480 (PR #537), #533 (PR #539) und #532 (PR #550) sind gemergt.
+
+## Kontext
+
+BaluHost nimmt die Kontrolle über jeden schreibbaren Lüfter und gibt sie nie
+zurück. Es gibt dadurch Zustände, in denen *niemand* regelt: BaluHost regelt
+nicht mehr (oder falsch), und die Board-Automatik ist abgeschaltet.
+
+### Was der Ist-Zustand tatsächlich ist
+
+Der Issue-Text nimmt an, `pwm_enable` werde einmal beim Start auf `1` gesetzt.
+Das stimmt nicht: **`set_pwm` schreibt `pwm_enable=1` bei jedem einzelnen
+PWM-Write** (`fan_backend_linux.py:183`). BaluHost übernimmt die Kontrolle also
+alle fünf Sekunden neu.
+
+Der Ursprungswert wird nirgends gesichert. Der Scan legt `pwm_enable_path` ab,
+liest den Wert aber nicht. Ein Muster für Sicherung und Rückgabe existiert im
+Repo — `AmdManualState` in `fan_gpu_manual.py:23-52` — allerdings nur für den
+AMD-Pfad.
+
+Ein Aufhängepunkt für den Shutdown ist vorhanden: `_shutdown()`
+(`lifespan.py:757`) ruft `fan_control.stop_fan_control()` bereits
+primary-gegated auf. `stop()` bricht dort heute nur die Monitoring-Task ab.
+
+### Die Prämisse ist gemessen, nicht angenommen
+
+Auf BaluNode (2026-09-05), Kanal 1 des nct6798, Dienst gestoppt:
+
+| | `pwm1_enable` | `pwm1` | RPM |
+|---|---|---|---|
+| BaluHost regelt | 1 | 76 | — |
+| nach `echo 5` | 5 | **87** | 508 |
+| nach Dienststart | 1 | 87 | — |
+
+`pwm1` wanderte ohne fremden Schreibzugriff von 76 auf 87 — der Chip hat die
+Regelung übernommen. Smart Fan IV greift also wirklich. Der letzte Schritt
+zeigt zugleich, dass BaluHost sich den Kanal binnen Sekunden von selbst
+zurückholt, weil `set_pwm` `pwm_enable=1` mitschreibt.
+
+### Was der frühere Aufhänger des Issues war
+
+Die ursprüngliche Messung im Issue („alle vier Lüfter fest auf `pwm=128`, keine
+Temperaturregelung im Gehäuse") ist überholt. Ursache war #517; seit dessen
+Deploy regelt die Kurve nachweislich. Übrig bleibt die Regelungslücke beim
+Dienst-Ende und bei ausgefallener oder unmöglicher Regelung.
+
+## Ziele
+
+- Beim Dienst-Ende die Kontrolle an die Board-Automatik zurückgeben.
+- Einen Lüfter, dessen Schreibversuche strukturell scheitern, an die Automatik
+  zurückgeben statt ihn weiter erfolglos zu beschreiben.
+- Einen Lüfter, für den kein Zielwert mehr gebildet werden kann, an die
+  Automatik zurückgeben statt den letzten Wert einzufrieren.
+
+## Nicht-Ziele
+
+- Keine Bedienoberfläche für den Rückgabewert. Er stammt aus der Sicherung oder
+  dem Treiber-Fallback.
+- Keine Rückgabe auf Hardware, für die kein Rückgabewert bekannt ist.
+- Keine Änderung am Notfallpfad, an der Kurvenauswertung oder am Backoff aus
+  #533 — der Backoff wird nur als Auslöser gelesen.
+
+### Die Grenze, die keine Lösung beseitigt
+
+Bei `SIGKILL` gibt es keine Rückgabe. `systemctl stop` und der Deploy-Neustart
+senden `SIGTERM`, dort greift der Shutdown-Pfad. Ein hartes Kill oder ein
+Stromausfall hinterlässt die Lüfter auf dem letzten Wert — das ist der heutige
+Zustand und im Prozess selbst nicht behebbar.
+
+---
+
+## 1. Das Besitz-Modell
+
+Ein Lüfter ist entweder in BaluHosts Hand oder freigegeben. Der Regelkreis
+fragt einmal pro Zyklus; ein freigegebener Lüfter wird übersprungen, `set_pwm`
+läuft für ihn also gar nicht erst und schreibt folglich kein `pwm_enable=1`.
+Die Rückgabe braucht damit **keinen Sonderfall im Schreibpfad**.
+
+### Besitz entsteht mit dem erfolgreichen `pwm_enable=1`
+
+Nicht durch den Scan, und **nicht** durch den erfolgreichen PWM-Wert-Write.
+`set_pwm` schreibt erst `pwm_enable=1`, dann den Wert (`fan_backend_linux.py:182-190`).
+Genau der erste Schritt *ist* die Übernahme — er schaltet die Board-Automatik ab.
+
+Der Unterschied ist nicht akademisch. Gelingt `pwm_enable=1` und scheitert der
+Wert-Write (etwa `EINVAL` auf einem Knoten, der den Modus annimmt aber keinen
+Wert), hat BaluHost die Automatik abgeschaltet, ohne selbst regeln zu können —
+der schlimmste erreichbare Zustand. Genau dieser Lüfter muss zurückgegeben
+werden können, und mit „Besitz = erfolgreicher Wert-Write" wäre er davon
+ausgenommen gewesen.
+
+Scheitert schon `pwm_enable=1`, wurde nie übernommen: dann wird bei der
+Freigabe **kein** Rückgabe-Write versucht, der Lüfter aber trotzdem als
+freigegeben markiert, damit der Regelkreis aufhört, ihn zu beschreiben.
+
+Sekundär-Worker laufen mit `monitoring=False` und rufen `set_pwm` nie auf. Ihr
+Besitz-Zustand bleibt leer, und wenn uvicorn einen Sekundär-Worker neu startet,
+gibt dessen `stop()` nichts zurück. Andernfalls übergäbe er den Lüfter ans
+Board, während der Primary noch regelt.
+
+### Drei Freigabegründe
+
+| Grund | Auslöser | Rückweg |
+|---|---|---|
+| `shutdown` | Dienst-Ende | kein Laufzeitzustand — der Prozess endet |
+| `not_controllable` | Backoff aus #533 hat den 15-Minuten-Deckel erreicht | **klebrig** — bis Neustart oder Nutzer-Klick |
+| `no_target` | 12 Zyklen ohne gültigen Temperaturwert | **selbstheilend** — sobald wieder ein Wert kommt |
+
+Der Nutzer-Klick braucht keinen neuen Mechanismus: `set_fan_pwm()` geht seit
+#533 über `force=True`, und Besitz entsteht durch einen erfolgreichen
+`set_pwm` — wer klickt, nimmt den Lüfter damit zurück.
+
+### Der GPU-Fall bleibt draußen
+
+`set_pwm` steigt bei `FIRMWARE_MANAGED` als Erstes aus (#480), bevor
+`pwm_enable` angefasst wird; auf BaluNode steht `hwmon2/pwm1_enable` deshalb
+unverändert auf `2`. Der Mechanismus zielt auf den generischen hwmon-Pfad.
+
+### Wo der Zustand liegt
+
+Neues Modul `backend/app/services/power/fan_ownership.py`, prozesslokal,
+`fan_id → Freigabe(grund, zeitpunkt)`. Kein DB-Feld: die Regelung läuft ohnehin
+nur im Primary-Worker, und ein persistierter „freigegeben"-Zustand arbeitete
+gegen die gewünschte Selbstheilung nach einem Neustart. Der Preis ist eine
+Backoff-Periode pro Neustart, und die ist nach #533 gedeckelt.
+
+Die Rückgabe wird **einmal** geschrieben, nicht wiederholt — es schreibt
+danach niemand mehr dagegen.
+
+---
+
+## 2. Der Rückgabewert
+
+Gesichert wird **beim Scan**, in `_scan_pwm_fans`, bevor irgendein `set_pwm`
+gelaufen ist. Das ist der einzige Moment, in dem der Wert echt sein kann: nach
+einem Kaltstart steht dort, was das BIOS gesetzt hat.
+
+**Eine `1` ist nie ein gültiges Ziel.** Sie bedeutet Handsteuerung, und die
+kann kein Board von sich aus wollen — sie ist der Beweis, dass schon jemand
+übernommen hat.
+
+### Persistenz
+
+Neue Spalte `fan_configs.pwm_enable_restore` (Integer, nullable). Nötig, weil
+die Sicherung nur nach einem Kaltstart stimmt: nach einem `SIGKILL` hinterlässt
+die Vorgängerinstanz eine `1`, und ohne gespeicherten Wert wäre der echte
+Ursprungswert dauerhaft verloren. Dass die Spalte an einer stabilen `fan_id`
+hängt, ist das Ergebnis von #532.
+
+Die Spalte braucht eine Alembic-Migration. **Die Elternrevision ist zum
+Zeitpunkt der Umsetzung frisch über `alembic heads` zu prüfen**, nicht aus
+diesem Dokument zu übernehmen — das Projekt hatte einen Deploy-Fehler durch
+mehrere Heads.
+
+### Die Auflösungsregel
+
+```
+gelesener Wert != 1   ->  als Ziel benutzen UND persistieren
+gelesener Wert == 1   ->  gespeicherten Wert benutzen, falls vorhanden
+                          sonst Treiber-Fallback benutzen, NICHT speichern
+kein Fallback bekannt ->  nicht zurueckgeben, WARNING mit Treibernamen
+```
+
+**Der Fallback wird benutzt, aber nie gespeichert.** Ohne diese Einschränkung
+wäre eine falsch geratene Annahme selbsterhaltend: wir schrieben `5`, läsen
+beim nächsten Start `5`, speicherten `5` — und der echte Board-Wert käme nie
+mehr zum Zug. So bleibt der Platz für eine echte Beobachtung dauerhaft offen.
+
+### Der Fallback, als Annahme dokumentiert
+
+| Treiber | Wert | Belegt durch |
+|---|---|---|
+| `nct6775` (deckt nct6798 ab) | `5` — Smart Fan IV | Messung oben: `pwm1` 76 → 87, 508 RPM |
+| `amdgpu` | `2` — Auto | Ist-Zustand auf BaluNode; derselbe Wert, den `disable_amd_manual` zurückschreibt |
+| alles andere | keiner | keine Rückgabe, WARNING |
+
+Dass für unbekannte Treiber **nichts** passiert, ist Absicht: ein geratener
+Modus auf fremder Hardware ist schlechter als der heutige Zustand, und der
+heutige Zustand ist bekannt.
+
+Fehlt `pwm_enable_path`, gibt es weder Übernahme noch Rückgabe.
+
+---
+
+## 3. Die drei Auslöser
+
+### Dienst-Ende
+
+In `stop()`, **nachdem** die Monitoring-Task abgebrochen ist — erst die
+Schleife stilllegen, damit sie nicht gegen die Rückgabe schreibt, dann alle
+besessenen Lüfter zurückgeben. `_shutdown()` ruft `stop_fan_control()` bereits
+primary-gegated auf; der leere Besitz-Zustand auf Sekundär-Workern sichert das
+doppelt ab.
+
+### Nicht steuerbar
+
+Aufhänger ist der Backoff aus #533. Die Bedingung ist **„das Fenster liegt
+erstmals am Deckel"**, nicht eine feste Fehlerzahl — mit den heutigen Konstanten
+(`PWM_BACKOFF_BASE_SECONDS = 10`, Verdopplung, `PWM_BACKOFF_MAX_SECONDS = 900`)
+ist das der achte aufeinanderfolgende Fehlschlag (10, 20, 40, 80, 160, 320, 640,
+dann gedeckelt). Die Bedingung wird gegen den Deckel formuliert, damit eine
+spätere Änderung der Konstanten sie nicht still verschiebt.
+
+An diesem Punkt sind die Schreibversuche strukturell gescheitert und nicht bloß
+kurz gestört. Dann Rückgabe, `not_controllable`, **eine** ERROR-Zeile — die
+Log-Hygiene aus #533 gilt hier genauso.
+
+**Scheitern PWM-Writes, scheitert das Zurückschreiben von `pwm_enable` sehr
+wahrscheinlich auch** — derselbe Knoten, dieselben Rechte, derselbe Treiber.
+Die Rückgabe wird versucht und ihr Ergebnis geloggt, aber der Lüfter gilt
+danach **in jedem Fall** als freigegeben. Wir geben unseren Anspruch auf, auch
+wenn wir den Board-Modus nicht wiederherstellen können; weiter alle fünf
+Sekunden erfolglos zu schreiben ist eindeutig schlechter.
+
+### Regelung ausgefallen
+
+Liefert die Sensorauflösung über **zwölf** aufeinanderfolgende Zyklen keinen
+Wert — bei 5-Sekunden-Takt eine Minute —, wird zurückgegeben mit `no_target`.
+Ein oder zwei ausgefallene Messungen sind Rauschen; eine Minute ohne
+verwertbare Temperatur heißt, dass die Quelle weg ist.
+
+Kommt wieder ein Wert, übernimmt BaluHost beim nächsten Zyklus von selbst: der
+Regelkreis hört auf zu überspringen, und der nächste `set_pwm` schreibt
+`pwm_enable=1` mit. Das ersetzt das heutige Einfrieren des letzten Werts.
+
+### Der Notfallpfad bleibt unangetastet
+
+Er greift bei `Temperatur >= emergency_temp_celsius` und schreibt mit
+`force=True` volle Leistung. Beide Freigabegründe machen ihn gegenstandslos,
+statt ihn zu behindern:
+
+- Bei `no_target` gibt es keine Temperatur, also keinen Notfall — und das Board
+  regelt inzwischen selbst. Auf dem nct6798 rampt Smart Fan IV bei 60 °C auf 255.
+- Bei `not_controllable` scheitern Schreibversuche ohnehin; ein erzwungener
+  Notfall-Write scheiterte genauso.
+
+Ein freigegebener Lüfter wird **nicht** durch den Notfall zurückgeholt. Das
+kehrt die Abwägung aus #533 bewusst um: dort war der Emergency-Bypass richtig,
+weil BaluHost die Kontrolle hatte. Hier hat sie das Board, und das Board ist
+für genau diesen Fall gebaut.
+
+---
+
+## 4. Integration
+
+### Regelkreis
+
+Eine Abfrage pro Lüfter, direkt nachdem die Config geladen ist: ist der Lüfter
+freigegeben, werden Zielwert-Berechnung und Write übersprungen. **Die
+Messwert-Aufzeichnung läuft weiter** — Drehzahl und Temperatur gehören auch
+dann in die Historie, wenn das Board regelt; sonst reißt der Verlaufsgraph
+genau dort ab, wo man am ehesten nachsieht.
+
+### Nutzer-Klick
+
+Kein eigener Pfad nötig (siehe Abschnitt 1). Bei einem
+`not_controllable`-Lüfter scheitert der Klick weiterhin, und der Nutzer bekommt
+die echte Fehlermeldung statt eines stillen `False` — die Absicht des
+`force`-Pfades aus #533. Läuft der Backoff danach erneut in den Deckel, wird
+wieder freigegeben.
+
+### API
+
+`FanInfo` bekommt `released_reason: Optional[str]`.
+
+### Frontend
+
+#480 hat `pwm_control` eingeführt, #537 hat `editingLocked` durch Profile,
+Save/Discard, `canEdit` und das Zeitplan-Panel gezogen, um firmware-verwaltete
+Lüfter zu sperren. Ein freigegebener Lüfter ist aus Nutzersicht derselbe Fall —
+die Regler sind wirkungslos, weil jemand anderes regelt. Also dieselbe Sperre
+mit eigenem Hinweistext:
+
+| Grund | Hinweis |
+|---|---|
+| `not_controllable` | „Nicht steuerbar — das Board regelt diesen Lüfter." |
+| `no_target` | „Kein Temperaturwert — das Board regelt, bis der Sensor zurückkommt." |
+
+Kein neues Sperr-Konzept, kein zweiter Zustandsbaum. i18n-Schlüssel in `de` und
+`en`.
+
+---
+
+## 5. Tests und Verifikation
+
+### Reine Einheiten
+
+Besitz-Modul und Auflösung des Rückgabewerts fassen weder sysfs noch Datenbank
+an. Die Auflösung ist als Tabelle prüfbar:
+
+| gelesen | gespeichert | Ergebnis | persistiert? |
+|---|---|---|---|
+| `5` | — | `5` | ja |
+| `1` | `5` | `5` | nein (unverändert) |
+| `1` | — | Treiber-Fallback | **nein** |
+| `1` | — , Treiber unbekannt | keine Rückgabe + WARNING | nein |
+
+Die dritte Zeile ist die wichtigste: bliebe der Fallback hängen, wäre eine
+falsche Annahme selbsterhaltend.
+
+### Scan
+
+`tmp_path`-Baum mit `pwm1_enable = 5`, Scan laufen lassen, gesicherten Wert
+prüfen. Platform-förmig und doppelpunktfrei, damit der Test auch unter Windows
+läuft (NTFS verbietet Doppelpunkte in Verzeichnisnamen, Lehre aus #532).
+
+### Die drei Auslöser
+
+- **Shutdown:** besessener Lüfter → nach `stop()` steht der Rückgabewert in der
+  Datei. Nicht besessener Lüfter → Datei unverändert. **Sekundär-Worker → gar
+  kein Write**, weil der Besitz-Zustand leer ist. Der dritte Fall ist der
+  wichtigste der drei.
+- **`not_controllable`:** Backoff am Deckel → Freigabe, genau eine ERROR-Zeile.
+  Scheitert auch das Zurückschreiben → Lüfter gilt trotzdem als freigegeben.
+- **`no_target`:** elf Zyklen ohne Wert → weiterhin besessen. Zwölfter →
+  freigegeben. Wert kommt zurück → wieder übernommen. Die Grenze wird von
+  beiden Seiten festgenagelt.
+
+### Notfallpfad
+
+Eigener Test, dass ein freigegebener Lüfter **nicht** zurückgeholt wird — es
+ist eine bewusste Umkehr gegenüber #533 und sähe ohne Test wie ein Versehen aus.
+
+### Gates
+
+`pytest -k "fan or power"` (Messlatte 621 passed, 2 skipped), `ruff check`,
+`eslint .`, `npm run build`, `vitest run`. Volle Backend-Suite in der CI.
+
+### Feldverifikation
+
+1. **Shutdown — der Kern.** `systemctl stop baluhost-backend`, dann
+   `cat /sys/class/hwmon/hwmon3/pwm{1,2,3,7}_enable`. Erwartung: viermal `5`
+   statt viermal `1`. Heute steht dort `1`; das ist die Lücke.
+2. **Der Kreis schließt sich.** Dienst starten, dann
+   `SELECT fan_id, pwm_enable_restore FROM fan_configs WHERE is_active`. Der
+   Scan sollte `5` gesichert haben, weil der Shutdown sie hinterlassen hat.
+   Damit ist die Selbstheilung belegt und der Treiber-Fallback arbeitslos.
+3. **`no_target` erzwingen, reversibel.** Einem Lüfter über die API eine nicht
+   existierende Sensor-ID zuweisen, eine Minute warten, `pwm_enable` lesen —
+   muss auf `5` stehen. Sensor zurücksetzen, prüfen dass BaluHost binnen eines
+   Zyklus wieder übernimmt.
+4. **`not_controllable`** bleibt den Einheitentests überlassen. Es im Feld zu
+   erzwingen hieße, Rechte oder Treiber zu manipulieren — mehr Risiko als
+   Erkenntnis.
+
+---
+
+## Risiken
+
+- **Der Treiber-Fallback ist eine Annahme**, für `nct6775` durch Messung
+  gedeckt, für `amdgpu` durch den Ist-Zustand. Für alles andere wird bewusst
+  nichts getan.
+- **Die Rückgabe kann scheitern**, gerade im `not_controllable`-Fall. Der
+  Lüfter gilt dann trotzdem als freigegeben; das Ergebnis wird geloggt.
+- **Ob das Board nach der Rückgabe tatsächlich regelt**, ist auf BaluNode
+  gemessen und für andere Hardware nicht garantiert. Da nur bei bekanntem
+  Treiber zurückgegeben wird, ist das Risiko auf die zwei Fälle in der Tabelle
+  begrenzt.
+- **`SIGKILL` bleibt ungedeckt** (siehe Nicht-Ziele).

--- a/docs/superpowers/specs/2026-09-05-fan-ownership-handback-design.md
+++ b/docs/superpowers/specs/2026-09-05-fan-ownership-handback-design.md
@@ -1,31 +1,34 @@
-# Regelung an die Board-Automatik zurückgeben
+# Regelung beim Dienst-Ende an die Board-Automatik zurückgeben
 
-**Status:** Design freigegeben (2026-09-05)
-**Issue:** #534
+**Status:** Design freigegeben (2026-09-05), nach kritischer Review auf den
+Shutdown-Pfad zurückgenommen
+**Issue:** #534 (Teilumfang — Punkte 1 und 2 des Issues bleiben offen)
 **Branch:** `feat/fan-ownership-handback-534` (von `main`)
-**Voraussetzung:** #517/#480 (PR #537), #533 (PR #539) und #532 (PR #550) sind gemergt.
+**Voraussetzung:** #517/#480 (PR #537), #533 (PR #539), #532 (PR #550) sind gemergt.
 
 ## Kontext
 
 BaluHost nimmt die Kontrolle über jeden schreibbaren Lüfter und gibt sie nie
-zurück. Es gibt dadurch Zustände, in denen *niemand* regelt: BaluHost regelt
-nicht mehr (oder falsch), und die Board-Automatik ist abgeschaltet.
+zurück. Beim Dienst-Ende — und das Backend startet bei **jedem Deploy** neu —
+bleibt `pwm_enable=1` stehen: die Board-Automatik ist abgeschaltet, der PWM
+friert auf dem letzten Wert ein, und bis der Dienst wieder läuft, regelt
+niemand.
 
 ### Was der Ist-Zustand tatsächlich ist
 
 Der Issue-Text nimmt an, `pwm_enable` werde einmal beim Start auf `1` gesetzt.
 Das stimmt nicht: **`set_pwm` schreibt `pwm_enable=1` bei jedem einzelnen
-PWM-Write** (`fan_backend_linux.py:183`). BaluHost übernimmt die Kontrolle also
+PWM-Write** (`fan_backend_linux.py:182-190`). BaluHost übernimmt die Kontrolle
 alle fünf Sekunden neu.
 
-Der Ursprungswert wird nirgends gesichert. Der Scan legt `pwm_enable_path` ab,
-liest den Wert aber nicht. Ein Muster für Sicherung und Rückgabe existiert im
-Repo — `AmdManualState` in `fan_gpu_manual.py:23-52` — allerdings nur für den
-AMD-Pfad.
+Der Ursprungswert wird nirgends gesichert (`fan_backend_linux.py:510` legt nur
+`pwm_enable_path` ab). `stop()` bricht heute ausschliesslich die
+Monitoring-Task ab (`fan_control.py:210-219`). Ein Aufhängepunkt existiert:
+`_shutdown()` ruft `stop_fan_control()` primary-gegated auf (`lifespan.py:747`
+Gate, `:759` Aufruf).
 
-Ein Aufhängepunkt für den Shutdown ist vorhanden: `_shutdown()`
-(`lifespan.py:757`) ruft `fan_control.stop_fan_control()` bereits
-primary-gegated auf. `stop()` bricht dort heute nur die Monitoring-Task ab.
+Ein Muster für Sicherung und Rückgabe gibt es bereits, aber nur für den
+AMD-Pfad: `AmdManualState` in `fan_gpu_manual.py:24-30`, `:65-78`.
 
 ### Die Prämisse ist gemessen, nicht angenommen
 
@@ -38,32 +41,40 @@ Auf BaluNode (2026-09-05), Kanal 1 des nct6798, Dienst gestoppt:
 | nach Dienststart | 1 | 87 | — |
 
 `pwm1` wanderte ohne fremden Schreibzugriff von 76 auf 87 — der Chip hat die
-Regelung übernommen. Smart Fan IV greift also wirklich. Der letzte Schritt
-zeigt zugleich, dass BaluHost sich den Kanal binnen Sekunden von selbst
-zurückholt, weil `set_pwm` `pwm_enable=1` mitschreibt.
+Regelung übernommen. Smart Fan IV greift wirklich.
 
-### Was der frühere Aufhänger des Issues war
+### Warum nur der Shutdown-Pfad
 
-Die ursprüngliche Messung im Issue („alle vier Lüfter fest auf `pwm=128`, keine
-Temperaturregelung im Gehäuse") ist überholt. Ursache war #517; seit dessen
-Deploy regelt die Kurve nachweislich. Übrig bleibt die Regelungslücke beim
-Dienst-Ende und bei ausgefallener oder unmöglicher Regelung.
+Der ursprüngliche Entwurf deckte alle drei Punkte des Issues ab. Zwei kritische
+Reviews fanden darin acht blockierende Befunde; **sechs davon entfielen
+ausschliesslich auf die zwei Laufzeit-Auslöser** („nicht steuerbar",
+„Regelung ausgefallen"), und beide sicherheitsrelevanten Fälle ebenfalls.
+
+Der Shutdown-Pfad braucht keinen Eingriff in den Regelkreis, keine
+Backoff-Introspektion, keinen Rückhol-Endpunkt und **keine UI-Anzeige** — und
+damit auch nicht den worker-übergreifenden Zustand, an dem die zwei
+Laufzeit-Auslöser scheitern (siehe #552: prozesslokale Flags erzeugen ein
+flackerndes Read-Only-Banner, weil `get_status()` in einem beliebigen Worker
+läuft).
+
+Die Befunde zu den beiden verbleibenden Punkten sind in #534 dokumentiert.
 
 ## Ziele
 
 - Beim Dienst-Ende die Kontrolle an die Board-Automatik zurückgeben.
-- Einen Lüfter, dessen Schreibversuche strukturell scheitern, an die Automatik
-  zurückgeben statt ihn weiter erfolglos zu beschreiben.
-- Einen Lüfter, für den kein Zielwert mehr gebildet werden kann, an die
-  Automatik zurückgeben statt den letzten Wert einzufrieren.
 
 ## Nicht-Ziele
 
-- Keine Bedienoberfläche für den Rückgabewert. Er stammt aus der Sicherung oder
-  dem Treiber-Fallback.
-- Keine Rückgabe auf Hardware, für die kein Rückgabewert bekannt ist.
-- Keine Änderung am Notfallpfad, an der Kurvenauswertung oder am Backoff aus
-  #533 — der Backoff wird nur als Auslöser gelesen.
+- **Keine Laufzeit-Rückgabe** (Punkte 1 und 2 des Issues). Bleiben offen.
+- Keine UI-Anzeige und kein neues Feld in `FanInfo`.
+- Keine Änderung an Regelkreis, Kurvenauswertung, Notfallpfad oder dem Backoff
+  aus #533.
+- **Keine Rückgabe für AMD-GPU-Lüfter.** Für sie existiert mit
+  `AmdManualState` / `disable_amd_manual` (`fan_gpu_manual.py:65-78`) bereits
+  ein eigener Rückgabeweg, der zusätzlich `power_dpm_force_performance_level`
+  zurücksetzt. Zwei konkurrierende Mechanismen auf demselben Knoten wären ein
+  Fehler. Ausgeschlossen wird über `gpu_vendor == "amd"`, nicht über
+  `FIRMWARE_MANAGED` — Letzteres deckt Pre-RDNA3-Karten nicht ab.
 
 ### Die Grenze, die keine Lösung beseitigt
 
@@ -74,291 +85,301 @@ Zustand und im Prozess selbst nicht behebbar.
 
 ---
 
-## 1. Das Besitz-Modell
+## 1. Besitz
 
-Ein Lüfter ist entweder in BaluHosts Hand oder freigegeben. Der Regelkreis
-fragt einmal pro Zyklus; ein freigegebener Lüfter wird übersprungen, `set_pwm`
-läuft für ihn also gar nicht erst und schreibt folglich kein `pwm_enable=1`.
-Die Rückgabe braucht damit **keinen Sonderfall im Schreibpfad**.
+Ein Lüfter gilt als **besessen**, sobald ein `pwm_enable=1`-Write auf ihm
+gelungen ist. Nicht der Wert-Write — der `pwm_enable`-Write *ist* die
+Übernahme, er schaltet die Board-Automatik ab.
 
-### Besitz entsteht mit dem erfolgreichen `pwm_enable=1`
+Der Unterschied ist nicht akademisch: gelingt `pwm_enable=1` und scheitert der
+Wert-Write, hat BaluHost die Automatik abgeschaltet, ohne selbst regeln zu
+können. Genau dieser Lüfter muss zurückgegeben werden.
 
-Nicht durch den Scan, und **nicht** durch den erfolgreichen PWM-Wert-Write.
-`set_pwm` schreibt erst `pwm_enable=1`, dann den Wert (`fan_backend_linux.py:182-190`).
-Genau der erste Schritt *ist* die Übernahme — er schaltet die Board-Automatik ab.
+### Besitz wird nur im Primary-Worker erworben
 
-Der Unterschied ist nicht akademisch. Gelingt `pwm_enable=1` und scheitert der
-Wert-Write (etwa `EINVAL` auf einem Knoten, der den Modus annimmt aber keinen
-Wert), hat BaluHost die Automatik abgeschaltet, ohne selbst regeln zu können —
-der schlimmste erreichbare Zustand. Genau dieser Lüfter muss zurückgegeben
-werden können, und mit „Besitz = erfolgreicher Wert-Write" wäre er davon
-ausgenommen gewesen.
+**Nicht** am `monitoring`-Flag festgemacht, sondern hart an
+`getattr(lifespan, "IS_PRIMARY_WORKER", False)` — als Attributzugriff auf das
+Modul, nie als `from ... import` (das Flag wird erst zur Laufzeit gesetzt;
+Muster wie in `fan_control.py:250`).
 
-Scheitert schon `pwm_enable=1`, wurde nie übernommen: dann wird bei der
-Freigabe **kein** Rückgabe-Write versucht, der Lüfter aber trotzdem als
-freigegeben markiert, damit der Regelkreis aufhört, ihn zu beschreiben.
+Grund: `set_pwm` ist auf **jedem** Worker erreichbar, über drei Wege:
 
-Sekundär-Worker laufen mit `monitoring=False` und rufen `set_pwm` nie auf. Ihr
-Besitz-Zustand bleibt leer, und wenn uvicorn einen Sekundär-Worker neu startet,
-gibt dessen `stop()` nichts zurück. Andernfalls übergäbe er den Lüfter ans
-Board, während der Primary noch regelt.
+1. `POST /api/fans/pwm` (`routes/fans.py:167` → `fan_control.py:1003`) — läuft
+   im bedienenden Worker, bei vier Workern also meist auf einem Sekundär.
+2. `POST /api/admin/services/fan_control/stop` (`routes/service_status.py:174`
+   → `service_registry.py:207`) — ruft `stop_fan_control()` im bedienenden
+   Worker.
+3. `.../restart` bzw. `/start` (`service_status.py:292`, `:438`) — ruft
+   `start_fan_control()` **ohne Argument**, also mit `monitoring=True`
+   (`fan_control.py:1287`); ein Sekundär-Worker startet dann eine vollwertige
+   zweite Regelschleife.
 
-### Drei Freigabegründe
+Ohne das Primary-Gate erwürbe ein Sekundär-Worker über Weg 1 Besitz, und Weg 2
+gäbe die Lüfter dann ans Board zurück, während der Primary weiterregelt.
 
-| Grund | Auslöser | Rückweg |
-|---|---|---|
-| `shutdown` | Dienst-Ende | kein Laufzeitzustand — der Prozess endet |
-| `not_controllable` | Backoff aus #533 hat den 15-Minuten-Deckel erreicht | **klebrig** — bis Neustart oder Nutzer-Klick |
-| `no_target` | 12 Zyklen ohne gültigen Temperaturwert | **selbstheilend** — sobald wieder ein Wert kommt |
+Weg 3 ist ein eigenständiger, vorbestehender Fehler — zwei konkurrierende
+Regelschleifen — und **nicht Gegenstand dieser Arbeit**; er ist als
+Nebenbefund festzuhalten.
 
-Der Nutzer-Klick braucht keinen neuen Mechanismus: `set_fan_pwm()` geht seit
-#533 über `force=True`, und Besitz entsteht durch einen erfolgreichen
-`set_pwm` — wer klickt, nimmt den Lüfter damit zurück.
-
-### Der GPU-Fall bleibt draußen
-
-`set_pwm` steigt bei `FIRMWARE_MANAGED` als Erstes aus (#480), bevor
-`pwm_enable` angefasst wird; auf BaluNode steht `hwmon2/pwm1_enable` deshalb
-unverändert auf `2`. Der Mechanismus zielt auf den generischen hwmon-Pfad.
-
-### Wo der Zustand liegt
+### Der Zustand
 
 Neues Modul `backend/app/services/power/fan_ownership.py`, prozesslokal,
-`fan_id → Freigabe(grund, zeitpunkt)`. Kein DB-Feld: die Regelung läuft ohnehin
-nur im Primary-Worker, und ein persistierter „freigegeben"-Zustand arbeitete
-gegen die gewünschte Selbstheilung nach einem Neustart. Der Preis ist eine
-Backoff-Periode pro Neustart, und die ist nach #533 gedeckelt.
-
-Die Rückgabe wird **einmal** geschrieben, nicht wiederholt — es schreibt
-danach niemand mehr dagegen.
+`fan_id → besessen`. Prozesslokal ist hier ausreichend und richtig, weil der
+Zustand **nirgends ausgelesen** wird: keine API, keine UI. Er dient
+ausschliesslich dazu, beim Beenden zu wissen, was zurückzugeben ist.
 
 ---
 
 ## 2. Der Rückgabewert
 
-Gesichert wird **beim Scan**, in `_scan_pwm_fans`, bevor irgendein `set_pwm`
-gelaufen ist. Das ist der einzige Moment, in dem der Wert echt sein kann: nach
-einem Kaltstart steht dort, was das BIOS gesetzt hat.
+### Gesichert wird beim Scan, persistiert wird im Service
 
-**Eine `1` ist nie ein gültiges Ziel.** Sie bedeutet Handsteuerung, und die
-kann kein Board von sich aus wollen — sie ist der Beweis, dass schon jemand
-übernommen hat.
+`_scan_pwm_fans` liest `pwm_enable` in den Cache (`pwm_enable_at_scan`) —
+**mehr nicht**. `LinuxFanControlBackend` kennt keine Datenbank
+(`fan_backend_linux.py:45-58`), und der Scan läuft in jedem Worker, vor dem
+Identitäts-Abgleich und vor der Anlage-Schleife.
 
-### Persistenz
+Persistiert wird in `_load_fan_configs`, **im Primary**, **nach** dem
+Reconcile-Commit (`fan_control.py:351`) und **nach** dem Primary-Gate
+(`:426`), ausschliesslich als **UPDATE auf existierende Zeilen — nie als
+INSERT**.
 
-Neue Spalte `fan_configs.pwm_enable_restore` (Integer, nullable). Nötig, weil
-die Sicherung nur nach einem Kaltstart stimmt: nach einem `SIGKILL` hinterlässt
-die Vorgängerinstanz eine `1`, und ohne gespeicherten Wert wäre der echte
-Ursprungswert dauerhaft verloren. Dass die Spalte an einer stabilen `fan_id`
-hängt, ist das Ergebnis von #532.
+Ein Upsert an dieser Stelle legte eine frische Zeile mit `updated_at="jetzt"`
+an, die im nächsten Identitäts-Abgleich gegen die echte Nutzerkurve gewönne
+(`fan_reconcile.py:151`) — genau der Datenverlust, den #532 beseitigt hat.
+`test_fan_reconcile_wiring.py:202-275` bewacht diesen Fall.
 
-Die Spalte braucht eine Alembic-Migration. **Die Elternrevision ist zum
-Zeitpunkt der Umsetzung frisch über `alembic heads` zu prüfen**, nicht aus
-diesem Dokument zu übernehmen — das Projekt hatte einen Deploy-Fehler durch
-mehrere Heads.
+Dass der Wert beim allerersten Erscheinen eines Lüfters einen Startzyklus
+später ankommt, ist der richtige Preis. Der Docstring von `_load_fan_configs`
+(„Existing configs are NOT modified", `:310-311`) gilt dann nicht mehr und ist
+mitzuziehen.
+
+### Gültige Zielwerte
+
+**Weder `0` noch `1`.** `1` ist Handsteuerung. `0` bedeutet nach
+hwmon-Konvention „keine Regelung durch den Chip" — beim nct6775 Vollgas, also
+gerade **nicht** Board-Automatik. Ein persistiertes `0` fährt die Lüfter nach
+jedem Dienst-Ende auf Anschlag und zementiert das über die Sicherung.
+
+Dass `1` kein Board-Default sein kann, ist eine **Entscheidung**, keine
+Tatsache: BIOS-Profile („Manual", „Full Speed") hinterlassen durchaus `1` mit
+fester Duty. Die Regel bleibt richtig — ein solcher Lüfter wird eben nicht
+zurückgegeben —, aber sie behauptet nicht, der Fall existiere nicht.
+
+### Herkunft mitspeichern
+
+Zwei Spalten in `fan_configs`:
+
+```
+pwm_enable_restore         Integer, nullable
+pwm_enable_restore_source  String(10), nullable   -- "observed" | "fallback"
+```
+
+Die zweite Spalte ist nicht Buchhaltung, sie schliesst ein Loch. Ohne sie hält
+die Invariante „der Fallback wird nie gespeichert" **genau einen Neustart**:
+der Shutdown schreibt den Fallback `5`, der nächste Scan liest `5` und
+persistiert ihn als vermeintliche Beobachtung — der Scan kann unseren eigenen
+Write nicht von einem BIOS-Wert unterscheiden. Die Annahme würde sich selbst
+zementieren.
 
 ### Die Auflösungsregel
 
 ```
-gelesener Wert != 1   ->  als Ziel benutzen UND persistieren
-gelesener Wert == 1   ->  gespeicherten Wert benutzen, falls vorhanden
-                          sonst Treiber-Fallback benutzen, NICHT speichern
-kein Fallback bekannt ->  nicht zurueckgeben, WARNING mit Treibernamen
+gelesener Wert in {0, 1}  ->  keine Beobachtung
+                              gespeicherten Wert benutzen, falls vorhanden
+                              sonst Treiber-Fallback benutzen, NICHT speichern
+
+gelesener Wert sonst      ->  ist er gleich dem gespeicherten Wert mit
+                              source="fallback"?  -> unveraendert lassen
+                                 (das ist sehr wahrscheinlich unser eigener
+                                  Rueckgabe-Write, keine Beobachtung)
+                              sonst -> als Ziel benutzen und mit
+                                       source="observed" persistieren
+
+kein Fallback bekannt     ->  keine Rueckgabe, WARNING mit Treibernamen
 ```
 
-**Der Fallback wird benutzt, aber nie gespeichert.** Ohne diese Einschränkung
-wäre eine falsch geratene Annahme selbsterhaltend: wir schrieben `5`, läsen
-beim nächsten Start `5`, speicherten `5` — und der echte Board-Wert käme nie
-mehr zum Zug. So bleibt der Platz für eine echte Beobachtung dauerhaft offen.
+Der mittlere Zweig ist der Kern: ein einmal geratener Fallback kann **nie** zur
+Beobachtung aufsteigen. Deckt sich der echte Board-Wert zufällig mit dem
+Fallback, bleibt er als `fallback` markiert — der Wert stimmt trotzdem.
 
 ### Der Fallback, als Annahme dokumentiert
 
 | Treiber | Wert | Belegt durch |
 |---|---|---|
 | `nct6775` (deckt nct6798 ab) | `5` — Smart Fan IV | Messung oben: `pwm1` 76 → 87, 508 RPM |
-| `amdgpu` | `2` — Auto | Ist-Zustand auf BaluNode; derselbe Wert, den `disable_amd_manual` zurückschreibt |
 | alles andere | keiner | keine Rückgabe, WARNING |
 
-Dass für unbekannte Treiber **nichts** passiert, ist Absicht: ein geratener
-Modus auf fremder Hardware ist schlechter als der heutige Zustand, und der
-heutige Zustand ist bekannt.
+`amdgpu` steht bewusst **nicht** in der Tabelle (siehe Nicht-Ziele).
+
+Dass für unbekannte Treiber nichts passiert, ist Absicht: ein geratener Modus
+auf fremder Hardware ist schlechter als der heutige Zustand, und der heutige
+Zustand ist bekannt.
 
 Fehlt `pwm_enable_path`, gibt es weder Übernahme noch Rückgabe.
 
----
+### Migration
 
-## 3. Die drei Auslöser
-
-### Dienst-Ende
-
-In `stop()`, **nachdem** die Monitoring-Task abgebrochen ist — erst die
-Schleife stilllegen, damit sie nicht gegen die Rückgabe schreibt, dann alle
-besessenen Lüfter zurückgeben. `_shutdown()` ruft `stop_fan_control()` bereits
-primary-gegated auf; der leere Besitz-Zustand auf Sekundär-Workern sichert das
-doppelt ab.
-
-### Nicht steuerbar
-
-Aufhänger ist der Backoff aus #533. Die Bedingung ist **„das Fenster liegt
-erstmals am Deckel"**, nicht eine feste Fehlerzahl — mit den heutigen Konstanten
-(`PWM_BACKOFF_BASE_SECONDS = 10`, Verdopplung, `PWM_BACKOFF_MAX_SECONDS = 900`)
-ist das der achte aufeinanderfolgende Fehlschlag (10, 20, 40, 80, 160, 320, 640,
-dann gedeckelt). Die Bedingung wird gegen den Deckel formuliert, damit eine
-spätere Änderung der Konstanten sie nicht still verschiebt.
-
-An diesem Punkt sind die Schreibversuche strukturell gescheitert und nicht bloß
-kurz gestört. Dann Rückgabe, `not_controllable`, **eine** ERROR-Zeile — die
-Log-Hygiene aus #533 gilt hier genauso.
-
-**Scheitern PWM-Writes, scheitert das Zurückschreiben von `pwm_enable` sehr
-wahrscheinlich auch** — derselbe Knoten, dieselben Rechte, derselbe Treiber.
-Die Rückgabe wird versucht und ihr Ergebnis geloggt, aber der Lüfter gilt
-danach **in jedem Fall** als freigegeben. Wir geben unseren Anspruch auf, auch
-wenn wir den Board-Modus nicht wiederherstellen können; weiter alle fünf
-Sekunden erfolglos zu schreiben ist eindeutig schlechter.
-
-### Regelung ausgefallen
-
-Liefert die Sensorauflösung über **zwölf** aufeinanderfolgende Zyklen keinen
-Wert — bei 5-Sekunden-Takt eine Minute —, wird zurückgegeben mit `no_target`.
-Ein oder zwei ausgefallene Messungen sind Rauschen; eine Minute ohne
-verwertbare Temperatur heißt, dass die Quelle weg ist.
-
-Kommt wieder ein Wert, übernimmt BaluHost beim nächsten Zyklus von selbst: der
-Regelkreis hört auf zu überspringen, und der nächste `set_pwm` schreibt
-`pwm_enable=1` mit. Das ersetzt das heutige Einfrieren des letzten Werts.
-
-### Der Notfallpfad bleibt unangetastet
-
-Er greift bei `Temperatur >= emergency_temp_celsius` und schreibt mit
-`force=True` volle Leistung. Beide Freigabegründe machen ihn gegenstandslos,
-statt ihn zu behindern:
-
-- Bei `no_target` gibt es keine Temperatur, also keinen Notfall — und das Board
-  regelt inzwischen selbst. Auf dem nct6798 rampt Smart Fan IV bei 60 °C auf 255.
-- Bei `not_controllable` scheitern Schreibversuche ohnehin; ein erzwungener
-  Notfall-Write scheiterte genauso.
-
-Ein freigegebener Lüfter wird **nicht** durch den Notfall zurückgeholt. Das
-kehrt die Abwägung aus #533 bewusst um: dort war der Emergency-Bypass richtig,
-weil BaluHost die Kontrolle hatte. Hier hat sie das Board, und das Board ist
-für genau diesen Fall gebaut.
+Beide Spalten brauchen eine Alembic-Migration. **Die Elternrevision ist zum
+Zeitpunkt der Umsetzung frisch über `alembic heads` zu prüfen**, nicht aus
+diesem Dokument zu übernehmen — das Projekt hatte einen Deploy-Fehler durch
+mehrere Heads.
 
 ---
 
-## 4. Integration
+## 3. Die Rückgabe
 
-### Regelkreis
+### Neue Backend-Methode
 
-Eine Abfrage pro Lüfter, direkt nachdem die Config geladen ist: ist der Lüfter
-freigegeben, werden Zielwert-Berechnung und Write übersprungen. **Die
-Messwert-Aufzeichnung läuft weiter** — Drehzahl und Temperatur gehören auch
-dann in die Historie, wenn das Board regelt; sonst reißt der Verlaufsgraph
-genau dort ab, wo man am ehesten nachsieht.
+Heute gibt es **keinen Weg**, `pwm_enable` auf etwas anderes als `1` zu
+schreiben: `_write_hwmon_file` ist privat, `set_pwm` schreibt den Literal `"1"`
+(`fan_backend_linux.py:183`). Die Rückgabe braucht deshalb eine neue Methode
+auf `FanControlBackend` (ABC: `fan_control.py:86-123`):
 
-### Nutzer-Klick
+```python
+async def release_to_board(self, fan_id: str, enable_value: int) -> bool: ...
+```
 
-Kein eigener Pfad nötig (siehe Abschnitt 1). Bei einem
-`not_controllable`-Lüfter scheitert der Klick weiterhin, und der Nutzer bekommt
-die echte Fehlermeldung statt eines stillen `False` — die Absicht des
-`force`-Pfades aus #533. Läuft der Backoff danach erneut in den Deckel, wird
-wieder freigegeben.
+Linux-Implementierung: schreibt den Wert, **liest ihn zurück** und meldet nur
+dann Erfolg, wenn er anliegt. Das Rücklesen ist billig (`_read_hwmon_file`
+existiert) und schliesst zwei Fälle: einen abgelehnten Modus (nicht jeder
+nct67xx kennt `5` — bei gleichem Chip an gleicher ISA-Adresse ergibt ein
+Board-Tausch dieselbe `fan_id`, aber nicht zwingend dieselbe Modus-Semantik)
+und einen stillschweigend ignorierten Write.
 
-### API
+Dev-Implementierung: no-op, gibt `True` zurück.
 
-`FanInfo` bekommt `released_reason: Optional[str]`.
+### Das Besitz-Signal
 
-### Frontend
+`set_pwm` verwirft heute das Ergebnis des `pwm_enable`-Writes:
+`ok_enable, _ = ...` wird nur für eine DEBUG-Zeile benutzt
+(`fan_backend_linux.py:183-186`), und der Rückgabewert von `set_pwm` spiegelt
+ausschliesslich den Wert-Write (`:190`, `:199`, `:246`).
 
-#480 hat `pwm_control` eingeführt, #537 hat `editingLocked` durch Profile,
-Save/Discard, `canEdit` und das Zeitplan-Panel gezogen, um firmware-verwaltete
-Lüfter zu sperren. Ein freigegebener Lüfter ist aus Nutzersicht derselbe Fall —
-die Regler sind wirkungslos, weil jemand anderes regelt. Also dieselbe Sperre
-mit eigenem Hinweistext:
+**Entscheidung: `set_pwm` markiert den Besitz selbst**, direkt nach einem
+gelungenen `pwm_enable`-Write, über `fan_ownership`. Kein Zyklus —
+`fan_backend_linux` importiert bereits aus `fan_control`, ein blattseitiges
+`fan_ownership` ist unkritisch.
 
-| Grund | Hinweis |
-|---|---|
-| `not_controllable` | „Nicht steuerbar — das Board regelt diesen Lüfter." |
-| `no_target` | „Kein Temperaturwert — das Board regelt, bis der Sensor zurückkommt." |
+Die Alternative — den Rückgabetyp von `set_pwm` erweitern — zöge die ABC, das
+Dev-Backend (`fan_backend_dev.py:138`) und mehrere Test-Doubles
+(`test_fan_pwm_backoff.py:253`, `test_fan_firmware_managed_loop.py:28`) nach
+sich, ohne dass irgendein anderer Aufrufer die Unterscheidung braucht.
 
-Kein neues Sperr-Konzept, kein zweiter Zustandsbaum. i18n-Schlüssel in `de` und
-`en`.
+### `stop()`
+
+Reihenfolge: erst die Monitoring-Task abbrechen (heutiges Verhalten), **dann**
+die Rückgabe. Umgekehrt schriebe die Schleife gegen die Rückgabe.
+
+Für jeden besessenen Lüfter: Zielwert nach der Regel aus Abschnitt 2
+auflösen, `release_to_board` aufrufen, Ergebnis pro Lüfter auf INFO,
+Zusammenfassung am Ende. Schlägt eine Rückgabe fehl, ist das eine
+**WARNING mit Treibername und Zielwert** — es ist der Fall, in dem niemand
+regelt, und er darf nicht im Rauschen untergehen.
+
+`stop()` ist mehrfach aufrufbar (Admin-Stop, danach Shutdown). Nach der
+Rückgabe wird der Besitz geleert; ein zweiter Lauf findet nichts mehr und
+schreibt nichts.
+
+### `switch_backend`
+
+`fan_control.py:1064-1090` tauscht das Backend aus, ohne zurückzugeben. Ein
+Wechsel Linux → dev lässt jeden Kanal auf `pwm_enable=1` zurück, während
+niemand mehr regelt — derselbe Zustand, den diese Arbeit beseitigt, nur über
+einen Admin-Endpunkt. Die Rückgabe läuft deshalb auch dort, vor dem Tausch,
+und der Besitz-Zustand wird geleert.
 
 ---
 
-## 5. Tests und Verifikation
+## 4. Tests und Verifikation
 
 ### Reine Einheiten
 
-Besitz-Modul und Auflösung des Rückgabewerts fassen weder sysfs noch Datenbank
-an. Die Auflösung ist als Tabelle prüfbar:
+Die Auflösung des Rückgabewerts fasst weder sysfs noch Datenbank an und ist als
+Tabelle prüfbar:
 
-| gelesen | gespeichert | Ergebnis | persistiert? |
+| gelesen | gespeichert (Wert / Herkunft) | Ergebnis | persistiert? |
 |---|---|---|---|
-| `5` | — | `5` | ja |
-| `1` | `5` | `5` | nein (unverändert) |
+| `5` | — | `5` | ja, `observed` |
+| `5` | `5` / `fallback` | `5` | **nein** (bleibt `fallback`) |
+| `5` | `2` / `observed` | `5` | ja, `observed` |
+| `1` | `5` / beliebig | `5` | nein |
 | `1` | — | Treiber-Fallback | **nein** |
+| `0` | — | Treiber-Fallback | **nein** |
 | `1` | — , Treiber unbekannt | keine Rückgabe + WARNING | nein |
 
-Die dritte Zeile ist die wichtigste: bliebe der Fallback hängen, wäre eine
-falsche Annahme selbsterhaltend.
+Zeile 2 und Zeile 6 sind die wichtigsten: die eine verhindert, dass ein
+geratener Fallback zur Beobachtung aufsteigt, die andere, dass „Vollgas" als
+Board-Automatik festgeschrieben wird.
 
-### Scan
+### Besitz
 
-`tmp_path`-Baum mit `pwm1_enable = 5`, Scan laufen lassen, gesicherten Wert
-prüfen. Platform-förmig und doppelpunktfrei, damit der Test auch unter Windows
-läuft (NTFS verbietet Doppelpunkte in Verzeichnisnamen, Lehre aus #532).
+- `pwm_enable`-Write gelingt, Wert-Write scheitert → **besessen**. Der Fall,
+  der die Definition trägt.
+- `pwm_enable`-Write scheitert → **nicht besessen**, kein Rückgabe-Write bei
+  `stop()`.
+- **Sekundär-Worker: `POST /api/fans/pwm` erwirbt keinen Besitz.** Nicht über
+  ein leeres Dict prüfen — das wäre tautologisch —, sondern über den echten
+  Weg: Flag auf `False`, `set_pwm` aufrufen, danach `stop()`, und die
+  `pwm1_enable`-Datei muss unverändert sein.
 
-### Die drei Auslöser
+### Rückgabe
 
-- **Shutdown:** besessener Lüfter → nach `stop()` steht der Rückgabewert in der
-  Datei. Nicht besessener Lüfter → Datei unverändert. **Sekundär-Worker → gar
-  kein Write**, weil der Besitz-Zustand leer ist. Der dritte Fall ist der
-  wichtigste der drei.
-- **`not_controllable`:** Backoff am Deckel → Freigabe, genau eine ERROR-Zeile.
-  Scheitert auch das Zurückschreiben → Lüfter gilt trotzdem als freigegeben.
-- **`no_target`:** elf Zyklen ohne Wert → weiterhin besessen. Zwölfter →
-  freigegeben. Wert kommt zurück → wieder übernommen. Die Grenze wird von
-  beiden Seiten festgenagelt.
+- Besessener Lüfter → nach `stop()` steht der Zielwert in der Datei.
+- Nicht besessener Lüfter → Datei unverändert.
+- **Rücklesen schlägt fehl** (Write geht durch, Wert liegt nicht an) →
+  `release_to_board` meldet `False`, WARNING, kein stiller Erfolg.
+- Zweiter `stop()`-Aufruf schreibt nichts.
+- AMD-GPU-Lüfter wird nie zurückgegeben.
 
-### Notfallpfad
+Aufbau über echte `tmp_path`-sysfs-Bäume, platform-förmig und doppelpunktfrei
+(NTFS verbietet Doppelpunkte in Verzeichnisnamen — Lehre aus #532). Muster
+liegen in `test_fan_pwm_backoff.py:28-51` und `test_fan_scan_stable_ids.py`.
 
-Eigener Test, dass ein freigegebener Lüfter **nicht** zurückgeholt wird — es
-ist eine bewusste Umkehr gegenüber #533 und sähe ohne Test wie ein Versehen aus.
+### Persistenz
+
+- Der Restore-Write ist ein **UPDATE**; für eine nicht existierende `fan_id`
+  entsteht **keine** Zeile. Das ist der Test gegen die #532-Kollision.
+- Er läuft nur im Primary und nur nach dem Reconcile-Commit.
 
 ### Gates
 
-`pytest -k "fan or power"` (Messlatte 621 passed, 2 skipped), `ruff check`,
-`eslint .`, `npm run build`, `vitest run`. Volle Backend-Suite in der CI.
+`pytest -k "fan or power"`, `ruff check`, `eslint .`, `npm run build`,
+`vitest run`. Die Messlatte ist unmittelbar vor der Umsetzung einmal zu messen
+und mit Datum zu notieren — die Zahl aus einem früheren Lauf ist keine
+Messlatte. Volle Backend-Suite in der CI.
+
+Frontend-Gates laufen mit, obwohl diese Arbeit das Frontend nicht anfasst.
 
 ### Feldverifikation
 
-1. **Shutdown — der Kern.** `systemctl stop baluhost-backend`, dann
+1. **Der Kern.** `systemctl stop baluhost-backend`, dann
    `cat /sys/class/hwmon/hwmon3/pwm{1,2,3,7}_enable`. Erwartung: viermal `5`
    statt viermal `1`. Heute steht dort `1`; das ist die Lücke.
-2. **Der Kreis schließt sich.** Dienst starten, dann
-   `SELECT fan_id, pwm_enable_restore FROM fan_configs WHERE is_active`. Der
-   Scan sollte `5` gesichert haben, weil der Shutdown sie hinterlassen hat.
-   Damit ist die Selbstheilung belegt und der Treiber-Fallback arbeitslos.
-3. **`no_target` erzwingen, reversibel.** Einem Lüfter über die API eine nicht
-   existierende Sensor-ID zuweisen, eine Minute warten, `pwm_enable` lesen —
-   muss auf `5` stehen. Sensor zurücksetzen, prüfen dass BaluHost binnen eines
-   Zyklus wieder übernimmt.
-4. **`not_controllable`** bleibt den Einheitentests überlassen. Es im Feld zu
-   erzwingen hieße, Rechte oder Treiber zu manipulieren — mehr Risiko als
-   Erkenntnis.
+2. **Die Herkunft.** Dienst starten, dann
+   `SELECT fan_id, pwm_enable_restore, pwm_enable_restore_source FROM fan_configs WHERE is_active`.
+   Erwartung: `5 / fallback` — **nicht** `5 / observed`. Steht dort `observed`,
+   ist die Regel aus Abschnitt 2 verletzt und der Fallback hat sich selbst zur
+   Beobachtung befördert. Das ist der Test, den die erste Fassung dieser Spec
+   fälschlich als Erfolgsbeleg geführt hat.
+3. **Der echte Wert.** Erst ein Kaltstart mit gestopptem Backend kann eine
+   echte Beobachtung liefern: Rechner booten, Backend vor dem ersten
+   Regelzyklus stoppen, `pwm_enable` lesen. Steht dort der BIOS-Wert, ist er
+   die Beobachtung, die die Spalte dauerhaft füllen soll. Optional — der
+   Fallback tut es bis dahin.
 
 ---
 
 ## Risiken
 
 - **Der Treiber-Fallback ist eine Annahme**, für `nct6775` durch Messung
-  gedeckt, für `amdgpu` durch den Ist-Zustand. Für alles andere wird bewusst
-  nichts getan.
-- **Die Rückgabe kann scheitern**, gerade im `not_controllable`-Fall. Der
-  Lüfter gilt dann trotzdem als freigegeben; das Ergebnis wird geloggt.
+  gedeckt. Für alles andere wird bewusst nichts getan.
+- **Die Rückgabe kann scheitern.** Sie wird zurückgelesen und im Fehlerfall als
+  WARNING gemeldet; der Zustand ist dann derselbe wie heute.
 - **Ob das Board nach der Rückgabe tatsächlich regelt**, ist auf BaluNode
   gemessen und für andere Hardware nicht garantiert. Da nur bei bekanntem
-  Treiber zurückgegeben wird, ist das Risiko auf die zwei Fälle in der Tabelle
-  begrenzt.
+  Treiber zurückgegeben wird, ist das Risiko auf einen Fall begrenzt.
 - **`SIGKILL` bleibt ungedeckt** (siehe Nicht-Ziele).
+- **Zwei Regelschleifen über `/api/admin/services/fan_control/restart`** sind
+  ein vorbestehender Fehler, den diese Arbeit nicht behebt und der als
+  Nebenbefund festzuhalten ist.

--- a/docs/superpowers/specs/2026-09-05-fan-ownership-handback-design.md
+++ b/docs/superpowers/specs/2026-09-05-fan-ownership-handback-design.md
@@ -1,18 +1,18 @@
 # Regelung beim Dienst-Ende an die Board-Automatik zurückgeben
 
-**Status:** Design freigegeben (2026-09-05), nach kritischer Review auf den
-Shutdown-Pfad zurückgenommen
+**Status:** Design freigegeben (2026-09-05); zweimal überarbeitet — zuerst auf
+den Shutdown-Pfad zurückgenommen, dann nach einer zweiten Review auf
+„nur beobachtete Werte" umgestellt
 **Issue:** #534 (Teilumfang — Punkte 1 und 2 des Issues bleiben offen)
 **Branch:** `feat/fan-ownership-handback-534` (von `main`)
 **Voraussetzung:** #517/#480 (PR #537), #533 (PR #539), #532 (PR #550) sind gemergt.
 
 ## Kontext
 
-BaluHost nimmt die Kontrolle über jeden schreibbaren Lüfter und gibt sie nie
-zurück. Beim Dienst-Ende — und das Backend startet bei **jedem Deploy** neu —
-bleibt `pwm_enable=1` stehen: die Board-Automatik ist abgeschaltet, der PWM
-friert auf dem letzten Wert ein, und bis der Dienst wieder läuft, regelt
-niemand.
+BaluHost nimmt die Kontrolle über jeden geregelten Lüfter (`pwm_enable=1`) und
+gibt sie nie zurück. Beim Dienst-Ende — und das Backend startet bei **jedem
+Deploy** neu — bleibt die Board-Automatik abgeschaltet, der PWM friert auf dem
+letzten Wert ein, und bis der Dienst wieder läuft, regelt niemand.
 
 ### Was der Ist-Zustand tatsächlich ist
 
@@ -22,15 +22,15 @@ PWM-Write** (`fan_backend_linux.py:182-190`). BaluHost übernimmt die Kontrolle
 alle fünf Sekunden neu.
 
 Der Ursprungswert wird nirgends gesichert (`fan_backend_linux.py:510` legt nur
-`pwm_enable_path` ab). `stop()` bricht heute ausschliesslich die
-Monitoring-Task ab (`fan_control.py:210-219`). Ein Aufhängepunkt existiert:
-`_shutdown()` ruft `stop_fan_control()` primary-gegated auf (`lifespan.py:747`
-Gate, `:759` Aufruf).
+`pwm_enable_path` ab). `stop()` bricht heute ausschliesslich die Monitoring-Task
+ab (`fan_control.py:210-219`). Ein Aufhängepunkt existiert: `_shutdown()` ruft
+`stop_fan_control()` primary-gegated auf (`lifespan.py:747` Gate, `:759` Aufruf).
 
-Ein Muster für Sicherung und Rückgabe gibt es bereits, aber nur für den
-AMD-Pfad: `AmdManualState` in `fan_gpu_manual.py:24-30`, `:65-78`.
+Es gibt heute **keinen Weg**, `pwm_enable` auf etwas anderes als `1` zu
+schreiben: `_write_hwmon_file` ist privat, `set_pwm` schreibt den Literal `"1"`
+(`fan_backend_linux.py:183`).
 
-### Die Prämisse ist gemessen, nicht angenommen
+### Die Prämisse ist gemessen
 
 Auf BaluNode (2026-09-05), Kanal 1 des nct6798, Dienst gestoppt:
 
@@ -41,189 +41,206 @@ Auf BaluNode (2026-09-05), Kanal 1 des nct6798, Dienst gestoppt:
 | nach Dienststart | 1 | 87 | — |
 
 `pwm1` wanderte ohne fremden Schreibzugriff von 76 auf 87 — der Chip hat die
-Regelung übernommen. Smart Fan IV greift wirklich.
+Regelung übernommen. **Belegt ist damit: Modus 5 wird auf diesem Chip
+angenommen und wirkt.** Nicht belegt ist, dass 5 der Board-Default ist — die
+Messung lief nach BaluHost-Betrieb, der BIOS-Ausgangswert wurde nie beobachtet.
+Diese Unterscheidung trägt den gesamten Entwurf (siehe Abschnitt 2).
 
 ### Warum nur der Shutdown-Pfad
 
-Der ursprüngliche Entwurf deckte alle drei Punkte des Issues ab. Zwei kritische
-Reviews fanden darin acht blockierende Befunde; **sechs davon entfielen
-ausschliesslich auf die zwei Laufzeit-Auslöser** („nicht steuerbar",
-„Regelung ausgefallen"), und beide sicherheitsrelevanten Fälle ebenfalls.
-
-Der Shutdown-Pfad braucht keinen Eingriff in den Regelkreis, keine
-Backoff-Introspektion, keinen Rückhol-Endpunkt und **keine UI-Anzeige** — und
-damit auch nicht den worker-übergreifenden Zustand, an dem die zwei
-Laufzeit-Auslöser scheitern (siehe #552: prozesslokale Flags erzeugen ein
-flackerndes Read-Only-Banner, weil `get_status()` in einem beliebigen Worker
-läuft).
-
-Die Befunde zu den beiden verbleibenden Punkten sind in #534 dokumentiert.
+Der erste Entwurf deckte alle drei Punkte des Issues ab; zwei Reviews fanden
+acht blockierende Befunde, **sechs davon ausschliesslich an den beiden
+Laufzeit-Auslösern**, ebenso beide sicherheitsrelevanten Fälle. Die Befunde
+sind in #534 dokumentiert.
 
 ## Ziele
 
-- Beim Dienst-Ende die Kontrolle an die Board-Automatik zurückgeben.
+- Beim Dienst-Ende die Kontrolle an die Board-Automatik zurückgeben — aber nur
+  auf einen Wert, den BaluHost am selben Chip **selbst beobachtet** hat.
 
 ## Nicht-Ziele
 
-- **Keine Laufzeit-Rückgabe** (Punkte 1 und 2 des Issues). Bleiben offen.
-- Keine UI-Anzeige und kein neues Feld in `FanInfo`.
-- Keine Änderung an Regelkreis, Kurvenauswertung, Notfallpfad oder dem Backoff
-  aus #533.
-- **Keine Rückgabe für AMD-GPU-Lüfter.** Für sie existiert mit
-  `AmdManualState` / `disable_amd_manual` (`fan_gpu_manual.py:65-78`) bereits
-  ein eigener Rückgabeweg, der zusätzlich `power_dpm_force_performance_level`
-  zurücksetzt. Zwei konkurrierende Mechanismen auf demselben Knoten wären ein
-  Fehler. Ausgeschlossen wird über `gpu_vendor == "amd"`, nicht über
-  `FIRMWARE_MANAGED` — Letzteres deckt Pre-RDNA3-Karten nicht ab.
+- **Keine Laufzeit-Rückgabe** (Punkte 1 und 2 des Issues).
+- **Kein Treiber-Fallback, kein geratener Modus.** Siehe Abschnitt 2 — die
+  frühere Fassung hatte einen; die Review hat ihn auf drei Ebenen zerlegt.
+- Keine UI-Anzeige, kein neues Feld in `FanInfo`.
+- Keine Änderung an Regelkreis, Kurvenauswertung, Notfallpfad oder Backoff (#533).
+- **Keine Rückgabe für GPU-Lüfter.** Für AMD existiert mit `AmdManualState` /
+  `disable_amd_manual` (`fan_gpu_manual.py:25-30`, `:65-78`) bereits ein eigener
+  Weg, der zusätzlich `power_dpm_force_performance_level` zurücksetzt; zwei
+  Mechanismen auf demselben Knoten wären ein Fehler. Ausgeschlossen wird über
+  `gpu_vendor is not None` — das deckt auch `nouveau`, das gar keinen
+  Rückgabeweg hat, und anders als `FIRMWARE_MANAGED` auch Pre-RDNA3-Karten.
 
 ### Die Grenze, die keine Lösung beseitigt
 
 Bei `SIGKILL` gibt es keine Rückgabe. `systemctl stop` und der Deploy-Neustart
 senden `SIGTERM`, dort greift der Shutdown-Pfad. Ein hartes Kill oder ein
-Stromausfall hinterlässt die Lüfter auf dem letzten Wert — das ist der heutige
-Zustand und im Prozess selbst nicht behebbar.
+Stromausfall hinterlässt die Lüfter auf dem letzten Wert — der heutige Zustand,
+im Prozess selbst nicht behebbar.
 
 ---
 
-## 1. Besitz
+## 1. Kein Besitz-Modell — der Zustand steht in sysfs
 
-Ein Lüfter gilt als **besessen**, sobald ein `pwm_enable=1`-Write auf ihm
-gelungen ist. Nicht der Wert-Write — der `pwm_enable`-Write *ist* die
-Übernahme, er schaltet die Board-Automatik ab.
+Die frühere Fassung verfolgte, welche Lüfter BaluHost „besitzt", und gab beim
+Beenden genau die zurück. Das trug nicht:
 
-Der Unterschied ist nicht akademisch: gelingt `pwm_enable=1` und scheitert der
-Wert-Write, hat BaluHost die Automatik abgeschaltet, ohne selbst regeln zu
-können. Genau dieser Lüfter muss zurückgegeben werden.
+Ein Lüfter im **MANUAL**-Modus wird vom Regelkreis nie geschrieben — `target_pwm`
+ist dort gleich `fan.pwm_percent` (`fan_control.py:670`), und geschrieben wird
+nur unter `if target_pwm != fan.pwm_percent` (`:740`). Sein einziger Schreibweg
+ist `POST /api/fans/pwm` (`routes/fans.py:167`), und der landet bei vier Workern
+meist auf einem Sekundär. Ein primary-gebundener Besitz hätte ihn nie erfasst —
+er stünde am Dienstende auf `pwm_enable=1`, und niemand regelte. Genau der
+Zustand, den diese Arbeit beseitigen soll.
 
-### Besitz wird nur im Primary-Worker erworben
+**Stattdessen: beim Beenden den tatsächlich anliegenden Wert lesen.** Der
+Zustand steht in sysfs, prozessübergreifend, ohne Buchführung. Ein Lüfter wird
+zurückgegeben, wenn
 
-**Nicht** am `monitoring`-Flag festgemacht, sondern hart an
-`getattr(lifespan, "IS_PRIMARY_WORKER", False)` — als Attributzugriff auf das
-Modul, nie als `from ... import` (das Flag wird erst zur Laufzeit gesetzt;
-Muster wie in `fan_control.py:250`).
+1. für ihn ein **beobachteter** Rückgabewert bekannt ist (Abschnitt 2), **und**
+2. `pwm_enable` gerade **nicht** auf diesem Wert steht.
 
-Grund: `set_pwm` ist auf **jedem** Worker erreichbar, über drei Wege:
+Damit entfallen die Besitzverfolgung, das Primary-Gate als Besitzkriterium und
+die gesamte Argumentation darüber, welcher Worker `set_pwm` aufrufen darf.
+Geblieben ist ein Gate an genau einer Stelle: **zurückgegeben wird nur im
+Primary-Worker**, gelesen als `getattr(lifespan, "IS_PRIMARY_WORKER", False)` —
+Modul-Attribut, nie `from ... import` (das Flag wird erst zur Laufzeit gesetzt;
+Muster wie `fan_control.py:250`).
 
-1. `POST /api/fans/pwm` (`routes/fans.py:167` → `fan_control.py:1003`) — läuft
-   im bedienenden Worker, bei vier Workern also meist auf einem Sekundär.
-2. `POST /api/admin/services/fan_control/stop` (`routes/service_status.py:174`
-   → `service_registry.py:207`) — ruft `stop_fan_control()` im bedienenden
-   Worker.
-3. `.../restart` bzw. `/start` (`service_status.py:292`, `:438`) — ruft
-   `start_fan_control()` **ohne Argument**, also mit `monitoring=True`
-   (`fan_control.py:1287`); ein Sekundär-Worker startet dann eine vollwertige
-   zweite Regelschleife.
+### Ein Lesehinweis zu `pwm_enable`
 
-Ohne das Primary-Gate erwürbe ein Sekundär-Worker über Weg 1 Besitz, und Weg 2
-gäbe die Lüfter dann ans Board zurück, während der Primary weiterregelt.
+Der Treiber meldet Manual-Modus mit Duty 255 als **`0`**, nicht als `1`:
 
-Weg 3 ist ein eigenständiger, vorbestehender Fehler — zwei konkurrierende
-Regelschleifen — und **nicht Gegenstand dieser Arbeit**; er ist als
-Nebenbefund festzuhalten.
+```c
+static enum pwm_enable reg_to_pwm_enable(int pwm, int mode)
+{
+	if (mode == 0 && pwm == 255)
+		return off;
+	return mode + 1;
+}
+```
 
-### Der Zustand
-
-Neues Modul `backend/app/services/power/fan_ownership.py`, prozesslokal,
-`fan_id → besessen`. Prozesslokal ist hier ausreichend und richtig, weil der
-Zustand **nirgends ausgelesen** wird: keine API, keine UI. Er dient
-ausschliesslich dazu, beim Beenden zu wissen, was zurückzugeben ist.
+Ein Lüfter, den BaluHost auf 100 % fährt, liest sich also als `0`. Die Bedingung
+„steht nicht auf dem Rückgabewert" deckt das ab, ohne Sonderfall — aber jede
+Prüfung von Hand (und die Feldverifikation) muss es wissen.
 
 ---
 
-## 2. Der Rückgabewert
+## 2. Nur beobachtete Werte — kein Fallback
 
-### Gesichert wird beim Scan, persistiert wird im Service
+### Warum der Treiber-Fallback gestrichen ist
 
-`_scan_pwm_fans` liest `pwm_enable` in den Cache (`pwm_enable_at_scan`) —
-**mehr nicht**. `LinuxFanControlBackend` kennt keine Datenbank
-(`fan_backend_linux.py:45-58`), und der Scan läuft in jedem Worker, vor dem
-Identitäts-Abgleich und vor der Anlage-Schleife.
+Die frühere Fassung schrieb bei unbekanntem Ursprungswert einen hartkodierten
+Modus (`nct6775 → 5`). Die Review hat ihn auf drei Ebenen zerlegt:
 
-Persistiert wird in `_load_fan_configs`, **im Primary**, **nach** dem
-Reconcile-Commit (`fan_control.py:351`) und **nach** dem Primary-Gate
-(`:426`), ausschliesslich als **UPDATE auf existierende Zeilen — nie als
-INSERT**.
+- **Der Schlüssel existierte nicht.** Der einzige Treiberwert im Code ist
+  `device_driver`, und das ist wörtlich der Inhalt von `hwmonN/name` —
+  beim `nct6775`-Treiber der **Chip**name. Auf BaluNode steht dort `nct6798`
+  (belegt durch die eigene Messung und durch die Fan-ID
+  `nct6798-isa-0290:pwm1`). Ein Lookup auf `nct6775` hätte nie getroffen.
+- **Die Begründung war falsch.** `store_pwm_enable()` prüft `data->kind` nur
+  für Modus 4 (Smart Fan III, NCT6775F only); Modus 5 ist chip-unabhängig
+  erlaubt. Dafür lehnt `check_trip_points()` Modus 5 ab, wenn die
+  BIOS-Stützstellen nicht monoton sind — zustandsabhängig, auf demselben Chip,
+  und als **EINVAL beim Schreiben**, nicht als abweichender Rücklesewert.
+- **Die Messung belegte ihn nicht.** Sie zeigt, dass 5 *angenommen wird und
+  wirkt* — nicht, dass 5 der Board-Default ist. Als Rückgabewert taugt sie
+  damit nicht.
 
-Ein Upsert an dieser Stelle legte eine frische Zeile mit `updated_at="jetzt"`
-an, die im nächsten Identitäts-Abgleich gegen die echte Nutzerkurve gewönne
-(`fan_reconcile.py:151`) — genau der Datenverlust, den #532 beseitigt hat.
-`test_fan_reconcile_wiring.py:202-275` bewacht diesen Fall.
+**Entscheidung: zurückgegeben wird ausschliesslich ein Wert, den BaluHost am
+selben Chip selbst gelesen hat.** Das kostet etwas Konkretes (siehe unten) und
+ist die einzige Variante, die keine Annahme über fremde Hardware trifft.
 
-Dass der Wert beim allerersten Erscheinen eines Lüfters einen Startzyklus
-später ankommt, ist der richtige Preis. Der Docstring von `_load_fan_configs`
-(„Existing configs are NOT modified", `:310-311`) gilt dann nicht mehr und ist
-mitzuziehen.
+### Wann ein Wert beobachtet werden kann
 
-### Gültige Zielwerte
+`_scan_pwm_fans` läuft aus `is_available()` heraus beim Backend-Init — **einmal
+pro Start und vor dem ersten `set_pwm`**. `get_fans()` rescannt nicht
+(`fan_backend_linux.py:109-147`, reine Cache-Lesung). Der Scan ist damit der
+einzige Moment, in dem der Board-Wert überhaupt sichtbar sein kann.
 
-**Weder `0` noch `1`.** `1` ist Handsteuerung. `0` bedeutet nach
-hwmon-Konvention „keine Regelung durch den Chip" — beim nct6775 Vollgas, also
-gerade **nicht** Board-Automatik. Ein persistiertes `0` fährt die Lüfter nach
-jedem Dienst-Ende auf Anschlag und zementiert das über die Sicherung.
+Was er sieht, hängt davon ab, wie der Prozess davor endete:
 
-Dass `1` kein Board-Default sein kann, ist eine **Entscheidung**, keine
-Tatsache: BIOS-Profile („Manual", „Full Speed") hinterlassen durchaus `1` mit
-fester Duty. Die Regel bleibt richtig — ein solcher Lüfter wird eben nicht
-zurückgegeben —, aber sie behauptet nicht, der Fall existiere nicht.
-
-### Herkunft mitspeichern
-
-Zwei Spalten in `fan_configs`:
-
-```
-pwm_enable_restore         Integer, nullable
-pwm_enable_restore_source  String(10), nullable   -- "observed" | "fallback"
-```
-
-Die zweite Spalte ist nicht Buchhaltung, sie schliesst ein Loch. Ohne sie hält
-die Invariante „der Fallback wird nie gespeichert" **genau einen Neustart**:
-der Shutdown schreibt den Fallback `5`, der nächste Scan liest `5` und
-persistiert ihn als vermeintliche Beobachtung — der Scan kann unseren eigenen
-Write nicht von einem BIOS-Wert unterscheiden. Die Annahme würde sich selbst
-zementieren.
-
-### Die Auflösungsregel
-
-```
-gelesener Wert in {0, 1}  ->  keine Beobachtung
-                              gespeicherten Wert benutzen, falls vorhanden
-                              sonst Treiber-Fallback benutzen, NICHT speichern
-
-gelesener Wert sonst      ->  ist er gleich dem gespeicherten Wert mit
-                              source="fallback"?  -> unveraendert lassen
-                                 (das ist sehr wahrscheinlich unser eigener
-                                  Rueckgabe-Write, keine Beobachtung)
-                              sonst -> als Ziel benutzen und mit
-                                       source="observed" persistieren
-
-kein Fallback bekannt     ->  keine Rueckgabe, WARNING mit Treibernamen
-```
-
-Der mittlere Zweig ist der Kern: ein einmal geratener Fallback kann **nie** zur
-Beobachtung aufsteigen. Deckt sich der echte Board-Wert zufällig mit dem
-Fallback, bleibt er als `fallback` markiert — der Wert stimmt trotzdem.
-
-### Der Fallback, als Annahme dokumentiert
-
-| Treiber | Wert | Belegt durch |
+| Vorgeschichte | Scan liest | Bedeutung |
 |---|---|---|
-| `nct6775` (deckt nct6798 ab) | `5` — Smart Fan IV | Messung oben: `pwm1` 76 → 87, 508 RPM |
-| alles andere | keiner | keine Rückgabe, WARNING |
+| Kaltstart | den BIOS-Wert | **echte Beobachtung** |
+| sauberer Shutdown, dann Neustart | den zurückgegebenen Wert | Beobachtung, wertgleich |
+| `SIGKILL`, dann Neustart | `1` bzw. `0` | keine Beobachtung |
+| laufender Betrieb | `1` bzw. `0` | keine Beobachtung |
 
-`amdgpu` steht bewusst **nicht** in der Tabelle (siehe Nicht-Ziele).
+### Die Regel
 
-Dass für unbekannte Treiber nichts passiert, ist Absicht: ein geratener Modus
-auf fremder Hardware ist schlechter als der heutige Zustand, und der heutige
-Zustand ist bekannt.
+```
+gelesener Wert >= 2  ->  beobachteter Automatikmodus:
+                         als Rueckgabewert speichern (ueberschreibt einen
+                         aelteren Wert -- die juengere Beobachtung gilt)
 
-Fehlt `pwm_enable_path`, gibt es weder Übernahme noch Rückgabe.
+gelesener Wert 0/1   ->  keine Beobachtung: gespeicherten Wert unveraendert
+                         lassen. Ist keiner gespeichert, gibt es fuer diesen
+                         Luefter keine Rueckgabe.
+```
 
-### Migration
+`0` und `1` sind beide keine Automatik. `1` ist Handsteuerung. `0` heisst laut
+generischer hwmon-Konvention „**no fan speed control (i.e. fan at full
+speed)**", und der Treiber setzt dabei zusätzlich Duty 255 — also gerade nicht
+Board-Automatik.
 
-Beide Spalten brauchen eine Alembic-Migration. **Die Elternrevision ist zum
-Zeitpunkt der Umsetzung frisch über `alembic heads` zu prüfen**, nicht aus
-diesem Dokument zu übernehmen — das Projekt hatte einen Deploy-Fehler durch
-mehrere Heads.
+Dass `1` kein Board-Default sein *kann*, ist eine Entscheidung, keine Tatsache:
+BIOS-Profile („Manual", „Full Speed") hinterlassen durchaus `1` mit fester Duty.
+Ein solcher Lüfter wird dann eben nie zurückgegeben — richtig, denn dorthin
+zurückzuschalten hiesse, die Automatik nicht wiederherzustellen.
+
+### Der Preis, ausdrücklich
+
+**Auf BaluNode passiert nach dem Deploy zunächst nichts.** Alle vier Kanäle
+stehen auf `1`, es gibt keine Beobachtung und keinen gespeicherten Wert. Erst
+der **nächste Kaltstart** liefert den BIOS-Wert; ab dann ist die Rückgabe
+scharf.
+
+Das ist die ehrliche Alternative zu einem geratenen Modus, und der einzige
+Preis ist ein Reboot. Wer nicht warten will, kann den Wert einmal von Hand
+setzen (`echo 5 > .../pwm1_enable` bei gestopptem Dienst) — der nächste Start
+liest ihn als Beobachtung. Das gehört in die Doku, nicht in den Code.
+
+### Persistenz
+
+Eine neue Spalte in `fan_configs`:
+
+```
+pwm_enable_restore  Integer, nullable
+```
+
+**Keine Herkunftsspalte.** Die frühere Fassung brauchte sie, um einen geratenen
+Fallback vom beobachteten Wert zu trennen; ohne Fallback gibt es nichts zu
+trennen. (Sie war ohnehin defekt: die Regel „Fallback nicht speichern" liess
+den Wert `fallback` nie entstehen.)
+
+Geschrieben wird **im Primary**, in `_load_fan_configs`, **nach** dem
+Reconcile-Commit (`fan_control.py:351`) und **nach** dem Primary-Gate (`:426`):
+
+- Für eine **neu angelegte** Zeile wird der Wert am `FanConfig(...)`-Objekt
+  mitgesetzt (`fan_control.py:428-468`). Das erzeugt keine zusätzliche Zeile —
+  die Zeile entsteht dort ohnehin — und ist die **einzige** Gelegenheit, die
+  Erstbeobachtung eines neuen Lüfters festzuhalten. Die frühere Fassung
+  verwarf sie mit einer UPDATE-only-Regel, deren Begründung (#532-Kollision)
+  sachlich nicht zutraf.
+- Für eine **bestehende** Zeile wird das Attribut nur gesetzt, wenn der Wert
+  sich unterscheidet.
+
+**`updated_at` darf dabei nicht wandern.** Die Spalte trägt
+`onupdate=func.now()` (`models/fans.py:107-112`), und der Identitäts-Abgleich
+benutzt sie als Rangkriterium (`fan_reconcile.py:151`, mit einem Snapshot
+davor bei `:101-103`). Ein Schreibvorgang bei jedem Start setzte jede Zeile auf
+„gerade angefasst" und entwertete das Kriterium. Deshalb: nur bei echter
+Änderung schreiben, und beim expliziten `update()` `updated_at` mitführen.
+
+Der Wert wird beim Start in den Speicher geladen, sodass `stop()` keine
+Datenbank braucht.
+
+Die Spalte braucht eine Alembic-Migration; **die Elternrevision ist zum
+Zeitpunkt der Umsetzung frisch über `alembic heads` zu prüfen** — das Projekt
+hatte einen Deploy-Fehler durch mehrere Heads. Kein Backfill: bestehende Zeilen
+bleiben `NULL`, bis eine Beobachtung anfällt.
 
 ---
 
@@ -231,155 +248,154 @@ mehrere Heads.
 
 ### Neue Backend-Methode
 
-Heute gibt es **keinen Weg**, `pwm_enable` auf etwas anderes als `1` zu
-schreiben: `_write_hwmon_file` ist privat, `set_pwm` schreibt den Literal `"1"`
-(`fan_backend_linux.py:183`). Die Rückgabe braucht deshalb eine neue Methode
-auf `FanControlBackend` (ABC: `fan_control.py:86-123`):
+Auf `FanControlBackend` (ABC: `fan_control.py:86-123`):
 
 ```python
 async def release_to_board(self, fan_id: str, enable_value: int) -> bool: ...
 ```
 
-Linux-Implementierung: schreibt den Wert, **liest ihn zurück** und meldet nur
-dann Erfolg, wenn er anliegt. Das Rücklesen ist billig (`_read_hwmon_file`
-existiert) und schliesst zwei Fälle: einen abgelehnten Modus (nicht jeder
-nct67xx kennt `5` — bei gleichem Chip an gleicher ISA-Adresse ergibt ein
-Board-Tausch dieselbe `fan_id`, aber nicht zwingend dieselbe Modus-Semantik)
-und einen stillschweigend ignorierten Write.
+Linux-Implementierung:
 
-Dev-Implementierung: no-op, gibt `True` zurück.
+- schreibt den Wert, **unter Umgehung des Write-Backoffs aus #533**. Läge sie
+  hinter dem Backoff, unterbliebe die Rückgabe ausgerechnet bei den Kanälen,
+  die zuvor Schreibfehler hatten — den kritischsten;
+- **liest zurück** und meldet nur bei anliegendem Wert Erfolg.
 
-### Das Besitz-Signal
+Was das Rücklesen leistet und was nicht: Es fängt den **still ignorierten**
+Write. Ein vom Treiber **abgelehnter** Modus kommt dagegen als `EINVAL` aus dem
+Write selbst zurück — etwa wenn `check_trip_points()` nicht-monotone
+BIOS-Stützstellen findet. Beide Fälle sind zu unterscheiden und zu loggen.
 
-`set_pwm` verwirft heute das Ergebnis des `pwm_enable`-Writes:
-`ok_enable, _ = ...` wird nur für eine DEBUG-Zeile benutzt
-(`fan_backend_linux.py:183-186`), und der Rückgabewert von `set_pwm` spiegelt
-ausschliesslich den Wert-Write (`:190`, `:199`, `:246`).
+Vorsicht bei der Fehlermeldung: `_write_hwmon_file` (`fan_backend_linux.py:548-592`)
+gibt nach einem gescheiterten `sudo tee`-Fallback `EACCES` zurück, nicht den
+echten Kernel-Fehler — eine `EINVAL`-Ablehnung kann sich so als Rechteproblem
+tarnen. Die Meldung sollte das nicht als Tatsache behaupten.
 
-**Entscheidung: `set_pwm` markiert den Besitz selbst**, direkt nach einem
-gelungenen `pwm_enable`-Write, über `fan_ownership`. Kein Zyklus —
-`fan_backend_linux` importiert bereits aus `fan_control`, ein blattseitiges
-`fan_ownership` ist unkritisch.
-
-Die Alternative — den Rückgabetyp von `set_pwm` erweitern — zöge die ABC, das
-Dev-Backend (`fan_backend_dev.py:138`) und mehrere Test-Doubles
-(`test_fan_pwm_backoff.py:253`, `test_fan_firmware_managed_loop.py:28`) nach
-sich, ohne dass irgendein anderer Aufrufer die Unterscheidung braucht.
+Dev-Implementierung: no-op, `True`.
 
 ### `stop()`
 
 Reihenfolge: erst die Monitoring-Task abbrechen (heutiges Verhalten), **dann**
-die Rückgabe. Umgekehrt schriebe die Schleife gegen die Rückgabe.
+die Rückgabe — umgekehrt schriebe die Schleife dagegen.
 
-Für jeden besessenen Lüfter: Zielwert nach der Regel aus Abschnitt 2
-auflösen, `release_to_board` aufrufen, Ergebnis pro Lüfter auf INFO,
-Zusammenfassung am Ende. Schlägt eine Rückgabe fehl, ist das eine
-**WARNING mit Treibername und Zielwert** — es ist der Fall, in dem niemand
-regelt, und er darf nicht im Rauschen untergehen.
+Für jeden Lüfter mit gespeichertem Rückgabewert, der kein GPU-Lüfter ist:
+aktuellen `pwm_enable`-Wert lesen; weicht er ab, `release_to_board` aufrufen.
+Ergebnis pro Lüfter auf INFO, Zusammenfassung am Ende. Eine **fehlgeschlagene**
+Rückgabe ist eine WARNING mit Chipname, Zielwert und `errno` — es ist der Fall,
+in dem niemand regelt, und er darf nicht im Rauschen untergehen.
 
-`stop()` ist mehrfach aufrufbar (Admin-Stop, danach Shutdown). Nach der
-Rückgabe wird der Besitz geleert; ein zweiter Lauf findet nichts mehr und
-schreibt nichts.
+Zur Idempotenz: über den realen Weg kann `stop()` nicht zweimal laufen —
+`stop_fan_control()` setzt `_fan_control_service = None` (`fan_control.py:1303`),
+der Shutdown findet danach `None` vor. Die Rückgabe ist trotzdem
+wiederholungssicher zu bauen (direkte `service.stop()`-Aufrufe, Tests): sie
+prüft den Ist-Wert und schreibt nur bei Abweichung, ist also von sich aus
+idempotent.
 
 ### `switch_backend`
 
-`fan_control.py:1064-1090` tauscht das Backend aus, ohne zurückzugeben. Ein
-Wechsel Linux → dev lässt jeden Kanal auf `pwm_enable=1` zurück, während
-niemand mehr regelt — derselbe Zustand, den diese Arbeit beseitigt, nur über
-einen Admin-Endpunkt. Die Rückgabe läuft deshalb auch dort, vor dem Tausch,
-und der Besitz-Zustand wird geleert.
+`fan_control.py:1065-1090` tauscht das Backend aus, ohne die Monitoring-Task
+abzubrechen und ohne zurückzugeben. Ein Wechsel Linux → dev lässt jeden Kanal
+auf `pwm_enable=1` zurück, während niemand mehr regelt — derselbe Zustand, den
+diese Arbeit beseitigt, über einen Admin-Endpunkt.
+
+Dort gilt dieselbe Reihenfolge wie in `stop()`: **Task abbrechen → Rückgabe →
+tauschen.** Wichtig auch der Scan-Zeitpunkt: bei `use_linux=True` baut die
+Methode zuerst ein neues Backend und ruft `is_available()` → `_scan_pwm_fans()`
+(`:1074-1075`), danach `_load_fan_configs()` (`:1078`). Die Rückgabe muss davor
+liegen, damit der neue Scan den zurückgegebenen Wert sieht — das ist dann eine
+gültige Beobachtung, wertgleich mit dem gespeicherten.
 
 ---
 
 ## 4. Tests und Verifikation
 
-### Reine Einheiten
+### Die Regel (rein, ohne sysfs und DB)
 
-Die Auflösung des Rückgabewerts fasst weder sysfs noch Datenbank an und ist als
-Tabelle prüfbar:
+| gelesen | gespeichert | Ergebnis |
+|---|---|---|
+| `5` | — | speichern: `5` |
+| `2` | `5` | speichern: `2` (jüngere Beobachtung gilt) |
+| `1` | `5` | unverändert `5` |
+| `0` | `5` | unverändert `5` |
+| `1` | — | kein Rückgabewert — keine Rückgabe |
+| `0` | — | kein Rückgabewert — keine Rückgabe |
 
-| gelesen | gespeichert (Wert / Herkunft) | Ergebnis | persistiert? |
-|---|---|---|---|
-| `5` | — | `5` | ja, `observed` |
-| `5` | `5` / `fallback` | `5` | **nein** (bleibt `fallback`) |
-| `5` | `2` / `observed` | `5` | ja, `observed` |
-| `1` | `5` / beliebig | `5` | nein |
-| `1` | — | Treiber-Fallback | **nein** |
-| `0` | — | Treiber-Fallback | **nein** |
-| `1` | — , Treiber unbekannt | keine Rückgabe + WARNING | nein |
-
-Zeile 2 und Zeile 6 sind die wichtigsten: die eine verhindert, dass ein
-geratener Fallback zur Beobachtung aufsteigt, die andere, dass „Vollgas" als
-Board-Automatik festgeschrieben wird.
-
-### Besitz
-
-- `pwm_enable`-Write gelingt, Wert-Write scheitert → **besessen**. Der Fall,
-  der die Definition trägt.
-- `pwm_enable`-Write scheitert → **nicht besessen**, kein Rückgabe-Write bei
-  `stop()`.
-- **Sekundär-Worker: `POST /api/fans/pwm` erwirbt keinen Besitz.** Nicht über
-  ein leeres Dict prüfen — das wäre tautologisch —, sondern über den echten
-  Weg: Flag auf `False`, `set_pwm` aufrufen, danach `stop()`, und die
-  `pwm1_enable`-Datei muss unverändert sein.
+Zeile 5 und 6 sind der Kern des Entwurfs: ohne Beobachtung passiert nichts.
 
 ### Rückgabe
 
-- Besessener Lüfter → nach `stop()` steht der Zielwert in der Datei.
-- Nicht besessener Lüfter → Datei unverändert.
-- **Rücklesen schlägt fehl** (Write geht durch, Wert liegt nicht an) →
-  `release_to_board` meldet `False`, WARNING, kein stiller Erfolg.
-- Zweiter `stop()`-Aufruf schreibt nichts.
-- AMD-GPU-Lüfter wird nie zurückgegeben.
+- Gespeicherter Wert `5`, `pwm_enable` steht auf `1` → Datei enthält danach `5`.
+- Gespeicherter Wert `5`, `pwm_enable` steht bereits auf `5` → **kein Write**.
+- Kein gespeicherter Wert → kein Write, egal was anliegt.
+- `pwm_enable` liest sich als `0` (Manual bei 100 %) → wird als Abweichung
+  behandelt, Rückgabe erfolgt.
+- Write geht durch, Rücklesen liefert einen anderen Wert → `False`, WARNING.
+- Write scheitert mit `EINVAL` → `False`, WARNING, und die Meldung behauptet
+  **nicht** „keine Rechte".
+- GPU-Lüfter (`gpu_vendor` gesetzt) → nie zurückgegeben.
+- Zweiter `stop()`-Aufruf schreibt nichts (Ist-Wert stimmt bereits).
 
 Aufbau über echte `tmp_path`-sysfs-Bäume, platform-förmig und doppelpunktfrei
-(NTFS verbietet Doppelpunkte in Verzeichnisnamen — Lehre aus #532). Muster
-liegen in `test_fan_pwm_backoff.py:28-51` und `test_fan_scan_stable_ids.py`.
+(NTFS verbietet Doppelpunkte in Verzeichnisnamen — Lehre aus #532). Muster:
+`test_fan_pwm_backoff.py:28-51`, `test_fan_scan_stable_ids.py`.
 
 ### Persistenz
 
-- Der Restore-Write ist ein **UPDATE**; für eine nicht existierende `fan_id`
-  entsteht **keine** Zeile. Das ist der Test gegen die #532-Kollision.
-- Er läuft nur im Primary und nur nach dem Reconcile-Commit.
+- **Neuer Lüfter:** Scan liest `5`, die Zeile wird angelegt, `pwm_enable_restore`
+  ist `5`. Das ist der Test gegen die verworfene UPDATE-only-Regel.
+- **Bestehende Zeile, unveränderter Wert:** kein Schreibvorgang, `updated_at`
+  bleibt gleich. Der Test dazu vergleicht `updated_at` vor und nach dem Lauf —
+  ohne ihn bliebe die Entwertung des Reconcile-Rangkriteriums unbemerkt.
+- **Bestehende Zeile, neue Beobachtung:** Wert wird ersetzt.
+- Läuft nur im Primary.
+
+### Der Round-Trip
+
+Ein Test über die Naht, den keine Tabellenzeile ersetzt: Scan liest `5` →
+Persistenz → `stop()` schreibt `5` → **neuer Scan auf demselben Baum** →
+gespeicherter Wert weiterhin `5`, keine Zeile doppelt, `updated_at` unverändert.
 
 ### Gates
 
 `pytest -k "fan or power"`, `ruff check`, `eslint .`, `npm run build`,
 `vitest run`. Die Messlatte ist unmittelbar vor der Umsetzung einmal zu messen
-und mit Datum zu notieren — die Zahl aus einem früheren Lauf ist keine
+und mit Datum zu notieren — eine Zahl aus einem früheren Lauf ist keine
 Messlatte. Volle Backend-Suite in der CI.
-
-Frontend-Gates laufen mit, obwohl diese Arbeit das Frontend nicht anfasst.
 
 ### Feldverifikation
 
-1. **Der Kern.** `systemctl stop baluhost-backend`, dann
-   `cat /sys/class/hwmon/hwmon3/pwm{1,2,3,7}_enable`. Erwartung: viermal `5`
-   statt viermal `1`. Heute steht dort `1`; das ist die Lücke.
-2. **Die Herkunft.** Dienst starten, dann
-   `SELECT fan_id, pwm_enable_restore, pwm_enable_restore_source FROM fan_configs WHERE is_active`.
-   Erwartung: `5 / fallback` — **nicht** `5 / observed`. Steht dort `observed`,
-   ist die Regel aus Abschnitt 2 verletzt und der Fallback hat sich selbst zur
-   Beobachtung befördert. Das ist der Test, den die erste Fassung dieser Spec
-   fälschlich als Erfolgsbeleg geführt hat.
-3. **Der echte Wert.** Erst ein Kaltstart mit gestopptem Backend kann eine
-   echte Beobachtung liefern: Rechner booten, Backend vor dem ersten
-   Regelzyklus stoppen, `pwm_enable` lesen. Steht dort der BIOS-Wert, ist er
-   die Beobachtung, die die Spalte dauerhaft füllen soll. Optional — der
-   Fallback tut es bis dahin.
+1. **Nach dem Deploy:**
+   `SELECT fan_id, pwm_enable_restore FROM fan_configs WHERE is_active`.
+   Erwartung: **`NULL`** für alle. Es gab keinen Kaltstart, also keine
+   Beobachtung. Steht dort ein Wert, ist die Regel verletzt.
+2. **Nach einem Reboot:** dieselbe Abfrage. Erwartung: der BIOS-Wert, für die
+   vier nct6798-Kanäle vermutlich `5`. **Das ist die erste echte Messung des
+   Board-Defaults auf dieser Maschine** — bisher wurde er nie beobachtet.
+3. **Dann der Kern:** `systemctl stop baluhost-backend`, danach
+   `cat /sys/class/hwmon/hwmon3/pwm{1,2,3,7}_enable`. Erwartung: der in Schritt 2
+   gelesene Wert. Heute steht dort `1` — das ist die Lücke.
+   Hinweis: ein Lüfter, der bei 100 % lief, zeigt vorher `0`, nicht `1`.
+4. **Gegenprobe:** Dienst wieder starten, eine Minute warten, `pwm_enable`
+   erneut lesen. Erwartung `1` — BaluHost hat die Kontrolle zurückgenommen.
 
 ---
 
 ## Risiken
 
-- **Der Treiber-Fallback ist eine Annahme**, für `nct6775` durch Messung
-  gedeckt. Für alles andere wird bewusst nichts getan.
-- **Die Rückgabe kann scheitern.** Sie wird zurückgelesen und im Fehlerfall als
-  WARNING gemeldet; der Zustand ist dann derselbe wie heute.
-- **Ob das Board nach der Rückgabe tatsächlich regelt**, ist auf BaluNode
-  gemessen und für andere Hardware nicht garantiert. Da nur bei bekanntem
-  Treiber zurückgegeben wird, ist das Risiko auf einen Fall begrenzt.
-- **`SIGKILL` bleibt ungedeckt** (siehe Nicht-Ziele).
+- **Auf einer laufenden Installation tut die Funktion zunächst nichts.** Sie
+  armiert sich beim nächsten Kaltstart. Bewusst gewählt gegenüber einem
+  geratenen Modus.
+- **Die Rückgabe kann scheitern** — abgelehnter Modus (`EINVAL`, etwa bei
+  nicht-monotonen Trip Points) oder still ignorierter Write. Beides wird
+  erkannt und gemeldet; der Zustand ist dann derselbe wie heute.
+- **`SIGKILL` bleibt ungedeckt.**
 - **Zwei Regelschleifen über `/api/admin/services/fan_control/restart`** sind
-  ein vorbestehender Fehler, den diese Arbeit nicht behebt und der als
-  Nebenbefund festzuhalten ist.
+  ein vorbestehender, unabhängiger Fehler — als #555 festgehalten, nicht Teil
+  dieser Arbeit.
+
+## Quellen
+
+- [Kernel driver NCT6775](https://docs.kernel.org/hwmon/nct6775.html)
+- [`drivers/hwmon/nct6775-core.c`](https://raw.githubusercontent.com/torvalds/linux/master/drivers/hwmon/nct6775-core.c)
+  — `store_pwm_enable`, `check_trip_points`, `reg_to_pwm_enable`
+- [`Documentation/hwmon/sysfs-interface.rst`](https://docs.kernel.org/hwmon/sysfs-interface.html)


### PR DESCRIPTION
Closes #534 teilweise — Punkt 3 (Dienst-Ende). Die Punkte 1 und 2 bleiben dort offen, mit allen Befunden dokumentiert.

## Das Problem

`set_pwm` setzt bei **jedem** Write `pwm_enable=1` (Handsteuerung), und niemand nimmt das je zurück. Beim Beenden des Backends bleiben die Lüfter deshalb auf dem letzten von BaluHost geschriebenen PWM-Wert stehen: nach einem Deploy-Neustart regelt weder BaluHost noch das Board.

## Die Lösung

Beim Beenden wird `pwm_enable` auf den Automatikmodus zurückgeschrieben, **den BaluHost am selben Chip zuvor selbst gelesen hat**.

Der Kern des Entwurfs ist eine Verzichtsentscheidung, die zwei kritische Reviews erzwungen haben: **es gibt keinen Treiber-Fallback und kein geratenes Ziel.** Ein Wert wird nur übernommen, wenn der Scan beim Start einen Automatikmodus (`pwm_enable >= 2`) vorfindet. Gibt es keine Beobachtung, passiert nichts. Ein geratener Treibermodus wäre eine Annahme über fremde Hardware, die niemand überprüfen kann — und ein falsch geratener Wert stellte den Lüfter still ab.

`0` ist dabei **kein** Automatikmodus: die hwmon-Konvention definiert ihn als „no fan speed control (i.e. fan at full speed)", und der nct6775-Treiber setzt dabei zusätzlich Duty 255.

## Aufbau

| Baustein | Datei |
|---|---|
| Die Regel — drei reine Funktionen, ohne sysfs- und DB-Zugriff | `services/power/fan_restore.py` (neu) |
| Spalte `pwm_enable_restore` + Migration `a6e0c0b1386b` | `models/fans.py` |
| Der Scan liest `pwm_enable`, bevor der erste Write ihn überschreibt | `fan_backend_linux.py` |
| `release_to_board` mit Rücklese-Kontrolle (ABC + Linux + Dev) | `fan_control.py`, beide Backends |
| Persistenz der Beobachtung, ohne `updated_at` zu bewegen | `fan_control.py` |
| Die Rückgabe in `stop()` und `switch_backend` | `fan_control.py` |

### Die Reihenfolge beim Beenden ist tragend

Erst die Monitoring-Schleife stilllegen, **dann** zurückgeben. Umgekehrt schriebe die weiterlaufende Schleife im nächsten Zyklus wieder `pwm_enable=1` gegen die Rückgabe. Ein Test hält die Reihenfolge fest.

### Warum am Ist-Wert entschieden wird, nicht an einer Besitz-Buchführung

Ein Lüfter im MANUAL-Modus wird vom Regelkreis nie geschrieben; sein einziger Schreibweg ist die HTTP-Route, und die landet bei vier Workern meist auf einem Sekundär. Eine primary-gebundene Besitzverfolgung hätte ihn nie erfasst — und genau er stünde am Ende ungeregelt da.

### Was bewusst draußen bleibt

- **GPU-Lüfter.** Für AMD-Karten existiert mit `AmdManualState` / `disable_amd_manual` bereits ein eigener Rückgabeweg, der zusätzlich das Performance-Level zurücksetzt.
- **Sekundär-Worker.** Geschrieben wird nur vom Primary, in die DB wie nach sysfs.
- **`SIGKILL` und Stromausfall.** `systemctl stop` und der Deploy-Neustart senden `SIGTERM` und sind abgedeckt.

## Wichtig für den Betrieb: die Funktion greift erst nach dem nächsten Kaltstart

Auf der laufenden Installation gab es seit dem letzten Kaltstart keine Beobachtung, also gibt es nichts zurückzugeben. Das ist kein Fehler, sondern der Preis des Verzichts auf geratene Werte — und in `docs/TECHNICAL_DOCUMENTATION.md` als solcher benannt.

Feldverifikation nach dem Deploy, in dieser Reihenfolge:

1. **Direkt nach dem Deploy:** `SELECT fan_id, pwm_enable_restore FROM fan_configs WHERE is_active` → erwartet **`NULL`** für alle. Steht dort ein Wert, ist die Regel verletzt.
2. **Nach einem Reboot:** dieselbe Abfrage → der BIOS-Wert. Das ist zugleich die erste echte Messung des Board-Defaults dieser Maschine; jede frühere Messung lief nach BaluHost-Betrieb.
3. **Der Kern:** `systemctl stop baluhost-backend`, dann `cat /sys/class/hwmon/hwmon3/pwm{1,2,3,7}_enable` → der in Schritt 2 gelesene Wert. Heute steht dort `1`.
4. **Gegenprobe:** Dienst starten, eine Minute warten, erneut lesen → `1`.

Wer nicht auf den Reboot warten will, setzt den Wert einmal bei gestopptem Dienst von Hand (`echo 5 > /sys/class/hwmon/hwmonN/pwmM_enable`); der nächste Start übernimmt ihn.

## Was das Abschluss-Review fand

Nichts Blockierendes, aber fünf Punkte — alle in `e798ac5a` behoben. Zwei davon waren Fehler im Plan, nicht in der Umsetzung:

- **Die Verdrahtung war ungetestet.** Man hätte alle drei Zeilen entfernen können, die Scan und Persistenz verbinden, und die Suite wäre grün geblieben — bei totem Feature. Genau die Falle, die dieses Projekt mit `SKIP_APP_INIT=1` schon einmal bezahlt hat. Es gibt jetzt einen Test, der `_load_fan_configs()` echt durchläuft; beide Gegenproben wurden ausgeführt und rot gesehen.
- **`switch_backend` konnte die Regelung dauerhaft stilllegen** — eine neue Regression dieses Branches. Der Neustart-Block stand hinter zwei Aufrufen, die werfen können (`is_available()`, `_load_fan_configs()`); eine kurz nicht erreichbare Datenbank hätte die Lüftersteuerung bis zum Prozess-Neustart still abgeschaltet. Jetzt per `try/finally` behoben, mit Test.
- **`resolve_restore_value` prüft jetzt auch den gespeicherten Wert**, nicht nur den gescannten. Die Spalte trägt keinen CHECK-Constraint; stünde dort je eine `1`, schriebe die Rückgabe beim Beenden genau den kaputten Zustand her, den dieser PR beseitigt. Die Zusage gilt damit lokal statt induktiv über alle Schreibpfade.
- Ein tautologischer Test (prüfte SQLAlchemys Konstruktor, nicht den Produktivcode) wurde gelöscht.
- Die Spec-Vorgabe „errno nennen, nicht deuten" ist jetzt durch eine `caplog`-Assertion gehalten. Hintergrund: `_write_hwmon_file` meldet nach einem gescheiterten `sudo tee`-Fallback `EACCES`, auch wenn der Kernel eigentlich `EINVAL` geliefert hat — eine Meldung „keine Rechte" wäre dann falsch.

## Tests

`pytest -k "fan or power"`: **660 bestanden, 2 übersprungen** (621 vor diesem Vorhaben, +39). Ruff sauber, Frontend `eslint` 0 Fehler, `npm run build` erfolgreich. Volle Backend-Suite der CI überlassen (hängt auf Windows).

Neue Testdateien: `test_fan_restore_rule.py`, `test_fan_scan_pwm_enable.py`, `test_fan_release_to_board.py`, `test_fan_restore_persistence.py`, `test_fan_handback_on_stop.py`, `test_fan_handback_roundtrip.py`.

## Migration

`a6e0c0b1386b` hängt an `193f03f94b4e` (der #532-Migration) und ist der einzige Head. `upgrade` → `downgrade -1` → `upgrade` lokal fehlerfrei durchlaufen. Das bekannte Autogenerate-Phantom auf `status_bar_pill_config.pill_id` (#549) wurde entfernt.

## Nicht Teil dieses PRs

Zwei gleichzeitige `switch_backend`-Aufrufe könnten zwei Monitoring-Schleifen erzeugen — dieselbe Klasse wie #555, braucht ein Lock. Im Review notiert, bewusst nicht mitgefixt.

---

Spec: `docs/superpowers/specs/2026-09-05-fan-ownership-handback-design.md`
Plan: `docs/superpowers/plans/2026-09-05-fan-handback-on-shutdown.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yrHzUD98edGYVz4yABy9m
