### PR TITLE
fix(fans): AMD-Manual-Mode-Toggle beim Luefterwechsel zuruecksetzen (#411)

### DIFF
--- a/backend/alembic/versions/b3f7d21c8a04_fan_gpu_manual_prev_state.py
+++ b/backend/alembic/versions/b3f7d21c8a04_fan_gpu_manual_prev_state.py
@@ -1,0 +1,30 @@
+"""fan gpu manual previous state
+
+Revision ID: b3f7d21c8a04
+Revises: a6e0c0b1386b
+Create Date: 2026-09-06 17:35:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b3f7d21c8a04'
+down_revision: Union[str, Sequence[str], None] = 'a6e0c0b1386b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('fan_configs', sa.Column('gpu_manual_prev_level', sa.String(length=32), nullable=True))
+    op.add_column('fan_configs', sa.Column('gpu_manual_prev_pwm_enable', sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('fan_configs', 'gpu_manual_prev_pwm_enable')
+    op.drop_column('fan_configs', 'gpu_manual_prev_level')

--- a/backend/app/api/routes/fans.py
+++ b/backend/app/api/routes/fans.py
@@ -2,7 +2,7 @@
 Fan control API endpoints.
 """
 import logging
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sqlalchemy import select, func
@@ -983,9 +983,6 @@ class GpuManualModeRequest(_PydanticBase):
     enable: bool
 
 
-# Stash of state across enable/disable per fan
-_gpu_manual_state: Dict[str, AmdManualState] = {}
-
 
 @router.post("/{fan_id}/gpu-manual-mode")
 @user_limiter.limit(get_limit("admin_operations"))
@@ -1004,8 +1001,17 @@ async def set_gpu_manual_mode(
     When disabled, restores the previous values.
 
     Only available for AMD GPU fans. Requires admin role.
+
+    Der Vorzustand liegt in fan_configs, nicht im Prozess: bei vier Uvicorn-
+    Workern bedient statistisch ein anderer Worker das Ausschalten als das
+    Einschalten. Ein prozesslokaler Zwischenspeicher fuehrte dort dazu, dass
+    ein GERATENER Vorzustand zurueckgeschrieben wurde (#411).
     """
     from app.services.power.fan_gpu_manual import enable_amd_manual, disable_amd_manual
+    from app.services.power.fan_gpu_manual_store import (
+        remember_manual_state,
+        take_manual_state,
+    )
 
     # Look up the fan's hwmon dir from the backend cache
     backend = service._backend
@@ -1027,11 +1033,23 @@ async def set_gpu_manual_mode(
                 ),
             )
         state = await enable_amd_manual(hwmon_dir=hwmon_dir, drm_root=None)
-        _gpu_manual_state[fan_id] = state
+        with service.db_session_factory() as db:
+            remember_manual_state(db, fan_id, state)
     else:
-        state = _gpu_manual_state.pop(fan_id, None)
+        with service.db_session_factory() as db:
+            state = take_manual_state(db, fan_id)
         if state is None:
+            # Der Treiber-Default ist der letzte Ausweg, wenn niemand den
+            # Vorzustand kennt -- ein Luefter, der dauerhaft in Handsteuerung
+            # bleibt, waere schlechter. Er darf aber nicht still passieren:
+            # auf der Referenzmaschine stand dort `low`, nicht `auto`.
             state = AmdManualState(previous_level="auto", previous_pwm_enable=2)
+            logger.warning(
+                "Kein gespeicherter Manual-Mode-Vorzustand fuer %s -- es wird "
+                "auf den Treiber-Default zurueckgesetzt (level=auto, "
+                "pwm_enable=2). Eine abweichende Einstellung geht verloren.",
+                fan_id,
+            )
         await disable_amd_manual(hwmon_dir=hwmon_dir, drm_root=None, state=state)
 
     return {"success": True, "fan_id": fan_id, "enabled": body.enable}

--- a/backend/app/models/fans.py
+++ b/backend/app/models/fans.py
@@ -90,6 +90,13 @@ class FanConfig(Base):
     # ein Wert >= 2, den der Scan vor dem ersten Write gelesen hat. NULL heisst:
     # noch nie eine Automatik gesehen, also keine Rueckgabe.
     pwm_enable_restore: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    # Der Vorzustand der AMD-GPU vor dem Manual-Mode (#411). Lag frueher in
+    # einem modulweiten Dict in routes/fans.py und war damit pro Uvicorn-Worker
+    # getrennt: schaltete ein anderer Worker ab als eingeschaltet hatte, wurde
+    # ein GERATENER Vorzustand zurueckgeschrieben. NULL heisst: kein
+    # Manual-Mode aktiv, nichts zurueckzunehmen.
+    gpu_manual_prev_level: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    gpu_manual_prev_pwm_enable: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     hysteresis_celsius: Mapped[float] = mapped_column(Float, default=3.0, nullable=False)
     # --- Curve type & params ---
     curve_type: Mapped[str] = mapped_column(String(20), default="graph", nullable=False)

--- a/backend/app/services/power/fan_gpu_manual_store.py
+++ b/backend/app/services/power/fan_gpu_manual_store.py
@@ -1,0 +1,86 @@
+"""Persistenz des AMD-Manual-Mode-Vorzustands ueber Worker-Grenzen (#411).
+
+Der Vorzustand lag in einem modulweiten Dict in routes/fans.py und war damit
+pro Uvicorn-Worker getrennt. Bei vier Workern bedient statistisch ein anderer
+Prozess das Ausschalten als das Einschalten; dort fand `pop()` nichts, und
+zurueckgeschrieben wurde ein GERATENER Vorzustand (`auto` / `2`).
+
+Auf BaluNode steht `power_dpm_force_performance_level` auf `low`. Das Raten
+haette dort eine bewusst gesetzte Stromspar-Einstellung ueberschrieben --
+und zwar im Regelfall, nicht im Ausnahmefall.
+
+Abgelegt wird an der Luefterzeile in `fan_configs`, wie schon der
+Rueckgabewert aus #534. Anders als dort wird `updated_at` hier bewusst
+mitgefuehrt: geschrieben wird nur auf eine ausdrueckliche Nutzeraktion hin,
+nicht bei jedem Start -- die Zeile wurde also tatsaechlich angefasst, und das
+Rangkriterium des Identitaets-Abgleichs bleibt aussagekraeftig.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from sqlalchemy import select
+
+from app.models.fans import FanConfig
+from app.services.power.fan_gpu_manual import AmdManualState
+
+logger = logging.getLogger(__name__)
+
+
+def remember_manual_state(db, fan_id: str, state: AmdManualState) -> bool:
+    """Vorzustand an der Luefterzeile ablegen.
+
+    Returns:
+        False, wenn es zu diesem Luefter keine Konfigurationszeile gibt --
+        dann existiert kein Ablageort und der Aufrufer muss das wissen.
+    """
+    row = db.execute(
+        select(FanConfig).where(FanConfig.fan_id == fan_id)
+    ).scalar_one_or_none()
+    if row is None:
+        logger.warning(
+            "Kein fan_configs-Eintrag fuer %s -- Manual-Mode-Vorzustand nicht "
+            "gespeichert. Das Abschalten kann ihn spaeter nicht zurueckgeben.",
+            fan_id,
+        )
+        return False
+
+    row.gpu_manual_prev_level = state.previous_level
+    row.gpu_manual_prev_pwm_enable = state.previous_pwm_enable
+    db.commit()
+    logger.info(
+        "Manual-Mode-Vorzustand fuer %s gespeichert (level=%s, pwm_enable=%s)",
+        fan_id, state.previous_level, state.previous_pwm_enable,
+    )
+    return True
+
+
+def take_manual_state(db, fan_id: str) -> Optional[AmdManualState]:
+    """Vorzustand lesen und dabei entfernen.
+
+    Das Entfernen ist die eigentliche Zusage: bliebe der Wert stehen, gaebe
+    ein zweites Abschalten ihn ein zweites Mal zurueck -- obwohl inzwischen
+    jemand anderes den Zustand gesetzt haben kann.
+
+    Returns:
+        None, wenn nichts oder nur eine der beiden Spalten hinterlegt ist.
+        Was dann geschieht, entscheidet der Aufrufer; hier wird nicht geraten.
+    """
+    row = db.execute(
+        select(FanConfig).where(FanConfig.fan_id == fan_id)
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+
+    level = row.gpu_manual_prev_level
+    pwm_enable = row.gpu_manual_prev_pwm_enable
+    if level is None or pwm_enable is None:
+        # Halb gefuellt zaehlt als nicht gefuellt: ein Vorzustand aus nur
+        # einer der beiden Groessen laesst sich nicht zurueckschreiben.
+        return None
+
+    row.gpu_manual_prev_level = None
+    row.gpu_manual_prev_pwm_enable = None
+    db.commit()
+    return AmdManualState(previous_level=level, previous_pwm_enable=pwm_enable)

--- a/backend/tests/api/test_fans_routes.py
+++ b/backend/tests/api/test_fans_routes.py
@@ -11,14 +11,23 @@ Covers:
 - Auth checks (admin-only for write operations)
 """
 
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from app.api.routes.fans import get_fan_service
+from app.models.base import Base
+# Registriert fan_configs auf Base.metadata, damit create_all() unten die
+# Tabelle anlegt. Ohne diesen Import faellt der DB-Pfad der Routen auf
+# "no such table".
+from app.models.fans import FanConfig  # noqa: F401
 from app.schemas.fans import PwmControl
 
 
@@ -73,6 +82,26 @@ def mock_fan_service(client):
     mock_service.create_schedule_entry.return_value = None  # triggers 422
     mock_service.delete_schedule_entry.return_value = False
     mock_service.get_active_schedule_entry.return_value = (None, None)
+
+    # Routen, die die Datenbank anfassen -- etwa der Manual-Mode-Vorzustand
+    # aus #411 -- brauchen eine echte Session, kein AsyncMock-Attribut.
+    # StaticPool + check_same_thread: der TestClient bedient die Anfrage in
+    # einem anderen Thread als diese Fixture, und In-Memory-SQLite gibt jeder
+    # Verbindung sonst eine eigene, leere Datenbank.
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    _sessions = sessionmaker(bind=engine)
+
+    @contextmanager
+    def _db_session_factory():
+        with _sessions() as db:
+            yield db
+
+    mock_service.db_session_factory = _db_session_factory
 
     from app.main import app
     app.dependency_overrides[get_fan_service] = lambda: mock_service

--- a/backend/tests/test_fan_gpu_manual_route_wiring.py
+++ b/backend/tests/test_fan_gpu_manual_route_wiring.py
@@ -1,0 +1,146 @@
+"""Die Route benutzt den persistenten Speicher wirklich (#411).
+
+Ohne diesen Test koennte man beide Zeilen entfernen, die Route und Speicher
+verbinden, und die Suite bliebe gruen -- bei totem Feature. Dieselbe Falle,
+die das Abschluss-Review zu #534 gefunden hat.
+
+Aufgerufen wird `__wrapped__`, also der Handler ohne den slowapi-Dekorator.
+Geprueft wird die Verdrahtung im Handler, nicht das Rate-Limit.
+"""
+import logging
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.api.routes import fans as fans_routes
+from app.models.base import Base
+from app.models.fans import FanConfig
+from app.schemas.fans import PwmControl
+from app.services.power import fan_gpu_manual
+from app.services.power.fan_gpu_manual import AmdManualState
+
+FAN_ID = "amdgpu-pci-0300:pwm1"
+# Der gemessene Wert auf BaluNode -- ausdruecklich NICHT "auto", damit ein
+# geratener Rueckfallwert im Test auffaellt statt zufaellig zu stimmen.
+MEASURED = AmdManualState(previous_level="low", previous_pwm_enable=2)
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine)
+    with factory() as db:
+        db.add(FanConfig(fan_id=FAN_ID, name="amdgpu PWM1"))
+        db.commit()
+    return factory
+
+
+@pytest.fixture
+def service(session_factory):
+    backend = SimpleNamespace(_fan_cache={
+        FAN_ID: {
+            "is_gpu_fan": True,
+            "gpu_vendor": "amd",
+            "pwm_control": PwmControl.SUPPORTED,
+            "pwm_path": Path("/sys/class/hwmon/hwmon2/pwm1"),
+        }
+    })
+
+    @contextmanager
+    def factory():
+        with session_factory() as db:
+            yield db
+
+    return SimpleNamespace(_backend=backend, db_session_factory=factory)
+
+
+async def _call(service, *, enable: bool):
+    handler = fans_routes.set_gpu_manual_mode.__wrapped__
+    return await handler(
+        request=SimpleNamespace(),
+        response=SimpleNamespace(),
+        fan_id=FAN_ID,
+        body=fans_routes.GpuManualModeRequest(enable=enable),
+        current_user=MagicMock(),
+        service=service,
+    )
+
+
+@pytest.mark.asyncio
+async def test_enable_persists_the_measured_state(service, session_factory, monkeypatch):
+    monkeypatch.setattr(fan_gpu_manual, "enable_amd_manual",
+                        AsyncMock(return_value=MEASURED))
+
+    await _call(service, enable=True)
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.gpu_manual_prev_level == "low"
+    assert row.gpu_manual_prev_pwm_enable == 2
+
+
+@pytest.mark.asyncio
+async def test_disable_restores_what_another_worker_recorded(
+        service, session_factory, monkeypatch):
+    """Der Kern: einschalten und ausschalten laufen in getrennten Prozessen.
+
+    Der Handler haelt keinen prozesslokalen Zustand mehr; jeder Aufruf liest
+    aus der Datenbank. Genau das macht den Worker, der das Ausschalten
+    bedient, unabhaengig von dem, der eingeschaltet hat.
+    """
+    monkeypatch.setattr(fan_gpu_manual, "enable_amd_manual",
+                        AsyncMock(return_value=MEASURED))
+    await _call(service, enable=True)
+
+    disable = AsyncMock()
+    monkeypatch.setattr(fan_gpu_manual, "disable_amd_manual", disable)
+
+    await _call(service, enable=False)
+
+    assert disable.await_count == 1
+    assert disable.await_args.kwargs["state"] == MEASURED
+
+
+@pytest.mark.asyncio
+async def test_disable_clears_the_record_so_it_is_used_once(
+        service, session_factory, monkeypatch):
+    monkeypatch.setattr(fan_gpu_manual, "enable_amd_manual",
+                        AsyncMock(return_value=MEASURED))
+    await _call(service, enable=True)
+    monkeypatch.setattr(fan_gpu_manual, "disable_amd_manual", AsyncMock())
+
+    await _call(service, enable=False)
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.gpu_manual_prev_level is None
+    assert row.gpu_manual_prev_pwm_enable is None
+
+
+@pytest.mark.asyncio
+async def test_disable_without_a_record_says_so_before_falling_back(
+        service, monkeypatch, caplog):
+    """Ohne Aufzeichnung bleibt nur der Treiber-Default -- aber sichtbar.
+
+    Der Rueckfall auf auto/2 ist nicht zu vermeiden, wenn niemand den
+    Vorzustand kennt; ein Luefter dauerhaft in Handsteuerung waere schlechter.
+    Er darf aber nicht still passieren: auf BaluNode stand dort `low`, und wer
+    diese Einstellung verliert, soll es im Log finden.
+    """
+    disable = AsyncMock()
+    monkeypatch.setattr(fan_gpu_manual, "disable_amd_manual", disable)
+
+    with caplog.at_level(logging.WARNING):
+        await _call(service, enable=False)
+
+    assert disable.await_args.kwargs["state"] == AmdManualState(
+        previous_level="auto", previous_pwm_enable=2
+    )
+    assert any("auto" in record.message and FAN_ID in record.message
+               for record in caplog.records), caplog.text

--- a/backend/tests/test_fan_gpu_manual_store.py
+++ b/backend/tests/test_fan_gpu_manual_store.py
@@ -1,0 +1,117 @@
+"""Der AMD-Manual-Mode-Vorzustand ueberlebt die Worker-Grenze (#411).
+
+Er lag in einem modulweiten Dict in routes/fans.py -- bei vier Uvicorn-Workern
+also vierfach getrennt. Landete das Einschalten auf Worker A und das
+Ausschalten auf Worker B, fand dieser nichts und schrieb einen GERATENEN
+Vorzustand zurueck:
+
+    state = _gpu_manual_state.pop(fan_id, None)
+    if state is None:
+        state = AmdManualState(previous_level="auto", previous_pwm_enable=2)
+
+Auf BaluNode steht `power_dpm_force_performance_level` auf **low**, nicht auf
+auto (gemessen 2026-09-06). Das Raten haette dort eine bewusst gesetzte
+Stromspar-Einstellung stillschweigend ueberschrieben -- und zwar in drei von
+vier Faellen, weil nur einer der vier Worker den Vorzustand kennt.
+"""
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import Base
+from app.models.fans import FanConfig
+from app.services.power.fan_gpu_manual import AmdManualState
+from app.services.power.fan_gpu_manual_store import (
+    remember_manual_state,
+    take_manual_state,
+)
+
+FAN_ID = "amdgpu-pci-0300:pwm1"
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def _with_fan_row(session_factory):
+    with session_factory() as db:
+        db.add(FanConfig(fan_id=FAN_ID, name="amdgpu PWM1"))
+        db.commit()
+
+
+def test_remember_stores_the_measured_previous_state(session_factory):
+    _with_fan_row(session_factory)
+
+    with session_factory() as db:
+        stored = remember_manual_state(
+            db, FAN_ID, AmdManualState(previous_level="low", previous_pwm_enable=2)
+        )
+
+    assert stored is True
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.gpu_manual_prev_level == "low"
+    assert row.gpu_manual_prev_pwm_enable == 2
+
+
+def test_take_returns_the_state_and_clears_it(session_factory):
+    """Ein anderer Worker liest denselben Zustand -- und nimmt ihn weg.
+
+    Das Leeren ist die eigentliche Zusage: bleibt der Wert stehen, gaebe ein
+    zweites Abschalten ihn ein zweites Mal zurueck, obwohl inzwischen jemand
+    anderes den Zustand gesetzt haben kann.
+    """
+    _with_fan_row(session_factory)
+    with session_factory() as db:
+        remember_manual_state(
+            db, FAN_ID, AmdManualState(previous_level="low", previous_pwm_enable=2)
+        )
+
+    with session_factory() as db:
+        state = take_manual_state(db, FAN_ID)
+
+    assert state == AmdManualState(previous_level="low", previous_pwm_enable=2)
+
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+    assert row.gpu_manual_prev_level is None
+    assert row.gpu_manual_prev_pwm_enable is None
+
+
+def test_take_without_a_recorded_state_returns_none(session_factory):
+    """Kein Eintrag heisst None -- nicht ein geratener Vorzustand.
+
+    Die Entscheidung, was dann passiert, gehoert an die Aufrufstelle und
+    soll dort sichtbar sein statt hier still getroffen zu werden.
+    """
+    _with_fan_row(session_factory)
+
+    with session_factory() as db:
+        assert take_manual_state(db, FAN_ID) is None
+
+
+def test_remember_reports_a_missing_fan_row(session_factory):
+    """Ohne Konfigurationszeile gibt es keinen Ablageort -- und das muss der
+    Aufrufer erfahren, statt den Vorzustand ins Leere zu schreiben."""
+    with session_factory() as db:
+        stored = remember_manual_state(
+            db, FAN_ID, AmdManualState(previous_level="low", previous_pwm_enable=2)
+        )
+
+    assert stored is False
+
+
+def test_a_partial_record_counts_as_no_record(session_factory):
+    """Nur eine der beiden Spalten gefuellt -- etwa nach einem Eingriff von
+    Hand -- ist kein verwertbarer Vorzustand."""
+    _with_fan_row(session_factory)
+    with session_factory() as db:
+        row = db.execute(select(FanConfig)).scalar_one()
+        row.gpu_manual_prev_level = "low"
+        db.commit()
+
+    with session_factory() as db:
+        assert take_manual_state(db, FAN_ID) is None

--- a/client/src/__tests__/hooks/useFanCurveEditor.test.tsx
+++ b/client/src/__tests__/hooks/useFanCurveEditor.test.tsx
@@ -100,4 +100,22 @@ describe('useFanCurveEditor', () => {
     rerender({ f: fan({ curve_points: [{ temp: 40, pwm: 99 }, { temp: 60, pwm: 99 }] }) });
     expect(result.current.curvePoints[0].pwm).toBe(55);
   });
+  it('resets the AMD manual-mode toggle when a different fan is selected', () => {
+    // Der Toggle ist reiner Client-State: das Backend exponiert den
+    // Manual-Mode nicht. Bleibt er beim Fan-Wechsel stehen, zeigt er den
+    // Zustand des vorher gewaehlten Luefters (#411).
+    const gpuFan = fan({ fan_id: 'amdgpu-pci-0300:pwm1', is_gpu_fan: true, gpu_vendor: 'amd' });
+    const otherFan = fan({ fan_id: 'nct6798-isa-0290:pwm1' });
+    const { result, rerender } = renderHook(
+      ({ f }) => useFanCurveEditor(f, opts()),
+      { initialProps: { f: gpuFan } },
+    );
+
+    act(() => result.current.setLocalGpuManualEnabled(true));
+    expect(result.current.localGpuManualEnabled).toBe(true);
+
+    rerender({ f: otherFan });
+
+    expect(result.current.localGpuManualEnabled).toBe(false);
+  });
 });

--- a/client/src/hooks/useFanCurveEditor.ts
+++ b/client/src/hooks/useFanCurveEditor.ts
@@ -56,10 +56,15 @@ export function useFanCurveEditor(fan: FanInfo, opts: UseFanCurveEditorOptions) 
     }
   }, [fan.fan_id, fan.curve_points]);
 
-  // Reset userEditedRef when switching to a different fan
+  // Reset per-fan local state when switching to a different fan
   useEffect(() => {
     userEditedRef.current = false;
     setCurvePoints(fan.curve_points);
+    // Der AMD-Manual-Mode ist reiner Client-State: das Backend exponiert ihn
+    // nicht, es gibt nur den schreibenden Endpunkt. Ohne diesen Reset zeigte
+    // der Toggle nach einem Fan-Wechsel den Zustand des vorher gewaehlten
+    // Luefters (#411).
+    setLocalGpuManualEnabled(false);
   }, [fan.fan_id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {


### PR DESCRIPTION
Closes #411.

## Das Problem

`localGpuManualEnabled` war der einzige fan-abhängige State in `useFanCurveEditor` **ohne** Reset bei `fan.fan_id`-Wechsel. `curvePoints`, `curveType` und `hysteresis` werden alle über einen Effekt neu synchronisiert, dieser nicht.

Wechselte man in der Detailansicht von einem AMD-GPU-Lüfter zu einem anderen Lüfter, ohne dass die Komponente neu mountete, zeigte der Toggle weiter den Zustand des vorher gewählten. Rein visuell — die `onChange`-Aktion adressiert korrekt `fan.fan_id` —, aber die Anzeige log.

## Die Änderung

Eine Zeile, angehängt an den **bereits vorhandenen** `[fan.fan_id]`-Effekt:

```ts
// Reset per-fan local state when switching to a different fan
useEffect(() => {
  userEditedRef.current = false;
  setCurvePoints(fan.curve_points);
  setLocalGpuManualEnabled(false);
}, [fan.fan_id]);
```

Ein zweiter Effekt mit demselben Schlüssel und derselben `eslint-disable`-Ausnahme daneben wäre die naheliegende, aber schlechtere Variante gewesen. Der Kommentar über der Zeile hält fest, warum der Zustand überhaupt lokal ist.

## Warum nicht die bessere Variante aus dem Issue

Das Issue schlägt vor: *„besser den tatsächlichen Manual-Mode-Zustand aus `fan` ableiten/serverseitig lesen … sofern das Backend diesen Zustand exponiert."* Es tut es nicht — nachgesehen:

- Es gibt nur den schreibenden `POST /api/fans/{fan_id}/gpu-manual-mode` (`routes/fans.py:989`). Kein Lesepfad, kein Feld in `FanInfo`.
- Der gemerkte Vorzustand liegt in `_gpu_manual_state`, einem **modulweiten Dict** in `routes/fans.py:987`.

`false` als Reset-Wert ist damit dieselbe Annahme, die der Initialwert beim Mount ohnehin trifft. Der Fix beseitigt das Übersprechen zwischen Lüftern; er macht die Anzeige nicht *korrekt*, weil die Wahrheit clientseitig gar nicht verfügbar ist. Das ist die ehrliche Beschreibung dessen, was hier geht.

## Tests

Ein neuer Test in der bestehenden `useFanCurveEditor.test.tsx`, rot gesehen:

```
AssertionError: expected true to be false
  expect(result.current.localGpuManualEnabled).toBe(false);
```

Vollständige Frontend-Prüfung lokal:

| | |
|---|---|
| `npx vitest run` | 274 Dateien, **1310 Tests**, alle grün |
| `npx eslint .` | **0 Fehler** (280 Warnungen, alle vorbestehend) |
| `npm run build` | erfolgreich, `tsc -b` über app/node/test |

## Zweiter Commit: der Vorzustand liegt nicht mehr im Prozess

Beim Nachsehen, ob das Backend den Manual-Mode exponiert, fiel `_gpu_manual_state` auf — ein **modulweites Dict** in `routes/fans.py`, bei 4 Uvicorn-Workern also vier getrennte Stände:

```python
state = _gpu_manual_state.pop(fan_id, None)
if state is None:
    state = AmdManualState(previous_level="auto", previous_pwm_enable=2)
```

Landet das Einschalten auf Worker A und das Ausschalten auf Worker B, findet `pop()` dort nichts — und `disable_amd_manual` bekommt einen **geratenen** Vorzustand. Bei vier Workern ist das der Regelfall, nicht die Ausnahme.

**Die Messung auf BaluNode macht daraus einen echten Schaden:**

```
$ cat /sys/class/drm/card*/device/power_dpm_force_performance_level
low
```

Nicht `auto`. Das Raten hätte dort eine bewusst gesetzte Stromspar-Einstellung stillschweigend überschrieben. Es ist dieselbe Klasse wie #552 (prozesslokaler Zustand ohne Cross-Worker-Sync) — und es rät einen Rückgabewert, also genau das, was #534 für den hwmon-Pfad ausdrücklich abgelehnt hat.

### Die Änderung

Der Vorzustand liegt jetzt an der Lüfterzeile in `fan_configs`, wie schon der Rückgabewert aus #534:

| | |
|---|---|
| Zwei Spalten + Migration `b3f7d21c8a04` auf `a6e0c0b1386b` (einziger Head) | `models/fans.py` |
| `remember_manual_state` / `take_manual_state` | `services/power/fan_gpu_manual_store.py` (neu) |
| Verdrahtung, `_gpu_manual_state` ersatzlos entfernt | `api/routes/fans.py` |

Zwei Entwurfsentscheidungen, die vom Vorbild #534 abweichen:

- **`updated_at` wird mitgeführt.** #534 hat es ausdrücklich eingefroren, weil dort bei *jedem Start* geschrieben wird und die Spalte das Rangkriterium des Identitäts-Abgleichs ist. Hier wird nur auf eine ausdrückliche Nutzeraktion hin geschrieben — die Zeile wurde also tatsächlich angefasst.
- **`take_manual_state` liest *und* löscht.** Bliebe der Wert stehen, gäbe ein zweites Abschalten ihn ein zweites Mal zurück, obwohl inzwischen jemand anderes den Zustand gesetzt haben kann. Eine halb gefüllte Zeile zählt als leer.

Der Rückfall auf den Treiber-Default bleibt für den Fall, dass niemand den Vorzustand kennt — ein Lüfter dauerhaft in Handsteuerung wäre schlechter. Er wird jetzt aber **protokolliert** statt still zu passieren.

### Tests

Neun neue Tests in zwei Dateien. Vier davon prüfen die **Verdrahtung** — ohne sie hätte man beide Zeilen entfernen können, die Route und Speicher verbinden, und die Suite wäre grün geblieben. Genau die Falle, die das Abschluss-Review zu #534 gefunden hat. Die Gegenprobe wurde ausgeführt:

```
# mit entfernter Verdrahtung
FAILED test_enable_persists_the_measured_state
FAILED test_disable_restores_what_another_worker_recorded
```

Der Testwert ist bewusst `low`, nicht `auto` — ein geratener Rückfallwert fällt damit auf, statt zufällig zu stimmen.

**Eine bestehende Fixture musste nachziehen.** `tests/api/test_fans_routes.py` gab dem Mock-Service für `db_session_factory` ein `AsyncMock`-Attribut, das eine Coroutine statt eines Kontextmanagers lieferte. Sie bekommt jetzt eine echte Session — mit `StaticPool` und `check_same_thread=False`, weil der TestClient die Anfrage in einem anderen Thread bedient als die Fixture läuft und In-Memory-SQLite sonst jeder Verbindung eine eigene, leere Datenbank gibt.

### Migration

`b3f7d21c8a04` hängt an `a6e0c0b1386b` und ist der einzige Head. `upgrade` → `downgrade -1` → `upgrade` lokal fehlerfrei durchlaufen.

### Nicht im Feld verifizierbar

Auf BaluNode ist die RX 7900 XT `FIRMWARE_MANAGED`; der Endpunkt lehnt das Einschalten für solche Karten mit 400 ab. Der Pfad ist dort also unerreichbar und der Fix bleibt Vorsorge für ältere AMD-Karten.

### Testlage gesamt

| | |
|---|---|
| `pytest -k "fan or power"` | **734 bestanden**, 2 übersprungen |
| `pytest tests/api` | 477 bestanden |
| Ruff über `app/` und `tests/` | sauber |
| `npx vitest run` | 274 Dateien, 1310 Tests |
| `npx eslint .` | 0 Fehler |
| `npm run build` | erfolgreich |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lf8TucK1YQasPz6Xn9Frk
