### PR TITLE
fix(fans): CPU-Sensorwahl und Sensorliste numerisch statt lexikografisch sortieren

### DIFF
--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -369,7 +369,7 @@ class LinuxFanControlBackend(FanControlBackend):
 
         identities = derive_all(self._hwmon_base)
 
-        for hwmon_dir in sorted(self._hwmon_base.iterdir()):
+        for hwmon_dir in sorted(self._hwmon_base.iterdir(), key=_by_leading_number):
             if not hwmon_dir.is_dir() or not hwmon_dir.name.startswith("hwmon"):
                 continue
 
@@ -389,8 +389,9 @@ class LinuxFanControlBackend(FanControlBackend):
             if identity is None:
                 continue
 
-            # Found a CPU sensor driver — use its first temp input
-            for temp_file in sorted(hwmon_dir.glob("temp[0-9]*_input")):
+            # Found a CPU sensor driver -- use its lowest-numbered temp input
+            for temp_file in sorted(hwmon_dir.glob("temp[0-9]*_input"),
+                                    key=_by_leading_number):
                 temp_num = temp_file.name.replace("temp", "").replace("_input", "")
                 sensor_id = build_sensor_id(identity, int(temp_num))
                 # I-3: ohne diesen Eintrag bliebe get_temperature() fuer einen
@@ -415,7 +416,7 @@ class LinuxFanControlBackend(FanControlBackend):
 
         identities = derive_all(self._hwmon_base)
 
-        for hwmon_dir in sorted(self._hwmon_base.iterdir()):
+        for hwmon_dir in sorted(self._hwmon_base.iterdir(), key=_by_leading_number):
             if not hwmon_dir.is_dir() or not hwmon_dir.name.startswith("hwmon"):
                 continue
 
@@ -433,7 +434,8 @@ class LinuxFanControlBackend(FanControlBackend):
 
             is_cpu = device_name in self._CPU_SENSOR_DRIVERS
 
-            for temp_file in sorted(hwmon_dir.glob("temp[0-9]*_input")):
+            for temp_file in sorted(hwmon_dir.glob("temp[0-9]*_input"),
+                                    key=_by_leading_number):
                 temp_num = temp_file.name.replace("temp", "").replace("_input", "")
                 sensor_id = build_sensor_id(identity, int(temp_num))
                 # I-3: gleicher Grund wie in _find_cpu_temp_sensor -- ohne

--- a/backend/tests/test_fan_scan_order.py
+++ b/backend/tests/test_fan_scan_order.py
@@ -5,7 +5,12 @@ Eingaenge unsortiert. Weder Path.iterdir() noch Path.glob() sortieren -- beide
 liefern os.scandir-Reihenfolge. Damit war die Einfuegereihenfolge von
 _fan_cache und die Wahl des Fallback-Sensors reine readdir-Reihenfolge.
 
-Beide Tests erzwingen eine numerisch absteigende Eingangsreihenfolge, statt
+Die beiden Schwesterfunktionen _find_cpu_temp_sensor und
+get_available_temp_sensors sortierten zwar, aber lexikografisch --
+deterministisch und trotzdem falsch, weil "temp10_input" vor "temp1_input"
+steht.
+
+Die Reihenfolge-Tests erzwingen eine numerisch absteigende Eingangsreihenfolge, statt
 sich auf die Reihenfolge des jeweiligen Dateisystems zu verlassen: auf NTFS
 ist sie alphabetisch, auf ext4 hashbasiert. Ein Test, der die eine Ordnung
 voraussetzt, waere auf dem anderen System gruen, ohne etwas zu pruefen.
