### PR TITLE
fix(power,raid,deploy): drei stille Fehlschlaege beheben (#570)

### DIFF
--- a/backend/app/api/routes/files.py
+++ b/backend/app/api/routes/files.py
@@ -236,6 +236,37 @@ def _jail_path(path: str, user: UserPublic, db: Session | None = None) -> str:
     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
 
 
+
+# Gesund heisst: kein Handlungsbedarf. "checking" gehoert dazu -- ein
+# monatlicher Scrub (Debians checkarray) ist Wartung, kein Fehler, und wuerde
+# sonst ein Warndreieck in der Oberflaeche erzeugen. "clean" und "active"
+# stehen bewusst NICHT hier: _derive_array_status liefert sie nie (clean faellt
+# auf "optimal", active ist ein Geraete-Zustand), und eine Aufzaehlung, die
+# unerreichbare Werte fuehrt, taeuscht Sorgfalt vor.
+_GESUNDE_ARRAY_ZUSTAENDE = frozenset({"optimal", "checking"})
+
+
+def worst_array_status(arrays: list) -> str:
+    """Der schlechteste Zustand ueber alle RAID-Arrays.
+
+    Umgedreht formuliert (#570): frueher hob nur "degraded" oder "rebuilding"
+    den Zustand von "optimal" weg -- jeder unbekannte Wert galt damit als in
+    Ordnung. Seit get_status() ein nicht lesbares Array als "unknown" meldet,
+    statt die ganze Antwort abzubrechen, waere das ein gruenes Signal fuer
+    einen Fehlerfall gewesen.
+
+    Eigene Funktion statt eines Blocks im Handler, damit die Bewertung ohne
+    Datenbank und Dateisystem pruefbar ist.
+    """
+    schlechtester = "optimal"
+    for array in arrays:
+        if array.status == "degraded":
+            return "degraded"
+        if array.status not in _GESUNDE_ARRAY_ZUSTAENDE and schlechtester == "optimal":
+            schlechtester = array.status
+    return schlechtester
+
+
 router = APIRouter()
 
 
@@ -481,19 +512,7 @@ async def get_mountpoints(
                     used_bytes = 0
                     available_bytes = 0
 
-            # Umgedreht formuliert (#570): frueher hob nur "degraded" oder
-            # "rebuilding" den Zustand von "optimal" weg -- jeder unbekannte
-            # Wert galt damit als in Ordnung. Seit get_status() ein nicht
-            # lesbares Array als "unknown" meldet statt die ganze Antwort
-            # abzubrechen, waere das ein gruenes Signal fuer einen Fehlerfall.
-            _GESUND = {"optimal", "clean", "active"}
-            worst_status = "optimal"
-            for a in raid_arrays:
-                if a.status == "degraded":
-                    worst_status = "degraded"
-                    break
-                if a.status not in _GESUND and worst_status == "optimal":
-                    worst_status = a.status
+            worst_status = worst_array_status(raid_arrays)
 
             breakdown = compute_storage_breakdown(
                 raid_mountpoint or str(ROOT_DIR), used_bytes, db,

--- a/backend/app/api/routes/files.py
+++ b/backend/app/api/routes/files.py
@@ -481,13 +481,19 @@ async def get_mountpoints(
                     used_bytes = 0
                     available_bytes = 0
 
+            # Umgedreht formuliert (#570): frueher hob nur "degraded" oder
+            # "rebuilding" den Zustand von "optimal" weg -- jeder unbekannte
+            # Wert galt damit als in Ordnung. Seit get_status() ein nicht
+            # lesbares Array als "unknown" meldet statt die ganze Antwort
+            # abzubrechen, waere das ein gruenes Signal fuer einen Fehlerfall.
+            _GESUND = {"optimal", "clean", "active"}
             worst_status = "optimal"
             for a in raid_arrays:
                 if a.status == "degraded":
                     worst_status = "degraded"
                     break
-                if a.status == "rebuilding" and worst_status != "degraded":
-                    worst_status = "rebuilding"
+                if a.status not in _GESUND and worst_status == "optimal":
+                    worst_status = a.status
 
             breakdown = compute_storage_breakdown(
                 raid_mountpoint or str(ROOT_DIR), used_bytes, db,

--- a/backend/app/services/hardware/raid/mdadm_backend.py
+++ b/backend/app/services/hardware/raid/mdadm_backend.py
@@ -63,7 +63,29 @@ class MdadmRaidBackend:
         arrays: List[RaidArray] = []
         for name in sorted(array_names):
             info = mdstat_info.get(name)
-            arrays.append(self._build_array(name, info, disk_type_map))
+            try:
+                arrays.append(self._build_array(name, info, disk_type_map))
+            except Exception as exc:
+                # Ein Array darf die Antwort fuer alle anderen nicht mitnehmen.
+                # _build_array ruft `mdadm --detail` mit check=True; scheitert
+                # das fuer EIN Array -- fehlende sudoers-Abdeckung fuer einen
+                # ungewoehnlichen Namen, ein gerade verschwundenes Geraet --,
+                # brach bisher die gesamte RAID-Statusabfrage ab. Der Nutzer
+                # sah dann gar keine Arrays statt eines fehlerhaften.
+                logger.warning("RAID-Details fuer %s nicht lesbar: %s", name, exc)
+                # Was /proc/mdstat hergibt, bleibt sichtbar: die Mitglieder
+                # stehen dort auch dann, wenn `mdadm --detail` scheitert.
+                # MdstatInfo fuehrt kein Level -- deshalb "unknown".
+                arrays.append(RaidArray(
+                    name=name,
+                    level="unknown",
+                    size_bytes=0,
+                    status="unknown",
+                    devices=[
+                        RaidDevice(name=m, state="unknown")
+                        for m in (info.members if info else [])
+                    ],
+                ))
 
         speed_limits = self._read_speed_limits()
 

--- a/backend/app/services/hardware/raid/mdadm_backend.py
+++ b/backend/app/services/hardware/raid/mdadm_backend.py
@@ -72,7 +72,13 @@ class MdadmRaidBackend:
                 # ungewoehnlichen Namen, ein gerade verschwundenes Geraet --,
                 # brach bisher die gesamte RAID-Statusabfrage ab. Der Nutzer
                 # sah dann gar keine Arrays statt eines fehlerhaften.
-                logger.warning("RAID-Details fuer %s nicht lesbar: %s", name, exc)
+                # exc_info, weil eine Ausnahme ohne Argumente sonst eine
+                # leere Meldung hinterliesse -- genau der Fall, den dieser
+                # Commit im GPU-Manager behebt. _run loggt denselben
+                # Fehlschlag bereits auf ERROR; hier steht der Kontext,
+                # WELCHES Array betroffen ist.
+                logger.warning("RAID-Details fuer %s nicht lesbar: %s", name, exc,
+                               exc_info=True)
                 # Was /proc/mdstat hergibt, bleibt sichtbar: die Mitglieder
                 # stehen dort auch dann, wenn `mdadm --detail` scheitert.
                 # MdstatInfo fuehrt kein Level -- deshalb "unknown".

--- a/backend/app/services/power/gpu/manager.py
+++ b/backend/app/services/power/gpu/manager.py
@@ -180,6 +180,16 @@ class GpuPowerManagerService:
             self._state = GpuPowerState.ACTIVE
         self._last_transition = state.get("last_transition")
         self._last_reason = state.get("last_reason")
+        # _standby_since mitfuehren, damit die Deep-Idle-Frist einen Neustart
+        # ueberlebt statt neu zu beginnen: der letzte Uebergang IST der Beginn
+        # des STANDBY. Naive Zeitstempel aus der Datenbank werden als UTC
+        # gelesen -- ein Vergleich mit einem aware datetime wuerde sonst
+        # TypeError werfen.
+        if self._state == GpuPowerState.STANDBY and self._last_transition is not None:
+            seit = self._last_transition
+            if seit.tzinfo is None:
+                seit = seit.replace(tzinfo=timezone.utc)
+            self._standby_since = seit
 
     async def stop(self) -> None:
         if not self._is_running:
@@ -220,8 +230,12 @@ class GpuPowerManagerService:
                 self._refresh_demand_cache()
                 await self._tick()
                 self._write_status_shm()
-            except Exception as exc:
-                logger.error("GPU power monitor tick failed: %s", exc)
+            except Exception:
+                # exception() statt error("%s", exc): eine Ausnahme ohne
+                # Argumente -- etwa ein AssertionError -- stringifiziert zu ''
+                # und hinterliess hier 778 Logzeilen, die nur aus dem Praefix
+                # bestanden. Typ und Traceback beantworten die Frage sofort.
+                logger.exception("GPU power monitor tick failed")
             await asyncio.sleep(self._config.monitor_interval_seconds)
 
     def _refresh_demand_cache(self) -> None:
@@ -272,7 +286,19 @@ class GpuPowerManagerService:
                 await self._transition(GpuPowerState.STANDBY, "idle_window_elapsed")
                 self._standby_since = now
         elif self._state == GpuPowerState.STANDBY:
-            assert self._standby_since is not None
+            if self._standby_since is None:
+                # Kein Programmierfehler, sondern der normale Zustand nach
+                # einem Neustart: _hydrate_from_runtime_state holt _state aus
+                # der Datenbank, _standby_since lebt aber nur im Prozess. Hier
+                # stand ein `assert`, dessen AssertionError ohne Meldung als
+                # leere Zeile im Log landete -- und der den Tick VOR dem
+                # Uebergang nach DEEP_IDLE abbrach. Die GPU blieb damit nach
+                # jedem Neustart im STANDBY haengen (#570-Nachlese).
+                self._standby_since = now
+                logger.info(
+                    "STANDBY ohne bekannten Startzeitpunkt -- Deep-Idle-Frist "
+                    "beginnt jetzt neu"
+                )
             if now - self._standby_since >= timedelta(seconds=self._config.deep_idle_extra_seconds):
                 await emit_deep_idle_entering()
                 if self._config.deep_idle_grace_seconds > 0:

--- a/backend/app/services/power/manager.py
+++ b/backend/app/services/power/manager.py
@@ -515,8 +515,8 @@ class PowerManagerService:
                 await self._check_expired_demands()
                 await self._check_auto_scaling()
                 await self._write_status_shm()
-            except Exception as e:
-                logger.error(f"Error in power monitor loop: {e}")
+            except Exception:
+                logger.exception("Error in power monitor loop")
 
             await asyncio.sleep(5)  # Check every 5 seconds
 
@@ -868,8 +868,8 @@ class PowerManagerService:
                 if self._primary and self._authority_active():
                     await self._watch_tick()
                     await self._enforce_current_profile()
-            except Exception as e:
-                logger.error(f"Error in enforcement loop: {e}")
+            except Exception:
+                logger.exception("Error in enforcement loop")
             await asyncio.sleep(2)
 
     async def _get_profile_config_from_preset(

--- a/backend/tests/test_ci_deploy_permission_sync.py
+++ b/backend/tests/test_ci_deploy_permission_sync.py
@@ -1,0 +1,68 @@
+"""Der Deploy benennt den einen sudoers-Blindfleck, statt still zu scheitern (#570).
+
+Gemessen im Deploy-Log vom 2026-09-07 (Lauf 34142444452):
+
+    INFO  Re-applying power sudoers...
+    sudo: Ein Passwort ist notwendig
+    WARN  Power sudoers sync failed (non-fatal - deploy continues).
+
+`/etc/sudoers.d/baluhost-deploy` ist die einzige der vier sudoers-Dateien, die
+ci-deploy.sh nicht neu rendern kann -- sie enthaelt genau die Erlaubnis, mit
+der die anderen drei installiert werden. Neue Zeilen der Vorlage erreichen eine
+bereits installierte Box deshalb nie, und der Fehlschlag sah aus wie ein
+beliebiger Fehler statt wie eine fehlende Provisionierung.
+
+Geprueft wird das Skript textlich: es laeuft nur auf der Maschine, aber die
+Zusicherungen unten wuerden jede Ruecknahme der Diagnose bemerken.
+"""
+import re
+from pathlib import Path
+
+CI_DEPLOY = Path(__file__).resolve().parents[2] / "deploy" / "scripts" / "ci-deploy.sh"
+DEPLOY_SUDOERS = (
+    Path(__file__).resolve().parents[2]
+    / "deploy" / "install" / "templates" / "baluhost-deploy-sudoers"
+)
+
+
+def _text() -> str:
+    return CI_DEPLOY.read_text(encoding="utf-8")
+
+
+def test_das_deploy_skript_ist_ueberhaupt_lesbar():
+    """Schutz gegen einen vakuum-gruenen Test: ohne Inhalt waeren die
+    Zusicherungen unten bedeutungslos."""
+    assert CI_DEPLOY.is_file()
+    assert "SYNC_PERMISSIONS" in _text()
+
+
+def test_der_power_sudoers_aufruf_wird_vorher_auf_erlaubnis_geprueft():
+    """`sudo -n -l` fragt, ob der Aufruf erlaubt WAERE, ohne ihn auszufuehren.
+    Ohne diese Vorabpruefung landete die Ursache als 'a password is required'
+    im Log und die Zusammenfassung sagte nur 'failed'."""
+    text = _text()
+    assert 'sudo -n -l bash "$POWER_SUDOERS_SCRIPT"' in text
+
+
+def test_die_meldung_nennt_den_befehl_der_es_behebt():
+    """Eine Warnung ohne Handlungsanweisung kostet beim naechsten Mal wieder
+    eine Stunde Suche."""
+    text = _text()
+    assert "install-deploy-sudoers.sh" in text
+    assert "NOT PERMITTED" in text
+
+
+def test_die_vorlage_erlaubt_den_power_aufruf_ueberhaupt():
+    """Die Gegenprobe zur Diagnose: waere der Eintrag in der Vorlage gar nicht
+    vorhanden, waere nicht die Box veraltet, sondern das Repo falsch -- und die
+    Handlungsanweisung ginge ins Leere."""
+    zeilen = [
+        z for z in DEPLOY_SUDOERS.read_text(encoding="utf-8").splitlines()
+        if not z.lstrip().startswith("#")
+    ]
+    treffer = [z for z in zeilen if "install-power-sudoers.sh" in z]
+    assert treffer, "die Vorlage muss den Aufruf erlauben"
+    assert all("NOPASSWD" in z for z in treffer)
+    # Beide bash-Pfade, weil sudo den aufgeloesten Pfad vergleicht.
+    assert any(re.search(r"/bin/bash ", z) for z in treffer)
+    assert any(re.search(r"/usr/bin/bash ", z) for z in treffer)

--- a/backend/tests/test_ci_deploy_permission_sync.py
+++ b/backend/tests/test_ci_deploy_permission_sync.py
@@ -36,12 +36,36 @@ def test_das_deploy_skript_ist_ueberhaupt_lesbar():
     assert "SYNC_PERMISSIONS" in _text()
 
 
-def test_der_power_sudoers_aufruf_wird_vorher_auf_erlaubnis_geprueft():
+def test_jedes_permission_skript_laeuft_ueber_den_helfer():
+    """Kein direkter `sudo bash` mehr auf eines der drei Skripte.
+
+    Der Helfer traegt die Vorabpruefung; ein Aufruf daran vorbei haette sie
+    nicht. Geprueft wird deshalb die Abwesenheit des alten Musters, nicht nur
+    die Anwesenheit des neuen."""
+    text = _text()
+    assert "run_permission_script()" in text, "der Helfer muss definiert sein"
+    # Zeilenfortsetzungen aufloesen, sonst stuenden Aufruf und Pfad in
+    # verschiedenen Zeilen und die Zuordnung waere nicht pruefbar. Die alte
+    # Fassung fragte nur, ob BEIDE Zeichenketten irgendwo in der Datei stehen --
+    # das haette auch ein Aufruf am Helfer vorbei erfuellt.
+    verbunden = re.sub(r"\\\s*\n\s*", " ", text)
+    aufrufe = re.findall(r'run_permission_script\s+"[^"]+"\s+(\S+)', verbunden)
+    for skript in ("install-amd-gpu-permissions.sh", "install-hardware-sudoers.sh",
+                   "install-power-sudoers.sh"):
+        assert any(skript in a for a in aufrufe), f"{skript} laeuft nicht ueber den Helfer"
+    # Der Helfer ist die einzige Stelle, die eines dieser Skripte ausfuehrt.
+    assert text.count('sudo bash "$script"') == 1
+    assert 'sudo bash "$POWER_SUDOERS_SCRIPT"' not in text
+    assert 'sudo bash "$HARDWARE_SUDOERS_SCRIPT"' not in text
+    assert 'sudo bash "$AMD_GPU_SCRIPT"' not in text
+
+
+def test_der_helfer_prueft_vorher_ob_der_aufruf_erlaubt_waere():
     """`sudo -n -l` fragt, ob der Aufruf erlaubt WAERE, ohne ihn auszufuehren.
     Ohne diese Vorabpruefung landete die Ursache als 'a password is required'
     im Log und die Zusammenfassung sagte nur 'failed'."""
     text = _text()
-    assert 'sudo -n -l bash "$POWER_SUDOERS_SCRIPT"' in text
+    assert 'sudo -n -l bash "$script"' in text
 
 
 def test_die_meldung_nennt_den_befehl_der_es_behebt():
@@ -50,6 +74,27 @@ def test_die_meldung_nennt_den_befehl_der_es_behebt():
     text = _text()
     assert "install-deploy-sudoers.sh" in text
     assert "NOT PERMITTED" in text
+
+
+def test_die_handlungsanweisung_kann_den_naechsten_deploy_nicht_lahmlegen():
+    """Zwei Fallen, beide in der Review gefunden, beide hier festgenagelt.
+
+    `$USER` in der ausgegebenen Zeile: die Anweisung wird in einer root-Shell
+    ausgefuehrt, dort waere das "root". Die Datei wuerde fuer root gerendert,
+    der Dienstbenutzer verloere alle NOPASSWD-Rechte, und der naechste Deploy
+    braeche beim Neustart der Dienste ab.
+
+    Fehlendes `env`: sudo lehnt Zuweisungen in der Kommandozeile ohne SETENV
+    ab (env_reset ist Debian-Standard) -- der Befehl waere schlicht nicht
+    ausfuehrbar.
+    """
+    zeile = next(
+        z for z in _text().splitlines()
+        if "install-deploy-sudoers.sh" in z and "log_warn" in z
+    )
+    assert "$USER" not in zeile, "Benutzername muss beim Drucken eingesetzt werden"
+    assert "$(id -un)" in zeile
+    assert "sudo env BALUHOST_USER=" in zeile
 
 
 def test_die_vorlage_erlaubt_den_power_aufruf_ueberhaupt():
@@ -63,6 +108,9 @@ def test_die_vorlage_erlaubt_den_power_aufruf_ueberhaupt():
     treffer = [z for z in zeilen if "install-power-sudoers.sh" in z]
     assert treffer, "die Vorlage muss den Aufruf erlauben"
     assert all("NOPASSWD" in z for z in treffer)
-    # Beide bash-Pfade, weil sudo den aufgeloesten Pfad vergleicht.
-    assert any(re.search(r"/bin/bash ", z) for z in treffer)
-    assert any(re.search(r"/usr/bin/bash ", z) for z in treffer)
+    # Beide bash-Pfade, weil sudo den aufgeloesten Pfad vergleicht. Verankert
+    # gegen den Doppelpunkt: "/bin/bash " ist eine Teilzeichenkette von
+    # "/usr/bin/bash ", eine blosse Suche waere also schon durch die zweite
+    # Zeile erfuellt und koennte den Verlust der ersten nicht bemerken.
+    pfade = {re.search(r"NOPASSWD:\s+(\S+)", z).group(1) for z in treffer}
+    assert pfade == {"/bin/bash", "/usr/bin/bash"}

--- a/backend/tests/test_gpu_standby_hydration.py
+++ b/backend/tests/test_gpu_standby_hydration.py
@@ -1,0 +1,118 @@
+"""Der GPU-Tick ueberlebt einen Neustart im Zustand STANDBY (#570-Nachlese).
+
+Auf BaluNode gemessen (2026-09-07): 778 Logzeilen `GPU power monitor tick
+failed: ` seit dem 06.09. 15:27 -- mit LEERER Meldung. Ursache war ein
+`assert self._standby_since is not None` im Tick: _hydrate_from_runtime_state
+holt _state aus der Datenbank, _standby_since lebt aber nur im Prozess. Ein
+AssertionError ohne Argumente stringifiziert zu '', deshalb sagte die Zeile
+nichts.
+
+Der Schaden war nicht der Logeintrag: der Tick brach VOR dem Uebergang nach
+DEEP_IDLE ab. Nach einem Neustart im STANDBY erreichte die GPU den Tiefschlaf
+also nie wieder.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.services.power.gpu import manager as manager_module
+from app.services.power.gpu.manager import GpuPowerManagerService
+from app.schemas.gpu_power import GpuPowerState
+
+
+def _service(monkeypatch, *, state: GpuPowerState, last_transition):
+    """Ein Dienst, dessen Zustand aus der Laufzeittabelle kommt -- wie nach
+    einem Neustart."""
+    svc = object.__new__(GpuPowerManagerService)
+    svc._state = GpuPowerState.ACTIVE
+    svc._standby_since = None
+    svc._idle_since = datetime.now(timezone.utc)
+    svc._last_transition = None
+    svc._last_reason = None
+    monkeypatch.setattr(
+        manager_module, "load_runtime_state",
+        lambda: {"current_state": state.value, "last_transition": last_transition,
+                 "last_reason": "idle_window_elapsed"},
+    )
+    return svc
+
+
+def test_standby_seit_wird_aus_der_laufzeittabelle_wiederhergestellt(monkeypatch):
+    """Der letzte Uebergang IST der Beginn des STANDBY -- die Deep-Idle-Frist
+    ueberlebt damit den Neustart, statt neu zu beginnen."""
+    vorher = datetime.now(timezone.utc) - timedelta(minutes=42)
+    svc = _service(monkeypatch, state=GpuPowerState.STANDBY, last_transition=vorher)
+
+    svc._hydrate_from_runtime_state()
+
+    assert svc._state is GpuPowerState.STANDBY
+    assert svc._standby_since == vorher
+
+
+def test_ein_naiver_zeitstempel_wird_als_utc_gelesen(monkeypatch):
+    """Die Datenbank liefert je nach Treiber einen naiven datetime. Ohne
+    tzinfo wuerde der Vergleich im Tick mit TypeError fliegen -- also genau
+    wieder eine Ausnahme im Tick, nur mit anderem Text."""
+    naiv = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=5)
+    svc = _service(monkeypatch, state=GpuPowerState.STANDBY, last_transition=naiv)
+
+    svc._hydrate_from_runtime_state()
+
+    assert svc._standby_since is not None
+    assert svc._standby_since.tzinfo is not None
+    # Vergleichbar mit einem aware datetime, ohne zu werfen:
+    assert datetime.now(timezone.utc) - svc._standby_since >= timedelta(minutes=4)
+
+
+def test_ohne_letzten_uebergang_bleibt_es_offen(monkeypatch):
+    """Kein Zeitstempel in der Tabelle: dann faengt der Tick die Luecke ab,
+    nicht das Hydrieren."""
+    svc = _service(monkeypatch, state=GpuPowerState.STANDBY, last_transition=None)
+
+    svc._hydrate_from_runtime_state()
+
+    assert svc._standby_since is None
+
+
+@pytest.mark.asyncio
+async def test_der_tick_wirft_nicht_wenn_der_zeitpunkt_fehlt(monkeypatch):
+    """Der eigentliche Regressionstest: STANDBY ohne _standby_since darf den
+    Tick nicht abbrechen. Vor dem Fix stand hier ein assert."""
+    svc = object.__new__(GpuPowerManagerService)
+    svc._state = GpuPowerState.STANDBY
+    svc._standby_since = None
+    svc._idle_since = datetime.now(timezone.utc)
+
+    class _Config:
+        enabled = True
+        usage_threshold_percent = 10.0
+        idle_window_seconds = 60
+        deep_idle_extra_seconds = 300
+        deep_idle_grace_seconds = 0
+
+    class _Backend:
+        detected = True
+
+    svc._config = _Config()
+    svc._backend = _Backend()
+    svc._demands = {}
+
+    async def _keine_displays():
+        return 0
+
+    async def _keine_last():
+        return 0.0
+
+    async def _nichts_zu_raeumen():
+        return None
+
+    monkeypatch.setattr(svc, "_get_displays", _keine_displays, raising=False)
+    monkeypatch.setattr(svc, "_get_usage_percent", _keine_last, raising=False)
+    monkeypatch.setattr(svc, "_purge_expired_demands", _nichts_zu_raeumen, raising=False)
+
+    await svc._tick()
+
+    # Der Tick hat die Frist eroeffnet statt zu werfen; DEEP_IDLE kommt beim
+    # naechsten Durchlauf, sobald deep_idle_extra_seconds verstrichen sind.
+    assert svc._standby_since is not None
+    assert svc._state is GpuPowerState.STANDBY

--- a/backend/tests/test_raid_status_degrades_per_array.py
+++ b/backend/tests/test_raid_status_degrades_per_array.py
@@ -9,6 +9,7 @@ Aufgefallen ist das beim Verengen der sudoers-Regeln: dort ist die Namensform
 auf md0..md999 begrenzt, und die Frage "was passiert mit einem bestehenden
 Array ausserhalb dieser Form" hatte bis dahin keine gute Antwort.
 """
+import subprocess
 from unittest.mock import MagicMock
 
 import pytest
@@ -28,18 +29,24 @@ def _backend(monkeypatch, *, arrays: dict, kaputt: set[str]) -> MdadmRaidBackend
     monkeypatch.setattr(MdadmRaidBackend, "_read_speed_limits",
                         lambda self: RaidSpeedLimits(minimum=1000, maximum=200000))
 
-    echtes_build = MdadmRaidBackend._build_array
+    # Der Fehler wird NICHT in _build_array injiziert, sondern dort, wo er real
+    # entsteht: subprocess.run wirft CalledProcessError, das echte _run wandelt
+    # ihn in RuntimeError um. Damit laeuft der Pfad, den die Produktion nimmt --
+    # eine Attrappe um _build_array herum haette die Umwandlung uebersprungen.
+    def _subprocess_run(cmd, **kw):
+        ziel = cmd[-1] if isinstance(cmd, (list, tuple)) else str(cmd)
+        if any(f"/dev/{name}" == ziel for name in kaputt):
+            raise subprocess.CalledProcessError(
+                returncode=1, cmd=cmd,
+                stderr=f"mdadm: cannot open {ziel}: No such file or directory",
+            )
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0,
+            stdout="Raid Level : raid1\nState : clean\n", stderr="",
+        )
 
-    def _build(self, name, info, disk_type_map=None):
-        if name in kaputt:
-            raise RuntimeError(f"mdadm: cannot open /dev/{name}: No such file or directory")
-        return echtes_build(self, name, info, disk_type_map)
-
-    monkeypatch.setattr(MdadmRaidBackend, "_build_array", _build)
-    monkeypatch.setattr(
-        MdadmRaidBackend, "_run",
-        lambda self, cmd, **kw: MagicMock(stdout="Raid Level : raid1\nState : clean\n"),
-    )
+    monkeypatch.setattr("app.services.hardware.raid.mdadm_backend.subprocess.run",
+                        _subprocess_run)
     monkeypatch.setattr(MdadmRaidBackend, "_resolve_array_size", lambda *a, **k: 1024)
     monkeypatch.setattr(MdadmRaidBackend, "_resolve_progress", lambda *a, **k: None)
     monkeypatch.setattr(MdadmRaidBackend, "_parse_devices", lambda *a, **k: [])

--- a/backend/tests/test_raid_status_degrades_per_array.py
+++ b/backend/tests/test_raid_status_degrades_per_array.py
@@ -1,0 +1,94 @@
+"""Ein unlesbares Array reisst die RAID-Statusantwort nicht mehr mit (#570).
+
+`_build_array` ruft `mdadm --detail` mit check=True. Scheitert das fuer EIN
+Array -- ein gerade entferntes Geraet, oder ein Name, den die verengten
+sudoers-Regeln nicht abdecken --, brach bisher die gesamte Statusabfrage ab:
+der Nutzer sah gar keine Arrays statt eines fehlerhaften.
+
+Aufgefallen ist das beim Verengen der sudoers-Regeln: dort ist die Namensform
+auf md0..md999 begrenzt, und die Frage "was passiert mit einem bestehenden
+Array ausserhalb dieser Form" hatte bis dahin keine gute Antwort.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.schemas.system import RaidSpeedLimits
+from app.services.hardware.raid.mdadm_backend import MdadmRaidBackend
+from app.services.hardware.raid.parsing import MdstatInfo
+
+
+def _backend(monkeypatch, *, arrays: dict, kaputt: set[str]) -> MdadmRaidBackend:
+    backend = object.__new__(MdadmRaidBackend)
+    backend._lsblk_available = False
+
+    monkeypatch.setattr(MdadmRaidBackend, "_read_mdstat", lambda self: arrays)
+    monkeypatch.setattr(MdadmRaidBackend, "_scan_arrays", lambda self: [])
+    monkeypatch.setattr(MdadmRaidBackend, "_get_disk_type_map", lambda self: {})
+    monkeypatch.setattr(MdadmRaidBackend, "_read_speed_limits",
+                        lambda self: RaidSpeedLimits(minimum=1000, maximum=200000))
+
+    echtes_build = MdadmRaidBackend._build_array
+
+    def _build(self, name, info, disk_type_map=None):
+        if name in kaputt:
+            raise RuntimeError(f"mdadm: cannot open /dev/{name}: No such file or directory")
+        return echtes_build(self, name, info, disk_type_map)
+
+    monkeypatch.setattr(MdadmRaidBackend, "_build_array", _build)
+    monkeypatch.setattr(
+        MdadmRaidBackend, "_run",
+        lambda self, cmd, **kw: MagicMock(stdout="Raid Level : raid1\nState : clean\n"),
+    )
+    monkeypatch.setattr(MdadmRaidBackend, "_resolve_array_size", lambda *a, **k: 1024)
+    monkeypatch.setattr(MdadmRaidBackend, "_resolve_progress", lambda *a, **k: None)
+    monkeypatch.setattr(MdadmRaidBackend, "_parse_devices", lambda *a, **k: [])
+    monkeypatch.setattr(MdadmRaidBackend, "_read_sync_action", lambda *a, **k: None)
+    return backend
+
+
+def test_ein_kaputtes_array_nimmt_die_gesunden_nicht_mit(monkeypatch):
+    backend = _backend(
+        monkeypatch,
+        arrays={"md1": MdstatInfo(members=["sda1", "sdb"]),
+                "md_data": MdstatInfo(members=["sdc"])},
+        kaputt={"md_data"},
+    )
+
+    antwort = backend.get_status()
+
+    namen = {a.name for a in antwort.arrays}
+    assert namen == {"md1", "md_data"}, "beide Arrays muessen sichtbar bleiben"
+    gesund = next(a for a in antwort.arrays if a.name == "md1")
+    assert gesund.level == "raid1"
+
+
+def test_das_kaputte_array_wird_als_unbekannt_gemeldet_statt_verschwiegen(monkeypatch):
+    backend = _backend(
+        monkeypatch,
+        arrays={"md_data": MdstatInfo(members=["sdc", "sdd"])},
+        kaputt={"md_data"},
+    )
+
+    antwort = backend.get_status()
+
+    array = antwort.arrays[0]
+    assert array.name == "md_data"
+    assert array.status == "unknown"
+    assert array.level == "unknown"
+    # Was /proc/mdstat hergibt, bleibt sichtbar -- die Mitglieder stehen dort
+    # auch dann, wenn mdadm --detail scheitert.
+    assert [d.name for d in array.devices] == ["sdc", "sdd"]
+
+
+def test_ohne_fehler_bleibt_alles_wie_vorher(monkeypatch):
+    backend = _backend(
+        monkeypatch,
+        arrays={"md0": MdstatInfo(members=["sda"]), "md1": MdstatInfo(members=["sdb"])},
+        kaputt=set(),
+    )
+
+    antwort = backend.get_status()
+
+    assert [a.name for a in antwort.arrays] == ["md0", "md1"]
+    assert all(a.status != "unknown" for a in antwort.arrays)

--- a/backend/tests/test_raid_status_degrades_per_array.py
+++ b/backend/tests/test_raid_status_degrades_per_array.py
@@ -10,9 +10,6 @@ auf md0..md999 begrenzt, und die Frage "was passiert mit einem bestehenden
 Array ausserhalb dieser Form" hatte bis dahin keine gute Antwort.
 """
 import subprocess
-from unittest.mock import MagicMock
-
-import pytest
 
 from app.schemas.system import RaidSpeedLimits
 from app.services.hardware.raid.mdadm_backend import MdadmRaidBackend

--- a/backend/tests/test_worst_array_status.py
+++ b/backend/tests/test_worst_array_status.py
@@ -1,0 +1,56 @@
+"""Die Gesamtbewertung der RAID-Arrays fuer die Mountpoint-Anzeige (#570).
+
+Vorgeschichte: die Bewertung startete auf "optimal" und wurde nur von
+"degraded" oder "rebuilding" davon weggehoben -- jeder andere Wert galt damit
+als in Ordnung. Solange get_status() bei einem unlesbaren Array die ganze
+Antwort abbrach, fiel das nicht auf (der Endpunkt lieferte einen 500er:
+falsch, aber laut). Seit dieselbe Runde die Antwort pro Array degradieren
+laesst und "unknown" melden kann, waere daraus ein GRUENES Signal fuer einen
+Fehlerfall geworden.
+"""
+import pytest
+
+from app.api.routes.files import worst_array_status
+from app.schemas.system import RaidArray
+
+
+def _array(name: str, status: str) -> RaidArray:
+    return RaidArray(name=name, level="raid1", size_bytes=1024,
+                     status=status, devices=[])
+
+
+def test_ohne_arrays_gilt_optimal():
+    assert worst_array_status([]) == "optimal"
+
+
+def test_alles_optimal_bleibt_optimal():
+    assert worst_array_status([_array("md0", "optimal"), _array("md1", "optimal")]) == "optimal"
+
+
+def test_ein_unlesbares_array_ist_nicht_optimal():
+    """Der eigentliche Regressionstest: 'unknown' darf nicht als gesund
+    durchgehen. Vorher meldete die Mountpoint-Anzeige hier 'optimal' und die
+    Oberflaeche zeigte kein Warnzeichen."""
+    assert worst_array_status([_array("md0", "optimal"), _array("md1", "unknown")]) == "unknown"
+
+
+def test_ein_scrub_ist_kein_fehler():
+    """'checking' entsteht bei Debians monatlichem checkarray. Das ist
+    Wartung, kein Handlungsbedarf -- ein Warndreieck waere ein Fehlalarm."""
+    assert worst_array_status([_array("md0", "checking")]) == "optimal"
+
+
+@pytest.mark.parametrize("status", ["rebuilding", "inactive", "unknown"])
+def test_jeder_nicht_gesunde_zustand_hebt_die_bewertung(status):
+    assert worst_array_status([_array("md0", status)]) == status
+
+
+def test_degraded_sticht_alles_andere():
+    """Auch wenn es hinten steht und ein anderer Zustand schon gesetzt ist."""
+    arrays = [_array("md0", "checking"), _array("md1", "unknown"), _array("md2", "degraded")]
+    assert worst_array_status(arrays) == "degraded"
+
+
+def test_degraded_sticht_auch_als_erstes():
+    arrays = [_array("md0", "degraded"), _array("md1", "rebuilding")]
+    assert worst_array_status(arrays) == "degraded"

--- a/deploy/scripts/ci-deploy.sh
+++ b/deploy/scripts/ci-deploy.sh
@@ -475,7 +475,19 @@ if [[ "${SYNC_PERMISSIONS:-0}" == "1" || "${SYNC_PERMISSIONS,,}" == "true" ]]; t
     POWER_SUDOERS_SCRIPT="$INSTALL_DIR/deploy/scripts/install-power-sudoers.sh"
     if [[ -f "$POWER_SUDOERS_SCRIPT" ]]; then
         log_info "Re-applying power sudoers..."
-        if sudo bash "$POWER_SUDOERS_SCRIPT"; then
+        if ! sudo -n -l bash "$POWER_SUDOERS_SCRIPT" >/dev/null 2>&1; then
+            # Die Diagnose, die hier bisher fehlte. /etc/sudoers.d/baluhost-deploy
+            # ist die EINZIGE der vier sudoers-Dateien, die dieser Deploy nicht
+            # neu rendern kann -- sie enthaelt genau die Erlaubnis, mit der die
+            # anderen drei installiert werden. Neue Zeilen der Vorlage erreichen
+            # eine bereits installierte Box deshalb nie, und der Aufruf unten
+            # scheiterte mit "sudo: a password is required" hinter einer
+            # nichtssagenden WARN-Zeile.
+            log_warn "Power sudoers sync NOT PERMITTED: /etc/sudoers.d/baluhost-deploy on this box"
+            log_warn "  predates the entry for install-power-sudoers.sh. One-time fix, as root:"
+            log_warn "    sudo BALUHOST_USER=\$USER bash $INSTALL_DIR/deploy/scripts/install-deploy-sudoers.sh"
+            log_warn "  Until then the power sudoers template (PPD authority) stays at its installed state."
+        elif sudo bash "$POWER_SUDOERS_SCRIPT"; then
             log_info "Power sudoers sync OK."
         else
             log_warn "Power sudoers sync failed (non-fatal — deploy continues)."

--- a/deploy/scripts/ci-deploy.sh
+++ b/deploy/scripts/ci-deploy.sh
@@ -427,74 +427,65 @@ log_info "Backend dependencies updated."
 #   - GitHub: workflow_dispatch input "sync_permissions" = true
 #   - Manual: SYNC_PERMISSIONS=1 ./ci-deploy.sh
 
+# Fuehrt eines der Permission-Skripte als root aus -- mit Vorabpruefung, ob der
+# Aufruf ueberhaupt erlaubt ist (#570).
+#
+# Der Grund fuer die Pruefung: /etc/sudoers.d/baluhost-deploy ist die einzige
+# der vier sudoers-Dateien, die dieser Deploy nicht neu rendern kann -- sie
+# enthaelt genau die Erlaubnis, mit der die anderen drei installiert werden.
+# Neue Zeilen der Vorlage erreichen eine bereits installierte Box deshalb nie,
+# und der Aufruf scheiterte dann mit "sudo: a password is required" hinter
+# einer nichtssagenden WARN-Zeile.
+#
+# `sudo -n -l <cmd>` endet mit 0 genau dann, wenn der Aufruf erlaubt waere --
+# ohne ihn auszufuehren. Es laeuft passwortlos, solange listpw auf Debians
+# Standard "any" steht und der Benutzer mindestens einen NOPASSWD-Eintrag hat
+# (beides gilt hier). Bei listpw=all waere die Pruefung falsch negativ und der
+# Sync uebersprungen.
+run_permission_script() {
+    local label="$1" script="$2"
+    if [[ ! -f "$script" ]]; then
+        log_warn "$label script not found at $script (skipping)."
+        return 0
+    fi
+    log_info "Re-applying $label..."
+    if ! sudo -n -l bash "$script" >/dev/null 2>&1; then
+        log_warn "$label sync NOT PERMITTED: /etc/sudoers.d/baluhost-deploy on this box"
+        log_warn "  predates the entry for $(basename "$script"). One-time fix:"
+        # Der Benutzername wird HIER eingesetzt, nicht als $USER ausgegeben:
+        # die Anweisung wird typischerweise in einer root-Shell ausgefuehrt, wo
+        # $USER zu "root" wuerde. Die Datei wuerde dann fuer root gerendert, und
+        # der Deploy-Benutzer verloere still alle NOPASSWD-Rechte -- der
+        # naechste Deploy braeche beim Neustart der Dienste ab. `env` davor,
+        # weil sudo Zuweisungen in der Kommandozeile ohne SETENV ablehnt.
+        log_warn "    sudo env BALUHOST_USER=$(id -un) bash $INSTALL_DIR/deploy/scripts/install-deploy-sudoers.sh"
+        log_warn "  Until then $label stays at its installed state."
+        return 0
+    fi
+    if sudo bash "$script"; then
+        log_info "$label sync OK."
+    else
+        log_warn "$label sync failed (non-fatal - deploy continues)."
+    fi
+}
+
 if [[ "${SYNC_PERMISSIONS:-0}" == "1" || "${SYNC_PERMISSIONS,,}" == "true" ]]; then
     log_step "OS Permission Grants (sync requested)"
 
     # AMD GPU sysfs power nodes: chgrp video + g+w via udev rule.
     # The script defaults BALUHOST_USER=sven internally; sudoers rule
     # whitelists this exact bash invocation, so no env vars are passed.
-    AMD_GPU_SCRIPT="$INSTALL_DIR/deploy/scripts/install-amd-gpu-permissions.sh"
-    if [[ -f "$AMD_GPU_SCRIPT" ]]; then
-        log_info "Re-applying AMD GPU sysfs permissions..."
-        if sudo bash "$AMD_GPU_SCRIPT"; then
-            log_info "AMD GPU permission sync OK."
-        else
-            log_warn "AMD GPU permission sync failed (non-fatal — deploy continues)."
-        fi
-    else
-        log_warn "AMD GPU permission script not found at $AMD_GPU_SCRIPT (skipping)."
-    fi
+    run_permission_script "AMD GPU permission"         "$INSTALL_DIR/deploy/scripts/install-amd-gpu-permissions.sh"
 
     # Hardware sudoers: RAID/SMART/fan/CPU-freq/suspend/rtcwake/ethtool grants.
-    # The installer renders @@BALUHOST_USER@@ from the running service user and
-    # validates with visudo before replacing the live file. This is the path by
-    # which baluhost-hardware-sudoers template changes reach an installed box.
-    # Invoked with no env vars (like the AMD-GPU script): the deploy sudoers rule
-    # whitelists this exact `bash <abs-path>` invocation, and the script's
-    # internal TEMPLATE default (/opt/baluhost/...) matches the prod INSTALL_DIR.
-    HARDWARE_SUDOERS_SCRIPT="$INSTALL_DIR/deploy/scripts/install-hardware-sudoers.sh"
-    if [[ -f "$HARDWARE_SUDOERS_SCRIPT" ]]; then
-        log_info "Re-applying hardware sudoers..."
-        if sudo bash "$HARDWARE_SUDOERS_SCRIPT"; then
-            log_info "Hardware sudoers sync OK."
-        else
-            log_warn "Hardware sudoers sync failed (non-fatal — deploy continues)."
-        fi
-    else
-        log_warn "Hardware sudoers script not found at $HARDWARE_SUDOERS_SCRIPT (skipping)."
-    fi
+    # Der Installer rendert @@BALUHOST_USER@@ aus dem laufenden Dienstbenutzer
+    # und prueft mit visudo, bevor er die Live-Datei ersetzt.
+    run_permission_script "Hardware sudoers"         "$INSTALL_DIR/deploy/scripts/install-hardware-sudoers.sh"
 
-    # Power sudoers: power-profiles-daemon stop/start/mask/unmask + logind idle
-    # helper + sddm desktop-toggle grants. The installer renders @@BALUHOST_USER@@
-    # from the running service user and validates with visudo before replacing the
-    # live file. This is the path by which sudoers-baluhost-power template changes
-    # reach an installed box; it also clears the obsolete /etc/sudoers.d/baluhost-ppd
-    # workaround once superseded. Invoked with no env vars (like the others): the
-    # deploy sudoers rule whitelists this exact `bash <abs-path>` invocation, and the
-    # script's internal TEMPLATE default (/opt/baluhost/...) matches the prod INSTALL_DIR.
-    POWER_SUDOERS_SCRIPT="$INSTALL_DIR/deploy/scripts/install-power-sudoers.sh"
-    if [[ -f "$POWER_SUDOERS_SCRIPT" ]]; then
-        log_info "Re-applying power sudoers..."
-        if ! sudo -n -l bash "$POWER_SUDOERS_SCRIPT" >/dev/null 2>&1; then
-            # Die Diagnose, die hier bisher fehlte. /etc/sudoers.d/baluhost-deploy
-            # ist die EINZIGE der vier sudoers-Dateien, die dieser Deploy nicht
-            # neu rendern kann -- sie enthaelt genau die Erlaubnis, mit der die
-            # anderen drei installiert werden. Neue Zeilen der Vorlage erreichen
-            # eine bereits installierte Box deshalb nie, und der Aufruf unten
-            # scheiterte mit "sudo: a password is required" hinter einer
-            # nichtssagenden WARN-Zeile.
-            log_warn "Power sudoers sync NOT PERMITTED: /etc/sudoers.d/baluhost-deploy on this box"
-            log_warn "  predates the entry for install-power-sudoers.sh. One-time fix, as root:"
-            log_warn "    sudo BALUHOST_USER=\$USER bash $INSTALL_DIR/deploy/scripts/install-deploy-sudoers.sh"
-            log_warn "  Until then the power sudoers template (PPD authority) stays at its installed state."
-        elif sudo bash "$POWER_SUDOERS_SCRIPT"; then
-            log_info "Power sudoers sync OK."
-        else
-            log_warn "Power sudoers sync failed (non-fatal — deploy continues)."
-        fi
-    else
-        log_warn "Power sudoers script not found at $POWER_SUDOERS_SCRIPT (skipping)."
-    fi
+    # Power sudoers: power-profiles-daemon stop/start/mask/unmask + logind-idle
+    # + sddm-Desktop-Toggle. Raeumt zusaetzlich die ueberholte
+    # /etc/sudoers.d/baluhost-ppd-Zwischenloesung ab.
+    run_permission_script "Power sudoers"         "$INSTALL_DIR/deploy/scripts/install-power-sudoers.sh"
 
     # Future permission scripts go here following the same pattern:
     # if [[ -f "$INSTALL_DIR/deploy/scripts/install-<thing>-permissions.sh" ]]; then ...


### PR DESCRIPTION
Drei unabhängige Fehler, alle bei der Verifikation des sudoers-Rollouts auf BaluNode aufgefallen. Gemeinsamer Nenner: jeder hatte sich selbst unsichtbar gemacht.

## 1. Die GPU erreicht seit dem 6. September keinen Tiefschlaf mehr

Im Journal standen 778 Zeilen `GPU power monitor tick failed: ` — mit **leerem** Text, seit dem 06.09. um 15:27.

`_hydrate_from_runtime_state()` stellt `_state` aus der Datenbank wieder her, `_standby_since` lebt aber nur im Prozess. Stand der gespeicherte Zustand auf `STANDBY`, lief jeder untätige Tick in `assert self._standby_since is not None` — und ein `AssertionError` ohne Argumente stringifiziert zu `''`. Daher die leere Zeile.

**Der Schaden war nicht der Logeintrag:** der Tick brach damit **vor** dem Übergang nach `DEEP_IDLE` ab. Nach einem Neustart im STANDBY erreichte die GPU den Tiefschlaf nie wieder — das Stromsparen war seit zwei Tagen ausser Betrieb, und die leere Meldung war der einzige Hinweis darauf.

Behoben an drei Stellen:
- Das Hydrieren führt `_standby_since` aus `last_transition` mit, damit die Deep-Idle-Frist einen Neustart **überlebt** statt neu zu beginnen. `_last_transition` wird nur in `_transition()` nach einem erfolgreichen `apply_state` geschrieben — bei gespeichertem STANDBY ist der letzte Übergang also genau der Eintritt in STANDBY. Naive Zeitstempel (SQLite) werden als UTC gelesen, sonst würfe der Vergleich `TypeError`.
- Der Tick fängt ein fehlendes `_standby_since` ab und eröffnet die Frist neu, statt zu werfen.
- Der Handler nutzt `logger.exception` statt `error("%s", exc)` und nennt damit Typ und Traceback.

Dieselbe Bauform stand noch zweimal im CPU-Manager (`power/manager.py:518` und `:871`, alle 5 bzw. 2 Sekunden) — mitbehoben.

## 2. Ein unlesbares Array nahm alle anderen mit

`get_status()` baut alle Arrays in einer Schleife, `_build_array` ruft `mdadm --detail` mit `check=True`. Ein einziges nicht lesbares Array — ein gerade entferntes Gerät, oder ein Name ausserhalb der in #576 verengten sudoers-Formen — brach die **gesamte** Statusantwort ab: der Nutzer sah gar keine Arrays statt eines fehlerhaften.

Die Schleife degradiert jetzt pro Array und behält die Mitglieder aus `/proc/mdstat`, die auch ohne `mdadm --detail` bekannt sind.

Das brachte eine zweite Stelle ans Licht: `files.py` bewertete den Gesamtzustand als `optimal`, solange kein Array `degraded` oder `rebuilding` meldet — ein `unknown` wäre also als **in Ordnung** durchgegangen. Vorher gab es dort einen 500er: falsch, aber laut. Die Bewertung ist umgedreht (alles ausserhalb der bekannten guten Werte hebt den Zustand), steht als `worst_array_status()` neben dem Handler statt darin, und hat sieben Tests. `checking` gilt dabei als gesund — Debians monatlicher `checkarray` ist Wartung, kein Handlungsbedarf, und hätte sonst regelmässig ein Warndreieck erzeugt.

## 3. Der Deploy verschwieg, dass eine sudoers-Datei nie synchronisiert wird

`/etc/sudoers.d/baluhost-deploy` ist die einzige der vier sudoers-Dateien, die `ci-deploy.sh` nicht neu rendern kann — sie enthält genau die Erlaubnis, mit der die anderen drei installiert werden. Neue Zeilen der Vorlage erreichen eine bereits installierte Box deshalb nie. Im Lauf 34142444452 sah das so aus:

```
INFO  Re-applying power sudoers...
sudo: Ein Passwort ist notwendig
WARN  Power sudoers sync failed (non-fatal - deploy continues).
```

Der Deploy prüft die Erlaubnis jetzt vorab mit `sudo -n -l` — das fragt, ob der Aufruf erlaubt *wäre*, ohne ihn auszuführen — und nennt bei Fehlen den einmaligen Befehl, der es behebt. Die Prüfung steckt in einem Helfer und deckt alle drei Permission-Skripte ab; der Blindfleck galt für AMD-GPU und Hardware genauso, dort war nur noch nichts danebengegangen.

## Was die Reviews gefunden haben

Zwei Prüfrunden, und die erste fand einen Blocker in genau der Handlungsanweisung, die dieser Branch ausgeben sollte: `sudo BALUHOST_USER=$USER bash …` hat zwei unabhängige Fehler. sudo lehnt Zuweisungen in der Kommandozeile ohne `SETENV` ab (`env_reset` ist Debian-Standard), der Befehl war also gar nicht ausführbar — und der Text sagte „als root", wo `$USER` zu `root` wird. Die Datei wäre für root gerendert worden, der Dienstbenutzer hätte **alle** `NOPASSWD`-Rechte verloren, und der nächste Deploy wäre beim Neustart der Dienste abgebrochen. Eine Copy-Paste-Anweisung, die die Produktion lahmlegt.

Jetzt wird der Benutzername beim Drucken eingesetzt (`$(id -un)`, ausgewertet vom Deploy, der als Dienstbenutzer läuft), mit `env` davor. Zwei Tests nageln beide Fallen fest.

Ausserdem aus den Reviews: eine Zusicherung, die nicht fehlschlagen konnte (`"/bin/bash "` ist eine Teilzeichenkette von `"/usr/bin/bash "`), eine zweite, die Aufruf und Pfad unabhängig voneinander prüfte und einen Aufruf am Helfer vorbei nicht bemerkt hätte, und ein RAID-Test, der einen erfundenen Fehler an `_build_array` vorbei warf — jetzt wirft `subprocess.run` einen echten `CalledProcessError`, den das reale `_run` umwandelt.

## Prüfung

- Für jeden der drei Fixes wurde die Gegenprobe ausgeführt: mit zurückgedrehtem Fix fallen 3 von 4 bzw. 2 von 3 Tests. Beim GPU-Fix mit **exakt** dem `AssertionError` aus der Produktion (`manager.py:279`).
- Die Zusicherungen des Deploy-Tests sind mutationsgeprüft: `$USER` wieder eingesetzt → rot, `env` entfernt → rot, Aufruf am Helfer vorbei → rot, `/bin/bash`-Zeile aus der Vorlage entfernt → rot.
- `pytest -k "gpu or raid or power or mountpoint or files"` → 868 bestanden, 9 übersprungen; `pytest -k "files or mountpoint or raid"` → 333 bestanden; `ruff` sauber; `bash -n` auf dem Deploy-Skript OK; der committete Blob des Shell-Skripts enthält kein CR.

## Nach dem Merge

Der GPU-Fix wirkt erst nach einem Neustart des Backends — den bringt der Deploy mit. Danach im Journal prüfen, dass keine `GPU power monitor tick failed`-Zeilen mehr auflaufen; sollte doch eine kommen, nennt sie jetzt Typ und Traceback.

Der Deploy-Blindfleck bleibt bis zu einem einmaligen Lauf von `install-deploy-sudoers.sh` als root bestehen — der nächste Sync-Deploy druckt den exakten Befehl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGS5jVzZpLcqpZ2VH8DqNn
