### PR TITLE
fix(security): mdadm und smartctl in sudoers auf die Aufrufformen des Codes verengen (#570)

### DIFF
--- a/backend/app/schemas/system.py
+++ b/backend/app/schemas/system.py
@@ -275,14 +275,18 @@ class CreateArrayRequest(BaseModel):
     @field_validator("name")
     @classmethod
     def validate_mdadm_name(cls, v: str) -> str:
-        if not re.fullmatch(r"md([0-9]+|_[a-zA-Z0-9]+)", v):
+        # Auf md<1-3 Ziffern> begrenzt (#570): die sudoers-Regeln zaehlen die
+        # erlaubten mdadm-Aufrufe einzeln auf, und ein unbegrenzt langer Name
+        # laesst sich dort nur mit einem Platzhalter abbilden. Ein Platzhalter
+        # mitten im Muster ist aber gefaehrlich -- er matcht auch Leerzeichen
+        # und liesse zusaetzliche Optionen durch. Ein Name ausserhalb dieser
+        # Form wuerde spaeter an sudo scheitern; besser hier melden.
+        if not re.fullmatch(r"md[0-9]{1,3}", v):
             raise ValueError(
                 f"Invalid array name '{v}'. "
-                "Name must start with 'md' followed by digits (e.g. md0, md127) "
-                "or 'md_' followed by alphanumerics (e.g. md_backup)."
+                "Name must be 'md' followed by one to three digits "
+                "(e.g. md0, md1, md127)."
             )
-        if len(v) > 32:
-            raise ValueError("Array name must not exceed 32 characters.")
         return v
 
 

--- a/backend/app/services/hardware/raid/mdadm_backend.py
+++ b/backend/app/services/hardware/raid/mdadm_backend.py
@@ -581,10 +581,12 @@ class MdadmRaidBackend:
                     raise ValueError(f"Cannot use {dev} for RAID: it is part of the OS disk ({os_disk})")
 
         # Validate array name (safety net in case schema validation is bypassed)
-        if not re.fullmatch(r"md([0-9]+|_[a-zA-Z0-9]+)", payload.name) or len(payload.name) > 32:
+        if not re.fullmatch(r"md[0-9]{1,3}", payload.name):
             raise ValueError(
                 f"Invalid array name '{payload.name}'. "
-                "Name must match 'md<digits>' or 'md_<alphanumerics>' (max 32 chars)."
+                "Name must match 'md<1-3 digits>' (e.g. md0, md127) -- the "
+                "sudoers rules enumerate the permitted mdadm invocations and "
+                "cannot cover unbounded names (#570)."
             )
 
         # Validate RAID level

--- a/backend/tests/test_raid_sudoers_scope.py
+++ b/backend/tests/test_raid_sudoers_scope.py
@@ -1,0 +1,170 @@
+"""Die mdadm-/smartctl-Regeln decken genau die Aufrufformen des Codes ab (#570).
+
+Bis #570 stand in der Vorlage `NOPASSWD: /sbin/mdadm` ohne Argumente. Ein
+sudoers-Eintrag ohne Argumente erlaubt JEDE Argumentliste -- darunter
+`mdadm --monitor --program <beliebiges Programm>`, also Codeausfuehrung als
+root. Das war ein laengerer Hebel als das in derselben Runde behobene
+`tee /sys/class/hwmon/*`.
+
+Modellierung wie in test_hardware_sudoers_scope.py: sudo fuegt die Argumente zu
+EINER Zeichenkette zusammen und matcht sie mit fnmatch ohne FNM_PATHNAME gegen
+das Muster aus der Vorlage. Deshalb wird hier `binary + " " + " ".join(args)`
+gegen den ganzen Eintrag gehalten.
+
+Die Geraeteformen stammen aus einer Messung auf BaluNode (2026-09-07):
+`smartctl --scan` meldet /dev/sda..sdc und /dev/nvme0..1, `/proc/mdstat` zeigt
+md1 mit sda1 (Partition) und sdb (ganze Platte).
+"""
+import fnmatch
+import re
+from pathlib import Path
+
+import pytest
+
+TEMPLATE = (
+    Path(__file__).resolve().parents[2]
+    / "deploy" / "install" / "templates" / "baluhost-hardware-sudoers"
+)
+
+MDADM = "/usr/sbin/mdadm"
+SMARTCTL = "/usr/sbin/smartctl"
+
+
+def _entries(binary: str) -> list[str]:
+    """Alle sudoers-Eintraege fuer ein Binary, Zeilenfortsetzungen aufgeloest.
+
+    Kommentarzeilen fallen vorher heraus -- sonst haette ein auskommentierter
+    Eintrag die Erlaubnis-Tests gruen gelassen, waehrend die Funktion auf der
+    Maschine ausfaellt.
+    """
+    zeilen = [
+        z for z in TEMPLATE.read_text(encoding="utf-8").splitlines()
+        if not z.lstrip().startswith("#")
+    ]
+    text = re.sub(r"\\\s*\n\s*", " ", "\n".join(zeilen))
+    return [e.strip() for e in re.findall(rf"({re.escape(binary)}[^,\n]*)", text)]
+
+
+def _erlaubt(binary: str, *args: str) -> bool:
+    """Wie sudo entscheiden wuerde.
+
+    Der Sonderfall ist der wichtige: ein Eintrag OHNE Argumente erlaubt in
+    sudoers JEDE Argumentliste. Wer ihn wie ein argumentloses Kommando
+    behandelt, baut sich einen Test, der den alten Zustand fuer sicher haelt --
+    beim Nachstellen des alten Eintrags blieben die Ablehnungs-Tests hier
+    zunaechst gruen.
+    """
+    kommando = " ".join([binary, *args])
+    for eintrag in _entries(binary):
+        if eintrag == binary:
+            return True
+        if fnmatch.fnmatchcase(kommando, eintrag):
+            return True
+    return False
+
+
+def test_die_vorlage_traegt_ueberhaupt_eintraege():
+    """Schutz gegen einen vakuum-gruenen Test: ohne gefundene Eintraege waeren
+    alle Ablehnungs-Zusicherungen unten trivial erfuellt.
+
+    Exakte Zahlen statt einer unteren Schranke, damit auch der Verlust
+    einzelner Eintraege auffaellt. Zusammensetzung mdadm: 1 (--detail --scan)
+    + 3*3 (--detail/--wait/--stop je Array-Form) + 4 (--zero-superblock je
+    Geraeteform) + 5*12 (fuenf Verben x Array x Geraet) + 6 (--grow --bitmap
+    je Array und Option) + 3 (--create je Array-Form) = 83.
+    smartctl: 1 (--scan -j) + 2*4 (Selftest je Typlaenge und Geraeteform)
+    + 2*4 (-t short/long je Geraeteform) = 17.
+    """
+    assert len(_entries(MDADM)) == 83
+    assert len(_entries(SMARTCTL)) == 17
+
+
+def test_kein_eintrag_steht_ohne_argumente():
+    """Der eigentliche Befund: ein Eintrag, der nur aus dem Binary besteht,
+    erlaubt in sudoers JEDE Argumentliste -- genau der alte Zustand."""
+    assert MDADM not in _entries(MDADM)
+    assert SMARTCTL not in _entries(SMARTCTL)
+
+
+# --- Die Aufrufformen aus services/hardware/raid/mdadm_backend.py ------------
+
+@pytest.mark.parametrize("args", [
+    ("--detail", "--scan"),                                   # :384
+    ("--detail", "/dev/md1"),                                 # :180
+    ("--detail", "/dev/md127"),
+    ("--wait", "/dev/md1"),                                   # :108
+    ("--stop", "/dev/md1"),                                   # :640
+    ("--zero-superblock", "/dev/sdb"),                        # :651
+    ("--zero-superblock", "/dev/sda1"),
+    ("--zero-superblock", "/dev/nvme0n1"),
+    ("/dev/md1", "--fail", "/dev/sdb"),                       # :82
+    ("/dev/md1", "--remove", "/dev/sdb"),                     # :101, :139
+    ("/dev/md1", "--add", "/dev/sda1"),                       # :102, :134
+    ("/dev/md1", "--readwrite", "/dev/sdb"),                  # :145
+    ("/dev/md1", "--write-mostly", "/dev/sdb"),               # :148
+    ("/dev/md127", "--add", "/dev/nvme1n1p2"),
+    ("/dev/md1", "--grow", "--bitmap=internal"),              # :129
+    ("/dev/md1", "--grow", "--bitmap=none"),
+])
+def test_die_mdadm_aufrufe_des_codes_bleiben_erlaubt(args):
+    assert _erlaubt(MDADM, *args)
+
+
+def test_das_anlegen_eines_arrays_bleibt_erlaubt():
+    """create_array baut die Argumentliste in dieser Reihenfolge (:605-624);
+    die Zahl der Geraete ist variabel, deshalb ist dies die einzige Zeile mit
+    einem '*' am Ende."""
+    assert _erlaubt(MDADM, "--create", "/dev/md0", "--level=1",
+                    "--raid-devices=2", "/dev/sda", "/dev/sdb")
+    assert _erlaubt(MDADM, "--create", "/dev/md0", "--level=5",
+                    "--raid-devices=3", "/dev/sda", "/dev/sdb", "/dev/sdc",
+                    "--assume-clean")
+
+
+# --- Die Aufrufformen aus services/hardware/smart/ ---------------------------
+
+@pytest.mark.parametrize("args", [
+    ("--scan", "-j"),                                                    # collector.py:40
+    ("-H", "-i", "-l", "selftest", "-j", "-d", "sat", "/dev/sda"),       # utils.py:95
+    ("-H", "-i", "-l", "selftest", "-j", "-d", "scsi", "/dev/sdb"),
+    ("-H", "-i", "-l", "selftest", "-j", "-d", "nvme", "/dev/nvme0"),
+    ("-H", "-i", "-l", "selftest", "-j", "-d", "auto", "/dev/nvme1"),
+    ("-t", "short", "/dev/sda"),                                         # scheduler.py:76
+    ("-t", "long", "/dev/nvme0"),
+])
+def test_die_smartctl_aufrufe_des_codes_bleiben_erlaubt(args):
+    assert _erlaubt(SMARTCTL, *args)
+
+
+# --- Was nicht mehr gehen darf ----------------------------------------------
+
+@pytest.mark.parametrize("args", [
+    # Der Ausfuehrungspfad: mdadm startet das Programm als root.
+    ("--monitor", "--program", "/tmp/beliebig.sh"),
+    ("--monitor", "--scan", "--program", "/tmp/beliebig.sh"),
+    # Andere Modi, die der Code nie benutzt.
+    ("--assemble", "--scan"),
+    ("--manage", "/dev/md1", "--fail", "/dev/sdb"),
+    ("--misc", "--zero-superblock", "/dev/sdb"),
+    ("--grow", "/dev/md1", "--size=max"),
+    # Ausbruch aus /dev.
+    ("--detail", "/dev/../etc/shadow"),
+    ("--zero-superblock", "/dev/../../etc/shadow"),
+    # Ein Array-Argument, das keines ist.
+    ("--stop", "/dev/sda"),
+    ("/etc/shadow", "--fail", "/dev/sdb"),
+])
+def test_gefaehrliche_mdadm_formen_werden_abgelehnt(args):
+    assert not _erlaubt(MDADM, *args)
+
+
+@pytest.mark.parametrize("args", [
+    # smartctl kann Geraeteeinstellungen dauerhaft veraendern.
+    ("--set=security-freeze", "/dev/sda"),
+    ("-t", "select,0-max", "/dev/sda"),
+    # Ausbruch aus /dev.
+    ("-t", "short", "/dev/../etc/shadow"),
+    ("-H", "-i", "-l", "selftest", "-j", "-d", "sat", "/dev/../etc/shadow"),
+])
+def test_gefaehrliche_smartctl_formen_werden_abgelehnt(args):
+    assert not _erlaubt(SMARTCTL, *args)

--- a/backend/tests/test_raid_sudoers_scope.py
+++ b/backend/tests/test_raid_sudoers_scope.py
@@ -111,15 +111,47 @@ def test_die_mdadm_aufrufe_des_codes_bleiben_erlaubt(args):
     assert _erlaubt(MDADM, *args)
 
 
-def test_das_anlegen_eines_arrays_bleibt_erlaubt():
-    """create_array baut die Argumentliste in dieser Reihenfolge (:605-624);
-    die Zahl der Geraete ist variabel, deshalb ist dies die einzige Zeile mit
-    einem '*' am Ende."""
-    assert _erlaubt(MDADM, "--create", "/dev/md0", "--level=1",
-                    "--raid-devices=2", "/dev/sda", "/dev/sdb")
-    assert _erlaubt(MDADM, "--create", "/dev/md0", "--level=5",
-                    "--raid-devices=3", "/dev/sda", "/dev/sdb", "/dev/sdc",
-                    "--assume-clean")
+@pytest.mark.parametrize("level,devices,spares", [
+    ("raid1", ["sda", "sdb"], []),
+    ("raid5", ["sda", "sdb", "sdc"], []),
+    ("raid10", ["sda", "sdb", "sdc", "sdb1"], []),   # zweistelliges Level
+    ("raid1", ["sda", "sdb"], ["sdc"]),              # --spare-devices vor den Geraeten
+])
+def test_das_anlegen_eines_arrays_wird_aus_dem_code_gewonnen(
+    level, devices, spares, monkeypatch
+):
+    """Die Argumentliste stammt aus create_array, nicht aus dieser Datei.
+
+    Dieselbe Lehre wie beim Selftest-Aufruf: die handgeschriebene Fassung hatte
+    `--level=10` und `--spare-devices` uebersehen, weil beide nur im Code
+    entstehen -- das Level aus `payload.level.replace('raid','')`, die
+    Spare-Option als eigenes Argument VOR dem ersten Geraet.
+    """
+    from app.schemas.system import CreateArrayRequest
+    from app.services.hardware.raid.mdadm_backend import MdadmRaidBackend
+
+    backend = object.__new__(MdadmRaidBackend)
+    backend._lsblk_available = False
+    aufgezeichnet: list[list[str]] = []
+
+    monkeypatch.setattr(MdadmRaidBackend, "_normalize_device",
+                        lambda self, d: d if d.startswith("/dev/") else f"/dev/{d}")
+    # _get_os_disk_name ruft selbst mdadm/lsblk -- fuer diesen Test still
+    # gelegt, damit nur der create-Aufruf aufgezeichnet wird.
+    monkeypatch.setattr(MdadmRaidBackend, "_get_os_disk_name", lambda self: None)
+    monkeypatch.setattr(MdadmRaidBackend, "_run",
+                        lambda self, cmd, **kw: aufgezeichnet.append(list(cmd)))
+    monkeypatch.setattr("app.services.hardware.raid.mdadm_backend.Path",
+                        lambda *_a, **_k: type("P", (), {"exists": lambda self: False})())
+
+    backend.create_array(CreateArrayRequest(
+        name="md0", level=level, devices=devices, spare_devices=spares,
+    ))
+
+    assert len(aufgezeichnet) == 1
+    argv = aufgezeichnet[0]
+    assert argv[0] == "mdadm"
+    assert _erlaubt(MDADM, *argv[1:]), f"nicht abgedeckt: {' '.join(argv)}"
 
 
 # --- Die Aufrufformen aus services/hardware/smart/ ---------------------------

--- a/backend/tests/test_raid_sudoers_scope.py
+++ b/backend/tests/test_raid_sudoers_scope.py
@@ -71,12 +71,13 @@ def test_die_vorlage_traegt_ueberhaupt_eintraege():
     einzelner Eintraege auffaellt. Zusammensetzung mdadm: 1 (--detail --scan)
     + 3*3 (--detail/--wait/--stop je Array-Form) + 4 (--zero-superblock je
     Geraeteform) + 5*12 (fuenf Verben x Array x Geraet) + 6 (--grow --bitmap
-    je Array und Option) + 3 (--create je Array-Form) = 83.
-    smartctl: 1 (--scan -j) + 2*4 (Selftest je Typlaenge und Geraeteform)
-    + 2*4 (-t short/long je Geraeteform) = 17.
+    je Array und Option) = 80, dazu 12 fuer --create (3 Array-Formen x 2
+    Level-Laengen x mit/ohne --spare-devices) = 92.
+    smartctl: 1 (--scan -j) + 2*2*4 (Selftest mit und ohne -A, je Typlaenge
+    und Geraeteform) + 2*4 (-t short/long je Geraeteform) = 25.
     """
-    assert len(_entries(MDADM)) == 83
-    assert len(_entries(SMARTCTL)) == 17
+    assert len(_entries(MDADM)) == 92
+    assert len(_entries(SMARTCTL)) == 25
 
 
 def test_kein_eintrag_steht_ohne_argumente():
@@ -125,15 +126,53 @@ def test_das_anlegen_eines_arrays_bleibt_erlaubt():
 
 @pytest.mark.parametrize("args", [
     ("--scan", "-j"),                                                    # collector.py:40
-    ("-H", "-i", "-l", "selftest", "-j", "-d", "sat", "/dev/sda"),       # utils.py:95
-    ("-H", "-i", "-l", "selftest", "-j", "-d", "scsi", "/dev/sdb"),
-    ("-H", "-i", "-l", "selftest", "-j", "-d", "nvme", "/dev/nvme0"),
-    ("-H", "-i", "-l", "selftest", "-j", "-d", "auto", "/dev/nvme1"),
     ("-t", "short", "/dev/sda"),                                         # scheduler.py:76
     ("-t", "long", "/dev/nvme0"),
 ])
 def test_die_smartctl_aufrufe_des_codes_bleiben_erlaubt(args):
     assert _erlaubt(SMARTCTL, *args)
+
+
+@pytest.mark.parametrize("dev_type,device", [
+    ("sat", "/dev/sda"),
+    ("scsi", "/dev/sdb"),
+    ("scsi", "/dev/sdc"),
+    ("auto", "/dev/sda1"),
+    ("nvme", "/dev/nvme0"),
+    ("nvme", "/dev/nvme1"),
+    ("auto", "/dev/nvme0n1"),
+])
+def test_die_selftest_abfrage_wird_aus_dem_code_gewonnen(dev_type, device, monkeypatch):
+    """Die Argumentliste stammt aus _run_smartctl, nicht aus dieser Datei.
+
+    Der Grund ist ein konkreter Fehlschlag: eine frueherere Fassung dieses
+    Tests hat die Form von Hand abgeschrieben und dabei uebersehen, dass
+    utils.py fuer alles ohne 'nvme' ein '-A' an Position 3 EINSCHIEBT. Die
+    sudoers-Vorlage kannte daraufhin nur die Form ohne -A -- auf der
+    Referenzmaschine waeren genau die drei SATA-Platten still aus der
+    SMART-Anzeige gefallen. Wer die Argumente abschreibt, testet seine eigene
+    Lesart des Codes, nicht den Code.
+    """
+    from app.services.hardware.smart import utils
+
+    aufgezeichnet: list[list[str]] = []
+
+    class _Ergebnis:
+        returncode = 0
+        stdout = "{}"
+        stderr = ""
+
+    def _aufzeichnen(argv, **_kwargs):
+        aufgezeichnet.append(list(argv))
+        return _Ergebnis()
+
+    monkeypatch.setattr("subprocess.run", _aufzeichnen)
+    utils._run_smartctl("/usr/sbin/smartctl", dev_type, device)
+
+    assert len(aufgezeichnet) == 1
+    argv = aufgezeichnet[0]
+    assert argv[:2] == ["sudo", "-n"]
+    assert _erlaubt(SMARTCTL, *argv[3:]), f"nicht abgedeckt: {' '.join(argv[2:])}"
 
 
 # --- Was nicht mehr gehen darf ----------------------------------------------

--- a/client/src/__tests__/components/raid-setup/raidWizardHelpers.test.ts
+++ b/client/src/__tests__/components/raid-setup/raidWizardHelpers.test.ts
@@ -29,11 +29,17 @@ describe('calculateArrayCapacity', () => {
 });
 
 describe('isValidArrayName', () => {
-  it('accepts md + digits', () => { expect(isValidArrayName('md0')).toBe(true); });
-  it('accepts md_ + alphanumerics', () => { expect(isValidArrayName('md_backup')).toBe(true); });
+  it('accepts md + one to three digits', () => {
+    expect(isValidArrayName('md0')).toBe(true);
+    expect(isValidArrayName('md127')).toBe(true);
+  });
+  // md_backup war bis #570 gueltig. Die sudoers-Regeln zaehlen die erlaubten
+  // mdadm-Aufrufe einzeln auf und koennen unbegrenzte Namen nicht abbilden --
+  // ein solcher Name wuerde beim Anlegen an sudo scheitern statt hier.
+  it('rejects md_ + alphanumerics', () => { expect(isValidArrayName('md_backup')).toBe(false); });
+  it('rejects more than three digits', () => { expect(isValidArrayName('md1234')).toBe(false); });
   it('rejects a non-md name', () => { expect(isValidArrayName('raid0')).toBe(false); });
   it('rejects bare "md"', () => { expect(isValidArrayName('md')).toBe(false); });
   it('rejects empty', () => { expect(isValidArrayName('')).toBe(false); });
-  it('rejects names longer than 32 chars', () => { expect(isValidArrayName('md' + '1'.repeat(40))).toBe(false); });
   it('rejects special chars', () => { expect(isValidArrayName('md_ab!')).toBe(false); });
 });

--- a/client/src/components/raid-setup/RaidConfirmationStep.tsx
+++ b/client/src/components/raid-setup/RaidConfirmationStep.tsx
@@ -45,7 +45,7 @@ export default function RaidConfirmationStep({
           />
           {arrayName && !isArrayNameValid && (
             <p className="mt-1 text-xs text-red-400">
-              {t('raidWizard.confirm.invalidName', 'Name must be "md" + digits (e.g. md0) or "md_" + alphanumerics (e.g. md_backup).')}
+              {t('raidWizard.confirm.invalidName', 'Name must be "md" followed by one to three digits (e.g. md0, md127).')}
             </p>
           )}
         </div>

--- a/client/src/components/raid-setup/RaidConfirmationStep.tsx
+++ b/client/src/components/raid-setup/RaidConfirmationStep.tsx
@@ -34,8 +34,8 @@ export default function RaidConfirmationStep({
             value={arrayName}
             onChange={(e) => onArrayNameChange(e.target.value)}
             required
-            pattern="^md([0-9]+|_[a-zA-Z0-9]+)$"
-            maxLength={32}
+            pattern="^md[0-9]{1,3}$"
+            maxLength={5}
             placeholder="md0"
             className={`mt-1 w-full rounded-lg border bg-slate-950/70 px-3 py-2 text-sm text-slate-200 focus:outline-none ${
               arrayName && !isArrayNameValid

--- a/client/src/components/raid-setup/raidWizardHelpers.ts
+++ b/client/src/components/raid-setup/raidWizardHelpers.ts
@@ -1,10 +1,13 @@
 import { formatBytes } from '../../lib/formatters';
 import { RAID_LEVELS } from './raidLevels';
 
-const MDADM_NAME_REGEX = /^md([0-9]+|_[a-zA-Z0-9]+)$/;
+// md0..md999 (#570): die sudoers-Regeln zaehlen die erlaubten
+// mdadm-Aufrufe einzeln auf und koennen unbegrenzt lange Namen nicht
+// abbilden. Ein Name ausserhalb dieser Form wuerde serverseitig abgelehnt.
+const MDADM_NAME_REGEX = /^md[0-9]{1,3}$/;
 
 export function isValidArrayName(name: string): boolean {
-  return MDADM_NAME_REGEX.test(name) && name.length <= 32;
+  return MDADM_NAME_REGEX.test(name);
 }
 
 export function calculateArrayCapacity(level: string, diskCount: number): string {

--- a/deploy/install/templates/baluhost-hardware-sudoers
+++ b/deploy/install/templates/baluhost-hardware-sudoers
@@ -8,12 +8,143 @@
 #   deploy/scripts/install-hardware-sudoers.sh manually. A routine deploy
 #   does NOT re-render it.
 
-# RAID management (mdadm)
-@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /sbin/mdadm
-@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/sbin/mdadm
+# RAID management (mdadm) und Disk-Health (smartctl)
+#
+# Bis #570 standen hier `NOPASSWD: /sbin/mdadm` und `/usr/sbin/smartctl` OHNE
+# Argumente. Ein sudoers-Eintrag ohne Argumente erlaubt JEDE Argumentliste --
+# darunter `mdadm --monitor --program /pfad/zu/beliebigem/programm`, also
+# Codeausfuehrung als root, und `--create`/`--zero-superblock` auf beliebigen
+# Block-Geraeten. Das war der laengste Hebel in dieser Datei.
+#
+# Aufgezaehlt sind jetzt genau die Aufrufformen, die der Code kennt
+# (services/hardware/raid/mdadm_backend.py, services/hardware/smart/).
+# Zeichenklassen statt '*', weil Wildcards in sudoers-ARGUMENTEN auch '/'
+# matchen; die einzige Ausnahme ist die --create-Zeile, siehe unten.
+# Gehalten wird die Liste von backend/tests/test_raid_sudoers_scope.py.
+#
+# Geraeteformen nach Messung auf BaluNode (2026-09-07): smartctl --scan meldet
+# /dev/sd[a-c] und /dev/nvme[0-1], das Array /dev/md1 fuehrt sda1 (Partition)
+# und sdb (ganze Platte) -- deshalb sowohl sd[a-z] als auch sd[a-z][0-9].
+#
+# NUR /usr/sbin: auf Debian 13 (usrmerge) ist /sbin ein Symlink dorthin. Auf
+# einer Distribution ohne usrmerge muessen die Eintraege verdoppelt werden.
 
-# Disk health (smartctl)
-@@BALUHOST_USER@@ ALL=(root) NOPASSWD: /usr/sbin/smartctl
+Cmnd_Alias BALUHOST_MDADM = \
+    /usr/sbin/mdadm --detail --scan, \
+    /usr/sbin/mdadm --detail /dev/md[0-9], \
+    /usr/sbin/mdadm --detail /dev/md[0-9][0-9], \
+    /usr/sbin/mdadm --detail /dev/md[0-9][0-9][0-9], \
+    /usr/sbin/mdadm --wait /dev/md[0-9], \
+    /usr/sbin/mdadm --wait /dev/md[0-9][0-9], \
+    /usr/sbin/mdadm --wait /dev/md[0-9][0-9][0-9], \
+    /usr/sbin/mdadm --stop /dev/md[0-9], \
+    /usr/sbin/mdadm --stop /dev/md[0-9][0-9], \
+    /usr/sbin/mdadm --stop /dev/md[0-9][0-9][0-9], \
+    /usr/sbin/mdadm --zero-superblock /dev/sd[a-z], \
+    /usr/sbin/mdadm --zero-superblock /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm --zero-superblock /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm --zero-superblock /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --fail /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9] --fail /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --fail /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --fail /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --fail /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --fail /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --fail /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --fail /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --fail /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --fail /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --fail /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --fail /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --remove /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9] --remove /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --remove /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --remove /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --remove /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --remove /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --remove /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --remove /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --remove /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --remove /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --remove /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --remove /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --add /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9] --add /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --add /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --add /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --add /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --add /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --add /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --add /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --add /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --add /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --add /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --add /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --readwrite /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9] --readwrite /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --readwrite /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --readwrite /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --readwrite /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --readwrite /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --readwrite /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --readwrite /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --readwrite /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --readwrite /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --readwrite /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --readwrite /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --write-mostly /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9] --write-mostly /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --write-mostly /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --write-mostly /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --write-mostly /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --write-mostly /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --write-mostly /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --write-mostly /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --write-mostly /dev/sd[a-z], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --write-mostly /dev/sd[a-z][0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --write-mostly /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --write-mostly /dev/nvme[0-9]n[0-9]p[0-9], \
+    /usr/sbin/mdadm /dev/md[0-9] --grow --bitmap=internal, \
+    /usr/sbin/mdadm /dev/md[0-9] --grow --bitmap=none, \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --grow --bitmap=internal, \
+    /usr/sbin/mdadm /dev/md[0-9][0-9] --grow --bitmap=none, \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --grow --bitmap=internal, \
+    /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --grow --bitmap=none
+
+# Die einzige Zeile mit '*': --create nimmt eine variable Zahl von Geraeten und
+# haengt je nach Einstellung --assume-clean an, laesst sich also nicht auf eine
+# feste Argumentzahl festnageln. Begrenzt ist sie durch den Praefix (Array
+# unter /dev/md, numerisches Level und Geraetezahl); was danach kommt, faengt
+# mdadms eigener Modus-Parser ab, nicht sudo. Das ist schwaecher als der Rest
+# und der Kandidat fuer einen argumentpruefenden Wrapper unter /usr/local/sbin,
+# wie ihn der Plugin-Worker bereits benutzt.
+Cmnd_Alias BALUHOST_MDADM_CREATE = \
+    /usr/sbin/mdadm --create /dev/md[0-9] --level=[0-9] --raid-devices=[0-9] /dev/*, \
+    /usr/sbin/mdadm --create /dev/md[0-9][0-9] --level=[0-9] --raid-devices=[0-9] /dev/*, \
+    /usr/sbin/mdadm --create /dev/md[0-9][0-9][0-9] --level=[0-9] --raid-devices=[0-9] /dev/*
+
+Cmnd_Alias BALUHOST_SMARTCTL = \
+    /usr/sbin/smartctl --scan -j, \
+    /usr/sbin/smartctl -H -i -l selftest -j -d [a-z][a-z][a-z] /dev/sd[a-z], \
+    /usr/sbin/smartctl -H -i -l selftest -j -d [a-z][a-z][a-z] /dev/sd[a-z][0-9], \
+    /usr/sbin/smartctl -H -i -l selftest -j -d [a-z][a-z][a-z] /dev/nvme[0-9], \
+    /usr/sbin/smartctl -H -i -l selftest -j -d [a-z][a-z][a-z] /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/smartctl -H -i -l selftest -j -d [a-z][a-z][a-z][a-z] /dev/sd[a-z], \
+    /usr/sbin/smartctl -H -i -l selftest -j -d [a-z][a-z][a-z][a-z] /dev/sd[a-z][0-9], \
+    /usr/sbin/smartctl -H -i -l selftest -j -d [a-z][a-z][a-z][a-z] /dev/nvme[0-9], \
+    /usr/sbin/smartctl -H -i -l selftest -j -d [a-z][a-z][a-z][a-z] /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/smartctl -t short /dev/sd[a-z], \
+    /usr/sbin/smartctl -t short /dev/sd[a-z][0-9], \
+    /usr/sbin/smartctl -t short /dev/nvme[0-9], \
+    /usr/sbin/smartctl -t short /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/smartctl -t long /dev/sd[a-z], \
+    /usr/sbin/smartctl -t long /dev/sd[a-z][0-9], \
+    /usr/sbin/smartctl -t long /dev/nvme[0-9], \
+    /usr/sbin/smartctl -t long /dev/nvme[0-9]n[0-9]
+
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: BALUHOST_MDADM
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: BALUHOST_MDADM_CREATE
+@@BALUHOST_USER@@ ALL=(root) NOPASSWD: BALUHOST_SMARTCTL
 
 # Fan control & CPU frequency (write to sysfs via tee)
 #

--- a/deploy/install/templates/baluhost-hardware-sudoers
+++ b/deploy/install/templates/baluhost-hardware-sudoers
@@ -39,6 +39,17 @@
 # Frontend-Wizard auf dieselbe Form verengt worden (#570). Ein Platzhalter fuer
 # freie Namen waere hier keine Loesung: er matcht auch Leerzeichen und liesse
 # zusaetzliche Optionen durch.
+#
+# ACHTUNG bei einer BESTEHENDEN Installation: ein bereits vorhandenes Array mit
+# einem Namen ausserhalb dieser Form (etwa /dev/md_data oder /dev/md1234) laesst
+# sich nach dem Sync nicht mehr verwalten -- `mdadm --detail /dev/md_data` wird
+# von sudo abgelehnt. Weil MdadmRaidBackend._build_array mit check=True in einer
+# Schleife ueber alle Arrays laeuft, reisst ein einziges solches Array die
+# GESAMTE RAID-Statusabfrage mit, nicht nur seine eigene Zeile. Vor dem Sync
+# also `cat /proc/mdstat` pruefen; bei einem abweichenden Namen entweder die
+# Muster oben um diese Form ergaenzen oder das Array umbenennen. Robuster waere,
+# _build_array pro Array degradieren zu lassen statt die Antwort abzubrechen --
+# eigene Arbeit, in #570 vermerkt.
 
 Cmnd_Alias BALUHOST_MDADM = \
     /usr/sbin/mdadm --detail --scan, \

--- a/deploy/install/templates/baluhost-hardware-sudoers
+++ b/deploy/install/templates/baluhost-hardware-sudoers
@@ -26,8 +26,19 @@
 # /dev/sd[a-c] und /dev/nvme[0-1], das Array /dev/md1 fuehrt sda1 (Partition)
 # und sdb (ganze Platte) -- deshalb sowohl sd[a-z] als auch sd[a-z][0-9].
 #
-# NUR /usr/sbin: auf Debian 13 (usrmerge) ist /sbin ein Symlink dorthin. Auf
-# einer Distribution ohne usrmerge muessen die Eintraege verdoppelt werden.
+# NUR /usr/sbin: auf Debian 13 (usrmerge) ist /sbin ein Symlink dorthin, und
+# sudo loest den blossen Namen `mdadm` ueber secure_path auf. Auf BaluNode
+# gemessen (2026-09-07):
+#   Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+# /usr/sbin steht dort vor /sbin, sudo matcht also gegen /usr/sbin/mdadm. Auf
+# einer Distribution ohne usrmerge oder mit umgekehrter Reihenfolge muessen die
+# Eintraege verdoppelt werden -- sonst greift keine einzige Zeile.
+#
+# Array-Namen: md0..md999. Weiter gehen die Muster nicht, und deshalb ist die
+# Namensvalidierung in schemas/system.py, mdadm_backend.py und dem
+# Frontend-Wizard auf dieselbe Form verengt worden (#570). Ein Platzhalter fuer
+# freie Namen waere hier keine Loesung: er matcht auch Leerzeichen und liesse
+# zusaetzliche Optionen durch.
 
 Cmnd_Alias BALUHOST_MDADM = \
     /usr/sbin/mdadm --detail --scan, \
@@ -111,17 +122,27 @@ Cmnd_Alias BALUHOST_MDADM = \
     /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --grow --bitmap=internal, \
     /usr/sbin/mdadm /dev/md[0-9][0-9][0-9] --grow --bitmap=none
 
-# Die einzige Zeile mit '*': --create nimmt eine variable Zahl von Geraeten und
-# haengt je nach Einstellung --assume-clean an, laesst sich also nicht auf eine
-# feste Argumentzahl festnageln. Begrenzt ist sie durch den Praefix (Array
-# unter /dev/md, numerisches Level und Geraetezahl); was danach kommt, faengt
-# mdadms eigener Modus-Parser ab, nicht sudo. Das ist schwaecher als der Rest
-# und der Kandidat fuer einen argumentpruefenden Wrapper unter /usr/local/sbin,
-# wie ihn der Plugin-Worker bereits benutzt.
+# Die einzigen Zeilen mit '*': --create nimmt eine variable Zahl von Geraeten
+# und haengt je nach Einstellung --assume-clean an, laesst sich also nicht auf
+# eine feste Argumentzahl festnageln. Begrenzt ist sie durch den Praefix; was
+# nach dem ersten /dev/ kommt, faengt mdadms eigener Modus-Parser ab, nicht
+# sudo. Das ist die schwaechste Stelle dieser Datei und der Kandidat fuer einen
+# argumentpruefenden Wrapper unter /usr/local/sbin, wie ihn der Plugin-Worker
+# bereits benutzt. Level zweistellig wegen raid10, --spare-devices als eigene
+# Form, weil es VOR dem ersten Geraet steht (mdadm_backend.py:613).
 Cmnd_Alias BALUHOST_MDADM_CREATE = \
     /usr/sbin/mdadm --create /dev/md[0-9] --level=[0-9] --raid-devices=[0-9] /dev/*, \
+    /usr/sbin/mdadm --create /dev/md[0-9] --level=[0-9] --raid-devices=[0-9] --spare-devices=[0-9] /dev/*, \
+    /usr/sbin/mdadm --create /dev/md[0-9] --level=[0-9][0-9] --raid-devices=[0-9] /dev/*, \
+    /usr/sbin/mdadm --create /dev/md[0-9] --level=[0-9][0-9] --raid-devices=[0-9] --spare-devices=[0-9] /dev/*, \
     /usr/sbin/mdadm --create /dev/md[0-9][0-9] --level=[0-9] --raid-devices=[0-9] /dev/*, \
-    /usr/sbin/mdadm --create /dev/md[0-9][0-9][0-9] --level=[0-9] --raid-devices=[0-9] /dev/*
+    /usr/sbin/mdadm --create /dev/md[0-9][0-9] --level=[0-9] --raid-devices=[0-9] --spare-devices=[0-9] /dev/*, \
+    /usr/sbin/mdadm --create /dev/md[0-9][0-9] --level=[0-9][0-9] --raid-devices=[0-9] /dev/*, \
+    /usr/sbin/mdadm --create /dev/md[0-9][0-9] --level=[0-9][0-9] --raid-devices=[0-9] --spare-devices=[0-9] /dev/*, \
+    /usr/sbin/mdadm --create /dev/md[0-9][0-9][0-9] --level=[0-9] --raid-devices=[0-9] /dev/*, \
+    /usr/sbin/mdadm --create /dev/md[0-9][0-9][0-9] --level=[0-9] --raid-devices=[0-9] --spare-devices=[0-9] /dev/*, \
+    /usr/sbin/mdadm --create /dev/md[0-9][0-9][0-9] --level=[0-9][0-9] --raid-devices=[0-9] /dev/*, \
+    /usr/sbin/mdadm --create /dev/md[0-9][0-9][0-9] --level=[0-9][0-9] --raid-devices=[0-9] --spare-devices=[0-9] /dev/*
 
 Cmnd_Alias BALUHOST_SMARTCTL = \
     /usr/sbin/smartctl --scan -j, \
@@ -133,6 +154,14 @@ Cmnd_Alias BALUHOST_SMARTCTL = \
     /usr/sbin/smartctl -H -i -l selftest -j -d [a-z][a-z][a-z][a-z] /dev/sd[a-z][0-9], \
     /usr/sbin/smartctl -H -i -l selftest -j -d [a-z][a-z][a-z][a-z] /dev/nvme[0-9], \
     /usr/sbin/smartctl -H -i -l selftest -j -d [a-z][a-z][a-z][a-z] /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/smartctl -A -H -i -l selftest -j -d [a-z][a-z][a-z] /dev/sd[a-z], \
+    /usr/sbin/smartctl -A -H -i -l selftest -j -d [a-z][a-z][a-z] /dev/sd[a-z][0-9], \
+    /usr/sbin/smartctl -A -H -i -l selftest -j -d [a-z][a-z][a-z] /dev/nvme[0-9], \
+    /usr/sbin/smartctl -A -H -i -l selftest -j -d [a-z][a-z][a-z] /dev/nvme[0-9]n[0-9], \
+    /usr/sbin/smartctl -A -H -i -l selftest -j -d [a-z][a-z][a-z][a-z] /dev/sd[a-z], \
+    /usr/sbin/smartctl -A -H -i -l selftest -j -d [a-z][a-z][a-z][a-z] /dev/sd[a-z][0-9], \
+    /usr/sbin/smartctl -A -H -i -l selftest -j -d [a-z][a-z][a-z][a-z] /dev/nvme[0-9], \
+    /usr/sbin/smartctl -A -H -i -l selftest -j -d [a-z][a-z][a-z][a-z] /dev/nvme[0-9]n[0-9], \
     /usr/sbin/smartctl -t short /dev/sd[a-z], \
     /usr/sbin/smartctl -t short /dev/sd[a-z][0-9], \
     /usr/sbin/smartctl -t short /dev/nvme[0-9], \


### PR DESCRIPTION
Schliesst den Rest von **#570 Punkt 5**: dieselbe Datei, die in PR #575 bei den `tee`-Regeln verengt wurde, gewährte `mdadm` und `smartctl` weiterhin **ohne jede Argumentbeschränkung**.

## Der Befund

```
NOPASSWD: /sbin/mdadm
NOPASSWD: /usr/sbin/mdadm
NOPASSWD: /usr/sbin/smartctl
```

Ein sudoers-Eintrag ohne Argumente erlaubt **jede** Argumentliste. Darunter:

- `mdadm --monitor --program <beliebiges Programm>` — mdadm startet das Programm als root. Ein Ausführungspfad, kein blosser Schreibzugriff.
- `--create` und `--zero-superblock` auf beliebigen Block-Geräten, vorbei an der OS-Disk-Sperre, die in Python sitzt.

Das war der längere Hebel als das in #575 behobene `tee /sys/class/hwmon/*` — und er stand direkt daneben.

## Die Änderung

Aufgezählt sind die zwölf Aufrufformen, die der Code kennt, mit Zeichenklassen statt Wildcards: 92 mdadm-Einträge (`--detail` mit und ohne Array, `--wait`, `--stop`, `--zero-superblock`, die fünf Verben `--fail`/`--remove`/`--add`/`--readwrite`/`--write-mostly`, `--grow --bitmap`, `--create`) und 25 smartctl-Einträge.

Die Gerätemuster stammen aus einer Messung auf BaluNode: `smartctl --scan` meldet `/dev/sd[a-c]` und `/dev/nvme[0-1]`, `/proc/mdstat` zeigt `md1` mit `sda1` (Partition) und `sdb` (ganze Platte). Auch der Binärpfad ist gemessen statt angenommen — `secure_path` führt `/usr/sbin` vor `/sbin`, sudo matcht also gegen `/usr/sbin/mdadm`; die frühere Doppelung war auf Debian 13 ohnehin derselbe Inode.

## Was die Reviews gefunden haben

Zwei Prüfrunden, beide mit Substanz:

**Ein Critical.** `smart/utils.py:96` schiebt ein `-A` an Position 3 ein, sobald weder `-d`-Typ noch Gerätename „nvme" enthält. Der reale Aufruf für SATA-Platten lautet also `smartctl -A -H -i -l selftest -j -d sat /dev/sda`; die erste Fassung kannte nur die Form ohne `-A`. Auf BaluNode wären damit genau die drei SATA-Platten — beide RAID1-Mitglieder darunter — **still** aus der SMART-Anzeige gefallen: `_run_smartctl` warnt nur und liefert `None`, die Karte hätte zwei statt fünf Geräte gezeigt, ohne Fehlermeldung.

Ursache: die Aufrufformen waren aus dem Code **abgeschrieben** statt aus ihm gewonnen. Der Test zieht sie jetzt aus `_run_smartctl` und aus `create_array` selbst, mit aufgezeichneter argv. Dabei fielen zwei weitere Formen auf, die der Handfassung entgangen waren: `--level=10` (raid10 steht in `valid_levels` und im Wizard) und `--spare-devices=N`, das **vor** dem ersten Gerät steht.

## Verhaltensänderung: Array-Namen

Erlaubt waren `md<beliebig viele Ziffern>` und `md_<alphanumerisch>`, bis 32 Zeichen. Eine sudoers-Regel kann das nicht abbilden, und ein Platzhalter mitten im Muster wäre keine Lösung — er matcht auch Leerzeichen und liesse zusätzliche Optionen durch, also genau den Ausführungspfad, um den es hier geht.

Die Validierung ist deshalb an allen vier Stellen auf `md[0-9]{1,3}` verengt: Pydantic-Schema, Backend-Sicherheitsnetz, Frontend-Helper und das HTML-`pattern` im Wizard. `md_backup` wird beim Anlegen jetzt mit klarer Meldung abgelehnt, statt später an sudo zu scheitern.

**Für bestehende Installationen im Vorlagenkommentar vermerkt:** ein bereits vorhandenes Array ausserhalb dieser Form liesse sich nach dem Sync nicht mehr verwalten, und weil `_build_array` mit `check=True` in einer Schleife über alle Arrays läuft, risse ein einziges solches Array die gesamte RAID-Statusabfrage mit. Auf BaluNode heisst das Array `md1`, ist also nicht betroffen. Die robustere Antwort — pro Array degradieren statt abbrechen — gehört in eigene Arbeit.

## Was bewusst offen bleibt

Die zwölf `--create`-Zeilen tragen als einzige ein `*` am Ende: die Zahl der Geräte ist variabel und `--assume-clean` kommt je nach Einstellung dazu. Begrenzt ist die Zeile über den Präfix; was nach dem ersten `/dev/` folgt, fängt mdadms eigener Modus-Parser ab, **nicht sudo**. Das ist die schwächste Stelle der Datei, im Kommentar als solche benannt, und der Kandidat für einen argumentprüfenden Wrapper unter `/usr/local/sbin` — dasselbe Muster, das der Plugin-Worker bereits benutzt.

Ausserdem unverändert: `mkfs.<fs>` läuft gar nicht über sudo (`_SUDO_COMMANDS` enthält es nicht), `format_disk` scheitert also schon heute an fehlenden Rechten. Vorbestehend, kein Regress dieses PRs.

## Prüfung

- `pytest tests/test_raid_sudoers_scope.py tests/test_hardware_sudoers_scope.py` → 71 bestanden.
- `pytest -k "raid or smart"` → 329 bestanden, 2 übersprungen. `ruff` sauber.
- Frontend: `vitest` der RAID-Wizard-Tests grün, `eslint .` → 0 Fehler, `npm run build` erfolgreich.
- **Gegenprobe:** der alte unbeschränkte Eintrag wieder eingesetzt → 12 Tests rot. Dabei kam eine Lücke im Testmodell selbst heraus: ein Eintrag **ohne** Argumente erlaubt in sudoers jede Argumentliste; die erste Fassung behandelte ihn als argumentloses Kommando und hielt den alten Zustand damit für sicher.

## Rollout

1. Wirkt erst nach einem Deploy mit `SYNC_PERMISSIONS=1` oder einem manuellen `install-hardware-sudoers.sh`. Ein Routine-Deploy rendert die Datei nicht neu.
2. Vor dem Sync `cat /proc/mdstat` — bei einem Array ausserhalb `md0..md999` erst die Muster ergänzen.
3. Der Installer prüft mit `visudo -cf` **vor** dem Austausch und legt ein Backup unter `/etc/sudoers.d/baluhost-hardware.bak.<zeitstempel>` an; schlägt die Prüfung fehl, bleibt die alte Datei stehen.
4. **Danach die Wirkung messen, nicht den Exit-Code:** die SMART-Seite muss alle drei SATA-Platten **und** beide NVMe zeigen, `journalctl -u baluhost-backend` darf keine „smartctl error … bits 0-1"-Zeilen bringen, und die Arrays aus `/proc/mdstat` müssen weiterhin in der RAID-Statusanzeige stehen. Trocken vorab: `sudo -n -l mdadm --detail --scan` — mit dem blossen Namen, weil sudo dann genau so auflöst wie das Backend aufruft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGS5jVzZpLcqpZ2VH8DqNn
