### PR TITLE
fix(fans): Rechte-Probe auf dem echten Schreibpfad statt auf dem ersten Luefter (#552)

### DIFF
--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -4,7 +4,6 @@ Linux hardware backend for fan control using hwmon sysfs.
 import errno
 import getpass
 import logging
-import os
 import re
 import subprocess
 import time
@@ -88,35 +87,43 @@ class LinuxFanControlBackend(FanControlBackend):
         return True
 
     async def _check_write_permission(self) -> None:
-        """Proactively test write permission on first PWM file."""
-        if not self._fan_cache:
-            return
+        """Prueft Schreibrechte auf dem Weg, den set_pwm tatsaechlich nimmt.
 
-        first_fan = next(iter(self._fan_cache.values()))
-        pwm_path = first_fan["pwm_path"]
+        Geschrieben wird pwm_enable mit dem Wert, der dort bereits steht:
+        dieselbe Datei, dieselben Rechte und dieselbe sudoers-Regel wie im
+        Regelbetrieb -- aber ohne den Modus zu veraendern.
 
-        # Fast check: direct write permission
-        if os.access(pwm_path, os.W_OK):
-            self._has_write_permission = True
-            logger.info("Fan control: direct write permission available")
-            return
+        pwm selbst taugt nicht als Probe. Der nct6775 lehnt pwm-Writes mit
+        EBUSY ab, solange pwm_enable >= 2 steht, und seit der Rueckgabe an
+        die Board-Automatik (#534) steht nach jedem Dienst-Ende genau das
+        an. Ein pwm_enable=1, wie set_pwm es setzt, waere umgekehrt ein
+        echter Eingriff als Nebenwirkung einer Frage.
 
-        # Fallback: test sudo tee (read current value, write it back unchanged)
-        current = await self._read_hwmon_file(pwm_path)
-        if current is not None:
-            try:
-                result = subprocess.run(
-                    ["sudo", "-n", "tee", str(pwm_path)],
-                    input=str(current).encode(),
-                    capture_output=True,
-                    timeout=5,
-                )
-                if result.returncode == 0:
-                    self._has_write_permission = True
-                    logger.info("Fan control: write permission available via sudo tee")
-                    return
-            except Exception:
-                pass
+        Geprueft werden alle Kanaele statt nur des ersten: Schreibrecht
+        besteht, sobald EIN steuerbarer Luefter beschreibbar ist. Der erste
+        Cache-Eintrag ist auf dieser Hardware der firmware-verwaltete
+        GPU-Luefter, den set_pwm gar nicht anfasst -- ueber unsere
+        Schreibfaehigkeit sagt er nichts aus (#552).
+        """
+        for fan_id, fan_info in self._fan_cache.items():
+            if fan_info.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
+                continue
+
+            # Fehlt das Modus-Register, bleibt nur der Duty-Knoten -- ohne
+            # Automatik kann der auch kein EBUSY liefern.
+            probe_path = fan_info.get("pwm_enable_path") or fan_info.get("pwm_path")
+            if probe_path is None:
+                continue
+
+            current = await self._read_hwmon_file(probe_path)
+            if current is None:
+                continue
+
+            ok, _ = await self._write_hwmon_file(probe_path, str(current))
+            if ok:
+                self._has_write_permission = True
+                logger.info(f"Fan control: write permission available ({fan_id})")
+                return
 
         logger.info("Fan control: no write permission (readonly mode)")
 

--- a/backend/tests/test_fan_write_permission_probe.py
+++ b/backend/tests/test_fan_write_permission_probe.py
@@ -1,0 +1,187 @@
+"""Der Rechte-Probe muss den echten Schreibpfad treffen (#552).
+
+Zwei Messungen auf BaluNode (2026-09-06) geben den Rahmen vor:
+
+1. Ein pwm-Write scheitert mit EBUSY, solange pwm_enable >= 2 steht:
+
+       $ sudo -n tee /sys/class/hwmon/hwmon3/pwm1 < /sys/class/hwmon/hwmon3/pwm1
+       tee: /sys/class/hwmon/hwmon3/pwm1: Das Geraet oder die Ressource ist belegt
+       exit=1
+
+   Seit #556 steht nach jedem Dienst-Ende genau dieser Auto-Modus an. Ein
+   Probe, der pwm schreibt, meldet also bei jedem Start "readonly".
+
+2. Ein Write auf pwm_enable mit dem gerade gelesenen Wert geht durch und
+   laesst den Modus unveraendert:
+
+       $ sudo -n tee /sys/class/hwmon/hwmon3/pwm1_enable < .../pwm1_enable
+       5
+       exit=0
+       $ cat /sys/class/hwmon/hwmon3/pwm1_enable
+       5
+
+Daraus folgt der Entwurf: geprueft wird auf dem Modus-Register, mit seinem
+eigenen Wert. Dieselbe Datei, dieselben Rechte, dieselbe sudoers-Regel wie im
+Regelbetrieb -- aber ohne Eingriff.
+
+os.access wird in diesen Tests auf False gezwungen und subprocess.run zum
+Scheitern gebracht. Beides bildet die Produktionslage nach: die pwm-Dateien
+gehoeren root:root 0644, der Dienst laeuft als unprivilegierter Nutzer, und
+kein Test darf `sudo` tatsaechlich aufrufen.
+"""
+import errno
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+from app.schemas.fans import PwmControl
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+class _FailedProcess:
+    returncode = 1
+    stdout = b""
+    stderr = b"tee: Permission denied\n"
+
+
+@pytest.fixture
+def unprivileged(monkeypatch):
+    """Kein direktes Schreibrecht, kein nutzbares sudo."""
+    monkeypatch.setattr(os, "access", lambda *args, **kwargs: False)
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: _FailedProcess())
+
+
+def _gpu_chip(sysfs: Path) -> None:
+    """amdgpu mit gpu_od/fan_ctrl/fan_curve -- also FIRMWARE_MANAGED."""
+    device = sysfs / "devices" / "platform" / "amdgpu-sim.1"
+    fan_ctrl = device / "gpu_od" / "fan_ctrl"
+    fan_ctrl.mkdir(parents=True)
+    (fan_ctrl / "fan_curve").write_text("OD_FAN_CURVE:\n0: 0C 0%\n")
+    (device / "vendor").write_text("0x1002\n")
+
+    hwmon = device / "hwmon" / "hwmon2"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("amdgpu\n")
+    (hwmon / "pwm1").write_text("0\n")
+    (hwmon / "pwm1_enable").write_text("2\n")
+    (hwmon / "fan1_input").write_text("0\n")
+    (hwmon / "temp1_input").write_text("35000\n")
+
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / "hwmon2", target_is_directory=True)
+
+
+def _super_io_chip(sysfs: Path) -> None:
+    """nct6798 im Auto-Modus, wie nach einem Dienst-Ende seit #556."""
+    device = sysfs / "devices" / "platform" / "nct6775.656"
+    hwmon = device / "hwmon" / "hwmon3"
+    hwmon.mkdir(parents=True)
+    (hwmon / "name").write_text("nct6798\n")
+    (hwmon / "pwm1").write_text("163\n")
+    (hwmon / "pwm1_enable").write_text("5\n")
+    (hwmon / "fan1_input").write_text("463\n")
+    (hwmon / "temp1_input").write_text("32000\n")
+
+    bus = sysfs / "bus" / "platform"
+    bus.mkdir(parents=True, exist_ok=True)
+    os.symlink(bus, device / "subsystem", target_is_directory=True)
+    os.symlink(device, hwmon / "device", target_is_directory=True)
+    klass = sysfs / "class" / "hwmon"
+    klass.mkdir(parents=True, exist_ok=True)
+    os.symlink(hwmon, klass / "hwmon3", target_is_directory=True)
+
+
+def _both_chips(tmp_path: Path) -> Path:
+    """Die Lage auf BaluNode: der GPU-Chip steht vor dem Super-I/O.
+
+    hwmon2 < hwmon3, der firmware-verwaltete Luefter kommt also zuerst --
+    seit #553 nicht mehr zufaellig, sondern verlaesslich.
+    """
+    sysfs = tmp_path / "sys"
+    _gpu_chip(sysfs)
+    _super_io_chip(sysfs)
+    return sysfs / "class" / "hwmon"
+
+
+async def _scanned_backend(klass: Path, monkeypatch) -> LinuxFanControlBackend:
+    backend = LinuxFanControlBackend(get_settings())
+    monkeypatch.setattr(backend, "_hwmon_base", klass)
+    await backend._scan_pwm_fans()
+    return backend
+
+
+@pytest.mark.asyncio
+async def test_probe_skips_firmware_managed_fan(tmp_path, monkeypatch, unprivileged):
+    """Der erste Luefter ist der GPU-Luefter -- und der sagt nichts aus.
+
+    set_pwm fasst einen FIRMWARE_MANAGED-Kanal gar nicht erst an. Ein Probe,
+    der ihn trotzdem beschreibt, misst eine Faehigkeit, die im Regelbetrieb
+    nie gebraucht wird, und meldet deshalb readonly, obwohl die Steuerung
+    arbeitet.
+    """
+    backend = await _scanned_backend(_both_chips(tmp_path), monkeypatch)
+    gpu_fans = [f for f in backend._fan_cache.values()
+                if f.get("pwm_control") is PwmControl.FIRMWARE_MANAGED]
+    assert gpu_fans, "der GPU-Luefter wurde nicht als firmware-verwaltet erkannt"
+
+    await backend._check_write_permission()
+
+    assert backend._has_write_permission is True
+
+
+@pytest.mark.asyncio
+async def test_probe_writes_the_mode_register_with_its_own_value(
+        tmp_path, monkeypatch, unprivileged):
+    """Geschrieben wird pwm_enable=5 auf den nct6798 -- der Wert, der dort steht.
+
+    pwm taugt nicht: im Auto-Modus lehnt der Treiber den Write mit EBUSY ab
+    (Messung im Modul-Docstring). Und ein pwm_enable=1, wie set_pwm es setzt,
+    waere ein echter Eingriff als Nebenwirkung einer Frage -- er schaltete
+    die Board-Automatik ab, die #556 gerade erst zurueckgegeben hat.
+    """
+    backend = await _scanned_backend(_both_chips(tmp_path), monkeypatch)
+
+    written: list[tuple[Path, str]] = []
+
+    async def recording_write(path, value):
+        written.append((path, value))
+        return True, None
+
+    monkeypatch.setattr(backend, "_write_hwmon_file", recording_write)
+
+    await backend._check_write_permission()
+
+    assert len(written) == 1, f"erwartet genau ein Write, war: {written}"
+    path, value = written[0]
+    assert path.parent.name == "hwmon3", "der GPU-Luefter wurde angefasst"
+    assert path.name == "pwm1_enable"
+    assert value == "5"
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_readonly_when_every_write_fails(
+        tmp_path, monkeypatch, unprivileged):
+    """Regressionsschutz: der Fix darf nicht pauschal True melden.
+
+    Dieser Test schlaegt vor dem Fix nicht fehl -- die alte Fassung meldet
+    hier ebenfalls readonly, nur aus dem falschen Grund. Er haelt fest, dass
+    der neue Probe weiterhin ein Nein kennt.
+    """
+    backend = await _scanned_backend(_both_chips(tmp_path), monkeypatch)
+
+    async def failing_write(path, value):
+        return False, errno.EACCES
+
+    monkeypatch.setattr(backend, "_write_hwmon_file", failing_write)
+
+    await backend._check_write_permission()
+
+    assert backend._has_write_permission is False


