### PR TITLE
fix(fans): Rechteanzeige kann zurueckfallen und benennt den Kanal (#568, #574)

### DIFF
--- a/backend/alembic/versions/c7a41b9e2f30_fan_runtime_denied_fan_ids.py
+++ b/backend/alembic/versions/c7a41b9e2f30_fan_runtime_denied_fan_ids.py
@@ -1,0 +1,33 @@
+"""fan_runtime_state.denied_fan_ids fuer die Anzeige je Luefter (#568)
+
+Der Zustand `pwm_control == NO_PERMISSION` lebt im `_fan_cache` des jeweiligen
+Uvicorn-Workers, gesetzt wird er aber nur von dem, der schreibt -- also vom
+Primary. Ohne eine gemeinsame Zeile melden die drei Follower fuer denselben
+Kanal weiter `supported`, und das Badge in der Luefterkarte erscheint und
+verschwindet im 5-Sekunden-Poll, je nachdem welcher Worker antwortet.
+
+Dieselbe Loesung wie fuer `has_write_permission` eine Ebene darueber (#552):
+der Primary veroeffentlicht, alle lesen von dort.
+
+Revision ID: c7a41b9e2f30
+Revises: d1e5a83f47c2
+Create Date: 2026-09-07
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c7a41b9e2f30"
+down_revision = "d1e5a83f47c2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "fan_runtime_state",
+        sa.Column("denied_fan_ids", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("fan_runtime_state", "denied_fan_ids")

--- a/backend/app/models/fans.py
+++ b/backend/app/models/fans.py
@@ -212,6 +212,15 @@ class FanRuntimeState(Base):
     has_write_permission: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False
     )
+    # Die Kanaele, auf denen der Primary ein EACCES gesehen hat, als
+    # JSON-Liste (#568 Punkt 2). Dieselbe Begruendung wie fuer die Spalte
+    # darueber, nur eine Ebene feiner: pwm_control lebt im _fan_cache des
+    # jeweiligen Workers, gesetzt wird es aber nur von dem, der schreibt --
+    # also vom Primary. Ohne diese Zeile meldeten die drei Follower fuer
+    # denselben Kanal weiter `supported`, und das Badge in der Karte
+    # erschiene und verschwaende im 5-Sekunden-Poll, je nachdem welcher
+    # Worker gerade antwortet.
+    denied_fan_ids: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -55,6 +55,12 @@ PWM_BACKOFF_MAX_SECONDS = 900.0  # 15 Minuten
 class LinuxFanControlBackend(FanControlBackend):
     """Linux hardware backend using hwmon sysfs."""
 
+    # Abstand zwischen zwei Rechte-Proben, wenn die Ableitung `readonly`
+    # sagt. Lang genug, dass ein dauerhaft rechteloser Zustand keine Last
+    # erzeugt, kurz genug, dass eine reparierte Rechtelage von selbst
+    # zurueckfindet (#568).
+    _PERMISSION_RECHECK_SECONDS = 60.0
+
     def __init__(self, config: Settings):
         self.config = config
         self._hwmon_base = Path("/sys/class/hwmon")
@@ -64,6 +70,8 @@ class LinuxFanControlBackend(FanControlBackend):
         # Bewusst NICHT in _fan_cache: der wird bei jedem Rescan neu gebaut,
         # der Backoff muss das ueberleben.
         self._write_backoff: Dict[str, Tuple[int, float]] = {}
+        # Fruehestens erlaubter Zeitpunkt der naechsten Rechte-Probe (#568).
+        self._next_permission_recheck: float = 0.0
         # Rueckabbildung stabile Sensor-Kennung -> tempN_input-Pfad. Ohne sie
         # kann get_temperature() die ID nicht mehr aufloesen, weil sie nicht
         # mehr aus dem hwmon-Verzeichnisnamen besteht (#532).
@@ -122,10 +130,43 @@ class LinuxFanControlBackend(FanControlBackend):
             ok, _ = await self._write_hwmon_file(probe_path, str(current))
             if ok:
                 self._has_write_permission = True
+                # Auch den Kanalzustand zuruecknehmen (#568): sonst bliebe die
+                # Ableitung in has_write_permission() auf NO_PERMISSION stehen,
+                # obwohl die Probe gerade bewiesen hat, dass geschrieben werden
+                # darf.
+                if fan_info.get("pwm_control") is PwmControl.NO_PERMISSION:
+                    fan_info["pwm_control"] = PwmControl.SUPPORTED
+                    fan_info["last_write_error"] = None
                 logger.info(f"Fan control: write permission available ({fan_id})")
                 return
 
         logger.info("Fan control: no write permission (readonly mode)")
+
+    async def recheck_write_permission(self) -> None:
+        """Die Probe erneut fahren, wenn die Ableitung gerade `readonly` sagt.
+
+        Ohne das kann sich der abgeleitete Zustand FESTSETZEN. Geheilt wird er
+        nur ueber einen erfolgreichen Write, und den loest im Regelbetrieb
+        allein der Regelkreis aus -- der einen Luefter im MANUAL-Modus nie
+        schreibt (Ziel == Ist, siehe fan_control._apply_fan_curve). Sind die
+        Rechte weg, meldet die Anzeige `readonly` und SPERRT die
+        Bedienelemente; damit faellt auch der einzige verbliebene Schreibweg
+        weg, die HTTP-Route. Der Nutzer kaeme ohne Dienst-Neustart nicht mehr
+        heraus -- ein lauter Fehler statt des behobenen stillen, und ein
+        schlechterer Tausch.
+
+        Die Probe schreibt pwm_enable mit dem Wert, der dort bereits steht, ist
+        also kein Eingriff. Sie laeuft hoechstens alle
+        `_PERMISSION_RECHECK_SECONDS`, damit ein dauerhaft rechteloser Zustand
+        nicht jeden Regelzyklus einen Schreibversuch je Kanal ausloest.
+        """
+        if self.has_write_permission():
+            return
+        jetzt = self._monotonic()
+        if jetzt < self._next_permission_recheck:
+            return
+        self._next_permission_recheck = jetzt + self._PERMISSION_RECHECK_SECONDS
+        await self._check_write_permission()
 
     def has_write_permission(self) -> bool:
         """Ob BaluHost derzeit ueberhaupt einen Luefter schreiben kann.

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -127,6 +127,51 @@ class LinuxFanControlBackend(FanControlBackend):
 
         logger.info("Fan control: no write permission (readonly mode)")
 
+    def has_write_permission(self) -> bool:
+        """Ob BaluHost derzeit ueberhaupt einen Luefter schreiben kann.
+
+        `_has_write_permission` allein taugt dafuer nicht: es wird auf True
+        gesetzt (Probe beim Start, erfolgreicher Write) und von NIEMANDEM auf
+        False zurueck (#568 Punkt 1). Gingen die Rechte zur Laufzeit verloren
+        -- eine udev-Regel, die nach einem Treiber-Reload nicht mehr greift,
+        eine sudoers-Aenderung, die die Box nie erreicht hat --, meldete
+        `GET /api/fans/permissions` weiter `ok`, waehrend nichts mehr
+        geschrieben wurde. Die Bedienelemente blieben frei und jede Eingabe
+        verpuffte.
+
+        Abgeleitet wird deshalb aus dem Zustand je Kanal, den set_pwm ohnehin
+        pflegt: NO_PERMISSION bei beobachtetem EACCES/EPERM, zurueck auf
+        SUPPORTED nach dem naechsten erfolgreichen Write.
+
+        NICHT am Backoff aus #533 aufgehaengt, obwohl das Issue es vorschlaegt:
+        die Sperre zaehlt Fehlschlaege jeder Art, auch EINVAL vom Treiber. Das
+        waere eine Aussage ueber "der Write klappt nicht", nicht ueber "wir
+        duerfen nicht" -- und die Rechteanzeige soll das zweite sagen.
+
+        Der Geltungsbereich ist bewusst global-restriktiv: ein einzelner
+        gesperrter Kanal macht die Steuerung nicht tot (auf dieser Hardware ist
+        genau ein Kanal firmware-verwaltet und vier sind steuerbar). Erst wenn
+        JEDER steuerbare Kanal ein EACCES gesehen hat, ist die Anzeige
+        `readonly`. Was einzelne Kanaele betrifft, zeigt die Karte je Luefter
+        (#568 Punkt 2).
+        """
+        if not self._has_write_permission:
+            return False
+
+        steuerbar = [
+            info for info in self._fan_cache.values()
+            if info.get("pwm_control") is not PwmControl.FIRMWARE_MANAGED
+        ]
+        if not steuerbar:
+            # Nichts Steuerbares erkannt: die Frage stellt sich nicht, und der
+            # Startwert der Probe ist die beste vorhandene Aussage.
+            return self._has_write_permission
+
+        return any(
+            info.get("pwm_control") is not PwmControl.NO_PERMISSION
+            for info in steuerbar
+        )
+
     async def get_fans(self) -> List[FanData]:
         """Get hardware fans from hwmon (uses cache from startup scan)."""
 

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -72,6 +72,9 @@ class LinuxFanControlBackend(FanControlBackend):
         self._write_backoff: Dict[str, Tuple[int, float]] = {}
         # Fruehestens erlaubter Zeitpunkt der naechsten Rechte-Probe (#568).
         self._next_permission_recheck: float = 0.0
+        # Ergebnis der letzten Probe -- nur fuer die Log-Hygiene: die
+        # Probe laeuft periodisch, gemeldet wird nur der Wechsel (#568).
+        self._letzte_probe_erfolgreich: Optional[bool] = None
         # Rueckabbildung stabile Sensor-Kennung -> tempN_input-Pfad. Ohne sie
         # kann get_temperature() die ID nicht mehr aufloesen, weil sie nicht
         # mehr aus dem hwmon-Verzeichnisnamen besteht (#532).
@@ -113,6 +116,7 @@ class LinuxFanControlBackend(FanControlBackend):
         GPU-Luefter, den set_pwm gar nicht anfasst -- ueber unsere
         Schreibfaehigkeit sagt er nichts aus (#552).
         """
+        erster_erfolg = None
         for fan_id, fan_info in self._fan_cache.items():
             if fan_info.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
                 continue
@@ -137,10 +141,28 @@ class LinuxFanControlBackend(FanControlBackend):
                 if fan_info.get("pwm_control") is PwmControl.NO_PERMISSION:
                     fan_info["pwm_control"] = PwmControl.SUPPORTED
                     fan_info["last_write_error"] = None
-                logger.info(f"Fan control: write permission available ({fan_id})")
-                return
+                if erster_erfolg is None:
+                    erster_erfolg = fan_id
 
-        logger.info("Fan control: no write permission (readonly mode)")
+        # KEIN frueher Ausstieg nach dem ersten Erfolg: bis #568 kehrte die
+        # Probe dort zurueck, und die Kanaele dahinter blieben auf ihrem alten
+        # NO_PERMISSION stehen. Solange das nur der Primary sah, war es ein
+        # Schoenheitsfehler; seit der Kanalzustand an alle Worker verteilt wird,
+        # behauptete es dauerhaft "kein Schreibrecht" auf funktionierenden
+        # Kanaelen -- und in MANUAL raeumt kein set_pwm das je auf.
+        if erster_erfolg is not None:
+            if not self._letzte_probe_erfolgreich:
+                logger.info(
+                    f"Fan control: write permission available ({erster_erfolg})")
+            self._letzte_probe_erfolgreich = True
+            return
+
+        # Nur beim Wechsel loggen: die Probe laeuft jetzt periodisch, eine
+        # Zeile je Lauf waere 1440 am Tag -- dieselbe Sorte Rauschen, die #533
+        # beseitigt hat.
+        if self._letzte_probe_erfolgreich is not False:
+            logger.info("Fan control: no write permission (readonly mode)")
+        self._letzte_probe_erfolgreich = False
 
     async def recheck_write_permission(self) -> None:
         """Die Probe erneut fahren, wenn die Ableitung gerade `readonly` sagt.

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -282,7 +282,12 @@ class FanControlService:
         """
         if not getattr(lifespan, "IS_PRIMARY_WORKER", False):
             return
-        current = getattr(self._backend, "_has_write_permission", None)
+        # has_write_permission() statt des rohen Attributs (#568): das
+        # Attribut kann nur True werden, die Methode leitet den Stand aus
+        # den Kanalzustaenden ab und kann damit auch zurueckfallen.
+        holen = getattr(self._backend, "has_write_permission", None)
+        current = holen() if callable(holen) else getattr(
+            self._backend, "_has_write_permission", None)
         if current is None or current == self._published_write_permission:
             return
         with self.db_session_factory() as db:
@@ -1292,7 +1297,7 @@ class FanControlService:
                 # Zeile (frisch migriert), entscheidet die eigene Messung.
                 with self.db_session_factory() as db:
                     shared = read_write_permission(db)
-                may_write = (self._backend._has_write_permission
+                may_write = (self._backend.has_write_permission()
                              if shared is None else shared)
                 permission_status = "ok" if may_write else "readonly"
 

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -308,11 +308,17 @@ class FanControlService:
                 self._published_write_permission = current
                 self._published_denied_fans = denied
 
-    def _denied_fan_ids(self) -> set:
-        """Die Kanaele, auf denen der Backend-Cache ein EACCES vermerkt hat."""
+    def _denied_fan_ids(self) -> Optional[set]:
+        """Die Kanaele, auf denen der Backend-Cache ein EACCES vermerkt hat.
+
+        None heisst "unbekannt" -- etwa beim Dev-Backend, das gar keinen
+        solchen Cache fuehrt. Eine leere Menge waere hier die Behauptung "kein
+        Kanal ist gesperrt", und die wuerde veroeffentlicht; None laesst die
+        gespeicherte Liste unberuehrt.
+        """
         cache = getattr(self._backend, "_fan_cache", None)
         if not isinstance(cache, dict):
-            return set()
+            return None
         return {
             fan_id for fan_id, info in cache.items()
             if isinstance(info, dict)
@@ -1327,9 +1333,16 @@ class FanControlService:
         # es aber nur von dem, der schreibt. Ohne diese Ueberlagerung meldeten
         # die drei Follower fuer denselben Kanal weiter `supported`, und das
         # Badge in der Karte erschiene und verschwaende im 5-Sekunden-Poll.
+        gesperrt = None
+        shared_permission = None
         if self._use_linux_backend:
+            # EINE Sitzung fuer beide Leser: sie holen dieselbe
+            # Singleton-Zeile, und get_status() bedient sowohl
+            # GET /api/fans/status als auch GET /api/fans/permissions -- im
+            # 5-Sekunden-Poll je Client und Worker.
             with self.db_session_factory() as db:
                 gesperrt = read_denied_fans(db)
+                shared_permission = read_write_permission(db)
             if gesperrt is not None:
                 for eintrag in fan_data_list:
                     if eintrag.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
@@ -1338,10 +1351,19 @@ class FanControlService:
                         continue
                     if eintrag["fan_id"] in gesperrt:
                         eintrag["pwm_control"] = PwmControl.NO_PERMISSION
-                    elif eintrag.get("pwm_control") is PwmControl.NO_PERMISSION:
-                        # Der Primary meldet den Kanal nicht mehr als gesperrt:
-                        # ein eigener, veralteter Befund wird zurueckgenommen.
-                        eintrag["pwm_control"] = PwmControl.SUPPORTED
+                    # KEINE Ruecknahme in der Gegenrichtung: eine
+                    # Nutzer-Eingabe geht ueber irgendeinen Worker, und bei
+                    # EACCES vermerkt genau DER den Kanal. Der Primary hat
+                    # diesen Write nie versucht -- in MANUAL schreibt er gar
+                    # nicht --, seine Liste kennt den Kanal also nicht. Wuerde
+                    # die Ueberlagerung ihn deshalb auf SUPPORTED zuruecksetzen,
+                    # verschwaende der frische Befund sofort wieder, und
+                    # dieselbe Antwort truege `last_write_error` neben
+                    # `pwm_control: supported` -- ein sich selbst
+                    # widersprechender Payload. Vereinigung statt Ersetzung:
+                    # zurueckgenommen wird ein NO_PERMISSION nur von dem
+                    # Worker, der es gesetzt hat, durch einen eigenen
+                    # erfolgreichen Write oder die eigene Probe.
 
         # Determine permission status
         permission_status = "ok"
@@ -1351,10 +1373,8 @@ class FanControlService:
                 # Messung: ein Follower schreibt im Regelbetrieb nie und
                 # bleibt deshalb auf seinem Startwert stehen. Fehlt die
                 # Zeile (frisch migriert), entscheidet die eigene Messung.
-                with self.db_session_factory() as db:
-                    shared = read_write_permission(db)
                 may_write = (self._backend.has_write_permission()
-                             if shared is None else shared)
+                             if shared_permission is None else shared_permission)
                 permission_status = "ok" if may_write else "readonly"
 
         return {

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -25,6 +25,7 @@ from app.models.fans import FanConfig, FanSample
 from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
 from app.services.power.fan_restore import is_observation, needs_release, resolve_restore_value
 from app.services.power.fan_runtime_store import (
+    read_denied_fans,
     publish_write_permission,
     read_write_permission,
 )
@@ -199,6 +200,9 @@ class FanControlService:
         # Zuletzt veroeffentlichter Rechtezustand. None heisst: noch nie
         # geschrieben -- dann wird beim ersten Abgleich veroeffentlicht (#552).
         self._published_write_permission: Optional[bool] = None
+        # Zuletzt veroeffentlichte Menge gesperrter Kanaele. None heisst wie
+        # oben: noch nie geschrieben (#568).
+        self._published_denied_fans: Optional[set] = None
 
         FanControlService._instance = self
 
@@ -288,11 +292,32 @@ class FanControlService:
         holen = getattr(self._backend, "has_write_permission", None)
         current = holen() if callable(holen) else getattr(
             self._backend, "_has_write_permission", None)
-        if current is None or current == self._published_write_permission:
+        if current is None:
+            return
+
+        # Die betroffenen Kanaele mitveroeffentlichen (#568 Punkt 2): sie
+        # leben im _fan_cache dessen, der schreibt -- also nur hier. Ohne das
+        # meldeten die drei Follower fuer denselben Kanal weiter `supported`
+        # und das Badge flackerte im 5-Sekunden-Poll.
+        denied = self._denied_fan_ids()
+        if (current == self._published_write_permission
+                and denied == self._published_denied_fans):
             return
         with self.db_session_factory() as db:
-            if publish_write_permission(db, current):
+            if publish_write_permission(db, current, denied):
                 self._published_write_permission = current
+                self._published_denied_fans = denied
+
+    def _denied_fan_ids(self) -> set:
+        """Die Kanaele, auf denen der Backend-Cache ein EACCES vermerkt hat."""
+        cache = getattr(self._backend, "_fan_cache", None)
+        if not isinstance(cache, dict):
+            return set()
+        return {
+            fan_id for fan_id, info in cache.items()
+            if isinstance(info, dict)
+            and info.get("pwm_control") is PwmControl.NO_PERMISSION
+        }
 
     async def _cancel_monitoring_task(self) -> None:
         """Bricht eine laufende Regelschleife ab und gibt die Referenz frei.
@@ -965,6 +990,16 @@ class FanControlService:
         while self._is_running:
             try:
                 await self._monitor_and_control_fans()
+                # Sagt die Ableitung gerade `readonly`, noch einmal probieren
+                # (#568): der Regelkreis schreibt einen Luefter im
+                # MANUAL-Modus nie, und die Anzeige sperrt die
+                # Bedienelemente -- ohne diese Probe gaebe es keinen Weg
+                # zurueck ausser einem Dienst-Neustart. Die Methode taktet
+                # sich selbst und ist ein No-op, solange geschrieben werden
+                # darf.
+                erneut = getattr(self._backend, "recheck_write_permission", None)
+                if erneut is not None:
+                    await erneut()
                 # Nach dem Regelzyklus: ein erfolgreicher Write kann den
                 # Rechtezustand geheilt haben, den die Follower nur ueber
                 # die veroeffentlichte Zeile erfahren (#552).
@@ -1286,6 +1321,27 @@ class FanControlService:
                         "response_time_seconds": 0.0,
                         "pwm_steps": 1,
                     })
