### PR TITLE
fix(fans): Lebenszyklus serialisieren und die Worker-Rolle festhalten (#555, #559)

### DIFF
--- a/backend/app/core/service_registry.py
+++ b/backend/app/core/service_registry.py
@@ -199,13 +199,24 @@ def register_all_services(
         config_enabled_fn=lambda: settings.gpu_power_management_enabled,
     )
 
-    # Fan Control
+    # Fan Control — start_fn closes over is_primary_worker so a service
+    # restart triggered via the admin UI keeps the worker's primary/follower
+    # role intact, mirroring the CPU and GPU power managers. Ohne den
+    # Wrapper griffe der Default monitoring=True, und ein Sekundaer-Worker
+    # startete eine zweite, vollwertige Regelschleife (#555).
+    _is_primary_worker_for_fans = is_primary_worker
+
+    async def _start_fan_control_for_worker():
+        await fan_control.start_fan_control(
+            monitoring=_is_primary_worker_for_fans
+        )
+
     register_service(
         name="fan_control",
         display_name="Fan Control",
         get_status_fn=fan_control.get_service_status,
         stop_fn=fan_control.stop_fan_control,
-        start_fn=fan_control.start_fan_control,
+        start_fn=_start_fan_control_for_worker,
         config_enabled_fn=lambda: settings.fan_control_enabled,
     )
 

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -172,6 +172,10 @@ class FanControlService:
         # Rueckgabewerte pro Luefter, beim Start aus der DB geladen. stop()
         # braucht sie ohne Datenbankzugriff (#534).
         self._restore_values: Dict[str, int] = {}
+        # Serialisiert start/stop/switch_backend: alle drei tauschen
+        # _monitoring_task aus, und eine ueberschriebene Referenz waere eine
+        # Regelschleife, die niemand mehr abbrechen kann (#559).
+        self._lifecycle_lock = asyncio.Lock()
 
         FanControlService._instance = self
 
@@ -202,47 +206,68 @@ class FanControlService:
             monitoring: If True, start the monitoring loop (primary worker).
                         If False, only initialize backend + configs (secondary workers).
         """
-        if not self.config.fan_control_enabled:
-            logger.info("Fan control disabled in config")
+        async with self._lifecycle_lock:
+            if not self.config.fan_control_enabled:
+                logger.info("Fan control disabled in config")
+                return
+
+            # Initialize backend
+            await self._initialize_backend()
+
+            if not self._backend:
+                logger.warning("No fan control backend available")
+                return
+
+            await self._rebuild_registry()
+
+            # Load fan configs from database
+            await self._load_fan_configs()
+
+            # Eine noch laufende Schleife gehoert zum alten Backend und zu
+            # den alten Konfigurationen -- und ihre Referenz ginge bei der
+            # Zuweisung unten verloren (#559).
+            await self._cancel_monitoring_task()
+
+            if monitoring:
+                # Start monitoring loop (primary worker only)
+                self._start_monitoring_task()
+            logger.info("Fan control service started (monitoring=%s)", monitoring)
+
+    async def _cancel_monitoring_task(self) -> None:
+        """Bricht eine laufende Regelschleife ab und gibt die Referenz frei.
+
+        Immer vor einer Neuzuweisung aufzurufen: eine ueberschriebene
+        Referenz laesst die alte Task unerreichbar weiterlaufen.
+        """
+        task = self._monitoring_task
+        self._monitoring_task = None
+        self._is_running = False
+        if task is None:
             return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
-        # Initialize backend
-        await self._initialize_backend()
-
-        if not self._backend:
-            logger.warning("No fan control backend available")
-            return
-
-        await self._rebuild_registry()
-
-        # Load fan configs from database
-        await self._load_fan_configs()
-
-        if monitoring:
-            # Start monitoring loop (primary worker only)
-            self._is_running = True
-            self._monitoring_task = asyncio.create_task(self._monitoring_loop())
-        logger.info("Fan control service started (monitoring=%s)", monitoring)
+    def _start_monitoring_task(self) -> None:
+        self._is_running = True
+        self._monitoring_task = asyncio.create_task(self._monitoring_loop())
 
     async def stop(self):
         """Stop fan control service."""
-        self._is_running = False
+        async with self._lifecycle_lock:
+            # Erst die Schleife stilllegen, dann zurueckgeben -- umgekehrt
+            # schriebe sie im naechsten Zyklus pwm_enable=1 gegen die
+            # Rueckgabe (#534).
+            await self._cancel_monitoring_task()
 
-        if self._monitoring_task:
-            self._monitoring_task.cancel()
             try:
-                await self._monitoring_task
-            except asyncio.CancelledError:
-                pass
+                await self._release_all_to_board()
+            except Exception:
+                logger.exception("Rueckgabe an die Board-Automatik fehlgeschlagen")
 
-        # Erst die Schleife stilllegen, dann zurueckgeben -- umgekehrt schriebe
-        # sie im naechsten Zyklus pwm_enable=1 gegen die Rueckgabe (#534).
-        try:
-            await self._release_all_to_board()
-        except Exception:
-            logger.exception("Rueckgabe an die Board-Automatik fehlgeschlagen")
-
-        logger.info("Fan control service stopped")
+            logger.info("Fan control service stopped")
 
     async def _release_all_to_board(self) -> None:
         """Gibt alle Luefter mit bekanntem Rueckgabewert an die Automatik zurueck.
@@ -1205,56 +1230,50 @@ class FanControlService:
         Returns:
             (success, is_using_linux_backend)
         """
-        # Gleiche Reihenfolge wie in stop(): erst die Schleife stilllegen, dann
-        # zurueckgeben, dann tauschen. Ohne das schriebe die weiterlaufende
-        # Schleife pwm_enable=1 gegen die Rueckgabe, und ein Wechsel auf das
-        # Dev-Backend liesse jeden Kanal in Handsteuerung zurueck -- niemand
-        # regelt, ueber einen Admin-Endpunkt (#534).
-        was_running = self._is_running
-        self._is_running = False
-        if self._monitoring_task:
-            self._monitoring_task.cancel()
+        async with self._lifecycle_lock:
+            # Gleiche Reihenfolge wie in stop(): erst die Schleife stilllegen,
+            # dann zurueckgeben, dann tauschen. Ohne das schriebe die
+            # weiterlaufende Schleife pwm_enable=1 gegen die Rueckgabe, und ein
+            # Wechsel auf das Dev-Backend liesse jeden Kanal in Handsteuerung
+            # zurueck -- niemand regelt, ueber einen Admin-Endpunkt (#534).
+            was_running = self._is_running
+            await self._cancel_monitoring_task()
             try:
-                await self._monitoring_task
-            except asyncio.CancelledError:
-                pass
-            self._monitoring_task = None
-        try:
-            await self._release_all_to_board()
-        except Exception:
-            logger.exception("Rueckgabe beim Backend-Wechsel fehlgeschlagen")
+                await self._release_all_to_board()
+            except Exception:
+                logger.exception("Rueckgabe beim Backend-Wechsel fehlgeschlagen")
 
-        try:
-            if use_linux:
-                # Try to switch to Linux backend
-                linux_backend = LinuxFanControlBackend(self.config)
-                if await linux_backend.is_available():
-                    self._backend = linux_backend
-                    self._use_linux_backend = True
-                    await self._load_fan_configs()
-                    logger.info("Switched to Linux fan control backend")
-                    result = True, True
+            try:
+                if use_linux:
+                    # Try to switch to Linux backend
+                    linux_backend = LinuxFanControlBackend(self.config)
+                    if await linux_backend.is_available():
+                        self._backend = linux_backend
+                        self._use_linux_backend = True
+                        await self._load_fan_configs()
+                        logger.info("Switched to Linux fan control backend")
+                        result = True, True
+                    else:
+                        logger.warning("Linux backend not available")
+                        result = False, self._use_linux_backend
                 else:
-                    logger.warning("Linux backend not available")
-                    result = False, self._use_linux_backend
-            else:
-                # Switch to dev backend
-                self._backend = DevFanControlBackend(self.config)
-                self._use_linux_backend = False
-                await self._load_fan_configs()
-                logger.info("Switched to dev fan control backend")
-                result = True, False
-        finally:
-            # Der Neustart gehoert ins finally: zwischen Abbruch (oben) und
-            # hier koennen is_available() und _load_fan_configs() werfen. Ohne
-            # das bliebe die Regelung nach einem gescheiterten Wechsel bis zum
-            # Prozess-Neustart still stehen -- schlimmer als der Zustand, den
-            # dieser Wechsel beheben sollte.
-            if was_running:
-                self._is_running = True
-                self._monitoring_task = asyncio.create_task(self._monitoring_loop())
+                    # Switch to dev backend
+                    self._backend = DevFanControlBackend(self.config)
+                    self._use_linux_backend = False
+                    await self._load_fan_configs()
+                    logger.info("Switched to dev fan control backend")
+                    result = True, False
+            finally:
+                # Der Neustart gehoert ins finally: zwischen Abbruch (oben)
+                # und hier koennen is_available() und _load_fan_configs()
+                # werfen. Ohne das bliebe die Regelung nach einem
+                # gescheiterten Wechsel bis zum Prozess-Neustart still stehen
+                # -- schlimmer als der Zustand, den dieser Wechsel beheben
+                # sollte.
+                if was_running:
+                    self._start_monitoring_task()
 
-        return result
+            return result
 
     # --- Delegating methods for backward compatibility ---
 

--- a/backend/tests/test_fan_lifecycle_lock.py
+++ b/backend/tests/test_fan_lifecycle_lock.py
@@ -1,0 +1,141 @@
+"""Es gibt hoechstens eine Regelschleife, und stop() beendet sie (#559).
+
+`start` und der Neustart-Block in `switch_backend` wiesen `_monitoring_task`
+unbedingt zu. Ueberlappten zwei Lebenszyklus-Operationen, ueberschrieb die
+zweite die Referenz auf die Task der ersten. Diese lief weiter, war von nichts
+mehr referenziert und liess sich weder von `stop()` noch von einem weiteren
+Aufruf abbrechen -- sie schrieb bis zum Prozess-Ende alle 5 Sekunden
+`pwm_enable=1` und hebelte die Rueckgabe an die Board-Automatik aus (#534).
+
+**Korrektur am Ausloeser aus #559.** Dort stand, zwei ueberlappende
+`switch_backend`-Aufrufe erzeugten die Waise. Nachgemessen trifft das NICHT
+zu: `switch_backend` liest `was_running` und setzt `_is_running` unmittelbar
+danach auf False, ohne await dazwischen. Der zweite Aufruf liest deshalb
+`was_running=False` und ueberspringt den Neustart im finally. Ein Test dafuer
+lief gegen den unveraenderten Code gruen.
+
+Erreichbar ist die Waise ueber die beiden Wege, die dieser Test festhaelt:
+
+* zwei `start(monitoring=True)` -- dort gibt es gar keinen Schutz, die
+  Zuweisung erfolgt unbedingt (Admin-Endpunkt /services/fan_control/start)
+* ein `stop()`, das in einen laufenden `switch_backend` faellt -- dessen
+  finally erzeugt danach eine neue Schleife, obwohl gerade gestoppt wurde
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_control import FanControlService
+
+
+@pytest.fixture
+def service(monkeypatch):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = True
+    config.is_dev_mode = True
+    svc = FanControlService(config, MagicMock())
+
+    monkeypatch.setattr(fan_control_module, "DevFanControlBackend",
+                        lambda *a, **k: MagicMock())
+    monkeypatch.setattr(svc, "_release_all_to_board", AsyncMock())
+    monkeypatch.setattr(svc, "_rebuild_registry", AsyncMock())
+    svc._backend = MagicMock()
+    monkeypatch.setattr(svc, "_initialize_backend", AsyncMock())
+
+    async def slow_load():
+        # Zwei Yield-Punkte: bildet die await-Strecke im echten Ablauf nach
+        # (Chip-Scan, Datenbankzugriffe) und laesst eine zweite Operation
+        # tatsaechlich dazwischenfahren.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(svc, "_load_fan_configs", slow_load)
+    return svc
+
+
+@pytest.fixture
+def loops(service, monkeypatch):
+    """Sammelt jede erzeugte Regelschleife, damit Waisen sichtbar werden."""
+    created: list[asyncio.Task] = []
+
+    async def fake_loop():
+        created.append(asyncio.current_task())
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(service, "_monitoring_loop", fake_loop)
+    return created
+
+
+async def _alive(loops) -> list:
+    await asyncio.sleep(0)
+    return [task for task in loops if not task.done()]
+
+
+@pytest.mark.asyncio
+async def test_starting_twice_leaves_a_single_loop(service, loops):
+    """start() hatte keinerlei Schutz: die Zuweisung erfolgte unbedingt."""
+    await service.start(monitoring=True)
+    await service.start(monitoring=True)
+
+    assert len(await _alive(loops)) == 1, "eine Regelschleife ist verwaist"
+
+
+@pytest.mark.asyncio
+async def test_a_second_start_does_not_survive_stop(service, loops):
+    """Der eigentliche Schaden: die Waise ueberlebt stop().
+
+    Sie schreibt danach weiter `pwm_enable=1` -- gegen die Rueckgabe an die
+    Board-Automatik, die stop() unmittelbar davor ausgefuehrt hat.
+    """
+    await service.start(monitoring=True)
+    await service.start(monitoring=True)
+
+    await service.stop()
+
+    assert await _alive(loops) == [], "eine Regelschleife hat stop() ueberlebt"
+
+
+@pytest.mark.asyncio
+async def test_stop_during_a_backend_switch_leaves_nothing_running(service, loops):
+    """stop() faellt in einen laufenden switch_backend.
+
+    Dessen finally startet die Schleife danach neu -- der Dienst gilt als
+    gestoppt und regelt trotzdem weiter.
+    """
+    service._is_running = True
+    service._monitoring_task = asyncio.create_task(service._monitoring_loop())
+    await asyncio.sleep(0)
+
+    switching = asyncio.create_task(service.switch_backend(False))
+    await asyncio.sleep(0)
+
+    await service.stop()
+    await switching
+
+    assert await _alive(loops) == [], "nach stop() laeuft noch eine Schleife"
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_switches_leave_a_single_loop(service, loops):
+    """Haelt die gemessene Eigenschaft fest, statt sie zu behaupten.
+
+    Dieser Fall war der in #559 genannte Ausloeser und ist es nicht: der Test
+    laeuft auch gegen den unveraenderten Code gruen. Er bleibt als Beleg
+    stehen -- und als Schutz davor, dass ein kuenftiger Umbau des
+    `was_running`-Griffs die Eigenschaft still verliert.
+    """
+    service._is_running = True
+    service._monitoring_task = asyncio.create_task(service._monitoring_loop())
+    await asyncio.sleep(0)
+
+    await asyncio.gather(
+        service.switch_backend(False),
+        service.switch_backend(False),
+    )
+
+    assert len(await _alive(loops)) == 1
+    await service.stop()
+    assert await _alive(loops) == []

--- a/backend/tests/test_fan_service_registry_worker_role.py
+++ b/backend/tests/test_fan_service_registry_worker_role.py
@@ -1,0 +1,68 @@
+"""Ein Admin-Neustart darf die Worker-Rolle nicht verlieren (#555).
+
+`POST /api/admin/services/fan_control/restart` hat kein Primary-Gate; bei vier
+Uvicorn-Workern bedient die Anfrage mit 3/4 Wahrscheinlichkeit einen Sekundaer.
+`restart_service` ruft `start_fn()` ohne Argument auf, und registriert war die
+nackte `start_fan_control`, deren Default `monitoring=True` lautet. Der
+Sekundaer startete damit eine zweite, vollwertige Regelschleife.
+
+power_manager und gpu_power_manager sind gegen genau das abgesichert: sie
+registrieren einen Wrapper, der die Rolle des Workers festhaelt.
+"""
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core import service_registry
+from app.services.power import fan_control
+from app.services import service_status
+
+
+@pytest.fixture
+def registry_snapshot():
+    """register_all_services schreibt in ein Modul-Dict -- danach aufraeumen."""
+    previous = dict(service_status._service_registry)
+    yield
+    service_status._service_registry.clear()
+    service_status._service_registry.update(previous)
+
+
+def _registered_start(monkeypatch, *, primary: bool) -> AsyncMock:
+    """Registriert neu und liefert das Mock, das der start_fn treffen muss.
+
+    Gepatcht wird VOR der Registrierung: die alte Fassung uebergab die nackte
+    Funktion als start_fn, ein spaeterer Patch haette diese Referenz nicht
+    mehr erreicht.
+    """
+    started = AsyncMock()
+    monkeypatch.setattr(fan_control, "start_fan_control", started)
+    service_registry.register_all_services(
+        is_primary_worker=primary, discovery_service=None
+    )
+    return started
+
+
+@pytest.mark.asyncio
+async def test_follower_restart_starts_no_monitoring_loop(monkeypatch, registry_snapshot):
+    started = _registered_start(monkeypatch, primary=False)
+    start_fn = service_status._service_registry["fan_control"]["start"]
+
+    await start_fn()
+
+    assert started.await_count == 1
+    assert started.await_args.kwargs.get("monitoring") is False
+
+
+@pytest.mark.asyncio
+async def test_primary_restart_starts_the_monitoring_loop(monkeypatch, registry_snapshot):
+    """Die Rolle wird ausdruecklich uebergeben, nicht dem Default ueberlassen.
+
+    Auf dem Primary war das Ergebnis schon vorher richtig -- aber nur durch
+    Zufall, weil der Default zufaellig passte.
+    """
+    started = _registered_start(monkeypatch, primary=True)
+    start_fn = service_status._service_registry["fan_control"]["start"]
+
+    await start_fn()
+
+    assert started.await_args.kwargs.get("monitoring") is True


### PR DESCRIPTION
Closes #555. Closes #559.

Zwei Wege führten zu einer zweiten Regelschleife. Beide heben die Rückgabe an die Board-Automatik aus #534 auf — ohne dass ein Log es zeigt. Sie fassen dieselben zwei Dateien an und gehören deshalb in einen PR.

## #555 — die Worker-Rolle ging beim Admin-Neustart verloren

`POST /api/admin/services/fan_control/restart` hat kein Primary-Gate; bei vier Uvicorn-Workern bedient die Anfrage mit 3/4 Wahrscheinlichkeit einen Sekundär. `restart_service` ruft `start_fn()` **ohne Argument** auf, und registriert war die nackte Funktion:

```python
start_fn=fan_control.start_fan_control,   # Default: monitoring=True
```

Der Sekundär startete damit eine vollwertige Regelschleife in einem eigenen Prozess. `power_manager` und `gpu_power_manager` sind gegen genau das abgesichert und registrieren einen Wrapper, der die Rolle festhält — `fan_control` war der Ausreißer. Der Fix übernimmt dieses Muster.

## #559 — die verwaiste Task, und eine Korrektur am Issue

`start()` und der Neustart-Block in `switch_backend` wiesen `_monitoring_task` **unbedingt** zu. Überlappten zwei Lebenszyklus-Operationen, überschrieb die zweite die Referenz auf die Task der ersten. Die lief unerreichbar weiter, ließ sich von `stop()` nicht mehr abbrechen und schrieb bis zum Prozess-Ende alle 5 Sekunden `pwm_enable=1`.

**Der in #559 genannte Auslöser stimmt nicht.** Dort steht, zwei überlappende `switch_backend`-Aufrufe erzeugten die Waise. Der erste Test dazu lief gegen den unveränderten Code **grün**, und das Nachlesen erklärt warum:

```python
was_running = self._is_running
self._is_running = False        # kein await dazwischen
```

Der zweite Aufruf liest `was_running=False` und überspringt den Neustart im `finally`. `switch_backend` ist gegen sich selbst geschützt — versehentlich, aber wirksam.

Erreichbar ist die Waise über zwei andere Wege, beide gemessen:

| Weg | Warum |
|---|---|
| Zwei `start(monitoring=True)` | `start()` hatte **gar keinen** Schutz — die Zuweisung erfolgte unbedingt. Erreichbar über `POST /api/admin/services/fan_control/start`. |
| `stop()` fällt in einen laufenden `switch_backend` | Dessen `finally` startet die Schleife danach neu: der Dienst gilt als gestoppt und regelt weiter. |

Der zweite Fall ist der schlimmere, weil er direkt gegen #534 arbeitet — `stop()` gibt die Kanäle ans Board zurück, und die neu gestartete Schleife nimmt sie fünf Sekunden später wieder.

Ich hänge die Korrektur auch als Kommentar an #559, damit der Issue-Text nicht falsch stehen bleibt.

## Die Änderung

- Ein `asyncio.Lock` serialisiert `start` / `stop` / `switch_backend`. Alle drei tauschen `_monitoring_task` aus; keiner ruft einen der anderen auf, es gibt also keine Reentranz.
- Zwei Helfer ersetzen den dreifach ausgeschriebenen Task-Wechsel: `_cancel_monitoring_task()` bricht ab **und gibt die Referenz frei**, `_start_monitoring_task()` weist neu zu. Damit kann eine Zuweisung ohne vorherigen Abbruch nicht mehr passieren.
- `start()` bricht eine noch laufende Schleife jetzt ausdrücklich ab, bevor es eine neue erzeugt — sie gehört zum alten Backend und zu den alten Konfigurationen.

## Tests

Sechs neue Tests in zwei Dateien.

Drei der vier Lebenszyklus-Tests wurden **rot gesehen**; der vierte hält die gemessene Eigenschaft fest, dass zwei `switch_backend`-Aufrufe *keine* Waise erzeugen. Er läuft auch gegen den alten Code grün — das steht offen in seinem Docstring. Er bleibt als Beleg für die Korrektur oben und als Schutz davor, dass ein künftiger Umbau des `was_running`-Griffs die Eigenschaft still verliert.

Beide Registry-Tests waren rot (`assert None is False` bzw. `is True`): `start_fn()` wurde ohne Argumente aufgerufen. Gepatcht wird **vor** der Registrierung — die alte Fassung übergab die nackte Funktion, ein späterer Patch hätte diese Referenz nicht mehr erreicht.

| | |
|---|---|
| `pytest -k "fan or power"` | **740 bestanden**, 2 übersprungen |
| `pytest tests/services tests/api` | 1789 bestanden |
| Ruff über `app/` und `tests/` | sauber |

## Feldverifikation nach dem Deploy

Der Normalbetrieb ändert sich nicht sichtbar — beide Fehler brauchen eine Doppelbetätigung. Prüfbar ist die #555-Hälfte:

```
sudo journalctl -u baluhost-backend --since "-5min" | grep "Fan control service started"
```

Erwartet nach einem Neustart: **einmal** `monitoring=True` und **dreimal** `monitoring=False`. Steht dort mehr als ein `True`, regeln mehrere Worker gegeneinander.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lf8TucK1YQasPz6Xn9Frk
