### PR TITLE
fix(fans): Schreibrecht zwischen den Workern teilen statt vierfach zu raten (#552)

### DIFF
--- a/backend/alembic/versions/c9a4e77b2d10_fan_runtime_state.py
+++ b/backend/alembic/versions/c9a4e77b2d10_fan_runtime_state.py
@@ -1,0 +1,37 @@
+"""fan runtime state
+
+Revision ID: c9a4e77b2d10
+Revises: b3f7d21c8a04
+Create Date: 2026-09-06 20:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c9a4e77b2d10'
+down_revision: Union[str, Sequence[str], None] = 'b3f7d21c8a04'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'fan_runtime_state',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('has_write_permission', sa.Boolean(), nullable=False,
+                  server_default=sa.false()),
+        sa.Column('updated_at', sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_by_pid', sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('fan_runtime_state')

--- a/backend/app/models/fans.py
+++ b/backend/app/models/fans.py
@@ -186,3 +186,39 @@ class CompositeTempSensor(Base):
 
     def __repr__(self) -> str:
         return f"<CompositeTempSensor(id={self.id}, function={self.function})>"
+
+
+class FanRuntimeState(Base):
+    """
+    Live runtime state of fan control, shared across Uvicorn workers.
+
+    Singleton row (id=1). The primary worker writes; secondary workers read,
+    so ``GET /api/fans/permissions`` answers the same regardless of which
+    worker handles the request.
+
+    Ohne diese Zeile war ``_has_write_permission`` ein reines Instanz-Attribut:
+    vier Worker, vier Wahrheiten. Geheilt hat sich nur, wer schreibt -- also
+    der Primary ueber den Regelkreis. Die drei Follower blieben auf ihrem
+    Startwert stehen, und der 5-Sekunden-Poll des Frontends landete
+    abwechselnd auf einem geheilten und drei ungeheilten Workern (#552).
+
+    Gleiches Muster wie ``PowerRuntimeState`` und ``GpuPowerRuntimeState``;
+    letztere fuehrt dieselbe Spalte fuer denselben Zweck.
+    """
+
+    __tablename__ = "fan_runtime_state"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    has_write_permission: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+    updated_by_pid: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<FanRuntimeState(has_write_permission={self.has_write_permission})>"

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -23,6 +23,10 @@ from app.core.config import Settings
 from app.models.fans import FanConfig, FanSample
 from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
 from app.services.power.fan_restore import is_observation, needs_release, resolve_restore_value
+from app.services.power.fan_runtime_store import (
+    publish_write_permission,
+    read_write_permission,
+)
 from app.services.power.fan_schedule import FanScheduleService
 from app.services.power.fan_profiles import FanProfileService
 from app.services.power.fan_reconcile import ChipFacts, reconcile_fan_identities
@@ -176,6 +180,9 @@ class FanControlService:
         # _monitoring_task aus, und eine ueberschriebene Referenz waere eine
         # Regelschleife, die niemand mehr abbrechen kann (#559).
         self._lifecycle_lock = asyncio.Lock()
+        # Zuletzt veroeffentlichter Rechtezustand. None heisst: noch nie
+        # geschrieben -- dann wird beim ersten Abgleich veroeffentlicht (#552).
+        self._published_write_permission: Optional[bool] = None
 
         FanControlService._instance = self
 
@@ -228,10 +235,36 @@ class FanControlService:
             # Zuweisung unten verloren (#559).
             await self._cancel_monitoring_task()
 
+            # Der Rechte-Probe ist beim Backend-Init gelaufen -- sein
+            # Ergebnis gehoert zu den Followern, bevor der erste Regelzyklus
+            # ueberhaupt stattfindet (#552).
+            self.publish_write_permission_if_changed()
+
             if monitoring:
                 # Start monitoring loop (primary worker only)
                 self._start_monitoring_task()
             logger.info("Fan control service started (monitoring=%s)", monitoring)
+
+    def publish_write_permission_if_changed(self) -> None:
+        """Veroeffentlicht den Rechtezustand des Primary, wenn er sich aendert.
+
+        Nur der Primary schreibt: er ist der einzige Worker, der die Hardware
+        im Regelbetrieb ueberhaupt anfasst und dessen Stand sich damit heilen
+        kann. Ein Follower wuerde seinen ungeheilten Startwert ueber den
+        gemessenen des Primary schreiben.
+
+        Der Aufruf sitzt im 5-Sekunden-Takt der Regelschleife -- geschrieben
+        wird deshalb nur bei echter Aenderung. Ein Schreibvorgang je Tick
+        waere dieselbe Sorte Last, die #533 beseitigt hat.
+        """
+        if not getattr(lifespan, "IS_PRIMARY_WORKER", False):
+            return
+        current = getattr(self._backend, "_has_write_permission", None)
+        if current is None or current == self._published_write_permission:
+            return
+        with self.db_session_factory() as db:
+            if publish_write_permission(db, current):
+                self._published_write_permission = current
 
     async def _cancel_monitoring_task(self) -> None:
         """Bricht eine laufende Regelschleife ab und gibt die Referenz frei.
@@ -803,6 +836,10 @@ class FanControlService:
         while self._is_running:
             try:
                 await self._monitor_and_control_fans()
+                # Nach dem Regelzyklus: ein erfolgreicher Write kann den
+                # Rechtezustand geheilt haben, den die Follower nur ueber
+                # die veroeffentlichte Zeile erfahren (#552).
+                self.publish_write_permission_if_changed()
 
                 sample_count += 1
 
@@ -1125,7 +1162,15 @@ class FanControlService:
         permission_status = "ok"
         if self._use_linux_backend:
             if isinstance(self._backend, LinuxFanControlBackend):
-                permission_status = "ok" if self._backend._has_write_permission else "readonly"
+                # Der veroeffentlichte Stand des Primary schlaegt die eigene
+                # Messung: ein Follower schreibt im Regelbetrieb nie und
+                # bleibt deshalb auf seinem Startwert stehen. Fehlt die
+                # Zeile (frisch migriert), entscheidet die eigene Messung.
+                with self.db_session_factory() as db:
+                    shared = read_write_permission(db)
+                may_write = (self._backend._has_write_permission
+                             if shared is None else shared)
+                permission_status = "ok" if may_write else "readonly"
 
         return {
             "fans": fan_data_list,

--- a/backend/app/services/power/fan_runtime_store.py
+++ b/backend/app/services/power/fan_runtime_store.py
@@ -1,0 +1,74 @@
+"""Wortlaut des Schreibrechts ueber Worker-Grenzen hinweg (#552).
+
+`LinuxFanControlBackend._has_write_permission` ist ein Instanz-Attribut. Bei
+vier Uvicorn-Workern gibt es damit vier Wahrheiten ueber denselben Zustand
+derselben Hardware -- obwohl alle vier als derselbe Nutzer mit denselben
+sudoers-Regeln laufen und die Antwort per Konstruktion identisch sein muesste.
+
+Geheilt hat sich nur, wer schreibt: der Primary ueber den Regelkreis. Die drei
+Follower blieben auf ihrem Startwert stehen.
+
+Der Primary veroeffentlicht seinen Stand deshalb in einer Singleton-Zeile,
+alle Worker lesen ihn von dort. Dasselbe Muster tragen `PowerRuntimeState`
+und `GpuPowerRuntimeState` -- letztere fuehrt sogar dieselbe Spalte fuer
+denselben Zweck.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+from sqlalchemy import select
+
+from app.models.fans import FanRuntimeState
+
+logger = logging.getLogger(__name__)
+
+_SINGLETON_ID = 1
+
+
+def read_write_permission(db) -> Optional[bool]:
+    """Der veroeffentlichte Stand.
+
+    Returns:
+        None, wenn noch nichts veroeffentlicht wurde. Das ist ausdruecklich
+        NICHT dasselbe wie "kein Schreibrecht": eine frisch migrierte
+        Datenbank meldete sonst readonly, obwohl niemand etwas gemessen hat.
+        Der Aufrufer faellt dann auf seine eigene Messung zurueck.
+    """
+    try:
+        row = db.execute(
+            select(FanRuntimeState).where(FanRuntimeState.id == _SINGLETON_ID)
+        ).scalar_one_or_none()
+    except Exception as exc:
+        # Der Rechtezustand ist eine Anzeige, kein Regelungseingang -- eine
+        # klemmende Datenbank darf get_status() nicht mitreissen.
+        logger.debug("fan_runtime_state nicht lesbar: %s", exc)
+        return None
+    return None if row is None else bool(row.has_write_permission)
+
+
+def publish_write_permission(db, may_write: bool) -> bool:
+    """Den eigenen Stand hinterlegen. Legt die Zeile an, falls noetig.
+
+    Returns:
+        False bei einem Datenbankfehler -- der Aufrufer soll dann seinen
+        gemerkten Stand NICHT als veroeffentlicht verbuchen, sonst versucht
+        er es nie wieder.
+    """
+    try:
+        row = db.execute(
+            select(FanRuntimeState).where(FanRuntimeState.id == _SINGLETON_ID)
+        ).scalar_one_or_none()
+        if row is None:
+            row = FanRuntimeState(id=_SINGLETON_ID)
+            db.add(row)
+        row.has_write_permission = bool(may_write)
+        row.updated_by_pid = os.getpid()
+        db.commit()
+        return True
+    except Exception as exc:
+        db.rollback()
+        logger.warning("fan_runtime_state nicht schreibbar: %s", exc)
+        return False

--- a/backend/tests/test_fan_permission_status.py
+++ b/backend/tests/test_fan_permission_status.py
@@ -12,17 +12,30 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 from app.api.routes import fans as fans_routes
+from app.models.base import Base
 from app.services.power.fan_backend_linux import LinuxFanControlBackend
 from app.services.power.fan_control import FanControlService
+
+
+def _empty_session_factory():
+    """Echte, leere Session: get_status liest den veroeffentlichten
+    Rechtezustand (#552). Ohne Zeile faellt es auf die eigene Messung
+    zurueck -- genau der Pfad, den diese Tests pruefen.
+    """
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
 
 
 def _service(*, backend, use_linux: bool) -> FanControlService:
     FanControlService._instance = None
     config = MagicMock()
     config.is_dev_mode = False
-    svc = FanControlService(config, MagicMock())
+    svc = FanControlService(config, _empty_session_factory())
     svc._backend = backend
     svc._use_linux_backend = use_linux
     return svc

--- a/backend/tests/test_fan_write_permission_sharing.py
+++ b/backend/tests/test_fan_write_permission_sharing.py
@@ -1,0 +1,224 @@
+"""Das Schreibrecht ist eine Eigenschaft der Maschine, nicht des Prozesses (#552).
+
+`_has_write_permission` war ein reines Instanz-Attribut. Bei vier Uvicorn-
+Workern gab es vier Wahrheiten ueber denselben Zustand derselben Hardware, und
+geheilt hat sich nur, wer schreibt -- also der Primary ueber den Regelkreis.
+Die drei Follower blieben auf ihrem Startwert stehen; der 5-Sekunden-Poll des
+Frontends landete abwechselnd auf einem geheilten und drei ungeheilten Workern.
+
+Der Primary veroeffentlicht seinen Stand jetzt in `fan_runtime_state`, alle
+Worker lesen ihn von dort. Gleiches Muster wie `PowerRuntimeState` und
+`GpuPowerRuntimeState` -- letztere fuehrt dieselbe Spalte fuer denselben Zweck.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import Base
+from app.models.fans import FanRuntimeState
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+from app.services.power.fan_control import FanControlService
+from app.services.power.fan_runtime_store import (
+    publish_write_permission,
+    read_write_permission,
+)
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def _service(session_factory, monkeypatch, *, may_write: bool, primary: bool):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.is_dev_mode = False
+    service = FanControlService(config, session_factory)
+    service._use_linux_backend = True
+
+    backend = LinuxFanControlBackend(MagicMock())
+    backend._has_write_permission = may_write
+    backend.get_fans = AsyncMock(return_value=[])
+    service._backend = backend
+
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        primary, raising=False)
+    return service
+
+
+# --- Der Speicher selbst ------------------------------------------------
+
+
+def test_reading_without_a_row_returns_none(session_factory):
+    """Kein Eintrag heisst "nicht veroeffentlicht" -- nicht "kein Schreibrecht".
+
+    Der Aufrufer muss beides unterscheiden koennen, sonst meldete eine frisch
+    migrierte Datenbank faelschlich readonly.
+    """
+    with session_factory() as db:
+        assert read_write_permission(db) is None
+
+
+def test_publishing_and_reading_round_trip(session_factory):
+    with session_factory() as db:
+        publish_write_permission(db, True)
+    with session_factory() as db:
+        assert read_write_permission(db) is True
+
+
+def test_publishing_twice_keeps_a_single_row(session_factory):
+    """Singleton-Zeile wie bei PowerRuntimeState -- kein Verlauf."""
+    with session_factory() as db:
+        publish_write_permission(db, True)
+    with session_factory() as db:
+        publish_write_permission(db, False)
+
+    with session_factory() as db:
+        rows = list(db.execute(select(FanRuntimeState)).scalars())
+    assert len(rows) == 1
+    assert rows[0].has_write_permission is False
+
+
+# --- Die Ableitung in get_status ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_follower_follows_the_published_value(session_factory, monkeypatch):
+    """Der Kern: der Follower haelt sich fuer schreibfaehig und ist es nicht.
+
+    Genau diese Divergenz erzeugte das Flackern -- der eine Worker meldete
+    "ok", die anderen "readonly", und der Poll traf mal den einen, mal die
+    anderen.
+    """
+    with session_factory() as db:
+        publish_write_permission(db, False)
+
+    service = _service(session_factory, monkeypatch, may_write=True, primary=False)
+
+    status = await service.get_status()
+
+    assert status["permission_status"] == "readonly"
+
+
+@pytest.mark.asyncio
+async def test_a_follower_learns_that_writing_works(session_factory, monkeypatch):
+    """Die Gegenrichtung: der Primary hat sich geheilt, der Follower zieht nach."""
+    with session_factory() as db:
+        publish_write_permission(db, True)
+
+    service = _service(session_factory, monkeypatch, may_write=False, primary=False)
+
+    status = await service.get_status()
+
+    assert status["permission_status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_without_a_published_value_the_local_probe_decides(
+        session_factory, monkeypatch):
+    """Frisch migrierte Datenbank, noch nichts veroeffentlicht."""
+    service = _service(session_factory, monkeypatch, may_write=False, primary=True)
+
+    status = await service.get_status()
+
+    assert status["permission_status"] == "readonly"
+
+
+# --- Der Primary veroeffentlicht ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_primary_publishes_its_own_state(session_factory, monkeypatch):
+    service = _service(session_factory, monkeypatch, may_write=True, primary=True)
+
+    service.publish_write_permission_if_changed()
+
+    with session_factory() as db:
+        assert read_write_permission(db) is True
+
+
+@pytest.mark.asyncio
+async def test_a_follower_never_publishes(session_factory, monkeypatch):
+    """Sonst ueberschriebe der ungeheilte Follower den Stand des Primary."""
+    service = _service(session_factory, monkeypatch, may_write=True, primary=False)
+
+    service.publish_write_permission_if_changed()
+
+    with session_factory() as db:
+        assert read_write_permission(db) is None
+
+
+@pytest.mark.asyncio
+async def test_the_primary_writes_only_on_change(session_factory, monkeypatch):
+    """Der Aufruf sitzt im 5-Sekunden-Takt -- ein Schreibvorgang je Tick waere
+    dieselbe Sorte Last, die #533 beseitigt hat."""
+    service = _service(session_factory, monkeypatch, may_write=True, primary=True)
+    service.publish_write_permission_if_changed()
+
+    with session_factory() as db:
+        first = db.execute(select(FanRuntimeState)).scalar_one().updated_at
+
+    for _ in range(5):
+        service.publish_write_permission_if_changed()
+
+    with session_factory() as db:
+        assert db.execute(select(FanRuntimeState)).scalar_one().updated_at == first
+
+
+# --- Verdrahtung -------------------------------------------------------
+#
+# Ohne diese beiden Tests koennte man beide Aufrufstellen entfernen und die
+# Suite bliebe gruen -- bei totem Feature. Die Falle aus dem Review zu #534.
+
+
+@pytest.mark.asyncio
+async def test_start_publishes_the_probe_result(session_factory, monkeypatch):
+    """Der Rechte-Probe laeuft beim Backend-Init, nicht im Regelzyklus.
+
+    Ohne die Veroeffentlichung in start() erfuehren die Follower sein
+    Ergebnis erst, wenn sich der Zustand spaeter zufaellig aendert.
+    """
+    service = _service(session_factory, monkeypatch, may_write=True, primary=True)
+    service.config.fan_control_enabled = True
+    monkeypatch.setattr(service, "_initialize_backend", AsyncMock())
+    monkeypatch.setattr(service, "_rebuild_registry", AsyncMock())
+    monkeypatch.setattr(service, "_load_fan_configs", AsyncMock())
+
+    await service.start(monitoring=False)
+
+    with session_factory() as db:
+        assert read_write_permission(db) is True
+
+
+@pytest.mark.asyncio
+async def test_the_monitoring_loop_publishes_a_later_change(
+        session_factory, monkeypatch):
+    """Der Fall aus dem Issue: der Probe scheitert, ein Write heilt spaeter.
+
+    Geheilt wird in _write_hwmon_file, tief im Regelzyklus. Ohne den Abgleich
+    in der Schleife bliebe das im Primary-Prozess stecken.
+    """
+    service = _service(session_factory, monkeypatch, may_write=False, primary=True)
+    service.config.fan_sample_interval_seconds = 0
+    service.publish_write_permission_if_changed()
+
+    with session_factory() as db:
+        assert read_write_permission(db) is False
+
+    async def one_cycle():
+        # bildet den erfolgreichen Write in _write_hwmon_file nach
+        service._backend._has_write_permission = True
+        service._is_running = False
+
+    monkeypatch.setattr(service, "_monitor_and_control_fans", one_cycle)
+    service._is_running = True
+
+    await service._monitoring_loop()
+
+    with session_factory() as db:
+        assert read_write_permission(db) is True


### PR DESCRIPTION
Closes #552.

## Das Problem

`_has_write_permission` war ein reines Instanz-Attribut. Bei vier Uvicorn-Workern gab es damit **vier Wahrheiten über denselben Zustand derselben Hardware** — obwohl alle vier als derselbe Nutzer mit denselben sudoers-Regeln laufen und die Antwort per Konstruktion identisch sein müsste.

Gesetzt wurde das Flag im Rechte-Probe und als Seiteneffekt eines erfolgreichen Writes. Geheilt hat sich deshalb nur, wer schreibt: der Primary über den Regelkreis. Die drei Follower blieben auf ihrem Startwert stehen, und der 5-Sekunden-Poll des Frontends landete abwechselnd auf einem geheilten und drei ungeheilten Workern.

## Der Entwurf ist nicht neu

Ich hatte im Issue den periodischen Re-Probe als den billigeren Weg empfohlen. Beim Nachrechnen trägt der nicht: der Probe geht auf dieser Box über `sudo tee`, weil der direkte Write an `root:root 0644` scheitert. Vier Worker mit einem 30-Sekunden-Intervall wären ~11.500 sudo-Aufrufe am Tag — dieselbe Größenordnung, die #533 gerade beseitigt hat. Und er hilft den Followern ohnehin nur, wenn sie eine periodische Aufgabe hätten; sie haben keine (`monitoring=False`).

Der Codebase hat die Frage bereits zweimal beantwortet:

```python
class GpuPowerRuntimeState(Base):
    """Singleton row (id=1). The primary worker writes; secondary workers read…"""
    has_write_permission: Mapped[bool] = mapped_column(Boolean, ...)
```

`PowerRuntimeState` und `GpuPowerRuntimeState` lösen exakt dieses Problem, letztere sogar mit **derselben Spalte für denselben Zweck**. `fan_runtime_state` ist die dritte Anwendung eines etablierten Musters, kein eigener Einfall.

Kosten: ein zusätzlicher DB-Read je `get_status()`. Die Funktion öffnet ohnehin eine Session, um die Konfiguration je Lüfter zu laden — praktisch gratis, und keine zusätzlichen sysfs-Writes.

## Vier Entscheidungen, die im Code stehen

- **Nur der Primary schreibt.** Ein Follower würde seinen ungeheilten Startwert über den gemessenen Stand des Primary schreiben.
- **Geschrieben wird nur bei echter Änderung.** Der Abgleich sitzt im 5-Sekunden-Takt der Regelschleife.
- **Fehlt die Zeile, entscheidet die eigene Messung.** „Nicht veröffentlicht" ist nicht dasselbe wie „kein Schreibrecht" — eine frisch migrierte Datenbank meldete sonst fälschlich `readonly`.
- **Veröffentlicht wird auch in `start()`**, nicht nur in der Schleife. Der Rechte-Probe läuft beim Backend-Init; sein Ergebnis gehört zu den Followern, bevor der erste Regelzyklus stattfindet.

## Tests

Elf neue Tests. Zwei davon prüfen die **Verdrahtung** — ohne sie hätte man beide Aufrufstellen entfernen können und die Suite wäre grün geblieben. Gegenprobe ausgeführt:

```
# mit entfernten Aufrufstellen
FAILED test_start_publishes_the_probe_result
FAILED test_the_monitoring_loop_publishes_a_later_change
```

**Eine bestehende Testdatei musste nachziehen.** `test_fan_permission_status.py` (aus #566, heute) gab `get_status()` einen `MagicMock` als Session-Factory. Seit der Ableitung die Datenbank liest, lieferte der Mock ein wahrheitsähnliches Objekt statt `None` und der `readonly`-Test kippte. Sie bekommt jetzt eine echte, leere Session — womit sie zusätzlich den Rückfallpfad prüft.

| | |
|---|---|
| `pytest -k "fan or power"` | **768 bestanden**, 2 übersprungen (vorher 757) |
| `pytest tests/services tests/api` | 1790 bestanden |
| Migration `c9a4e77b2d10` | `upgrade` → `downgrade -1` → `upgrade` durch, einziger Head |
| Ruff über `app/` und `tests/` | sauber |

## Was offen bleibt

**Das Flag geht nie auf `False` zurück.** Gesetzt wird es nur von einem *erfolgreichen* Write. Gehen die Rechte zur Laufzeit verloren, meldet die UI weiter „ok" — jetzt auf allen vier Workern gleichzeitig statt nur auf dem Primary. Der Fix macht die Anzeige konsistent, nicht selbstheilend in dieser Richtung.

Das ließe sich an das Backoff aus #533 hängen: ein Kanal, der wegen `EACCES` dauerhaft in die Sperre läuft, ist der Beleg für einen Rechteverlust. Bewusst nicht in diesem PR — es ist eine eigene Entscheidung mit eigenem Schwellenwert.

Ebenfalls offen, aus dem Issue: `permission_status` pro Lüfter statt global. Auf BaluNode ist genau ein Kanal nicht schreibbar (der firmware-verwaltete GPU-Lüfter) und einer schon; ein globales Flag kann dem Nutzer nicht sagen, *welcher* Regler wirkungslos ist. Ich hänge beides als Nachtrag an ein Folge-Issue, wenn du eins willst.

## Feldverifikation nach dem Deploy

```
sudo -u postgres psql -d baluhost -c "SELECT * FROM fan_runtime_state;"
```

Erwartet: **eine** Zeile, `has_write_permission = t`, `updated_by_pid` = die PID des Primary (dieselbe, die im Log `monitoring=True` meldet).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lf8TucK1YQasPz6Xn9Frk