+
+        # Den vom Primary gemeldeten Kanalzustand ueberlagern (#568 Punkt 2).
+        # pwm_control lebt im _fan_cache des jeweiligen Workers, gesetzt wird
+        # es aber nur von dem, der schreibt. Ohne diese Ueberlagerung meldeten
+        # die drei Follower fuer denselben Kanal weiter `supported`, und das
+        # Badge in der Karte erschiene und verschwaende im 5-Sekunden-Poll.
+        if self._use_linux_backend:
+            with self.db_session_factory() as db:
+                gesperrt = read_denied_fans(db)
+            if gesperrt is not None:
+                for eintrag in fan_data_list:
+                    if eintrag.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
+                        # Eine dauerhafte Hardware-Eigenschaft. Sie darf von
+                        # einem Laufzeit-Befund nicht ueberschrieben werden.
+                        continue
+                    if eintrag["fan_id"] in gesperrt:
+                        eintrag["pwm_control"] = PwmControl.NO_PERMISSION
+                    elif eintrag.get("pwm_control") is PwmControl.NO_PERMISSION:
+                        # Der Primary meldet den Kanal nicht mehr als gesperrt:
+                        # ein eigener, veralteter Befund wird zurueckgenommen.
+                        eintrag["pwm_control"] = PwmControl.SUPPORTED
 
         # Determine permission status
         permission_status = "ok"

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -1336,6 +1336,19 @@ class FanControlService:
         gesperrt = None
         shared_permission = None
         if self._use_linux_backend:
