### PR TITLE
fix(fans): Rueckweg fuer Luefterkennungen bauen (#585)

### DIFF
--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -42,7 +42,14 @@ from app.services.power.fan_runtime_store import (
 )
 from app.services.power.fan_schedule import FanScheduleService
 from app.services.power.fan_profiles import FanProfileService
-from app.services.power.fan_reconcile import ChipFacts, reconcile_fan_identities
+from app.services.power.fan_reconcile import (
+    ChipFacts,
+    ReconcileReport,
+    UnstableChip,
+    reconcile_fan_identities,
+    reconcile_unstable_identities,
+    split_legacy_fan_id,
+)
 from app.services.power.fan_sources import (
     TempSourceRegistry, HwmonTempSource, GpuTempSource, DiskTempSource, MixTempSource,
 )
@@ -596,6 +603,11 @@ class FanControlService:
         Ohne Linux-Backend liefe der Abgleich gegen eine Chip-Menge ohne
         einen einzigen hwmon-Chip; ohne gefundenen Chip gegen eine leere.
         In beiden Faellen faende keine Altzeile ihren Chip wieder.
+
+        chip_count zaehlt seit #585 stabile UND instabile Chips. Zaehlte es
+        nur die stabilen, liefe im Vollfall des Rueckfalls -- keine einzige
+        Kennung mehr stabil -- gar kein Abgleich, also ausgerechnet dann
+        nicht, wenn der Rueckweg gebraucht wird.
         """
         if not getattr(lifespan, "IS_PRIMARY_WORKER", False):
             return False
@@ -636,6 +648,70 @@ class FanControlService:
                 ambiguous=len(keys) > 1,
             )
         return facts
+
+    def _collect_unstable_chips(self) -> Dict[str, UnstableChip]:
+        """Chips ohne stabile Kennung: Praefix -> Kanaele (#585).
+
+        Gegenstueck zu _collect_chip_facts(), das genau diese Chips
+        ueberspringt. Geschluesselt wird nach Praefix, weil er der Anker der
+        Rueckzuordnung ist; treten zwei hwmon-Knoten mit demselben Praefix
+        auf, wird der Eintrag als mehrdeutig markiert statt geraten -- ihre
+        Indizes koennen ueber Boots tauschen.
+        """
+        fan_cache = getattr(self._backend, "_fan_cache", None)
+        if not isinstance(fan_cache, dict):
+            # Gleiche Absicherung wie in _collect_chip_facts: ein
+            # unspezifizierter Test-Mock liefert hier selbst wieder ein Mock.
+            fan_cache = {}
+
+        gesammelt: Dict[str, Dict] = {}
+        for fan_id, info in fan_cache.items():
+            if info.get("identity_stable"):
+                continue
+            treffer = split_legacy_fan_id(fan_id or "")
+            if treffer is None:
+                # Instabil, aber nicht in der hwmon-Form: ein Dev-Backend-
+                # Luefter oder eine GPU-Kennung. Fuer die gibt es nichts
+                # zurueckzunehmen.
+                continue
+            prefix = info.get("device_driver") or "Unknown"
+            knoten_nr, kanal_nr = treffer
+            hwmon_name = f"hwmon{knoten_nr}"
+            eintrag = gesammelt.setdefault(
+                prefix, {"hwmon_names": set(), "pwm": set()})
+            eintrag["hwmon_names"].add(hwmon_name)
+            eintrag["pwm"].add(kanal_nr)
+
+        # Temperaturkanaele haengen am hwmon-Knoten, nicht am PWM-Kanal. Der
+        # Pfad ist die verlaessliche Quelle: der Schluessel in _temp_paths
+        # traegt bereits die aktuelle (hier: instabile) Kennung, aber
+        # path.parent.name nennt den Knoten unabhaengig von der Namensform.
+        temps_je_knoten: Dict[str, set] = {}
+        paths = getattr(self._backend, "_temp_paths", None)
+        if isinstance(paths, dict):
+            for path in paths.values():
+                try:
+                    knoten = path.parent.name
+                    nummer = int(path.name[len("temp"):-len("_input")])
+                except (AttributeError, ValueError):
+                    continue
+                temps_je_knoten.setdefault(knoten, set()).add(nummer)
+
+        chips: Dict[str, UnstableChip] = {}
+        for prefix, eintrag in gesammelt.items():
+            namen = eintrag["hwmon_names"]
+            hwmon_name = next(iter(sorted(namen)))
+            temps = set()
+            for knoten in namen:
+                temps |= temps_je_knoten.get(knoten, set())
+            chips[prefix] = UnstableChip(
+                hwmon_name=hwmon_name,
+                prefix=prefix,
+                pwm_channels=frozenset(eintrag["pwm"]),
+                temp_channels=frozenset(temps),
+                ambiguous=len(namen) > 1,
+            )
+        return chips
 
     def _collect_sensor_map(self) -> Dict[str, str]:
         """Alt-Sensor-ID (hwmon<N>_temp<M>) -> neue, praefixierte Kennung."""
@@ -743,15 +819,41 @@ class FanControlService:
 
         with self.db_session_factory() as db:
             chip_facts = self._collect_chip_facts()
-            if self._should_reconcile(len(chip_facts)):
+            unstable_chips = self._collect_unstable_chips()
+            if self._should_reconcile(len(chip_facts) + len(unstable_chips)):
                 try:
-                    report = reconcile_fan_identities(
-                        db,
-                        chips=chip_facts,
-                        sensor_map=self._collect_sensor_map(),
-                        cpu_sensor_id=TempSourceRegistry._normalize_id(cpu_sensor_id)
-                        if cpu_sensor_id else None,
-                    )
+                    # Der Hinweg braucht mindestens einen stabilen Chip. Seit
+                    # #585 kann die Vorbedingung oben auch allein von
+                    # instabilen Chips erfuellt sein -- dann liefe er gegen
+                    # eine leere Faktenmenge, in der keine Altzeile ihren Chip
+                    # wiederfaende. Er deaktivierte dabei zwar nichts (dafuer
+                    # braucht es Fakten), aber die Zusage aus
+                    # _should_reconcile gilt unveraendert: gegen eine leere
+                    # Menge laeuft er gar nicht erst.
+                    report = ReconcileReport()
+                    if chip_facts:
+                        report = reconcile_fan_identities(
+                            db,
+                            chips=chip_facts,
+                            sensor_map=self._collect_sensor_map(),
+                            cpu_sensor_id=TempSourceRegistry._normalize_id(cpu_sensor_id)
+                            if cpu_sensor_id else None,
+                        )
+                    # Der Rueckweg (#585) in derselben Transaktion: ein Chip
+                    # ist entweder stabil oder nicht, die beiden Wege fassen
+                    # also disjunkte Chips an. Gemeinsam scheitern sollen sie
+                    # trotzdem -- die Fehlerbehandlung unten ("keine Configs
+                    # anlegen") gilt fuer beide Richtungen gleichermassen.
+                    if unstable_chips:
+                        rueckweg = reconcile_unstable_identities(
+                            db, chips=unstable_chips)
+                        # renamed bleibt dem Hinweg: der Rueckweg fuellt
+                        # ausschliesslich readopted, und die zwei Richtungen
+                        # im selben Feld zu mischen machte den Audit-Eintrag
+                        # unlesbar.
+                        report.deactivated.extend(rueckweg.deactivated)
+                        report.readopted.extend(rueckweg.readopted)
+                        report.orphaned_inactive.extend(rueckweg.orphaned_inactive)
                     # Eigenstaendiger Commit VOR dem Audit-Eintrag: der
                     # Abgleich muss die Datenbank erreicht haben, BEVOR die
                     # Anlage-Schleife unten startet (R4) -- und bevor der
@@ -764,7 +866,9 @@ class FanControlService:
                     # ein UNIQUE-Verstoss aus einem Rename wuerde sonst erst
                     # hier auftreten und aus dem try entkommen.
                     db.commit()
-                    if report.renamed or report.deactivated or report.unresolved_sensors:
+                    if (report.renamed or report.deactivated
+                            or report.unresolved_sensors or report.readopted
+                            or report.orphaned_inactive):
                         try:
                             # Eigene Session (db=None): AuditLoggerDB.log_event
                             # committet die uebergebene Session selbst. Mit
@@ -784,6 +888,12 @@ class FanControlService:
                                     # Nutzeraenderung dieses Laufs, die sonst
                                     # nirgends revisionssicher gelandet waere.
                                     "unresolved_sensors": report.unresolved_sensors,
+                                    # #585: eine zurueckgenommene Kennung und
+                                    # ein Luefter, der ungeregelt bleibt, sind
+                                    # beide revisionswuerdig -- der zweite
+                                    # besonders, weil ihn sonst nichts nennt.
+                                    "readopted": report.readopted,
+                                    "orphaned_inactive": report.orphaned_inactive,
                                 },
                                 db=None,
                             )

--- a/backend/app/services/power/fan_reconcile.py
+++ b/backend/app/services/power/fan_reconcile.py
@@ -1,4 +1,10 @@
-"""Ueberfuehrt hwmon-indizierte fan_configs auf stabile Kennungen (#532).
+"""Fuehrt fan_configs auf die heute gescannte Kennung nach.
+
+Hinweg (#532): hwmon-indizierte Zeilen auf stabile Kennungen.
+Rueckweg (#585): stabile Zeilen zurueck auf hwmon-Kennungen, wenn die
+Ableitung fuer einen Chip nicht mehr stabil ist. Ohne ihn bliebe ein Kanal,
+dessen Chip in den Rueckfall faellt, an einer deaktivierten Altzeile haengen
+und wuerde stillschweigend nicht geregelt.
 
 Reines Modul: es bekommt die Scan-Fakten uebergeben und fasst kein sysfs an.
 Der Aufrufer haelt die Transaktion.
@@ -37,12 +43,30 @@ class ChipFacts:
     ambiguous: bool
 
 
+@dataclass(frozen=True)
+class UnstableChip:
+    """Ein Chip, fuer den der Scan gerade keine stabile Kennung bilden kann.
+
+    Der Anker fuer die Zuordnung ist `prefix` -- der Inhalt von hwmon/name.
+    Eine instabile ChipIdentity fuehrt ihn weiter, und jede stabile Kennung
+    beginnt mit genau diesem Praefix (format_chip_name bildet
+    "<prefix>-<bus>-<addr>", der adresslose Zweig "<prefix>@<devname>").
+    """
+    hwmon_name: str
+    prefix: str
+    pwm_channels: frozenset
+    temp_channels: frozenset
+    ambiguous: bool
+
+
 @dataclass
 class ReconcileReport:
     renamed: List[Tuple[str, str]] = field(default_factory=list)
     deactivated: List[str] = field(default_factory=list)
     skipped_absent: List[str] = field(default_factory=list)
     unresolved_sensors: List[str] = field(default_factory=list)
+    readopted: List[Tuple[str, str]] = field(default_factory=list)
+    orphaned_inactive: List[str] = field(default_factory=list)
 
 
 def _chip_from_name(name: Optional[str]) -> Optional[str]:
@@ -199,6 +223,209 @@ def reconcile_fan_identities(
         "Identitaets-Abgleich: %d uebernommen, %d deaktiviert, %d ohne Chip",
         len(report.renamed), len(report.deactivated), len(report.skipped_absent),
     )
+    return report
+
+
+# --- Rueckweg: stabil -> hwmon-indiziert (#585) ------------------------------
+
+
+def split_legacy_fan_id(fan_id: str):
+    """"hwmon2_pwm7" -> (2, 7); alles andere -> None.
+
+    Oeffentlich, damit der Aufrufer die Altform erkennen kann, ohne das
+    Modulmuster zu importieren -- die Form ist Teil des Vertrags zwischen
+    build_fan_id() und diesem Abgleich, nicht ein Detail dieses Moduls.
+    """
+    match = _LEGACY_FAN_ID.match(fan_id or "")
+    if not match:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+
+def _stable_form(prefix: str, kind: str, num: int) -> "re.Pattern":
+    """Muster fuer die stabile Form eines Kanals dieses Chips.
+
+    `.*` statt `[^:]*`, weil der adresslose Zweig von derive_chip_identity
+    den Geraetenamen anhaengt ("nct6798@0000:03:00.0") und der einen
+    Doppelpunkt enthalten kann. Der Endanker plus die woertliche Kanalnummer
+    halten das Muster trotzdem eng: ":pwm1$" trifft "…:pwm11" nicht.
+    """
+    return re.compile(rf"^{re.escape(prefix)}[-@].*:{kind}{num}$")
+
+
+def _reverse_sensor_id(sensor_id: Optional[str],
+                       chips: Dict[str, "UnstableChip"]) -> Optional[str]:
+    """Stabile Sensorkennung auf die heutige hwmon-Form zuruecknehmen.
+
+    Ohne diesen Schritt zeigte die Zeile nach dem Rueckweg auf einen Sensor,
+    den der Scan nicht mehr kennt -- get_temp() lieferte None, und seit #534
+    Punkt 2 gaebe der Regelkreis den Kanal nach 300 s an die Board-Automatik
+    ab. Der Rueckweg reichte dann gerade so weit, den Fehler zu verschieben.
+
+    Sensoren fremder Chips bleiben unberuehrt: ein k10temp-Sensor ist von
+    der Instabilitaet des nct6798 nicht betroffen.
+    """
+    if not sensor_id:
+        return sensor_id
+    bare = sensor_id[len("hwmon:"):] if sensor_id.startswith("hwmon:") else sensor_id
+    for chip in chips.values():
+        if chip.ambiguous or chip.prefix in ("", "Unknown"):
+            continue
+        for num in chip.temp_channels:
+            if _stable_form(chip.prefix, "temp", num).match(bare):
+                return f"hwmon:{chip.hwmon_name}_temp{num}"
+    return sensor_id
+
+
+def _reverse_labels_and_composites(db: Session,
+                                   chips: Dict[str, "UnstableChip"]) -> None:
+    """Nutzer-Labels und Composite-Quellen ziehen mit.
+
+    Beides spiegelt den Hinweg: bei einer Kollision bleibt die vorhandene
+    Zeile stehen und die umzuschluesselnde wird ignoriert -- geloescht wird
+    nichts. Composites sind nicht bloss Kosmetik: eine Composite-Quelle, die
+    niemand mehr aufloest, endet in derselben Abgabe nach 300 s wie ein
+    direkt zugewiesener Sensor.
+    """
+    rows = list(db.execute(select(TempSensorLabel)).scalars())
+    belegt = {row.sensor_id for row in rows}
+    for row in rows:
+        neu = _reverse_sensor_id(row.sensor_id, chips)
+        if neu == row.sensor_id or neu in belegt:
+            continue
+        row.legacy_sensor_id = row.sensor_id
+        row.sensor_id = neu
+        belegt.add(neu)
+        logger.info("Sensor-Label zurueckgenommen: %s -> %s",
+                    row.legacy_sensor_id, neu)
+
+    for composite in db.execute(select(CompositeTempSensor)).scalars():
+        try:
+            sources = json.loads(composite.source_ids_json)
+        except (TypeError, ValueError):
+            logger.warning("Composite %s: source_ids_json unlesbar", composite.id)
+            continue
+        if not isinstance(sources, list):
+            continue
+        umgeschrieben = [_reverse_sensor_id(s, chips) if isinstance(s, str) else s
+                         for s in sources]
+        if umgeschrieben != sources:
+            composite.source_ids_json = json.dumps(umgeschrieben)
+            logger.info("Composite %s: Quell-IDs zurueckgenommen", composite.id)
+
+
+def reconcile_unstable_identities(
+    db: Session,
+    *,
+    chips: Dict[str, "UnstableChip"],
+) -> ReconcileReport:
+    """Nimmt stabile Zeilen auf die heutige hwmon-Kennung zurueck. Committet NICHT.
+
+    Gegenstueck zu reconcile_fan_identities(): aufgerufen fuer die Chips,
+    deren Kennung der Scan gerade NICHT stabil bilden kann. Der Rueckfall in
+    build_fan_id() ist lebender Code, kein Altbestand -- auf BaluNode hat er
+    zwei Generationen von Zeilen hinterlassen.
+
+    Im Zweifel geschieht nichts: ein falsch zugeordneter Luefter ist
+    schlimmer als ein nicht zugeordneter.
+    """
+    report = ReconcileReport()
+    rows = list(db.execute(select(FanConfig)).scalars())
+    # Rangfolge VOR dem ersten Schreibzugriff festhalten -- updated_at traegt
+    # ein onupdate=func.now() und aenderte sich sonst waehrend des Laufs.
+    order = {row.id: row.updated_at for row in rows}
+    vorhanden = {row.fan_id: row for row in rows}
+
+    for chip in chips.values():
+        if chip.ambiguous or chip.prefix in ("", "Unknown"):
+            # Mehrere Chips desselben Praefix (deren Indizes koennen ueber
+            # Boots tauschen), oder hwmon/name war unlesbar -- "Unknown"
+            # waere ueber Chips hinweg mehrdeutig.
+            continue
+        for kanal in sorted(chip.pwm_channels):
+            ziel = f"{chip.hwmon_name}_pwm{kanal}"
+            muster = _stable_form(chip.prefix, "pwm", kanal)
+            kandidaten = [row for row in rows
+                          if row.is_active and muster.match(row.fan_id or "")]
+
+            if len(kandidaten) != 1:
+                if len(kandidaten) > 1:
+                    logger.warning(
+                        "Rueckweg %s: %d aktive Zeilen passen auf %s -- keine "
+                        "Zuordnung", ziel, len(kandidaten), chip.prefix,
+                    )
+                inkumbent = vorhanden.get(ziel)
+                if inkumbent is not None and not inkumbent.is_active:
+                    # Der Restfall: eine Zeile unter der heutigen Kennung
+                    # existiert, ist deaktiviert, und es gibt keine stabile
+                    # Vorgaengerin, die sie erklaert. Sie bleibt inaktiv --
+                    # deaktiviert wurde sie einmal bewusst zugunsten einer
+                    # anderen. Der Regelkreis wird sie ueberspringen, und
+                    # ohne diese Zeile stuende nirgends, warum.
+                    report.orphaned_inactive.append(ziel)
+                    logger.warning(
+                        "Luefter %s ist deaktiviert und wird NICHT geregelt: "
+                        "keine stabile Vorgaengerzeile zuzuordnen (#585)", ziel,
+                    )
+                continue
+
+            gewinner = kandidaten[0]
+            inkumbent = vorhanden.get(ziel)
+            if inkumbent is not None and inkumbent is not gewinner:
+                gruppe = [gewinner, inkumbent]
+                gewinner = max(gruppe,
+                               key=lambda r: (order.get(r.id) or _EPOCH, r.id or 0))
+                verlierer = next(r for r in gruppe if r is not gewinner)
+                if verlierer.is_active:
+                    verlierer.is_active = False
+                    report.deactivated.append(verlierer.fan_id)
+                if verlierer.fan_id == ziel:
+                    # Dieselbe Falle wie I-2 auf dem Hinweg: die Zielkennung
+                    # muss frei sein, BEVOR der Gewinner sie uebernimmt --
+                    # sonst halten zwei Zeilen denselben fan_id und der
+                    # Unique-Index schlaegt beim Flush zu. row.id ist
+                    # Primaerschluessel und damit ohne Rueckfrage eindeutig.
+                    verlierer.fan_id = f"{ziel}#legacy{verlierer.id}"
+                    db.flush()
+
+            if gewinner.fan_id != ziel:
+                alt = gewinner.fan_id
+                gewinner.legacy_fan_id = alt
+                gewinner.fan_id = ziel
+                report.readopted.append((alt, ziel))
+                logger.info("Fan-Identitaet zurueckgenommen: %s -> %s", alt, ziel)
+                _rewrite_references(db, alt, ziel)
+
+            # Der Kanal wurde gerade gescannt -- er existiert. Eine Zeile,
+            # die ihn traegt, gehoert aktiv. is_active wird sonst NUR beim
+            # Anlegen gesetzt (fan_control.py:875), und ein Rueckfall auf eine
+            # deaktivierte Altzeile liesse den Luefter ungeregelt -- ohne eine
+            # Logzeile, ohne ein Zeichen in der Oberflaeche.
+            #
+            # Wirksam wird die Zeile nur in einem Fall: wenn die Altzeile den
+            # Rangvergleich gewinnt und deshalb ein inaktiver Gewinner
+            # dasteht. Im Normalfall traegt die stabile Zeile ihre Aktivitaet
+            # durch die Umbenennung mit. Trotzdem hier und nicht im
+            # Rangzweig -- die Aussage gilt fuer jeden gescannten Kanal, und
+            # sie an die Bedingung zu haengen hiesse, sie beim naechsten
+            # Umbau zu verlieren.
+            #
+            # Es ueberschreibt keine Nutzerentscheidung: die API kennt das
+            # Feld nicht (routes/fans.py enthaelt is_active nirgends), nur
+            # dieser Abgleich setzt es je auf False. Kaeme ein Bedienelement
+            # dafuer hinzu, muesste diese Zeile neu bewertet werden.
+            gewinner.is_active = True
+            gewinner.temp_sensor_id = _reverse_sensor_id(
+                gewinner.temp_sensor_id, chips)
+
+    _reverse_labels_and_composites(db, chips)
+
+    if report.readopted or report.orphaned_inactive:
+        logger.info(
+            "Rueckweg: %d zurueckgenommen, %d ohne Zuordnung deaktiviert",
+            len(report.readopted), len(report.orphaned_inactive),
+        )
     return report
 
 

--- a/backend/tests/test_fan_reconcile_reverse.py
+++ b/backend/tests/test_fan_reconcile_reverse.py
@@ -1,0 +1,396 @@
+"""Der Rueckweg: stabile Kennung -> hwmon-indiziert (#585).
+
+Ausgangslage ist die auf BaluNode am 2026-09-07 gemessene Datenlage: vier
+aktive Zeilen in stabiler Form, dazu zwei Generationen deaktivierter
+hwmon-Zeilen aus frueheren Laeufen des Hinwegs (#532).
+
+Der geprueft Fall ist der, den es dort bisher nicht gab: der Scan bildet fuer
+den nct6798 keine stabile Kennung mehr und liefert wieder hwmon2_pwmN. Ohne
+den Rueckweg fiele die Anlage-Schleife auf die deaktivierte Altzeile zurueck
+und der Luefter bliebe ungeregelt -- ohne Logzeile und ohne Zeichen in der
+Oberflaeche.
+"""
+import json
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import Base
+from app.models.fans import (
+    CompositeTempSensor,
+    FanConfig,
+    FanScheduleEntry,
+    TempSensorLabel,
+)
+from app.services.power.fan_reconcile import (
+    ChipFacts,
+    UnstableChip,
+    reconcile_fan_identities,
+    reconcile_unstable_identities,
+    split_legacy_fan_id,
+)
+
+NCT_INSTABIL = UnstableChip(
+    hwmon_name="hwmon2",
+    prefix="nct6798",
+    pwm_channels=frozenset({1, 2, 3, 7}),
+    temp_channels=frozenset({1, 2, 6}),
+    ambiguous=False,
+)
+CHIPS = {"nct6798": NCT_INSTABIL}
+
+
+def _dt(text: str) -> datetime:
+    return datetime.fromisoformat(text).replace(tzinfo=timezone.utc)
+
+
+# (fan_id, name, temp_sensor_id, is_active, updated_at)
+ROWS = [
+    ("hwmon2_pwm1", "nct6798 PWM1", "hwmon:hwmon3_temp6", False, "2026-09-05T23:29:01"),
+    ("hwmon2_pwm2", "nct6798 PWM2", "hwmon:hwmon3_temp6", False, "2026-09-05T23:29:01"),
+    ("hwmon5_pwm1", "nct6798 PWM1", "hwmon:hwmon3_temp6", False, "2026-09-05T23:29:01"),
+    ("nct6798-isa-0290:pwm1", "nct6798 PWM1",
+     "hwmon:nct6798-isa-0290:temp6", True, "2026-09-06T19:02:07"),
+    ("nct6798-isa-0290:pwm2", "nct6798 PWM2",
+     "hwmon:k10temp-pci-00c3:temp1", True, "2026-09-06T19:02:07"),
+    ("nct6798-isa-0290:pwm3", "nct6798 PWM3",
+     "hwmon:nct6798-isa-0290:temp1", True, "2026-09-05T23:29:01"),
+    ("nct6798-isa-0290:pwm7", "nct6798 PWM7",
+     "hwmon:nct6798-isa-0290:temp1", True, "2026-09-05T23:29:01"),
+    ("amdgpu-pci-0300:pwm1", "amdgpu PWM1", None, True, "2026-09-06T16:44:27"),
+]
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    for fan_id, name, sensor, aktiv, updated in ROWS:
+        session.add(FanConfig(fan_id=fan_id, name=name, mode="auto",
+                              temp_sensor_id=sensor, is_active=aktiv,
+                              updated_at=_dt(updated)))
+    session.commit()
+    yield session
+    session.close()
+
+
+def _zeile(db, fan_id):
+    return db.execute(
+        select(FanConfig).where(FanConfig.fan_id == fan_id)).scalar_one_or_none()
+
+
+def _aktiv(db):
+    return {r.fan_id for r in db.execute(
+        select(FanConfig).where(FanConfig.is_active.is_(True))).scalars()}
+
+
+# --- Der Kern ---------------------------------------------------------------
+
+
+def test_die_stabile_zeile_kommt_unter_der_heutigen_kennung_zurueck(db):
+    bericht = reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+
+    zeile = _zeile(db, "hwmon2_pwm1")
+    assert zeile is not None
+    assert zeile.is_active is True
+    assert zeile.legacy_fan_id == "nct6798-isa-0290:pwm1"
+    assert ("nct6798-isa-0290:pwm1", "hwmon2_pwm1") in bericht.readopted
+
+
+def test_der_kanal_ist_hinterher_geregelt_statt_stillgelegt(db):
+    """Die Aussage von #585 in einem Satz: vorher traegt die Zeile unter der
+    heutigen Kennung is_active=False -- der Regelkreis steigt bei
+    `not config.is_active` aus (fan_control.py:1160) --, hinterher ist der
+    Kanal aktiv.
+
+    Welcher Weg dorthin fuehrt, laesst dieser Test offen, und das ist
+    Absicht: im Normalfall gewinnt die stabile Zeile, ist ohnehin aktiv und
+    bringt ihre Aktivitaet mit der Umbenennung mit. Die ausdrueckliche
+    Reaktivierung greift nur, wenn die Altzeile den Rangvergleich gewinnt --
+    dafuer gibt es weiter unten einen eigenen Test."""
+    vorher = _zeile(db, "hwmon2_pwm1")
+    assert vorher.is_active is False
+
+    reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+
+    assert _zeile(db, "hwmon2_pwm1").is_active is True
+
+
+def test_die_verdraengte_altzeile_bleibt_erhalten_und_inaktiv(db):
+    """Loeschen ist Nicht-Ziel -- schon in #532, hier unveraendert. Die
+    Zielkennung muss aber frei werden, sonst halten zwei Zeilen denselben
+    fan_id und der Unique-Index schlaegt beim Commit zu."""
+    reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+
+    assert db.query(FanConfig).count() == len(ROWS)
+    verdraengt = [r for r in db.execute(select(FanConfig)).scalars()
+                  if r.fan_id.startswith("hwmon2_pwm1#legacy")]
+    assert len(verdraengt) == 1
+    assert verdraengt[0].is_active is False
+
+
+def test_alle_gescannten_kanaele_kommen_zurueck(db):
+    reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+
+    assert _aktiv(db) == {"hwmon2_pwm1", "hwmon2_pwm2", "hwmon2_pwm3",
+                          "hwmon2_pwm7", "amdgpu-pci-0300:pwm1"}
+
+
+# --- Sensoren: ohne sie verschoebe der Rueckweg den Fehler nur --------------
+
+
+def test_der_sensor_desselben_chips_wird_mitgenommen(db):
+    """Bliebe er auf der stabilen Kennung stehen, lieferte get_temp() None --
+    und seit #534 Punkt 2 gaebe der Regelkreis den Kanal nach 300 s an die
+    Board-Automatik ab. Der Rueckweg haette den Fehler dann nur verschoben."""
+    reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+
+    assert _zeile(db, "hwmon2_pwm1").temp_sensor_id == "hwmon:hwmon2_temp6"
+
+
+def test_der_sensor_eines_fremden_chips_bleibt_unberuehrt(db):
+    """k10temp ist von der Instabilitaet des nct6798 nicht betroffen."""
+    reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+
+    assert _zeile(db, "hwmon2_pwm2").temp_sensor_id == "hwmon:k10temp-pci-00c3:temp1"
+
+
+def test_ein_nicht_gescannter_temperaturkanal_wird_nicht_erfunden(db):
+    """temp9 gibt es im Scan nicht -- eine Zuordnung waere geraten."""
+    chips = {"nct6798": UnstableChip(
+        hwmon_name="hwmon2", prefix="nct6798",
+        pwm_channels=frozenset({1}), temp_channels=frozenset({1}),
+        ambiguous=False)}
+    zeile = _zeile(db, "nct6798-isa-0290:pwm1")
+    zeile.temp_sensor_id = "hwmon:nct6798-isa-0290:temp9"
+    db.commit()
+
+    reconcile_unstable_identities(db, chips=chips)
+    db.commit()
+
+    assert _zeile(db, "hwmon2_pwm1").temp_sensor_id == "hwmon:nct6798-isa-0290:temp9"
+
+
+def test_labels_und_composites_ziehen_mit(db):
+    db.add(TempSensorLabel(sensor_id="hwmon:nct6798-isa-0290:temp6",
+                           custom_label="Gehaeuse hinten"))
+    db.add(CompositeTempSensor(
+        id="comp1", name="Mittelwert", function="avg",
+        source_ids_json=json.dumps(["hwmon:nct6798-isa-0290:temp1",
+                                    "hwmon:k10temp-pci-00c3:temp1"])))
+    db.commit()
+
+    reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+
+    label = db.execute(select(TempSensorLabel)).scalar_one()
+    assert label.sensor_id == "hwmon:hwmon2_temp6"
+    assert label.legacy_sensor_id == "hwmon:nct6798-isa-0290:temp6"
+
+    composite = db.execute(select(CompositeTempSensor)).scalar_one()
+    assert json.loads(composite.source_ids_json) == [
+        "hwmon:hwmon2_temp1", "hwmon:k10temp-pci-00c3:temp1"]
+
+
+# --- Die Wachen: im Zweifel geschieht nichts -------------------------------
+
+
+def test_zwei_chips_desselben_praefix_werden_nicht_zugeordnet(db):
+    """Ihre hwmon-Indizes koennen ueber Boots tauschen -- dieselbe Regel, mit
+    der derive_all() Duplikate fuer instabil erklaert."""
+    chips = {"nct6798": UnstableChip(
+        hwmon_name="hwmon2", prefix="nct6798",
+        pwm_channels=frozenset({1}), temp_channels=frozenset({6}),
+        ambiguous=True)}
+
+    bericht = reconcile_unstable_identities(db, chips=chips)
+    db.commit()
+
+    assert bericht.readopted == []
+    assert _zeile(db, "nct6798-isa-0290:pwm1").fan_id == "nct6798-isa-0290:pwm1"
+    assert _zeile(db, "hwmon2_pwm1").is_active is False
+
+
+def test_ohne_lesbaren_chipnamen_wird_nichts_zugeordnet(db):
+    """hwmon/name war unlesbar -- "Unknown" waere ueber Chips hinweg
+    mehrdeutig und traefe irgendeine Zeile."""
+    chips = {"Unknown": UnstableChip(
+        hwmon_name="hwmon2", prefix="Unknown",
+        pwm_channels=frozenset({1}), temp_channels=frozenset(),
+        ambiguous=False)}
+
+    assert reconcile_unstable_identities(db, chips=chips).readopted == []
+    assert _zeile(db, "hwmon2_pwm1").is_active is False
+
+
+def test_zwei_passende_aktive_zeilen_werden_nicht_zugeordnet(db):
+    """Zwei Chips desselben Praefix haben zwei stabile Zeilen hinterlassen.
+    Welche zu hwmon2 gehoert, ist nicht entscheidbar."""
+    db.add(FanConfig(fan_id="nct6798-isa-0a20:pwm1", name="nct6798 PWM1",
+                     mode="auto", is_active=True,
+                     updated_at=_dt("2026-09-06T19:02:07")))
+    db.commit()
+
+    bericht = reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+
+    assert ("nct6798-isa-0290:pwm1", "hwmon2_pwm1") not in bericht.readopted
+    assert _zeile(db, "hwmon2_pwm1").is_active is False
+
+
+def test_eine_kanalnummer_wird_nicht_mit_ihrem_praefix_verwechselt(db):
+    """":pwm1$" darf ":pwm11" nicht treffen -- sonst uebernaehme Kanal 1 die
+    Zeile von Kanal 11."""
+    db.add(FanConfig(fan_id="nct6798-isa-0290:pwm11", name="nct6798 PWM11",
+                     mode="auto", is_active=True,
+                     updated_at=_dt("2026-09-07T00:00:00")))
+    db.commit()
+
+    reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+
+    assert _zeile(db, "nct6798-isa-0290:pwm11") is not None
+    assert _zeile(db, "hwmon2_pwm1").legacy_fan_id == "nct6798-isa-0290:pwm1"
+
+
+def test_eine_inaktive_stabile_zeile_tritt_nicht_mehr_an(db):
+    """Spiegel der Regel aus dem Hinweg: eine deaktivierte Zeile wurde in
+    einem frueheren Lauf final entschieden. Liesse man sie erneut antreten,
+    koennte sie per Ranggleichstand gewinnen und den Unique-Index verletzen --
+    ohne dass eine einzige neue Information vorlaege.
+
+    Folge: der Kanal faellt in den Restfall und wird gemeldet, statt still
+    eine alte Zeile wiederzubeleben."""
+    stabil = _zeile(db, "nct6798-isa-0290:pwm3")
+    stabil.is_active = False
+    db.commit()
+    chips = {"nct6798": UnstableChip(
+        hwmon_name="hwmon2", prefix="nct6798",
+        pwm_channels=frozenset({3}), temp_channels=frozenset(),
+        ambiguous=False)}
+
+    bericht = reconcile_unstable_identities(db, chips=chips)
+    db.commit()
+
+    assert bericht.readopted == []
+    assert _zeile(db, "nct6798-isa-0290:pwm3").is_active is False
+
+
+# --- Der Restfall, den auch der Rueckweg nicht loest ------------------------
+
+
+def test_ein_kanal_ohne_stabile_vorgaengerin_wird_gemeldet(db):
+    """Variante A aus #585, hier als Restfall: der Luefter bleibt ungeregelt,
+    aber es steht im Bericht und im Journal, warum."""
+    db.add(FanConfig(fan_id="hwmon2_pwm4", name="nct6798 PWM4", mode="auto",
+                     is_active=False, updated_at=_dt("2026-09-05T23:29:01")))
+    db.commit()
+    chips = {"nct6798": UnstableChip(
+        hwmon_name="hwmon2", prefix="nct6798",
+        pwm_channels=frozenset({4}), temp_channels=frozenset(),
+        ambiguous=False)}
+
+    bericht = reconcile_unstable_identities(db, chips=chips)
+    db.commit()
+
+    assert bericht.orphaned_inactive == ["hwmon2_pwm4"]
+    assert _zeile(db, "hwmon2_pwm4").is_active is False
+
+
+def test_ein_unbekannter_kanal_meldet_nichts(db):
+    """Kein Eintrag, keine Zeile -- die Anlage-Schleife legt gleich eine an.
+    Eine Warnung waere hier Rauschen."""
+    chips = {"nct6798": UnstableChip(
+        hwmon_name="hwmon9", prefix="nct6798",
+        pwm_channels=frozenset({5}), temp_channels=frozenset(),
+        ambiguous=False)}
+
+    assert reconcile_unstable_identities(db, chips=chips).orphaned_inactive == []
+
+
+# --- Zusammenspiel mit dem Hinweg ------------------------------------------
+
+
+def test_rueckweg_und_hinweg_sind_zueinander_invers(db):
+    """Erholt sich die Ableitung, fuehrt #532 die Zeile zurueck. Ohne diese
+    Eigenschaft waere der Rueckweg eine Einbahnstrasse mit umgekehrtem
+    Vorzeichen -- also derselbe Fehler noch einmal."""
+    reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+    assert _zeile(db, "hwmon2_pwm1").is_active is True
+
+    reconcile_fan_identities(
+        db,
+        chips={"nct6798": ChipFacts(key="nct6798-isa-0290",
+                                    pwm_channels=frozenset({1, 2, 3, 7}),
+                                    ambiguous=False)},
+        sensor_map={"hwmon2_temp6": "hwmon:nct6798-isa-0290:temp6"},
+        cpu_sensor_id="hwmon:k10temp-pci-00c3:temp1",
+    )
+    db.commit()
+
+    zurueck = _zeile(db, "nct6798-isa-0290:pwm1")
+    assert zurueck is not None
+    assert zurueck.is_active is True
+    assert zurueck.temp_sensor_id == "hwmon:nct6798-isa-0290:temp6"
+
+
+def test_ein_zweiter_lauf_aendert_nichts(db):
+    erster = reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+    zweiter = reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+
+    assert len(erster.readopted) == 4
+    assert zweiter.readopted == []
+    assert zweiter.deactivated == []
+
+
+def test_verweise_ziehen_mit(db):
+    """sync_fan_id und Zeitplaneintraege zeigen sonst ins Leere."""
+    quelle = _zeile(db, "nct6798-isa-0290:pwm2")
+    quelle.sync_fan_id = "nct6798-isa-0290:pwm1"
+    db.add(FanScheduleEntry(fan_id="nct6798-isa-0290:pwm1", name="Nacht",
+                            start_time="22:00", end_time="06:00",
+                            curve_json="[]"))
+    db.commit()
+
+    reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+
+    assert _zeile(db, "hwmon2_pwm2").sync_fan_id == "hwmon2_pwm1"
+    eintrag = db.execute(select(FanScheduleEntry)).scalar_one()
+    assert eintrag.fan_id == "hwmon2_pwm1"
+
+
+def test_die_juengere_zeile_gewinnt_auch_wenn_sie_die_altzeile_ist(db):
+    """Der Rang entscheidet, nicht die Namensform -- dieselbe Regel wie auf
+    dem Hinweg. Eine Altzeile, die neuer ist, traegt die aktuellere
+    Nutzereinstellung."""
+    alt = _zeile(db, "hwmon2_pwm1")
+    alt.updated_at = _dt("2026-09-07T23:00:00")
+    db.commit()
+
+    reconcile_unstable_identities(db, chips=CHIPS)
+    db.commit()
+
+    gewinner = _zeile(db, "hwmon2_pwm1")
+    assert gewinner.id == alt.id
+    assert gewinner.is_active is True
+    assert _zeile(db, "nct6798-isa-0290:pwm1") is None or \
+        _zeile(db, "nct6798-isa-0290:pwm1").is_active is False
+
+
+def test_split_legacy_fan_id():
+    assert split_legacy_fan_id("hwmon2_pwm7") == (2, 7)
+    assert split_legacy_fan_id("nct6798-isa-0290:pwm7") is None
+    assert split_legacy_fan_id("") is None

--- a/backend/tests/test_fan_reconcile_wiring.py
+++ b/backend/tests/test_fan_reconcile_wiring.py
@@ -273,3 +273,73 @@ async def test_reconcile_runs_before_anlage_and_no_duplicate_row(monkeypatch):
         row = rows[0]
         assert row.fan_id == "nct6798-isa-0290:pwm1"
         assert row.legacy_fan_id == "hwmon5_pwm1"
+
+
+# --- Rueckweg: Fakten ueber instabile Chips (#585) ---------------------------
+
+
+class _NurCache:
+    """Backend-Double mit echten dict-Attributen, ohne get_fans()."""
+
+    def __init__(self, fan_cache, temp_paths):
+        self._fan_cache = fan_cache
+        self._temp_paths = temp_paths
+
+
+def _cache(**eintraege):
+    return {fan_id: {"device_driver": treiber, "identity_stable": stabil}
+            for fan_id, (treiber, stabil) in eintraege.items()}
+
+
+def test_instabile_chips_werden_mit_praefix_und_kanaelen_gesammelt(monkeypatch):
+    from pathlib import Path as _Path
+    service = _service(monkeypatch, primary=True, linux=True)
+    service._backend = _NurCache(
+        _cache(hwmon2_pwm1=("nct6798", False),
+               hwmon2_pwm7=("nct6798", False),
+               **{"amdgpu-pci-0300:pwm1": ("amdgpu", True)}),
+        {"hwmon2_temp6": _Path("/sys/class/hwmon/hwmon2/temp6_input")},
+    )
+
+    chips = service._collect_unstable_chips()
+
+    assert set(chips) == {"nct6798"}          # der stabile amdgpu ist draussen
+    chip = chips["nct6798"]
+    assert chip.hwmon_name == "hwmon2"
+    assert chip.pwm_channels == frozenset({1, 7})
+    assert chip.temp_channels == frozenset({6})
+    assert chip.ambiguous is False
+
+
+def test_zwei_knoten_desselben_praefix_gelten_als_mehrdeutig(monkeypatch):
+    service = _service(monkeypatch, primary=True, linux=True)
+    service._backend = _NurCache(
+        _cache(hwmon2_pwm1=("nct6798", False), hwmon5_pwm1=("nct6798", False)), {})
+
+    assert service._collect_unstable_chips()["nct6798"].ambiguous is True
+
+
+def test_instabile_kennungen_ausserhalb_der_hwmon_form_werden_uebergangen(monkeypatch):
+    """Ein Dev-Backend-Luefter oder eine GPU-Kennung ist zwar instabil, aber
+    fuer sie gibt es nichts zurueckzunehmen."""
+    service = _service(monkeypatch, primary=True, linux=True)
+    service._backend = _NurCache(_cache(dev_cpu_fan=("Simulated", False)), {})
+
+    assert service._collect_unstable_chips() == {}
+
+
+def test_ein_backend_ohne_cache_liefert_keine_chips(monkeypatch):
+    service = _service(monkeypatch, primary=True, linux=True)
+    service._backend = MagicMock()          # _fan_cache ist selbst ein Mock
+
+    assert service._collect_unstable_chips() == {}
+
+
+def test_der_abgleich_laeuft_auch_wenn_kein_chip_stabil_ist(monkeypatch):
+    """Der Vollfall des Rueckfalls. Zaehlte die Vorbedingung nur die stabilen
+    Chips, liefe hier gar kein Abgleich -- also ausgerechnet dann nicht, wenn
+    der Rueckweg gebraucht wird."""
+    service = _service(monkeypatch, primary=True, linux=True)
+
+    assert service._should_reconcile(chip_count=0) is False
+    assert service._should_reconcile(chip_count=1) is True

--- a/docs/superpowers/specs/2026-09-08-fan-identity-return-path-design.md
+++ b/docs/superpowers/specs/2026-09-08-fan-identity-return-path-design.md
@@ -1,0 +1,80 @@
+# Rückweg für Lüfterkennungen: stabil → hwmon-indiziert (#585)
+
+Entwurf vom 2026-09-08. Spiegelt den Hinweg aus #532, der bisher nur in eine Richtung läuft.
+
+## Ausgangslage
+
+#532 überführt hwmon-indizierte `fan_configs` auf stabile Kennungen (`nct6798-isa-0290:pwm1`). Bei einer Kollision gewinnt die jüngste Zeile, die Verliererinnen werden auf `is_active = False` gesetzt und bleiben liegen — Löschen ist dort ausdrückliches Nicht-Ziel.
+
+Der umgekehrte Fall hat keinen Weg. `build_fan_id()` fällt auf `hwmon<N>_pwm<M>` zurück, sobald `derive_chip_identity()` keine stabile Kennung bilden kann: `hwmon/name` unlesbar, kein `device`-Symlink, nicht bildbarer Bustyp (`i2c`, `scsi`, …), kein pci/platform-Elter, oder zwei hwmon-Knoten mit derselben Kennung (`derive_all` markiert beide als instabil).
+
+Feldstand BaluNode am 2026-09-07 — drei Generationen für dieselben vier Kanäle:
+
+```
+nct6798-isa-0290:pwm1..7  is_active=t   legacy_fan_id=hwmon3_pwm*
+hwmon2_pwm1..7            is_active=f   legacy_fan_id=(leer)
+hwmon5_pwm1..7            is_active=f   legacy_fan_id=(leer)
+```
+
+## Was heute passierte, wenn der Rückfall greift
+
+Der Scan liefert `hwmon2_pwm1`. Dann:
+
+1. Die Anlage-Schleife findet die Zeile vor (`fan_control.py:857-860`, `if not existing`) und legt keine neue an.
+2. Die vorgefundene Zeile trägt `is_active = False`. `is_active = True` wird im ganzen Dienst nur beim Anlegen gesetzt (`fan_control.py:875`); `routes/fans.py` kennt das Feld nicht — es gibt keinen Weg zurück.
+3. Der Regelkreis steigt bei `not config.is_active` aus (`fan_control.py:1160`).
+4. `get_status` filtert inaktive Lüfter nicht (`fan_control.py:1544`), und kein Frontend-Bauteil liest das Feld. Die Karte sieht normal aus, mit Modusknöpfen und Kurveneditor — und nichts davon wirkt.
+
+Ein Lüfter, um den sich niemand kümmert, ohne eine einzige Logzeile. Landete der Index auf einer Nummer ohne Altzeile, entstünde stattdessen eine frische Zeile mit Standardkurve: geregelt, aber die getunte Konfiguration wäre still verwaist.
+
+## Die Verschärfung durch #580
+
+Seit #534 Punkt 2 gibt BaluHost einen Kanal an die Board-Automatik ab, wenn seine Temperaturquelle 300 s keinen Messwert liefert. `build_sensor_id()` fällt gemeinsam mit `build_fan_id()` zurück — die Zeile zeigt danach auf `hwmon:nct6798-isa-0290:temp6`, während der Scan nur noch `hwmon:hwmon2_temp6` kennt. `get_temp()` liefert `None`.
+
+Der Rückweg muss die Sensoren also mitnehmen. Täte er es nicht, wäre das Ergebnis nicht bloß eine falsche Kennung, sondern ein Lüfter, den BaluHost fünf Minuten später an das Board abgibt.
+
+## Der Anker
+
+Eine instabile `ChipIdentity` trägt weiterhin ihren `prefix` — den Inhalt von `hwmon/name`, also `nct6798`. Und jede stabile Kennung beginnt mit genau diesem Präfix: `format_chip_name()` bildet `<prefix>-<bus>-<addr>`, der adresslose Zweig `<prefix>@<devname>`.
+
+Damit ist die Zuordnung: **ein instabiler Kanal (`prefix`, `pwm_num`) gehört zu der Zeile, deren `fan_id` die Form `<prefix>[-@]…:pwm<pwm_num>` hat.** Für Sensoren dasselbe mit `:temp<K>`.
+
+Der Name der Zeile (`"nct6798 PWM1"`, den der Hinweg über `_chip_from_name()` auswertet) wird hier nicht gebraucht: die stabile `fan_id` enthält den Chipnamen selbst und ist der festere Anker.
+
+## Wachen
+
+Jede einzelne blockiert die Zuordnung — im Zweifel geschieht nichts, denn ein falsch zugeordneter Lüfter ist schlimmer als ein unzugeordneter:
+
+| Wache | Grund |
+|---|---|
+| `prefix` fehlt oder ist `"Unknown"` | `hwmon/name` war unlesbar; „Unknown" wäre über Chips hinweg mehrdeutig |
+| mehr als eine Kandidatenzeile | zwei Chips desselben Präfix — dieselbe Regel, mit der `derive_all` Duplikate für instabil erklärt |
+| mehr als ein instabiler Chip mit demselben Präfix im Scan | die Indizes zweier gleicher Chips können über Boots tauschen |
+
+## Wirkung
+
+Bei genau einem Kandidaten gilt dieselbe Mechanik wie auf dem Hinweg, unverändert übernommen:
+
+1. Gewinnerin ist die jüngste Zeile (`updated_at`) aus Kandidat und einer etwaigen Zeile, die die aktuelle Kennung schon trägt — auf BaluNode also die stabile Zeile gegen die 2026-09-05 deaktivierte.
+2. Eine Inkumbentin auf der Zielkennung wird zuerst freigemacht (`fan_id = f"{ziel}#legacy{row.id}"`), dann `db.flush()`, dann die Umbenennung — die Reihenfolge-Falle I-2 aus #532 gilt hier genauso.
+3. `legacy_fan_id` nimmt die alte Kennung auf, `_rewrite_references()` zieht `sync_fan_id` und Zeitplaneinträge mit.
+4. Verliererinnen werden deaktiviert.
+5. `temp_sensor_id` der Gewinnerin wird über die Präfix-Abbildung auf die aktuelle Sensorkennung umgeschrieben.
+
+Nutzer-Labels und Composite-Quellen ziehen mit derselben Abbildung mit. Bei Labels ist das Kosmetik, bei Composites nicht: eine Quelle, die niemand mehr auflöst, endet in derselben Abgabe nach 300 s wie ein direkt zugewiesener Sensor. Kollisionen werden wie auf dem Hinweg behandelt — die vorhandene Zeile bleibt stehen, die umzuschlüsselnde wird ignoriert, gelöscht wird nichts.
+
+Erholt sich die Ableitung später wieder, greift der Hinweg aus #532 und führt die Zeile zurück auf die stabile Kennung. Die beiden Wege sind zueinander invers; `legacy_fan_id` trägt jeweils die zuletzt verlassene Form.
+
+## Die Vorbedingung muss sich ändern
+
+`_should_reconcile()` verlangt heute `chip_count > 0`, und `_collect_chip_facts()` überspringt instabile Chips. Fällt die Ableitung für **alle** Chips zurück, ist die Faktenmenge leer und es läuft gar kein Abgleich — ausgerechnet im Vollfall. Die Vorbedingung zählt künftig stabile Chips **und** instabile Kanäle; „kein Linux-Backend" und „leerer Scan" bleiben harte Ausschlüsse.
+
+## Der Rest, der keine Zuordnung findet
+
+Findet sich kein Kandidat und die vorgefundene Zeile ist inaktiv, bleibt der Lüfter ungeregelt — daran ändert dieser Entwurf nichts. Aber er wird **hörbar**: eine WARNING mit Kennung und Grund. Das ist die Variante A aus #585, hier als Restfall enthalten statt als Alternative.
+
+## Nicht-Ziele
+
+- **Zeilen löschen.** Nicht-Ziel schon in #532; hier unverändert.
+- **Reaktivieren ohne Identitätsnachweis.** Eine inaktive Zeile, zu der kein Kandidat passt, bleibt inaktiv. Sie wurde einmal bewusst zugunsten einer anderen deaktiviert, und ohne Zuordnung gibt es keinen Grund anzunehmen, dass sich das geändert hat.
+- **Ein Bedienelement für `is_active`.** Dass es keines gibt, ist die Voraussetzung dafür, dass dieser Entwurf keine Nutzerentscheidung überschreibt. Käme eines dazu, müsste die Reaktivierung neu bewertet werden — als Kommentar im Code festgehalten.


### PR DESCRIPTION
Baut den Rückweg für Lüfterkennungen — Variante **B** aus #585. Der Identitäts-Abgleich aus #532 lief bisher nur in eine Richtung.

## Das Problem

`build_fan_id()` fällt auf `hwmon<N>_pwm<M>` zurück, sobald `derive_chip_identity()` keine stabile Kennung bilden kann: unlesbares `hwmon/name`, fehlender `device`-Symlink, nicht bildbarer Bustyp, oder zwei hwmon-Knoten mit derselben Kennung. Das ist **lebender Code**, kein Altbestand — auf BaluNode stehen drei Generationen für dieselben vier Kanäle:

```
nct6798-isa-0290:pwm1..7  is_active=t   legacy_fan_id=hwmon3_pwm*
hwmon2_pwm1..7            is_active=f   legacy_fan_id=(leer)
hwmon5_pwm1..7            is_active=f   legacy_fan_id=(leer)
```

Griffe der Rückfall wieder und landete der Chip auf `hwmon2`, passierte Folgendes — jeder Schritt für sich richtig, zusammen ein Ausfall ohne Anzeige:

1. Die Anlage-Schleife findet die Zeile vor (`if not existing`) und legt keine neue an.
2. Die Zeile ist deaktiviert. `is_active = True` wird im ganzen Dienst **nur** beim Anlegen gesetzt (`fan_control.py:875`); `routes/fans.py` enthält das Feld nirgends — es gibt keinen Weg zurück.
3. Der Regelkreis steigt bei `not config.is_active` aus (`fan_control.py:1160`).
4. `get_status` filtert inaktive Lüfter nicht, und kein Frontend-Bauteil liest das Feld. Die Karte sieht normal aus, mit Modusknöpfen und Kurveneditor — und nichts davon wirkt.

Ein Lüfter, um den sich niemand kümmert, ohne eine einzige Logzeile.

## Der Anker

Eine instabile `ChipIdentity` führt ihren `prefix` weiter — den Inhalt von `hwmon/name`. Und jede stabile Kennung beginnt damit: `format_chip_name()` bildet `<prefix>-<bus>-<addr>`, der adresslose Zweig `<prefix>@<devname>`. Damit gehört ein instabiler Kanal `(prefix, pwm_num)` zu der Zeile, deren `fan_id` die Form `<prefix>[-@]…:pwm<num>` hat.

Die Mechanik danach ist die des Hinwegs, unverändert übernommen: Rang nach `updated_at`, die Zielkennung **vor** der Umbenennung freimachen (dieselbe Reihenfolge-Falle I-2, sonst halten zwei Zeilen denselben `fan_id`), `legacy_fan_id`, `_rewrite_references()`, Verlierer deaktivieren, nichts löschen.

## Die Sensoren waren nicht optional

Bliebe `temp_sensor_id` auf der stabilen Kennung stehen, lieferte `get_temp()` `None` — und seit **#534 Punkt 2** gibt der Regelkreis einen Kanal nach 300 s ohne Messwert an die Board-Automatik ab. Der Rückweg hätte den Fehler dann nur verschoben: statt „ungeregelt, weil inaktiv" wäre es „abgegeben, weil blind". Labels und Composite-Quellen ziehen mit derselben Abbildung mit; bei Composites ist das aus demselben Grund keine Kosmetik.

## Drei Wachen, weil Raten teurer ist als Nichtstun

| Wache | Grund |
|---|---|
| mehr als ein hwmon-Knoten desselben Präfix | ihre Indizes können über Boots tauschen — dieselbe Regel, mit der `derive_all()` Duplikate für instabil erklärt |
| Präfix fehlt oder ist `"Unknown"` | `hwmon/name` war unlesbar; der Platzhalter wäre über Chips hinweg mehrdeutig |
| mehr als eine passende aktive Zeile | zwei Chips desselben Präfix haben zwei stabile Zeilen hinterlassen — welche gemeint ist, ist nicht entscheidbar |

Eine bereits deaktivierte stabile Zeile tritt nicht mehr an — Spiegel der Regel aus dem Hinweg: sie wurde in einem früheren Lauf final entschieden, und ein erneuter Antritt könnte sie per Ranggleichstand gewinnen lassen, ohne dass eine neue Information vorläge.

## Der Restfall ist Variante A

Findet sich keine Zuordnung und die vorgefundene Zeile ist inaktiv, bleibt der Lüfter ungeregelt — daran ändert dieser PR nichts. Aber er wird hörbar: WARNING mit Kennung und Grund, plus Audit-Eintrag. Das ist Variante A aus dem Issue, hier als Restfall enthalten statt als Alternative.

## Die Vorbedingung musste sich mitändern

`_should_reconcile()` zählte nur stabile Chips. Im Vollfall des Rückfalls — keine einzige Kennung mehr stabil — wäre die Faktenmenge leer und es liefe **gar kein** Abgleich, also ausgerechnet dann nicht, wenn der Rückweg gebraucht wird. Sie zählt jetzt beide. Der Hinweg bekommt dafür eine eigene Wache, damit seine Zusage („gegen eine leere Faktenmenge läuft er nicht") unverändert gilt.

## Prüfung

- `pytest -k "fan"` → 516 bestanden, 2 übersprungen; `ruff` sauber.
- **Mutationsproben**, alle acht rot: Reaktivierung entfernt · Sensor-Rücknahme abgeschaltet · Mehrdeutigkeits-Wache entfernt · Kandidaten-Eindeutigkeit aufgeweicht · Freimachen der Zielkennung entfernt (14 Tests) · Restfall-Meldung entfernt · Endanker der Kanalnummer entfernt · Rangvergleich durch „stabile Zeile gewinnt immer" ersetzt.

Eine dieser Proben hat einen Fehler in meinen eigenen Tests aufgedeckt: `gewinner.is_active = True` tötete nur **einen** Test statt der zwei, die ich dafür geschrieben zu haben glaubte. Der Grund ist lehrreich — im Normalfall gewinnt die stabile Zeile, ist ohnehin aktiv und bringt ihre Aktivität durch die Umbenennung mit; die ausdrückliche Reaktivierung greift nur, wenn die Altzeile den Rangvergleich gewinnt. Der Test, dessen Docstring das Gegenteil behauptete, ist umbenannt und sagt jetzt, was er misst.

## Bekannte Reste

- Die Reaktivierung überschreibt keine Nutzerentscheidung, **weil** es keine gibt: `routes/fans.py` kennt `is_active` nicht. Käme ein Bedienelement dazu, müsste die Zeile neu bewertet werden — im Code so vermerkt.
- Der Rückfall selbst bleibt unbehandelt: dieser PR macht ihn überlebbar, verhindert ihn nicht.
- Ein zurückgegebener Kanal ohne Zuordnung bleibt inaktiv und damit ungeregelt. Bewusst: deaktiviert wurde er einmal zugunsten einer anderen Zeile, und ohne Zuordnung gibt es keinen Grund anzunehmen, dass sich das geändert hat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGS5jVzZpLcqpZ2VH8DqNn