### PR DESCRIPTION
Behebt Ursache 1 aus #552. Ursache 2 bleibt dort offen — bewusst **kein** `Closes`-Schlüsselwort, damit das Issue nicht wie #534 vorzeitig zumacht.

## Das Problem

`_check_write_permission()` nahm blind den ersten Cache-Eintrag:

```python
first_fan = next(iter(self._fan_cache.values()))
pwm_path = first_fan["pwm_path"]
```

Auf BaluNode ist das der amdgpu-Lüfter — firmware-verwaltet, von `set_pwm()` bewusst nie angefasst, vom Kernel entsprechend abgewiesen. Der Probe scheiterte dadurch **deterministisch in allen vier Workern bei jedem Start**, und die Fan-Control-Seite zeigte „Read-Only Mode", obwohl die Steuerung nachweislich arbeitete. Das Banner ist nicht kosmetisch: `isReadOnly` sperrt die Bedienelemente.

## Zwei Messungen, die den Entwurf bestimmt haben

Der Fix-Vorschlag im Issue lautete, den Probe an `set_pwm()` anzugleichen — also `pwm_enable=1` zu setzen und dann `pwm` zu schreiben. Ich hielt das `pwm_enable=1` zunächst für kosmetische Angleichung und wollte es weglassen. Die Hardware sagt etwas anderes:

```
$ sudo -n tee /sys/class/hwmon/hwmon3/pwm1 < /sys/class/hwmon/hwmon3/pwm1
tee: /sys/class/hwmon/hwmon3/pwm1: Das Gerät oder die Ressource ist belegt
exit=1
```

**`EBUSY`.** Der nct6775 lehnt `pwm`-Writes ab, solange `pwm_enable >= 2` steht. Das `pwm_enable=1` ist also tragend, nicht kosmetisch.

Daraus folgt eine Wechselwirkung, die vorher niemand sehen konnte: **seit #556 setzt jeder Dienst-Stopp `pwm_enable` auf `5` zurück.** Vorher blieb nach einem Neustart die `1` stehen, ein `pwm`-Write wäre durchgegangen. Jetzt steht bei jedem Start Auto-Modus an — ein `pwm`-Probe liefe ab sofort immer in `EBUSY`. #556 hat diesen Fehler unbemerkt verschärft.

Die zweite Messung zeigt den Ausweg:

```
$ sudo -n tee /sys/class/hwmon/hwmon3/pwm1_enable < /sys/class/hwmon/hwmon3/pwm1_enable
5
exit=0
$ cat /sys/class/hwmon/hwmon3/pwm1_enable
5
```

Das Modus-Register ist in jedem Zustand beschreibbar, und mit seinem **eigenen Wert** beschrieben ändert es nichts.

