### PR TITLE
feat(fans): nicht steuerbaren Kanal an die Board-Automatik zurueckgeben (#534 Punkt 1)

### DIFF
--- a/backend/alembic/versions/e2f81c4a7b93_fan_runtime_released_fans.py
+++ b/backend/alembic/versions/e2f81c4a7b93_fan_runtime_released_fans.py
@@ -1,0 +1,33 @@
+"""fan_runtime_state.released_fans -- an die Board-Automatik zurueckgegebene Kanaele (#534)
+
+Ein Kanal, den BaluHost nicht schreiben kann, wird an die Chip-Automatik
+zurueckgegeben. Welcher Kanal in welchem Zustand ist, muss jeder Uvicorn-Worker
+beantworten koennen: get_status() laeuft in einem beliebigen der vier, und ein
+prozesslokaler Besitzzustand lieferte bei dreien davon None -- die Anzeige
+flackerte dann genauso wie das Read-Only-Banner vor #552.
+
+Werte: "released" (die Board-Automatik regelt) und "abandoned" (die Rueckgabe
+scheiterte oder blieb wirkungslos -- es regelt niemand).
+
+Revision ID: e2f81c4a7b93
+Revises: c7a41b9e2f30
+Create Date: 2026-09-07
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "e2f81c4a7b93"
+down_revision = "c7a41b9e2f30"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "fan_runtime_state",
+        sa.Column("released_fans", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("fan_runtime_state", "released_fans")

--- a/backend/app/api/routes/fans.py
+++ b/backend/app/api/routes/fans.py
@@ -14,6 +14,7 @@ from app.core.exceptions import ServiceUnavailableError
 from app.core.rate_limiter import user_limiter, get_limit
 from app.models.user import User
 from app.schemas.fans import (
+    ReacquireFanRequest,
     FanStatusResponse,
     FanInfo,
     SetFanModeRequest,
@@ -125,6 +126,32 @@ async def list_fans(
     status = await service.get_status()
     fans = [FanInfo(**fan_data) for fan_data in status["fans"]]
     return fans
+
+
+@router.post("/reacquire")
+@user_limiter.limit(get_limit("admin_operations"))
+async def reacquire_fan(
+    request: Request, response: Response,
+    body: ReacquireFanRequest,
+    current_user: User = Depends(get_current_admin),  # Admin only
+    service: FanControlService = Depends(get_fan_service),
+):
+    """Einen an die Board-Automatik zurueckgegebenen Luefter wieder uebernehmen.
+
+    Der Rueckweg zu #534 Punkt 1. Er MUSS ein eigener Endpunkt sein: die
+    Bedienelemente eines freigegebenen Luefters sind in der Oberflaeche
+    gesperrt, und ein Rueckweg ueber Modus oder PWM waere damit selbst
+    gesperrt -- ein Zustand ohne Ausgang.
+
+    Requires admin role.
+    """
+    erfolg = await service.reacquire_fan(body.fan_id)
+    if not erfolg:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Fan {body.fan_id} is not released to the board",
+        )
+    return {"success": True, "fan_id": body.fan_id}
 
 
 @router.post("/mode", response_model=SetFanModeResponse)

--- a/backend/app/models/fans.py
+++ b/backend/app/models/fans.py
@@ -221,6 +221,13 @@ class FanRuntimeState(Base):
     # erschiene und verschwaende im 5-Sekunden-Poll, je nachdem welcher
     # Worker gerade antwortet.
     denied_fan_ids: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # Die freigegebenen Kanaele als JSON-Objekt fan_id -> Zustand
+    # ("released" = die Board-Automatik regelt, "abandoned" = die Rueckgabe
+    # scheiterte, es regelt niemand). Aus demselben Grund hier und nicht im
+    # Prozess wie die Spalte darueber: get_status() laeuft in einem
+    # beliebigen der vier Worker, ein prozesslokaler Besitzzustand lieferte
+    # bei dreien davon None und die Anzeige flackerte (#534).
+    released_fans: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/backend/app/schemas/fans.py
+++ b/backend/app/schemas/fans.py
@@ -96,6 +96,16 @@ class FanInfo(BaseModel):
     max_pwm_percent: int = Field(default=100, ge=0, le=100)
     emergency_temp_celsius: float = Field(default=85.0, ge=0, le=150)
     temp_sensor_id: Optional[str] = Field(default=None, description="Associated temperature sensor ID")
+    ownership: str = Field(
+        default="owned",
+        description=(
+            "Wer den Kanal regelt: 'owned' (BaluHost), 'released' (die "
+            "Board-Automatik, nach einer geglueckten Rueckgabe) oder "
+            "'abandoned' (niemand -- die Rueckgabe scheiterte). Eigenes Feld "
+            "statt eines Werts in `mode`: das ist ein validiertes Enum, ein "
+            "fremder Wert darin waere eine 500 (#534)."
+        ),
+    )
     curve_points: List[FanCurvePoint] = Field(default_factory=list)
     hysteresis_celsius: float = Field(default=3.0, ge=0, le=15, description="Temperature hysteresis to prevent oscillation")
     active_schedule: Optional[FanActiveSchedule] = None
@@ -159,6 +169,12 @@ class FanStatusResponse(BaseModel):
                 "backend_available": True
             }
         }
+
+
+class ReacquireFanRequest(BaseModel):
+    """Einen freigegebenen Luefter wieder uebernehmen (#534)."""
+
+    fan_id: str = Field(..., description="Fan identifier")
 
 
 class SetFanModeRequest(BaseModel):

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -164,6 +164,19 @@ class LinuxFanControlBackend(FanControlBackend):
             logger.info("Fan control: no write permission (readonly mode)")
         self._letzte_probe_erfolgreich = False
 
+    def clear_write_failures(self, fan_id: str) -> None:
+        """Den Fehlerzaehler dieses Kanals zuruecksetzen (#534).
+
+        Gebraucht bei der Wiederuebernahme eines freigegebenen Kanals: der
+        Zaehler lebt im Prozess, die Anfrage kommt aber ueber einen beliebigen
+        der vier Worker. Ohne dieses Zuruecksetzen im PRIMARY saehe dessen
+        Regelkreis den Kanal zwar wieder als besessen, fragte aber seinen
+        eigenen -- weiterhin am Deckel stehenden -- Zaehler und gaebe ihn
+        binnen eines Sample-Intervalls erneut ab. Der Nutzer bekaeme einen
+        Erfolg gemeldet und fuenf Sekunden spaeter wieder "Board regelt".
+        """
+        self._write_backoff.pop(fan_id, None)
+
     def write_failure_state(self, fan_id: str) -> Tuple[int, bool]:
         """Wie oft der Regelkreis auf diesem Kanal nacheinander gescheitert ist.
 

--- a/backend/app/services/power/fan_backend_linux.py
+++ b/backend/app/services/power/fan_backend_linux.py
@@ -164,6 +164,26 @@ class LinuxFanControlBackend(FanControlBackend):
             logger.info("Fan control: no write permission (readonly mode)")
         self._letzte_probe_erfolgreich = False
 
+    def write_failure_state(self, fan_id: str) -> Tuple[int, bool]:
+        """Wie oft der Regelkreis auf diesem Kanal nacheinander gescheitert ist.
+
+        Returns:
+            (fail_count, at_cap). `at_cap` heisst: das Backoff-Fenster ist auf
+            PWM_BACKOFF_MAX_SECONDS gedeckelt, der Kanal lehnt also seit acht
+            aufeinanderfolgenden Versuchen ab (mit den heutigen Konstanten).
+
+        Ohne diesen Zugriff waere die Rueckgabe-Entscheidung aus #534 nicht
+        formulierbar: `_write_backoff` ist privat, das aktuelle Fenster wird
+        nicht gespeichert, und ein Aufrufer muesste den Deckel aus fail_count
+        nachrechnen -- eine Verdopplung der Backoff-Formel an einer zweiten
+        Stelle.
+        """
+        fail_count = self._write_backoff.get(fan_id, (0, 0.0))[0]
+        if fail_count <= 0:
+            return 0, False
+        fenster = PWM_BACKOFF_BASE_SECONDS * (2 ** (fail_count - 1))
+        return fail_count, fenster >= PWM_BACKOFF_MAX_SECONDS
+
     async def recheck_write_permission(self) -> None:
         """Die Probe erneut fahren, wenn die Ableitung gerade `readonly` sagt.
 
@@ -362,6 +382,25 @@ class LinuxFanControlBackend(FanControlBackend):
                 f"pwm_enable={enable_val}, "
                 f"errno={errno.errorcode.get(err_code, err_code)})."
             )
+
+        if force:
+            # Erzwungene Writes zaehlen nicht ins Backoff (#534): der Zaehler
+            # traegt seit #568 eine zweite Bedeutung -- am Deckel gilt ein Kanal
+            # als nicht steuerbar und wird an die Board-Automatik
+            # zurueckgegeben. Acht erfolglose Nutzer-Klicks (oder Notfall-Writes)
+            # duerfen den Luefter nicht abgeben; gezaehlt wird nur, was der
+            # Regelkreis von sich aus versucht hat.
+            #
+            # Gemeldet wird trotzdem, und zwar als ERROR: ein erzwungener
+            # Write kommt von einer Nutzeraktion oder aus dem Notfall -- beide
+            # will man im Log sehen, unabhaengig davon, ob der Zaehler laeuft.
+            # Fuer die Log-Hygiene aus #533 ist das unschaedlich: erzwungene
+            # Writes sind selten und umgehen das Fenster ohnehin.
+            logger.error(
+                f"{fan_id}: erzwungener PWM-Write fehlgeschlagen -- "
+                f"{fan_info.get('last_write_error')}"
+            )
+            return False
 
         fail_count = self._write_backoff.get(fan_id, (0, 0.0))[0] + 1
         delay = min(

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -150,6 +150,14 @@ class FanControlBackend(ABC):
         """
         pass
 
+    def clear_write_failures(self, fan_id: str) -> None:
+        """Den Fehlerzaehler dieses Kanals zuruecksetzen (#534).
+
+        Kein @abstractmethod, aus demselben Grund wie write_failure_state:
+        ein Backend ohne Backoff hat nichts zurueckzusetzen.
+        """
+        return None
+
     def write_failure_state(self, fan_id: str) -> Tuple[int, bool]:
         """Wie oft der Regelkreis auf diesem Kanal nacheinander gescheitert ist.
 
@@ -226,6 +234,10 @@ class FanControlService:
         # Zuletzt veroeffentlichte Menge gesperrter Kanaele. None heisst wie
         # oben: noch nie geschrieben (#568).
         self._published_denied_fans: Optional[set] = None
+        # Die zuletzt im Regelkreis gesehene Freigabe-Menge. Nur dazu da,
+        # eine Wiederuebernahme zu ERKENNEN -- sie geschieht ueber einen
+        # anderen Worker (#534).
+        self._zuletzt_freigegeben: set = set()
 
         FanControlService._instance = self
 
@@ -272,6 +284,23 @@ class FanControlService:
 
             # Load fan configs from database
             await self._load_fan_configs()
+
+            # Jeder Neustart gibt jedem Kanal eine neue Chance (#534): der
+            # Fehlerzaehler, der zur Freigabe gefuehrt hat, lebte im Prozess
+            # und ist jetzt weg. Bliebe die Freigabe stehen, haette ein
+            # Betreiber, der die Ursache behebt und neu startet, keinen
+            # automatischen Rueckweg -- die Karte zeigte weiter "Board regelt"
+            # oder, schlimmer, "niemand regelt". Faellt der Kanal wieder aus,
+            # ist er nach acht Fehlschlaegen erneut freigegeben; das kostet
+            # eine Logzeile und stellt den ehrlichen Zustand her.
+            if getattr(lifespan, "IS_PRIMARY_WORKER", False):
+                with self.db_session_factory() as db:
+                    if read_released_fans(db):
+                        publish_released_fans(db, {})
+                        logger.info(
+                            "Freigaben an die Board-Automatik zurueckgesetzt -- "
+                            "jeder Kanal wird neu versucht")
+                self._zuletzt_freigegeben = set()
 
             # Die GPU-Akustik gehoert zum Start, nicht in den Regelzyklus:
             # sie ist Konfiguration, kein Regelkreis (#516).
@@ -1067,6 +1096,27 @@ class FanControlService:
             freigegeben = read_released_fans(db)
         freigaben_vorher = dict(freigegeben)
 
+        # Eine Wiederuebernahme kommt ueber einen BELIEBIGEN Worker (die Route
+        # laeuft dort, wo die Anfrage landet), der Fehlerzaehler lebt aber im
+        # Prozess des Primary. Ohne diesen Abgleich saehe er den Kanal zwar
+        # wieder als besessen, fragte aber seinen eigenen -- weiterhin am
+        # Deckel stehenden -- Zaehler und gaebe ihn im selben Zyklus erneut ab.
+        # Der Nutzer bekaeme einen Erfolg gemeldet und fuenf Sekunden spaeter
+        # wieder "Board regelt" (#534).
+        zurueckgeholt = self._zuletzt_freigegeben - set(freigegeben)
+        for fan_id in zurueckgeholt:
+            self._backend.clear_write_failures(fan_id)
+            self._hysteresis_state.pop(fan_id, None)
+            aktuell = next((f for f in fans if f.fan_id == fan_id), None)
+            if aktuell is not None:
+                # Genau EIN erzwungener Write, sonst bliebe pwm_enable auf dem
+                # Auto-Wert stehen, falls das Board zufaellig denselben PWM
+                # eingestellt hat, den die Kurve berechnet -- der Regelkreis
+                # schreibt nur bei Wertaenderung.
+                await self._backend.set_pwm(fan_id, aktuell.pwm_percent, force=True)
+            logger.info("%s: wieder uebernommen, Fehlerzaehler zurueckgesetzt", fan_id)
+        self._zuletzt_freigegeben = set(freigegeben)
+
         with self.db_session_factory() as db:
             for fan in fans:
                 config = db.execute(
@@ -1218,6 +1268,7 @@ class FanControlService:
                     mode == FanMode.EMERGENCY
                     and config.mode != FanMode.EMERGENCY.value
                     and fan.pwm_control is not PwmControl.FIRMWARE_MANAGED
+                    and not is_released(zustand)
                 ):
                     # Bei firmware-verwalteten Lueftern brachte EMERGENCY nichts
                     # ausser einem Zustand, aus dem nur der AUTO-Button wieder
@@ -1238,7 +1289,18 @@ class FanControlService:
         # dieselbe Sorte Last, die #533 beseitigt hat.
         if freigegeben != freigaben_vorher:
             with self.db_session_factory() as db:
-                publish_released_fans(db, freigegeben)
+                if publish_released_fans(db, freigegeben):
+                    self._zuletzt_freigegeben = set(freigegeben)
+                else:
+                    # Scheitert der Schreibvorgang, darf der Stand NICHT als
+                    # veroeffentlicht gelten: sonst haelte dieser Prozess den
+                    # Kanal fuer freigegeben, waehrend die anderen Worker und
+                    # der naechste Zyklus nichts davon wissen -- und die
+                    # Zusage "Zustand statt Flanke" haenge an einem Write, der
+                    # nicht stattgefunden hat.
+                    logger.warning(
+                        "Freigabe-Zustand nicht veroeffentlicht -- naechster "
+                        "Zyklus versucht es erneut")
 
     def _apply_hysteresis(
         self,
@@ -1522,17 +1584,13 @@ class FanControlService:
             del freigegeben[fan_id]
             publish_released_fans(db, freigegeben)
 
-        # Genau EIN erzwungener Write, sonst bliebe pwm_enable auf dem
-        # Auto-Wert stehen, falls das Board zufaellig denselben PWM eingestellt
-        # hat, den die Kurve berechnet -- der Regelkreis schreibt nur bei
-        # Wertaenderung, und BaluHost hielte sich fuer zustaendig, waehrend das
-        # Board weiterregelt (#534).
-        fans = await self._backend.get_fans()
-        aktuell = next((f for f in fans if f.fan_id == fan_id), None)
-        if aktuell is not None:
-            await self._backend.set_pwm(fan_id, aktuell.pwm_percent, force=True)
-        self._hysteresis_state.pop(fan_id, None)
-        logger.info("%s: wieder uebernommen", fan_id)
+        # Der erzwungene Write und das Zuruecksetzen des Fehlerzaehlers
+        # geschehen NICHT hier, sondern im naechsten Zyklus des Primary. Diese
+        # Route laeuft auf einem beliebigen der vier Worker, und der Zaehler
+        # lebt im Prozess: ein Reset hier traefe den falschen. Der Primary
+        # erkennt die Wiederuebernahme daran, dass der Kanal aus der
+        # veroeffentlichten Menge verschwunden ist (#534).
+        logger.info("%s: Wiederuebernahme angefordert", fan_id)
         return True
 
     async def set_fan_mode(self, fan_id: str, mode: FanMode) -> bool:

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -24,8 +24,16 @@ from app.core.config import Settings
 from app.models.fans import FanConfig, FanSample
 from app.schemas.fans import FanMode, FanCurvePoint, PwmControl
 from app.services.power.fan_restore import is_observation, needs_release, resolve_restore_value
+from app.services.power.fan_ownership import (
+    FanOwnership,
+    is_released,
+    ownership_after_release,
+    should_release,
+)
 from app.services.power.fan_runtime_store import (
+    publish_released_fans,
     read_denied_fans,
+    read_released_fans,
     publish_write_permission,
     read_write_permission,
 )
@@ -141,6 +149,21 @@ class FanControlBackend(ABC):
             True nur, wenn der Wert danach tatsaechlich anliegt.
         """
         pass
+
+    def write_failure_state(self, fan_id: str) -> Tuple[int, bool]:
+        """Wie oft der Regelkreis auf diesem Kanal nacheinander gescheitert ist.
+
+        Returns:
+            (fail_count, at_cap). `at_cap` heisst: das Backoff-Fenster steht am
+            Maximum, der Kanal lehnt also seit acht aufeinanderfolgenden
+            Versuchen ab.
+
+        Kein @abstractmethod, sondern eine Vorgabe: ein Backend ohne Backoff
+        (Dev) hat nie einen nicht steuerbaren Kanal, und ein neues Backend soll
+        nicht an einer Methode scheitern, die nur die Rueckgabe-Entscheidung
+        aus #534 braucht.
+        """
+        return 0, False
 
     @abstractmethod
     async def get_temperature(self, sensor_id: str) -> Optional[float]:
@@ -1038,6 +1061,12 @@ class FanControlService:
         # Map for sync curve type
         other_fan_pwms = {f.fan_id: f.pwm_percent for f in fans}
 
+        # Der Besitzzustand je Kanal (#534). Einmal je Zyklus gelesen statt je
+        # Luefter: es ist dieselbe Singleton-Zeile.
+        with self.db_session_factory() as db:
+            freigegeben = read_released_fans(db)
+        freigaben_vorher = dict(freigegeben)
+
         with self.db_session_factory() as db:
             for fan in fans:
                 config = db.execute(
@@ -1119,6 +1148,63 @@ class FanControlService:
                     # und der Sample protokolliert den tatsaechlichen Wert.
                     target_pwm = fan.pwm_percent
 
+                # --- Rueckgabe an die Board-Automatik (#534 Punkt 1) ---------
+                #
+                # Die Stelle ist mit Bedacht gewaehlt: KEIN `continue` weiter
+                # oben. Der Uebersprung sitzt hier, weil damit alles darueber
+                # weiterlaeuft -- die Temperaturlesung, die Notfall-Emitter und
+                # weiter unten der Sample-Puffer. Ein `continue` nach dem
+                # Config-Load haette die Messwerte mitgenommen, und der
+                # Verlaufsgraph risse genau dort ab, wo man nachsieht.
+                #
+                # Wirksam wird die Freigabe ueber denselben Weg wie
+                # FIRMWARE_MANAGED zwei Zeilen darueber: target_pwm auf den
+                # Ist-Wert, damit die Write-Bedingung nicht greift. Das schreibt
+                # nebenbei _last_pwm_by_fan auf den echten Wert fort -- sonst
+                # ginge nach einer Wiederuebernahme ein minutenalter Wert in die
+                # Glaettung ein.
+                zustand = FanOwnership(freigegeben.get(fan.fan_id, FanOwnership.OWNED))
+
+                # Die Rueckgabe ist ein Hardware-Write und gehoert dem
+                # Primary -- so wie _release_all_to_board() beim Dienst-Ende
+                # (#465). Der Regelkreis laeuft ohnehin nur dort; die Pruefung
+                # steht trotzdem da, weil die Folge eines Irrtums ein Luefter
+                # waere, den zwei Prozesse gegeneinander umschalten.
+                ist_primary = getattr(lifespan, "IS_PRIMARY_WORKER", False)
+                if zustand is FanOwnership.OWNED and ist_primary:
+                    fehlschlaege, am_deckel = self._backend.write_failure_state(
+                        fan.fan_id)
+                    if should_release(
+                        at_write_cap=am_deckel,
+                        ownership=zustand,
+                        has_observed_restore_value=(
+                            self._restore_values.get(fan.fan_id) is not None
+                        ),
+                        is_firmware_managed=(
+                            fan.pwm_control is PwmControl.FIRMWARE_MANAGED
+                        ),
+                        is_active=bool(config.is_active),
+                    ):
+                        geglueckt = await self._backend.release_to_board(
+                            fan.fan_id, self._restore_values[fan.fan_id]
+                        )
+                        zustand = ownership_after_release(geglueckt)
+                        freigegeben[fan.fan_id] = zustand.value
+                        # Die Hysterese eingefroren stehen zu lassen, hiesse
+                        # nach der Wiederuebernahme gegen einen alten
+                        # Referenzwert zu daempfen.
+                        self._hysteresis_state.pop(fan.fan_id, None)
+                        logger.warning(
+                            "%s: nicht steuerbar (%d Fehlschlaege in Folge) -- "
+                            "%s", fan.fan_id, fehlschlaege,
+                            "an die Board-Automatik zurueckgegeben"
+                            if geglueckt else
+                            "Rueckgabe gescheitert, es regelt niemand",
+                        )
+
+                if is_released(zustand):
+                    target_pwm = fan.pwm_percent
+
                 if target_pwm != fan.pwm_percent:
                     # Im Notfall das Backoff-Fenster umgehen (#533): ein
                     # Ueberhitzungsfall ist per Definition kein Dauerzustand,
@@ -1147,6 +1233,12 @@ class FanControlService:
                     "temperature_celsius": temperature,
                     "mode": mode.value,
                 })
+
+        # Nur bei echter Aenderung schreiben -- ein Schreibvorgang je Tick waere
+        # dieselbe Sorte Last, die #533 beseitigt hat.
+        if freigegeben != freigaben_vorher:
+            with self.db_session_factory() as db:
+                publish_released_fans(db, freigegeben)
 
     def _apply_hysteresis(
         self,
@@ -1356,6 +1448,13 @@ class FanControlService:
             with self.db_session_factory() as db:
                 gesperrt = read_denied_fans(db)
                 shared_permission = read_write_permission(db)
+                freigegeben = read_released_fans(db)
+            # Der Besitzzustand kommt ausschliesslich aus der gemeinsamen
+            # Zeile (#534): er entsteht im Primary, und ein prozesslokaler
+            # Wert lieferte bei drei von vier Workern None.
+            for eintrag in fan_data_list:
+                eintrag["ownership"] = freigegeben.get(
+                    eintrag["fan_id"], FanOwnership.OWNED.value)
             if gesperrt is not None:
                 for eintrag in fan_data_list:
                     if eintrag.get("pwm_control") is PwmControl.FIRMWARE_MANAGED:
@@ -1397,6 +1496,44 @@ class FanControlService:
             "permission_status": permission_status,
             "backend_available": True,
         }
+
+    async def reacquire_fan(self, fan_id: str) -> bool:
+        """Einen freigegebenen Kanal wieder uebernehmen (#534 Punkt 1).
+
+        Der Rueckweg muss ausdruecklich existieren: eine Oberflaeche, die einen
+        freigegebenen Luefter wie einen firmware-verwalteten sperrt, deaktiviert
+        genau die Bedienelemente, ueber die man zurueckkaeme -- ein Zustand ohne
+        Ausgang.
+
+        Entfernt wird nur der veroeffentlichte Zustand. Den erzwungenen Write
+        uebernimmt der naechste Regelzyklus: er sieht den Kanal wieder als
+        besessen, und weil der Zaehler des Backoffs beim Freigeben nicht
+        zurueckgesetzt wurde, faellt der Kanal bei anhaltendem Fehler nach einem
+        weiteren Fehlschlag erneut heraus -- gewollt, sonst pendelte die
+        Anzeige.
+
+        Returns:
+            False, wenn der Kanal gar nicht freigegeben war.
+        """
+        with self.db_session_factory() as db:
+            freigegeben = read_released_fans(db)
+            if fan_id not in freigegeben:
+                return False
+            del freigegeben[fan_id]
+            publish_released_fans(db, freigegeben)
+
+        # Genau EIN erzwungener Write, sonst bliebe pwm_enable auf dem
+        # Auto-Wert stehen, falls das Board zufaellig denselben PWM eingestellt
+        # hat, den die Kurve berechnet -- der Regelkreis schreibt nur bei
+        # Wertaenderung, und BaluHost hielte sich fuer zustaendig, waehrend das
+        # Board weiterregelt (#534).
+        fans = await self._backend.get_fans()
+        aktuell = next((f for f in fans if f.fan_id == fan_id), None)
+        if aktuell is not None:
+            await self._backend.set_pwm(fan_id, aktuell.pwm_percent, force=True)
+        self._hysteresis_state.pop(fan_id, None)
+        logger.info("%s: wieder uebernommen", fan_id)
+        return True
 
     async def set_fan_mode(self, fan_id: str, mode: FanMode) -> bool:
         """Set fan operation mode."""

--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -285,6 +285,18 @@ class FanControlService:
             # Load fan configs from database
             await self._load_fan_configs()
 
+            # Die GPU-Akustik gehoert zum Start, nicht in den Regelzyklus:
+            # sie ist Konfiguration, kein Regelkreis (#516).
+            try:
+                await self.apply_gpu_acoustics()
+            except Exception:
+                logger.exception("GPU-Akustik konnte nicht angewendet werden")
+
+            # Eine noch laufende Schleife gehoert zum alten Backend und zu
+            # den alten Konfigurationen -- und ihre Referenz ginge bei der
+            # Zuweisung unten verloren (#559).
+            await self._cancel_monitoring_task()
+
             # Jeder Neustart gibt jedem Kanal eine neue Chance (#534): der
             # Fehlerzaehler, der zur Freigabe gefuehrt hat, lebte im Prozess
             # und ist jetzt weg. Bliebe die Freigabe stehen, haette ein
@@ -301,18 +313,11 @@ class FanControlService:
                             "Freigaben an die Board-Automatik zurueckgesetzt -- "
                             "jeder Kanal wird neu versucht")
                 self._zuletzt_freigegeben = set()
+            # Bewusst HINTER _cancel_monitoring_task(): ein noch laufender
+            # Zyklus der alten Schleife koennte sonst direkt danach seine
+            # veraltete Gesamtkarte veroeffentlichen und den Reset still
+            # rueckgaengig machen.
 
-            # Die GPU-Akustik gehoert zum Start, nicht in den Regelzyklus:
-            # sie ist Konfiguration, kein Regelkreis (#516).
-            try:
-                await self.apply_gpu_acoustics()
-            except Exception:
-                logger.exception("GPU-Akustik konnte nicht angewendet werden")
-
-            # Eine noch laufende Schleife gehoert zum alten Backend und zu
-            # den alten Konfigurationen -- und ihre Referenz ginge bei der
-            # Zuweisung unten verloren (#559).
-            await self._cancel_monitoring_task()
 
             # Der Rechte-Probe ist beim Backend-Init gelaufen -- sein
             # Ergebnis gehoert zu den Followern, bevor der erste Regelzyklus
@@ -1103,7 +1108,10 @@ class FanControlService:
         # Deckel stehenden -- Zaehler und gaebe ihn im selben Zyklus erneut ab.
         # Der Nutzer bekaeme einen Erfolg gemeldet und fuenf Sekunden spaeter
         # wieder "Board regelt" (#534).
-        zurueckgeholt = self._zuletzt_freigegeben - set(freigegeben)
+        zurueckgeholt = (
+            self._zuletzt_freigegeben - set(freigegeben)
+            if getattr(lifespan, "IS_PRIMARY_WORKER", False) else set()
+        )
         for fan_id in zurueckgeholt:
             self._backend.clear_write_failures(fan_id)
             self._hysteresis_state.pop(fan_id, None)
@@ -1568,11 +1576,21 @@ class FanControlService:
         Ausgang.
 
         Entfernt wird nur der veroeffentlichte Zustand. Den erzwungenen Write
-        uebernimmt der naechste Regelzyklus: er sieht den Kanal wieder als
-        besessen, und weil der Zaehler des Backoffs beim Freigeben nicht
-        zurueckgesetzt wurde, faellt der Kanal bei anhaltendem Fehler nach einem
-        weiteren Fehlschlag erneut heraus -- gewollt, sonst pendelte die
-        Anzeige.
+        UND das Zuruecksetzen des Fehlerzaehlers uebernimmt der naechste
+        Regelzyklus des Primary -- diese Route laeuft auf einem beliebigen der
+        vier Worker, der Zaehler lebt aber im Prozess.
+
+        Was das fuer einen weiterhin defekten Kanal heisst, und zwar
+        absichtlich: der Zaehler startet bei null, es braucht also wieder acht
+        Fehlschlaege bis zur naechsten Freigabe. Weil das Backoff-Fenster
+        dazwischen waechst (10, 20, 40 ... 640 Sekunden) und set_pwm innerhalb
+        des Fensters gar nicht erst schreibt, dauert das rund 21 Minuten. In
+        dieser Zeit zeigt die Karte "BaluHost regelt", obwohl kein Write
+        stattfindet.
+
+        Das ist der Preis gegen ein Pendeln zwischen zwei Reglern -- den
+        Zustand, den #534 ausdruecklich vermeiden will. Die Alternative waere,
+        sofort wieder freizugeben, und dann waere der Knopf wirkungslos.
 
         Returns:
             False, wenn der Kanal gar nicht freigegeben war.
@@ -1582,7 +1600,12 @@ class FanControlService:
             if fan_id not in freigegeben:
                 return False
             del freigegeben[fan_id]
-            publish_released_fans(db, freigegeben)
+            if not publish_released_fans(db, freigegeben):
+                # Ohne diesen Write ist die Wiederuebernahme nicht passiert --
+                # der Primary sieht den Kanal weiter als freigegeben. Einen
+                # Erfolg zu melden waere eine Luege im Erfolgs-Toast.
+                logger.warning("%s: Wiederuebernahme nicht veroeffentlicht", fan_id)
+                return False
 
         # Der erzwungene Write und das Zuruecksetzen des Fehlerzaehlers
         # geschehen NICHT hier, sondern im naechsten Zyklus des Primary. Diese

--- a/backend/app/services/power/fan_ownership.py
+++ b/backend/app/services/power/fan_ownership.py
@@ -1,0 +1,96 @@
+"""Wem gehoert ein Luefterkanal -- BaluHost, der Board-Automatik, oder niemandem (#534 Punkt 1).
+
+Reine Regeln: kein sysfs, keine Datenbank, kein Zustand. Dieselbe Bauform wie
+`fan_restore.py`, aus demselben Grund -- die Entscheidung, einen Kanal
+abzugeben, ist die sicherheitsrelevanteste in diesem Modul und soll ohne
+Hardware pruefbar sein.
+
+Warum ueberhaupt abgeben: BaluHost schaltet beim Start die Chip-Automatik ab
+(`pwm_enable=1`). Kann es den Kanal danach nicht schreiben, regelt NIEMAND --
+der Chip nicht, weil er abgeschaltet wurde, und BaluHost nicht, weil es nicht
+darf. Die Rueckgabe stellt den Zustand her, der ohne BaluHost gegolten haette.
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class FanOwnership(str, Enum):
+    """Wer den Kanal gerade regelt."""
+
+    OWNED = "owned"
+    """BaluHost. Der Normalfall."""
+
+    RELEASED = "released"
+    """Die Board-Automatik. Die Rueckgabe wurde geschrieben UND zurueckgelesen."""
+
+    ABANDONED = "abandoned"
+    """Niemand. Die Rueckgabe wurde versucht, der Write scheiterte aber oder
+    blieb wirkungslos.
+
+    Bei einem nicht schreibbaren Kanal ist das der wahrscheinliche Fall -- es
+    ist derselbe Knoten mit denselben Rechten, an dem schon die Regelung
+    scheitert. Der Zustand existiert als eigener, weil eine Oberflaeche, die
+    hier "das Board regelt diesen Luefter" anzeigt, luegt.
+    """
+
+
+def should_release(
+    *,
+    at_write_cap: bool,
+    ownership: FanOwnership,
+    has_observed_restore_value: bool,
+    is_firmware_managed: bool,
+    is_active: bool,
+) -> bool:
+    """Ob dieser Kanal jetzt an die Board-Automatik zurueckgegeben werden soll.
+
+    Als ZUSTAND formuliert, nicht als Flanke. Ein "erstmals am Deckel" haette
+    pro Prozess hoechstens einmal gefeuert: das Backoff wird nur von einem
+    erfolgreichen Write geleert, nach einer Wiederuebernahme ohne erfolgreichen
+    Write steht der Zaehler also bereits am Deckel und wird nie wieder
+    "erstmals" erreicht (#534).
+
+    Args:
+        at_write_cap: Das Write-Backoff dieses Kanals steht am Maximum -- mit
+            den heutigen Konstanten der achte aufeinanderfolgende Fehlschlag.
+            Erzwungene Writes (Nutzer, Notfall) zaehlen nicht mit hinein, sonst
+            koennten acht erfolglose Klicks den Luefter abgeben.
+        has_observed_restore_value: Es gibt einen SELBST GELESENEN
+            pwm_enable-Wert (>= 2, vor dem ersten eigenen Write). Ohne ihn wird
+            nicht zurueckgegeben -- ein geratener Treibermodus waere eine
+            Annahme ueber fremde Hardware, und ein falsch geratener Wert
+            stellte den Luefter still ab (#556).
+        is_firmware_managed: Die Karte regelt ohnehin selbst; BaluHost hat den
+            Kanal nie uebernommen, es gibt nichts zurueckzugeben (#480).
+    """
+    if not is_active:
+        return False
+    if is_firmware_managed:
+        return False
+    if ownership is not FanOwnership.OWNED:
+        return False
+    if not has_observed_restore_value:
+        return False
+    return at_write_cap
+
+
+def ownership_after_release(release_succeeded: bool) -> FanOwnership:
+    """Der Zustand nach einem Rueckgabeversuch.
+
+    `release_to_board()` schreibt und LIEST ZURUECK; ein False heisst also
+    nicht "Fehler beim Schreiben", sondern "der Wert liegt danach nicht an".
+    Beides fuehrt zum selben Ergebnis: die Chip-Automatik ist nicht aktiv, und
+    BaluHost regelt auch nicht mehr.
+    """
+    return FanOwnership.RELEASED if release_succeeded else FanOwnership.ABANDONED
+
+
+def is_released(ownership: FanOwnership) -> bool:
+    """Ob der Regelkreis diesen Kanal in Ruhe lassen soll.
+
+    Gilt fuer BEIDE Freigabe-Zustaende: bei ABANDONED regelt zwar niemand, aber
+    weiterzuschreiben brachte nichts ausser Lograuschen -- der Kanal hat gerade
+    acht Fehlschlaege in Folge geliefert.
+    """
+    return ownership in (FanOwnership.RELEASED, FanOwnership.ABANDONED)

--- a/backend/app/services/power/fan_runtime_store.py
+++ b/backend/app/services/power/fan_runtime_store.py
@@ -76,6 +76,56 @@ def read_denied_fans(db: Session) -> Optional[set]:
     return set(werte) if isinstance(werte, list) else None
 
 
+def read_released_fans(db: Session) -> dict:
+    """Die freigegebenen Kanaele mit ihrem Zustand (#534).
+
+    Returns:
+        `{fan_id: "released" | "abandoned"}`. Eine leere Abbildung heisst
+        "kein Kanal freigegeben" -- anders als bei read_denied_fans gibt es
+        hier kein None, weil der Besitzzustand ausschliesslich hier lebt und
+        nicht mit einer prozesslokalen Sicht zusammengefuehrt wird.
+    """
+    try:
+        row = db.execute(
+            select(FanRuntimeState).where(FanRuntimeState.id == _SINGLETON_ID)
+        ).scalar_one_or_none()
+    except Exception as exc:
+        logger.debug("fan_runtime_state nicht lesbar: %s", exc)
+        return {}
+    if row is None or not row.released_fans:
+        return {}
+    try:
+        werte = json.loads(row.released_fans)
+    except (ValueError, TypeError) as exc:
+        logger.debug("released_fans nicht lesbar: %s", exc)
+        return {}
+    return werte if isinstance(werte, dict) else {}
+
+
+def publish_released_fans(db: Session, released: dict) -> bool:
+    """Die freigegebenen Kanaele hinterlegen. Nur der Primary schreibt.
+
+    Returns:
+        False bei einem Datenbankfehler -- der Aufrufer soll seinen Stand dann
+        NICHT als veroeffentlicht verbuchen.
+    """
+    try:
+        row = db.execute(
+            select(FanRuntimeState).where(FanRuntimeState.id == _SINGLETON_ID)
+        ).scalar_one_or_none()
+        if row is None:
+            row = FanRuntimeState(id=_SINGLETON_ID)
+            db.add(row)
+        row.released_fans = json.dumps(released, sort_keys=True)
+        row.updated_by_pid = os.getpid()
+        db.commit()
+        return True
+    except Exception as exc:
+        db.rollback()
+        logger.warning("released_fans nicht schreibbar: %s", exc)
+        return False
+
+
 def publish_write_permission(db: Session, may_write: bool,
                              denied_fan_ids: Optional[set] = None) -> bool:
     """Den eigenen Stand hinterlegen. Legt die Zeile an, falls noetig.

--- a/backend/tests/test_fan_ownership_rules.py
+++ b/backend/tests/test_fan_ownership_rules.py
@@ -1,0 +1,91 @@
+"""Die Regeln fuer die Rueckgabe an die Board-Automatik (#534 Punkt 1).
+
+Reine Funktionen, deshalb hier ohne Hardware pruefbar. Jeder Test entspricht
+einem der Befunde, an denen der erste Anlauf gescheitert ist -- sie stehen als
+Prueflliste in #534.
+"""
+import pytest
+
+from app.services.power.fan_ownership import (
+    FanOwnership,
+    is_released,
+    ownership_after_release,
+    should_release,
+)
+
+
+def _bedingungen(**abweichungen):
+    basis = dict(
+        at_write_cap=True,
+        ownership=FanOwnership.OWNED,
+        has_observed_restore_value=True,
+        is_firmware_managed=False,
+        is_active=True,
+    )
+    basis.update(abweichungen)
+    return basis
+
+
+def test_am_deckel_und_besessen_wird_freigegeben():
+    assert should_release(**_bedingungen()) is True
+
+
+def test_unterhalb_des_deckels_passiert_nichts():
+    """Ein einzelner Fehlschlag ist kein Grund, die Regelung abzugeben --
+    genau deshalb haengt die Bedingung am Deckel des Backoffs und nicht am
+    ersten Fehler."""
+    assert should_release(**_bedingungen(at_write_cap=False)) is False
+
+
+@pytest.mark.parametrize("zustand", [FanOwnership.RELEASED, FanOwnership.ABANDONED])
+def test_ein_bereits_freigegebener_kanal_wird_nicht_erneut_freigegeben(zustand):
+    """Die Bedingung ist ein ZUSTAND, keine Flanke. Waere sie als 'erstmals am
+    Deckel' formuliert, feuerte sie pro Prozess hoechstens einmal: das Backoff
+    wird nur von einem erfolgreichen Write geleert, nach einer
+    Wiederuebernahme ohne Erfolg steht der Zaehler also schon am Deckel."""
+    assert should_release(**_bedingungen(ownership=zustand)) is False
+
+
+def test_ohne_beobachteten_wert_wird_nichts_zurueckgegeben():
+    """Die geerbte Randbedingung aus #556: zurueckgegeben wird nur ein Wert,
+    den BaluHost am selben Chip selbst gelesen hat. Ein geratener
+    Treibermodus waere eine Annahme ueber fremde Hardware -- ein falsch
+    geratener Wert stellte den Luefter still ab.
+
+    Auf BaluNode betrifft das pwm7: dort gibt es nichts zurueckzugeben, und
+    der Kanal bleibt in Handsteuerung."""
+    assert should_release(**_bedingungen(has_observed_restore_value=False)) is False
+
+
+def test_ein_firmware_kanal_wird_nicht_freigegeben():
+    """BaluHost hat ihn nie uebernommen (#480) -- es gibt nichts abzugeben,
+    und ein Write gegen den Knoten waere genau der, den #480 abgeschafft hat."""
+    assert should_release(**_bedingungen(is_firmware_managed=True)) is False
+
+
+def test_ein_inaktiver_luefter_wird_nicht_freigegeben():
+    assert should_release(**_bedingungen(is_active=False)) is False
+
+
+def test_eine_geglueckte_rueckgabe_heisst_das_board_regelt():
+    assert ownership_after_release(True) is FanOwnership.RELEASED
+
+
+def test_eine_gescheiterte_rueckgabe_heisst_niemand_regelt():
+    """release_to_board() schreibt UND liest zurueck; ein False heisst also
+    nicht nur 'Schreibfehler', sondern auch 'der Wert liegt danach nicht an'.
+    Beides fuehrt zum selben Ergebnis -- und eine Oberflaeche, die hier 'das
+    Board regelt' anzeigt, waere unehrlich."""
+    assert ownership_after_release(False) is FanOwnership.ABANDONED
+
+
+@pytest.mark.parametrize("zustand,erwartet", [
+    (FanOwnership.OWNED, False),
+    (FanOwnership.RELEASED, True),
+    (FanOwnership.ABANDONED, True),
+])
+def test_der_regelkreis_laesst_beide_freigabe_zustaende_in_ruhe(zustand, erwartet):
+    """Auch bei ABANDONED: dort regelt zwar niemand, aber weiterzuschreiben
+    braechte nichts ausser Lograuschen -- der Kanal hat gerade acht
+    Fehlschlaege in Folge geliefert."""
+    assert is_released(zustand) is erwartet

--- a/backend/tests/test_fan_ownership_rules.py
+++ b/backend/tests/test_fan_ownership_rules.py
@@ -89,3 +89,105 @@ def test_der_regelkreis_laesst_beide_freigabe_zustaende_in_ruhe(zustand, erwarte
     braechte nichts ausser Lograuschen -- der Kanal hat gerade acht
     Fehlschlaege in Folge geliefert."""
     assert is_released(zustand) is erwartet
+
+
+# --- Die beiden Entscheidungen am echten Backend (#534) ----------------------
+#
+# Gegen die ECHTE LinuxFanControlBackend-Instanz, nicht gegen eine Attrappe:
+# beide Zusagen unten waren in der ersten Fassung durch keinen Test gedeckt,
+# und beide sind sicherheitsrelevant -- die eine entscheidet, wann ein Luefter
+# abgegeben wird, die andere verhindert, dass acht erfolglose Nutzer-Klicks
+# das ausloesen.
+
+from unittest.mock import MagicMock  # noqa: E402
+
+from app.services.power.fan_backend_linux import (  # noqa: E402
+    PWM_BACKOFF_BASE_SECONDS,
+    PWM_BACKOFF_MAX_SECONDS,
+    LinuxFanControlBackend,
+)
+
+
+def _linux_backend(tmp_path):
+    backend = object.__new__(LinuxFanControlBackend)
+    backend._write_backoff = {}
+    backend._monotonic = lambda: 0.0
+    backend._has_write_permission = True
+    pwm = tmp_path / "pwm1"
+    pwm.write_text("128\n")
+    backend._fan_cache = {
+        "nct6798:pwm1": {
+            "pwm_path": pwm,
+            "pwm_enable_path": None,
+            "device_driver": "nct6798",
+            "pwm_control": None,
+        }
+    }
+    return backend
+
+
+def test_der_deckel_wird_nach_acht_fehlschlaegen_gemeldet(tmp_path):
+    """Die Zahl steht nirgends geschrieben, sie folgt aus der Backoff-Formel:
+    10 s * 2^(n-1) >= 900 s ist ab n = 8 erfuellt. Der Test rechnet sie aus
+    denselben Konstanten nach, statt eine 8 zu behaupten -- aendert jemand die
+    Formel, aendert sich beides gemeinsam."""
+    backend = _linux_backend(tmp_path)
+    erwartet = 1
+    while PWM_BACKOFF_BASE_SECONDS * (2 ** (erwartet - 1)) < PWM_BACKOFF_MAX_SECONDS:
+        erwartet += 1
+
+    for n in range(1, erwartet + 1):
+        backend._write_backoff["nct6798:pwm1"] = (n, 0.0)
+        anzahl, am_deckel = backend.write_failure_state("nct6798:pwm1")
+        assert anzahl == n
+        assert am_deckel is (n >= erwartet), f"n={n}"
+
+
+def test_ohne_fehlschlaege_ist_der_zaehler_leer(tmp_path):
+    backend = _linux_backend(tmp_path)
+    assert backend.write_failure_state("nct6798:pwm1") == (0, False)
+    assert backend.write_failure_state("gibt-es-nicht") == (0, False)
+
+
+@pytest.mark.asyncio
+async def test_ein_erzwungener_fehlschlag_zaehlt_nicht(tmp_path, monkeypatch):
+    """Der Befund aus #534: der Zaehler stieg unabhaengig von `force`. Acht
+    erfolglose Nutzer-Klicks haetten den Luefter an die Board-Automatik
+    abgegeben -- und wegen des fehlenden Rueckwegs waere der Nutzer nicht mehr
+    zurueckgekommen."""
+    backend = _linux_backend(tmp_path)
+
+    async def _scheitert(path, value):
+        return False, 13  # EACCES
+
+    monkeypatch.setattr(backend, "_write_hwmon_file", _scheitert, raising=False)
+
+    for _ in range(10):
+        await backend.set_pwm("nct6798:pwm1", 50, force=True)
+
+    assert backend.write_failure_state("nct6798:pwm1") == (0, False)
+
+
+@pytest.mark.asyncio
+async def test_ein_fehlschlag_aus_dem_regelkreis_zaehlt(tmp_path, monkeypatch):
+    """Die Gegenrichtung -- sonst koennte der Zaehler nie den Deckel
+    erreichen und die Rueckgabe nie ausloesen."""
+    backend = _linux_backend(tmp_path)
+
+    async def _scheitert(path, value):
+        return False, 13
+
+    monkeypatch.setattr(backend, "_write_hwmon_file", _scheitert, raising=False)
+
+    await backend.set_pwm("nct6798:pwm1", 50)
+
+    assert backend.write_failure_state("nct6798:pwm1")[0] == 1
+
+
+def test_die_wiederuebernahme_raeumt_den_zaehler(tmp_path):
+    backend = _linux_backend(tmp_path)
+    backend._write_backoff["nct6798:pwm1"] = (8, 999.0)
+
+    backend.clear_write_failures("nct6798:pwm1")
+
+    assert backend.write_failure_state("nct6798:pwm1") == (0, False)

--- a/backend/tests/test_fan_ownership_rules.py
+++ b/backend/tests/test_fan_ownership_rules.py
@@ -99,8 +99,6 @@ def test_der_regelkreis_laesst_beide_freigabe_zustaende_in_ruhe(zustand, erwarte
 # abgegeben wird, die andere verhindert, dass acht erfolglose Nutzer-Klicks
 # das ausloesen.
 
-from unittest.mock import MagicMock  # noqa: E402
-
 from app.services.power.fan_backend_linux import (  # noqa: E402
     PWM_BACKOFF_BASE_SECONDS,
     PWM_BACKOFF_MAX_SECONDS,

--- a/backend/tests/test_fan_release_loop.py
+++ b/backend/tests/test_fan_release_loop.py
@@ -9,7 +9,7 @@ die diese Entscheidung nachbaut, wuerde genau das nicht messen.
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from app.models.base import Base
@@ -173,8 +173,25 @@ async def test_der_notfall_wird_weiter_gemeldet(session_factory, monkeypatch):
     service._registry.get_temp = AsyncMock(return_value=95.0)
 
     await service._monitor_and_control_fans()
-
     assert gemeldet, "die Ueberhitzung eines freigegebenen Kanals muss gemeldet werden"
+
+    # ZWEI Zyklen, und das ist der Punkt: ein Test mit nur einem Aufruf war
+    # blind gegen den eigentlichen Fehler. Der EMERGENCY-Zweig schrieb
+    # config.mode in die Datenbank; im naechsten Zyklus las der Regelkreis
+    # daraus mode == EMERGENCY, uebersprang den AUTO/SCHEDULED-Zweig -- und
+    # damit die Meldung. Ein freigegebener Kanal waere nach dem ersten Tick
+    # dauerhaft verstummt, ausgerechnet der, den niemand regelt.
+    gemeldet.clear()
+    await service._monitor_and_control_fans()
+    assert gemeldet, "auch im zweiten Zyklus muss gemeldet werden"
+
+    with session_factory() as db:
+        config = db.execute(
+            select(FanConfig).where(FanConfig.fan_id == "nct6798:pwm1")
+        ).scalar_one()
+        assert config.mode == FanMode.AUTO.value, (
+            "der gespeicherte Nutzer-Modus darf nicht ueberschrieben werden -- "
+            "es fand kein einziger Write statt")
 
 
 @pytest.mark.asyncio
@@ -190,21 +207,55 @@ async def test_last_pwm_traegt_den_ist_wert(session_factory, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_wieder_uebernehmen_erzwingt_genau_einen_write(
-    session_factory, monkeypatch
-):
-    """Ohne den erzwungenen Write bliebe pwm_enable auf dem Auto-Wert stehen,
-    falls das Board zufaellig denselben PWM eingestellt hat, den die Kurve
-    berechnet -- der Regelkreis schreibt nur bei Wertaenderung."""
+async def test_wieder_uebernehmen_wirkt_im_primary(session_factory, monkeypatch):
+    """Der Rueckweg muss dort wirken, wo der Fehlerzaehler lebt.
+
+    Die Route laeuft auf einem beliebigen der vier Worker, das Backoff ist
+    prozesslokal im Primary. Setzt die Wiederuebernahme nur den Zaehler ihres
+    EIGENEN Prozesses zurueck, saehe der Primary den Kanal zwar wieder als
+    besessen, fragte aber seinen weiterhin am Deckel stehenden Zaehler und
+    gaebe ihn im selben Zyklus erneut ab -- Erfolgs-Toast, fuenf Sekunden
+    spaeter wieder "Board regelt".
+
+    Geprueft wird deshalb der ganze Weg: Freigabe, Wiederuebernahme ueber die
+    Dienstmethode, und danach EIN Regelzyklus des Primary.
+    """
     service, backend = _service(session_factory, monkeypatch,
                                 fans=[_fan()], am_deckel=True)
     await service._monitor_and_control_fans()
     backend.set_pwm.reset_mock()
 
     assert await service.reacquire_fan("nct6798:pwm1") is True
+    with session_factory() as db:
+        assert read_released_fans(db) == {}
 
-    backend.set_pwm.assert_awaited_once()
-    assert backend.set_pwm.await_args.kwargs.get("force") is True
+    # Der Kanal ist weiterhin am Deckel -- ohne das Zuruecksetzen im Primary
+    # faellt er in diesem Zyklus sofort wieder heraus.
+    await service._monitor_and_control_fans()
+
+    backend.clear_write_failures.assert_called_once_with("nct6798:pwm1")
+    backend.set_pwm.assert_awaited()
+    assert backend.set_pwm.await_args_list[0].kwargs.get("force") is True
+
+
+@pytest.mark.asyncio
+async def test_ein_neustart_gibt_jedem_kanal_eine_neue_chance(
+    session_factory, monkeypatch
+):
+    """Der Fehlerzaehler, der zur Freigabe fuehrte, lebte im Prozess und ist
+    nach einem Neustart weg. Bliebe die Freigabe stehen, haette ein Betreiber,
+    der die Ursache behebt und neu startet, keinen automatischen Rueckweg."""
+    service, backend = _service(session_factory, monkeypatch,
+                                fans=[_fan()], am_deckel=True)
+    await service._monitor_and_control_fans()
+    with session_factory() as db:
+        assert read_released_fans(db) != {}
+
+    service._monitoring_task = None
+    service._is_running = False
+    backend.is_available = MagicMock(return_value=True)
+    await service.start(monitoring=False)
+
     with session_factory() as db:
         assert read_released_fans(db) == {}
 

--- a/backend/tests/test_fan_release_loop.py
+++ b/backend/tests/test_fan_release_loop.py
@@ -51,7 +51,15 @@ def _service(session_factory, monkeypatch, *, fans, am_deckel, beobachtet=5,
     backend.get_fans = AsyncMock(return_value=fans)
     backend.set_pwm = AsyncMock(return_value=True)
     backend.release_to_board = AsyncMock(return_value=rueckgabe_glueckt)
-    backend.write_failure_state = MagicMock(return_value=(8 if am_deckel else 1, am_deckel))
+    # Zustandsbehaftet statt konstant: ein Mock, der immer (8, True) meldet,
+    # laesst clear_write_failures wirkungslos aussehen -- der Kanal faellt im
+    # selben Zyklus wieder heraus, und ein Test kann dann nur noch den AUFRUF
+    # pruefen, nicht die WIRKUNG.
+    zaehler = {"deckel": am_deckel}
+    backend.write_failure_state = MagicMock(
+        side_effect=lambda fan_id: (8, True) if zaehler["deckel"] else (0, False))
+    backend.clear_write_failures = MagicMock(
+        side_effect=lambda fan_id: zaehler.__setitem__("deckel", False))
     service._backend = backend
 
     service._restore_values = (
@@ -236,6 +244,11 @@ async def test_wieder_uebernehmen_wirkt_im_primary(session_factory, monkeypatch)
     backend.clear_write_failures.assert_called_once_with("nct6798:pwm1")
     backend.set_pwm.assert_awaited()
     assert backend.set_pwm.await_args_list[0].kwargs.get("force") is True
+    # Die eigentliche Zusage: der Kanal bleibt uebernommen. Ohne das
+    # Zuruecksetzen im Primary stuende er nach diesem Zyklus wieder in der
+    # Menge -- Erfolgs-Toast, und fuenf Sekunden spaeter "Board regelt".
+    with session_factory() as db:
+        assert read_released_fans(db) == {}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_fan_release_loop.py
+++ b/backend/tests/test_fan_release_loop.py
@@ -1,0 +1,229 @@
+"""Die Rueckgabe im laufenden Regelkreis (#534 Punkt 1).
+
+Geprueft wird der Regelkreis selbst, nicht eine Nachbildung: die Befunde, an
+denen der erste Anlauf scheiterte, betreffen fast alle die Stelle, an der der
+Uebersprung sitzt -- ob der Sample-Puffer weiterlaeuft, ob die Notfall-Emitter
+erhalten bleiben, ob _last_pwm_by_fan fortgeschrieben wird. Eine Hilfsfunktion,
+die diese Entscheidung nachbaut, wuerde genau das nicht messen.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import Base
+from app.models.fans import FanConfig
+from app.schemas.fans import FanMode, PwmControl
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_control import FanControlService, FanData
+from app.services.power.fan_ownership import FanOwnership
+from app.services.power.fan_runtime_store import read_released_fans
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def _fan(fan_id="nct6798:pwm1", pwm=40, pwm_control=PwmControl.SUPPORTED) -> FanData:
+    return FanData(
+        fan_id=fan_id, name=fan_id, rpm=800, pwm_percent=pwm,
+        temperature_celsius=45.0, mode=FanMode.AUTO,
+        min_pwm_percent=0, max_pwm_percent=100, emergency_temp_celsius=85.0,
+        temp_sensor_id="hwmon:x", curve_points=[], is_active=True,
+        pwm_control=pwm_control,
+    )
+
+
+def _service(session_factory, monkeypatch, *, fans, am_deckel, beobachtet=5,
+             rueckgabe_glueckt=True):
+    FanControlService._instance = None
+    config = MagicMock()
+    config.is_dev_mode = False
+    config.fan_sample_interval_seconds = 5
+    service = FanControlService(config, session_factory)
+    service._use_linux_backend = True
+
+    backend = MagicMock()
+    backend.get_fans = AsyncMock(return_value=fans)
+    backend.set_pwm = AsyncMock(return_value=True)
+    backend.release_to_board = AsyncMock(return_value=rueckgabe_glueckt)
+    backend.write_failure_state = MagicMock(return_value=(8 if am_deckel else 1, am_deckel))
+    service._backend = backend
+
+    service._restore_values = (
+        {f.fan_id: beobachtet for f in fans} if beobachtet is not None else {}
+    )
+    service._registry = MagicMock()
+    service._registry.get_temp = AsyncMock(return_value=45.0)
+    monkeypatch.setattr(fan_control_module.lifespan, "IS_PRIMARY_WORKER",
+                        True, raising=False)
+
+    with session_factory() as db:
+        for f in fans:
+            db.add(FanConfig(fan_id=f.fan_id, name=f.name, mode=FanMode.AUTO.value,
+                             is_active=True, min_pwm_percent=0, max_pwm_percent=100,
+                             temp_sensor_id="hwmon:x",
+                             curve_json='[{"temp": 30, "pwm": 30}, {"temp": 60, "pwm": 80}]'))
+        db.commit()
+    return service, backend
+
+
+@pytest.mark.asyncio
+async def test_ein_kanal_am_deckel_wird_zurueckgegeben(session_factory, monkeypatch):
+    service, backend = _service(session_factory, monkeypatch,
+                                fans=[_fan()], am_deckel=True)
+
+    await service._monitor_and_control_fans()
+
+    backend.release_to_board.assert_awaited_once_with("nct6798:pwm1", 5)
+    with session_factory() as db:
+        assert read_released_fans(db) == {"nct6798:pwm1": FanOwnership.RELEASED.value}
+
+
+@pytest.mark.asyncio
+async def test_unterhalb_des_deckels_bleibt_alles_wie_bisher(session_factory, monkeypatch):
+    service, backend = _service(session_factory, monkeypatch,
+                                fans=[_fan()], am_deckel=False)
+
+    await service._monitor_and_control_fans()
+
+    backend.release_to_board.assert_not_awaited()
+    with session_factory() as db:
+        assert read_released_fans(db) == {}
+
+
+@pytest.mark.asyncio
+async def test_ohne_beobachteten_wert_wird_nicht_zurueckgegeben(
+    session_factory, monkeypatch
+):
+    """Die geerbte Randbedingung aus #556 -- auf BaluNode betrifft das pwm7."""
+    service, backend = _service(session_factory, monkeypatch,
+                                fans=[_fan()], am_deckel=True, beobachtet=None)
+
+    await service._monitor_and_control_fans()
+
+    backend.release_to_board.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_eine_gescheiterte_rueckgabe_heisst_niemand_regelt(
+    session_factory, monkeypatch
+):
+    """Bei einem nicht schreibbaren Kanal der wahrscheinliche Fall -- derselbe
+    Knoten, dieselben Rechte. Eine Oberflaeche, die hier 'das Board regelt'
+    anzeigt, waere unehrlich."""
+    service, _ = _service(session_factory, monkeypatch, fans=[_fan()],
+                          am_deckel=True, rueckgabe_glueckt=False)
+
+    await service._monitor_and_control_fans()
+
+    with session_factory() as db:
+        assert read_released_fans(db) == {"nct6798:pwm1": FanOwnership.ABANDONED.value}
+
+
+@pytest.mark.asyncio
+async def test_ein_freigegebener_kanal_wird_nicht_mehr_geschrieben(
+    session_factory, monkeypatch
+):
+    service, backend = _service(session_factory, monkeypatch,
+                                fans=[_fan()], am_deckel=True)
+    await service._monitor_and_control_fans()
+    backend.set_pwm.reset_mock()
+
+    await service._monitor_and_control_fans()
+
+    backend.set_pwm.assert_not_awaited()
+    # Und kein zweiter Rueckgabeversuch: die Bedingung ist ein Zustand, keine
+    # Flanke -- sonst schriebe jeder Zyklus erneut gegen den Knoten.
+    assert backend.release_to_board.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_der_sample_puffer_laeuft_weiter(session_factory, monkeypatch):
+    """Der Uebersprung darf die Messwerte nicht mitnehmen -- sonst risse der
+    Verlaufsgraph genau dort ab, wo man nachsieht. Deshalb kein `continue`."""
+    service, _ = _service(session_factory, monkeypatch, fans=[_fan()], am_deckel=True)
+
+    await service._monitor_and_control_fans()
+    service._sample_buffer.clear()
+    await service._monitor_and_control_fans()
+
+    assert len(service._sample_buffer) == 1
+    probe = service._sample_buffer[0]
+    assert probe["fan_id"] == "nct6798:pwm1"
+    assert probe["rpm"] == 800
+    assert probe["temperature_celsius"] == 45.0
+
+
+@pytest.mark.asyncio
+async def test_der_notfall_wird_weiter_gemeldet(session_factory, monkeypatch):
+    """Bei einem freigegebenen Kanal ist die Temperatur weiter lesbar. Ein
+    Uebersprung, der die Emitter mitnimmt, machte aus einem gemeldeten
+    Ueberhitzungsfall einen stillen."""
+    gemeldet = []
+    import app.services.notifications.events as events
+    monkeypatch.setattr(events, "emit_temperature_critical_sync",
+                        lambda *a: gemeldet.append(a), raising=False)
+
+    service, _ = _service(session_factory, monkeypatch, fans=[_fan()], am_deckel=True)
+    service._registry.get_temp = AsyncMock(return_value=95.0)
+
+    await service._monitor_and_control_fans()
+
+    assert gemeldet, "die Ueberhitzung eines freigegebenen Kanals muss gemeldet werden"
+
+
+@pytest.mark.asyncio
+async def test_last_pwm_traegt_den_ist_wert(session_factory, monkeypatch):
+    """Sonst ginge nach der Wiederuebernahme ein minutenalter Wert als `prev`
+    in die Glaettung ein."""
+    service, _ = _service(session_factory, monkeypatch,
+                          fans=[_fan(pwm=37)], am_deckel=True)
+
+    await service._monitor_and_control_fans()
+
+    assert service._last_pwm_by_fan["nct6798:pwm1"] == 37
+
+
+@pytest.mark.asyncio
+async def test_wieder_uebernehmen_erzwingt_genau_einen_write(
+    session_factory, monkeypatch
+):
+    """Ohne den erzwungenen Write bliebe pwm_enable auf dem Auto-Wert stehen,
+    falls das Board zufaellig denselben PWM eingestellt hat, den die Kurve
+    berechnet -- der Regelkreis schreibt nur bei Wertaenderung."""
+    service, backend = _service(session_factory, monkeypatch,
+                                fans=[_fan()], am_deckel=True)
+    await service._monitor_and_control_fans()
+    backend.set_pwm.reset_mock()
+
+    assert await service.reacquire_fan("nct6798:pwm1") is True
+
+    backend.set_pwm.assert_awaited_once()
+    assert backend.set_pwm.await_args.kwargs.get("force") is True
+    with session_factory() as db:
+        assert read_released_fans(db) == {}
+
+
+@pytest.mark.asyncio
+async def test_wieder_uebernehmen_eines_nicht_freigegebenen_kanals(
+    session_factory, monkeypatch
+):
+    service, _ = _service(session_factory, monkeypatch, fans=[_fan()], am_deckel=False)
+
+    assert await service.reacquire_fan("nct6798:pwm1") is False
+
+
+@pytest.mark.asyncio
+async def test_ein_firmware_kanal_wird_nicht_freigegeben(session_factory, monkeypatch):
+    service, backend = _service(
+        session_factory, monkeypatch,
+        fans=[_fan(pwm_control=PwmControl.FIRMWARE_MANAGED)], am_deckel=True)
+
+    await service._monitor_and_control_fans()
+
+    backend.release_to_board.assert_not_awaited()

--- a/client/src/__tests__/components/fan-control/FanCard.test.tsx
+++ b/client/src/__tests__/components/fan-control/FanCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import FanCard from '../../../components/fan-control/FanCard';
 import { FanMode } from '../../../api/fan-control';
 import type { FanInfo } from '../../../api/fan-control';
@@ -153,5 +153,83 @@ describe('FanCard bei fehlendem Schreibrecht (#568 Punkt 2)', () => {
   it('zeigt das Firmware-Badge nicht mit', () => {
     renderCard(fan({ pwm_control: 'no_permission' }));
     expect(screen.queryByTestId('fan-firmware-badge')).toBeNull();
+  });
+});
+
+describe('FanCard bei Rueckgabe an die Board-Automatik (#534)', () => {
+  function renderMitRueckweg(f: FanInfo, onReacquire = vi.fn()) {
+    render(
+      <FanCard
+        fan={f}
+        isSelected={false}
+        onSelect={noop}
+        onModeChange={noop}
+        onPWMChange={noop}
+        onReacquire={onReacquire}
+        isReadOnly={false}
+        isLoading={false}
+        sensors={[]}
+      />
+    );
+    return onReacquire;
+  }
+
+  it('zeigt im Normalfall kein Badge', () => {
+    renderMitRueckweg(fan({ ownership: 'owned' }));
+    expect(screen.queryByTestId('fan-released-badge')).toBeNull();
+    expect(screen.queryByTestId('fan-abandoned-badge')).toBeNull();
+    expect(screen.queryByTestId('fan-reacquire-button')).toBeNull();
+  });
+
+  it('sagt bei geglueckter Rueckgabe, dass das Board regelt', () => {
+    renderMitRueckweg(fan({ ownership: 'released' }));
+    expect(screen.getByTestId('fan-released-badge')).toBeInTheDocument();
+    expect(screen.queryByTestId('fan-abandoned-badge')).toBeNull();
+  });
+
+  it('sagt bei gescheiterter Rueckgabe, dass NIEMAND regelt', () => {
+    // Der Unterschied ist der Kern von #534: bei 'abandoned' ist die
+    // Rueckgabe selbst fehlgeschlagen -- eine Karte, die auch hier "das Board
+    // regelt" anzeigt, behauptet eine Regelung, die es nicht gibt.
+    renderMitRueckweg(fan({ ownership: 'abandoned' }));
+    expect(screen.getByTestId('fan-abandoned-badge')).toBeInTheDocument();
+    expect(screen.queryByTestId('fan-released-badge')).toBeNull();
+  });
+
+  it('bietet den Rueckweg an und meldet ihn', () => {
+    const onReacquire = renderMitRueckweg(fan({ ownership: 'released' }));
+    fireEvent.click(screen.getByTestId('fan-reacquire-button'));
+    expect(onReacquire).toHaveBeenCalledWith('hwmon2_pwm1');
+  });
+
+  it('laesst den Rueckweg auch dann erreichbar, wenn alles andere gesperrt ist', () => {
+    // Der Befund, an dem der erste Anlauf haengenblieb: eine Sperre analog zu
+    // firmware_managed wuerde genau das Bedienelement deaktivieren, ueber das
+    // man zurueckkaeme -- ein Zustand ohne Ausgang.
+    render(
+      <FanCard
+        fan={fan({ ownership: 'abandoned', mode: FanMode.AUTO })}
+        isSelected={false}
+        onSelect={noop}
+        onModeChange={noop}
+        onPWMChange={noop}
+        onReacquire={vi.fn()}
+        isReadOnly={true}
+        isLoading={false}
+        sensors={[]}
+      />
+    );
+    const zurueck = screen.getByTestId('fan-reacquire-button') as HTMLButtonElement;
+    expect(zurueck.disabled).toBe(false);
+    const manual = screen.getByRole('button', { name: /card\.manual/ }) as HTMLButtonElement;
+    expect(manual.disabled).toBe(true);
+  });
+
+  it('sperrt die Modus-Knoepfe eines freigegebenen Luefters', () => {
+    // Schreiben ist ohnehin ausgesetzt -- ein bedienbarer Regler waere hier
+    // dasselbe leere Versprechen wie bei firmware_managed.
+    renderMitRueckweg(fan({ ownership: 'released', mode: FanMode.AUTO }));
+    const manual = screen.getByRole('button', { name: /card\.manual/ }) as HTMLButtonElement;
+    expect(manual.disabled).toBe(true);
   });
 });

--- a/client/src/api/fan-control.ts
+++ b/client/src/api/fan-control.ts
@@ -74,6 +74,11 @@ export interface FanInfo {
   gpu_vendor?: string | null;
   last_write_error?: string | null;
   pwm_control?: 'supported' | 'firmware_managed' | 'no_permission';
+  // Wer den Kanal regelt (#534): 'owned' = BaluHost, 'released' = die
+  // Board-Automatik nach einer geglueckten Rueckgabe, 'abandoned' = niemand,
+  // weil die Rueckgabe scheiterte. Eigenes Feld statt eines Werts in `mode` --
+  // das ist serverseitig ein validiertes Enum.
+  ownership?: 'owned' | 'released' | 'abandoned';
   // Curve type and tuning fields (Task 15)
   curve_type?: 'graph' | 'flat' | 'target' | 'mix' | 'sync';
   flat_pwm_percent?: number | null;
@@ -612,6 +617,13 @@ export async function deleteComposite(id: string): Promise<void> {
 /**
  * Set GPU manual PWM mode (AMD only)
  */
+// Einen an die Board-Automatik zurueckgegebenen Luefter wieder uebernehmen.
+// Eigener Endpunkt, weil die Bedienelemente eines freigegebenen Luefters
+// gesperrt sind -- ein Rueckweg ueber Modus oder PWM waere selbst gesperrt.
+export async function reacquireFan(fanId: string): Promise<void> {
+  await apiClient.post('/api/fans/reacquire', { fan_id: fanId });
+}
+
 export async function setGpuManualMode(fanId: string, enabled: boolean): Promise<void> {
   await apiClient.post(`/api/fans/${encodeURIComponent(fanId)}/gpu-manual-mode`, { enabled });
 }

--- a/client/src/components/fan-control/FanCard.tsx
+++ b/client/src/components/fan-control/FanCard.tsx
@@ -25,6 +25,7 @@ interface FanCardProps {
   onSelect: () => void;
   onModeChange: (fanId: string, mode: FanMode) => void;
   onPWMChange: (fanId: string, pwm: number) => void;
+  onReacquire?: (fanId: string) => void;
   isReadOnly: boolean;
   isLoading: boolean;
   sensors: TempSensorInfo[];
@@ -36,6 +37,7 @@ export default function FanCard({
   onSelect,
   onModeChange,
   onPWMChange,
+  onReacquire,
   isReadOnly,
   isLoading,
   sensors
@@ -96,6 +98,14 @@ export default function FanCard({
   // koennte dann nicht einmal den Modus vorbereiten, in dem der Luefter danach
   // laufen soll.
   const isDenied = fan.pwm_control === 'no_permission';
+  // Freigegeben an die Board-Automatik (#534). Zwei Zustaende, weil sie
+  // Verschiedenes bedeuten: bei 'released' regelt der Chip, bei 'abandoned'
+  // regelt NIEMAND -- die Rueckgabe selbst ist gescheitert. Eine Karte, die
+  // beides gleich anzeigt, behauptet im zweiten Fall eine Regelung, die es
+  // nicht gibt.
+  const isReleased = fan.ownership === 'released';
+  const isAbandoned = fan.ownership === 'abandoned';
+  const isHandedOver = isReleased || isAbandoned;
   // Abgeleitet, nicht gelesen: einen fan_zero_rpm_enable-Knoten gibt es erst
   // ab Kernel 6.13. Geschlossen wird aus "firmware-verwaltet und 0 RPM" (#516).
   const isZeroRpm = isFirmwareManaged && fan.rpm === 0;
@@ -126,6 +136,23 @@ export default function FanCard({
                 title={t('system:fanControl.gpu.firmware.badgeHint')}
               >
                 {t('system:fanControl.gpu.firmware.badge')}
+              </span>
+            )}
+            {isHandedOver && (
+              <span
+                data-testid={isReleased ? 'fan-released-badge' : 'fan-abandoned-badge'}
+                className={`inline-flex items-center px-1.5 py-0.5 text-xs rounded ${
+                  isReleased
+                    ? 'bg-sky-500/20 text-sky-300'
+                    : 'bg-red-500/20 text-red-300'
+                }`}
+                title={t(isReleased
+                  ? 'system:fanControl.card.releasedHint'
+                  : 'system:fanControl.card.abandonedHint')}
+              >
+                {t(isReleased
+                  ? 'system:fanControl.card.released'
+                  : 'system:fanControl.card.abandoned')}
               </span>
             )}
             {isDenied && (
@@ -223,7 +250,7 @@ export default function FanCard({
             e.stopPropagation();
             onModeChange(fan.fan_id, FanMode.SCHEDULED);
           }}
-          disabled={fan.mode === FanMode.SCHEDULED || isReadOnly || isLoading || isFirmwareManaged}
+          disabled={fan.mode === FanMode.SCHEDULED || isReadOnly || isLoading || isFirmwareManaged || isHandedOver}
           className={`flex-1 px-3 py-1 text-xs rounded-lg transition-colors ${
             fan.mode === FanMode.SCHEDULED
               ? 'bg-amber-500 text-white shadow-lg shadow-amber-500/30'
@@ -241,7 +268,7 @@ export default function FanCard({
             e.stopPropagation();
             onModeChange(fan.fan_id, FanMode.MANUAL);
           }}
-          disabled={fan.mode === FanMode.MANUAL || isReadOnly || isLoading || isFirmwareManaged}
+          disabled={fan.mode === FanMode.MANUAL || isReadOnly || isLoading || isFirmwareManaged || isHandedOver}
           className={`flex-1 px-3 py-1 text-xs rounded-lg transition-colors ${
             fan.mode === FanMode.MANUAL
               ? 'bg-purple-500 text-white shadow-lg shadow-purple-500/30'
@@ -265,6 +292,29 @@ export default function FanCard({
         >
           {t('system:fanControl.gpu.firmware.cardHint')}
         </p>
+      )}
+
+      {/* Der Rueckweg (#534). Er ist von der Sperre AUSGENOMMEN: eine
+          Oberflaeche, die einen freigegebenen Luefter wie einen
+          firmware-verwalteten sperrt, deaktiviert genau das Bedienelement,
+          ueber das man zurueckkaeme -- ein Zustand ohne Ausgang. Deshalb
+          haengt der Knopf nur an isLoading, nicht an isReadOnly. */}
+      {isHandedOver && onReacquire && (
+        <div className="mb-3" onClick={(e) => e.stopPropagation()}>
+          <p className="text-xs text-slate-400 mb-2">
+            {t(isReleased
+              ? 'system:fanControl.card.releasedHint'
+              : 'system:fanControl.card.abandonedHint')}
+          </p>
+          <button
+            data-testid="fan-reacquire-button"
+            onClick={() => onReacquire(fan.fan_id)}
+            disabled={isLoading}
+            className="px-3 py-1 text-xs rounded-lg bg-slate-700 text-slate-200 hover:bg-slate-600 disabled:opacity-50"
+          >
+            {t('system:fanControl.card.reacquire')}
+          </button>
+        </div>
       )}
 
       {/* Manual PWM Slider */}

--- a/client/src/i18n/locales/de/system.json
+++ b/client/src/i18n/locales/de/system.json
@@ -874,7 +874,13 @@
       "pwmError": "PWM-Fehler",
       "zeroRpm": "Zero-RPM — die Karte hat den Lüfter angehalten",
       "noPermission": "Kein Schreibrecht",
-      "noPermissionHint": "BaluHost darf diesen Kanal gerade nicht schreiben. Die Regelung greift hier nicht, bis die Rechte wieder passen; die Einstellungen bleiben bedienbar und wirken, sobald ein Schreibvorgang wieder gelingt."
+      "noPermissionHint": "BaluHost darf diesen Kanal gerade nicht schreiben. Die Regelung greift hier nicht, bis die Rechte wieder passen; die Einstellungen bleiben bedienbar und wirken, sobald ein Schreibvorgang wieder gelingt.",
+      "released": "Board regelt",
+      "releasedHint": "BaluHost konnte diesen Kanal wiederholt nicht schreiben und hat die Regelung an die Automatik des Mainboards zurueckgegeben. Die Temperaturueberwachung laeuft weiter.",
+      "abandoned": "Niemand regelt",
+      "abandonedHint": "BaluHost konnte diesen Kanal nicht schreiben und die Rueckgabe an die Board-Automatik ist ebenfalls fehlgeschlagen. Der Luefter laeuft auf seinem letzten Wert weiter; die Temperaturueberwachung laeuft weiter.",
+      "reacquire": "Wieder uebernehmen",
+      "reacquireSuccess": "Luefter wieder uebernommen"
     },
     "details": {
       "temperatureCol": "Temperatur (°C)",

--- a/client/src/i18n/locales/en/system.json
+++ b/client/src/i18n/locales/en/system.json
@@ -879,7 +879,13 @@
       "pwmError": "PWM error",
       "zeroRpm": "Zero RPM — the card has stopped the fan",
       "noPermission": "No write access",
-      "noPermissionHint": "BaluHost currently cannot write this channel. Control does not take effect here until permissions are restored; the settings stay editable and apply as soon as a write succeeds again."
+      "noPermissionHint": "BaluHost currently cannot write this channel. Control does not take effect here until permissions are restored; the settings stay editable and apply as soon as a write succeeds again.",
+      "released": "Board in control",
+      "releasedHint": "BaluHost repeatedly failed to write this channel and handed control back to the mainboard's automation. Temperature monitoring continues.",
+      "abandoned": "Nobody in control",
+      "abandonedHint": "BaluHost could not write this channel, and handing control back to the board automation failed as well. The fan keeps running at its last value; temperature monitoring continues.",
+      "reacquire": "Take back control",
+      "reacquireSuccess": "Fan control taken back"
     },
     "details": {
       "temperatureCol": "Temperature (°C)",

--- a/client/src/pages/FanControl.tsx
+++ b/client/src/pages/FanControl.tsx
@@ -9,7 +9,8 @@ import { Fan, Settings, AlertTriangle } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { handleApiError } from '../lib/errorHandling';
 import { LoadingOverlay } from '../components/ui/Spinner';
-import { setFanMode, setFanPWM, updateFanCurve, switchBackend, FanMode, listProfiles, applyProfileToFan, listTempSensors, listComposites } from '../api/fan-control';
+import {
+  reacquireFan, setFanMode, setFanPWM, updateFanCurve, switchBackend, FanMode, listProfiles, applyProfileToFan, listTempSensors, listComposites } from '../api/fan-control';
 import type { FanCurvePoint, FanCurveProfile, TempSensorInfo, CompositeSensorInfo } from '../api/fan-control';
 import { useFanControl } from '../hooks/useFanControl';
 import { FanCard, FanDetails, FanSchedulePanel, ProfileManager, SensorsPanel } from '../components/fan-control';
@@ -84,6 +85,19 @@ export default function FanControl() {
       setOperationLoading(prev => ({ ...prev, [opKey]: false }));
     }
   }, [refetch, t]);
+
+  // Der Rueckweg aus der Freigabe an die Board-Automatik (#534). Danach neu
+  // laden, damit das Badge verschwindet, statt bis zum naechsten Poll zu
+  // stehen.
+  const handleReacquire = async (fanId: string) => {
+    try {
+      await reacquireFan(fanId);
+      toast.success(t('system:fanControl.card.reacquireSuccess'));
+      refetch();
+    } catch (err) {
+      handleApiError(err, t('system:fanControl.card.reacquire'));
+    }
+  };
 
   const handlePWMChange = useCallback(async (fanId: string, pwm: number) => {
     try {
@@ -263,6 +277,7 @@ export default function FanControl() {
             onSelect={() => setSelectedFan(fan.fan_id)}
             onModeChange={handleModeChange}
             onPWMChange={handlePWMChange}
+            onReacquire={handleReacquire}
             isReadOnly={isReadOnly}
             isLoading={operationLoading[`mode-${fan.fan_id}`] || false}
             sensors={sensors}

--- a/docs/superpowers/specs/2026-09-07-fan-release-not-controllable-design.md
+++ b/docs/superpowers/specs/2026-09-07-fan-release-not-controllable-design.md
@@ -1,0 +1,63 @@
+# Nicht steuerbarer Lüfter → Board übernimmt (#534 Punkt 1)
+
+Entwurf vom 2026-09-07. Setzt Punkt 1 um; Punkt 2 („Regelung fällt aus") bleibt offen und wird danach nur noch eine zweite Auslösebedingung an derselben Mechanik.
+
+## Ausgangslage
+
+BaluHost übernimmt beim Start jeden erkannten Lüfter (`pwm{n}_enable=1`). Beim Beenden gibt es die Kontrolle seit #556 zurück. **Im laufenden Betrieb nicht** — auch dann nicht, wenn feststeht, dass die eigene Regelung für diesen Kanal nicht funktioniert. Es bleibt ein Zustand, in dem niemand regelt: der Chip nicht, weil BaluHost seine Automatik abgeschaltet hat, und BaluHost nicht, weil es nicht schreiben kann.
+
+Ein früherer Anlauf über alle drei Punkte sammelte **acht blockierende Befunde** ein und wurde auf Punkt 3 zurückgeschnitten. Die Befunde stehen in #534 und sind hier die Prüfliste, nicht der Hintergrund.
+
+## Die geerbte Randbedingung
+
+#556 gibt ausschliesslich einen Wert zurück, den BaluHost am selben Chip **selbst gelesen** hat (`pwm_enable >= 2`, vor dem ersten eigenen Write). Ein geratener Treibermodus wäre eine Annahme über fremde Hardware, und ein falsch geratener Wert stellte den Lüfter still ab.
+
+Das gilt hier unverändert: **ein Kanal ohne Beobachtung wird nicht freigegeben.** Auf BaluNode betrifft das `pwm7` (kein beobachteter Wert) — dort bleibt es beim heutigen Verhalten, und das ist richtig so.
+
+## Die acht Befunde und was der Entwurf ihnen entgegensetzt
+
+| # | Befund | Antwort |
+|---|---|---|
+| 1 | Der Rückweg existiert nicht — eine UI-Sperre deaktiviert genau die Bedienelemente, über die man zurückkäme | Eigener Endpunkt `POST /api/fans/reacquire` und ein Knopf, den die Sperre **nicht** mitdeaktiviert |
+| 2 | Der Auslöser ist von aussen nicht ablesbar (`_write_backoff` privat, kein Zugriff, Dev-Backend hat ihn nicht) | ABC-Erweiterung `write_failure_state(fan_id) -> (fail_count, at_cap)`, Linux liest das Backoff, Dev liefert `(0, False)` |
+| 3 | „Erstmals am Deckel" feuert pro Prozess höchstens einmal | Die Bedingung ist ein **Zustand** („am Deckel **und** aktuell besessen"), keine Flanke |
+| 4 | Nutzer-Klicks können die Freigabe auslösen — der Zähler steigt unabhängig von `force` | Erzwungene Writes (Nutzer, Notfall) zählen nicht mehr ins Backoff |
+| 5 | Der Übersprung im Regelkreis darf den Sample-Puffer nicht mitnehmen | Kein `continue`: `target_pwm = fan.pwm_percent` wie bei `FIRMWARE_MANAGED` — der Write entfällt, der Sample läuft weiter |
+| 6 | Vier Zustandsvariablen hängen daran | `_last_pwm_by_fan` bekommt den Ist-Wert (Folge von Punkt 5), `_hysteresis_state` wird bei der Freigabe gelöscht, `other_fan_pwms` bleibt der Ist-Wert (ein `sync`-Lüfter kopiert dann die Board-Kurve — plausibel), der Sample behält sein bestehendes Modus-Feld |
+| 7 | Die Notfall-Emitter dürfen nicht mit übersprungen werden | Folge von Punkt 5: sie liegen oberhalb der Write-Entscheidung und laufen unverändert |
+| 8 | Ein anzeigbarer Freigabe-Zustand braucht einen worker-übergreifenden Träger | Neue Spalte `fan_runtime_state.released_fans` (JSON), gelesen von jedem Worker — dasselbe Muster wie `denied_fan_ids` aus #568 |
+
+## Auslösebedingung
+
+Ein Kanal wird freigegeben, wenn **alle** vier Aussagen gelten:
+
+1. Das Write-Backoff dieses Kanals steht am Deckel (`at_cap`) — mit den heutigen Konstanten der achte aufeinanderfolgende Fehlschlag aus dem Regelkreis.
+2. BaluHost besitzt den Kanal gerade (er ist nicht schon freigegeben, nicht `FIRMWARE_MANAGED`).
+3. Es gibt einen **beobachteten** Rückgabewert (`_restore_values[fan_id]`).
+4. Der Lüfter ist aktiv konfiguriert (`config.is_active`).
+
+Fehlt Nummer 3, bleibt der Kanal in Handsteuerung — sichtbar als eigener Zustand, damit die Oberfläche nicht „das Board regelt" behauptet, wo niemand regelt.
+
+## Drei Zustände, nicht zwei
+
+| Zustand | Bedeutung | Wer regelt |
+|---|---|---|
+| `owned` | Normalfall | BaluHost |
+| `released` | Rückgabe geschrieben **und zurückgelesen** | die Board-Automatik |
+| `abandoned` | Freigabe versucht, aber der Write scheiterte oder blieb wirkungslos | **niemand** |
+
+`abandoned` ist bei einem nicht schreibbaren Kanal der wahrscheinliche Fall — es ist derselbe Knoten mit denselben Rechten. `release_to_board()` liefert diese Unterscheidung bereits: es schreibt, liest zurück und meldet `False`, wenn der Wert nicht anliegt.
+
+Eine Oberfläche, die in diesem Fall „das Board regelt diesen Lüfter" anzeigt, lügt. Deshalb der dritte Zustand mit eigenem Text — und die Temperaturauswertung läuft in beiden Fällen weiter, die Notfallmeldung also auch.
+
+## Rückweg
+
+`POST /api/fans/reacquire` (Admin) entfernt den Kanal aus der veröffentlichten Menge. Der nächste Regelzyklus behandelt ihn wieder als besessen und **erzwingt genau einen Write** — sonst bliebe `pwm_enable` auf dem Auto-Wert stehen, falls das Board zufällig denselben PWM eingestellt hat wie die Kurve berechnet (der Regelkreis schreibt nur bei Wertänderung).
+
+Der Knopf sitzt auf der Lüfterkarte und ist von der Sperre ausgenommen.
+
+## Nicht-Ziele
+
+- **Punkt 2** (Regelung fällt aus → Board). Braucht eine eigene, enger gefasste Bedingung (`mode`, `curve_type`, gesetzter Sensor) und eine Zeit- statt Zyklenschwelle. Die Mechanik hier ist so gebaut, dass Punkt 2 nur eine zweite Auslösebedingung ergänzt.
+- **Automatische Wiederübernahme.** Ein Pendeln zwischen zwei Reglern ist der Zustand, den #534 ausdrücklich vermeiden will. Zurück geht es nur auf Knopfdruck.
+- **Freigabe ohne beobachteten Wert.** Siehe die geerbte Randbedingung.


### PR DESCRIPTION
Setzt **#534 Punkt 1** um: ein Lüfterkanal, den BaluHost wiederholt nicht schreiben kann, wird im laufenden Betrieb an die Automatik des Mainboards zurückgegeben. Punkt 2 („Regelung fällt aus") bleibt offen und ist danach nur noch eine zweite Auslösebedingung an dieser Mechanik.

## Das Problem

BaluHost schaltet beim Start die Chip-Automatik ab (`pwm_enable=1`). Kann es den Kanal danach nicht schreiben, regelt **niemand** — der Chip nicht, weil er abgeschaltet wurde, und BaluHost nicht, weil es nicht darf. Beim Dienst-Ende gibt es die Kontrolle seit #556 zurück, im laufenden Betrieb bisher nicht.

Ein früherer Anlauf über alle drei Punkte des Issues sammelte **acht blockierende Befunde** ein und wurde auf Punkt 3 zurückgeschnitten. Sie stehen in #534 und waren hier die Prüfliste; der Entwurf (`docs/superpowers/specs/2026-09-07-fan-release-not-controllable-design.md`) beantwortet sie einzeln.

## Der Übersprung brauchte keine neue Konstruktion

Der aufwendigste der acht Befunde — „der Übersprung im Regelkreis kann nicht dort sitzen, wo er intuitiv hingehört" — löste sich an einem Muster, das zwei Zeilen darüber schon steht: bei `FIRMWARE_MANAGED` setzt der Regelkreis `target_pwm = fan.pwm_percent`, wodurch die Write-Bedingung nicht greift. Dasselbe für einen freigegebenen Kanal beantwortet vier Befunde auf einmal:

- der Sample-Puffer läuft weiter (ein `continue` hätte den Verlaufsgraphen genau dort abreissen lassen, wo man nachsieht),
- die Notfall-Emitter bleiben erhalten (sie liegen darüber),
- `_last_pwm_by_fan` bekommt den Ist-Wert, statt einen minutenalten Wert in die Glättung zu tragen,
- die Hysterese wird bei der Freigabe gelöscht.

## Drei Zustände, nicht zwei

`release_to_board()` schreibt **und** liest zurück. Daraus folgen:

| Zustand | Bedeutung | Wer regelt |
|---|---|---|
| `owned` | Normalfall | BaluHost |
| `released` | Rückgabe geschrieben und zurückgelesen | die Board-Automatik |
| `abandoned` | Rückgabe versucht, Write scheiterte oder blieb wirkungslos | **niemand** |

Bei einem nicht schreibbaren Kanal ist `abandoned` der wahrscheinliche Fall — derselbe Knoten, dieselben Rechte. Eine Oberfläche, die dort „das Board regelt" anzeigt, lügt: eigener Zustand, eigener Text, eigene Farbe. Die Temperaturauswertung läuft in beiden Fällen weiter.

## Zwei Entscheidungen gegen die naheliegende Variante

- **Erzwungene Writes zählen nicht mehr ins Backoff.** Sonst hätten acht erfolglose Nutzer-Klicks den Lüfter abgegeben — und wegen des fehlenden Rückwegs wäre der Nutzer nicht mehr zurückgekommen. Gemeldet werden sie trotzdem, jetzt als ERROR.
- **Die Auslösebedingung ist ein Zustand, keine Flanke.** „Erstmals am Deckel" hätte pro Prozess höchstens einmal gefeuert: das Backoff wird nur von einem erfolgreichen Write geleert, nach einer Wiederübernahme ohne Erfolg steht der Zähler bereits am Deckel.

## Der Rückweg

`POST /api/fans/reacquire`, und der Knopf hängt **nur** an `isLoading`, nicht an der Sperre. Eine Oberfläche, die einen freigegebenen Lüfter wie einen firmware-verwalteten sperrt, deaktiviert genau das Bedienelement, über das man zurückkäme.

Die Route löscht nur den veröffentlichten Zustand. Das Zurücksetzen des Fehlerzählers und der eine erzwungene Write gehören dem Primary — das war der Critical der ersten Review (siehe unten).

Bei einem weiterhin defekten Kanal braucht es danach wieder acht Fehlschläge, und weil das Backoff-Fenster wächst, dauert das rund **21 Minuten**, in denen die Karte „BaluHost regelt" zeigt, obwohl kein Write stattfindet. Das ist der Preis gegen ein Pendeln zwischen zwei Reglern — im Docstring benannt.

## Der Träger

Neue Spalte `fan_runtime_state.released_fans` (Migration `e2f81c4a7b93` auf `c7a41b9e2f30`), gelesen von jedem Worker. Ein prozesslokaler Besitzzustand lieferte bei drei von vier Workern `None` und die Anzeige flackerte — dasselbe Muster wie `denied_fan_ids` aus #568.

**Geerbt und unverändert:** zurückgegeben wird nur ein **selbst gelesener** `pwm_enable`-Wert. Auf BaluNode hat `pwm7` keinen — der Kanal bleibt in Handsteuerung, und das ist richtig so.

## Was die zwei Reviews gefunden haben

**Ein Critical, und er traf genau die Falle, an der der erste Anlauf hing** — nur eine Ebene tiefer: `reacquire_fan()` setzte den erzwungenen Write auf dem Worker ab, der die Anfrage bedient, der Fehlerzähler lebt aber im Prozess des Primary. Der sah den Kanal wieder als besessen, fragte seinen eigenen — weiterhin am Deckel stehenden — Zähler und gab ihn binnen fünf Sekunden erneut ab. Erfolgs-Toast, dann wieder „Board regelt". Ein Zustand ohne Ausgang, nur mit Zwischenanimation.

**Ein Important, der subtiler ist:** der EMERGENCY-Zweig schrieb `config.mode` in die Datenbank, auch für einen freigegebenen Kanal, obwohl kein Write stattfand. Im nächsten Zyklus las der Regelkreis daraus `mode == EMERGENCY`, übersprang den AUTO-Zweig — und damit die Meldung. Die Überhitzungsmeldung wäre nach einem Tick dauerhaft verstummt, ausgerechnet auf dem Kanal, den niemand regelt. Mein Test war dagegen blind, weil er den Regelkreis nur einmal aufrief.

Dazu: zwei sicherheitsrelevante Entscheidungen waren durch keinen Test gedeckt (beide Mutationen liessen die Suite grün), der Freigabe-Zustand überlebte einen Neustart ohne erneute Probe, und mein Docstring behauptete am Ende das Gegenteil des Codes.

## Prüfung

- `pytest -k "fan or power"` → 822 bestanden, 2 übersprungen; `ruff` sauber; `alembic heads` ein Head.
- Frontend: `vitest` der fan-control-Tests → 76 bestanden; `eslint .` → 0 Fehler; `npm run build` erfolgreich.
- **Mutationsproben** (vom Reviewer unabhängig durchgeführt): Auslöser aus → 5 von 11 rot; `is_released()` immer False → 4 rot; Übersprung entfernt → 2 rot; `ownership_after_release` immer RELEASED → 2 Backend + 2 Frontend rot; `reacquire` ohne `force` → 1 rot; Rückweg-Knopf der Sperre unterworfen → 2 rot; `clear_write_failures` als No-op → 1 rot; Start-Reset entfernt → 1 rot; `force`-Zweig entfernt → 1 rot.

## Bekannte Reste

- Ein Kanal, der zwischen DB-Lesen und Veröffentlichen wieder übernommen wird, kann von der Gesamtkarte überschrieben werden (schmales Fenster, dasselbe Symptom wie C1 im Kleinen).
- `CurveEditorSync.tsx` filtert weiterhin nur `firmware_managed` — ein freigegebener Kanal bleibt als Sync-Quelle wählbar.
- Serverseitig ist die Freigabe nicht durchgesetzt: `set_fan_pwm` mit `force=True` nimmt den Kanal dem Board wieder weg, ohne den Zustand zu löschen. In der Oberfläche zugehängt, über die API offen.
- Das Modus-Feld im Sample unterscheidet nicht, ob BaluHost geregelt hat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGS5jVzZpLcqpZ2VH8DqNn