+            # Die erneute Probe gehoert auch hierher, nicht nur in den
+            # Regelkreis (#568): der laeuft NUR im Primary. Ein Follower, der
+            # ueber eine Nutzer-Eingabe ein EACCES gesehen hat, schreibt von
+            # sich aus nie wieder -- sein NO_PERMISSION haette ohne diesen
+            # Aufruf keinen Rueckweg ausser einem Dienst-Neustart. Dieselbe
+            # Sackgasse wie beim globalen Flag, nur eine Ebene tiefer.
+            #
+            # Kein Lastproblem: die Methode taktet sich selbst auf hoechstens
+            # einen Lauf je 60 s und ist ein No-op, solange geschrieben werden
+            # darf -- im Normalbetrieb kostet sie einen Attributzugriff.
+            erneut = getattr(self._backend, "recheck_write_permission", None)
+            if erneut is not None:
+                await erneut()
             # EINE Sitzung fuer beide Leser: sie holen dieselbe
             # Singleton-Zeile, und get_status() bedient sowohl
             # GET /api/fans/status als auch GET /api/fans/permissions -- im

--- a/backend/app/services/power/fan_runtime_store.py
+++ b/backend/app/services/power/fan_runtime_store.py
@@ -15,6 +15,7 @@ denselben Zweck.
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 from typing import Optional
@@ -50,8 +51,39 @@ def read_write_permission(db: Session) -> Optional[bool]:
     return None if row is None else bool(row.has_write_permission)
 
 
-def publish_write_permission(db: Session, may_write: bool) -> bool:
+def read_denied_fans(db: Session) -> Optional[set]:
+    """Die vom Primary gemeldeten Kanaele ohne Schreibrecht (#568 Punkt 2).
+
+    Returns:
+        None, wenn nichts veroeffentlicht wurde -- das ist ausdruecklich NICHT
+        dasselbe wie "kein Kanal betroffen". Der Aufrufer soll dann seine
+        eigene Sicht behalten statt eine leere Menge als Tatsache zu nehmen.
+    """
+    try:
+        row = db.execute(
+            select(FanRuntimeState).where(FanRuntimeState.id == _SINGLETON_ID)
+        ).scalar_one_or_none()
+    except Exception as exc:
+        logger.debug("fan_runtime_state nicht lesbar: %s", exc)
+        return None
+    if row is None or not row.denied_fan_ids:
+        return None
+    try:
+        werte = json.loads(row.denied_fan_ids)
+    except (ValueError, TypeError) as exc:
+        logger.debug("denied_fan_ids nicht lesbar: %s", exc)
+        return None
+    return set(werte) if isinstance(werte, list) else None
+
+
+def publish_write_permission(db: Session, may_write: bool,
+                             denied_fan_ids: Optional[set] = None) -> bool:
     """Den eigenen Stand hinterlegen. Legt die Zeile an, falls noetig.
+
+    Args:
+        denied_fan_ids: die Kanaele, auf denen ein EACCES beobachtet wurde.
+            None laesst die gespeicherte Liste unberuehrt -- so bleibt der
+            Aufrufer, der nur das Flag kennt, rueckwaertskompatibel.
 
     Returns:
         False bei einem Datenbankfehler -- der Aufrufer soll dann seinen
@@ -66,6 +98,8 @@ def publish_write_permission(db: Session, may_write: bool) -> bool:
             row = FanRuntimeState(id=_SINGLETON_ID)
             db.add(row)
         row.has_write_permission = bool(may_write)
+        if denied_fan_ids is not None:
+            row.denied_fan_ids = json.dumps(sorted(denied_fan_ids))
         row.updated_by_pid = os.getpid()
         db.commit()
         return True

--- a/backend/tests/test_fan_denied_fans_shared.py
+++ b/backend/tests/test_fan_denied_fans_shared.py
@@ -45,8 +45,15 @@ def test_veroeffentlichte_kanaele_kommen_zurueck(session_factory):
 
 def test_eine_leere_menge_ist_eine_aussage(session_factory):
     """'Kein Kanal ist gesperrt' muss sich von 'nichts veroeffentlicht'
-    unterscheiden lassen -- sonst koennte ein Follower einen veralteten
-    eigenen Befund nie zuruecknehmen."""
+    unterscheiden lassen.
+
+    Die Unterscheidung traegt auf der SCHREIBSEITE: None laesst die
+    gespeicherte Liste unberuehrt (ein Aufrufer, der nur das Flag kennt, darf
+    sie nicht loeschen), die leere Menge ersetzt sie. Auf der Leseseite ist sie
+    seit der Umstellung auf Vereinigung ohne Wirkung -- get_status nimmt einen
+    eigenen Befund ohnehin nicht mehr zurueck. Die urspruengliche Begruendung
+    hier ("sonst koennte ein Follower einen veralteten Befund nie
+    zuruecknehmen") galt nur fuer die verworfene Ersetzungs-Variante."""
     with session_factory() as db:
         publish_write_permission(db, False, {"nct6798:pwm1"})
     with session_factory() as db:

--- a/backend/tests/test_fan_denied_fans_shared.py
+++ b/backend/tests/test_fan_denied_fans_shared.py
@@ -1,0 +1,91 @@
+"""Der Kanalzustand gilt fuer alle Worker gleich (#568 Punkt 2).
+
+`pwm_control` lebt im `_fan_cache` des jeweiligen Uvicorn-Workers, gesetzt wird
+es aber nur von dem, der schreibt -- im Regelbetrieb also allein vom Primary.
+Ohne eine gemeinsame Zeile melden die drei Follower fuer denselben Kanal weiter
+`supported`, und das Badge in der Luefterkarte erscheint und verschwindet im
+5-Sekunden-Poll, je nachdem welcher Worker antwortet.
+
+Dieselbe Loesung wie fuer `has_write_permission` eine Ebene darueber (#552):
+der Primary veroeffentlicht, alle lesen von dort.
+"""
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import Base
+from app.services.power.fan_runtime_store import (
+    publish_write_permission,
+    read_denied_fans,
+    read_write_permission,
+)
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def test_ohne_zeile_ist_die_antwort_none(session_factory):
+    """None heisst 'nichts veroeffentlicht' und ist ausdruecklich NICHT
+    dasselbe wie 'kein Kanal betroffen' -- der Leser soll dann seine eigene
+    Sicht behalten statt eine leere Menge als Tatsache zu nehmen."""
+    with session_factory() as db:
+        assert read_denied_fans(db) is None
+
+
+def test_veroeffentlichte_kanaele_kommen_zurueck(session_factory):
+    with session_factory() as db:
+        assert publish_write_permission(db, False, {"nct6798:pwm2", "nct6798:pwm1"})
+    with session_factory() as db:
+        assert read_denied_fans(db) == {"nct6798:pwm1", "nct6798:pwm2"}
+
+
+def test_eine_leere_menge_ist_eine_aussage(session_factory):
+    """'Kein Kanal ist gesperrt' muss sich von 'nichts veroeffentlicht'
+    unterscheiden lassen -- sonst koennte ein Follower einen veralteten
+    eigenen Befund nie zuruecknehmen."""
+    with session_factory() as db:
+        publish_write_permission(db, False, {"nct6798:pwm1"})
+    with session_factory() as db:
+        publish_write_permission(db, True, set())
+    with session_factory() as db:
+        assert read_denied_fans(db) == set()
+
+
+def test_none_laesst_die_liste_unberuehrt(session_factory):
+    """Rueckwaertskompatibel: ein Aufrufer, der nur das Flag kennt, darf die
+    veroeffentlichten Kanaele nicht versehentlich loeschen."""
+    with session_factory() as db:
+        publish_write_permission(db, False, {"nct6798:pwm1"})
+    with session_factory() as db:
+        publish_write_permission(db, True)
+    with session_factory() as db:
+        assert read_denied_fans(db) == {"nct6798:pwm1"}
+        assert read_write_permission(db) is True
+
+
+def test_unlesbarer_inhalt_wird_nicht_zur_aussage(session_factory):
+    """Eine kaputte Zeile darf nicht als 'kein Kanal gesperrt' gelesen werden
+    -- das waere ein gruenes Signal aus einem Fehlerfall."""
+    from app.models.fans import FanRuntimeState
+
+    with session_factory() as db:
+        db.add(FanRuntimeState(id=1, has_write_permission=True,
+                               denied_fan_ids="{kein gueltiges json"))
+        db.commit()
+    with session_factory() as db:
+        assert read_denied_fans(db) is None
+
+
+def test_ein_objekt_statt_einer_liste_wird_abgelehnt(session_factory):
+    from app.models.fans import FanRuntimeState
+
+    with session_factory() as db:
+        db.add(FanRuntimeState(id=1, has_write_permission=True,
+                               denied_fan_ids='{"a": 1}'))
+        db.commit()
+    with session_factory() as db:
+        assert read_denied_fans(db) is None

--- a/backend/tests/test_fan_status_overlay.py
+++ b/backend/tests/test_fan_status_overlay.py
@@ -1,0 +1,97 @@
+"""Die sichtbare Haelfte von #568 Punkt 2: die Ueberlagerung in get_status().
+
+Der Kanalzustand `pwm_control` lebt im `_fan_cache` des jeweiligen Workers,
+gesetzt wird er nur von dem, der schreibt. Jeder Worker ueberlagert seinen
+Cache deshalb mit der Liste, die der Primary veroeffentlicht hat.
+
+Die Verdrahtung im Regelkreis wird hier mitgeprueft: die Nachbardatei
+test_fan_write_permission_sharing.py fuehrt genau diese Luecke als bekannte
+Falle -- ein Aufruf, den niemand festnagelt, verschwindet beim naechsten
+Refactor unbemerkt.
+"""
+import inspect
+
+import pytest
+
+from app.schemas.fans import PwmControl
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_control import FanControlService
+
+
+def _dienst(monkeypatch, *, veroeffentlicht):
+    dienst = object.__new__(FanControlService)
+    dienst._use_linux_backend = True
+    monkeypatch.setattr(fan_control_module, "read_denied_fans",
+                        lambda db: veroeffentlicht)
+    return dienst
+
+
+def _ueberlagern(dienst, eintraege, veroeffentlicht):
+    """Nur der Ueberlagerungsblock aus get_status(), auf denselben Regeln.
+
+    Statt die ganze get_status() mit Datenbank und Backend nachzubauen, wird
+    hier dieselbe Entscheidung geprueft, die dort getroffen wird -- und der
+    Test darunter stellt sicher, dass diese Entscheidung dort auch wirklich
+    steht.
+    """
+    if veroeffentlicht is None:
+        return eintraege
+    for eintrag in eintraege:
+        if eintrag.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
+            continue
+        if eintrag["fan_id"] in veroeffentlicht:
+            eintrag["pwm_control"] = PwmControl.NO_PERMISSION
+    return eintraege
+
+
+def test_der_ueberlagerungsblock_steht_wirklich_in_get_status():
+    """Verdrahtungspruefung. Ohne sie koennte der Block verschwinden und alle
+    Zusicherungen unten blieben gruen -- sie pruefen dann nur noch die
+    Nachbildung in dieser Datei."""
+    quelle = inspect.getsource(FanControlService.get_status)
+    assert "read_denied_fans" in quelle
+    assert "PwmControl.NO_PERMISSION" in quelle
+    assert "PwmControl.FIRMWARE_MANAGED" in quelle
+
+
+def test_der_regelkreis_ruft_die_erneute_probe():
+    """Zweite Verdrahtungspruefung: ohne diesen Aufruf kann sich die
+    Rechteanzeige festsetzen (der Befund, der die Fixwelle ausgeloest hat)."""
+    quelle = inspect.getsource(FanControlService._monitoring_loop)
+    assert "recheck_write_permission" in quelle
+
+
+def test_der_primary_veroeffentlicht_die_kanaele_mit():
+    quelle = inspect.getsource(FanControlService.publish_write_permission_if_changed)
+    assert "_denied_fan_ids" in quelle
+
+
+@pytest.mark.parametrize("veroeffentlicht,erwartet", [
+    (None, PwmControl.SUPPORTED),          # nichts veroeffentlicht
+    (set(), PwmControl.SUPPORTED),         # nichts gesperrt
+    ({"nct6798:pwm1"}, PwmControl.NO_PERMISSION),
+])
+def test_der_gemeldete_zustand_schlaegt_durch(veroeffentlicht, erwartet):
+    eintraege = [{"fan_id": "nct6798:pwm1", "pwm_control": PwmControl.SUPPORTED}]
+    _ueberlagern(None, eintraege, veroeffentlicht)
+    assert eintraege[0]["pwm_control"] is erwartet
+
+
+def test_ein_firmware_kanal_bleibt_unangetastet():
+    """Eine dauerhafte Hardware-Eigenschaft darf ein Laufzeit-Befund nicht
+    ueberschreiben -- sonst verschwaende das Firmware-Badge, sobald der Primary
+    denselben Kanal einmal als gesperrt gemeldet hat."""
+    eintraege = [{"fan_id": "amdgpu:pwm1", "pwm_control": PwmControl.FIRMWARE_MANAGED}]
+    _ueberlagern(None, eintraege, {"amdgpu:pwm1"})
+    assert eintraege[0]["pwm_control"] is PwmControl.FIRMWARE_MANAGED
+
+
+def test_ein_eigener_befund_wird_nicht_zurueckgenommen():
+    """Vereinigung statt Ersetzung: eine Nutzer-Eingabe geht ueber irgendeinen
+    Worker, und bei EACCES vermerkt genau DER den Kanal. Der Primary hat den
+    Write nie versucht, seine Liste kennt den Kanal also nicht -- eine
+    Ruecksetzung auf SUPPORTED liesse den frischen Befund sofort wieder
+    verschwinden, neben einem `last_write_error`, der stehen bleibt."""
+    eintraege = [{"fan_id": "nct6798:pwm1", "pwm_control": PwmControl.NO_PERMISSION}]
+    _ueberlagern(None, eintraege, set())
+    assert eintraege[0]["pwm_control"] is PwmControl.NO_PERMISSION

--- a/backend/tests/test_fan_status_overlay.py
+++ b/backend/tests/test_fan_status_overlay.py
@@ -4,94 +4,132 @@ Der Kanalzustand `pwm_control` lebt im `_fan_cache` des jeweiligen Workers,
 gesetzt wird er nur von dem, der schreibt. Jeder Worker ueberlagert seinen
 Cache deshalb mit der Liste, die der Primary veroeffentlicht hat.
 
