### PR TITLE
fix(fans): Testschuld abtragen und simulierte Luefter aus der Prod-DB halten (#356, #554, #558)

### DIFF
--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -583,7 +583,21 @@ class FanControlService:
                 logger.debug("Sekundaer-Worker: Anlage-Schleife uebersprungen")
                 return
 
-            for fan in fans:
+            # Simulierte Luefter gehoeren nur in eine Dev-Datenbank. Ein
+            # Produktionsdienst, der ueber POST /api/fans/backend auf das
+            # Dev-Backend geschaltet wurde, sieht sonst Zeilen an, die
+            # niemand wieder los wird: der Identitaets-Abgleich fasst sie
+            # mangels stabiler Chip-Kennung nicht an, und ein
+            # Zurueckschalten entfernt sie nicht (#558).
+            creatable = fans if (self._use_linux_backend
+                                 or self.config.is_dev_mode) else []
+            if fans and not creatable:
+                logger.info(
+                    "Dev-Backend ausserhalb des Dev-Modus: keine Konfiguration "
+                    "fuer %d simulierte Luefter angelegt", len(fans),
+                )
+
+            for fan in creatable:
                 existing = db.execute(
                     select(FanConfig).where(FanConfig.fan_id == fan.fan_id)
                 ).scalar_one_or_none()

--- a/backend/tests/services/test_fan_control.py
+++ b/backend/tests/services/test_fan_control.py
@@ -7,12 +7,17 @@ Tests:
 - PWM calculation and temperature hysteresis
 """
 import asyncio
+import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from app.core import lifespan
+from app.core.config import get_settings
 from app.schemas.fans import FanCurvePoint, FanMode
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+from app.services.power.fan_curve_eval import evaluate_curve
 from app.services.power.fan_control import (
     DevFanControlBackend,
     FanData,
@@ -196,91 +201,61 @@ class TestFanCurvePoints:
 
 
 class TestFanControlCurveInterpolation:
-    """Tests for temperature-to-PWM curve interpolation."""
+    """Interpolation der graph-Kurve, gegen evaluate_curve().
 
-    def interpolate_pwm(self, curve: list, temp: float) -> int:
-        """Helper function to interpolate PWM from temperature curve."""
-        if not curve:
-            return 50  # Default
+    Diese Klasse definierte die Interpolation frueher selbst und pruefte die
+    eigene Kopie. Der Produktivcode liegt in fan_curve_eval.evaluate_curve;
+    er haette beliebig kaputt sein koennen, ohne dass ein Test es meldet
+    (#356).
+    """
 
-        # Below lowest point
-        if temp <= curve[0].temp:
-            return curve[0].pwm
+    @staticmethod
+    def _pwm_at(points, temp):
+        config = SimpleNamespace(
+            curve_type="graph",
+            curve_json=json.dumps(points),
+            min_pwm_percent=0,
+            max_pwm_percent=100,
+            stop_below_temp_celsius=None,
+            start_pwm_percent=None,
+            response_time_seconds=0.0,
+            pwm_steps=1,
+        )
+        return evaluate_curve(
+            config,
+            temp=temp,
+            prev_pwm=0,
+            other_fan_pwms={},
+            profile_loader=lambda _: [],
+            dt_seconds=1.0,
+        )
 
-        # Above highest point
-        if temp >= curve[-1].temp:
-            return curve[-1].pwm
+    CURVE = [
+        {"temp": 35, "pwm": 30},
+        {"temp": 50, "pwm": 50},
+        {"temp": 70, "pwm": 80},
+    ]
 
-        # Find surrounding points
-        for i in range(len(curve) - 1):
-            if curve[i].temp <= temp <= curve[i + 1].temp:
-                # Linear interpolation
-                t1, p1 = curve[i].temp, curve[i].pwm
-                t2, p2 = curve[i + 1].temp, curve[i + 1].pwm
-                ratio = (temp - t1) / (t2 - t1)
-                return int(p1 + (p2 - p1) * ratio)
+    def test_below_the_first_point_holds_its_pwm(self):
+        assert self._pwm_at(self.CURVE, 25) == 30
 
-        return curve[-1].pwm
+    def test_above_the_last_point_holds_its_pwm(self):
+        assert self._pwm_at(self.CURVE, 90) == 80
 
-    def test_interpolation_below_curve(self):
-        """Test interpolation below lowest curve point."""
-        curve = [
-            FanCurvePoint(temp=35, pwm=30),
-            FanCurvePoint(temp=50, pwm=50),
-            FanCurvePoint(temp=70, pwm=80),
-        ]
+    def test_an_exact_point_returns_that_point(self):
+        assert self._pwm_at(self.CURVE, 50) == 50
 
-        result = self.interpolate_pwm(curve, 25)
+    def test_midpoint_is_interpolated_linearly(self):
+        points = [{"temp": 40, "pwm": 40}, {"temp": 60, "pwm": 60}]
+        assert self._pwm_at(points, 50) == 50
 
-        assert result == 30  # Should use lowest value
+    def test_quarter_point_is_interpolated_linearly(self):
+        points = [{"temp": 40, "pwm": 40}, {"temp": 80, "pwm": 80}]
+        assert self._pwm_at(points, 50) == 50
 
-    def test_interpolation_above_curve(self):
-        """Test interpolation above highest curve point."""
-        curve = [
-            FanCurvePoint(temp=35, pwm=30),
-            FanCurvePoint(temp=50, pwm=50),
-            FanCurvePoint(temp=70, pwm=80),
-        ]
-
-        result = self.interpolate_pwm(curve, 90)
-
-        assert result == 80  # Should use highest value
-
-    def test_interpolation_exact_point(self):
-        """Test interpolation at exact curve point."""
-        curve = [
-            FanCurvePoint(temp=35, pwm=30),
-            FanCurvePoint(temp=50, pwm=50),
-        ]
-
-        result = self.interpolate_pwm(curve, 50)
-
-        assert result == 50
-
-    def test_interpolation_midpoint(self):
-        """Test interpolation between points."""
-        curve = [
-            FanCurvePoint(temp=40, pwm=40),
-            FanCurvePoint(temp=60, pwm=60),
-        ]
-
-        result = self.interpolate_pwm(curve, 50)
-
-        assert result == 50  # Midpoint should give midpoint PWM
-
-    def test_interpolation_quarter_point(self):
-        """Test interpolation at quarter points."""
-        curve = [
-            FanCurvePoint(temp=40, pwm=40),
-            FanCurvePoint(temp=80, pwm=80),
-        ]
-
-        result = self.interpolate_pwm(curve, 50)
-
-        # 50 is 1/4 of the way from 40 to 80
-        # PWM should be 1/4 of the way from 40 to 80 = 50
-        assert result == 50
-
+    def test_an_empty_curve_falls_back_without_raising(self):
+        """Der Randfall, den die Testkopie mit einer eigenen 50 beantwortete."""
+        assert 0 <= self._pwm_at([], 45) <= 100
 
 class TestFanModes:
     """Tests for fan mode functionality."""
@@ -299,64 +274,57 @@ class TestFanModes:
 
 
 class TestPWMConversion:
-    """Tests for PWM value conversion."""
+    """Prozent <-> PWM, gegen die Umrechnung des Linux-Backends.
 
-    def test_percent_to_pwm_zero(self):
-        """Test converting 0% to PWM."""
-        pwm = round(0 * 255 / 100)
-        assert pwm == 0
+    Vorher rechnete dieser Block die Formel im Test selbst nach und pruefte
+    damit nur Pythons Arithmetik. Eine Aenderung an _percent_to_pwm haette
+    keinen dieser Tests rot gemacht (#356).
+    """
 
-    def test_percent_to_pwm_hundred(self):
-        """Test converting 100% to PWM."""
-        pwm = round(100 * 255 / 100)
-        assert pwm == 255
+    @staticmethod
+    def _backend():
+        return LinuxFanControlBackend(get_settings())
 
-    def test_percent_to_pwm_fifty(self):
-        """Test converting 50% to PWM."""
-        pwm = round(50 * 255 / 100)
-        assert pwm == 128
+    @pytest.mark.parametrize("percent,expected", [(0, 0), (50, 128), (100, 255)])
+    def test_percent_to_pwm(self, percent, expected):
+        assert self._backend()._percent_to_pwm(percent) == expected
 
-    def test_pwm_to_percent_zero(self):
-        """Test converting 0 PWM to percent."""
-        percent = round(0 * 100 / 255)
-        assert percent == 0
+    @pytest.mark.parametrize("pwm,expected", [(0, 0), (128, 50), (255, 100)])
+    def test_pwm_to_percent(self, pwm, expected):
+        assert self._backend()._pwm_to_percent(pwm) == expected
 
-    def test_pwm_to_percent_max(self):
-        """Test converting 255 PWM to percent."""
-        percent = round(255 * 100 / 255)
-        assert percent == 100
-
-    def test_pwm_to_percent_mid(self):
-        """Test converting 128 PWM to percent."""
-        percent = round(128 * 100 / 255)
-        assert percent == 50
-
-    def test_round_trip_all_values(self):
-        """Verify percent→PWM→percent round-trip for all 0-100 values."""
-        for pct in range(101):
-            pwm = round(pct * 255 / 100)
-            back = round(pwm * 100 / 255)
-            assert back == pct, f"Round-trip failed: {pct}% → PWM {pwm} → {back}%"
-
+    def test_round_trip_over_the_full_range(self):
+        """Jeder Prozentwert ueberlebt Hin- und Rueckrechnung."""
+        backend = self._backend()
+        for percent in range(101):
+            pwm = backend._percent_to_pwm(percent)
+            back = backend._pwm_to_percent(pwm)
+            assert back == percent, f"{percent}% -> PWM {pwm} -> {back}%"
 
 class TestSimulatedStateUpdate:
     """Tests for simulated state updates."""
 
-    def test_temperature_fluctuation(self, mock_settings):
-        """Test that temperatures fluctuate over time."""
+    def test_simulation_keeps_its_invariants(self, mock_settings):
+        """Statt `assert True`: die Zusagen, die der Simulator einhalten muss.
+
+        Der Vorgaenger berechnete `changed`, benutzte es nicht und behauptete
+        dann `assert True` -- er konnte nicht fehlschlagen (#356). Geprueft
+        werden jetzt die drei Eigenschaften, die der Code tatsaechlich
+        garantiert: Paket kuehler als CPU, RPM innerhalb der Grenzen, und
+        dass sich ueberhaupt etwas bewegt.
+        """
         backend = DevFanControlBackend(mock_settings)
+        cpu_temps = set()
 
-        temps_before = backend._temps.copy()
-        backend._update_simulated_state()
-        temps_after = backend._temps.copy()
+        for _ in range(50):
+            backend._update_simulated_state()
+            cpu = backend._temps["dev_cpu_temp"]
+            cpu_temps.add(cpu)
+            assert backend._temps["dev_package_temp"] < cpu
+            for fan in backend._fans.values():
+                assert fan["min_rpm"] <= fan["current_rpm"] <= fan["max_rpm"]
 
-        # At least one temperature should have changed
-        changed = any(
-            temps_before[k] != temps_after[k]
-            for k in temps_before
-        )
-        # May or may not change due to randomness
-        assert True  # Just verify no exception
+        assert len(cpu_temps) > 1, "die Simulation bewegt sich nicht"
 
     @pytest.mark.asyncio
     async def test_rpm_updates_on_get_fans(self, mock_settings):

--- a/backend/tests/test_fan_dev_config_creation.py
+++ b/backend/tests/test_fan_dev_config_creation.py
@@ -1,0 +1,115 @@
+"""Simulierte Luefter gehoeren nicht in eine Produktionsdatenbank (#558).
+
+Auf BaluNode standen drei `dev_*`-Zeilen mit `is_active=true` in `fan_configs`.
+Sie entstehen ueber `POST /api/fans/backend`: der Wechsel auf das Dev-Backend
+ruft `_load_fan_configs()`, und die Anlage-Schleife legte fuer jeden
+gescannten -- also simulierten -- Luefter eine Zeile an.
+
+Weg gehen sie von selbst nicht mehr: der Identitaets-Abgleich aus #532 fasst
+sie nicht an, weil sie keine stabile Chip-Kennung tragen, und ein
+Zurueckschalten auf das Linux-Backend entfernt sie nicht.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import Base
+from app.models.fans import FanConfig
+from app.schemas.fans import FanCurvePoint, FanMode
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_control import FanControlService, FanData
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def _fan(fan_id: str, name: str) -> FanData:
+    return FanData(
+        fan_id=fan_id,
+        name=name,
+        rpm=900,
+        pwm_percent=40,
+        temperature_celsius=None,
+        mode=FanMode.AUTO,
+        min_pwm_percent=0,
+        max_pwm_percent=100,
+        emergency_temp_celsius=85.0,
+        temp_sensor_id=None,
+        curve_points=[FanCurvePoint(temp=35, pwm=30)],
+        is_active=True,
+    )
+
+
+def _service(session_factory, monkeypatch, *, linux: bool, dev_mode: bool,
+             fans: list[FanData]):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.fan_control_enabled = True
+    config.is_dev_mode = dev_mode
+    service = FanControlService(config, session_factory)
+    service._use_linux_backend = linux
+
+    backend = AsyncMock()
+    backend.get_fans.return_value = fans
+    backend.get_available_temp_sensors.return_value = []
+    backend._fan_cache = {
+        fan.fan_id: {"identity_stable": linux, "device_driver": "nct6798"}
+        for fan in fans
+    }
+    backend._temp_paths = {}
+    service._backend = backend
+
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        True, raising=False)
+    return service
+
+
+DEV_FANS = [
+    _fan("dev_cpu_fan", "CPU Fan (Simulated)"),
+    _fan("dev_case_fan_1", "Case Fan 1 (Simulated)"),
+]
+
+
+def _fan_ids(session_factory) -> set[str]:
+    with session_factory() as db:
+        return {row.fan_id for row in db.execute(select(FanConfig)).scalars()}
+
+
+@pytest.mark.asyncio
+async def test_dev_backend_in_production_creates_no_configs(session_factory, monkeypatch):
+    """Der Fall aus dem Issue: ein Klick auf "Dev-Backend" in der Produktions-UI."""
+    service = _service(session_factory, monkeypatch,
+                       linux=False, dev_mode=False, fans=DEV_FANS)
+
+    await service._load_fan_configs()
+
+    assert _fan_ids(session_factory) == set()
+
+
+@pytest.mark.asyncio
+async def test_dev_backend_in_dev_mode_still_creates_configs(session_factory, monkeypatch):
+    """Im Dev-Modus sind die simulierten Luefter der Zweck der Uebung."""
+    service = _service(session_factory, monkeypatch,
+                       linux=False, dev_mode=True, fans=DEV_FANS)
+
+    await service._load_fan_configs()
+
+    assert _fan_ids(session_factory) == {"dev_cpu_fan", "dev_case_fan_1"}
+
+
+@pytest.mark.asyncio
+async def test_the_linux_backend_creates_configs_as_before(session_factory, monkeypatch):
+    """Die Absicherung darf den eigentlichen Betriebsfall nicht treffen."""
+    fans = [_fan("nct6798-isa-0290:pwm1", "nct6798 PWM1")]
+    service = _service(session_factory, monkeypatch,
+                       linux=True, dev_mode=False, fans=fans)
+
+    await service._load_fan_configs()
+
+    assert _fan_ids(session_factory) == {"nct6798-isa-0290:pwm1"}

--- a/backend/tests/test_fan_permission_status.py
+++ b/backend/tests/test_fan_permission_status.py
@@ -1,0 +1,121 @@
+"""permission_status und sein Weg bis in die Antwort (#554).
+
+Dieser Pfad war vollstaendig ungetestet -- und genau er hat in #552 gelogen:
+die Fan-Control-Seite pollt ihn alle 5 Sekunden, `isReadOnly` sperrt daraufhin
+die Bedienelemente. Ein Fehler darin ist fuer den Nutzer nicht von einem
+kaputten Backend zu unterscheiden.
+
+Die Route wird ueber `__wrapped__` aufgerufen, also ohne den slowapi-Dekorator:
+geprueft wird die Ableitung, nicht das Rate-Limit.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.api.routes import fans as fans_routes
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+from app.services.power.fan_control import FanControlService
+
+
+def _service(*, backend, use_linux: bool) -> FanControlService:
+    FanControlService._instance = None
+    config = MagicMock()
+    config.is_dev_mode = False
+    svc = FanControlService(config, MagicMock())
+    svc._backend = backend
+    svc._use_linux_backend = use_linux
+    return svc
+
+
+def _linux_backend(*, may_write: bool) -> LinuxFanControlBackend:
+    backend = LinuxFanControlBackend(MagicMock())
+    backend._has_write_permission = may_write
+    backend.get_fans = AsyncMock(return_value=[])
+    return backend
+
+
+@pytest.mark.asyncio
+async def test_without_a_backend_the_status_is_unavailable():
+    svc = _service(backend=None, use_linux=False)
+
+    status = await svc.get_status()
+
+    assert status["permission_status"] == "unavailable"
+    assert status["backend_available"] is False
+
+
+@pytest.mark.asyncio
+async def test_the_dev_backend_is_always_ok():
+    """Im Dev-Backend gibt es keine sysfs-Rechte, an denen etwas scheitern koennte."""
+    dev = SimpleNamespace(get_fans=AsyncMock(return_value=[]))
+    svc = _service(backend=dev, use_linux=False)
+
+    status = await svc.get_status()
+
+    assert status["permission_status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_a_writable_linux_backend_is_ok():
+    svc = _service(backend=_linux_backend(may_write=True), use_linux=True)
+
+    status = await svc.get_status()
+
+    assert status["permission_status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_a_linux_backend_without_write_permission_is_readonly():
+    """Der Zustand, der in #552 faelschlich in allen vier Workern anlag."""
+    svc = _service(backend=_linux_backend(may_write=False), use_linux=True)
+
+    status = await svc.get_status()
+
+    assert status["permission_status"] == "readonly"
+
+
+async def _response_for(status: str):
+    service = SimpleNamespace(get_status=AsyncMock(return_value={
+        "fans": [],
+        "is_dev_mode": False,
+        "is_using_linux_backend": True,
+        "permission_status": status,
+        "backend_available": True,
+    }))
+    handler = fans_routes.get_permission_status.__wrapped__
+    return await handler(
+        request=SimpleNamespace(),
+        response=SimpleNamespace(),
+        current_user=MagicMock(),
+        service=service,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ok_answers_without_suggestions():
+    body = await _response_for("ok")
+
+    assert body.has_write_permission is True
+    assert body.status == "ok"
+    assert body.suggestions == []
+
+
+@pytest.mark.asyncio
+async def test_readonly_answers_with_the_sudoers_hint():
+    """Die Vorschlaege sind die einzige Hilfe, die der Nutzer an der Stelle bekommt."""
+    body = await _response_for("readonly")
+
+    assert body.has_write_permission is False
+    assert body.status == "readonly"
+    assert body.suggestions, "readonly ohne Handlungshinweis"
+    assert any("tee" in hint for hint in body.suggestions)
+
+
+@pytest.mark.asyncio
+async def test_unavailable_points_at_the_sensor_setup():
+    body = await _response_for("unavailable")
+
+    assert body.has_write_permission is False
+    assert body.status == "unavailable"
+    assert any("sensors-detect" in hint for hint in body.suggestions)

--- a/backend/tests/test_fan_write_hwmon_file.py
+++ b/backend/tests/test_fan_write_hwmon_file.py
@@ -1,0 +1,132 @@
+"""Die Fallback-Leiter von _write_hwmon_file (#554).
+
+Die Funktion wird in mehreren Testdateien gemockt, aber nirgends ausgefuehrt.
+Seit #552 fuehrt auch der Rechte-Probe seinen Write ueber sie -- ihre Leiter
+liegt damit im Startpfad jeder Prod-Instanz.
+
+Sie hat vier Ausgaenge, und der dritte ist der, der schon einmal zu einer
+falschen Fehlermeldung gefuehrt hat: nach einem gescheiterten sudo-tee meldet
+sie `EACCES`, obwohl der privilegierte Write am Kernel und nicht an den
+Rechten gescheitert sein kann. Der errno gehoert deshalb genannt, nicht
+gedeutet (Vorgabe aus #534).
+"""
+import errno
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+@pytest.fixture
+def backend():
+    return LinuxFanControlBackend(MagicMock())
+
+
+@pytest.fixture
+def node(tmp_path) -> Path:
+    """Ein hwmon-Knoten mit Inhalt -- angelegt, bevor write_text gepatcht wird."""
+    path = tmp_path / "pwm1_enable"
+    path.write_text("5\n")
+    return path
+
+
+def _write_raises(code: int):
+    def _write(self, *args, **kwargs):
+        raise OSError(code, os.strerror(code))
+    return _write
+
+
+class _Result:
+    def __init__(self, returncode: int):
+        self.returncode = returncode
+        self.stdout = b""
+        self.stderr = b"tee: failed\n"
+
+
+@pytest.mark.asyncio
+async def test_a_direct_write_succeeds_and_sets_the_flag(backend, node):
+    ok, code = await backend._write_hwmon_file(node, "1")
+
+    assert (ok, code) == (True, None)
+    assert node.read_text().strip() == "1"
+    assert backend._has_write_permission is True
+
+
+@pytest.mark.asyncio
+async def test_a_missing_node_reports_no_errno(backend, tmp_path):
+    """Kein Knoten ist kein Rechteproblem -- der Aufrufer darf das unterscheiden."""
+    ok, code = await backend._write_hwmon_file(tmp_path / "nicht_da", "1")
+
+    assert (ok, code) == (False, None)
+    assert backend._has_write_permission is False
+
+
+@pytest.mark.asyncio
+async def test_eacces_falls_back_to_sudo_tee(backend, node, monkeypatch):
+    monkeypatch.setattr(Path, "write_text", _write_raises(errno.EACCES))
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _Result(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ok, code = await backend._write_hwmon_file(node, "1")
+
+    assert (ok, code) == (True, None)
+    assert backend._has_write_permission is True
+    assert calls[0][:3] == ["sudo", "-n", "tee"], calls
+
+
+@pytest.mark.asyncio
+async def test_a_failed_sudo_tee_reports_the_direct_errno(backend, node, monkeypatch):
+    """Der Fallstrick: gemeldet wird EACCES vom direkten Versuch.
+
+    Der privilegierte Write kann am Kernel gescheitert sein (EINVAL, EBUSY) --
+    das sieht diese Funktion nicht. Wer die Meldung formuliert, muss den errno
+    nennen statt ihn als "keine Rechte" zu deuten.
+    """
+    monkeypatch.setattr(Path, "write_text", _write_raises(errno.EACCES))
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: _Result(1))
+
+    ok, code = await backend._write_hwmon_file(node, "1")
+
+    assert ok is False
+    assert code == errno.EACCES
+    assert backend._has_write_permission is False
+
+
+@pytest.mark.asyncio
+async def test_another_errno_skips_sudo_entirely(backend, node, monkeypatch):
+    """EBUSY ist kein Rechteproblem -- sudo wuerde daran nichts aendern.
+
+    Der nct6775 liefert genau das fuer pwm-Writes im Auto-Modus.
+    """
+    monkeypatch.setattr(Path, "write_text", _write_raises(errno.EBUSY))
+    called = []
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **kw: called.append(cmd))
+
+    ok, code = await backend._write_hwmon_file(node, "1")
+
+    assert (ok, code) == (False, errno.EBUSY)
+    assert called == [], "sudo wurde trotz EBUSY versucht"
+
+
+@pytest.mark.asyncio
+async def test_a_hanging_sudo_does_not_escape_into_the_loop(backend, node, monkeypatch):
+    """Ein Timeout darf die Regelschleife nicht mitreissen."""
+    monkeypatch.setattr(Path, "write_text", _write_raises(errno.EACCES))
+
+    def timing_out(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, 5)
+
+    monkeypatch.setattr(subprocess, "run", timing_out)
+
+    ok, code = await backend._write_hwmon_file(node, "1")
+
+    assert (ok, code) == (False, errno.EACCES)


### PR DESCRIPTION
Closes #356. Closes #554. Closes #558.

Drei kleine, unabhängige Punkte im selben Bereich, gebündelt statt in drei PRs.

## #356 — Tests, die eigenen Testcode prüfen

Drei Blöcke in `tests/services/test_fan_control.py` konnten nicht fehlschlagen:

**`TestFanControlCurveInterpolation`** definierte `interpolate_pwm` selbst und testete die Kopie. Der Produktivcode liegt in `fan_curve_eval.evaluate_curve` und hätte beliebig kaputt sein können. Jetzt gegen die echte Funktion, plus ein Fall für die leere Kurve — den beantwortete die Testkopie mit einer eigenen `50`.

**`TestPWMConversion`** rechnete die Formel im Test nach:

```python
def test_percent_to_pwm_fifty(self):
    pwm = round(50 * 255 / 100)
    assert pwm == 128            # prüft Pythons Arithmetik, nicht BaluHost
```

Jetzt gegen `_percent_to_pwm` / `_pwm_to_percent` des Linux-Backends.

**`test_temperature_fluctuation`** berechnete `changed`, benutzte es nicht und behauptete dann `assert True  # Just verify no exception`. Ersetzt durch die drei Zusagen, die der Simulator wirklich einhält: Paket kühler als CPU, RPM innerhalb `[min_rpm, max_rpm]`, und dass sich über 50 Durchläufe überhaupt etwas bewegt — das war die ursprüngliche Absicht des Tests, bevor sie aufgegeben wurde.

**Gegenprobe ausgeführt.** Mit einem um 1 verschobenen `_percent_to_pwm` und einem konstanten `_interpolate` fallen **10 Tests** rot. Dieselbe Änderung hätte in dieser Datei vorher nichts gemeldet.

## #554 — zwei ungetestete Pfade

**`permission_status`** und sein Weg bis in die `PermissionStatusResponse`: sieben Tests über alle drei Zustände (`ok` / `readonly` / `unavailable`), Ableitung und Route. Genau dieser Pfad hat in #552 gelogen und dabei die Bedienelemente gesperrt, ohne dass ein Test anschlug. Gegenprobe: setzt man die Ableitung auf ein festes `"ok"`, fällt der `readonly`-Test.

**`_write_hwmon_file`** wurde in vier Testdateien nur gemockt, nie ausgeführt. Seit #552 führt auch der Rechte-Probe seinen Write über sie — ihre Fallback-Leiter liegt damit im Startpfad jeder Prod-Instanz. Sechs Tests über alle Ausgänge, darunter der Fallstrick aus #534:

> Nach einem gescheiterten `sudo tee` meldet die Funktion `EACCES` vom **direkten** Versuch — obwohl der privilegierte Write am Kernel gescheitert sein kann (`EINVAL`, `EBUSY`). Wer die Meldung formuliert, muss den errno nennen statt ihn als „keine Rechte" zu deuten.

Ebenfalls festgehalten: `EBUSY` überspringt den sudo-Versuch ganz. Das ist der Fall, den der nct6775 für `pwm`-Writes im Auto-Modus liefert und der in #563 den Entwurf bestimmt hat.

## #558 — simulierte Lüfter in der Produktionsdatenbank

Die Anlage-Schleife legte für **jeden** gescannten Lüfter eine Zeile an, auch wenn das Dev-Backend gescannt hat. Ein Klick auf „Dev-Backend" in der Produktions-UI (`POST /api/fans/backend`) schrieb damit dauerhaft `dev_*`-Zeilen in `fan_configs` — und weg gehen sie von selbst nicht mehr: der Identitäts-Abgleich aus #532 fasst sie mangels stabiler Chip-Kennung nicht an, ein Zurückschalten auf das Linux-Backend entfernt sie nicht.

Angelegt wird jetzt nur noch, wenn das Linux-Backend aktiv ist **oder** der Dienst im Dev-Modus läuft. Ein Produktionsdienst, dessen Linux-Backend beim Start nicht verfügbar war und der deshalb auf das Dev-Backend zurückgefallen ist, schreibt damit ebenfalls nichts mehr — auch das ist gewollt.

### Einmalig auf BaluNode nachzuholen

Die drei bestehenden Zeilen räumt der Fix nicht auf. Nach dem Deploy:

```
sudo -u postgres psql -d baluhost -c "DELETE FROM fan_configs WHERE fan_id LIKE 'dev\_%';"
```

Erwartet: `DELETE 3`. Danach zur Kontrolle:

```
sudo -u postgres psql -d baluhost -c "SELECT fan_id, is_active FROM fan_configs ORDER BY fan_id;"
```

Es sollten nur noch die fünf echten Kanäle übrig sein (vier `nct6798`, einer `amdgpu`) plus die inaktiven Altkennungen aus #532. `DELETE` statt `is_active=false`, weil die Zeilen nichts bezeichnen, was es gibt — eine deaktivierte Zeile wäre wieder nur Datenmüll mit anderem Flag.

## Tests

| | |
|---|---|
| `pytest -k "fan or power"` | **757 bestanden**, 2 übersprungen (vorher 740) |
| `pytest tests/services tests/api` | 1790 bestanden |
| Ruff über `app/` und `tests/` | sauber |

Volle Backend-Suite der CI überlassen (hängt auf Windows).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lf8TucK1YQasPz6Xn9Frk
