### PR TITLE
fix(fans): keine wirkungslosen Modus-Regler auf firmware-verwalteten Luefterkarten (#534)

### DIFF
--- a/client/src/__tests__/components/fan-control/FanCard.test.tsx
+++ b/client/src/__tests__/components/fan-control/FanCard.test.tsx
@@ -64,12 +64,34 @@ describe('FanCard bei firmware-verwalteter GPU', () => {
     expect(slider.disabled).toBe(true);
   });
 
-  it('laesst die Modus-Buttons bedienbar — sonst sperrt sich der Nutzer aus', () => {
+  it('laesst Auto erreichbar — sonst sperrt sich der Nutzer im Modus ein', () => {
+    // Haelt die Absicht des Vorgaengertests fest: es muss einen Weg zurueck
+    // geben. Auto ist der neutrale Modus -- BaluHost haelt den Luefter dann
+    // nicht von Hand, was fuer einen firmware-verwalteten Kanal ohnehin gilt.
+    renderCard(fan({ pwm_control: 'firmware_managed', mode: FanMode.MANUAL }));
+    const auto = screen.getByRole('button', { name: /card\.auto/ }) as HTMLButtonElement;
+    expect(auto.disabled).toBe(false);
+  });
+
+  it('sperrt Manual und Schedule — beide versprechen eine Steuerung, die nicht stattfindet', () => {
+    renderCard(fan({ pwm_control: 'firmware_managed', mode: FanMode.AUTO }));
+    const manual = screen.getByRole('button', { name: /card\.manual/ }) as HTMLButtonElement;
+    const scheduled = screen.getByRole('button', { name: /card\.scheduled/ }) as HTMLButtonElement;
+    expect(manual.disabled).toBe(true);
+    expect(scheduled.disabled).toBe(true);
+  });
+
+  it('nennt den Grund, statt nur zu sperren', () => {
     renderCard(fan({ pwm_control: 'firmware_managed' }));
-    const enabled = screen
-      .getAllByRole('button')
-      .filter((b) => !(b as HTMLButtonElement).disabled);
-    // AUTO und SCHEDULED sind klickbar (MANUAL ist der aktive Modus)
-    expect(enabled.length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByTestId('fan-uncontrollable-hint')).toBeTruthy();
+  });
+
+  it('laesst einen steuerbaren Luefter unangetastet', () => {
+    renderCard(fan({ pwm_control: 'supported', mode: FanMode.AUTO }));
+    const manual = screen.getByRole('button', { name: /card\.manual/ }) as HTMLButtonElement;
+    const scheduled = screen.getByRole('button', { name: /card\.scheduled/ }) as HTMLButtonElement;
+    expect(manual.disabled).toBe(false);
+    expect(scheduled.disabled).toBe(false);
+    expect(screen.queryByTestId('fan-uncontrollable-hint')).toBeNull();
   });
 });

--- a/client/src/components/fan-control/FanCard.tsx
+++ b/client/src/components/fan-control/FanCard.tsx
@@ -198,7 +198,7 @@ export default function FanCard({
             e.stopPropagation();
             onModeChange(fan.fan_id, FanMode.SCHEDULED);
           }}
-          disabled={fan.mode === FanMode.SCHEDULED || isReadOnly || isLoading}
+          disabled={fan.mode === FanMode.SCHEDULED || isReadOnly || isLoading || isFirmwareManaged}
           className={`flex-1 px-3 py-1 text-xs rounded-lg transition-colors ${
             fan.mode === FanMode.SCHEDULED
               ? 'bg-amber-500 text-white shadow-lg shadow-amber-500/30'
@@ -216,7 +216,7 @@ export default function FanCard({
             e.stopPropagation();
             onModeChange(fan.fan_id, FanMode.MANUAL);
           }}
-          disabled={fan.mode === FanMode.MANUAL || isReadOnly || isLoading}
+          disabled={fan.mode === FanMode.MANUAL || isReadOnly || isLoading || isFirmwareManaged}
           className={`flex-1 px-3 py-1 text-xs rounded-lg transition-colors ${
             fan.mode === FanMode.MANUAL
               ? 'bg-purple-500 text-white shadow-lg shadow-purple-500/30'
@@ -230,6 +230,17 @@ export default function FanCard({
           )}
         </button>
       </div>
+
+      {/* Warum die Regler nichts bewirken. Auto bleibt erreichbar, damit
+          niemand in einem Modus festsitzt -- siehe FanCard.test.tsx. */}
+      {isFirmwareManaged && (
+        <p
+          data-testid="fan-uncontrollable-hint"
+          className="text-xs text-slate-400 mb-3"
+        >
+          {t('system:fanControl.gpu.firmware.cardHint')}
+        </p>
+      )}
 
       {/* Manual PWM Slider */}
       {fan.mode === FanMode.MANUAL && (

--- a/client/src/i18n/locales/de/system.json
+++ b/client/src/i18n/locales/de/system.json
@@ -1023,6 +1023,7 @@
       "firmware": {
         "badge": "Firmware",
         "badgeHint": "Die Lüfterkurve dieser GPU wird von der Firmware verwaltet und kann von BaluHost nicht gesetzt werden.",
+        "cardHint": "Die Karte regelt diesen Lüfter selbst. Zeitplan und Manuell hätten hier keine Wirkung.",
         "title": "Firmware-verwaltete Lüfterkurve",
         "explanation": "Ab RDNA3 liegt die Lüfterkurve in der GPU-Firmware. Der amdgpu-Treiber lehnt direkte PWM-Steuerung ab — auch mit gesetztem Kernel-Parameter amdgpu.ppfeaturemask. Drehzahl und Temperatur werden weiter angezeigt.",
         "resetButton": "Manuellen Modus zurücksetzen",

--- a/client/src/i18n/locales/en/system.json
+++ b/client/src/i18n/locales/en/system.json
@@ -1028,6 +1028,7 @@
       "firmware": {
         "badge": "Firmware",
         "badgeHint": "This GPU's fan curve is managed by firmware and cannot be set by BaluHost.",
+        "cardHint": "The card regulates this fan itself. Schedule and Manual would have no effect here.",
         "title": "Firmware-managed fan curve",
         "explanation": "From RDNA3 onward the fan curve lives in the GPU firmware. The amdgpu driver rejects direct PWM control — even with the amdgpu.ppfeaturemask kernel parameter set. Speed and temperature are still shown.",
         "resetButton": "Reset manual mode",


### PR DESCRIPTION
Setzt die UI-Hälfte von Punkt 1 aus #534 um. **Kein `Closes`** — Punkt 1 hat noch eine Backend-Hälfte und Punkt 2 ist unberührt.

## Das Problem

Die Karte zeigte für einen `FIRMWARE_MANAGED`-Lüfter bedienbare Auto-, Zeitplan- und Manuell-Schaltflächen:

```
┌──────────────────────────────────────────────┐
│ amdgpu PWM1   [GPU (AMD)] [Firmware]  (AUTO) │
│ [   Auto   ] [ Schedule ] [  Manual  ]       │
└──────────────────────────────────────────────┘
```

`set_pwm()` steigt bei so einem Kanal sofort mit `False` aus, bevor überhaupt ein Write versucht wird. Ein Klick änderte den gespeicherten Modus, an der Hardware passierte nichts, und der Nutzer bekam keinen Hinweis.

**Der Schieber war bereits gesperrt** (`disabled={isReadOnly || isFirmwareManaged}`) — an den drei Modus-Buttons hatte die Bedingung schlicht gefehlt. Es war keine Konzeptlücke, sondern eine vergessene Zeile an drei Stellen.

## Warum nicht alle drei gesperrt werden

Hier stand ein Test im Weg, und zwar zu Recht:

```tsx
it('laesst die Modus-Buttons bedienbar — sonst sperrt sich der Nutzer aus', ...)
```

Die Sorge trägt: hätte der Lüfter im Modus **Manuell** gestanden, säße er dort für immer fest, weil kein Weg zurück bliebe.

Der Test ist deshalb **umgeschrieben statt gelöscht** — seine Absicht bleibt als eigener Fall erhalten:

```tsx
it('laesst Auto erreichbar — sonst sperrt sich der Nutzer im Modus ein', ...)
```

Gesperrt sind **Zeitplan und Manuell**: beide versprechen eine Steuerung, die nicht stattfindet. **Auto bleibt erreichbar** und ist der neutrale Modus — BaluHost hält den Kanal dann nicht von Hand, was für einen firmware-verwalteten Lüfter ohnehin gilt.

Dazu eine Zeile unter der Button-Reihe, die den Grund nennt, statt nur zu sperren. Neuer i18n-Schlüssel in `de` und `en`.

## Eine Korrektur an mir selbst

In #568 habe ich behauptet, `pwm_control == "no_permission"` sei „dieselbe UI-Änderung". Beim Umsetzen zeigt sich: **ist es nicht.**

| | `firmware_managed` | `no_permission` |
|---|---|---|
| Natur | dauerhafte Eigenschaft der Hardware | vorübergehender Laufzeit-Befund |
| Kann sich ändern? | nein | ja — Rechte können zurückkommen, `set_pwm` nimmt den Zustand nach einem erfolgreichen Write selbst zurück |
| Sperren angemessen? | ja | nein, das wäre übergriffig |

Bei fehlenden Rechten *würde* BaluHost den Kanal steuern, sobald es darf. Die Regler dort zu sperren, hieße einen behebbaren Zustand wie einen dauerhaften zu behandeln. Dieser PR fasst `no_permission` deshalb nicht an; ich korrigiere die Behauptung in #568.

## Tests

Vier Tests in `FanCard.test.tsx`, zwei davon rot gesehen (`expected false to be true` für die gesperrten Buttons, fehlender Hinweis-Knoten). Der vierte hält fest, dass ein steuerbarer Lüfter unangetastet bleibt — sonst wäre die Bedingung leicht zu breit geraten.

| | |
|---|---|
| `npx vitest run` | 274 Dateien, **1313 Tests** (vorher 1310) |
| `npx eslint .` | 0 Fehler |
| `npm run build` | erfolgreich |

## Was von #534 offen bleibt

- **Punkt 1, Backend-Hälfte:** ein generischer hwmon-Kanal, der `EACCES`/`EINVAL` liefert, wird weiterhin nicht an die Automatik zurückgegeben. Für die GPU ist das durch #480 faktisch erledigt.
- **Punkt 2:** Regelung fällt aus (Sensor weg) → Rückgabe. Unberührt, samt der offenen Frage nach dem Rückkehrverhalten.

Beides hängt an der Richtungsentscheidung in #536: kommt die Firmware-Kurve als Grundsicherung, wird die softwareseitige Rückgabe teilweise gegenstandslos.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lf8TucK1YQasPz6Xn9Frk