-Die Verdrahtung im Regelkreis wird hier mitgeprueft: die Nachbardatei
-test_fan_write_permission_sharing.py fuehrt genau diese Luecke als bekannte
-Falle -- ein Aufruf, den niemand festnagelt, verschwindet beim naechsten
-Refactor unbemerkt.
+Die erste Fassung dieser Datei bildete die Entscheidung in einer Hilfsfunktion
+NACH, statt get_status() zu rufen -- sie prueft dann die Testdatei gegen sich
+selbst. Nachgemessen: eine semantische Ruecknahme in get_status (`in gesperrt`
+zu `not in gesperrt`) liess alle 441 Luefter-Tests gruen. Hier laeuft deshalb
+der echte Aufruf.
 """
-import inspect
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
-from app.schemas.fans import PwmControl
+from app.models.base import Base
+from app.schemas.fans import FanMode, PwmControl
 from app.services.power import fan_control as fan_control_module
-from app.services.power.fan_control import FanControlService
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+from app.services.power.fan_control import FanControlService, FanData
+from app.services.power.fan_runtime_store import publish_write_permission
 
 
-def _dienst(monkeypatch, *, veroeffentlicht):
-    dienst = object.__new__(FanControlService)
-    dienst._use_linux_backend = True
-    monkeypatch.setattr(fan_control_module, "read_denied_fans",
-                        lambda db: veroeffentlicht)
-    return dienst
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
 
 
-def _ueberlagern(dienst, eintraege, veroeffentlicht):
-    """Nur der Ueberlagerungsblock aus get_status(), auf denselben Regeln.
-
-    Statt die ganze get_status() mit Datenbank und Backend nachzubauen, wird
-    hier dieselbe Entscheidung geprueft, die dort getroffen wird -- und der
-    Test darunter stellt sicher, dass diese Entscheidung dort auch wirklich
-    steht.
-    """
-    if veroeffentlicht is None:
-        return eintraege
-    for eintrag in eintraege:
-        if eintrag.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
-            continue
-        if eintrag["fan_id"] in veroeffentlicht:
-            eintrag["pwm_control"] = PwmControl.NO_PERMISSION
-    return eintraege
+def _fan(fan_id: str, pwm_control: PwmControl) -> FanData:
+    return FanData(
+        fan_id=fan_id, name=fan_id, rpm=800, pwm_percent=40,
+        temperature_celsius=42.0, mode=FanMode.MANUAL,
+        min_pwm_percent=0, max_pwm_percent=100, emergency_temp_celsius=85.0,
+        temp_sensor_id=None, curve_points=[], is_active=True,
+        pwm_control=pwm_control,
+    )
 
 
-def test_der_ueberlagerungsblock_steht_wirklich_in_get_status():
-    """Verdrahtungspruefung. Ohne sie koennte der Block verschwinden und alle
-    Zusicherungen unten blieben gruen -- sie pruefen dann nur noch die
-    Nachbildung in dieser Datei."""
-    quelle = inspect.getsource(FanControlService.get_status)
-    assert "read_denied_fans" in quelle
-    assert "PwmControl.NO_PERMISSION" in quelle
-    assert "PwmControl.FIRMWARE_MANAGED" in quelle
+def _service(session_factory, monkeypatch, fans):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.is_dev_mode = False
+    service = FanControlService(config, session_factory)
+    service._use_linux_backend = True
+
+    backend = LinuxFanControlBackend(MagicMock())
+    backend._has_write_permission = True
+    backend._fan_cache = {}
+    backend.get_fans = AsyncMock(return_value=fans)
+    service._backend = backend
+
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        False, raising=False)
+    return service
 
 
-def test_der_regelkreis_ruft_die_erneute_probe():
-    """Zweite Verdrahtungspruefung: ohne diesen Aufruf kann sich die
-    Rechteanzeige festsetzen (der Befund, der die Fixwelle ausgeloest hat)."""
-    quelle = inspect.getsource(FanControlService._monitoring_loop)
-    assert "recheck_write_permission" in quelle
+async def _zustand(service, fan_id: str) -> PwmControl:
+    status = await service.get_status()
+    eintrag = next(f for f in status["fans"] if f["fan_id"] == fan_id)
+    return eintrag["pwm_control"]
 
 
-def test_der_primary_veroeffentlicht_die_kanaele_mit():
-    quelle = inspect.getsource(FanControlService.publish_write_permission_if_changed)
-    assert "_denied_fan_ids" in quelle
+@pytest.mark.asyncio
+async def test_ohne_veroeffentlichte_liste_bleibt_der_eigene_stand(
+    session_factory, monkeypatch
+):
+    """Nichts veroeffentlicht heisst ausdruecklich NICHT 'kein Kanal
+    gesperrt' -- der Worker behaelt dann seine eigene Sicht."""
+    service = _service(session_factory, monkeypatch,
+                       [_fan("nct6798:pwm1", PwmControl.SUPPORTED)])
+
+    assert await _zustand(service, "nct6798:pwm1") is PwmControl.SUPPORTED
 
 
-@pytest.mark.parametrize("veroeffentlicht,erwartet", [
-    (None, PwmControl.SUPPORTED),          # nichts veroeffentlicht
-    (set(), PwmControl.SUPPORTED),         # nichts gesperrt
-    ({"nct6798:pwm1"}, PwmControl.NO_PERMISSION),
-])
-def test_der_gemeldete_zustand_schlaegt_durch(veroeffentlicht, erwartet):
-    eintraege = [{"fan_id": "nct6798:pwm1", "pwm_control": PwmControl.SUPPORTED}]
-    _ueberlagern(None, eintraege, veroeffentlicht)
-    assert eintraege[0]["pwm_control"] is erwartet
+@pytest.mark.asyncio
+async def test_der_gemeldete_kanal_wird_uebernommen(session_factory, monkeypatch):
+    """Der Kern: ein Follower, der selbst nie schreibt, zeigt den Befund des
+    Primary. Vorher meldete er weiter `supported`, und das Badge in der Karte
+    erschien und verschwand im 5-Sekunden-Poll."""
+    with session_factory() as db:
+        publish_write_permission(db, True, {"nct6798:pwm1"})
+    service = _service(session_factory, monkeypatch,
+                       [_fan("nct6798:pwm1", PwmControl.SUPPORTED),
+                        _fan("nct6798:pwm2", PwmControl.SUPPORTED)])
+
+    assert await _zustand(service, "nct6798:pwm1") is PwmControl.NO_PERMISSION
+    assert await _zustand(service, "nct6798:pwm2") is PwmControl.SUPPORTED
 
 
-def test_ein_firmware_kanal_bleibt_unangetastet():
+@pytest.mark.asyncio
+async def test_ein_firmware_kanal_bleibt_unangetastet(session_factory, monkeypatch):
     """Eine dauerhafte Hardware-Eigenschaft darf ein Laufzeit-Befund nicht
     ueberschreiben -- sonst verschwaende das Firmware-Badge, sobald der Primary
     denselben Kanal einmal als gesperrt gemeldet hat."""
-    eintraege = [{"fan_id": "amdgpu:pwm1", "pwm_control": PwmControl.FIRMWARE_MANAGED}]
-    _ueberlagern(None, eintraege, {"amdgpu:pwm1"})
-    assert eintraege[0]["pwm_control"] is PwmControl.FIRMWARE_MANAGED
+    with session_factory() as db:
+        publish_write_permission(db, True, {"amdgpu:pwm1"})
+    service = _service(session_factory, monkeypatch,
+                       [_fan("amdgpu:pwm1", PwmControl.FIRMWARE_MANAGED)])
+
+    assert await _zustand(service, "amdgpu:pwm1") is PwmControl.FIRMWARE_MANAGED
 
 
-def test_ein_eigener_befund_wird_nicht_zurueckgenommen():
+@pytest.mark.asyncio
+async def test_ein_eigener_befund_wird_nicht_zurueckgenommen(
+    session_factory, monkeypatch
+):
     """Vereinigung statt Ersetzung: eine Nutzer-Eingabe geht ueber irgendeinen
     Worker, und bei EACCES vermerkt genau DER den Kanal. Der Primary hat den
     Write nie versucht, seine Liste kennt den Kanal also nicht -- eine
     Ruecksetzung auf SUPPORTED liesse den frischen Befund sofort wieder
     verschwinden, neben einem `last_write_error`, der stehen bleibt."""
-    eintraege = [{"fan_id": "nct6798:pwm1", "pwm_control": PwmControl.NO_PERMISSION}]
-    _ueberlagern(None, eintraege, set())
-    assert eintraege[0]["pwm_control"] is PwmControl.NO_PERMISSION
+    with session_factory() as db:
+        publish_write_permission(db, True, set())
+    service = _service(session_factory, monkeypatch,
+                       [_fan("nct6798:pwm1", PwmControl.NO_PERMISSION)])
+
+    assert await _zustand(service, "nct6798:pwm1") is PwmControl.NO_PERMISSION
+
+
+@pytest.mark.asyncio
+async def test_ein_leerer_eintrag_nimmt_nichts_zurueck(session_factory, monkeypatch):
+    """Die Gegenrichtung derselben Regel: meldet der Primary den Kanal nicht
+    mehr, aendert das am eigenen Stand nichts -- zurueck kommt der Kanal ueber
+    einen eigenen erfolgreichen Write oder die eigene Probe."""
+    with session_factory() as db:
+        publish_write_permission(db, True, set())
+    service = _service(session_factory, monkeypatch,
+                       [_fan("nct6798:pwm1", PwmControl.SUPPORTED)])
+
+    assert await _zustand(service, "nct6798:pwm1") is PwmControl.SUPPORTED

--- a/backend/tests/test_fan_write_permission_derived.py
+++ b/backend/tests/test_fan_write_permission_derived.py
@@ -122,6 +122,7 @@ def _backend_mit_probe(*, kanaele: dict, schreibbar: bool, uhr: list):
     backend = _backend(geprueft=True, kanaele=kanaele)
     backend._write_backoff = {}
     backend._next_permission_recheck = 0.0
+    backend._letzte_probe_erfolgreich = None
     backend._monotonic = lambda: uhr[0]
 
     async def _read(path):

