### PR TITLE
fix(fans): sync-Kurve kennzeichnet Quellen, die BaluHost nicht regelt (#582)

### DIFF
--- a/client/src/__tests__/components/fan-control/CurveEditorSync.test.tsx
+++ b/client/src/__tests__/components/fan-control/CurveEditorSync.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CurveEditorSync from '../../../components/fan-control/CurveEditorSync';
+import type { FanInfo } from '../../../api/fan-control';
+
+// `t` gibt den Schluessel zurueck -- dieselbe Bauform wie in den uebrigen
+// fan-control-Tests, damit keine echten Locale-Dateien geladen werden.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+function fan(over: Partial<FanInfo> & { fan_id: string }): FanInfo {
+  return {
+    name: over.fan_id,
+    rpm: 800,
+    pwm_percent: 40,
+    temperature_celsius: 45,
+    mode: 'auto',
+    min_pwm_percent: 0,
+    max_pwm_percent: 100,
+    emergency_temp_celsius: 85,
+    temp_sensor_id: 'hwmon:x',
+    curve_points: [],
+    is_active: true,
+    ownership: 'owned',
+    ...over,
+  } as FanInfo;
+}
+
+function renderMit(fans: FanInfo[]) {
+  return render(
+    <CurveEditorSync
+      allFans={fans}
+      currentFanId="self"
+      syncFanId={null}
+      onChange={() => {}}
+    />,
+  );
+}
+
+const SELBST = fan({ fan_id: 'self' });
+
+describe('CurveEditorSync: Quellen, die BaluHost nicht regelt', () => {
+  it('behaelt einen an das Board zurueckgegebenen Luefter, kennzeichnet ihn aber', () => {
+    // Ausblenden waere die einfachere Loesung und die schlechtere: eine
+    // BESTEHENDE Sync-Kurve, deren Quelle gerade freigegeben wurde,
+    // verschwaende dann aus der Liste, und das Feld zeigte einen leeren Wert
+    // bei intakter Konfiguration (#582).
+    renderMit([SELBST, fan({ fan_id: 'nct6798:pwm2', ownership: 'released' })]);
+
+    const option = screen.getByRole('option', { name: /nct6798:pwm2/ });
+    expect(option).toHaveValue('nct6798:pwm2');
+    expect(option.textContent).toContain(
+      'system:fanControl.curveTypes.sourceReleased',
+    );
+  });
+
+  it('kennzeichnet einen aufgegebenen Luefter anders als einen freigegebenen', () => {
+    // Der Unterschied ist keine Wortklauberei: bei `released` gibt die
+    // Board-Automatik einen echten, lebenden Wert vor. Bei `abandoned`
+    // regelt niemand -- der Wert steht seit der Freigabe still, und eine
+    // Sync-Kurve darauf friert mit ein.
+    renderMit([SELBST, fan({ fan_id: 'nct6798:pwm3', ownership: 'abandoned' })]);
+
+    const option = screen.getByRole('option', { name: /nct6798:pwm3/ });
+    expect(option.textContent).toContain(
+      'system:fanControl.curveTypes.sourceAbandoned',
+    );
+  });
+
+  it('laesst einen firmware-verwalteten Luefter weiterhin verschwinden', () => {
+    // Regressionswache fuer #480: dort ist die Karte dauerhaft nicht von
+    // BaluHost regelbar, und die Option zu zeigen hiesse, eine Quelle
+    // anzubieten, die es nie geben wird. Nicht dasselbe wie eine Freigabe,
+    // die auf Knopfdruck zurueckgeht.
+    renderMit([
+      SELBST,
+      fan({ fan_id: 'amdgpu:pwm1', pwm_control: 'firmware_managed' }),
+    ]);
+
+    expect(screen.queryByRole('option', { name: /amdgpu:pwm1/ })).toBeNull();
+  });
+
+  it('laesst einen selbst geregelten Luefter unbeschriftet', () => {
+    renderMit([SELBST, fan({ fan_id: 'nct6798:pwm7' })]);
+
+    const option = screen.getByRole('option', { name: /nct6798:pwm7/ });
+    expect(option.textContent).toBe('nct6798:pwm7');
+  });
+});

--- a/client/src/components/fan-control/CurveEditorSync.tsx
+++ b/client/src/components/fan-control/CurveEditorSync.tsx
@@ -9,6 +9,25 @@ interface Props {
   disabled?: boolean;
 }
 
