### PR TITLE
fix(fans): Scan-Reihenfolge numerisch sortieren statt readdir zu folgen (#553)

### DIFF
--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -5,6 +5,7 @@ import errno
 import getpass
 import logging
 import os
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -21,6 +22,19 @@ from app.services.power.fan_identity import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _by_leading_number(path: Path) -> Tuple[int, str]:
+    """Sortierschluessel fuer hwmon-Eintraege: numerisch, nicht lexikografisch.
+
+    Ein blosses sorted() stellte "hwmon10" vor "hwmon2" und "temp10_input" vor
+    "temp1_input" -- deterministisch, aber falsch. Auf dem nct6798 traegt der
+    Chip temp1..temp13, und temp10 ist PCH_CHIP_TEMP mit Messwert 0; als
+    Fallback-Kurvenquelle waere das eine tote Zahl (#553).
+    """
+    match = re.search(r"\d+", path.name)
+    return (int(match.group()) if match else -1, path.name)
+
 
 FIRMWARE_MANAGED_WRITE_ERROR = (
     "This GPU manages its fan curve in firmware (RDNA3+). The amdgpu driver "
@@ -478,7 +492,7 @@ class LinuxFanControlBackend(FanControlBackend):
         cpu_sensor_id = cpu_sensor[0] if cpu_sensor else None
         cpu_temp_path = cpu_sensor[1] if cpu_sensor else None
 
-        for hwmon_dir in self._hwmon_base.iterdir():
+        for hwmon_dir in sorted(self._hwmon_base.iterdir(), key=_by_leading_number):
             if not hwmon_dir.is_dir() or not hwmon_dir.name.startswith("hwmon"):
                 continue
 
@@ -491,7 +505,8 @@ class LinuxFanControlBackend(FanControlBackend):
             # (k10temp, NVMe) liefern Kurvenquellen fuer get_temperature()
             # und muessten sonst aufloesbar bleiben, obwohl sie hier nie
             # einen PWM-Kanal durchlaufen.
-            for temp_file in hwmon_dir.glob("temp[0-9]*_input"):
+            for temp_file in sorted(hwmon_dir.glob("temp[0-9]*_input"),
+                                    key=_by_leading_number):
                 num = temp_file.name[len("temp"):-len("_input")]
                 new_temp_paths[build_sensor_id(identity, int(num))] = temp_file
 
@@ -512,7 +527,7 @@ class LinuxFanControlBackend(FanControlBackend):
             )
 
             # Find PWM files
-            for pwm_file in hwmon_dir.glob("pwm[0-9]*"):
+            for pwm_file in sorted(hwmon_dir.glob("pwm[0-9]*"), key=_by_leading_number):
                 if "_" in pwm_file.name:  # Skip pwm1_enable, etc
                     continue
 
@@ -540,10 +555,11 @@ class LinuxFanControlBackend(FanControlBackend):
                     temp_sensor_id = cpu_sensor_id
                     temp_path = cpu_temp_path
                 else:
-                    # Fallback: use first temp sensor in same hwmon dir
+                    # Fallback: lowest-numbered temp sensor in same hwmon dir
                     temp_sensor_id = None
                     temp_path = None
-                    for temp_file in hwmon_dir.glob("temp[0-9]*_input"):
+                    for temp_file in sorted(hwmon_dir.glob("temp[0-9]*_input"),
+                                            key=_by_leading_number):
                         temp_num = temp_file.name.replace("temp", "").replace("_input", "")
                         temp_sensor_id = build_sensor_id(identity, int(temp_num))
                         temp_path = temp_file

--- a/backend/tests/test_fan_scan_order.py
+++ b/backend/tests/test_fan_scan_order.py
@@ -1,0 +1,135 @@
+"""Die Scan-Reihenfolge darf kein Dateisystem-Zufall sein (#553).
+
+_scan_pwm_fans iterierte hwmon-Verzeichnisse, PWM-Kanaele und Temperatur-
+Eingaenge unsortiert. Weder Path.iterdir() noch Path.glob() sortieren -- beide
+liefern os.scandir-Reihenfolge. Damit war die Einfuegereihenfolge von
+_fan_cache und die Wahl des Fallback-Sensors reine readdir-Reihenfolge.
+
+Beide Tests erzwingen eine numerisch absteigende Eingangsreihenfolge, statt
+sich auf die Reihenfolge des jeweiligen Dateisystems zu verlassen: auf NTFS
+ist sie alphabetisch, auf ext4 hashbasiert. Ein Test, der die eine Ordnung
+voraussetzt, waere auf dem anderen System gruen, ohne etwas zu pruefen.
+"""
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+def _leading_number(name: str) -> int:
+    """hwmon10 -> 10, pwm2 -> 2, temp10_input -> 10."""
+    digits = re.search(r"\d+", name)
+    return int(digits.group()) if digits else 0
+
+
+@pytest.fixture
+def descending_filesystem(monkeypatch):
+    """Liefert Verzeichniseintraege numerisch absteigend.
+
+    Das ist die denkbar unguenstigste Reihenfolge: ohne Sortierung im
+    Produktivcode landet sie unveraendert im Cache, und die Erwartung
+    (aufsteigend) schlaegt fehl. Mit Sortierung ist die Eingangsreihenfolge
+    gleichgueltig -- genau die Eigenschaft, um die es geht.
+    """
+    original_iterdir = Path.iterdir
+    original_glob = Path.glob
+
+    def descending_iterdir(self):
+        return iter(sorted(original_iterdir(self),
+                           key=lambda p: _leading_number(p.name), reverse=True))
+
+    def descending_glob(self, pattern):
+        return iter(sorted(original_glob(self, pattern),
+                           key=lambda p: _leading_number(p.name), reverse=True))
+
+    monkeypatch.setattr(Path, "iterdir", descending_iterdir)
+    monkeypatch.setattr(Path, "glob", descending_glob)
+
+
+def _chip(sysfs: Path, device_name: str, hwmon_name: str, chip_name: str,
+          pwm_channels: list[int], temp_inputs: dict[int, str]) -> None:
+    """Ein Platform-Chip. Doppelpunktfrei, damit es auf Windows laeuft."""
+    device = sysfs / "devices" / "platform" / device_name
+    hwmon = device / "hwmon" / hwmon_name
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text(f"{chip_name}\n")
+
+    for channel in pwm_channels:
+        (hwmon / f"pwm{channel}").write_text("128\n")
+        (hwmon / f"pwm{channel}_enable").write_text("1\n")
+        (hwmon / f"fan{channel}_input").write_text("900\n")
+    for number, millicelsius in temp_inputs.items():
+        (hwmon / f"temp{number}_input").write_text(millicelsius + "\n")
+
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / hwmon_name, target_is_directory=True)
+
+
+def _two_chip_tree(tmp_path: Path) -> Path:
+    """hwmon2 mit drei Kanaelen, hwmon10 mit einem.
+
+    Die Indizes sind so gewaehlt, dass numerische und lexikografische Ordnung
+    auseinanderfallen: lexikografisch steht "hwmon10" vor "hwmon2" und "pwm10"
+    vor "pwm2". Ein blosses sorted() wuerde diesen Test nicht bestehen.
+    """
+    sysfs = tmp_path / "sys"
+    _chip(sysfs, "chipa.100", "hwmon2", "chipa",
+          pwm_channels=[1, 2, 10], temp_inputs={1: "42000", 10: "0"})
+    _chip(sysfs, "chipb.200", "hwmon10", "chipb",
+          pwm_channels=[1], temp_inputs={1: "38000"})
+    return sysfs / "class" / "hwmon"
+
+
+def _channel_order(cache: dict) -> list[tuple[str, str]]:
+    """(hwmon-Verzeichnis, PWM-Datei) je Cache-Eintrag, in Cache-Reihenfolge."""
+    return [(info["pwm_path"].parent.name, info["pwm_path"].name)
+            for info in cache.values()]
+
+
+@pytest.mark.asyncio
+async def test_scan_order_is_numeric_not_filesystem_order(
+        tmp_path, monkeypatch, descending_filesystem):
+    """Chips und Kanaele stehen numerisch aufsteigend im Cache."""
+    klass = _two_chip_tree(tmp_path)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+
+    cache = await backend._scan_pwm_fans()
+
+    assert _channel_order(cache) == [
+        ("hwmon2", "pwm1"),
+        ("hwmon2", "pwm2"),
+        ("hwmon2", "pwm10"),
+        ("hwmon10", "pwm1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_temp_fallback_picks_lowest_numbered_sensor(
+        tmp_path, monkeypatch, descending_filesystem):
+    """Ohne CPU-Sensor bindet der Fallback an temp1, nicht an temp10.
+
+    Auf BaluNode traegt der nct6798 temp1..temp13; temp10 ist PCH_CHIP_TEMP
+    und meldet 0. Genau so ein Eingang darf nicht zur Kurvenquelle werden,
+    bloss weil er in irgendeiner Ordnung zuerst kommt.
+    """
+    klass = _two_chip_tree(tmp_path)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+
+    cache = await backend._scan_pwm_fans()
+
+    chip_a = [info for info in cache.values()
+              if info["pwm_path"].parent.name == "hwmon2"]
+    assert chip_a, "chipa wurde gar nicht gescannt"
+    for info in chip_a:
+        assert info["temp_path"].name == "temp1_input"


### PR DESCRIPTION
Closes #553.

## Das Problem

`_scan_pwm_fans` iterierte hwmon-Verzeichnisse, PWM-Kanäle und Temperatur-Eingänge unsortiert. Weder `Path.iterdir()` noch `Path.glob()` sortieren — beide liefern `os.scandir`-Reihenfolge. Die Einfügereihenfolge von `_fan_cache` war damit reine Dateisystem-Reihenfolge; auf BaluNode listet readdir `hwmon6 4 2 0 5 3 1`, wodurch der amdgpu-Chip vor dem nct6798 im Cache landet.

## Warum numerisch und nicht einfach `sorted()`

Das Issue schlug ein blosses `sorted()` vor, analog zu `_find_cpu_temp_sensor`. Das wäre deterministisch, aber an einer Stelle deterministisch **falsch**: lexikografisch steht `"temp10_input"` vor `"temp1_input"`.

Das ist keine Kosmetik. Eine der vier Iterationen ist der Fallback „erster Temperatursensor im selben hwmon-Verzeichnis", der die **Kurvenquelle** des Lüfters festlegt. Auf dem nct6798 dieser Box gibt es `temp1..temp13`, und `temp10` ist `PCH_CHIP_TEMP` — gemessen am 2026-09-06:

```
temp1  SYSTIN          32000        temp10 PCH_CHIP_TEMP        0
temp2  CPUTIN          32000        temp11 PCH_CPU_TEMP         0
temp3  AUXTIN0         26000        temp12 PCH_MCH_TEMP         0
temp13 TSI0_TEMP       38625
```

Ein lexikografisches `sorted()` hätte die Lüfterkurve dort deterministisch an einen Eingang gebunden, der konstant `0` meldet. `_by_leading_number` sortiert deshalb nach der führenden Zahl, mit dem Dateinamen als Tiebreak.

## Vier Iterationen, nicht zwei

Der Issue-Text nennt zwei (`iterdir` und der `pwm`-Glob). Beim Nachlesen waren es vier:

| Stelle | Ordnung relevant für |
|---|---|
| `self._hwmon_base.iterdir()` | welcher Chip zuerst im Cache steht — der Verstärker unter #552 |
| `glob("pwm[0-9]*")` | Kanalreihenfolge je Chip, Frontend-Autoselect `status.fans[0]` |
| `glob("temp[0-9]*_input")` (Sensor-Rückabbildung) | nichts — Dict-Keys sind eindeutig; der Vollständigkeit halber mitsortiert |
| `glob("temp[0-9]*_input")` (Fallback-Kurvenquelle) | **welcher Sensor die Kurve speist** |

## Tests

Zwei neue Tests in `test_fan_scan_order.py`. Beide erzwingen über eine Fixture eine **numerisch absteigende** Eingangsreihenfolge, statt sich auf die des Dateisystems zu verlassen: auf NTFS ist readdir alphabetisch, auf ext4 hashbasiert. Ohne diesen Zwang wäre der Test auf einem der beiden Systeme grün, ohne etwas zu prüfen — bei einem Bug, dessen ganzer Kern die Abhängigkeit von dieser Reihenfolge ist, wäre das die falsche Art von grün.

Der synthetische Baum nutzt bewusst Indizes, bei denen numerische und lexikografische Ordnung auseinanderfallen (`hwmon2`/`hwmon10`, `pwm1/2/10`, `temp1/temp10`). Beide Tests wurden rot gesehen:

```
E   AssertionError: assert [('hwmon10', ...)] == [('hwmon2', ...)]
E     At index 0 diff: ('hwmon10', 'pwm1') != ('hwmon2', 'pwm1')

E   AssertionError: assert 'temp10_input' == 'temp1_input'
```

Ruff sauber. Volle Backend-Suite der CI überlassen (hängt auf Windows); die Testzahlen stehen unten, nach dem zweiten Commit.

## Zweiter Commit: dieselbe Schwaeche in den Schwesterfunktionen

Das Issue fuehrt `_find_cpu_temp_sensor` (`:392`) und `get_available_temp_sensors` (`:435`) als die guten Beispiele — sie sortieren ja bereits. Beim Nachlesen tragen sie exakt die Schwaeche, die diesen PR zum numerischen Sortieren gebracht hat: sie sortieren **lexikografisch**.

Bei `_find_cpu_temp_sensor` ist das folgenreich. Die Funktion nimmt den ersten Temperatureingang des gefundenen CPU-Chips und liefert damit die **Kurvenquelle fuer jeden Luefter**. `coretemp` exponiert `temp1` als Package-Temperatur und je einen Eingang pro Kern; ab zehn Eintraegen waehlt lexikografisches Sortieren deterministisch einen einzelnen Kern statt des Pakets. Der Test zeigt es im Log:

```
Found CPU temp sensor: coretemp-isa-0000:temp10 (driver=coretemp)
```

Auf dieser AMD-Box ohne Wirkung — k10temp hat `temp1..temp3` —, auf einem vielkernigen Intel-System nicht.

Bei `get_available_temp_sensors` betrifft es die Reihenfolge der Auswahlliste im Frontend: `chipa:temp10` stand vor `chipa:temp1`, `hwmon10` vor `hwmon2`.

Zwei weitere Tests, beide rot gesehen. Gesamt jetzt vier Tests in `test_fan_scan_order.py`, `pytest -k "fan or power"`: **722 bestanden, 2 uebersprungen**.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lf8TucK1YQasPz6Xn9Frk