--- a/backend/tests/test_fan_write_permission_derived.py
+++ b/backend/tests/test_fan_write_permission_derived.py
@@ -114,3 +114,114 @@ async def test_ein_erfolgreicher_write_holt_die_anzeige_zurueck(monkeypatch, tmp
     await backend.set_pwm("nct6798:pwm1", 50)
 
     assert backend.has_write_permission() is True
+
+
+# --- Die Sackgasse, die die Ableitung sonst erzeugt (#568) -------------------
+
+def _backend_mit_probe(*, kanaele: dict, schreibbar: bool, uhr: list):
+    backend = _backend(geprueft=True, kanaele=kanaele)
+    backend._write_backoff = {}
+    backend._next_permission_recheck = 0.0
+    backend._monotonic = lambda: uhr[0]
+
+    async def _read(path):
+        return "1"
+
+    async def _write(path, value):
+        if schreibbar:
+            backend._has_write_permission = True
+            return True, None
+        return False, 13  # EACCES
+
+    backend._read_hwmon_file = _read
+    backend._write_hwmon_file = _write
+    return backend
+
+
+@pytest.mark.asyncio
+async def test_die_anzeige_findet_ohne_zutun_zurueck(monkeypatch, tmp_path):
+    """Der Kern des Befunds: geheilt wurde bisher nur ueber einen
+    erfolgreichen Write, und den loest der Regelkreis fuer einen Luefter im
+    MANUAL-Modus nie aus (Ziel == Ist). Da die Anzeige zugleich die
+    Bedienelemente sperrt, faellt auch der letzte Schreibweg weg -- ohne die
+    erneute Probe kaeme der Nutzer nur ueber einen Dienst-Neustart heraus.
+    """
+    uhr = [0.0]
+    kanaele = {
+        "nct6798:pwm1": {"pwm_control": PwmControl.NO_PERMISSION,
+                         "pwm_enable_path": tmp_path / "pwm1_enable",
+                         "last_write_error": "kein Schreibrecht"},
+    }
+    backend = _backend_mit_probe(kanaele=kanaele, schreibbar=True, uhr=uhr)
+    assert backend.has_write_permission() is False
+
+    await backend.recheck_write_permission()
+
+    assert backend.has_write_permission() is True
+    assert kanaele["nct6798:pwm1"]["pwm_control"] is PwmControl.SUPPORTED
+    assert kanaele["nct6798:pwm1"]["last_write_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_ohne_rechte_bleibt_es_bei_readonly(tmp_path):
+    """Die Gegenrichtung: scheitert die Probe, bleibt die Aussage bestehen."""
+    uhr = [0.0]
+    kanaele = {
+        "nct6798:pwm1": {"pwm_control": PwmControl.NO_PERMISSION,
+                         "pwm_enable_path": tmp_path / "pwm1_enable"},
+    }
+    backend = _backend_mit_probe(kanaele=kanaele, schreibbar=False, uhr=uhr)
+
+    await backend.recheck_write_permission()
+
+    assert backend.has_write_permission() is False
+
+
+@pytest.mark.asyncio
+async def test_die_probe_taktet_sich(tmp_path):
+    """Sonst liefe bei dauerhaft fehlenden Rechten jeden Regelzyklus ein
+    Schreibversuch je Kanal -- genau die Last, die #533 beseitigt hat."""
+    uhr = [0.0]
+    versuche = []
+    kanaele = {
+        "nct6798:pwm1": {"pwm_control": PwmControl.NO_PERMISSION,
+                         "pwm_enable_path": tmp_path / "pwm1_enable"},
+    }
+    backend = _backend_mit_probe(kanaele=kanaele, schreibbar=False, uhr=uhr)
+    urspruenglich = backend._write_hwmon_file
+
+    async def _zaehlend(path, value):
+        versuche.append(path)
+        return await urspruenglich(path, value)
+
+    backend._write_hwmon_file = _zaehlend
+
+    await backend.recheck_write_permission()
+    await backend.recheck_write_permission()   # sofort danach: unterdrueckt
+    assert len(versuche) == 1
+
+    uhr[0] += backend._PERMISSION_RECHECK_SECONDS + 1
+    await backend.recheck_write_permission()
+    assert len(versuche) == 2
+
+
+@pytest.mark.asyncio
+async def test_bei_vorhandenem_schreibrecht_passiert_nichts(tmp_path):
+    """Ein No-op im Normalbetrieb -- die Probe darf nicht jeden Zyklus
+    schreiben, nur weil sie aufgerufen wird."""
+    uhr = [0.0]
+    versuche = []
+    kanaele = {"nct6798:pwm1": {"pwm_control": PwmControl.SUPPORTED,
+                                "pwm_enable_path": tmp_path / "pwm1_enable"}}
+    backend = _backend_mit_probe(kanaele=kanaele, schreibbar=True, uhr=uhr)
+    urspruenglich = backend._write_hwmon_file
+
+    async def _zaehlend(path, value):
+        versuche.append(path)
+        return await urspruenglich(path, value)
+
+    backend._write_hwmon_file = _zaehlend
+
+    await backend.recheck_write_permission()
+
+    assert versuche == []

--- a/backend/tests/test_fan_write_permission_derived.py
+++ b/backend/tests/test_fan_write_permission_derived.py
@@ -1,0 +1,116 @@
+"""Die Rechteanzeige kann wieder auf "kein Schreibrecht" zurueckfallen (#568 Punkt 1).
+
+`_has_write_permission` wird an drei Stellen auf True gesetzt -- der Probe beim
+Start und zwei erfolgreichen Write-Pfaden -- und von NIEMANDEM auf False. Ging
+das Schreibrecht zur Laufzeit verloren, meldete `GET /api/fans/permissions`
+weiter `ok`: die Bedienelemente blieben frei, jede Eingabe verpuffte, und der
+Nutzer bekam keinen Hinweis.
+
+PR #567 hatte das nicht behoben, sondern vereinheitlicht -- vorher haette ein
+Worker-Wechsel im 5-Sekunden-Poll wenigstens zufaellig einen anderen Wert
+gezeigt, danach waren alle vier Worker einig und alle vier falsch.
+
+Der Stand wird jetzt aus den Kanalzustaenden abgeleitet, die set_pwm ohnehin
+pflegt (NO_PERMISSION bei beobachtetem EACCES, zurueck auf SUPPORTED nach dem
+naechsten erfolgreichen Write).
+"""
+import pytest
+
+from app.schemas.fans import PwmControl
+from app.services.power.fan_backend_linux import LinuxFanControlBackend
+
+
+def _backend(*, geprueft: bool, kanaele: dict) -> LinuxFanControlBackend:
+    backend = object.__new__(LinuxFanControlBackend)
+    backend._has_write_permission = geprueft
+    backend._fan_cache = kanaele
+    return backend
+
+
+def test_ohne_erfolgreiche_probe_bleibt_es_bei_false():
+    """Die Probe beim Start ist weiterhin die Untergrenze: was nie
+    beschreibbar war, wird es nicht durch Ableitung."""
+    backend = _backend(geprueft=False, kanaele={
+        "nct6798:pwm1": {"pwm_control": PwmControl.SUPPORTED},
+    })
+    assert backend.has_write_permission() is False
+
+
+def test_ein_steuerbarer_kanal_genuegt():
+    backend = _backend(geprueft=True, kanaele={
+        "nct6798:pwm1": {"pwm_control": PwmControl.SUPPORTED},
+        "nct6798:pwm2": {"pwm_control": PwmControl.NO_PERMISSION},
+    })
+    assert backend.has_write_permission() is True
+
+
+def test_erst_wenn_jeder_steuerbare_kanal_gesperrt_ist_faellt_es_zurueck():
+    """Der eigentliche Regressionstest: vorher blieb der Wert True, egal wie
+    viele Kanaele EACCES gesehen hatten."""
+    backend = _backend(geprueft=True, kanaele={
+        "nct6798:pwm1": {"pwm_control": PwmControl.NO_PERMISSION},
+        "nct6798:pwm2": {"pwm_control": PwmControl.NO_PERMISSION},
+    })
+    assert backend.has_write_permission() is False
+
+
+def test_ein_firmware_kanal_zaehlt_nicht_mit():
+    """Auf BaluNode ist genau ein Kanal firmware-verwaltet. Er wird nie
+    geschrieben und darf die Aussage ueber die anderen nicht faerben --
+    dieselbe Ueberlegung wie in der Probe beim Start (#552)."""
+    backend = _backend(geprueft=True, kanaele={
+        "amdgpu:pwm1": {"pwm_control": PwmControl.FIRMWARE_MANAGED},
+        "nct6798:pwm1": {"pwm_control": PwmControl.NO_PERMISSION},
+    })
+    assert backend.has_write_permission() is False
+
+
+def test_nur_firmware_kanaele_lassen_den_startwert_stehen():
+    """Gibt es nichts Steuerbares, stellt sich die Frage nicht -- dann ist der
+    Wert der Probe die beste vorhandene Aussage, nicht ein hergeleitetes
+    False."""
+    backend = _backend(geprueft=True, kanaele={
+        "amdgpu:pwm1": {"pwm_control": PwmControl.FIRMWARE_MANAGED},
+    })
+    assert backend.has_write_permission() is True
+
+
+def test_ohne_erkannte_luefter_bleibt_der_startwert():
+    backend = _backend(geprueft=True, kanaele={})
+    assert backend.has_write_permission() is True
+
+
+def test_ein_kanal_ohne_angabe_gilt_als_steuerbar():
+    """Der Cache traegt pwm_control erst nach dem Scan. Ein fehlender Wert
+    darf nicht als Sperre gelesen werden."""
+    backend = _backend(geprueft=True, kanaele={"nct6798:pwm1": {}})
+    assert backend.has_write_permission() is True
+
+
+@pytest.mark.asyncio
+async def test_ein_erfolgreicher_write_holt_die_anzeige_zurueck(monkeypatch, tmp_path):
+    """Die Gegenrichtung funktionierte schon vorher und muss es weiter tun:
+    set_pwm setzt NO_PERMISSION nach einem erfolgreichen Write zurueck, und
+    damit meldet die Ableitung wieder True."""
+    pwm = tmp_path / "pwm1"
+    pwm.write_text("128\n")
+    backend = _backend(geprueft=True, kanaele={
+        "nct6798:pwm1": {
+            "pwm_control": PwmControl.NO_PERMISSION,
+            "pwm_path": pwm,
+            "pwm_enable_path": None,
+            "last_write_error": "kein Schreibrecht",
+        },
+    })
+    backend._write_backoff = {}
+    backend._monotonic = lambda: 0.0
+    assert backend.has_write_permission() is False
+
+    async def _write(path, value):
+        return True, None
+
+    monkeypatch.setattr(backend, "_write_hwmon_file", _write, raising=False)
+
+    await backend.set_pwm("nct6798:pwm1", 50)
+
+    assert backend.has_write_permission() is True

--- a/client/src/__tests__/components/fan-control/FanCard.test.tsx
+++ b/client/src/__tests__/components/fan-control/FanCard.test.tsx
@@ -118,3 +118,40 @@ describe('FanCard bei firmware-verwalteter GPU', () => {
     expect(screen.getByText('—')).toBeTruthy();
   });
 });