@@ -133,3 +138,42 @@ async def test_temp_fallback_picks_lowest_numbered_sensor(
     assert chip_a, "chipa wurde gar nicht gescannt"
     for info in chip_a:
         assert info["temp_path"].name == "temp1_input"
+
+
+def _cpu_chip_tree(tmp_path: Path) -> Path:
+    """Ein coretemp-Chip mit temp1 und temp10, ohne PWM-Kanal.
+
+    coretemp exponiert temp1 als Package-Temperatur und je einen Eingang pro
+    Kern. Ab zehn Eintraegen faellt die lexikografische Ordnung auseinander:
+    "temp10_input" steht dann vor "temp1_input".
+    """
+    sysfs = tmp_path / "sys"
+    _chip(sysfs, "coretemp.0", "hwmon4", "coretemp",
+          pwm_channels=[], temp_inputs={1: "45000", 10: "70000"})
+    return sysfs / "class" / "hwmon"
+
+
+def test_cpu_sensor_is_the_package_not_a_core(tmp_path, monkeypatch):
+    """_find_cpu_temp_sensor nimmt den niedrigsten Eingang, nicht temp10."""
+    klass = _cpu_chip_tree(tmp_path)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+
+    sensor = backend._find_cpu_temp_sensor()
+
+    assert sensor is not None, "coretemp-Chip wurde nicht gefunden"
+    assert sensor[1].name == "temp1_input"
+
+
+@pytest.mark.asyncio
+async def test_available_sensors_are_listed_numerically(tmp_path, monkeypatch):
+    """Die Auswahlliste folgt der Chip- und Sensornummer, nicht dem Alphabet."""
+    klass = _two_chip_tree(tmp_path)
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+
+    sensors = await backend.get_available_temp_sensors()
+
+    listed = [(entry.device_name, int(entry.sensor_id.rpartition(":temp")[2]))
+              for entry in sensors]
+    assert listed == [("chipa", 1), ("chipa", 10), ("chipb", 1)]


### PR DESCRIPTION
Nachzug zu #561 / #553. Der Befund kam beim Umsetzen von #553 auf und war dort als „Nicht Teil dieses PRs" notiert; #561 wurde gemergt, bevor dieser Commit dazukam.

## Das Problem

#553 stellte fest, dass `_scan_pwm_fans` unsortiert iteriert, und führte `_find_cpu_temp_sensor` (`fan_backend_linux.py:392`) sowie `get_available_temp_sensors` (`:435`) ausdrücklich als die **guten** Beispiele an — sie sortieren ja bereits.

Sie sortieren aber **lexikografisch**. Damit tragen sie genau die Schwäche, die #561 dazu gebracht hat, numerisch statt lexikografisch zu sortieren: `"temp10_input"` steht vor `"temp1_input"`.

## Warum das bei der CPU-Sensorwahl zählt

`_find_cpu_temp_sensor` nimmt den ersten Temperatureingang des gefundenen CPU-Chips. Der Rückgabewert ist nicht irgendein Anzeigewert — er wird in `_scan_pwm_fans` **allen PWM-Kanälen als `temp_sensor_id` zugewiesen** und ist damit die Kurvenquelle für jeden Lüfter.

`coretemp` exponiert `temp1` als Package-Temperatur und je einen weiteren Eingang pro Kern. Ab zehn Einträgen wählt lexikografisches Sortieren deterministisch einen einzelnen Kern statt des Pakets. Der neue Test zeigt es im Log der Funktion selbst:

```
Found CPU temp sensor: coretemp-isa-0000:temp10 (driver=coretemp)
```

Auf einem vielkernigen Intel-System hinge die gesamte Lüfterregelung damit an einem einzelnen Kern — der im Leerlauf kühl bleiben kann, während andere heiß laufen. Auf BaluNode ohne Wirkung, weil k10temp nur `temp1..temp3` hat; deshalb ist es nie aufgefallen.

Bei `get_available_temp_sensors` ist die Folge harmlos: die Auswahlliste im Frontend zeigte `temp10` vor `temp1` und `hwmon10` vor `hwmon2`.

## Änderung

Beide Funktionen bekommen `key=_by_leading_number` — den Sortierschlüssel, den #561 bereits eingeführt hat. Kein neuer Mechanismus, vier Aufrufstellen.

## Tests

Zwei neue Tests in `test_fan_scan_order.py` (die Datei stammt aus #561), beide rot gesehen:

```
E   AssertionError: assert 'temp10_input' == 'temp1_input'
E   AssertionError: assert [('chipa', 10), ('chipa', 1), ...] == [('chipa', 1), ('chipa', 10), ...]
```

Der synthetische `coretemp`-Chip trägt bewusst `temp1` und `temp10`, weil dort numerische und lexikografische Ordnung auseinanderfallen.

`pytest -k "fan or power"`: **722 bestanden, 2 übersprungen**. Ruff sauber. Volle Backend-Suite der CI überlassen (hängt auf Windows).

## Kein separates Issue

Der Befund wurde beim Review von #561 benannt und auf Zuruf direkt umgesetzt, statt erst ein Issue anzulegen. #553 selbst ist mit #561 geschlossen und bleibt es — die Schwesterfunktionen waren dort nicht im Scope, sondern als korrekt beschrieben.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lf8TucK1YQasPz6Xn9Frk
