### PR TITLE
fix(fans): ein PWM-Aufruf holt den freigegebenen Kanal zurueck (#583)

### DIFF
--- a/backend/app/services/power/fan_control.py
+++ b/backend/app/services/power/fan_control.py
@@ -1871,7 +1871,22 @@ class FanControlService:
         return True
 
     async def set_fan_pwm(self, fan_id: str, pwm_percent: int) -> Tuple[bool, Optional[int]]:
-        """Set manual PWM value."""
+        """Set manual PWM value.
+
+        Ein freigegebener Kanal wird dabei zurueckgeholt (#583). Die Freigabe
+        an die Board-Automatik (#534) war bis dahin nur in der Oberflaeche eine
+        Sperre: dieser Aufruf schrieb weiter -- mit `force=True` sogar am
+        Backoff vorbei --, waehrend `released_fans` den Kanal unveraendert dem
+        Board zuschrieb. Die Karte zeigte danach "Board regelt", obwohl
+        BaluHost gerade geschrieben hatte, und der naechste Regelzyklus
+        uebersprang den Kanal wieder; der Wert blieb als Fremdkoerper stehen.
+
+        Abgelehnt wird der Aufruf deshalb NICHT. Wer den Regler bedient, will
+        den Kanal offensichtlich steuern -- die Invariante, die zaehlt, ist
+        "wer schreibt, besitzt auch", nicht "die Freigabe ist unumkehrbar".
+        Den Rueckweg gibt es ohnehin schon als eigenen Endpunkt; hier wird
+        dieselbe Mechanik nur mitbenutzt.
+        """
         if not self._backend:
             return False, None
 
@@ -1890,6 +1905,19 @@ class FanControlService:
 
             # Apply min/max limits
             pwm_percent = max(config.min_pwm_percent, min(config.max_pwm_percent, pwm_percent))
+
+            # In derselben Sitzung wie die Konfiguration: der haeufige Weg --
+            # nichts ist freigegeben -- kostet damit keine zweite Verbindung.
+            freigegeben = fan_id in read_released_fans(db)
+
+        if freigegeben and not await self.reacquire_fan(fan_id):
+            # Die Ruecknahme ist nicht veroeffentlicht. Jetzt trotzdem zu
+            # schreiben erzeugte genau den Widerspruch, den diese Methode
+            # beseitigen soll -- nur sehenden Auges. Ein fehlgeschlagener Klick
+            # mit Fehlermeldung ist das ehrlichere Ergebnis.
+            logger.warning("%s: PWM abgelehnt, Ruecknahme nicht veroeffentlicht",
+                           fan_id)
+            return False, None
 
         # Set PWM. Nutzeraktion: das Backoff-Fenster umgehen (#533), damit der
         # Klick einen echten Versuch und eine echte Fehlermeldung bekommt.

--- a/backend/tests/test_fan_pwm_release_enforcement.py
+++ b/backend/tests/test_fan_pwm_release_enforcement.py
@@ -1,0 +1,142 @@
+"""Ein PWM-Aufruf holt einen freigegebenen Kanal zurueck (#583).
+
+Die Freigabe an die Board-Automatik (#534) war bisher nur in der Oberflaeche
+eine Sperre. `POST /api/fans/pwm` schrieb weiter -- mit `force=True`, also
+sogar am Backoff vorbei --, waehrend `fan_runtime_state.released_fans` den
+Kanal unveraendert als freigegeben fuehrte. Danach zeigte die Karte "Board
+regelt", obwohl BaluHost gerade geschrieben hatte, und der naechste
+Regelzyklus uebersprang den Kanal wieder: der Wert blieb als Fremdkoerper
+stehen, erklaert weder von der Anzeige noch von der Regelung.
+
+Geheilt wird das nicht durch eine Ablehnung, sondern durch die Invariante
+"wer schreibt, besitzt auch": der Aufruf holt den Kanal vorher zurueck.
+Gemessen wird deshalb die WIRKUNG auf den veroeffentlichten Zustand, nicht
+der Aufruf einer Hilfsmethode -- eine Zusicherung auf `reacquire_fan` waere
+gruen, auch wenn die Ruecknahme nie in der Zeile landet.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import Base
+from app.models.fans import FanConfig
+from app.schemas.fans import FanMode
+from app.services.power import fan_control as fan_control_module
+from app.services.power.fan_control import FanControlService, FanData
+from app.services.power.fan_ownership import FanOwnership, ReleaseReason
+from app.services.power.fan_runtime_store import (
+    publish_released_fans,
+    read_released_fans,
+)
+
+FAN = "nct6798-isa-0290:pwm1"
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def _service(session_factory):
+    """Ein Dienst im MANUAL-Modus -- der einzige, in dem set_fan_pwm schreibt."""
+    FanControlService._instance = None
+    config = MagicMock()
+    config.is_dev_mode = False
+    config.fan_sample_interval_seconds = 5
+    service = FanControlService(config, session_factory)
+    service._use_linux_backend = True
+
+    backend = MagicMock()
+    backend.set_pwm = AsyncMock(return_value=True)
+    backend.get_fans = AsyncMock(return_value=[
+        FanData(
+            fan_id=FAN, name=FAN, rpm=900, pwm_percent=50,
+            temperature_celsius=45.0, mode=FanMode.MANUAL,
+            min_pwm_percent=0, max_pwm_percent=100, emergency_temp_celsius=85.0,
+            temp_sensor_id="hwmon:x", curve_points=[], is_active=True,
+        ),
+    ])
+    service._backend = backend
+
+    with session_factory() as db:
+        db.add(FanConfig(fan_id=FAN, name=FAN, mode=FanMode.MANUAL.value,
+                         is_active=True, min_pwm_percent=0, max_pwm_percent=100,
+                         temp_sensor_id="hwmon:x"))
+        db.commit()
+    return service, backend
+
+
+def _freigeben(session_factory, zustand):
+    with session_factory() as db:
+        publish_released_fans(db, {
+            FAN: {"state": zustand,
+                  "reason": ReleaseReason.NOT_CONTROLLABLE.value},
+        })
+
+
+@pytest.mark.parametrize("zustand", [FanOwnership.RELEASED.value,
+                                     FanOwnership.ABANDONED.value])
+@pytest.mark.asyncio
+async def test_ein_pwm_aufruf_holt_den_kanal_zurueck(session_factory, zustand):
+    """Beide Zustaende, aus demselben Grund.
+
+    `released` heisst "die Board-Automatik regelt", `abandoned` heisst "es
+    regelt niemand". Fuer die Invariante ist der Unterschied gleichgueltig:
+    in beiden Faellen fuehrt die Zeile den Kanal als nicht von BaluHost
+    besessen, und in beiden Faellen schreibt der Aufruf gleich darauf.
+    """
+    service, backend = _service(session_factory)
+    _freigeben(session_factory, zustand)
+
+    erfolg, _ = await service.set_fan_pwm(FAN, 50)
+
+    assert erfolg is True
+    backend.set_pwm.assert_awaited_once_with(FAN, 50, force=True)
+    with session_factory() as db:
+        assert read_released_fans(db) == {}
+
+
+@pytest.mark.asyncio
+async def test_ohne_veroeffentlichte_ruecknahme_wird_nicht_geschrieben(
+    session_factory, monkeypatch
+):
+    """Scheitert die Ruecknahme, darf der Write nicht stattfinden.
+
+    Sonst entstuende genau der Zustand, den dieser Fix beseitigt -- nur
+    diesmal sehenden Auges: BaluHost schriebe einen Kanal, den die
+    veroeffentlichte Zeile weiter dem Board zuschreibt. Lieber ein
+    fehlgeschlagener Klick mit Fehlermeldung als ein stiller Widerspruch.
+    """
+    service, backend = _service(session_factory)
+    _freigeben(session_factory, FanOwnership.RELEASED.value)
+    monkeypatch.setattr(fan_control_module, "publish_released_fans",
+                        lambda db, released: False)
+
+    erfolg, rpm = await service.set_fan_pwm(FAN, 50)
+
+    assert erfolg is False
+    assert rpm is None
+    backend.set_pwm.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ein_besessener_kanal_laeuft_unveraendert(session_factory):
+    """Regressionswache fuer den Normalfall: sie ist auch ohne den Fix gruen.
+
+    Ihr Wert liegt in der Gegenrichtung -- eine Ruecknahme, die den
+    haeufigsten Weg mitnimmt, wuerde hier auffallen: ein Schreibversuch auf
+    die Singleton-Zeile bei jedem PWM-Klick, obwohl nie etwas freigegeben
+    war.
+    """
+    service, backend = _service(session_factory)
+
+    erfolg, _ = await service.set_fan_pwm(FAN, 50)
+
+    assert erfolg is True
+    backend.set_pwm.assert_awaited_once_with(FAN, 50, force=True)
+    with session_factory() as db:
+        assert read_released_fans(db) == {}


### PR DESCRIPTION
Schliesst **#583**. Umgesetzt ist **Variante 2** aus dem Issue: nicht ablehnen, sondern zurückholen.

## Das Problem

Ein an die Board-Automatik zurückgegebener Lüfter (#534) war nur in der Oberfläche gesperrt. `POST /api/fans/pwm` schrieb weiter — mit `force=True` aus #533 sogar am Backoff vorbei —, während `fan_runtime_state.released_fans` den Kanal unverändert dem Board zuschrieb.

Der Zustand danach war von nichts erklärt: die Karte zeigte „Board regelt", obwohl BaluHost gerade geschrieben hatte, und der nächste Regelzyklus übersprang den Kanal wieder. Der geschriebene Wert blieb als Fremdkörper stehen — weder von der Anzeige noch von der Regelung gedeckt.

## Warum Zurückholen und nicht 400

Ein 400 wäre konsequent, kostet aber einen zweiten Klick für etwas, das der Nutzer eindeutig will: wer den Regler bedient, will den Kanal steuern. Die Invariante, die hier zählt, ist **„wer schreibt, besitzt auch"** — nicht „die Freigabe ist unumkehrbar".

Benutzt wird dafür die vorhandene Mechanik statt einer zweiten: `reacquire_fan()` plus der Abgleich im Regelkreis. Das ist auch die Antwort auf die Vorsicht, die das Issue von #580 erbt — das Zurückholen gehört dem Primary, der PWM-Aufruf landet auf einem beliebigen der vier Worker. Genau diese Trennung hält `reacquire_fan()` bereits ein: es räumt nur die veröffentlichte Zeile, den erzwungenen Write und das Zurücksetzen des Fehlerzählers übernimmt der Primary im nächsten Zyklus.

## Zwei Entscheidungen im Detail

**Scheitert die Veröffentlichung der Rücknahme, unterbleibt der Write.** `publish_released_fans()` meldet einen Datenbankfehler mit `False`; trotzdem zu schreiben erzeugte denselben Widerspruch, den dieser PR beseitigt, nur sehenden Auges. Ein fehlgeschlagener Klick mit Fehlermeldung ist das ehrlichere Ergebnis.

**Gelesen wird `released_fans` in der Sitzung, die ohnehin die Konfiguration holt.** Der häufige Weg — nichts ist freigegeben — kostet damit keine zweite Verbindung; die zweite Sitzung entsteht nur auf dem seltenen Pfad, den `reacquire_fan()` selbst öffnet.

Beide Zustände sind erfasst: `released` (die Board-Automatik regelt) und `abandoned` (es regelt niemand). Für die Invariante ist der Unterschied gleichgültig — in beiden Fällen führt die Zeile den Kanal als nicht von BaluHost besessen, und in beiden Fällen schreibt der Aufruf gleich darauf.

## Prüfung

- Neue Datei `backend/tests/test_fan_pwm_release_enforcement.py`, vier Fälle. Gemessen wird die **Wirkung auf die veröffentlichte Zeile**, nicht der Aufruf einer Hilfsmethode — eine Zusicherung auf `reacquire_fan` wäre grün, auch wenn die Rücknahme nie in der Zeile landet.
- **Gegenproben, beide ausgeführt:** ohne den Fix fallen drei der vier Tests (`released_fans` führt den Kanal weiter, und der Write findet trotz gescheiterter Rücknahme statt). Die vierte bewacht den Normalfall und ist auch ohne den Fix grün — ihr Wert liegt in der Gegenrichtung, und die wurde gemessen: mit unbedingter Rücknahme (`freigegeben and` entfernt) fällt sie.
- `pytest -k "fan or power"` → 875 bestanden, 2 übersprungen. `ruff` über beide Dateien sauber.

Die volle Backend-Suite gehört der CI; sie hängt unter Windows.

## Bekannte Reste, bewusst so

- **Die 400-Meldung des neuen Fehlerpfads ist unspezifisch.** Scheitert die Rücknahme, antwortet die Route mit dem vorhandenen „Failed to set PWM (fan not in manual mode or not found)" — beide genannten Ursachen treffen dann nicht zu. Der Pfad setzt einen Datenbankfehler voraus, in dessen Gegenwart ohnehin wenig funktioniert; eine eigene Meldung bräuchte einen Grund im Rückgabewert von `set_fan_pwm()` und damit eine Signaturänderung. Im Log steht die Ursache als eigene WARNING-Zeile.
- **Ein weiterhin defekter Kanal bleibt rund 21 Minuten „übernommen", bevor er erneut freigegeben wird.** Das ist keine Folge dieses PRs, sondern die dokumentierte Zusage von `reacquire_fan()`: der Fehlerzähler startet bei null, und das wachsende Backoff-Fenster streckt die acht nötigen Fehlschläge. Der Preis gegen ein Pendeln zwischen zwei Reglern.
- **`POST /api/fans/mode` bleibt unberührt.** Ein Moduswechsel schreibt keine Hardware, und der Regelkreis überspringt einen freigegebenen Kanal ohnehin — es entsteht also kein Widerspruch, den man auflösen müsste. Das Issue nennt ausdrücklich nur den PWM-Aufruf.

## Feldbefund

Auf BaluNode ist `released_fans` leer und `denied_fan_ids` ist `[]` — seit dem Deploy von #579/#580 hat dort kein Kanal einen der Auslöser erreicht. Die Lücke ist damit real, aber heute nicht auslösbar; dieser PR schliesst sie, bevor der erste Auslöser eintritt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5Bov4YyuW8HEScgv9kBzU