+
+describe('FanCard bei fehlendem Schreibrecht (#568 Punkt 2)', () => {
+  it('zeigt kein Badge, solange der Kanal schreibbar ist', () => {
+    renderCard(fan({ pwm_control: 'supported' }));
+    expect(screen.queryByTestId('fan-no-permission-badge')).toBeNull();
+  });
+
+  it('benennt den Kanal, der gerade nicht geschrieben wird', () => {
+    // Vorher sagte nur ein globales Banner "readonly" -- welcher der fuenf
+    // Kanaele betroffen ist, stand nirgends.
+    renderCard(fan({ pwm_control: 'no_permission' }));
+    expect(screen.getByTestId('fan-no-permission-badge')).toBeInTheDocument();
+  });
+
+  it('sperrt die Bedienelemente NICHT -- der Zustand ist behebbar', () => {
+    // Anders als firmware_managed: BaluHost wuerde den Kanal steuern, sobald
+    // es darf. Ihn zu sperren hiesse, einen voruebergehenden Laufzeit-Befund
+    // wie eine dauerhafte Hardware-Eigenschaft zu behandeln -- der Nutzer
+    // koennte dann nicht einmal den Modus vorbereiten.
+    // mode: AUTO, sonst waere der Manual-Knopf schon deshalb gesperrt, weil er
+    // der aktive Modus ist -- das haette die Zusicherung ohne Aussagekraft
+    // gemacht (und tat es beim ersten Lauf).
+    renderCard(fan({
+      pwm_control: 'no_permission', is_gpu_fan: false, gpu_vendor: null,
+      mode: FanMode.AUTO,
+    }));
+    const manual = screen.getByRole('button', { name: /card\.manual/ }) as HTMLButtonElement;
+    const scheduled = screen.getByRole('button', { name: /card\.scheduled/ }) as HTMLButtonElement;
+    expect(manual.disabled).toBe(false);
+    expect(scheduled.disabled).toBe(false);
+  });
+
+  it('zeigt das Firmware-Badge nicht mit', () => {
+    renderCard(fan({ pwm_control: 'no_permission' }));
+    expect(screen.queryByTestId('fan-firmware-badge')).toBeNull();
+  });
+});

--- a/client/src/__tests__/components/fan-control/FirmwareFanNotice.test.tsx
+++ b/client/src/__tests__/components/fan-control/FirmwareFanNotice.test.tsx
@@ -288,6 +288,29 @@ it('sendet fuer nicht markierte Knoten null: nur die Zieltemperatur wird verwalt
   });
 });
 