+/**
+ * Wer den Kanal gerade vorgibt, sofern es nicht BaluHost ist (#582).
+ *
+ * Ausgeblendet werden diese Luefter bewusst NICHT: eine bestehende
+ * Sync-Kurve, deren Quelle gerade freigegeben wurde, verschwaende dann aus
+ * der Liste, und das Feld zeigte einen leeren Wert bei intakter
+ * Konfiguration. Sichtbar und beschriftet ist ehrlicher als weg.
+ *
+ * Die beiden Zustaende sind auseinandergehalten, weil sie verschiedene Dinge
+ * bedeuten: bei `released` gibt die Board-Automatik einen lebenden Wert vor,
+ * bei `abandoned` regelt niemand -- der Wert steht seit der Freigabe still,
+ * und eine Sync-Kurve darauf friert mit ein.
+ */
+function quellHinweis(fan: FanInfo, t: (k: string) => string): string | null {
+  if (fan.ownership === 'released') return t('system:fanControl.curveTypes.sourceReleased');
+  if (fan.ownership === 'abandoned') return t('system:fanControl.curveTypes.sourceAbandoned');
+  return null;
+}
+
 export default function CurveEditorSync({ allFans, currentFanId, syncFanId, onChange, disabled }: Props) {
   const { t } = useTranslation(['system']);
   return (
@@ -23,10 +42,18 @@ export default function CurveEditorSync({ allFans, currentFanId, syncFanId, onCh
         <option value="">{t('system:fanControl.curveTypes.selectFan')}</option>
         {allFans
           .filter((f) => f.fan_id !== currentFanId)
+          // Bleibt eine Ausblendung, anders als die Freigabe darunter: eine
+          // firmware-verwaltete Karte regelt BaluHost dauerhaft nicht (#480),
+          // die Option waere eine Quelle, die es nie geben wird.
           .filter((f) => f.pwm_control !== 'firmware_managed')
-          .map((f) => (
-            <option key={f.fan_id} value={f.fan_id}>{f.name}</option>
-          ))}
+          .map((f) => {
+            const hinweis = quellHinweis(f, t);
+            return (
+              <option key={f.fan_id} value={f.fan_id}>
+                {hinweis ? `${f.name} — ${hinweis}` : f.name}
+              </option>
+            );
+          })}
       </select>
     </div>
   );

--- a/client/src/i18n/locales/de/system.json
+++ b/client/src/i18n/locales/de/system.json
@@ -1013,7 +1013,9 @@
       "selectCurve": "Profil wählen…",
       "sync": "Sync",
       "syncDescription": "Übernimm PWM von einem anderen Lüfter.",
-      "selectFan": "Lüfter wählen…"
+      "selectFan": "Lüfter wählen…",
+      "sourceReleased": "gibt gerade das Board vor",
+      "sourceAbandoned": "steht still, niemand regelt"
     },
     "advanced": {
       "title": "Erweiterte Einstellungen",

--- a/client/src/i18n/locales/en/system.json
+++ b/client/src/i18n/locales/en/system.json
@@ -1018,7 +1018,9 @@
       "selectCurve": "Select profile…",
       "sync": "Sync",
       "syncDescription": "Copy PWM from another fan.",
-      "selectFan": "Select fan…"
+      "selectFan": "Select fan…",
+      "sourceReleased": "currently set by the board",
+      "sourceAbandoned": "frozen, nobody is controlling it"
     },
     "advanced": {
       "title": "Advanced settings",


### PR DESCRIPTION
Schliesst **#582**. Reines Frontend plus zwei i18n-Schlüssel je Sprache.

## Das Problem

Der zweite Filter in `CurveEditorSync.tsx` stammt aus #480 und meinte damals die einzige Kategorie von Lüftern, die BaluHost nicht regelt. Seit #579/#580 gibt es zwei weitere — `ownership === 'released'` (die Board-Automatik regelt) und `'abandoned'` (es regelt niemand). Beide Felder liegen auf demselben `FanInfo` bereits vor; die Lüfterkarte wertet sie aus, die Auswahlliste nicht.

Eine `sync`-Kurve kopiert den PWM-Wert ihrer Quelle. Zeigt sie auf einen zurückgegebenen Kanal, kopiert der Nutzer damit die **Board-Kurve** auf einen von BaluHost geregelten Lüfter. Das ist nicht falsch — der Wert ist real und wird gelesen —, aber es ist nirgends erkennbar. Bei `abandoned` wird es fragwürdig: dort regelt niemand, der Wert steht seit der Freigabe still, und die Sync-Kurve friert mit ein.

## Kennzeichnen statt ausblenden

Ausblenden wäre die kleinere Änderung und die schlechtere. Der Haken steht im Issue: eine **bestehende** Sync-Kurve, deren Quelle gerade freigegeben wurde, verschwände dann aus der Liste, und das Feld zeigte einen leeren Wert bei intakter Konfiguration. Sichtbar und beschriftet ist ehrlicher als weg — und es ist dieselbe Unterscheidung, die die Lüfterkarte bereits anzeigt.

Die beiden Zustände tragen **getrennte** Beschriftungen, weil sie verschiedene Dinge bedeuten: bei `released` gibt die Board-Automatik einen lebenden Wert vor, bei `abandoned` steht der Wert still. Eine gemeinsame Formulierung („wird nicht von BaluHost geregelt") wäre für den zweiten Fall zu freundlich.

**Der Filter aus #480 bleibt ein Filter.** Eine firmware-verwaltete Karte regelt BaluHost dauerhaft nicht — die Option wäre eine Quelle, die es nie geben wird. Das ist kategorial etwas anderes als eine Freigabe, die auf Knopfdruck zurückgeht, und der Unterschied steht jetzt als Kommentar an der Stelle, an der beide Fälle nebeneinander stehen.

## Prüfung

- Neue Datei `client/src/__tests__/components/fan-control/CurveEditorSync.test.tsx`, vier Fälle: die beiden neuen Kennzeichnungen, plus zwei Wachen (firmware-verwaltet bleibt ausgeblendet, ein selbst geregelter Lüfter bleibt unbeschriftet).
- **Gegenproben, beide ausgeführt:** ohne die Änderung fallen die zwei Kennzeichnungs-Tests. Die beiden Wachen waren von Anfang an grün — deshalb wurde der Produktivcode mutiert (Firmware-Filter entfernt, Hinweis auch für `owned`), und beide fallen dann. Danach zurückgenommen, wieder 4/4 grün.
- `vitest` über `components/fan-control/` → 83 bestanden (13 Dateien). `eslint .` → 0 Fehler. `npm run build` erfolgreich.

## Anmerkung zu den Locale-Dateien

Die zwei Schlüssel sind über einen Parser eingesetzt und nicht von Hand — der Diff bleibt dadurch bei vier Zeilen je Datei statt einer Neuformatierung. Deutsch: „gibt gerade das Board vor" / „steht still, niemand regelt". Englisch: „currently set by the board" / „frozen, nobody is controlling it".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5Bov4YyuW8HEScgv9kBzU