## Die Änderung

Der Probe läuft jetzt über alle Kanäle, überspringt `FIRMWARE_MANAGED`, und schreibt `pwm_enable` mit dem gerade gelesenen Wert — über `_write_hwmon_file()`, also denselben Weg wie `set_pwm()`, samt `sudo tee`-Fallback. Schreibrecht besteht, sobald **ein** steuerbarer Lüfter beschreibbar ist.

Zwei Dinge fallen dabei weg:

- **Die duplizierte `subprocess`-Passage.** Der Probe baute den sudo-tee-Aufruf selbst nach. Ihn stattdessen über `_write_hwmon_file()` zu führen, ist der Grund, warum die drei im Issue aufgezählten Abweichungen künftig nicht wieder auseinanderlaufen können.
- **`os.access`.** Auf dieser Box immer `False` (die pwm-Dateien sind `root:root 0644`, der Dienst läuft unprivilegiert), und `_write_hwmon_file()` versucht den direkten Write ohnehin zuerst.

**Bewusst nicht übernommen:** `pwm_enable=1` zu setzen, wie `set_pwm()` es tut. Das wäre ein echter Eingriff als Nebenwirkung einer Rechtefrage — er schaltete auf allen vier Workern die Board-Automatik ab, die #556 gerade zurückgegeben hat.

## Tests

Drei neue Tests in `test_fan_write_permission_probe.py`. Der Baum bildet die Lage auf BaluNode nach: ein `amdgpu` mit `gpu_od/fan_ctrl/fan_curve` (also `FIRMWARE_MANAGED`) auf `hwmon2`, davor gescannt, und ein `nct6798` auf `hwmon3` mit `pwm1_enable = 5` — dem Zustand nach einem Dienst-Ende.

Eine Fixture zwingt `os.access` auf `False` und lässt `subprocess.run` scheitern. Beides bildet die Produktionslage nach; ohne das wäre der Test im tmp-Verzeichnis trivial grün, und kein Test darf `sudo` tatsächlich aufrufen.

Zwei der drei wurden rot gesehen, mit exakt dem Produktions-Log:

```
INFO Fan control: no write permission (readonly mode)
E    assert False is True
```

Der dritte ist ein Regressionsschutz gegen ein pauschales `True` und schlägt vor dem Fix nicht fehl — das steht so in seinem Docstring.

`pytest -k "fan or power"`: **725 bestanden, 2 übersprungen**. Ruff sauber. Volle Backend-Suite der CI überlassen (hängt auf Windows).

## Was offen bleibt

**Ursache 2 aus #552:** `_has_write_permission` ist prozesslokal, ohne Cross-Worker-Sync über SHM. Auf dieser Box wird sie gegenstandslos, weil der Probe künftig in allen vier Workern gelingt — die Klasse besteht aber fort: scheitert der Probe irgendwo legitim und heilt sich später über einen Write, bleiben die Follower auf ihrem Startwert stehen.

Ebenso offen: `permission_status` pro Lüfter statt global. Auf dieser Box ist genau ein Kanal nicht schreibbar und einer schon — ein globales Flag kann das nicht abbilden.

## Feldverifikation nach dem Deploy

```
sudo journalctl -u baluhost-backend --since "-5min" | grep "Fan control:"
```

Erwartet: **viermal** `write permission available (nct6798-isa-0290:pwm1)`, kein einziges `no write permission`. Heute stehen dort bei jedem Start vier `readonly`-Zeilen.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lf8TucK1YQasPz6Xn9Frk