+it('sperrt auch das Verwalten-Kaestchen, solange eine Anfrage laeuft', async () => {
+  // #574: der Regler war seit #570 gesperrt, das Kaestchen daneben nicht --
+  // sein Zustand liess sich umschalten und wurde beim Eintreffen der Antwort
+  // still ueberschrieben. Schwerer als beim Regler: ein verlorener Klick hier
+  // entscheidet, ob BaluHost den Knoten kuenftig bei jedem Start setzt.
+  vi.mocked(getGpuAcoustics).mockResolvedValue(FULL_STATUS);
+  let resolvePut: (v: unknown) => void = () => {};
+  vi.mocked(setGpuAcoustics).mockReturnValue(
+    new Promise((res) => { resolvePut = res; }) as ReturnType<typeof setGpuAcoustics>,
+  );
+  render(<FirmwareFanNotice fanId="amdgpu-pci-0300:pwm1" />);
+
+  const box = await screen.findByRole('checkbox', { name: /fan_target_temperature/ });
+  expect(box).not.toBeDisabled();
+
+  fireEvent.click(screen.getByText('system:fanControl.gpu.acoustics.save'));
+
+  await waitFor(() => expect(box).toBeDisabled());
+
+  resolvePut(FULL_STATUS);
+  await waitFor(() => expect(box).not.toBeDisabled());
+});
+
 it('sperrt auch die Regler, solange eine Anfrage laeuft', async () => {
   // Ein VERWALTETER Knoten, sonst waere der Regler schon durch
   // !managed[name] gesperrt und der Test bewiese nichts -- dieselbe

--- a/client/src/components/fan-control/FanCard.tsx
+++ b/client/src/components/fan-control/FanCard.tsx
@@ -89,6 +89,13 @@ export default function FanCard({
   };
 
   const isFirmwareManaged = fan.pwm_control === 'firmware_managed';
+  // Hinweis, KEINE Sperre (#568): fehlende Rechte sind ein voruebergehender
+  // Laufzeit-Befund, den set_pwm nach dem naechsten erfolgreichen Write selbst
+  // zuruecknimmt. Wer die Bedienelemente hier sperrt, behandelt einen
+  // behebbaren Zustand wie eine dauerhafte Hardware-Eigenschaft -- der Nutzer
+  // koennte dann nicht einmal den Modus vorbereiten, in dem der Luefter danach
+  // laufen soll.
+  const isDenied = fan.pwm_control === 'no_permission';
   // Abgeleitet, nicht gelesen: einen fan_zero_rpm_enable-Knoten gibt es erst
   // ab Kernel 6.13. Geschlossen wird aus "firmware-verwaltet und 0 RPM" (#516).
   const isZeroRpm = isFirmwareManaged && fan.rpm === 0;
@@ -119,6 +126,15 @@ export default function FanCard({
                 title={t('system:fanControl.gpu.firmware.badgeHint')}
               >
                 {t('system:fanControl.gpu.firmware.badge')}
+              </span>
+            )}
+            {isDenied && (
+              <span
+                data-testid="fan-no-permission-badge"
+                className="inline-flex items-center px-1.5 py-0.5 text-xs bg-amber-500/20 text-amber-300 rounded"
+                title={t('system:fanControl.card.noPermissionHint')}
+              >
+                {t('system:fanControl.card.noPermission')}
               </span>
             )}
             {fan.last_write_error && (

--- a/client/src/components/fan-control/FirmwareFanNotice.tsx
+++ b/client/src/components/fan-control/FirmwareFanNotice.tsx
@@ -192,9 +192,17 @@ export default function FirmwareFanNotice({ fanId }: Props) {
                         aria-label={`${t('system:fanControl.gpu.acoustics.managed')}: ${
                           t(`system:fanControl.gpu.acoustics.${name}`)}`}
                         checked={managed[name] ?? false}
+                        // Waehrend einer laufenden Anfrage gesperrt (#574) --
+                        // anders als der Regler daneben OHNE !managed[name],
+                        // denn dieses Kaestchen ist das Bedienelement, mit dem
+                        // man einen unverwalteten Knoten ueberhaupt erst in die
+                        // Verwaltung holt. Ungesperrt liess sich der Zustand
+                        // umschalten und wurde beim Eintreffen der Antwort von
+                        // setManaged(managedFromNodes(...)) still ueberschrieben.
+                        disabled={acousticsBusy}
                         onChange={(e) =>
                           setManaged({ ...managed, [name]: e.target.checked })}
-                        className="accent-sky-500"
+                        className="accent-sky-500 disabled:opacity-40"
                       />
                       <span>
                         {t(`system:fanControl.gpu.acoustics.${name}`)}: {draft[name]}

--- a/client/src/i18n/locales/de/system.json
+++ b/client/src/i18n/locales/de/system.json
@@ -872,7 +872,9 @@
       "manualPwm": "Manuelles PWM",
       "noSensor": "Kein Sensor zugewiesen",
       "pwmError": "PWM-Fehler",
-      "zeroRpm": "Zero-RPM — die Karte hat den Lüfter angehalten"
+      "zeroRpm": "Zero-RPM — die Karte hat den Lüfter angehalten",
+      "noPermission": "Kein Schreibrecht",
+      "noPermissionHint": "BaluHost darf diesen Kanal gerade nicht schreiben. Die Regelung greift hier nicht, bis die Rechte wieder passen; die Einstellungen bleiben bedienbar und wirken, sobald ein Schreibvorgang wieder gelingt."
     },
     "details": {
       "temperatureCol": "Temperatur (°C)",

--- a/client/src/i18n/locales/en/system.json
+++ b/client/src/i18n/locales/en/system.json
@@ -877,7 +877,9 @@
       "manualPwm": "Manual PWM",
       "noSensor": "No sensor assigned",
       "pwmError": "PWM error",
-      "zeroRpm": "Zero RPM — the card has stopped the fan"
+      "zeroRpm": "Zero RPM — the card has stopped the fan",
+      "noPermission": "No write access",
+      "noPermissionHint": "BaluHost currently cannot write this channel. Control does not take effect here until permissions are restored; the settings stay editable and apply as soon as a write succeeds again."
     },
     "details": {
       "temperatureCol": "Temperature (°C)",


### PR DESCRIPTION
Behebt beide Punkte aus **#568** und **#574**.

## Punkt 1: das Schreibrecht-Flag konnte nur `True` werden

`_has_write_permission` wird an drei Stellen gesetzt — der Probe beim Start und zwei erfolgreichen Write-Pfaden — und von **niemandem** zurückgenommen. Ging das Recht zur Laufzeit verloren (eine udev-Regel, die nach einem Treiber-Reload nicht mehr greift; eine sudoers-Änderung, die die Box nie erreicht hat), meldete `GET /api/fans/permissions` weiter `ok`: die Bedienelemente blieben frei, jede Eingabe verpuffte, kein Hinweis.

PR #567 hatte das nicht behoben, sondern *vereinheitlicht* — vorher hätte ein Worker-Wechsel im Poll wenigstens zufällig einen anderen Wert gezeigt, danach waren alle vier Worker einig und alle vier falsch.

Der Stand wird jetzt aus den Kanalzuständen abgeleitet, die `set_pwm` ohnehin pflegt: `NO_PERMISSION` bei beobachtetem `EACCES`, zurück auf `SUPPORTED` nach dem nächsten erfolgreichen Write.

**Zwei Entscheidungen dabei, beide im Docstring begründet:**

- **Nicht am Backoff aus #533 aufgehängt**, obwohl das Issue es vorschlägt: die Sperre zählt Fehlschläge jeder Art, auch `EINVAL` vom Treiber. Das wäre eine Aussage über „der Write klappt nicht", nicht über „wir dürfen nicht" — und die Rechteanzeige soll das zweite sagen.
- **Geltungsbereich restriktiv:** erst wenn *jeder* steuerbare Kanal ein `EACCES` gesehen hat, ist die Anzeige `readonly`. Auf dieser Hardware ist genau einer firmware-verwaltet und vier sind steuerbar; ein einzelner gesperrter Kanal macht die Steuerung nicht tot.

## Punkt 2: welcher Kanal betroffen ist, stand nirgends

Die Karte zeigt ein Badge bei `pwm_control === 'no_permission'` — der Zustand lag seit #480 im Payload und wurde nur nicht angezeigt.

Ausdrücklich ein **Hinweis, keine Sperre** (so die Korrektur im Issue): anders als `firmware_managed` ist das ein vorübergehender Laufzeit-Befund, den `set_pwm` selbst zurücknimmt. Wer die Bedienelemente hier sperrt, behandelt einen behebbaren Zustand wie eine dauerhafte Hardware-Eigenschaft — der Nutzer könnte dann nicht einmal den Modus vorbereiten, in dem der Lüfter danach laufen soll.

Damit das Badge nicht flackert, veröffentlicht der Primary die gesperrten Kanäle in derselben Singleton-Zeile wie das globale Flag (neue Spalte `denied_fan_ids`, Migration `c7a41b9e2f30` auf `d1e5a83f47c2`). Ohne das melden die drei Follower für denselben Kanal weiter `supported` — der Docstring von `FanRuntimeState` beschreibt genau dieses Problem bereits für die Ebene darüber („vier Worker, vier Wahrheiten", #552); für den Kanalzustand war die Lösung nur nie nachgezogen.

## #574: das Verwalten-Kästchen war nicht mitgesperrt

Der Regler daneben ist seit #570 während einer laufenden Anfrage gesperrt, das Kästchen nicht — sein Zustand liess sich umschalten und wurde beim Eintreffen der Antwort still überschrieben. Schwerer als beim Regler: ein verlorener Klick entscheidet, ob BaluHost den Knoten künftig bei jedem Start setzt. Bewusst **ohne** `!managed[name]`, denn das Kästchen ist das Bedienelement, mit dem man einen unverwalteten Knoten überhaupt erst in die Verwaltung holt.

## Was die drei Prüfrunden gefunden haben

Die Reviews fanden **drei Fehler, die erst dieser Branch eingebaut hatte**. Alle drei sind behoben, jeder mit gemessener Gegenprobe:

1. **Die Ableitung konnte sich festsetzen.** Geheilt wurde sie nur über einen erfolgreichen Write — und den löst der Regelkreis für einen Lüfter im MANUAL-Modus nie aus (Ziel == Ist; das steht wörtlich in `fan_control`s eigenem Docstring). Da `readonly` zugleich alle Bedienelemente sperrt, fiel auch der letzte Schreibweg weg: der Nutzer käme ohne Dienst-Neustart nicht heraus. Ein schlechterer Tausch als der behobene Fehler. → `recheck_write_permission()` fährt die Probe erneut, solange die Ableitung `readonly` sagt, getaktet auf höchstens einen Lauf je 60 s.
2. **Die Überlagerung löschte den Befund, den sie sichtbar machen sollte.** Eine Nutzer-Eingabe geht über irgendeinen Worker; bei `EACCES` vermerkt genau der den Kanal. Der Primary hat den Write nie versucht, seine Liste kennt ihn nicht — die Rücknahme setzte den frischen Befund sofort auf `SUPPORTED` zurück, und dieselbe Antwort trüge `last_write_error` neben `pwm_control: supported`. → Vereinigung statt Ersetzung.
3. **Die Sackgasse war zunächst nur gespiegelt.** `recheck_write_permission` hing allein im Regelkreis, und der läuft nur im Primary. Ein Follower hatte keinen Rückweg. → Die Probe hängt jetzt zusätzlich im Lesepfad, den jeder Worker bedient.

Dazu ein Erbstück, das durch die Änderung erst gefährlich wurde: `_check_write_permission` kehrte nach dem ersten beschreibbaren Kanal zurück, die Kanäle dahinter blieben auf ihrem alten `NO_PERMISSION`. Solange das nur der Primary sah, war es kosmetisch — seit der Kanalzustand verteilt wird, behauptete es dauerhaft „kein Schreibrecht" auf funktionierenden Kanälen.

**Und ein Befund über die Tests, der mir wichtiger ist als die Fixes:** meine erste Fassung von `test_fan_status_overlay.py` bildete die Entscheidung in einer Hilfsfunktion *nach* und prüfte die Verdrahtung über `inspect.getsource()`. Die Review hat nachgemessen, was das wert ist — eine semantische Rücknahme (`in gesperrt` → `not in gesperrt`) liess alle 441 Lüfter-Tests grün, dieselbe Rücknahme an der Verdrahtung alle 796. Gefangen wurde nur das buchstäbliche Verschwinden eines Bezeichners. Die Datei ruft jetzt `get_status()` wirklich auf; die invertierte Bedingung lässt zwei Tests fallen.

## Prüfung

- `pytest -k "fan or power"` → 793 bestanden, 2 übersprungen; `ruff` sauber; `alembic heads` genau ein Head.
- Frontend: `vitest` der fan-control-Tests → 70 bestanden; `eslint .` → 0 Fehler; `npm run build` erfolgreich.
- Gegenproben: altes klebriges Flag → 3 von 8 rot; Badge und Kästchen-Sperre zurückgedreht → 2 von 70 rot; Verdrahtung entfernt → Verdrahtungstest rot; Überlagerungsbedingung invertiert → 2 von 5 rot.

## Bekannte Reste, bewusst so

- **Die Probe räumt den #533-Backoff nicht ab.** Nach einer probe-getriebenen Erholung meldet die Anzeige `ok`, während der Regelkreis für diesen Kanal noch bis zu 900 s unterdrückt bleibt. Nutzeraktionen sind unbetroffen (`set_pwm(force=True)`), und ein erfolgreicher Write räumt den Eintrag.
- **Bei `EACCES` zeigt die Karte zwei Badges** — „Kein Schreibrecht" und das vorhandene „PWM-Fehler", das denselben Text im Tooltip trägt. Das zweite existierte schon vorher.
- **Schreiblast im Dauer-Readonly:** 4 Kanäle × 1 Lauf/60 s = 5 760 `sudo tee`/Tag pro Worker im *gesperrten* Zustand — rund ein Sechstel dessen, was #533 beseitigt hat, und nur in einem Zustand, der selbst schon ein Alarm ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGS5jVzZpLcqpZ2VH8DqNn
