### PR TITLE
feat(displays): Display-Outputs erkennen und umschalten als bundled Plugin (#590)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -103,6 +103,7 @@ All API routes are prefixed with `/api`:
 - `/api/notifications/*` - Firebase push notifications
 - `/api/plugins/*` - Plugin system
 - `/api/plugins/audio_control/*` - Audiosteuerung (Pegel, Ausgabegerät, Per-App-Mixer)
+- `/api/plugins/display_output/*` - Displaysteuerung (Ausgangswahl, Video-Modus)
 - `/api/pihole/*` - Pi-hole DNS management
 - `/api/updates/*` - Self-hosted update mechanism
 - `/api/sleep/*` - Sleep mode management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ client/
 **Tests**: `backend/tests/`
 **Fan control**: `backend/app/services/power/fan_control.py`
 **Audio control**: `backend/app/plugins/installed/audio_control/` (bundled Plugin; `pactl.py` kapselt den gesamten pactl-Kontakt)
+**Display outputs**: `backend/app/plugins/installed/display_output/` (bundled Plugin; `kscreen.py` kapselt den gesamten kscreen-doctor-Kontakt)
 **Power management**: `backend/app/services/power/manager.py`
 **Monitoring orchestrator**: `backend/app/services/monitoring/orchestrator.py`
 **Service status**: `backend/app/services/service_status.py`

--- a/backend/alembic/versions/b8c41d92e7f5_add_can_manage_displays_permission.py
+++ b/backend/alembic/versions/b8c41d92e7f5_add_can_manage_displays_permission.py
@@ -1,0 +1,31 @@
+"""add can_manage_displays permission
+
+Revision ID: b8c41d92e7f5
+Revises: e2f81c4a7b93
+Create Date: 2026-09-08 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b8c41d92e7f5'
+down_revision: Union[str, Sequence[str], None] = 'e2f81c4a7b93'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Fuegt can_manage_displays zu user_power_permissions hinzu (standardmaessig aus)."""
+    op.add_column(
+        'user_power_permissions',
+        sa.Column('can_manage_displays', sa.Boolean(), nullable=False, server_default='0'),
+    )
+
+
+def downgrade() -> None:
+    """Entfernt can_manage_displays."""
+    op.drop_column('user_power_permissions', 'can_manage_displays')

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -402,6 +402,7 @@ require_power_suspend = _make_power_dependency("suspend")
 require_power_wol = _make_power_dependency("wol")
 require_power_toggle_desktop = _make_power_dependency("toggle_desktop")
 require_power_control_audio = _make_power_dependency("control_audio")
+require_power_manage_displays = _make_power_dependency("manage_displays")
 
 
 async def require_local_or_setup_secret(

--- a/backend/app/api/routes/sleep.py
+++ b/backend/app/api/routes/sleep.py
@@ -362,6 +362,7 @@ async def get_my_power_permissions(
             can_soft_sleep=True, can_wake=True, can_suspend=True, can_wol=True,
             can_toggle_desktop=True, can_unlock_session=True,
             can_control_audio=True,
+            can_manage_displays=True,
         )
     from app.services.power_permissions import get_permissions
     perms = get_permissions(db, current_user.id)
@@ -373,6 +374,7 @@ async def get_my_power_permissions(
         can_toggle_desktop=perms.can_toggle_desktop,
         can_unlock_session=perms.can_unlock_session,
         can_control_audio=perms.can_control_audio,
+        can_manage_displays=perms.can_manage_displays,
     )
 
 

--- a/backend/app/core/rate_limiter.py
+++ b/backend/app/core/rate_limiter.py
@@ -186,6 +186,11 @@ RATE_LIMITS = {
     # admin_operations (30/Minute) waere hier falsch: die Abfrage allein
     # verbraucht schon 30 Anfragen pro Minute.
     "audio_control": "240/minute",
+
+    # Displaysteuerung — das Popover fragt nur im geoeffneten Zustand alle 5 s
+    # ab (~12/Minute). admin_operations (30/Minute) waere bei zwei offenen
+    # Tabs bereits knapp.
+    "display_output": "60/minute",
 }
 
 

--- a/backend/app/models/power_permissions.py
+++ b/backend/app/models/power_permissions.py
@@ -27,6 +27,7 @@ class UserPowerPermission(Base):
     can_toggle_desktop: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
     can_unlock_session: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
     can_control_audio: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+    can_manage_displays: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
 
     granted_by: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True

--- a/backend/app/plugins/CLAUDE.md
+++ b/backend/app/plugins/CLAUDE.md
@@ -27,7 +27,7 @@ plugins/
 ├── smart_device/        # SmartDevice plugin framework (base class, manager, poller, capabilities)
 └── installed/           # Bundled plugin implementations (one CLAUDE.md each)
     ├── audio_control/      # Volume, output device and per-app mixer of the desktop session (pactl)
-    ├── display_output/      # KWin-Ausgangswahl und Video-Modus (kscreen-doctor)
+    ├── display_output/     # KWin output selection and video mode (kscreen-doctor)
     ├── optical_drive/      # CD/DVD burning, reading, ISO browsing (own router)
     ├── steam_gaming/       # Status pill, session ledger, Gaming-Mode menu action
     ├── storage_analytics/  # DEMO ONLY — every number is hard-coded, see its CLAUDE.md

--- a/backend/app/plugins/CLAUDE.md
+++ b/backend/app/plugins/CLAUDE.md
@@ -27,6 +27,7 @@ plugins/
 ├── smart_device/        # SmartDevice plugin framework (base class, manager, poller, capabilities)
 └── installed/           # Bundled plugin implementations (one CLAUDE.md each)
     ├── audio_control/      # Volume, output device and per-app mixer of the desktop session (pactl)
+    ├── display_output/      # KWin-Ausgangswahl und Video-Modus (kscreen-doctor)
     ├── optical_drive/      # CD/DVD burning, reading, ISO browsing (own router)
     ├── steam_gaming/       # Status pill, session ledger, Gaming-Mode menu action
     ├── storage_analytics/  # DEMO ONLY — every number is hard-coded, see its CLAUDE.md

--- a/backend/app/plugins/installed/display_output/CLAUDE.md
+++ b/backend/app/plugins/installed/display_output/CLAUDE.md
@@ -1,0 +1,150 @@
+# Display Output Plugin
+
+Bundled (in-process, fully trusted) plugin: enumerates the KWin outputs, picks
+which one is active and sets its video mode, driven from a popover in the topbar.
+Ships its own FastAPI router; the UI is a **core** component, not a sandbox bundle.
+
+Trust tier, lifecycle and the `PluginBase` contract are in `../../CLAUDE.md` —
+this file only covers what is specific to this plugin.
+
+## Layout
+
+| File | Contents |
+|---|---|
+| `__init__.py` | `DisplayOutputPlugin`, the router, the audit helper, the error mapping |
+| `kscreen.py` | The **only** module that knows `kscreen-doctor` exists: parser, runner, argv builder |
+| `backend.py` | `DisplayBackend` protocol, `DevDisplayBackend`, `KWinDisplayBackend` |
+| `service.py` | `DisplayService` — backend choice, the whole validation, module singleton |
+| `models.py` | Pydantic models; the field names are the API contract to the frontend |
+
+Frontend counterparts: `client/src/components/topbar/DisplayMenu.tsx`,
+`client/src/api/displayOutput.ts`, `client/src/i18n/locales/{de,en}/display.json`.
+
+## Why it must be a bundled plugin
+
+Same reason as `audio_control`: the plugin runs in the host process and therefore
+under the same UID as the desktop session, which is what gets it to the KWin
+socket through `wayland_session_env()` alone — no sudo, no wrapper. A **sandbox
+plugin would not reach the socket at all**: it runs as `baluhost-plugin` in its
+own network namespace.
+
+Measured proof of the env's necessity: `kscreen-doctor -j` from an SSH session
+without `XDG_RUNTIME_DIR`/`WAYLAND_DISPLAY` aborts — Qt falls back to the `xcb`
+platform plugin and finds no display.
+
+## Mode names are ambiguous — address modes by ID
+
+`libkscreen`'s `findMode()` builds a mode's name with `qRound(refreshRate)`:
+
+    "%1x%2@%3".arg(width, height, qRound(mode->refreshRate()))
+    if (mode->id() == query || name == query) return mode;
+
+So 119.88 and 120.000 are **both** called `3840x2160@120`, and the function
+returns the first match and stops. Measured on BaluNode: HDMI-A-1 has 55 modes
+but only 45 distinct names; DP-3's ids 57 and 58 are exactly that pair.
+
+Addressing by name would therefore set an arbitrary member of the group, with no
+error. The same code line proves the ID **is** a valid argument, so that is what
+is used.
+
+**But never a stored ID.** That is the defect in #589, where a hard-coded id in
+`deploy/scripts/display-switch` outlives the reboot that renumbered it. Here the
+id comes from the enumeration of the same request cycle and `apply` re-reads and
+cross-checks it against the client-supplied `mode_name` — a mismatch is a 409,
+not a silently wrong mode. `mode_id` and `mode_name` are all-or-nothing on the
+wire; accepting one without the other would make the cross-check optional.
+
+## Two levels of "on"
+
+| Level | Source | Field |
+|---|---|---|
+| KWin | `kscreen-doctor -j`, `enabled` | `selected` |
+| DRM | sysfs `enabled` per connector | `lit` |
+
+With DPMS off **every** DRM connector is `disabled` while KWin keeps its choice —
+that is why `DesktopTogglePanel` can say "stopped" while KWin holds DP-3 active.
+Not a bug, two truths about different things. They are never folded into one
+field, and a name that maps to no connector yields `lit=None`, not `False`:
+reporting an unknown answer as "off" would be a false statement.
+
+`get_connector_states()` lives in `services/power/gpu/display_detector.py`, not
+here — `desktop_backend` and `steam_gaming` already read that sysfs tree.
+
+## `kscreen-doctor` lists only connected outputs
+
+`/sys/class/drm/` shows `card0-DP-1` and `card0-DP-2` on BaluNode; the JSON does
+not mention them. `connected` stays in the schema but is true in practice, and
+`DevDisplayBackend` deliberately serves **no** disconnected output — it would be
+a state the real backend never produces.
+
+Field presence also varies between outputs: HDMI-A-1 carries `vrrPolicy`, DP-3
+does not. Every field access goes through `.get()`.
+
+## Security invariants
+
+- **Every route** carries `require_power_manage_displays` — the reading one
+  included. The output list reveals the attached hardware, EDID sizes included.
+- **Every route** carries `@user_limiter.limit(get_limit("display_output"))`,
+  its own category at `60/minute`: the popover polls only while open, every 5 s.
+- **Nothing from the request becomes an argv element without having appeared in
+  the live enumeration first.** Names and mode ids are matched against measured
+  values, not escaped or filtered. List-args already rule out shell injection —
+  this is the belt to that suspender.
+- **`kscreen-doctor` output never reaches a client.** stdout/stderr carry EDID
+  names and paths; they are logged, and a success answers `{"success": true}`.
+- **An `apply` after which no connected output would be selected is rejected.**
+  "Nothing should be lit" belongs on the DPMS switch in `PowerMenu` — reversible,
+  and it does not throw the KWin configuration away.
+- One `apply` is exactly **one** `kscreen-doctor` invocation; the tool applies
+  all arguments together, so there is no partial state on failure. The argument
+  order follows the enumeration, not the request — deterministic and beyond
+  client influence.
+- A 502 is always raised as `BadGatewayError`, never `HTTPException(502)` — the
+  global 5xx handler in `core/exception_handlers.py` rewrites a plain
+  `HTTPException`'s detail to "Internal server error" from 500 up; only a
+  `ServiceError` subclass survives that scrubber with its curated message.
+
+## The two traps inherited from `audio_control`
+
+**No `from __future__ import annotations` in `__init__.py`.** With Pydantic v2
+and FastAPI's body detection through slowapi's `@user_limiter.limit` wrapper,
+deferred annotations become ForwardRefs FastAPI no longer resolves — the request
+body is mistaken for query parameters and every `POST` answers 422.
+
+**`get_ui_manifest()` must be overridden.** `PluginBase` returns `None`, and only
+plugins with a truthy manifest appear in `GET /api/plugins/ui/manifest` — exactly
+the list `usePluginEnabled('display_output')` reads. Without it the plugin counts
+as disabled forever and the topbar stays empty, with no error and no log line.
+
+## Routes
+
+| Method | Path | Body |
+|---|---|---|
+| GET | `/state` | — (returns outputs, `displays_powered`, `available`, `detail`) |
+| POST | `/apply` | `{"outputs": [{"name", "selected", "mode_id"?, "mode_name"?}]}` |
+
+Failure mapping: validation → 400, stale `mode_name` for a live `mode_id` → 409,
+KWin unreachable on a write → 502. A **read** with an unreachable session is not
+an error — it answers 200 with `available: false` so the UI can show that state.
+
+Because the plugin contributes a router, it is mounted **once at startup**
+(`core/lifespan.py`). Enabling it at runtime leaves these paths at 404 until
+`baluhost-backend` restarts.
+
+## Permission
+
+`can_manage_displays` (table `user_power_permissions`, migration `b8c41d92e7f5`,
+`server_default="0"` — denied by default). It stands **beside** the sleep/suspend
+chains and is deliberately absent from `_apply_implications`; admins get it
+implicitly.
+
+## Tests
+
+`backend/tests/plugins/test_display_output_{parser,kscreen,backend,service,routes,ui_manifest}.py`
+plus `backend/tests/test_display_detector_connector_states.py`.
+
+The fixture `backend/tests/plugins/fixtures/kscreen_balunode.json` is a
+**measured** `kscreen-doctor -j` recording from BaluNode (2026-09-08), not an
+invented payload. The duplicate and ambiguous modes in it are the test subject —
+re-measure rather than hand-edit. No test invokes real `kscreen-doctor`; the CI
+runner has no Wayland session.

--- a/backend/app/plugins/installed/display_output/__init__.py
+++ b/backend/app/plugins/installed/display_output/__init__.py
@@ -16,6 +16,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
 from app.api.deps import require_power_manage_displays
+from app.core.exceptions import BadGatewayError
 from app.core.rate_limiter import get_limit, user_limiter
 from app.plugins.base import PluginBase, PluginMetadata, PluginUIManifest
 from app.plugins.installed.display_output import service as service_module
@@ -101,10 +102,12 @@ async def apply_display_layout(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     except ModeMismatch as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
-    except DisplayUnavailable:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY, detail="Displays nicht erreichbar"
-        )
+    except DisplayUnavailable as exc:
+        # BadGatewayError statt HTTPException(502): der globale 5xx-Scrubber in
+        # ``core/exception_handlers.py`` ersetzt jedes HTTPException-detail ab
+        # Status 500 durch "Internal server error". Nur ein ServiceError
+        # transportiert eine kuratierte Meldung durch diesen Filter.
+        raise BadGatewayError("Displays nicht erreichbar") from exc
 
     _audit(current_user, ok, wanted)
 
@@ -112,11 +115,10 @@ async def apply_display_layout(
         return {"success": True}
 
     # `message` stammt roh aus kscreen-doctor und kann EDID-Namen und Pfade
-    # enthalten. Es wird geloggt, aber nie ausgeliefert.
+    # enthalten. Es wird geloggt, aber nie ausgeliefert. BadGatewayError statt
+    # HTTPException(502): siehe Kommentar oben beim DisplayUnavailable-Zweig.
     logger.warning("Display-Anwendung fehlgeschlagen: %s", message)
-    raise HTTPException(
-        status_code=status.HTTP_502_BAD_GATEWAY, detail="Aktion fehlgeschlagen"
-    )
+    raise BadGatewayError("Aktion fehlgeschlagen")
 
 
 class DisplayOutputPlugin(PluginBase):

--- a/backend/app/plugins/installed/display_output/__init__.py
+++ b/backend/app/plugins/installed/display_output/__init__.py
@@ -36,11 +36,35 @@ router = APIRouter()
 _LIMIT = get_limit("display_output")
 
 
-def _audit(user: UserPublic, success: bool, wanted: dict) -> None:
-    """Schreibt einen Audit-Eintrag fuer jede Aenderung der Ausgangswahl.
+def _audit(
+    user: UserPublic,
+    success: bool,
+    *,
+    status_code: int,
+    argv=None,
+    detail: str = "",
+) -> None:
+    """Schreibt einen Audit-Eintrag fuer JEDEN apply-Versuch — Erfolg wie Ablehnung.
 
-    Anders als bei den Pegeln der Audiosteuerung ist hier jeder Vorgang
-    interessant: ein apply schaltet Bildschirme.
+    Fruher wurde nur der rohe, ungeprueften Request-Wunsch protokolliert
+    (``{name: (selected, mode_id)}``); das verzeichnete auch eine mode_id auf
+    einem ``selected: false``-Ausgang, obwohl der Service diese Kombination
+    verwirft — der Eintrag behauptete damit einen Modus-Wechsel, der nie
+    stattfand. Und eine Ablehnung (400/409/502) schrieb ueberhaupt keinen
+    Eintrag, weil alle drei Ausnahmen vor dieser Funktion auslösten — dabei
+    schaltet diese Route physische Bildschirme, ein abgelehnter Versuch
+    gehoert in die Spur.
+
+    ``argv`` ist — bei Erfolg oder einem Fehlschlag NACH der Validierung —
+    genau der Vektor, den der Service tatsaechlich geprueft (und bei
+    ``KWinDisplayBackend`` an kscreen-doctor geschickt) hat. Bei einer
+    Ablehnung VOR dem Bau des Vektors (400/409/502 aus der Validierung) bleibt
+    ``argv`` ``None`` — es gibt keinen geprueften Vektor, ueber den sich etwas
+    Wahres aussagen liesse.
+
+    ``detail`` darf hier mehr tragen als die Client-Antwort: der Audit-Trail
+    ist serverseitig, die Regel "kein rohes kscreen-doctor-stdout/stderr zum
+    Client" gilt fuer die HTTP-Antwort, nicht fuer das Log.
     """
     audit_logger = get_audit_logger_db()
     audit_logger.log_event(
@@ -49,7 +73,7 @@ def _audit(user: UserPublic, success: bool, wanted: dict) -> None:
         user=user.username,
         resource="displays",
         success=success,
-        details={"wanted": {k: list(v) for k, v in wanted.items()}},
+        details={"status_code": status_code, "argv": argv, "detail": detail},
     )
     if getattr(user, "role", None) != "admin":
         audit_logger.log_security_event(
@@ -93,31 +117,48 @@ async def apply_display_layout(
     Jeder Name und jede Mode-ID aus dem Rumpf wird zuvor gegen die live
     enumerierten Werte **dieses** Ausgangs geprueft (im Service). Was dort
     nicht steht, wird nie zu einem argv-Element.
+
+    Jeder Ausgang dieser Funktion schreibt einen Audit-Eintrag — Erfolg UND
+    Ablehnung. ``details.argv`` traegt den vom Service tatsaechlich
+    geprueften Vektor (siehe ``ApplyResult``), nicht den rohen Request.
     """
     service = service_module.get_display_service()
-    wanted = {o.name: (o.selected, o.mode_id) for o in body.outputs}
     try:
-        ok, message = await service.apply(body)
+        result = await service.apply(body)
     except InvalidRequest as exc:
+        _audit(current_user, False, status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     except ModeMismatch as exc:
+        _audit(current_user, False, status_code=status.HTTP_409_CONFLICT, detail=str(exc))
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
     except DisplayUnavailable as exc:
         # BadGatewayError statt HTTPException(502): der globale 5xx-Scrubber in
         # ``core/exception_handlers.py`` ersetzt jedes HTTPException-detail ab
         # Status 500 durch "Internal server error". Nur ein ServiceError
         # transportiert eine kuratierte Meldung durch diesen Filter.
+        _audit(
+            current_user, False,
+            status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc),
+        )
         raise BadGatewayError("Displays nicht erreichbar") from exc
 
-    _audit(current_user, ok, wanted)
-
-    if ok:
+    if result.success:
+        _audit(
+            current_user, True,
+            status_code=status.HTTP_200_OK, argv=result.argv, detail=result.message,
+        )
         return {"success": True}
 
-    # `message` stammt roh aus kscreen-doctor und kann EDID-Namen und Pfade
-    # enthalten. Es wird geloggt, aber nie ausgeliefert. BadGatewayError statt
-    # HTTPException(502): siehe Kommentar oben beim DisplayUnavailable-Zweig.
-    logger.warning("Display-Anwendung fehlgeschlagen: %s", message)
+    # `result.message` stammt roh aus kscreen-doctor und kann EDID-Namen und
+    # Pfade enthalten. Sie wird geloggt und in den (serverseitigen) Audit-
+    # Eintrag geschrieben, aber nie an den Client ausgeliefert.
+    # BadGatewayError statt HTTPException(502): siehe Kommentar oben beim
+    # DisplayUnavailable-Zweig.
+    _audit(
+        current_user, False,
+        status_code=status.HTTP_502_BAD_GATEWAY, argv=result.argv, detail=result.message,
+    )
+    logger.warning("Display-Anwendung fehlgeschlagen: %s", result.message)
     raise BadGatewayError("Aktion fehlgeschlagen")
 
 

--- a/backend/app/plugins/installed/display_output/__init__.py
+++ b/backend/app/plugins/installed/display_output/__init__.py
@@ -5,3 +5,153 @@ kscreen-doctor. Laeuft als bundled Plugin im Host-Prozess und damit unter
 derselben UID wie die Desktop-Session; ein Sandbox-Plugin kaeme nicht an den
 Wayland-Socket.
 """
+# NB: kein ``from __future__ import annotations`` hier (vgl. audio_control).
+# Zusammen mit Pydantic v2 + FastAPIs Body-Erkennung durch slowapis
+# ``@user_limiter.limit``-Wrapper werden aufgeschobene Annotationen zu
+# ForwardRefs, die FastAPI nicht mehr als Pydantic-Modell aufloest — der
+# Request-Body wuerde als Query-Parameter fehlinterpretiert und jedes
+# POST liefert 422.
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+
+from app.api.deps import require_power_manage_displays
+from app.core.rate_limiter import get_limit, user_limiter
+from app.plugins.base import PluginBase, PluginMetadata, PluginUIManifest
+from app.plugins.installed.display_output import service as service_module
+from app.plugins.installed.display_output.models import DisplayApplyRequest, DisplayLayout
+from app.plugins.installed.display_output.service import (
+    DisplayUnavailable,
+    InvalidRequest,
+    ModeMismatch,
+)
+from app.schemas.user import UserPublic
+from app.services.audit.logger_db import get_audit_logger_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_LIMIT = get_limit("display_output")
+
+
+def _audit(user: UserPublic, success: bool, wanted: dict) -> None:
+    """Schreibt einen Audit-Eintrag fuer jede Aenderung der Ausgangswahl.
+
+    Anders als bei den Pegeln der Audiosteuerung ist hier jeder Vorgang
+    interessant: ein apply schaltet Bildschirme.
+    """
+    audit_logger = get_audit_logger_db()
+    audit_logger.log_event(
+        event_type="POWER",
+        action="display_apply",
+        user=user.username,
+        resource="displays",
+        success=success,
+        details={"wanted": {k: list(v) for k, v in wanted.items()}},
+    )
+    if getattr(user, "role", None) != "admin":
+        audit_logger.log_security_event(
+            action="delegated_power_action",
+            user=user.username,
+            resource="manage_displays",
+            details={"action": "display_apply"},
+            success=True,
+        )
+
+
+@router.get("/state", response_model=DisplayLayout)
+@user_limiter.limit(_LIMIT)
+async def get_display_state(
+    request: Request,
+    response: Response,
+    current_user=Depends(require_power_manage_displays),
+) -> DisplayLayout:
+    """Liefert alle Ausgaenge, ihre Modi und den globalen DPMS-Zustand.
+
+    Hinter derselben Berechtigung wie die Schreibroute: die Ausgangsliste
+    verraet die angeschlossene Hardware samt EDID-Groessenangaben.
+
+    Eine unerreichbare Session ist hier **kein** Fehler, sondern
+    ``available=false`` — die UI soll das anzeigen koennen, statt nur eine
+    Fehlermeldung zu bekommen.
+    """
+    return await service_module.get_display_service().get_layout()
+
+
+@router.post("/apply")
+@user_limiter.limit(_LIMIT)
+async def apply_display_layout(
+    body: DisplayApplyRequest,
+    request: Request,
+    response: Response,
+    current_user=Depends(require_power_manage_displays),
+) -> dict:
+    """Setzt Auswahl und Modus in genau einem kscreen-doctor-Aufruf.
+
+    Jeder Name und jede Mode-ID aus dem Rumpf wird zuvor gegen die live
+    enumerierten Werte **dieses** Ausgangs geprueft (im Service). Was dort
+    nicht steht, wird nie zu einem argv-Element.
+    """
+    service = service_module.get_display_service()
+    wanted = {o.name: (o.selected, o.mode_id) for o in body.outputs}
+    try:
+        ok, message = await service.apply(body)
+    except InvalidRequest as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    except ModeMismatch as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+    except DisplayUnavailable:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY, detail="Displays nicht erreichbar"
+        )
+
+    _audit(current_user, ok, wanted)
+
+    if ok:
+        return {"success": True}
+
+    # `message` stammt roh aus kscreen-doctor und kann EDID-Namen und Pfade
+    # enthalten. Es wird geloggt, aber nie ausgeliefert.
+    logger.warning("Display-Anwendung fehlgeschlagen: %s", message)
+    raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY, detail="Aktion fehlgeschlagen"
+    )
+
+
+class DisplayOutputPlugin(PluginBase):
+    """Bundled Plugin fuer die Displaysteuerung."""
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="display_output",
+            version="1.0.0",
+            display_name="Displaysteuerung",
+            description=(
+                "Angeschlossene Bildschirme erkennen, den Ausgang waehlen und "
+                "Aufloesung samt Bildwiederholrate setzen."
+            ),
+            author="Xveyn",
+            category="system",
+        )
+
+    def get_router(self) -> APIRouter:
+        return router
+
+    def get_ui_manifest(self) -> PluginUIManifest:
+        """Meldet das Plugin ans Frontend, ohne einen Nav-Eintrag beizusteuern.
+
+        **Ohne diese Ueberschreibung ist das Feature unsichtbar.**
+        ``PluginBase`` liefert hier ``None``, und
+        ``PluginManager.get_ui_manifest()`` nimmt nur Plugins mit einem aktiven
+        Manifest in ``/api/plugins/ui/manifest`` auf — genau die Liste, aus der
+        ``usePluginEnabled`` speist. Ohne Manifest gilt das Plugin dort
+        dauerhaft als abgeschaltet, und die Topbar rendert das Monitor-Symbol
+        nie: kein Fehler, keine Logzeile.
+
+        ``nav_items`` bleibt leer: die Bedienung sitzt in der Topbar. Ein
+        leeres ``nav_items`` erzeugt keine Route, also wird auch kein
+        ``bundle.js`` nachgeladen.
+        """
+        return PluginUIManifest(enabled=True)

--- a/backend/app/plugins/installed/display_output/__init__.py
+++ b/backend/app/plugins/installed/display_output/__init__.py
@@ -1,0 +1,7 @@
+"""Displaysteuerung — bundled Plugin.
+
+Enumeriert die KWin-Ausgaenge und setzt Auswahl und Video-Modus ueber
+kscreen-doctor. Laeuft als bundled Plugin im Host-Prozess und damit unter
+derselben UID wie die Desktop-Session; ein Sandbox-Plugin kaeme nicht an den
+Wayland-Socket.
+"""

--- a/backend/app/plugins/installed/display_output/__init__.py
+++ b/backend/app/plugins/installed/display_output/__init__.py
@@ -12,6 +12,7 @@ Wayland-Socket.
 # Request-Body wuerde als Query-Parameter fehlinterpretiert und jedes
 # POST liefert 422.
 import logging
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
@@ -41,7 +42,7 @@ def _audit(
     success: bool,
     *,
     status_code: int,
-    argv=None,
+    argv: Optional[List[str]] = None,
     detail: str = "",
 ) -> None:
     """Schreibt einen Audit-Eintrag fuer JEDEN apply-Versuch — Erfolg wie Ablehnung.

--- a/backend/app/plugins/installed/display_output/backend.py
+++ b/backend/app/plugins/installed/display_output/backend.py
@@ -1,0 +1,135 @@
+"""Display-Backends: ein Protokoll, eine Attrappe, eine echte Umsetzung.
+
+Der Aufbau spiegelt ``services/power/desktop_backend.py`` und
+``audio_control/backend.py``: ein Protocol, ein Dev-Backend fuer Windows und
+Entwicklungsbetrieb, ein Linux-Backend, das mit der realen Session spricht.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, List, Optional, Protocol, Tuple
+
+from app.plugins.installed.display_output.kscreen import (
+    build_apply_args,
+    parse_outputs,
+    run_kscreen,
+    run_kscreen_json,
+)
+from app.plugins.installed.display_output.models import (
+    DisplayLayout,
+    DisplayMode,
+    DisplayOutput,
+)
+from app.services.power.gpu.display_detector import get_connector_states
+
+
+class DisplayBackend(Protocol):
+    async def get_layout(self) -> DisplayLayout: ...
+    async def apply(
+        self, wanted: Dict[str, Tuple[bool, Optional[str]]], live_outputs: List[DisplayOutput]
+    ) -> Tuple[bool, str]: ...
+
+
+def _dev_modes(entries: List[tuple]) -> List[DisplayMode]:
+    return [
+        DisplayMode(id=i, name=n, width=w, height=h, refresh_rate=r)
+        for i, n, w, h, r in entries
+    ]
+
+
+class DevDisplayBackend:
+    """Zustand im Speicher, damit das Feature auf Windows entwickelbar ist.
+
+    Bildet BaluNode nach: **zwei** verbundene Ausgaenge. Ein
+    ``disconnected``-Ausgang gehoert bewusst nicht dazu — kscreen-doctor listet
+    unverbundene Connectoren gar nicht erst, ein solcher Eintrag waere also ein
+    Zustand, den das echte Backend nie liefert.
+
+    Die namensgleichen Modus-Paare sind Absicht: an ihnen haengt die gesamte
+    Begruendung fuer die ID-Adressierung, und ohne sie liesse sich die
+    Beschriftung unter Windows nicht pruefen.
+    """
+
+    def __init__(self) -> None:
+        self._outputs: List[DisplayOutput] = [
+            DisplayOutput(
+                name="HDMI-A-1", connected=True, selected=False,
+                current_mode_id="1", preferred_mode_id="1", scale=1.0, priority=0,
+                modes=_dev_modes([
+                    ("1", "2560x1440@144", 2560, 1440, 143.99899291992188),
+                    ("8", "1920x1200@144", 1920, 1200, 143.99899291992188),
+                    ("9", "1920x1080@60", 1920, 1080, 60.0),
+                    ("11", "1920x1080@60", 1920, 1080, 59.939998626708984),
+                    ("50", "1920x1080@144", 1920, 1080, 143.8820037841797),
+                ]),
+            ),
+            DisplayOutput(
+                name="DP-3", connected=True, selected=True,
+                current_mode_id="57", preferred_mode_id="56", scale=2.5, priority=1,
+                modes=_dev_modes([
+                    ("57", "3840x2160@120", 3840, 2160, 120.0),
+                    ("58", "3840x2160@120", 3840, 2160, 119.87999725341797),
+                    ("56", "3840x2160@60", 3840, 2160, 60.0),
+                    ("67", "2560x1440@120", 2560, 1440, 119.99800109863281),
+                    ("69", "1920x1080@120", 1920, 1080, 120.0),
+                ]),
+            ),
+        ]
+
+    async def get_layout(self) -> DisplayLayout:
+        # lit folgt hier direkt selected: das Dev-Backend simuliert keine
+        # eigene DPMS-Ebene, sondern gibt vor, dass beide Ebenen deckungsgleich sind.
+        outputs = [o.model_copy(update={"lit": o.selected}) for o in self._outputs]
+        return DisplayLayout(
+            outputs=outputs,
+            displays_powered=any(o.lit is True for o in outputs),
+            available=True,
+            detail="Dev-Backend (im Speicher)",
+        )
+
+    async def apply(
+        self, wanted: Dict[str, Tuple[bool, Optional[str]]], live_outputs: List[DisplayOutput]
+    ) -> Tuple[bool, str]:
+        for output in self._outputs:
+            if output.name not in wanted:
+                continue
+            selected, mode_id = wanted[output.name]
+            output.selected = selected
+            if selected and mode_id:
+                output.current_mode_id = mode_id
+        return True, "Angewendet (Dev)"
+
+
+class KWinDisplayBackend:
+    """Spricht ueber kscreen-doctor mit der KWin-Instanz der Desktop-Session.
+
+    Das Backend laeuft unter derselben UID wie die Session, deshalb genuegt die
+    Umgebung aus ``wayland_session_env()``; es wird kein Sudo benoetigt.
+    """
+
+    async def get_layout(self) -> DisplayLayout:
+        payload = await asyncio.to_thread(run_kscreen_json)
+        if payload is None:
+            return DisplayLayout(available=False, detail="KWin nicht erreichbar")
+
+        outputs = parse_outputs(payload)
+        states = await get_connector_states()
+        merged = [
+            # .get() statt [] : ein Name ohne Connector ist "unbekannt",
+            # nicht "aus". Eine unbekannte Antwort als aus auszugeben waere
+            # eine Falschaussage.
+            o.model_copy(update={"lit": states.get(o.name)})
+            for o in outputs
+        ]
+        return DisplayLayout(
+            outputs=merged,
+            displays_powered=any(o.lit is True for o in merged),
+            available=True,
+        )
+
+    async def apply(
+        self, wanted: Dict[str, Tuple[bool, Optional[str]]], live_outputs: List[DisplayOutput]
+    ) -> Tuple[bool, str]:
+        args = build_apply_args(wanted, live_outputs)
+        # Genau ein Aufruf: kscreen-doctor wendet alle Argumente gemeinsam an.
+        return await asyncio.to_thread(run_kscreen, args[1:])

--- a/backend/app/plugins/installed/display_output/kscreen.py
+++ b/backend/app/plugins/installed/display_output/kscreen.py
@@ -1,0 +1,135 @@
+"""Der einzige Ort, der weiss, dass es kscreen-doctor gibt.
+
+Kapselt Aufruf, Auswertung und Argumentbau. Ein spaeterer Wechsel auf die
+KScreen-D-Bus-Schnittstelle beruehrt nur diese Datei.
+
+**Modi werden ueber ihre ID adressiert, niemals ueber den Namen.** libkscreen
+bildet den Namen in ``findMode()`` mit ``qRound(refreshRate)``, weshalb 119,88
+und 120,000 beide ``3840x2160@120`` heissen; die Funktion nimmt den ersten
+Treffer und bricht ab. Eine Adressierung ueber den Namen setzt also je nach
+Listenreihenfolge einen anderen Modus — ohne Fehlermeldung.
+"""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from app.plugins.installed.display_output.models import DisplayMode, DisplayOutput
+
+logger = logging.getLogger(__name__)
+
+# Auf wie viele Nachkommastellen zwei Bildwiederholraten als gleich gelten.
+# Feiner zu unterscheiden hiesse, Gleitkomma-Rauschen zu Modi zu erklaeren.
+_RATE_PRECISION = 3
+
+
+def parse_modes(raw_modes: object) -> List[DisplayMode]:
+    """Wandelt die Modenliste eines Ausgangs in eine anzeigbare Liste.
+
+    Drei Schritte, alle drei aus gemessenen Daten begruendet:
+
+    1. **Exakte Dubletten zusammenfassen** (gleiche Breite, Hoehe und
+       Bildwiederholrate). Auf BaluNode traegt HDMI-A-1 fuenf solcher Paare;
+       sie unterscheiden sich nur in DRM-Timing-Flags (CEA gegen DMT), was
+       sich einem Menschen nicht sinnvoll anzeigen laesst. Die kleinere ID
+       gewinnt.
+    2. **Absteigend nach Flaeche, dann nach Rate sortieren.** kscreen-doctor
+       liefert lexikografisch nach ID-String ("1", "10", "11", ..., "2", "20").
+    3. Die Rate bleibt **ungerundet** — ``119.88`` und ``120.00`` sind der
+       einzige Unterschied, an dem ein Mensch die beiden 4K-Modi von DP-3
+       auseinanderhaelt.
+
+    Args:
+        raw_modes: Die ``modes``-Liste eines Ausgangs aus ``kscreen-doctor -j``.
+
+    Returns:
+        Sortierte, entdoppelte Modi. Unbrauchbare Eintraege werden
+        uebersprungen, nicht als Fehler gemeldet — ein defekter Modus darf
+        die Enumeration nicht scheitern lassen.
+    """
+    if not isinstance(raw_modes, list):
+        return []
+
+    seen: dict[tuple, DisplayMode] = {}
+    for raw in raw_modes:
+        if not isinstance(raw, dict):
+            continue
+        size = raw.get("size")
+        mode_id = raw.get("id")
+        if not isinstance(size, dict) or mode_id is None:
+            logger.debug("Modus ohne Groesse oder ID uebersprungen: %r", raw)
+            continue
+        width = size.get("width")
+        height = size.get("height")
+        if not isinstance(width, int) or not isinstance(height, int):
+            continue
+        try:
+            rate = float(raw.get("refreshRate", 0.0))
+        except (TypeError, ValueError):
+            continue
+
+        mode = DisplayMode(
+            id=str(mode_id),
+            name=str(raw.get("name", "")),
+            width=width,
+            height=height,
+            refresh_rate=rate,
+        )
+        key = (width, height, round(rate, _RATE_PRECISION))
+        existing = seen.get(key)
+        # Kleinere ID gewinnt. IDs sind Zeichenketten, deshalb numerisch
+        # vergleichen, wo moeglich - sonst waere "10" kleiner als "9".
+        if existing is None or _id_sort_key(mode.id) < _id_sort_key(existing.id):
+            seen[key] = mode
+
+    return sorted(seen.values(), key=lambda m: (-(m.width * m.height), -m.refresh_rate, m.id))
+
+
+def _id_sort_key(mode_id: str) -> tuple:
+    """Sortierschluessel, der numerische IDs numerisch ordnet."""
+    return (0, int(mode_id)) if mode_id.isdigit() else (1, mode_id)
+
+
+def parse_outputs(payload: object) -> List[DisplayOutput]:
+    """Liest die Ausgangsliste aus der JSON-Struktur von ``kscreen-doctor -j``.
+
+    ``lit`` bleibt hier ``None``: dieses Modul kennt sysfs nicht. Die
+    DRM-Ebene ergaenzt das Backend (Task 4).
+
+    Jeder Feldzugriff laeuft ueber ``.get()``. Die Felder sind nicht bei jedem
+    Ausgang vorhanden — auf BaluNode traegt HDMI-A-1 ein ``vrrPolicy``, DP-3
+    nicht.
+    """
+    if not isinstance(payload, dict):
+        return []
+    raw_outputs = payload.get("outputs")
+    if not isinstance(raw_outputs, list):
+        return []
+
+    outputs: List[DisplayOutput] = []
+    for raw in raw_outputs:
+        if not isinstance(raw, dict):
+            continue
+        name = raw.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        preferred = raw.get("preferredModes")
+        preferred_id: Optional[str] = None
+        if isinstance(preferred, list) and preferred:
+            preferred_id = str(preferred[0])
+        current = raw.get("currentModeId")
+
+        outputs.append(
+            DisplayOutput(
+                name=name,
+                connected=bool(raw.get("connected", False)),
+                selected=bool(raw.get("enabled", False)),
+                lit=None,
+                current_mode_id=str(current) if current is not None else None,
+                preferred_mode_id=preferred_id,
+                scale=float(raw.get("scale", 1.0) or 1.0),
+                priority=int(raw.get("priority", 0) or 0),
+                modes=parse_modes(raw.get("modes")),
+            )
+        )
+    return outputs

--- a/backend/app/plugins/installed/display_output/kscreen.py
+++ b/backend/app/plugins/installed/display_output/kscreen.py
@@ -26,8 +26,14 @@ logger = logging.getLogger(__name__)
 _RATE_PRECISION = 3
 
 
-def parse_modes(raw_modes: object) -> List[DisplayMode]:
-    """Wandelt die Modenliste eines Ausgangs in eine anzeigbare Liste.
+def _collapse_modes(raw_modes: object) -> tuple[List[DisplayMode], dict[str, str]]:
+    """Baut die entdoppelte Modenliste UND eine ID-Abbildung fuer den Aufrufer.
+
+    Tut, was frueher in ``parse_modes`` allein stand, gibt aber zusaetzlich
+    zurueck, auf welche ueberlebende ID jede rohe ID zeigt (auch die des
+    Siegers selbst — die zeigt auf sich). ``parse_outputs`` braucht diese
+    Abbildung, um ``currentModeId``/``preferredModes[0]`` umzuhaengen, falls
+    KWin ausgerechnet die kollabierte (verworfene) ID meldet.
 
     Drei Schritte, alle drei aus gemessenen Daten begruendet:
 
@@ -46,14 +52,15 @@ def parse_modes(raw_modes: object) -> List[DisplayMode]:
         raw_modes: Die ``modes``-Liste eines Ausgangs aus ``kscreen-doctor -j``.
 
     Returns:
-        Sortierte, entdoppelte Modi. Unbrauchbare Eintraege werden
-        uebersprungen, nicht als Fehler gemeldet — ein defekter Modus darf
-        die Enumeration nicht scheitern lassen.
+        (sortierte, entdoppelte Modi; rohe ID -> ueberlebende ID). Unbrauchbare
+        Eintraege werden uebersprungen, nicht als Fehler gemeldet — ein
+        defekter Modus darf die Enumeration nicht scheitern lassen.
     """
     if not isinstance(raw_modes, list):
-        return []
+        return [], {}
 
     seen: dict[tuple, DisplayMode] = {}
+    raw_ids_by_key: dict[tuple, List[str]] = {}
     for raw in raw_modes:
         if not isinstance(raw, dict):
             continue
@@ -84,8 +91,31 @@ def parse_modes(raw_modes: object) -> List[DisplayMode]:
         # vergleichen, wo moeglich - sonst waere "10" kleiner als "9".
         if existing is None or _id_sort_key(mode.id) < _id_sort_key(existing.id):
             seen[key] = mode
+        raw_ids_by_key.setdefault(key, []).append(mode.id)
 
-    return sorted(seen.values(), key=lambda m: (-(m.width * m.height), -m.refresh_rate, m.id))
+    remap = {
+        raw_id: seen[key].id
+        for key, raw_ids in raw_ids_by_key.items()
+        for raw_id in raw_ids
+    }
+    modes = sorted(seen.values(), key=lambda m: (-(m.width * m.height), -m.refresh_rate, m.id))
+    return modes, remap
+
+
+def parse_modes(raw_modes: object) -> List[DisplayMode]:
+    """Wandelt die Modenliste eines Ausgangs in eine anzeigbare Liste.
+
+    Duennwrapper um ``_collapse_modes`` fuer Aufrufer, die nur die Liste
+    brauchen (das oeffentliche Format dieser Funktion bleibt unveraendert).
+
+    Args:
+        raw_modes: Die ``modes``-Liste eines Ausgangs aus ``kscreen-doctor -j``.
+
+    Returns:
+        Sortierte, entdoppelte Modi.
+    """
+    modes, _ = _collapse_modes(raw_modes)
+    return modes
 
 
 def _id_sort_key(mode_id: str) -> tuple:
@@ -102,6 +132,13 @@ def parse_outputs(payload: object) -> List[DisplayOutput]:
     Jeder Feldzugriff laeuft ueber ``.get()``. Die Felder sind nicht bei jedem
     Ausgang vorhanden — auf BaluNode traegt HDMI-A-1 ein ``vrrPolicy``, DP-3
     nicht.
+
+    ``currentModeId`` und ``preferredModes[0]`` werden ueber die
+    Kollaps-Abbildung aus ``_collapse_modes`` gejagt: zeigt KWin auf die
+    groessere (verworfene) ID eines exakt-gleichen Modus-Paares, existiert
+    diese ID in der zurueckgegebenen Modenliste nicht mehr, und das
+    Frontend-Auswahlfeld faende kein passendes ``<option>`` — die Anzeige
+    zeigte dann gar keine aktuelle Aufloesung.
     """
     if not isinstance(payload, dict):
         return []
@@ -116,11 +153,17 @@ def parse_outputs(payload: object) -> List[DisplayOutput]:
         name = raw.get("name")
         if not isinstance(name, str) or not name:
             continue
+
+        modes, id_remap = _collapse_modes(raw.get("modes"))
+
         preferred = raw.get("preferredModes")
         preferred_id: Optional[str] = None
         if isinstance(preferred, list) and preferred:
-            preferred_id = str(preferred[0])
+            preferred_id = id_remap.get(str(preferred[0]), str(preferred[0]))
         current = raw.get("currentModeId")
+        current_id: Optional[str] = None
+        if current is not None:
+            current_id = id_remap.get(str(current), str(current))
 
         outputs.append(
             DisplayOutput(
@@ -128,11 +171,11 @@ def parse_outputs(payload: object) -> List[DisplayOutput]:
                 connected=bool(raw.get("connected", False)),
                 selected=bool(raw.get("enabled", False)),
                 lit=None,
-                current_mode_id=str(current) if current is not None else None,
+                current_mode_id=current_id,
                 preferred_mode_id=preferred_id,
                 scale=float(raw.get("scale", 1.0) or 1.0),
                 priority=int(raw.get("priority", 0) or 0),
-                modes=parse_modes(raw.get("modes")),
+                modes=modes,
             )
         )
     return outputs

--- a/backend/app/plugins/installed/display_output/kscreen.py
+++ b/backend/app/plugins/installed/display_output/kscreen.py
@@ -11,10 +11,13 @@ Listenreihenfolge einen anderen Modus — ohne Fehlermeldung.
 """
 from __future__ import annotations
 
+import json
 import logging
+import subprocess
 from typing import List, Optional
 
 from app.plugins.installed.display_output.models import DisplayMode, DisplayOutput
+from app.services.power.session_env import wayland_session_env
 
 logger = logging.getLogger(__name__)
 
@@ -133,3 +136,98 @@ def parse_outputs(payload: object) -> List[DisplayOutput]:
             )
         )
     return outputs
+
+
+# kscreen-doctor darf niemals haengen bleiben und dabei einen Worker blockieren.
+KSCREEN_TIMEOUT_SECONDS = 10
+KSCREEN_BINARY = "kscreen-doctor"
+
+
+def run_kscreen(args: List[str]) -> tuple[bool, str]:
+    """Fuehrt kscreen-doctor mit Listen-Argumenten aus.
+
+    Args:
+        args: Argumente ohne den Programmnamen, etwa ``["-j"]``.
+
+    Returns:
+        (Erfolg, Ausgabe bzw. Fehlertext). Die Ausgabe ist roh und enthaelt
+        EDID-Namen und Pfade. Sie ist fuer Log und Weiterverarbeitung gedacht —
+        Aufrufer duerfen sie **nicht** in eine Client-Antwort uebernehmen.
+    """
+    try:
+        completed = subprocess.run(
+            [KSCREEN_BINARY, *args],
+            capture_output=True,
+            text=True,
+            timeout=KSCREEN_TIMEOUT_SECONDS,
+            env=wayland_session_env(),
+        )
+    except FileNotFoundError:
+        logger.warning("kscreen-doctor ist nicht installiert")
+        return False, "kscreen-doctor nicht gefunden"
+    except subprocess.TimeoutExpired:
+        logger.warning("kscreen-doctor-Zeitueberschreitung: %s", args)
+        return False, "Zeitueberschreitung"
+    except OSError as exc:
+        logger.warning("kscreen-doctor-Aufruf fehlgeschlagen: %s", exc)
+        return False, "Aufruf fehlgeschlagen"
+
+    if completed.returncode != 0:
+        logger.warning(
+            "kscreen-doctor %s endete mit %s: %s",
+            args, completed.returncode, completed.stderr.strip(),
+        )
+        return False, completed.stderr.strip() or "kscreen-doctor-Fehler"
+    return True, completed.stdout.strip()
+
+
+def run_kscreen_json() -> Optional[object]:
+    """Liest ``kscreen-doctor -j`` und gibt die geparste Struktur zurueck.
+
+    Returns:
+        Die geparste JSON-Struktur, oder None bei Fehler oder ungueltigem JSON.
+    """
+    ok, output = run_kscreen(["-j"])
+    if not ok:
+        return None
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError:
+        logger.warning("kscreen-doctor lieferte ungueltiges JSON")
+        return None
+
+
+def build_apply_args(
+    wanted: dict,
+    live_outputs: List[DisplayOutput],
+) -> List[str]:
+    """Baut den vollstaendigen Argumentvektor fuer **einen** Aufruf.
+
+    kscreen-doctor wendet alle Argumente eines Aufrufs gemeinsam an. Genau ein
+    Unterprozess heisst deshalb: kein Teilzustand, wenn etwas schiefgeht.
+
+    Die Reihenfolge folgt der **Enumeration**, nicht dem Request. Das macht den
+    Vektor deterministisch und damit pruefbar, und es nimmt dem Client jeden
+    Einfluss auf die Abarbeitungsreihenfolge.
+
+    Args:
+        wanted: Abbildung Ausgangsname -> (selected, mode_id oder None). Nur
+            Ausgaenge, die der Aufrufer bereits validiert hat.
+        live_outputs: Die aktuelle Enumeration; bestimmt Reihenfolge und
+            Zugehoerigkeit.
+
+    Returns:
+        Der vollstaendige argv inklusive Programmname.
+    """
+    args: List[str] = [KSCREEN_BINARY]
+    for output in live_outputs:
+        if output.name not in wanted:
+            continue
+        selected, mode_id = wanted[output.name]
+        if not selected:
+            args.append(f"output.{output.name}.disable")
+            continue
+        args.append(f"output.{output.name}.enable")
+        if mode_id:
+            args.append(f"output.{output.name}.mode.{mode_id}")
+    return args

--- a/backend/app/plugins/installed/display_output/models.py
+++ b/backend/app/plugins/installed/display_output/models.py
@@ -1,0 +1,71 @@
+"""Pydantic-Modelle der Displaysteuerung.
+
+Die Feldnamen sind zugleich der API-Vertrag zum Frontend.
+
+``selected`` und ``lit`` heissen absichtlich nicht beide ``enabled``: KWin und
+DRM meinen mit diesem Wort verschiedene Dinge (die Ausgangswahl gegen "es
+werden wirklich Pixel getrieben"), und die Namensgleichheit ist die Ursache
+der Verwirrung, die dieses Feature aufloesen soll.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class DisplayMode(BaseModel):
+    """Ein waehlbarer Video-Modus eines Ausgangs."""
+
+    id: str = Field(..., description="Lebende KWin-Mode-ID; nur innerhalb dieses Vorgangs gueltig")
+    name: str = Field(..., description="'3840x2160@120' — NICHT eindeutig, dient nur der Gegenpruefung")
+    width: int
+    height: int
+    refresh_rate: float = Field(..., description="Ungerundet, z. B. 119.87999725341797")
+
+
+class DisplayOutput(BaseModel):
+    """Ein von KWin gemeldeter Ausgang."""
+
+    name: str = Field(..., description="Connector-Name, z. B. 'DP-3'")
+    connected: bool
+    selected: bool = Field(..., description="KWin-Ebene: ist dieser Ausgang gewaehlt?")
+    lit: Optional[bool] = Field(
+        default=None,
+        description="DRM-Ebene: werden Pixel getrieben? None = nicht zuordenbar",
+    )
+    current_mode_id: Optional[str] = None
+    preferred_mode_id: Optional[str] = None
+    scale: float = Field(default=1.0, description="Nur Anzeige; in v1 nicht setzbar")
+    priority: int = 0
+    modes: List[DisplayMode] = Field(default_factory=list)
+
+
+class DisplayLayout(BaseModel):
+    """Gesamtzustand, wie ihn GET /state liefert."""
+
+    outputs: List[DisplayOutput] = Field(default_factory=list)
+    displays_powered: bool = Field(
+        default=False, description="Globaler DPMS-Zustand: leuchtet mindestens ein Ausgang?"
+    )
+    available: bool = Field(default=True, description="False, wenn KWin nicht erreichbar ist")
+    detail: Optional[str] = Field(default=None, description="Kurzer Hinweis fuer die UI")
+
+
+class DisplayOutputRequest(BaseModel):
+    """Gewuenschter Zustand eines Ausgangs."""
+
+    name: str = Field(..., min_length=1, max_length=64)
+    selected: bool
+    mode_id: Optional[str] = Field(default=None, max_length=32)
+    mode_name: Optional[str] = Field(
+        default=None,
+        max_length=64,
+        description="Pflicht, sobald mode_id gesetzt ist — die Gegenprobe zur ID",
+    )
+
+
+class DisplayApplyRequest(BaseModel):
+    """Rumpf von POST /apply."""
+
+    outputs: List[DisplayOutputRequest] = Field(..., min_length=1)

--- a/backend/app/plugins/installed/display_output/models.py
+++ b/backend/app/plugins/installed/display_output/models.py
@@ -68,4 +68,8 @@ class DisplayOutputRequest(BaseModel):
 class DisplayApplyRequest(BaseModel):
     """Rumpf von POST /apply."""
 
-    outputs: List[DisplayOutputRequest] = Field(..., min_length=1)
+    # max_length=16: kein Host meldet gleichzeitig mehr als 16 Ausgaenge
+    # (gemessen: BaluNode hat zwei). Ohne obere Grenze koennte ein
+    # berechtigter Aufrufer einen beliebig grossen Rumpf schicken, den ein
+    # Worker parsen muss, bevor die erste inhaltliche Pruefung greift.
+    outputs: List[DisplayOutputRequest] = Field(..., min_length=1, max_length=16)

--- a/backend/app/plugins/installed/display_output/service.py
+++ b/backend/app/plugins/installed/display_output/service.py
@@ -1,0 +1,140 @@
+"""Service-Schicht der Displaysteuerung.
+
+Waehlt das Backend, haelt die Auswahl als Singleton und traegt die gesamte
+Validierung. Der Aufbau spiegelt ``audio_control/service.py``.
+
+**Die Validierung ist die eigentliche Schutzmassnahme.** Listen-Argumente
+schliessen eine Shell-Injektion ohnehin aus; hier wird sichergestellt, dass
+ueberhaupt nur Werte in den Argumentvektor gelangen, die zuvor in der
+Live-Enumeration standen.
+"""
+from __future__ import annotations
+
+import logging
+import platform
+from typing import Dict, Optional, Tuple
+
+from app.core.config import settings
+from app.plugins.installed.display_output.backend import (
+    DevDisplayBackend,
+    DisplayBackend,
+    KWinDisplayBackend,
+)
+from app.plugins.installed.display_output.models import DisplayApplyRequest, DisplayLayout
+
+logger = logging.getLogger(__name__)
+
+_service: Optional["DisplayService"] = None
+
+
+class DisplayError(Exception):
+    """Basis der Fehler, die die Route in Statuscodes uebersetzt."""
+
+
+class DisplayUnavailable(DisplayError):
+    """KWin ist nicht erreichbar — wird zu 502."""
+
+
+class InvalidRequest(DisplayError):
+    """Der Wunsch ist nicht erfuellbar — wird zu 400."""
+
+
+class ModeMismatch(DisplayError):
+    """Die ID meint inzwischen einen anderen Modus — wird zu 409."""
+
+
+class DisplayService:
+    """Duenne Huelle um das gewaehlte Backend, plus Validierung."""
+
+    def __init__(self, backend: Optional[DisplayBackend] = None) -> None:
+        if backend is not None:
+            self._backend: DisplayBackend = backend
+        elif getattr(settings, "is_dev_mode", False) or platform.system() != "Linux":
+            # kscreen-doctor gibt es auf Windows nicht, und im Dev-Modus soll
+            # nichts an einer echten Session herumstellen.
+            self._backend = DevDisplayBackend()
+        else:
+            self._backend = KWinDisplayBackend()
+
+    async def get_layout(self) -> DisplayLayout:
+        """Liest Ausgaenge, Modi und den globalen DPMS-Zustand."""
+        return await self._backend.get_layout()
+
+    async def apply(self, request: DisplayApplyRequest) -> Tuple[bool, str]:
+        """Prueft den Wunsch gegen die Live-Enumeration und wendet ihn an.
+
+        Raises:
+            DisplayUnavailable: KWin antwortet nicht.
+            InvalidRequest: unbekannter Ausgang, unbekannte oder fremde
+                Mode-ID, doppelter Ausgang, unvollstaendige Modusangabe, oder
+                ein Ergebnis ohne einen einzigen gewaehlten Ausgang.
+            ModeMismatch: die ID existiert, meint aber einen anderen Modus als
+                der mitgeschickte Name.
+        """
+        layout = await self._backend.get_layout()
+        if not layout.available:
+            raise DisplayUnavailable(layout.detail or "KWin nicht erreichbar")
+
+        by_name = {o.name: o for o in layout.outputs}
+        wanted: Dict[str, Tuple[bool, Optional[str]]] = {}
+
+        for item in request.outputs:
+            if item.name in wanted:
+                raise InvalidRequest(f"Ausgang doppelt im Wunsch: {item.name}")
+            output = by_name.get(item.name)
+            if output is None:
+                raise InvalidRequest(f"Unbekannter Ausgang: {item.name}")
+
+            mode_id: Optional[str] = None
+            if item.mode_id is not None or item.mode_name is not None:
+                if item.mode_id is None or item.mode_name is None:
+                    # Ohne beide Haelften waere die Gegenprobe abschaltbar.
+                    raise InvalidRequest("mode_id und mode_name gehoeren zusammen")
+                if item.selected:
+                    mode = next((m for m in output.modes if m.id == item.mode_id), None)
+                    if mode is None:
+                        raise InvalidRequest(
+                            f"Modus {item.mode_id} gehoert nicht zu {item.name}"
+                        )
+                    if mode.name != item.mode_name:
+                        raise ModeMismatch(
+                            f"Modus {item.mode_id} heisst inzwischen {mode.name}"
+                        )
+                    mode_id = mode.id
+                # Bei selected=False bleibt mode_id None: KWin behaelt die
+                # Modus-Wahl eines abgewaehlten Ausgangs ohnehin.
+
+            wanted[item.name] = (item.selected, mode_id)
+
+        self._assert_something_stays_selected(by_name, wanted)
+
+        logger.info("Display-Wunsch: %s", wanted)
+        return await self._backend.apply(wanted, layout.outputs)
+
+    @staticmethod
+    def _assert_something_stays_selected(by_name: dict, wanted: dict) -> None:
+        """Verbietet ein apply, nach dem kein Ausgang mehr gewaehlt waere.
+
+        "Nichts soll leuchten" ist ein legitimer Wunsch, aber der Weg dafuer
+        ist der DPMS-Schalter: der ist reversibel und wirft die
+        KWin-Konfiguration nicht weg. Alle Ausgaenge abzuwaehlen wuerde sie
+        wegwerfen.
+
+        Ausgaenge, die der Wunsch nicht nennt, behalten ihren Zustand und
+        zaehlen deshalb mit.
+        """
+        for name, output in by_name.items():
+            if not output.connected:
+                continue
+            selected = wanted[name][0] if name in wanted else output.selected
+            if selected:
+                return
+        raise InvalidRequest("Mindestens ein verbundener Ausgang muss gewaehlt bleiben")
+
+
+def get_display_service() -> DisplayService:
+    """Liefert die Service-Instanz und legt sie beim ersten Aufruf an."""
+    global _service
+    if _service is None:
+        _service = DisplayService()
+    return _service

--- a/backend/app/plugins/installed/display_output/service.py
+++ b/backend/app/plugins/installed/display_output/service.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 import logging
 import platform
-from typing import Dict, Optional, Tuple
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
 
 from app.core.config import settings
 from app.plugins.installed.display_output.backend import (
@@ -20,11 +21,30 @@ from app.plugins.installed.display_output.backend import (
     DisplayBackend,
     KWinDisplayBackend,
 )
+from app.plugins.installed.display_output.kscreen import build_apply_args
 from app.plugins.installed.display_output.models import DisplayApplyRequest, DisplayLayout
 
 logger = logging.getLogger(__name__)
 
 _service: Optional["DisplayService"] = None
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """Ergebnis eines apply-Aufrufs, samt des tatsaechlich geprueften argv.
+
+    Der Audit-Eintrag muss festhalten, was ``kscreen-doctor`` wirklich
+    bekommen hat — nicht den rohen, ungeprueften Request. ``argv`` ist genau
+    der Vektor aus ``kscreen.build_apply_args(wanted, layout.outputs)``, also
+    bereits gegen die Live-Enumeration gepruefte Namen und IDs; ein
+    Ausgang mit ``selected: false`` und mitgeschickter ``mode_id`` taucht
+    darin nicht auf, weil der Service diese Kombination beim Aufbau von
+    ``wanted`` ohnehin verwirft.
+    """
+
+    success: bool
+    message: str
+    argv: List[str]
 
 
 class DisplayError(Exception):
@@ -60,8 +80,17 @@ class DisplayService:
         """Liest Ausgaenge, Modi und den globalen DPMS-Zustand."""
         return await self._backend.get_layout()
 
-    async def apply(self, request: DisplayApplyRequest) -> Tuple[bool, str]:
+    async def apply(self, request: DisplayApplyRequest) -> ApplyResult:
         """Prueft den Wunsch gegen die Live-Enumeration und wendet ihn an.
+
+        Returns:
+            ApplyResult mit dem Ergebnis des Backend-Aufrufs UND dem
+            argv-Vektor, den ``kscreen.build_apply_args`` daraus gebaut hat —
+            derselbe Vektor, den (bei ``KWinDisplayBackend``) auch
+            tatsaechlich an ``kscreen-doctor`` ging. Der Aufbau ist eine reine
+            Funktion von ``wanted`` und der Live-Enumeration, also unabhaengig
+            vom gewaehlten Backend berechenbar; das Protocol selbst bleibt
+            unveraendert.
 
         Raises:
             DisplayUnavailable: KWin antwortet nicht.
@@ -108,8 +137,10 @@ class DisplayService:
 
         self._assert_something_stays_selected(by_name, wanted)
 
+        argv = build_apply_args(wanted, layout.outputs)
         logger.info("Display-Wunsch: %s", wanted)
-        return await self._backend.apply(wanted, layout.outputs)
+        ok, message = await self._backend.apply(wanted, layout.outputs)
+        return ApplyResult(success=ok, message=message, argv=argv)
 
     @staticmethod
     def _assert_something_stays_selected(by_name: dict, wanted: dict) -> None:

--- a/backend/app/schemas/power_permissions.py
+++ b/backend/app/schemas/power_permissions.py
@@ -17,6 +17,7 @@ class UserPowerPermissionsResponse(BaseModel):
     can_toggle_desktop: bool = False
     can_unlock_session: bool = False
     can_control_audio: bool = False
+    can_manage_displays: bool = False
     granted_by: Optional[int] = None
     granted_by_username: Optional[str] = None
     granted_at: Optional[datetime] = None
@@ -34,6 +35,7 @@ class UserPowerPermissionsUpdate(BaseModel):
     can_toggle_desktop: Optional[bool] = Field(default=None, description="Allow toggling the desktop (DPMS on/off)")
     can_unlock_session: Optional[bool] = Field(default=None, description="Allow unlocking the desktop session from the web app")
     can_control_audio: Optional[bool] = Field(default=None, description="Allow controlling desktop audio (volume, output device, per-app mixer)")
+    can_manage_displays: Optional[bool] = Field(default=None, description="Allow choosing display outputs and video modes")
 
 
 class MyPowerPermissionsResponse(BaseModel):
@@ -46,3 +48,4 @@ class MyPowerPermissionsResponse(BaseModel):
     can_toggle_desktop: bool = False
     can_unlock_session: bool = False
     can_control_audio: bool = False
+    can_manage_displays: bool = False

--- a/backend/app/services/power/gpu/display_detector.py
+++ b/backend/app/services/power/gpu/display_detector.py
@@ -26,11 +26,18 @@ def _iter_connector_states(sysfs_root: Path) -> Iterator[tuple[str, bool]]:
     connector name (card0-DP-1 and card1-DP-1 both strip to "DP-1"). Callers
     that need a count must count entries, not distinct names - collapsing
     them would undercount real displays.
+
+    This generator does not warn about ambiguous names and does not resolve
+    them - it just yields every entry as measured. `_count_sync` runs
+    through here once per monitoring tick and does not care about the
+    name-to-connector mapping at all; a warning placed here would fire every
+    tick, forever, from a path that has no use for it. The one caller that
+    *does* need unambiguous names (`_states_sync`) does that resolution and
+    the warning itself.
     """
     drm = sysfs_root / "sys" / "class" / "drm"
     if not drm.exists():
         return
-    seen: set[str] = set()
     for entry in sorted(drm.iterdir()):
         if not _CONNECTOR_RE.match(entry.name):
             continue
@@ -46,22 +53,37 @@ def _iter_connector_states(sysfs_root: Path) -> Iterator[tuple[str, bool]]:
             continue
         # KWin knows the connector without the "card<N>-" prefix.
         name = _CONNECTOR_RE.sub("", entry.name)
-        if name in seen:
-            logger.warning(
-                "Multiple DRM connectors strip to the same KWin name %r; "
-                "the KWin-name-to-connector mapping is ambiguous.",
-                name,
-            )
-        seen.add(name)
         yield name, (status == "connected" and enabled == "enabled")
 
 
 def _states_sync(sysfs_root: Path) -> dict[str, bool]:
     """Per-connector 'is this lit?', keyed by the KWin name.
 
-    When a name is ambiguous (see `_iter_connector_states`), last-wins.
+    When a name is ambiguous - two DRM connectors strip to the same KWin
+    name - the mapping cannot say which connector "DP-1" in KWin's world
+    actually refers to. Reporting the last one seen (last-wins) would turn
+    an unresolvable question into a confident True/False, which is exactly
+    the false-statement pattern this feature exists to avoid (spec 5): the
+    name is removed from the map entirely instead, so a caller's
+    `states.get(name)` answers `None` - "not resolvable", the honest
+    answer.
     """
-    return dict(_iter_connector_states(sysfs_root))
+    states: dict[str, bool] = {}
+    ambiguous: set[str] = set()
+    for name, lit in _iter_connector_states(sysfs_root):
+        if name in ambiguous:
+            continue
+        if name in states:
+            logger.warning(
+                "Multiple DRM connectors strip to the same KWin name %r; "
+                "the KWin-name-to-connector mapping is ambiguous.",
+                name,
+            )
+            ambiguous.add(name)
+            del states[name]
+            continue
+        states[name] = lit
+    return states
 
 
 def _count_sync(sysfs_root: Path) -> int:

--- a/backend/app/services/power/gpu/display_detector.py
+++ b/backend/app/services/power/gpu/display_detector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from collections.abc import Iterator
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -11,20 +12,25 @@ logger = logging.getLogger(__name__)
 _CONNECTOR_RE = re.compile(r"^card\d+-")
 
 
-def _states_sync(sysfs_root: Path) -> dict[str, bool]:
-    """Read, per connector, whether it is actually driving pixels.
+def _iter_connector_states(sysfs_root: Path) -> Iterator[tuple[str, bool]]:
+    """Yield (KWin name, is-lit) for every DRM connector under sysfs_root.
 
-    This is the single sysfs walk for "is this connector lit?" - a connector
-    is lit when status='connected' AND enabled='enabled' (`enabled` covers
-    DPMS-off / unused: physically connected but no active mode). Keys are
-    KWin-style names (the "card<N>-" prefix stripped). `_count_sync` derives
-    its count from this map instead of re-walking sysfs with its own copy of
-    the predicate, so the count and the per-connector map cannot drift apart.
+    The single place that knows how to walk /sys/class/drm and what "lit"
+    means - a connector is lit when status='connected' AND enabled='enabled'
+    (`enabled` covers DPMS-off / unused: physically connected but no active
+    mode). Both the count and the per-connector map derive from this
+    generator, so they cannot drift apart.
+
+    Names are KWin-style (the "card<N>-" prefix stripped), and this can
+    yield the same name more than once: two cards can expose the same
+    connector name (card0-DP-1 and card1-DP-1 both strip to "DP-1"). Callers
+    that need a count must count entries, not distinct names - collapsing
+    them would undercount real displays.
     """
     drm = sysfs_root / "sys" / "class" / "drm"
     if not drm.exists():
-        return {}
-    states: dict[str, bool] = {}
+        return
+    seen: set[str] = set()
     for entry in sorted(drm.iterdir()):
         if not _CONNECTOR_RE.match(entry.name):
             continue
@@ -39,15 +45,33 @@ def _states_sync(sysfs_root: Path) -> dict[str, bool]:
             logger.debug("Cannot read %s: %s", entry.name, exc)
             continue
         # KWin knows the connector without the "card<N>-" prefix.
-        states[_CONNECTOR_RE.sub("", entry.name)] = (
-            status == "connected" and enabled == "enabled"
-        )
-    return states
+        name = _CONNECTOR_RE.sub("", entry.name)
+        if name in seen:
+            logger.warning(
+                "Multiple DRM connectors strip to the same KWin name %r; "
+                "the KWin-name-to-connector mapping is ambiguous.",
+                name,
+            )
+        seen.add(name)
+        yield name, (status == "connected" and enabled == "enabled")
+
+
+def _states_sync(sysfs_root: Path) -> dict[str, bool]:
+    """Per-connector 'is this lit?', keyed by the KWin name.
+
+    When a name is ambiguous (see `_iter_connector_states`), last-wins.
+    """
+    return dict(_iter_connector_states(sysfs_root))
 
 
 def _count_sync(sysfs_root: Path) -> int:
-    """Count of the connectors `_states_sync` reports as lit."""
-    return sum(_states_sync(sysfs_root).values())
+    """Count of lit connectors.
+
+    Counts entries, not distinct names: two cards can expose the same
+    connector name, and collapsing them via `_states_sync`'s dict would
+    undercount real displays.
+    """
+    return sum(1 for _, lit in _iter_connector_states(sysfs_root) if lit)
 
 
 async def get_active_display_count(sysfs_root: Path = Path("/")) -> int:

--- a/backend/app/services/power/gpu/display_detector.py
+++ b/backend/app/services/power/gpu/display_detector.py
@@ -11,51 +11,16 @@ logger = logging.getLogger(__name__)
 _CONNECTOR_RE = re.compile(r"^card\d+-")
 
 
-def _count_sync(sysfs_root: Path) -> int:
-    drm = sysfs_root / "sys" / "class" / "drm"
-    if not drm.exists():
-        return 0
-    count = 0
-    for entry in drm.iterdir():
-        if not _CONNECTOR_RE.match(entry.name):
-            continue
-        status_file = entry / "status"
-        enabled_file = entry / "enabled"
-        if not status_file.exists() or not enabled_file.exists():
-            continue
-        try:
-            status = status_file.read_text().strip()
-            enabled = enabled_file.read_text().strip()
-        except OSError as exc:
-            logger.debug("Cannot read %s: %s", entry.name, exc)
-            continue
-        if status == "connected" and enabled == "enabled":
-            count += 1
-    return count
-
-
-async def get_active_display_count(sysfs_root: Path = Path("/")) -> int:
-    """Count DRM connectors with status='connected' AND enabled='enabled'.
-
-    `enabled` covers DPMS-off / unused: physically connected but no active mode.
-    """
-    return await asyncio.to_thread(_count_sync, sysfs_root)
-
-
-def get_active_display_count_sync(sysfs_root: Path = Path("/")) -> int:
-    """Same count, for callers that cannot await.
-
-    The work is a handful of small sysfs reads - the async variant above only
-    wraps it in a thread because it sits on request paths that already are
-    async. The plugin UI manifest is built synchronously and needs the same
-    answer, and reaching into the private helper from there would make this
-    module's public surface a lie.
-    """
-    return _count_sync(sysfs_root)
-
-
 def _states_sync(sysfs_root: Path) -> dict[str, bool]:
-    """Read, per connector, whether it is actually driving pixels."""
+    """Read, per connector, whether it is actually driving pixels.
+
+    This is the single sysfs walk for "is this connector lit?" - a connector
+    is lit when status='connected' AND enabled='enabled' (`enabled` covers
+    DPMS-off / unused: physically connected but no active mode). Keys are
+    KWin-style names (the "card<N>-" prefix stripped). `_count_sync` derives
+    its count from this map instead of re-walking sysfs with its own copy of
+    the predicate, so the count and the per-connector map cannot drift apart.
+    """
     drm = sysfs_root / "sys" / "class" / "drm"
     if not drm.exists():
         return {}
@@ -80,12 +45,37 @@ def _states_sync(sysfs_root: Path) -> dict[str, bool]:
     return states
 
 
+def _count_sync(sysfs_root: Path) -> int:
+    """Count of the connectors `_states_sync` reports as lit."""
+    return sum(_states_sync(sysfs_root).values())
+
+
+async def get_active_display_count(sysfs_root: Path = Path("/")) -> int:
+    """Count DRM connectors that are actually driving pixels.
+
+    See `_states_sync` for what "lit" means.
+    """
+    return await asyncio.to_thread(_count_sync, sysfs_root)
+
+
+def get_active_display_count_sync(sysfs_root: Path = Path("/")) -> int:
+    """Same count, for callers that cannot await.
+
+    The work is a handful of small sysfs reads - the async variant above only
+    wraps it in a thread because it sits on request paths that already are
+    async. The plugin UI manifest is built synchronously and needs the same
+    answer, and reaching into the private helper from there would make this
+    module's public surface a lie.
+    """
+    return _count_sync(sysfs_root)
+
+
 def get_connector_states_sync(sysfs_root: Path = Path("/")) -> dict[str, bool]:
     """Per-connector 'is this driving pixels?', keyed by the KWin name.
 
-    Same sysfs pass as get_active_display_count(), but keeps the names. The
-    display_output plugin needs to say WHICH output is lit, not how many are -
-    and a second sysfs reader for the same question would be the worse answer.
+    The display_output plugin needs to say WHICH output is lit, not how many
+    are - and a second sysfs reader for the same question would be the worse
+    answer, so this just exposes `_states_sync`.
     """
     return _states_sync(sysfs_root)
 

--- a/backend/app/services/power/gpu/display_detector.py
+++ b/backend/app/services/power/gpu/display_detector.py
@@ -77,7 +77,7 @@ def _count_sync(sysfs_root: Path) -> int:
 async def get_active_display_count(sysfs_root: Path = Path("/")) -> int:
     """Count DRM connectors that are actually driving pixels.
 
-    See `_states_sync` for what "lit" means.
+    See `_iter_connector_states` for what "lit" means.
     """
     return await asyncio.to_thread(_count_sync, sysfs_root)
 

--- a/backend/app/services/power/gpu/display_detector.py
+++ b/backend/app/services/power/gpu/display_detector.py
@@ -52,3 +52,44 @@ def get_active_display_count_sync(sysfs_root: Path = Path("/")) -> int:
     module's public surface a lie.
     """
     return _count_sync(sysfs_root)
+
+
+def _states_sync(sysfs_root: Path) -> dict[str, bool]:
+    """Read, per connector, whether it is actually driving pixels."""
+    drm = sysfs_root / "sys" / "class" / "drm"
+    if not drm.exists():
+        return {}
+    states: dict[str, bool] = {}
+    for entry in sorted(drm.iterdir()):
+        if not _CONNECTOR_RE.match(entry.name):
+            continue
+        status_file = entry / "status"
+        enabled_file = entry / "enabled"
+        if not status_file.exists() or not enabled_file.exists():
+            continue
+        try:
+            status = status_file.read_text().strip()
+            enabled = enabled_file.read_text().strip()
+        except OSError as exc:
+            logger.debug("Cannot read %s: %s", entry.name, exc)
+            continue
+        # KWin knows the connector without the "card<N>-" prefix.
+        states[_CONNECTOR_RE.sub("", entry.name)] = (
+            status == "connected" and enabled == "enabled"
+        )
+    return states
+
+
+def get_connector_states_sync(sysfs_root: Path = Path("/")) -> dict[str, bool]:
+    """Per-connector 'is this driving pixels?', keyed by the KWin name.
+
+    Same sysfs pass as get_active_display_count(), but keeps the names. The
+    display_output plugin needs to say WHICH output is lit, not how many are -
+    and a second sysfs reader for the same question would be the worse answer.
+    """
+    return _states_sync(sysfs_root)
+
+
+async def get_connector_states(sysfs_root: Path = Path("/")) -> dict[str, bool]:
+    """Async variant, for callers already on an event loop."""
+    return await asyncio.to_thread(_states_sync, sysfs_root)

--- a/backend/app/services/power_permissions.py
+++ b/backend/app/services/power_permissions.py
@@ -211,7 +211,7 @@ def check_permission(db: Session, user_id: int, action: str) -> bool:
         db: Database session
         user_id: User ID to check
         action: One of 'soft_sleep', 'wake', 'suspend', 'wol', 'toggle_desktop',
-            'unlock_session', 'control_audio'
+            'unlock_session', 'control_audio', 'manage_displays'
 
     Returns:
         True if the user has the permission, False otherwise.

--- a/backend/app/services/power_permissions.py
+++ b/backend/app/services/power_permissions.py
@@ -21,6 +21,7 @@ _ACTION_FIELD_MAP = {
     "toggle_desktop": "can_toggle_desktop",
     "unlock_session": "can_unlock_session",
     "control_audio": "can_control_audio",
+    "manage_displays": "can_manage_displays",
 }
 
 
@@ -49,6 +50,7 @@ def get_permissions(db: Session, user_id: int) -> UserPowerPermissionsResponse:
         can_toggle_desktop=perm.can_toggle_desktop,
         can_unlock_session=perm.can_unlock_session,
         can_control_audio=perm.can_control_audio,
+        can_manage_displays=perm.can_manage_displays,
         granted_by=perm.granted_by,
         granted_by_username=granted_by_username,
         granted_at=perm.granted_at,
@@ -122,6 +124,7 @@ def update_permissions(
         "can_toggle_desktop": perm.can_toggle_desktop,
         "can_unlock_session": perm.can_unlock_session,
         "can_control_audio": perm.can_control_audio,
+        "can_manage_displays": perm.can_manage_displays,
     }
 
     # Track which fields were explicitly set so implications can be applied
@@ -156,6 +159,8 @@ def update_permissions(
         perm.can_unlock_session = update.can_unlock_session
     if update.can_control_audio is not None:
         perm.can_control_audio = update.can_control_audio
+    if update.can_manage_displays is not None:
+        perm.can_manage_displays = update.can_manage_displays
 
     # Apply implication rules
     perm.can_soft_sleep, perm.can_wake, perm.can_suspend, perm.can_wol = (
@@ -179,6 +184,7 @@ def update_permissions(
         "can_toggle_desktop": perm.can_toggle_desktop,
         "can_unlock_session": perm.can_unlock_session,
         "can_control_audio": perm.can_control_audio,
+        "can_manage_displays": perm.can_manage_displays,
     }
 
     # Audit log

--- a/backend/tests/plugins/fixtures/kscreen_balunode.json
+++ b/backend/tests/plugins/fixtures/kscreen_balunode.json
@@ -1,0 +1,1113 @@
+{
+  "features": 255,
+  "outputs": [
+    {
+      "clones": [],
+      "connected": true,
+      "currentModeId": "1",
+      "enabled": false,
+      "followPreferredMode": false,
+      "hdr": false,
+      "icon": "",
+      "id": 1,
+      "modes": [
+        {
+          "id": "1",
+          "name": "2560x1440@144",
+          "refreshRate": 143.99899291992188,
+          "size": {
+            "height": 1440,
+            "width": 2560
+          }
+        },
+        {
+          "id": "10",
+          "name": "1920x1080@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "11",
+          "name": "1920x1080@60",
+          "refreshRate": 59.939998626708984,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "12",
+          "name": "1920x1080@50",
+          "refreshRate": 50,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "13",
+          "name": "1600x1200@144",
+          "refreshRate": 143.99899291992188,
+          "size": {
+            "height": 1200,
+            "width": 1600
+          }
+        },
+        {
+          "id": "14",
+          "name": "1680x1050@60",
+          "refreshRate": 59.882999420166016,
+          "size": {
+            "height": 1050,
+            "width": 1680
+          }
+        },
+        {
+          "id": "15",
+          "name": "1280x1024@75",
+          "refreshRate": 75.0250015258789,
+          "size": {
+            "height": 1024,
+            "width": 1280
+          }
+        },
+        {
+          "id": "16",
+          "name": "1280x1024@60",
+          "refreshRate": 60.02000045776367,
+          "size": {
+            "height": 1024,
+            "width": 1280
+          }
+        },
+        {
+          "id": "17",
+          "name": "1440x900@60",
+          "refreshRate": 59.9010009765625,
+          "size": {
+            "height": 900,
+            "width": 1440
+          }
+        },
+        {
+          "id": "18",
+          "name": "1280x960@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 960,
+            "width": 1280
+          }
+        },
+        {
+          "id": "19",
+          "name": "1280x800@60",
+          "refreshRate": 59.90999984741211,
+          "size": {
+            "height": 800,
+            "width": 1280
+          }
+        },
+        {
+          "id": "2",
+          "name": "3840x2160@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "20",
+          "name": "1152x864@75",
+          "refreshRate": 75,
+          "size": {
+            "height": 864,
+            "width": 1152
+          }
+        },
+        {
+          "id": "21",
+          "name": "1280x720@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 720,
+            "width": 1280
+          }
+        },
+        {
+          "id": "22",
+          "name": "1280x720@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 720,
+            "width": 1280
+          }
+        },
+        {
+          "id": "23",
+          "name": "1280x720@60",
+          "refreshRate": 59.939998626708984,
+          "size": {
+            "height": 720,
+            "width": 1280
+          }
+        },
+        {
+          "id": "24",
+          "name": "1280x720@50",
+          "refreshRate": 50,
+          "size": {
+            "height": 720,
+            "width": 1280
+          }
+        },
+        {
+          "id": "25",
+          "name": "1024x768@75",
+          "refreshRate": 75.02899932861328,
+          "size": {
+            "height": 768,
+            "width": 1024
+          }
+        },
+        {
+          "id": "26",
+          "name": "1024x768@70",
+          "refreshRate": 70.06900024414062,
+          "size": {
+            "height": 768,
+            "width": 1024
+          }
+        },
+        {
+          "id": "27",
+          "name": "1024x768@60",
+          "refreshRate": 60.00400161743164,
+          "size": {
+            "height": 768,
+            "width": 1024
+          }
+        },
+        {
+          "id": "28",
+          "name": "832x624@75",
+          "refreshRate": 74.5510025024414,
+          "size": {
+            "height": 624,
+            "width": 832
+          }
+        },
+        {
+          "id": "29",
+          "name": "800x600@75",
+          "refreshRate": 75,
+          "size": {
+            "height": 600,
+            "width": 800
+          }
+        },
+        {
+          "id": "3",
+          "name": "3840x2160@60",
+          "refreshRate": 59.939998626708984,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "30",
+          "name": "800x600@72",
+          "refreshRate": 72.18800354003906,
+          "size": {
+            "height": 600,
+            "width": 800
+          }
+        },
+        {
+          "id": "31",
+          "name": "800x600@60",
+          "refreshRate": 60.31700134277344,
+          "size": {
+            "height": 600,
+            "width": 800
+          }
+        },
+        {
+          "id": "32",
+          "name": "800x600@56",
+          "refreshRate": 56.25,
+          "size": {
+            "height": 600,
+            "width": 800
+          }
+        },
+        {
+          "id": "33",
+          "name": "720x576@50",
+          "refreshRate": 50,
+          "size": {
+            "height": 576,
+            "width": 720
+          }
+        },
+        {
+          "id": "34",
+          "name": "720x576@50",
+          "refreshRate": 50,
+          "size": {
+            "height": 576,
+            "width": 720
+          }
+        },
+        {
+          "id": "35",
+          "name": "720x480@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 480,
+            "width": 720
+          }
+        },
+        {
+          "id": "36",
+          "name": "720x480@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 480,
+            "width": 720
+          }
+        },
+        {
+          "id": "37",
+          "name": "720x480@60",
+          "refreshRate": 59.939998626708984,
+          "size": {
+            "height": 480,
+            "width": 720
+          }
+        },
+        {
+          "id": "38",
+          "name": "720x480@60",
+          "refreshRate": 59.939998626708984,
+          "size": {
+            "height": 480,
+            "width": 720
+          }
+        },
+        {
+          "id": "39",
+          "name": "640x480@75",
+          "refreshRate": 75,
+          "size": {
+            "height": 480,
+            "width": 640
+          }
+        },
+        {
+          "id": "4",
+          "name": "3840x2160@50",
+          "refreshRate": 50,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "40",
+          "name": "640x480@73",
+          "refreshRate": 72.80899810791016,
+          "size": {
+            "height": 480,
+            "width": 640
+          }
+        },
+        {
+          "id": "41",
+          "name": "640x480@67",
+          "refreshRate": 66.66699981689453,
+          "size": {
+            "height": 480,
+            "width": 640
+          }
+        },
+        {
+          "id": "42",
+          "name": "640x480@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 480,
+            "width": 640
+          }
+        },
+        {
+          "id": "43",
+          "name": "640x480@60",
+          "refreshRate": 59.939998626708984,
+          "size": {
+            "height": 480,
+            "width": 640
+          }
+        },
+        {
+          "id": "44",
+          "name": "720x400@70",
+          "refreshRate": 70.08200073242188,
+          "size": {
+            "height": 400,
+            "width": 720
+          }
+        },
+        {
+          "id": "45",
+          "name": "1600x1200@60",
+          "refreshRate": 59.86899948120117,
+          "size": {
+            "height": 1200,
+            "width": 1600
+          }
+        },
+        {
+          "id": "46",
+          "name": "1280x1024@144",
+          "refreshRate": 143.79299926757812,
+          "size": {
+            "height": 1024,
+            "width": 1280
+          }
+        },
+        {
+          "id": "47",
+          "name": "1024x768@144",
+          "refreshRate": 143.8679962158203,
+          "size": {
+            "height": 768,
+            "width": 1024
+          }
+        },
+        {
+          "id": "48",
+          "name": "1920x1200@60",
+          "refreshRate": 59.8849983215332,
+          "size": {
+            "height": 1200,
+            "width": 1920
+          }
+        },
+        {
+          "id": "49",
+          "name": "1280x800@144",
+          "refreshRate": 143.8350067138672,
+          "size": {
+            "height": 800,
+            "width": 1280
+          }
+        },
+        {
+          "id": "5",
+          "name": "2560x1440@120",
+          "refreshRate": 119.99800109863281,
+          "size": {
+            "height": 1440,
+            "width": 2560
+          }
+        },
+        {
+          "id": "50",
+          "name": "1920x1080@144",
+          "refreshRate": 143.8820037841797,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "51",
+          "name": "1600x900@60",
+          "refreshRate": 59.94599914550781,
+          "size": {
+            "height": 900,
+            "width": 1600
+          }
+        },
+        {
+          "id": "52",
+          "name": "1600x900@144",
+          "refreshRate": 143.92599487304688,
+          "size": {
+            "height": 900,
+            "width": 1600
+          }
+        },
+        {
+          "id": "53",
+          "name": "1368x768@60",
+          "refreshRate": 59.88199996948242,
+          "size": {
+            "height": 768,
+            "width": 1368
+          }
+        },
+        {
+          "id": "54",
+          "name": "1368x768@144",
+          "refreshRate": 143.7689971923828,
+          "size": {
+            "height": 768,
+            "width": 1368
+          }
+        },
+        {
+          "id": "55",
+          "name": "1280x720@144",
+          "refreshRate": 143.6719970703125,
+          "size": {
+            "height": 720,
+            "width": 1280
+          }
+        },
+        {
+          "id": "6",
+          "name": "2560x1440@100",
+          "refreshRate": 99.94599914550781,
+          "size": {
+            "height": 1440,
+            "width": 2560
+          }
+        },
+        {
+          "id": "7",
+          "name": "2560x1440@60",
+          "refreshRate": 59.95100021362305,
+          "size": {
+            "height": 1440,
+            "width": 2560
+          }
+        },
+        {
+          "id": "8",
+          "name": "1920x1200@144",
+          "refreshRate": 143.99899291992188,
+          "size": {
+            "height": 1200,
+            "width": 1920
+          }
+        },
+        {
+          "id": "9",
+          "name": "1920x1080@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        }
+      ],
+      "name": "HDMI-A-1",
+      "overscan": 0,
+      "pos": {
+        "x": 0,
+        "y": 0
+      },
+      "preferredModes": [
+        "1"
+      ],
+      "priority": 0,
+      "replicationSource": 0,
+      "rotation": 1,
+      "scale": 1,
+      "sdr-brightness": 455,
+      "size": {
+        "height": 1440,
+        "width": 2560
+      },
+      "sizeMM": {
+        "height": 336,
+        "width": 597
+      },
+      "type": 6,
+      "vrrPolicy": 0,
+      "wcg": false
+    },
+    {
+      "clones": [],
+      "connected": true,
+      "currentModeId": "57",
+      "enabled": true,
+      "followPreferredMode": false,
+      "hdr": true,
+      "icon": "",
+      "id": 2,
+      "modes": [
+        {
+          "id": "100",
+          "name": "2560x1600@60",
+          "refreshRate": 59.98699951171875,
+          "size": {
+            "height": 1600,
+            "width": 2560
+          }
+        },
+        {
+          "id": "101",
+          "name": "2560x1600@120",
+          "refreshRate": 119.93499755859375,
+          "size": {
+            "height": 1600,
+            "width": 2560
+          }
+        },
+        {
+          "id": "102",
+          "name": "1920x1200@120",
+          "refreshRate": 119.90399932861328,
+          "size": {
+            "height": 1200,
+            "width": 1920
+          }
+        },
+        {
+          "id": "103",
+          "name": "1280x800@120",
+          "refreshRate": 119.84600067138672,
+          "size": {
+            "height": 800,
+            "width": 1280
+          }
+        },
+        {
+          "id": "104",
+          "name": "3200x1800@60",
+          "refreshRate": 59.95600128173828,
+          "size": {
+            "height": 1800,
+            "width": 3200
+          }
+        },
+        {
+          "id": "105",
+          "name": "3200x1800@120",
+          "refreshRate": 119.95899963378906,
+          "size": {
+            "height": 1800,
+            "width": 3200
+          }
+        },
+        {
+          "id": "106",
+          "name": "2880x1620@60",
+          "refreshRate": 59.959999084472656,
+          "size": {
+            "height": 1620,
+            "width": 2880
+          }
+        },
+        {
+          "id": "107",
+          "name": "2880x1620@120",
+          "refreshRate": 119.9530029296875,
+          "size": {
+            "height": 1620,
+            "width": 2880
+          }
+        },
+        {
+          "id": "108",
+          "name": "2560x1440@60",
+          "refreshRate": 59.96099853515625,
+          "size": {
+            "height": 1440,
+            "width": 2560
+          }
+        },
+        {
+          "id": "109",
+          "name": "1600x900@60",
+          "refreshRate": 59.94599914550781,
+          "size": {
+            "height": 900,
+            "width": 1600
+          }
+        },
+        {
+          "id": "110",
+          "name": "1600x900@120",
+          "refreshRate": 119.947998046875,
+          "size": {
+            "height": 900,
+            "width": 1600
+          }
+        },
+        {
+          "id": "111",
+          "name": "1368x768@60",
+          "refreshRate": 59.88199996948242,
+          "size": {
+            "height": 768,
+            "width": 1368
+          }
+        },
+        {
+          "id": "112",
+          "name": "1368x768@120",
+          "refreshRate": 119.83100128173828,
+          "size": {
+            "height": 768,
+            "width": 1368
+          }
+        },
+        {
+          "id": "113",
+          "name": "1280x720@120",
+          "refreshRate": 119.85800170898438,
+          "size": {
+            "height": 720,
+            "width": 1280
+          }
+        },
+        {
+          "id": "56",
+          "name": "3840x2160@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "57",
+          "name": "3840x2160@120",
+          "refreshRate": 120,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "58",
+          "name": "3840x2160@120",
+          "refreshRate": 119.87999725341797,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "59",
+          "name": "3840x2160@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "60",
+          "name": "3840x2160@60",
+          "refreshRate": 59.939998626708984,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "61",
+          "name": "3840x2160@50",
+          "refreshRate": 50,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "62",
+          "name": "3840x2160@30",
+          "refreshRate": 30,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "63",
+          "name": "3840x2160@30",
+          "refreshRate": 29.969999313354492,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "64",
+          "name": "3840x2160@25",
+          "refreshRate": 25,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "65",
+          "name": "3840x2160@24",
+          "refreshRate": 24,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "66",
+          "name": "3840x2160@24",
+          "refreshRate": 23.97599983215332,
+          "size": {
+            "height": 2160,
+            "width": 3840
+          }
+        },
+        {
+          "id": "67",
+          "name": "2560x1440@120",
+          "refreshRate": 119.99800109863281,
+          "size": {
+            "height": 1440,
+            "width": 2560
+          }
+        },
+        {
+          "id": "68",
+          "name": "1920x1200@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 1200,
+            "width": 1920
+          }
+        },
+        {
+          "id": "69",
+          "name": "1920x1080@120",
+          "refreshRate": 120,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "70",
+          "name": "1920x1080@120",
+          "refreshRate": 119.87999725341797,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "71",
+          "name": "1920x1080@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "72",
+          "name": "1920x1080@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "73",
+          "name": "1920x1080@60",
+          "refreshRate": 59.939998626708984,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "74",
+          "name": "1920x1080@50",
+          "refreshRate": 50,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "75",
+          "name": "1920x1080@30",
+          "refreshRate": 30,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "76",
+          "name": "1920x1080@30",
+          "refreshRate": 29.969999313354492,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "77",
+          "name": "1920x1080@25",
+          "refreshRate": 25,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "78",
+          "name": "1920x1080@24",
+          "refreshRate": 24,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "79",
+          "name": "1920x1080@24",
+          "refreshRate": 23.97599983215332,
+          "size": {
+            "height": 1080,
+            "width": 1920
+          }
+        },
+        {
+          "id": "80",
+          "name": "1600x1200@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 1200,
+            "width": 1600
+          }
+        },
+        {
+          "id": "81",
+          "name": "1680x1050@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 1050,
+            "width": 1680
+          }
+        },
+        {
+          "id": "82",
+          "name": "1280x1024@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 1024,
+            "width": 1280
+          }
+        },
+        {
+          "id": "83",
+          "name": "1440x900@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 900,
+            "width": 1440
+          }
+        },
+        {
+          "id": "84",
+          "name": "1280x800@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 800,
+            "width": 1280
+          }
+        },
+        {
+          "id": "85",
+          "name": "1280x720@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 720,
+            "width": 1280
+          }
+        },
+        {
+          "id": "86",
+          "name": "1280x720@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 720,
+            "width": 1280
+          }
+        },
+        {
+          "id": "87",
+          "name": "1280x720@60",
+          "refreshRate": 59.939998626708984,
+          "size": {
+            "height": 720,
+            "width": 1280
+          }
+        },
+        {
+          "id": "88",
+          "name": "1280x720@50",
+          "refreshRate": 50,
+          "size": {
+            "height": 720,
+            "width": 1280
+          }
+        },
+        {
+          "id": "89",
+          "name": "1024x768@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 768,
+            "width": 1024
+          }
+        },
+        {
+          "id": "90",
+          "name": "800x600@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 600,
+            "width": 800
+          }
+        },
+        {
+          "id": "91",
+          "name": "720x576@50",
+          "refreshRate": 50,
+          "size": {
+            "height": 576,
+            "width": 720
+          }
+        },
+        {
+          "id": "92",
+          "name": "720x480@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 480,
+            "width": 720
+          }
+        },
+        {
+          "id": "93",
+          "name": "720x480@60",
+          "refreshRate": 59.939998626708984,
+          "size": {
+            "height": 480,
+            "width": 720
+          }
+        },
+        {
+          "id": "94",
+          "name": "640x480@60",
+          "refreshRate": 60,
+          "size": {
+            "height": 480,
+            "width": 640
+          }
+        },
+        {
+          "id": "95",
+          "name": "640x480@60",
+          "refreshRate": 59.939998626708984,
+          "size": {
+            "height": 480,
+            "width": 640
+          }
+        },
+        {
+          "id": "96",
+          "name": "640x480@60",
+          "refreshRate": 59.939998626708984,
+          "size": {
+            "height": 480,
+            "width": 640
+          }
+        },
+        {
+          "id": "97",
+          "name": "1600x1200@120",
+          "refreshRate": 119.822998046875,
+          "size": {
+            "height": 1200,
+            "width": 1600
+          }
+        },
+        {
+          "id": "98",
+          "name": "1280x1024@120",
+          "refreshRate": 119.83499908447266,
+          "size": {
+            "height": 1024,
+            "width": 1280
+          }
+        },
+        {
+          "id": "99",
+          "name": "1024x768@120",
+          "refreshRate": 119.80400085449219,
+          "size": {
+            "height": 768,
+            "width": 1024
+          }
+        }
+      ],
+      "name": "DP-3",
+      "overscan": 0,
+      "pos": {
+        "x": 0,
+        "y": 0
+      },
+      "preferredModes": [
+        "56"
+      ],
+      "priority": 1,
+      "replicationSource": 0,
+      "rotation": 1,
+      "scale": 2.5,
+      "sdr-brightness": 300,
+      "size": {
+        "height": 2160,
+        "width": 3840
+      },
+      "sizeMM": {
+        "height": 810,
+        "width": 1440
+      },
+      "type": 14,
+      "wcg": true
+    }
+  ],
+  "screen": {
+    "currentSize": {
+      "height": 864,
+      "width": 1536
+    },
+    "id": 0,
+    "maxActiveOutputsCount": 2,
+    "maxSize": {
+      "height": 64000,
+      "width": 64000
+    },
+    "minSize": {
+      "height": 0,
+      "width": 0
+    }
+  },
+  "tabletModeAvailable": false,
+  "tabletModeEngaged": false
+}

--- a/backend/tests/plugins/test_display_output_backend.py
+++ b/backend/tests/plugins/test_display_output_backend.py
@@ -1,0 +1,106 @@
+"""Dev-Backend und die DRM-Verschmelzung des KWin-Backends."""
+from unittest.mock import patch
+
+import pytest
+
+from app.plugins.installed.display_output.backend import DevDisplayBackend, KWinDisplayBackend
+
+
+class TestDevBackend:
+    @pytest.mark.asyncio
+    async def test_mirrors_balunode_with_two_connected_outputs(self):
+        layout = await DevDisplayBackend().get_layout()
+        assert [o.name for o in layout.outputs] == ["HDMI-A-1", "DP-3"]
+        assert all(o.connected for o in layout.outputs)
+
+    @pytest.mark.asyncio
+    async def test_carries_the_ambiguous_120hz_pair(self):
+        # Ohne diese Dublette laesst sich die Beschriftungslogik unter Windows
+        # nicht bedienen - und genau sie ist der Grund fuer die ID-Adressierung.
+        layout = await DevDisplayBackend().get_layout()
+        dp3 = next(o for o in layout.outputs if o.name == "DP-3")
+        names = [m.name for m in dp3.modes if m.name == "3840x2160@120"]
+        assert len(names) == 2
+
+    @pytest.mark.asyncio
+    async def test_apply_changes_what_the_next_read_returns(self):
+        backend = DevDisplayBackend()
+        live = (await backend.get_layout()).outputs
+        ok, _ = await backend.apply({"HDMI-A-1": (True, "1"), "DP-3": (False, None)}, live)
+        assert ok is True
+        after = {o.name: o for o in (await backend.get_layout()).outputs}
+        assert after["HDMI-A-1"].selected is True
+        assert after["DP-3"].selected is False
+        assert after["HDMI-A-1"].current_mode_id == "1"
+
+    @pytest.mark.asyncio
+    async def test_lit_follows_selected_in_dev_mode(self):
+        backend = DevDisplayBackend()
+        layout = await backend.get_layout()
+        for output in layout.outputs:
+            assert output.lit == output.selected
+        assert layout.displays_powered is True
+
+
+class TestKWinBackend:
+    @pytest.mark.asyncio
+    async def test_an_unreachable_session_is_reported_not_raised(self):
+        with patch(
+            "app.plugins.installed.display_output.backend.run_kscreen_json", return_value=None
+        ):
+            layout = await KWinDisplayBackend().get_layout()
+        assert layout.available is False
+        assert layout.outputs == []
+
+    @pytest.mark.asyncio
+    async def test_merges_the_drm_layer_into_lit(self):
+        payload = {"outputs": [{
+            "name": "DP-3", "connected": True, "enabled": True, "currentModeId": "57",
+            "modes": [{"id": "57", "name": "3840x2160@120", "refreshRate": 120,
+                       "size": {"width": 3840, "height": 2160}}],
+        }]}
+        with patch(
+            "app.plugins.installed.display_output.backend.run_kscreen_json", return_value=payload
+        ), patch(
+            "app.plugins.installed.display_output.backend.get_connector_states",
+            return_value={"DP-3": True},
+        ):
+            layout = await KWinDisplayBackend().get_layout()
+        assert layout.outputs[0].lit is True
+        assert layout.displays_powered is True
+
+    @pytest.mark.asyncio
+    async def test_an_unmappable_output_stays_unknown_not_dark(self):
+        payload = {"outputs": [{
+            "name": "DP-9", "connected": True, "enabled": True,
+            "modes": [{"id": "1", "name": "1920x1080@60", "refreshRate": 60,
+                       "size": {"width": 1920, "height": 1080}}],
+        }]}
+        with patch(
+            "app.plugins.installed.display_output.backend.run_kscreen_json", return_value=payload
+        ), patch(
+            "app.plugins.installed.display_output.backend.get_connector_states",
+            return_value={"DP-3": True},
+        ):
+            layout = await KWinDisplayBackend().get_layout()
+        assert layout.outputs[0].lit is None
+
+    @pytest.mark.asyncio
+    async def test_the_selection_is_dark_when_no_connector_is_lit(self):
+        payload = {"outputs": [{
+            "name": "DP-3", "connected": True, "enabled": True,
+            "modes": [{"id": "1", "name": "1920x1080@60", "refreshRate": 60,
+                       "size": {"width": 1920, "height": 1080}}],
+        }]}
+        with patch(
+            "app.plugins.installed.display_output.backend.run_kscreen_json", return_value=payload
+        ), patch(
+            "app.plugins.installed.display_output.backend.get_connector_states",
+            return_value={"DP-3": False},
+        ):
+            layout = await KWinDisplayBackend().get_layout()
+        # Genau der Zustand, der DesktopTogglePanel "Gestoppt" melden laesst,
+        # waehrend KWin DP-3 fuer gewaehlt haelt. Kein Widerspruch, zwei Ebenen.
+        assert layout.outputs[0].selected is True
+        assert layout.outputs[0].lit is False
+        assert layout.displays_powered is False

--- a/backend/tests/plugins/test_display_output_kscreen.py
+++ b/backend/tests/plugins/test_display_output_kscreen.py
@@ -2,6 +2,8 @@
 import subprocess
 from unittest.mock import patch
 
+import pytest
+
 from app.plugins.installed.display_output import kscreen
 from app.plugins.installed.display_output.models import DisplayMode, DisplayOutput
 
@@ -59,6 +61,18 @@ class TestBuildApplyArgs:
 
 
 class TestRunKscreen:
+    # wayland_session_env() liest os.getuid(), das es unter Windows nicht
+    # gibt - und wird als Argument ausgewertet, BEVOR das gepatchte
+    # subprocess.run ueberhaupt aufgerufen wird. Ohne diesen Patch bricht
+    # jeder Test hier schon beim Aufbau von env= ab, egal was subprocess.run
+    # zurueckgeben soll. Gegenstand dieser Tests ist die Fehlerbehandlung
+    # des Runners, nicht der Umgebungs-Helfer (eigene Tests in
+    # tests/test_session_env.py) - deshalb wird er hier nur stillgelegt.
+    @pytest.fixture(autouse=True)
+    def _stub_session_env(self):
+        with patch.object(kscreen, "wayland_session_env", return_value={}):
+            yield
+
     def test_a_missing_binary_is_reported_not_raised(self):
         with patch("subprocess.run", side_effect=FileNotFoundError()):
             ok, message = kscreen.run_kscreen(["--dpms", "on"])

--- a/backend/tests/plugins/test_display_output_kscreen.py
+++ b/backend/tests/plugins/test_display_output_kscreen.py
@@ -1,0 +1,99 @@
+"""Runner und Argumentbau: kein Wert ohne Enumeration, ein Aufruf, kein Hang."""
+import subprocess
+from unittest.mock import patch
+
+from app.plugins.installed.display_output import kscreen
+from app.plugins.installed.display_output.models import DisplayMode, DisplayOutput
+
+
+def _output(name: str, selected: bool, mode_ids: list[str]) -> DisplayOutput:
+    return DisplayOutput(
+        name=name,
+        connected=True,
+        selected=selected,
+        modes=[
+            DisplayMode(id=i, name=f"m{i}", width=1920, height=1080, refresh_rate=60.0)
+            for i in mode_ids
+        ],
+    )
+
+
+LIVE = [_output("HDMI-A-1", False, ["1", "9"]), _output("DP-3", True, ["57", "58"])]
+
+
+class TestBuildApplyArgs:
+    def test_one_call_carries_every_change(self):
+        args = kscreen.build_apply_args(
+            {"DP-3": (True, "57"), "HDMI-A-1": (False, None)}, LIVE
+        )
+        assert args == [
+            "kscreen-doctor",
+            "output.HDMI-A-1.disable",
+            "output.DP-3.enable",
+            "output.DP-3.mode.57",
+        ]
+
+    def test_order_follows_the_enumeration_not_the_request(self):
+        # Deterministisch, damit der Vektor pruefbar ist - und unabhaengig
+        # davon, in welcher Reihenfolge der Client seine Ausgaenge schickt.
+        a = kscreen.build_apply_args({"DP-3": (True, None), "HDMI-A-1": (True, None)}, LIVE)
+        b = kscreen.build_apply_args({"HDMI-A-1": (True, None), "DP-3": (True, None)}, LIVE)
+        assert a == b
+        assert a.index("output.HDMI-A-1.enable") < a.index("output.DP-3.enable")
+
+    def test_an_output_the_request_omits_is_left_alone(self):
+        args = kscreen.build_apply_args({"DP-3": (True, "58")}, LIVE)
+        assert not any("HDMI-A-1" in a for a in args)
+
+    def test_a_mode_on_a_deselected_output_is_ignored(self):
+        # Siehe Spec 7: KWin behaelt die Modus-Wahl eines abgewaehlten
+        # Ausgangs ohnehin; ein Fehler waere Schikane gegen eine UI, die
+        # schlicht den angezeigten Zustand zurueckschickt.
+        args = kscreen.build_apply_args({"HDMI-A-1": (False, "9")}, LIVE)
+        assert args == ["kscreen-doctor", "output.HDMI-A-1.disable"]
+
+    def test_mode_is_addressed_by_id_never_by_name(self):
+        args = kscreen.build_apply_args({"DP-3": (True, "58")}, LIVE)
+        assert "output.DP-3.mode.58" in args
+        assert not any("@" in a for a in args)
+
+
+class TestRunKscreen:
+    def test_a_missing_binary_is_reported_not_raised(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            ok, message = kscreen.run_kscreen(["--dpms", "on"])
+        assert ok is False
+        assert "kscreen-doctor" in message
+
+    def test_a_timeout_is_reported_not_raised(self):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("x", 10)):
+            ok, message = kscreen.run_kscreen(["-j"])
+        assert ok is False
+
+    def test_a_nonzero_exit_is_a_failure(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
+        with patch("subprocess.run", return_value=completed):
+            ok, message = kscreen.run_kscreen(["-j"])
+        assert ok is False
+        assert message == "boom"
+
+    def test_the_call_always_carries_a_timeout(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr="")
+        with patch("subprocess.run", return_value=completed) as run:
+            kscreen.run_kscreen(["-j"])
+        assert run.call_args.kwargs["timeout"] == kscreen.KSCREEN_TIMEOUT_SECONDS
+        assert run.call_args.kwargs.get("shell") in (None, False)
+
+
+class TestRunKscreenJson:
+    def test_invalid_json_yields_none_instead_of_raising(self):
+        with patch.object(kscreen, "run_kscreen", return_value=(True, "not json")):
+            assert kscreen.run_kscreen_json() is None
+
+    def test_a_failed_call_yields_none(self):
+        with patch.object(kscreen, "run_kscreen", return_value=(False, "boom")):
+            assert kscreen.run_kscreen_json() is None
+
+    def test_valid_json_is_parsed(self):
+        with patch.object(kscreen, "run_kscreen", return_value=(True, '{"outputs": []}')):
+            assert kscreen.run_kscreen_json() == {"outputs": []}

--- a/backend/tests/plugins/test_display_output_parser.py
+++ b/backend/tests/plugins/test_display_output_parser.py
@@ -96,3 +96,47 @@ class TestParseModesInIsolation:
 
     def test_an_empty_list_yields_no_modes(self):
         assert parse_modes([]) == []
+
+
+class TestCollapsedCurrentModeRemap:
+    """currentModeId/preferredModes[0] duerfen nie auf eine kollabierte ID zeigen.
+
+    parse_modes fasst exakte Dubletten zusammen und behaelt die kleinere ID.
+    Zeigt KWins currentModeId (oder preferredModes[0]) auf die groessere,
+    verworfene ID des Paars, existiert diese ID in der zurueckgegebenen
+    Modenliste nicht mehr - das Frontend-Auswahlfeld (`value={entry.modeId
+    ?? ''}`) trifft dann kein <option> und zeigt keine aktuelle Aufloesung.
+    """
+
+    @staticmethod
+    def _payload(current_mode_id=None, preferred_modes=None) -> dict:
+        output = {
+            "name": "HDMI-A-1", "connected": True, "enabled": True,
+            "modes": [
+                {"id": "9", "name": "1920x1080@60", "refreshRate": 60,
+                 "size": {"width": 1920, "height": 1080}},
+                {"id": "10", "name": "1920x1080@60", "refreshRate": 60,
+                 "size": {"width": 1920, "height": 1080}},
+            ],
+        }
+        if current_mode_id is not None:
+            output["currentModeId"] = current_mode_id
+        if preferred_modes is not None:
+            output["preferredModes"] = preferred_modes
+        return {"outputs": [output]}
+
+    def test_current_mode_id_remaps_to_the_surviving_duplicate(self):
+        outputs = parse_outputs(self._payload(current_mode_id="10"))
+        surviving_ids = [m.id for m in outputs[0].modes]
+        assert outputs[0].current_mode_id == "9"
+        assert outputs[0].current_mode_id in surviving_ids
+
+    def test_preferred_mode_id_remaps_to_the_surviving_duplicate(self):
+        outputs = parse_outputs(self._payload(preferred_modes=["10"]))
+        surviving_ids = [m.id for m in outputs[0].modes]
+        assert outputs[0].preferred_mode_id == "9"
+        assert outputs[0].preferred_mode_id in surviving_ids
+
+    def test_a_non_collapsed_current_mode_id_is_left_alone(self):
+        outputs = parse_outputs(self._payload(current_mode_id="9"))
+        assert outputs[0].current_mode_id == "9"

--- a/backend/tests/plugins/test_display_output_parser.py
+++ b/backend/tests/plugins/test_display_output_parser.py
@@ -1,0 +1,98 @@
+"""Parser-Tests gegen den gemessenen kscreen-doctor-Mitschnitt von BaluNode."""
+import json
+from pathlib import Path
+
+import pytest
+
+from app.plugins.installed.display_output.kscreen import parse_modes, parse_outputs
+
+FIXTURE = Path(__file__).parent / "fixtures" / "kscreen_balunode.json"
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def outputs(payload):
+    return parse_outputs(payload)
+
+
+class TestOutputs:
+    def test_lists_both_connected_outputs(self, outputs):
+        assert [o.name for o in outputs] == ["HDMI-A-1", "DP-3"]
+
+    def test_selected_mirrors_kwin_enabled(self, outputs):
+        by_name = {o.name: o for o in outputs}
+        assert by_name["DP-3"].selected is True
+        assert by_name["HDMI-A-1"].selected is False
+
+    def test_lit_is_unknown_until_the_drm_layer_is_merged(self, outputs):
+        # Der Parser kennt sysfs nicht. None heisst "nicht beantwortet",
+        # nicht "aus" - siehe Spec 5.
+        assert all(o.lit is None for o in outputs)
+
+    def test_current_and_preferred_are_mode_ids(self, outputs):
+        by_name = {o.name: o for o in outputs}
+        assert by_name["DP-3"].current_mode_id == "57"
+        assert by_name["DP-3"].preferred_mode_id == "56"
+        assert by_name["HDMI-A-1"].current_mode_id == "1"
+
+    def test_scale_is_read(self, outputs):
+        by_name = {o.name: o for o in outputs}
+        assert by_name["DP-3"].scale == 2.5
+
+    def test_a_missing_optional_field_does_not_break_the_parser(self, outputs):
+        # DP-3 traegt kein vrrPolicy. Ein direkter Indexzugriff kippte hier.
+        assert len(outputs) == 2
+
+
+class TestModes:
+    def test_exact_duplicates_collapse_and_distinct_rates_survive(self, outputs):
+        hdmi = next(o for o in outputs if o.name == "HDMI-A-1")
+        # 55 Roheintraege, fuenf exakte Dubletten fallen weg.
+        assert len(hdmi.modes) == 50
+
+    def test_the_collapsed_duplicate_keeps_the_lower_id(self, outputs):
+        hdmi = next(o for o in outputs if o.name == "HDMI-A-1")
+        fullhd_60 = [
+            m for m in hdmi.modes
+            if m.width == 1920 and m.height == 1080 and round(m.refresh_rate, 2) == 60.0
+        ]
+        assert len(fullhd_60) == 1
+        assert fullhd_60[0].id == "9"
+
+    def test_the_120hz_pair_is_kept_apart(self, outputs):
+        dp3 = next(o for o in outputs if o.name == "DP-3")
+        uhd = [m for m in dp3.modes if m.width == 3840 and m.height == 2160]
+        rates = sorted(round(m.refresh_rate, 2) for m in uhd if round(m.refresh_rate, 2) >= 119)
+        assert rates == [119.88, 120.0]
+
+    def test_both_of_the_pair_carry_the_same_ambiguous_name(self, outputs):
+        dp3 = next(o for o in outputs if o.name == "DP-3")
+        pair = {m.id: m.name for m in dp3.modes if m.id in ("57", "58")}
+        assert pair == {"57": "3840x2160@120", "58": "3840x2160@120"}
+
+    def test_modes_are_sorted_by_area_then_refresh_descending(self, outputs):
+        dp3 = next(o for o in outputs if o.name == "DP-3")
+        keys = [(-(m.width * m.height), -m.refresh_rate) for m in dp3.modes]
+        assert keys == sorted(keys)
+
+    def test_the_refresh_rate_is_not_rounded(self, outputs):
+        dp3 = next(o for o in outputs if o.name == "DP-3")
+        mode58 = next(m for m in dp3.modes if m.id == "58")
+        assert mode58.refresh_rate == pytest.approx(119.87999725, rel=1e-9)
+
+
+class TestParseModesInIsolation:
+    def test_a_mode_without_size_is_skipped(self):
+        modes = parse_modes([
+            {"id": "1", "name": "1920x1080@60", "refreshRate": 60,
+             "size": {"width": 1920, "height": 1080}},
+            {"id": "2", "name": "broken"},
+        ])
+        assert [m.id for m in modes] == ["1"]
+
+    def test_an_empty_list_yields_no_modes(self):
+        assert parse_modes([]) == []

--- a/backend/tests/plugins/test_display_output_routes.py
+++ b/backend/tests/plugins/test_display_output_routes.py
@@ -1,0 +1,155 @@
+"""Routen-Tests: Berechtigung, Statuscodes, keine Interna in der Antwort."""
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.deps import require_power_manage_displays
+from app.plugins.installed.display_output import DisplayOutputPlugin
+from app.plugins.installed.display_output import service as service_module
+from app.plugins.installed.display_output.backend import DevDisplayBackend
+from app.plugins.installed.display_output.models import DisplayLayout
+from app.plugins.installed.display_output.service import DisplayService
+
+BASE = "/api/plugins/display_output"
+
+
+class _User:
+    username = "admin"
+    role = "admin"
+    id = 1
+
+
+def _app(service: DisplayService) -> TestClient:
+    app = FastAPI()
+    app.include_router(DisplayOutputPlugin().get_router(), prefix=BASE)
+    app.dependency_overrides[require_power_manage_displays] = lambda: _User()
+    return TestClient(app)
+
+
+@pytest.fixture
+def client(monkeypatch) -> TestClient:
+    service = DisplayService(backend=DevDisplayBackend())
+    monkeypatch.setattr(service_module, "get_display_service", lambda: service)
+    return _app(service)
+
+
+class TestStateRoute:
+    def test_returns_both_outputs_with_their_modes(self, client):
+        body = client.get(f"{BASE}/state").json()
+        assert body["available"] is True
+        assert [o["name"] for o in body["outputs"]] == ["HDMI-A-1", "DP-3"]
+        assert body["outputs"][1]["modes"]
+
+    def test_the_two_levels_are_separate_fields(self, client):
+        output = client.get(f"{BASE}/state").json()["outputs"][0]
+        assert "selected" in output and "lit" in output
+        assert "enabled" not in output
+
+    def test_a_mode_carries_id_name_and_unrounded_rate(self, client):
+        dp3 = client.get(f"{BASE}/state").json()["outputs"][1]
+        mode = next(m for m in dp3["modes"] if m["id"] == "58")
+        assert mode["name"] == "3840x2160@120"
+        assert mode["refresh_rate"] == pytest.approx(119.87999725, rel=1e-9)
+
+
+class TestApplyRoute:
+    def test_a_valid_change_succeeds(self, client):
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "HDMI-A-1", "selected": True, "mode_id": "1", "mode_name": "2560x1440@144"},
+        ]})
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+    def test_an_unknown_output_is_400(self, client):
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "DP-99", "selected": True},
+        ]})
+        assert resp.status_code == 400
+
+    def test_a_foreign_mode_is_400(self, client):
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "HDMI-A-1", "selected": True,
+             "mode_id": "57", "mode_name": "3840x2160@120"},
+        ]})
+        assert resp.status_code == 400
+
+    def test_a_stale_mode_name_is_409(self, client):
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "DP-3", "selected": True,
+             "mode_id": "58", "mode_name": "1920x1080@60"},
+        ]})
+        assert resp.status_code == 409
+
+    def test_deselecting_everything_is_400(self, client):
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "HDMI-A-1", "selected": False},
+            {"name": "DP-3", "selected": False},
+        ]})
+        assert resp.status_code == 400
+
+    def test_an_empty_body_is_422(self, client):
+        assert client.post(f"{BASE}/apply", json={"outputs": []}).status_code == 422
+
+    def test_a_raw_dict_body_is_rejected(self, client):
+        assert client.post(f"{BASE}/apply", json={"nonsense": 1}).status_code == 422
+
+
+class TestFailureMapping:
+    def test_an_unreachable_session_reads_as_available_false_not_an_error(self, monkeypatch):
+        class _Dead:
+            async def get_layout(self):
+                return DisplayLayout(available=False, detail="KWin nicht erreichbar")
+
+            async def apply(self, wanted, live_outputs):
+                raise AssertionError("darf nicht laufen")
+
+        service = DisplayService(backend=_Dead())
+        monkeypatch.setattr(service_module, "get_display_service", lambda: service)
+        resp = _app(service).get(f"{BASE}/state")
+        # Lesen liefert available=false statt eines Fehlers: die UI soll den
+        # Zustand anzeigen koennen, nicht nur eine Fehlermeldung.
+        assert resp.status_code == 200
+        assert resp.json()["available"] is False
+
+    def test_an_unreachable_session_is_502_on_write(self, monkeypatch):
+        class _Dead:
+            async def get_layout(self):
+                return DisplayLayout(available=False, detail="KWin nicht erreichbar")
+
+            async def apply(self, wanted, live_outputs):
+                raise AssertionError("darf nicht laufen")
+
+        service = DisplayService(backend=_Dead())
+        monkeypatch.setattr(service_module, "get_display_service", lambda: service)
+        resp = _app(service).post(f"{BASE}/apply", json={"outputs": [
+            {"name": "DP-3", "selected": True},
+        ]})
+        assert resp.status_code == 502
+
+    def test_no_kscreen_output_reaches_the_client(self, monkeypatch):
+        secret = "/sys/devices/pci0000:00/EDID-Geheimnis"
+
+        class _Chatty:
+            async def get_layout(self):
+                return (await DevDisplayBackend().get_layout())
+
+            async def apply(self, wanted, live_outputs):
+                return False, secret
+
+        service = DisplayService(backend=_Chatty())
+        monkeypatch.setattr(service_module, "get_display_service", lambda: service)
+        resp = _app(service).post(f"{BASE}/apply", json={"outputs": [
+            {"name": "DP-3", "selected": True},
+        ]})
+        assert resp.status_code == 502
+        assert secret not in resp.text
+
+
+class TestPermission:
+    def test_the_read_route_is_gated_too(self):
+        # Die Ausgangsliste verraet die angeschlossene Hardware.
+        app = FastAPI()
+        app.include_router(DisplayOutputPlugin().get_router(), prefix=BASE)
+        # Ohne dependency_overrides greift die echte Abhaengigkeit und
+        # scheitert mangels Token.
+        assert TestClient(app).get(f"{BASE}/state").status_code in (401, 403)

--- a/backend/tests/plugins/test_display_output_routes.py
+++ b/backend/tests/plugins/test_display_output_routes.py
@@ -3,6 +3,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+import app.plugins.installed.display_output as plugin_module
 from app.api.deps import require_power_manage_displays
 from app.core.exception_handlers import register_exception_handlers
 from app.plugins.installed.display_output import DisplayOutputPlugin
@@ -18,6 +19,12 @@ class _User:
     username = "admin"
     role = "admin"
     id = 1
+
+
+class _NonAdminUser:
+    username = "someone"
+    role = "user"
+    id = 2
 
 
 def _app(service: DisplayService) -> TestClient:
@@ -96,6 +103,15 @@ class TestApplyRoute:
 
     def test_an_empty_body_is_422(self, client):
         assert client.post(f"{BASE}/apply", json={"outputs": []}).status_code == 422
+
+    def test_an_oversized_body_is_422(self, client):
+        # Task 3: kein Host meldet gleichzeitig mehr als 16 Ausgaenge. Ohne
+        # obere Grenze koennte ein berechtigter Aufrufer einen beliebig
+        # grossen Rumpf schicken, den ein Worker parsen muss, bevor die
+        # erste inhaltliche Pruefung ueberhaupt greift.
+        outputs = [{"name": f"OUT-{i}", "selected": True} for i in range(17)]
+        resp = client.post(f"{BASE}/apply", json={"outputs": outputs})
+        assert resp.status_code == 422
 
     def test_a_raw_dict_body_is_rejected(self, client):
         assert client.post(f"{BASE}/apply", json={"nonsense": 1}).status_code == 422
@@ -195,3 +211,155 @@ class TestPermission:
             {"name": "DP-3", "selected": True},
         ]})
         assert resp.status_code in (401, 403)
+
+
+class TestAuditLogging:
+    """Task 1: JEDER apply-Versuch schreibt einen display_apply-Eintrag.
+
+    Ersetzt ``get_audit_logger_db`` im Namensraum des Plugin-Moduls durch
+    einen mitschreibenden Stub statt nur auf den HTTP-Statuscode zu schauen —
+    sonst blieben zwei Fehler unentdeckt: dass ``details.argv`` den rohen,
+    ungeprueften Request trug (statt des validierten Vektors), und dass eine
+    Ablehnung (400/409/502) ueberhaupt keinen Eintrag hinterliess.
+    """
+
+    @pytest.fixture
+    def audit_client(self, monkeypatch):
+        events: list[dict] = []
+        security_events: list[dict] = []
+
+        class _RecordingAuditLogger:
+            def log_event(self, **kwargs):
+                events.append(kwargs)
+
+            def log_security_event(self, **kwargs):
+                security_events.append(kwargs)
+
+        monkeypatch.setattr(plugin_module, "get_audit_logger_db", lambda: _RecordingAuditLogger())
+        service = DisplayService(backend=DevDisplayBackend())
+        monkeypatch.setattr(service_module, "get_display_service", lambda: service)
+        app = FastAPI()
+        register_exception_handlers(app)
+        app.include_router(DisplayOutputPlugin().get_router(), prefix=BASE)
+        app.dependency_overrides[require_power_manage_displays] = lambda: _User()
+        return TestClient(app), events, security_events
+
+    def test_a_successful_apply_writes_one_entry_with_the_validated_argv(self, audit_client):
+        client, events, _ = audit_client
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "HDMI-A-1", "selected": True,
+             "mode_id": "1", "mode_name": "2560x1440@144"},
+        ]})
+        assert resp.status_code == 200
+        assert len(events) == 1
+        entry = events[0]
+        assert entry["action"] == "display_apply"
+        assert entry["success"] is True
+        assert entry["details"]["argv"] == [
+            "kscreen-doctor", "output.HDMI-A-1.enable", "output.HDMI-A-1.mode.1",
+        ]
+
+    def test_a_mode_on_a_deselected_output_is_not_audited_as_applied(self, audit_client):
+        # Der zentrale Befund aus dem Auftrag: der Service verwirft eine
+        # mode_id auf einem selected=false-Ausgang. Der Audit-Eintrag darf
+        # diese verworfene Halbwahrheit nicht so aufschreiben, als waere sie
+        # Teil des tatsaechlichen Vorgangs gewesen.
+        client, events, _ = audit_client
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "HDMI-A-1", "selected": False,
+             "mode_id": "1", "mode_name": "2560x1440@144"},
+        ]})
+        assert resp.status_code == 200
+        assert len(events) == 1
+        argv = events[0]["details"]["argv"]
+        assert not any("mode" in arg for arg in argv)
+
+    def test_a_400_rejection_still_writes_an_entry(self, audit_client):
+        client, events, _ = audit_client
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "DP-99", "selected": True},
+        ]})
+        assert resp.status_code == 400
+        assert len(events) == 1
+        assert events[0]["action"] == "display_apply"
+        assert events[0]["success"] is False
+        assert events[0]["details"]["status_code"] == 400
+
+    def test_a_409_rejection_still_writes_an_entry(self, audit_client):
+        client, events, _ = audit_client
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "DP-3", "selected": True,
+             "mode_id": "58", "mode_name": "1920x1080@60"},
+        ]})
+        assert resp.status_code == 409
+        assert len(events) == 1
+        assert events[0]["success"] is False
+        assert events[0]["details"]["status_code"] == 409
+
+    def test_a_502_unavailable_rejection_still_writes_an_entry(self, monkeypatch):
+        events: list[dict] = []
+
+        class _RecordingAuditLogger:
+            def log_event(self, **kwargs):
+                events.append(kwargs)
+
+            def log_security_event(self, **kwargs):
+                pass
+
+        monkeypatch.setattr(plugin_module, "get_audit_logger_db", lambda: _RecordingAuditLogger())
+
+        class _Dead:
+            async def get_layout(self):
+                return DisplayLayout(available=False, detail="KWin nicht erreichbar")
+
+            async def apply(self, wanted, live_outputs):
+                raise AssertionError("darf nicht laufen")
+
+        service = DisplayService(backend=_Dead())
+        monkeypatch.setattr(service_module, "get_display_service", lambda: service)
+        resp = _app(service).post(f"{BASE}/apply", json={"outputs": [
+            {"name": "DP-3", "selected": True},
+        ]})
+        assert resp.status_code == 502
+        assert len(events) == 1
+        assert events[0]["success"] is False
+        assert events[0]["details"]["status_code"] == 502
+        assert events[0]["details"]["argv"] is None
+
+    def test_a_non_admin_also_gets_the_delegated_power_action_entry(self, monkeypatch):
+        events: list[dict] = []
+        security_events: list[dict] = []
+
+        class _RecordingAuditLogger:
+            def log_event(self, **kwargs):
+                events.append(kwargs)
+
+            def log_security_event(self, **kwargs):
+                security_events.append(kwargs)
+
+        monkeypatch.setattr(plugin_module, "get_audit_logger_db", lambda: _RecordingAuditLogger())
+        service = DisplayService(backend=DevDisplayBackend())
+        monkeypatch.setattr(service_module, "get_display_service", lambda: service)
+        app = FastAPI()
+        register_exception_handlers(app)
+        app.include_router(DisplayOutputPlugin().get_router(), prefix=BASE)
+        app.dependency_overrides[require_power_manage_displays] = lambda: _NonAdminUser()
+        client = TestClient(app)
+
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "HDMI-A-1", "selected": True,
+             "mode_id": "1", "mode_name": "2560x1440@144"},
+        ]})
+        assert resp.status_code == 200
+        assert len(security_events) == 1
+        assert security_events[0]["action"] == "delegated_power_action"
+        assert security_events[0]["resource"] == "manage_displays"
+
+    def test_an_admin_gets_no_delegated_power_action_entry(self, audit_client):
+        client, _, security_events = audit_client
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "HDMI-A-1", "selected": True,
+             "mode_id": "1", "mode_name": "2560x1440@144"},
+        ]})
+        assert resp.status_code == 200
+        assert security_events == []

--- a/backend/tests/plugins/test_display_output_routes.py
+++ b/backend/tests/plugins/test_display_output_routes.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.api.deps import require_power_manage_displays
+from app.core.exception_handlers import register_exception_handlers
 from app.plugins.installed.display_output import DisplayOutputPlugin
 from app.plugins.installed.display_output import service as service_module
 from app.plugins.installed.display_output.backend import DevDisplayBackend
@@ -21,6 +22,12 @@ class _User:
 
 def _app(service: DisplayService) -> TestClient:
     app = FastAPI()
+    # Registriert den echten globalen 5xx-Scrubber (core/exception_handlers.py),
+    # damit die Tests genau das sehen, was ein realer Client sieht: ein
+    # bloss gebautes FastAPI() liesse ein rohes HTTPException(502, detail=...)
+    # unveraendert durch, waehrend die echte App jedes HTTPException-detail ab
+    # Status 500 auf "Internal server error" scrubbt.
+    register_exception_handlers(app)
     app.include_router(DisplayOutputPlugin().get_router(), prefix=BASE)
     app.dependency_overrides[require_power_manage_displays] = lambda: _User()
     return TestClient(app)
@@ -126,6 +133,29 @@ class TestFailureMapping:
         ]})
         assert resp.status_code == 502
 
+    def test_the_curated_message_survives_the_5xx_scrubber(self, monkeypatch):
+        # Regressionstest fuer eine Vorgabe im Auftrag, die selbst falsch war:
+        # ein rohes HTTPException(502, detail=...) wird vom globalen
+        # 5xx-Scrubber (core/exception_handlers.py) auf "Internal server
+        # error" ueberschrieben, sodass "Displays nicht erreichbar" den
+        # Client nie erreicht haette. Nur ein ServiceError (BadGatewayError)
+        # transportiert eine kuratierte Meldung durch diesen Filter.
+        class _Dead:
+            async def get_layout(self):
+                return DisplayLayout(available=False, detail="KWin nicht erreichbar")
+
+            async def apply(self, wanted, live_outputs):
+                raise AssertionError("darf nicht laufen")
+
+        service = DisplayService(backend=_Dead())
+        monkeypatch.setattr(service_module, "get_display_service", lambda: service)
+        resp = _app(service).post(f"{BASE}/apply", json={"outputs": [
+            {"name": "DP-3", "selected": True},
+        ]})
+        assert resp.status_code == 502
+        assert resp.json()["detail"] == "Displays nicht erreichbar"
+        assert resp.json()["detail"] != "Internal server error"
+
     def test_no_kscreen_output_reaches_the_client(self, monkeypatch):
         secret = "/sys/devices/pci0000:00/EDID-Geheimnis"
 
@@ -153,3 +183,15 @@ class TestPermission:
         # Ohne dependency_overrides greift die echte Abhaengigkeit und
         # scheitert mangels Token.
         assert TestClient(app).get(f"{BASE}/state").status_code in (401, 403)
+
+    def test_the_write_route_is_gated_too(self):
+        # Die Schreibroute schaltet physische Bildschirme — mindestens so
+        # schuetzenswert wie die Ausgangsliste der Leseroute oben.
+        app = FastAPI()
+        app.include_router(DisplayOutputPlugin().get_router(), prefix=BASE)
+        # Ohne dependency_overrides greift die echte Abhaengigkeit und
+        # scheitert mangels Token.
+        resp = TestClient(app).post(f"{BASE}/apply", json={"outputs": [
+            {"name": "DP-3", "selected": True},
+        ]})
+        assert resp.status_code in (401, 403)

--- a/backend/tests/plugins/test_display_output_service.py
+++ b/backend/tests/plugins/test_display_output_service.py
@@ -4,6 +4,7 @@ import pytest
 from app.plugins.installed.display_output.backend import DevDisplayBackend
 from app.plugins.installed.display_output.models import DisplayApplyRequest
 from app.plugins.installed.display_output.service import (
+    ApplyResult,
     DisplayService,
     DisplayUnavailable,
     InvalidRequest,
@@ -23,20 +24,54 @@ def service() -> DisplayService:
 class TestHappyPath:
     @pytest.mark.asyncio
     async def test_a_valid_change_is_applied(self, service):
-        ok, _ = await service.apply(_req([
+        result = await service.apply(_req([
             {"name": "HDMI-A-1", "selected": True, "mode_id": "1", "mode_name": "2560x1440@144"},
             {"name": "DP-3", "selected": False},
         ]))
-        assert ok is True
+        assert isinstance(result, ApplyResult)
+        assert result.success is True
         layout = await service.get_layout()
         assert {o.name: o.selected for o in layout.outputs} == {"HDMI-A-1": True, "DP-3": False}
 
     @pytest.mark.asyncio
     async def test_selecting_without_a_mode_keeps_the_current_one(self, service):
-        ok, _ = await service.apply(_req([{"name": "DP-3", "selected": True}]))
-        assert ok is True
+        result = await service.apply(_req([{"name": "DP-3", "selected": True}]))
+        assert result.success is True
         dp3 = next(o for o in (await service.get_layout()).outputs if o.name == "DP-3")
         assert dp3.current_mode_id == "57"
+
+
+class TestApplyResultArgv:
+    """Der argv-Vektor in ApplyResult ist der Gegenstand von Task 1.
+
+    Er muss das abbilden, was der Service tatsaechlich geprueft (und bei
+    KWinDisplayBackend an kscreen-doctor geschickt) hat — nicht die rohe
+    Anfrage.
+    """
+
+    @pytest.mark.asyncio
+    async def test_argv_carries_the_validated_change(self, service):
+        result = await service.apply(_req([{
+            "name": "HDMI-A-1", "selected": True,
+            "mode_id": "1", "mode_name": "2560x1440@144",
+        }]))
+        assert result.argv == [
+            "kscreen-doctor",
+            "output.HDMI-A-1.enable",
+            "output.HDMI-A-1.mode.1",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_mode_on_a_deselected_output_never_reaches_argv(self, service):
+        # Der zentrale Fall aus Task 1: eine mode_id auf einem selected=false
+        # -Ausgang wird vom Service verworfen (siehe Zeile "Bei selected=False
+        # bleibt mode_id None") - sie darf deshalb auch nicht so aussehen, als
+        # waere sie Teil des Vorgangs gewesen.
+        result = await service.apply(_req([{
+            "name": "HDMI-A-1", "selected": False,
+            "mode_id": "1", "mode_name": "2560x1440@144",
+        }]))
+        assert result.argv == ["kscreen-doctor", "output.HDMI-A-1.disable"]
 
 
 class TestWhitelist:
@@ -98,11 +133,11 @@ class TestModeCrossCheck:
         # Beide heissen "3840x2160@120". Ueber die ID sind sie trotzdem
         # unterscheidbar - der ganze Punkt des Entwurfs.
         for mode_id in ("57", "58"):
-            ok, _ = await service.apply(_req([{
+            result = await service.apply(_req([{
                 "name": "DP-3", "selected": True,
                 "mode_id": mode_id, "mode_name": "3840x2160@120",
             }]))
-            assert ok is True
+            assert result.success is True
             dp3 = next(o for o in (await service.get_layout()).outputs if o.name == "DP-3")
             assert dp3.current_mode_id == mode_id
 
@@ -120,16 +155,21 @@ class TestInvariant:
     async def test_an_omitted_output_still_counts_as_selected(self, service):
         # DP-3 steht nicht im Request und bleibt gewaehlt - also ist das
         # Abwaehlen von HDMI-A-1 erlaubt.
-        ok, _ = await service.apply(_req([{"name": "HDMI-A-1", "selected": False}]))
-        assert ok is True
+        result = await service.apply(_req([{"name": "HDMI-A-1", "selected": False}]))
+        assert result.success is True
 
     @pytest.mark.asyncio
     async def test_a_mode_on_a_deselected_output_is_ignored_not_rejected(self, service):
-        ok, _ = await service.apply(_req([{
+        result = await service.apply(_req([{
             "name": "HDMI-A-1", "selected": False,
             "mode_id": "1", "mode_name": "2560x1440@144",
         }]))
-        assert ok is True
+        assert result.success is True
+        # Task 1: der geprueften argv-Vektor enthaelt keinen Modus fuer einen
+        # abgewaehlten Ausgang - der Service verwirft diese Kombination beim
+        # Aufbau von `wanted`, und der Audit-Eintrag darf nur berichten, was
+        # tatsaechlich geprueft wurde.
+        assert not any("mode" in arg for arg in result.argv if "HDMI-A-1" in arg)
 
 
 class TestUnavailable:

--- a/backend/tests/plugins/test_display_output_service.py
+++ b/backend/tests/plugins/test_display_output_service.py
@@ -1,0 +1,149 @@
+"""Validierung: kein Wert wird zum Argument, der nicht enumeriert wurde."""
+import pytest
+
+from app.plugins.installed.display_output.backend import DevDisplayBackend
+from app.plugins.installed.display_output.models import DisplayApplyRequest
+from app.plugins.installed.display_output.service import (
+    DisplayService,
+    DisplayUnavailable,
+    InvalidRequest,
+    ModeMismatch,
+)
+
+
+def _req(outputs: list) -> DisplayApplyRequest:
+    return DisplayApplyRequest(outputs=outputs)
+
+
+@pytest.fixture
+def service() -> DisplayService:
+    return DisplayService(backend=DevDisplayBackend())
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_a_valid_change_is_applied(self, service):
+        ok, _ = await service.apply(_req([
+            {"name": "HDMI-A-1", "selected": True, "mode_id": "1", "mode_name": "2560x1440@144"},
+            {"name": "DP-3", "selected": False},
+        ]))
+        assert ok is True
+        layout = await service.get_layout()
+        assert {o.name: o.selected for o in layout.outputs} == {"HDMI-A-1": True, "DP-3": False}
+
+    @pytest.mark.asyncio
+    async def test_selecting_without_a_mode_keeps_the_current_one(self, service):
+        ok, _ = await service.apply(_req([{"name": "DP-3", "selected": True}]))
+        assert ok is True
+        dp3 = next(o for o in (await service.get_layout()).outputs if o.name == "DP-3")
+        assert dp3.current_mode_id == "57"
+
+
+class TestWhitelist:
+    @pytest.mark.asyncio
+    async def test_an_unknown_output_is_rejected(self, service):
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([{"name": "DP-99", "selected": True}]))
+
+    @pytest.mark.asyncio
+    async def test_a_mode_belonging_to_another_output_is_rejected(self, service):
+        # Das ist #589 als Testfall: Mode-IDs sind global vergeben, also
+        # existiert "57" - aber nicht an HDMI-A-1.
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([{
+                "name": "HDMI-A-1", "selected": True,
+                "mode_id": "57", "mode_name": "3840x2160@120",
+            }]))
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_mode_id_is_rejected(self, service):
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([{
+                "name": "DP-3", "selected": True, "mode_id": "9999", "mode_name": "x",
+            }]))
+
+    @pytest.mark.asyncio
+    async def test_a_duplicate_output_in_one_request_is_rejected(self, service):
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([
+                {"name": "DP-3", "selected": True},
+                {"name": "DP-3", "selected": False},
+            ]))
+
+
+class TestModeCrossCheck:
+    @pytest.mark.asyncio
+    async def test_a_mode_id_without_a_name_is_rejected(self, service):
+        # Sonst waere die Gegenprobe vom Client abschaltbar.
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([{"name": "DP-3", "selected": True, "mode_id": "58"}]))
+
+    @pytest.mark.asyncio
+    async def test_a_name_without_an_id_is_rejected(self, service):
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([{
+                "name": "DP-3", "selected": True, "mode_name": "3840x2160@120",
+            }]))
+
+    @pytest.mark.asyncio
+    async def test_a_stale_name_for_a_live_id_is_a_conflict(self, service):
+        with pytest.raises(ModeMismatch):
+            await service.apply(_req([{
+                "name": "DP-3", "selected": True,
+                "mode_id": "58", "mode_name": "1920x1080@60",
+            }]))
+
+    @pytest.mark.asyncio
+    async def test_the_ambiguous_pair_is_addressable_member_by_member(self, service):
+        # Beide heissen "3840x2160@120". Ueber die ID sind sie trotzdem
+        # unterscheidbar - der ganze Punkt des Entwurfs.
+        for mode_id in ("57", "58"):
+            ok, _ = await service.apply(_req([{
+                "name": "DP-3", "selected": True,
+                "mode_id": mode_id, "mode_name": "3840x2160@120",
+            }]))
+            assert ok is True
+            dp3 = next(o for o in (await service.get_layout()).outputs if o.name == "DP-3")
+            assert dp3.current_mode_id == mode_id
+
+
+class TestInvariant:
+    @pytest.mark.asyncio
+    async def test_deselecting_every_connected_output_is_rejected(self, service):
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([
+                {"name": "HDMI-A-1", "selected": False},
+                {"name": "DP-3", "selected": False},
+            ]))
+
+    @pytest.mark.asyncio
+    async def test_an_omitted_output_still_counts_as_selected(self, service):
+        # DP-3 steht nicht im Request und bleibt gewaehlt - also ist das
+        # Abwaehlen von HDMI-A-1 erlaubt.
+        ok, _ = await service.apply(_req([{"name": "HDMI-A-1", "selected": False}]))
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_a_mode_on_a_deselected_output_is_ignored_not_rejected(self, service):
+        ok, _ = await service.apply(_req([{
+            "name": "HDMI-A-1", "selected": False,
+            "mode_id": "1", "mode_name": "2560x1440@144",
+        }]))
+        assert ok is True
+
+
+class TestUnavailable:
+    @pytest.mark.asyncio
+    async def test_an_unreachable_session_raises_before_anything_is_applied(self):
+        from app.plugins.installed.display_output.models import DisplayLayout
+
+        class _Dead:
+            async def get_layout(self):
+                return DisplayLayout(available=False, detail="KWin nicht erreichbar")
+
+            async def apply(self, wanted, live_outputs):
+                raise AssertionError("apply darf bei toter Session nicht laufen")
+
+        dead = DisplayService(backend=_Dead())
+        with pytest.raises(DisplayUnavailable):
+            await dead.apply(_req([{"name": "DP-3", "selected": True}]))

--- a/backend/tests/plugins/test_display_output_ui_manifest.py
+++ b/backend/tests/plugins/test_display_output_ui_manifest.py
@@ -1,0 +1,17 @@
+"""Ohne diese Ueberschreibung ist das Plugin im Frontend unsichtbar."""
+from app.plugins.installed.display_output import DisplayOutputPlugin
+
+
+class TestUiManifest:
+    def test_the_manifest_is_present_and_enabled(self):
+        manifest = DisplayOutputPlugin().get_ui_manifest()
+        assert manifest is not None
+        assert manifest.enabled is True
+
+    def test_it_contributes_no_nav_item(self):
+        # Ein Nav-Eintrag erzeugte eine Route und damit einen bundle.js-Abruf.
+        # Die Bedienung sitzt in der Topbar.
+        assert DisplayOutputPlugin().get_ui_manifest().nav_items == []
+
+    def test_the_metadata_name_matches_the_route_prefix(self):
+        assert DisplayOutputPlugin().metadata.name == "display_output"

--- a/backend/tests/test_display_detector_connector_states.py
+++ b/backend/tests/test_display_detector_connector_states.py
@@ -1,4 +1,6 @@
 """Pro-Connector-Zustaende aus sysfs, mit KWin-kompatiblen Namen."""
+import logging
+
 import pytest
 
 from app.services.power.gpu.display_detector import (
@@ -56,11 +58,60 @@ class TestConnectorStates:
         _connector(tmp_path, "card1-DP-1", "connected", "enabled")
         assert get_active_display_count_sync(tmp_path) == 2
 
-    def test_same_name_on_two_cards_one_dark_counts_as_one_and_map_has_one_key(
+    def test_same_name_on_two_cards_one_dark_still_counts_as_one(
         self, tmp_path
     ):
+        # Zaehlung unveraendert (siehe Task 2 im Fix-Wave-Auftrag): entries,
+        # nicht distinct names.
         _connector(tmp_path, "card0-DP-1", "connected", "enabled")
         _connector(tmp_path, "card1-DP-1", "disconnected", "disabled")
         assert get_active_display_count_sync(tmp_path) == 1
+
+    def test_same_name_on_two_cards_is_ambiguous_and_absent_from_the_map(
+        self, tmp_path
+    ):
+        # Verhaltensaenderung ggue. vorher (Fix-Wave, Task 2): eine
+        # mehrdeutige Zuordnung darf nicht per "last wins" in ein definitives
+        # True/False aufgeloest werden - das waere eine Falschaussage ueber
+        # einen Namen, den die Abbildung gar nicht sicher zuordnen kann.
+        # states.get("DP-1") liefert jetzt None (unbekannt), nicht den Wert
+        # des zuletzt gesehenen Connectors.
+        _connector(tmp_path, "card0-DP-1", "connected", "enabled")
+        _connector(tmp_path, "card1-DP-1", "disconnected", "disabled")
         states = get_connector_states_sync(tmp_path)
-        assert list(states) == ["DP-1"]
+        assert "DP-1" not in states
+        assert states.get("DP-1") is None
+
+    def test_the_ambiguity_warning_fires_once_for_a_duplicate_name(self, tmp_path, caplog):
+        _connector(tmp_path, "card0-DP-1", "connected", "enabled")
+        _connector(tmp_path, "card1-DP-1", "connected", "enabled")
+        with caplog.at_level(
+            logging.WARNING, logger="app.services.power.gpu.display_detector"
+        ):
+            get_connector_states_sync(tmp_path)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "DP-1" in warnings[0].message
+
+    def test_no_warning_for_an_ordinary_single_card_layout(self, tmp_path, caplog):
+        _connector(tmp_path, "card0-DP-3", "connected", "enabled")
+        _connector(tmp_path, "card0-HDMI-A-1", "connected", "disabled")
+        with caplog.at_level(
+            logging.WARNING, logger="app.services.power.gpu.display_detector"
+        ):
+            get_connector_states_sync(tmp_path)
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+    def test_the_counting_path_never_warns_even_with_a_duplicate_name(self, tmp_path, caplog):
+        # Der eigentliche Fehler: get_active_display_count() laeuft aus dem
+        # Monitor-Loop und aus desktop_backend.get_status() heraus, einmal pro
+        # Intervall - ein Pfad, der Eintraege zaehlt und sich fuer die
+        # Namensmehrdeutigkeit gar nicht interessiert, darf das Log nicht
+        # fluten.
+        _connector(tmp_path, "card0-DP-1", "connected", "enabled")
+        _connector(tmp_path, "card1-DP-1", "connected", "enabled")
+        with caplog.at_level(
+            logging.WARNING, logger="app.services.power.gpu.display_detector"
+        ):
+            get_active_display_count_sync(tmp_path)
+        assert caplog.records == []

--- a/backend/tests/test_display_detector_connector_states.py
+++ b/backend/tests/test_display_detector_connector_states.py
@@ -1,0 +1,49 @@
+"""Pro-Connector-Zustaende aus sysfs, mit KWin-kompatiblen Namen."""
+import pytest
+
+from app.services.power.gpu.display_detector import (
+    get_connector_states,
+    get_connector_states_sync,
+)
+
+
+def _connector(root, name: str, status: str, enabled: str) -> None:
+    d = root / "sys" / "class" / "drm" / name
+    d.mkdir(parents=True)
+    (d / "status").write_text(status)
+    (d / "enabled").write_text(enabled)
+
+
+class TestConnectorStates:
+    def test_strips_the_card_prefix_to_match_kwin_names(self, tmp_path):
+        _connector(tmp_path, "card0-DP-3", "connected", "enabled")
+        assert get_connector_states_sync(tmp_path) == {"DP-3": True}
+
+    def test_a_dark_connector_is_false_not_absent(self, tmp_path):
+        # DPMS-off: verbunden, aber es werden keine Pixel getrieben.
+        _connector(tmp_path, "card0-DP-3", "connected", "disabled")
+        assert get_connector_states_sync(tmp_path) == {"DP-3": False}
+
+    def test_a_disconnected_connector_is_reported_as_dark(self, tmp_path):
+        _connector(tmp_path, "card0-DP-1", "disconnected", "disabled")
+        assert get_connector_states_sync(tmp_path) == {"DP-1": False}
+
+    def test_a_writeback_connector_is_never_lit(self, tmp_path):
+        # Gemessen auf BaluNode: status=unknown, enabled=disabled. Ein
+        # Writeback-Connector ist kein Bildschirm.
+        _connector(tmp_path, "card0-Writeback-1", "unknown", "disabled")
+        assert get_connector_states_sync(tmp_path) == {"Writeback-1": False}
+
+    def test_entries_that_are_not_connectors_are_skipped(self, tmp_path):
+        drm = tmp_path / "sys" / "class" / "drm" / "renderD128"
+        drm.mkdir(parents=True)
+        _connector(tmp_path, "card0-DP-3", "connected", "enabled")
+        assert list(get_connector_states_sync(tmp_path)) == ["DP-3"]
+
+    def test_a_missing_drm_directory_yields_an_empty_map(self, tmp_path):
+        assert get_connector_states_sync(tmp_path) == {}
+
+    @pytest.mark.asyncio
+    async def test_the_async_variant_agrees_with_the_sync_one(self, tmp_path):
+        _connector(tmp_path, "card0-HDMI-A-1", "connected", "enabled")
+        assert await get_connector_states(tmp_path) == get_connector_states_sync(tmp_path)

--- a/backend/tests/test_display_detector_connector_states.py
+++ b/backend/tests/test_display_detector_connector_states.py
@@ -2,6 +2,7 @@
 import pytest
 
 from app.services.power.gpu.display_detector import (
+    get_active_display_count_sync,
     get_connector_states,
     get_connector_states_sync,
 )
@@ -47,3 +48,19 @@ class TestConnectorStates:
     async def test_the_async_variant_agrees_with_the_sync_one(self, tmp_path):
         _connector(tmp_path, "card0-HDMI-A-1", "connected", "enabled")
         assert await get_connector_states(tmp_path) == get_connector_states_sync(tmp_path)
+
+    def test_same_name_on_two_cards_both_lit_counts_as_two(self, tmp_path):
+        # card0-DP-1 and card1-DP-1 both strip to "DP-1". The count must not
+        # collapse two real, independently lit connectors into one.
+        _connector(tmp_path, "card0-DP-1", "connected", "enabled")
+        _connector(tmp_path, "card1-DP-1", "connected", "enabled")
+        assert get_active_display_count_sync(tmp_path) == 2
+
+    def test_same_name_on_two_cards_one_dark_counts_as_one_and_map_has_one_key(
+        self, tmp_path
+    ):
+        _connector(tmp_path, "card0-DP-1", "connected", "enabled")
+        _connector(tmp_path, "card1-DP-1", "disconnected", "disabled")
+        assert get_active_display_count_sync(tmp_path) == 1
+        states = get_connector_states_sync(tmp_path)
+        assert list(states) == ["DP-1"]

--- a/backend/tests/test_power_permissions_manage_displays.py
+++ b/backend/tests/test_power_permissions_manage_displays.py
@@ -1,0 +1,71 @@
+"""Das neue Power-Recht: Standard aus, Admin implizit, sauber verdrahtet."""
+import pytest
+
+from app.schemas.power_permissions import (
+    MyPowerPermissionsResponse,
+    UserPowerPermissionsResponse,
+    UserPowerPermissionsUpdate,
+)
+from app.services.power_permissions import _ACTION_FIELD_MAP
+
+
+class TestWiring:
+    def test_the_action_maps_to_the_column(self):
+        assert _ACTION_FIELD_MAP["manage_displays"] == "can_manage_displays"
+
+    def test_the_dependency_exists(self):
+        from app.api import deps
+        assert hasattr(deps, "require_power_manage_displays")
+
+    def test_the_model_has_the_column(self):
+        from app.models.power_permissions import UserPowerPermission
+        assert hasattr(UserPowerPermission, "can_manage_displays")
+
+
+class TestSchemas:
+    def test_it_defaults_to_denied(self):
+        assert UserPowerPermissionsResponse(user_id=1).can_manage_displays is False
+        assert MyPowerPermissionsResponse().can_manage_displays is False
+
+    def test_the_update_schema_leaves_it_untouched_by_default(self):
+        # None heisst "nicht angefasst" - nicht "entziehen".
+        assert UserPowerPermissionsUpdate().can_manage_displays is None
+
+    def test_the_update_schema_accepts_it(self):
+        assert UserPowerPermissionsUpdate(can_manage_displays=True).can_manage_displays is True
+
+
+class TestGrantAndRevoke:
+    def test_granting_and_revoking_round_trip(self, db_session, test_user, admin_user):
+        from app.services.power_permissions import check_permission, update_permissions
+
+        assert check_permission(db_session, test_user.id, "manage_displays") is False
+
+        update_permissions(
+            db_session, test_user.id,
+            UserPowerPermissionsUpdate(can_manage_displays=True),
+            granted_by=admin_user.id,
+        )
+        assert check_permission(db_session, test_user.id, "manage_displays") is True
+
+        update_permissions(
+            db_session, test_user.id,
+            UserPowerPermissionsUpdate(can_manage_displays=False),
+            granted_by=admin_user.id,
+        )
+        assert check_permission(db_session, test_user.id, "manage_displays") is False
+
+    def test_it_does_not_drag_other_permissions_along(self, db_session, test_user, admin_user):
+        # Es steht neben den Sleep-Ketten und ist bewusst nicht in
+        # _apply_implications - wie can_control_audio.
+        from app.services.power_permissions import get_permissions, update_permissions
+
+        update_permissions(
+            db_session, test_user.id,
+            UserPowerPermissionsUpdate(can_manage_displays=True),
+            granted_by=admin_user.id,
+        )
+        perms = get_permissions(db_session, test_user.id)
+        assert perms.can_manage_displays is True
+        assert perms.can_suspend is False
+        assert perms.can_toggle_desktop is False

--- a/client/src/__tests__/api/displayOutput.test.ts
+++ b/client/src/__tests__/api/displayOutput.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { formatMode } from '../../api/displayOutput';
+
+const MODE_120 = { id: '57', name: '3840x2160@120', width: 3840, height: 2160, refresh_rate: 120 };
+const MODE_11988 = {
+  id: '58', name: '3840x2160@120', width: 3840, height: 2160,
+  refresh_rate: 119.87999725341797,
+};
+
+describe('formatMode', () => {
+  it('trennt das Paar, das denselben Namen traegt', () => {
+    // Genau hier scheitert die Adressierung ueber den Namen: beide heissen
+    // "3840x2160@120". Zwei Nachkommastellen machen sie unterscheidbar.
+    expect(formatMode(MODE_120, 'de')).not.toBe(formatMode(MODE_11988, 'de'));
+  });
+
+  it('rundet auf zwei Nachkommastellen', () => {
+    expect(formatMode(MODE_11988, 'en')).toContain('119.88');
+    expect(formatMode(MODE_120, 'en')).toContain('120.00');
+  });
+
+  it('nutzt das Dezimaltrennzeichen der Sprache', () => {
+    expect(formatMode(MODE_11988, 'de')).toContain('119,88');
+  });
+
+  it('nennt Aufloesung und Einheit', () => {
+    expect(formatMode(MODE_120, 'en')).toBe('3840 × 2160 @ 120.00 Hz');
+  });
+});

--- a/client/src/__tests__/components/topbar/DisplayMenu.test.tsx
+++ b/client/src/__tests__/components/topbar/DisplayMenu.test.tsx
@@ -29,6 +29,8 @@ vi.mock('../../../api/powerPermissions', () => ({
 import { DisplayMenu } from '../../../components/topbar/DisplayMenu';
 import { getDisplayLayout, applyDisplayLayout } from '../../../api/displayOutput';
 import { getMyPowerPermissions } from '../../../api/powerPermissions';
+import displayDe from '../../../i18n/locales/de/display.json';
+import displayEn from '../../../i18n/locales/en/display.json';
 
 const LAYOUT = {
   available: true,
@@ -126,5 +128,20 @@ describe('DisplayMenu', () => {
     } as never);
     await open();
     expect(await screen.findByText('display:unavailable')).toBeTruthy();
+  });
+});
+
+describe('display i18n locale contract', () => {
+  // Der react-i18next-Mock oben kann diesen Fehler grundsaetzlich nicht
+  // fangen: er baut den Anzeigetext IMMER aus `options` zusammen, egal ob der
+  // echte Uebersetzungsstring ueberhaupt einen {{output}}-Platzhalter hat.
+  // Echtes react-i18next ignoriert eine Interpolation ohne passenden
+  // Platzhalter dagegen lautlos — jedes Auswahlfeld haette denselben
+  // aria-label-Text, zwei Formularelemente waeren fuer einen Screenreader
+  // ununterscheidbar. Nur ein Test gegen die echten JSON-Dateien deckt das
+  // auf.
+  it('mode-Label traegt den {{output}}-Platzhalter in beiden Sprachen', () => {
+    expect(displayDe.mode).toContain('{{output}}');
+    expect(displayEn.mode).toContain('{{output}}');
   });
 });

--- a/client/src/__tests__/components/topbar/DisplayMenu.test.tsx
+++ b/client/src/__tests__/components/topbar/DisplayMenu.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
 vi.mock('react-i18next', () => ({
@@ -56,6 +56,14 @@ const LAYOUT = {
 beforeEach(() => {
   vi.mocked(getMyPowerPermissions).mockResolvedValue({ can_manage_displays: true } as never);
   vi.mocked(getDisplayLayout).mockResolvedValue(structuredClone(LAYOUT) as never);
+});
+
+// setup.ts hat keinen aequivalenten globalen Hook. Muss unconditional laufen,
+// nicht erst nach der letzten Assertion eines Fake-Timer-Tests — sonst
+// ueberlebt ein Fehlschlag dort die Umstellung und faelscht jeden Timer in
+// den danach laufenden Tests dieser Datei.
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 async function open() {
@@ -173,6 +181,26 @@ describe('DisplayMenu', () => {
 
     expect(screen.getByText('display:saveError')).toBeTruthy();
     vi.useRealTimers();
+  });
+
+  it('raeumt eine apply-Fehlermeldung beim erneuten Oeffnen aus', async () => {
+    vi.mocked(applyDisplayLayout).mockRejectedValueOnce({ response: { status: 500 } });
+    render(<DisplayMenu />);
+    const button = await screen.findByLabelText('display:title');
+
+    fireEvent.click(button);
+    await waitFor(() => expect(screen.getByText('DP-3')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('display:apply'));
+    await waitFor(() => expect(applyDisplayLayout).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText('display:saveError')).toBeInTheDocument());
+
+    // Schliessen (Klick auf den Trigger-Button toggelt isOpen)...
+    fireEvent.click(button);
+    // ...und wieder oeffnen: eine Interaktion, von der der Nutzer laengst
+    // weg ist, darf im frisch geoeffneten Popover nicht mehr auftauchen.
+    fireEvent.click(button);
+    await waitFor(() => expect(screen.queryByText('display:saveError')).toBeNull());
   });
 });
 

--- a/client/src/__tests__/components/topbar/DisplayMenu.test.tsx
+++ b/client/src/__tests__/components/topbar/DisplayMenu.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      const values = options ? Object.values(options).join('/') : '';
+      return values ? `${ns}:${key}:${values}` : `${ns}:${key}`;
+    },
+    i18n: { language: 'de' },
+  }),
+}));
+
+vi.mock('../../../api/displayOutput', async () => {
+  const actual = await vi.importActual<typeof import('../../../api/displayOutput')>(
+    '../../../api/displayOutput',
+  );
+  return {
+    ...actual,
+    getDisplayLayout: vi.fn(),
+    applyDisplayLayout: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('../../../api/powerPermissions', () => ({
+  getMyPowerPermissions: vi.fn(),
+}));
+
+import { DisplayMenu } from '../../../components/topbar/DisplayMenu';
+import { getDisplayLayout, applyDisplayLayout } from '../../../api/displayOutput';
+import { getMyPowerPermissions } from '../../../api/powerPermissions';
+
+const LAYOUT = {
+  available: true,
+  detail: null,
+  displays_powered: false,
+  outputs: [
+    {
+      name: 'HDMI-A-1', connected: true, selected: false, lit: false,
+      current_mode_id: '1', preferred_mode_id: '1', scale: 1, priority: 0,
+      modes: [{ id: '1', name: '2560x1440@144', width: 2560, height: 1440, refresh_rate: 143.999 }],
+    },
+    {
+      name: 'DP-3', connected: true, selected: true, lit: false,
+      current_mode_id: '57', preferred_mode_id: '56', scale: 2.5, priority: 1,
+      modes: [
+        { id: '57', name: '3840x2160@120', width: 3840, height: 2160, refresh_rate: 120 },
+        { id: '58', name: '3840x2160@120', width: 3840, height: 2160, refresh_rate: 119.87999725 },
+      ],
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.mocked(getMyPowerPermissions).mockResolvedValue({ can_manage_displays: true } as never);
+  vi.mocked(getDisplayLayout).mockResolvedValue(structuredClone(LAYOUT) as never);
+});
+
+async function open() {
+  render(<DisplayMenu />);
+  const button = await screen.findByLabelText('display:title');
+  fireEvent.click(button);
+  await waitFor(() => expect(getDisplayLayout).toHaveBeenCalled());
+}
+
+describe('DisplayMenu', () => {
+  it('bleibt unsichtbar ohne das Recht', async () => {
+    vi.mocked(getMyPowerPermissions).mockResolvedValue({ can_manage_displays: false } as never);
+    const { container } = render(<DisplayMenu />);
+    await waitFor(() => expect(getMyPowerPermissions).toHaveBeenCalled());
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('fragt erst ab, wenn das Popover offen ist', async () => {
+    render(<DisplayMenu />);
+    await screen.findByLabelText('display:title');
+    expect(getDisplayLayout).not.toHaveBeenCalled();
+  });
+
+  it('listet beide Ausgaenge', async () => {
+    await open();
+    expect(await screen.findByText('DP-3')).toBeTruthy();
+    expect(screen.getByText('HDMI-A-1')).toBeTruthy();
+  });
+
+  it('zeigt gewaehlt und leuchtet als getrennte Aussagen', async () => {
+    // Der mehrdeutige Zustand von BaluNode: KWin haelt DP-3 fuer gewaehlt,
+    // DRM meldet dunkel. Beides muss sichtbar sein, sonst widerspricht sich
+    // die Oberflaeche.
+    await open();
+    expect(screen.getAllByText('display:selected').length).toBe(1);
+    expect(screen.getAllByText('display:dark').length).toBe(2);
+  });
+
+  it('unterscheidet die beiden namensgleichen 4K-Modi im Auswahlfeld', async () => {
+    await open();
+    const select = screen.getByLabelText('display:mode:DP-3') as HTMLSelectElement;
+    const labels = Array.from(select.options).map((o) => o.textContent);
+    expect(new Set(labels).size).toBe(labels.length);
+    expect(labels.some((l) => l?.includes('119,88'))).toBe(true);
+  });
+
+  it('schickt id und name zusammen', async () => {
+    await open();
+    const select = screen.getByLabelText('display:mode:DP-3') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '58' } });
+    fireEvent.click(screen.getByText('display:apply'));
+    await waitFor(() => expect(applyDisplayLayout).toHaveBeenCalled());
+    const wishes = vi.mocked(applyDisplayLayout).mock.calls[0][0];
+    const dp3 = wishes.find((w) => w.name === 'DP-3');
+    expect(dp3).toEqual({
+      name: 'DP-3', selected: true, mode_id: '58', mode_name: '3840x2160@120',
+    });
+  });
+
+  it('sperrt Anwenden, wenn nichts mehr gewaehlt waere', async () => {
+    await open();
+    fireEvent.click(screen.getByLabelText('display:outputs:DP-3'));
+    const apply = screen.getByText('display:apply').closest('button') as HTMLButtonElement;
+    expect(apply.disabled).toBe(true);
+  });
+
+  it('meldet eine unerreichbare Sitzung statt einer leeren Liste', async () => {
+    vi.mocked(getDisplayLayout).mockResolvedValue({
+      ...LAYOUT, available: false, outputs: [],
+    } as never);
+    await open();
+    expect(await screen.findByText('display:unavailable')).toBeTruthy();
+  });
+});

--- a/client/src/__tests__/components/topbar/DisplayMenu.test.tsx
+++ b/client/src/__tests__/components/topbar/DisplayMenu.test.tsx
@@ -129,6 +129,51 @@ describe('DisplayMenu', () => {
     await open();
     expect(await screen.findByText('display:unavailable')).toBeTruthy();
   });
+
+  it('zeigt das neutrale Monitor-Symbol vor dem ersten Laden, nicht "dunkel"', async () => {
+    // Vor dem ersten Oeffnen wurde nie gefragt, ob etwas leuchtet - "dunkel"
+    // zu behaupten waere hier dieselbe Falschaussage wie bei `lit === null`.
+    const { container } = render(<DisplayMenu />);
+    await screen.findByLabelText('display:title');
+    expect(container.querySelector('.lucide-monitor-off')).toBeNull();
+    expect(container.querySelector('.lucide-monitor')).toBeTruthy();
+  });
+
+  it('zeigt MonitorOff erst, nachdem ein geladenes Layout nichts Leuchtendes zeigt', async () => {
+    // LAYOUT hat beide Ausgaenge mit lit: false - jetzt ist "dunkel"
+    // tatsaechlich beantwortet, nicht nur unbekannt.
+    const { container } = render(<DisplayMenu />);
+    const button = await screen.findByLabelText('display:title');
+    fireEvent.click(button);
+    await waitFor(() => expect(getDisplayLayout).toHaveBeenCalled());
+    await waitFor(() => expect(container.querySelector('.lucide-monitor-off')).toBeTruthy());
+  });
+
+  it('behaelt eine apply-Fehlermeldung ueber den naechsten Poll-Takt hinweg', async () => {
+    vi.mocked(applyDisplayLayout).mockRejectedValueOnce({ response: { status: 500 } });
+    render(<DisplayMenu />);
+    const button = await screen.findByLabelText('display:title');
+
+    // Die Fake-Timer MUESSEN vor dem Oeffnen aktiv sein: das Poll-Intervall
+    // wird beim Oeffnen aufgesetzt und lebt sonst auf der echten Uhr weiter,
+    // egal wie weit `advanceTimersByTimeAsync` danach vorspult.
+    vi.useFakeTimers();
+    fireEvent.click(button);
+    await vi.waitFor(() => expect(screen.getByText('DP-3')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('display:apply'));
+    await vi.waitFor(() => expect(applyDisplayLayout).toHaveBeenCalled());
+    await vi.waitFor(() => expect(screen.getByText('display:saveError')).toBeInTheDocument());
+
+    // Ein weiterer Poll-Takt (POLL_MS = 5000) laeuft erfolgreich durch und
+    // darf die Fehlermeldung nicht loeschen - genau der Fehler, den dieser
+    // Fix behebt (refresh() loeschte frueher jeden Fehler, nicht nur seinen
+    // eigenen).
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(screen.getByText('display:saveError')).toBeTruthy();
+    vi.useRealTimers();
+  });
 });
 
 describe('display i18n locale contract', () => {

--- a/client/src/__tests__/components/user-management/PowerPermissionsSection.displays.test.tsx
+++ b/client/src/__tests__/components/user-management/PowerPermissionsSection.displays.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns: string) => ({
+    t: (key: string) => `${ns}:${key}`,
+    i18n: { language: 'de' },
+  }),
+}));
+
+vi.mock('../../../api/powerPermissions', () => ({
+  getUserPowerPermissions: vi.fn(),
+  updateUserPowerPermissions: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Die Komponente zieht beides unbedingt herein; ohne Mock scheitert der
+// Import, nicht die Zusicherung.
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../../lib/errorHandling', () => ({
+  handleApiError: vi.fn(),
+}));
+
+import { PowerPermissionsSection } from '../../../components/user-management/PowerPermissionsSection';
+import { getUserPowerPermissions } from '../../../api/powerPermissions';
+
+const PERMS = {
+  user_id: 7,
+  can_soft_sleep: false, can_wake: false, can_suspend: false, can_wol: false,
+  can_toggle_desktop: false, can_unlock_session: false, can_control_audio: false,
+  can_manage_displays: false,
+  granted_by: null, granted_by_username: null, granted_at: null,
+};
+
+beforeEach(() => {
+  vi.mocked(getUserPowerPermissions).mockResolvedValue(structuredClone(PERMS) as never);
+});
+
+describe('PowerPermissionsSection — Displays', () => {
+  it('bietet den Schalter fuer can_manage_displays an', async () => {
+    render(<PowerPermissionsSection userId={7} userRole="user" />);
+    await waitFor(() => expect(getUserPowerPermissions).toHaveBeenCalled());
+    expect(
+      await screen.findByText('admin:users.systemPermissions.items.manageDisplays.label'),
+    ).toBeTruthy();
+  });
+});

--- a/client/src/api/displayOutput.ts
+++ b/client/src/api/displayOutput.ts
@@ -1,0 +1,80 @@
+/**
+ * API-Client der Displaysteuerung (bundled Plugin `display_output`).
+ *
+ * Alle Routen liegen hinter dem Recht `can_manage_displays` — auch die
+ * lesende, weil die Ausgangsliste die angeschlossene Hardware verrät.
+ *
+ * Modi werden über `id` adressiert, nie über `name`: KWin bildet den Namen mit
+ * gerundeter Bildwiederholrate, weshalb 119,88 und 120,00 Hz beide
+ * „3840x2160@120" heißen. `mode_name` reist nur als Gegenprobe mit.
+ */
+
+import { apiClient } from '../lib/api';
+
+const BASE = '/api/plugins/display_output';
+
+export interface DisplayMode {
+  /** Lebende KWin-Mode-ID. Nie speichern — sie gilt nur für diesen Abruf. */
+  id: string;
+  /** "3840x2160@120" — NICHT eindeutig. */
+  name: string;
+  width: number;
+  height: number;
+  /** Ungerundet, z. B. 119.87999725341797. */
+  refresh_rate: number;
+}
+
+export interface DisplayOutput {
+  name: string;
+  connected: boolean;
+  /** KWin-Ebene: ist dieser Ausgang gewählt? */
+  selected: boolean;
+  /** DRM-Ebene: werden Pixel getrieben? null = nicht zuordenbar. */
+  lit: boolean | null;
+  current_mode_id: string | null;
+  preferred_mode_id: string | null;
+  scale: number;
+  priority: number;
+  modes: DisplayMode[];
+}
+
+export interface DisplayLayout {
+  outputs: DisplayOutput[];
+  displays_powered: boolean;
+  available: boolean;
+  detail: string | null;
+}
+
+export interface DisplayOutputWish {
+  name: string;
+  selected: boolean;
+  mode_id?: string;
+  /** Pflicht, sobald mode_id gesetzt ist. */
+  mode_name?: string;
+}
+
+/** Liest Ausgänge, Modi und den globalen DPMS-Zustand in einem Rundlauf. */
+export async function getDisplayLayout(): Promise<DisplayLayout> {
+  const { data } = await apiClient.get<DisplayLayout>(`${BASE}/state`);
+  return data;
+}
+
+/** Setzt Auswahl und Modus — ein Aufruf, den das Backend atomar anwendet. */
+export async function applyDisplayLayout(outputs: DisplayOutputWish[]): Promise<void> {
+  await apiClient.post(`${BASE}/apply`, { outputs });
+}
+
+/**
+ * Beschriftet einen Modus für das Auswahlfeld.
+ *
+ * Zwei Nachkommastellen sind nicht Kosmetik: sie sind das Einzige, woran ein
+ * Mensch die beiden 4K-Modi von DP-3 auseinanderhält. Formatiert wird hier und
+ * nicht im Backend, weil das Dezimaltrennzeichen sprachabhängig ist.
+ */
+export function formatMode(mode: DisplayMode, locale: string): string {
+  const hz = new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(mode.refresh_rate);
+  return `${mode.width} × ${mode.height} @ ${hz} Hz`;
+}

--- a/client/src/api/powerPermissions.ts
+++ b/client/src/api/powerPermissions.ts
@@ -13,6 +13,7 @@ export interface UserPowerPermissions {
   can_toggle_desktop: boolean;
   can_unlock_session: boolean;
   can_control_audio: boolean;
+  can_manage_displays: boolean;
   granted_by: number | null;
   granted_by_username: string | null;
   granted_at: string | null;
@@ -26,6 +27,7 @@ export interface UserPowerPermissionsUpdate {
   can_toggle_desktop?: boolean;
   can_unlock_session?: boolean;
   can_control_audio?: boolean;
+  can_manage_displays?: boolean;
 }
 
 export interface MyPowerPermissions {

--- a/client/src/api/powerPermissions.ts
+++ b/client/src/api/powerPermissions.ts
@@ -36,6 +36,7 @@ export interface MyPowerPermissions {
   can_toggle_desktop: boolean;
   can_unlock_session: boolean;
   can_control_audio: boolean;
+  can_manage_displays: boolean;
 }
 
 /**

--- a/client/src/components/layout/LayoutHeader.tsx
+++ b/client/src/components/layout/LayoutHeader.tsx
@@ -3,6 +3,7 @@ import PowerMenu from '../PowerMenu';
 import UserMenu from '../UserMenu';
 import { TopbarStatusStrip } from '../topbar/TopbarStatusStrip';
 import { AudioMenu } from '../topbar/AudioMenu';
+import { DisplayMenu } from '../topbar/DisplayMenu';
 import { isPi } from '../../lib/features';
 import { usePluginEnabled } from '../../contexts/PluginContext';
 import { SidebarBrand } from './SidebarBrand';
@@ -18,6 +19,7 @@ interface LayoutHeaderProps {
 
 export function LayoutHeader({ isImpersonating, isAdmin, onOpenMobileMenu, onShutdown, onRestart, onLogout }: LayoutHeaderProps) {
   const audioEnabled = usePluginEnabled('audio_control');
+  const displaysEnabled = usePluginEnabled('display_output');
   return (
     <header className={`fixed right-0 left-0 lg:left-72 z-30 border-b border-slate-800/50 bg-slate-900/20 px-4 py-4 shadow-[0_8px_32px_rgba(0,0,0,0.3)] backdrop-blur-2xl sm:px-6 lg:px-10 ${isImpersonating ? 'top-10' : 'top-0'}`}>
       <div className="flex items-center justify-between">
@@ -41,6 +43,7 @@ export function LayoutHeader({ isImpersonating, isAdmin, onOpenMobileMenu, onShu
 
         {/* Header Right */}
         <div className="flex items-center gap-3">
+          {!isPi && displaysEnabled && <DisplayMenu />}
           {!isPi && audioEnabled && <AudioMenu />}
           {!isPi && <NotificationCenter />}
           <UserMenu />

--- a/client/src/components/topbar/DisplayMenu.tsx
+++ b/client/src/components/topbar/DisplayMenu.tsx
@@ -33,6 +33,13 @@ interface Draft {
   modeId: string | null;
 }
 
+/**
+ * i18n-Schlüssel statt übersetztem Text: `error` überlebt so einen
+ * Sprachwechsel, während das Popover offen bleibt — übersetzt wird erst beim
+ * Rendern (`t(error)`), nie beim Setzen.
+ */
+type ErrorKey = 'loadError' | 'saveError' | 'conflictError';
+
 export function DisplayMenu() {
   const { t, i18n } = useTranslation('display');
   const [allowed, setAllowed] = useState<boolean | null>(null);
@@ -40,7 +47,7 @@ export function DisplayMenu() {
   const [layout, setLayout] = useState<DisplayLayout | null>(null);
   const [draft, setDraft] = useState<Record<string, Draft>>({});
   const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<ErrorKey | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const inFlight = useRef(false);
   const dirty = useRef(false);
@@ -74,16 +81,20 @@ export function DisplayMenu() {
       }
       setError(null);
     } catch {
-      setError(t('loadError'));
+      setError('loadError');
     } finally {
       inFlight.current = false;
     }
-    // `t` bewusst NICHT in den Deps: t() wechselt bei jedem Render die
-    // Identität (react-i18next liefert nur pro Sprache eine stabile
-    // Referenz), refresh() hängt aber am Poll-Intervall — eine instabile
-    // Dependency würde das Intervall bei jedem Render neu aufsetzen und
-    // sofort erneut abfragen (Endlosschleife).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Leere Deps sind hier Absicht, nicht Nachlässigkeit: refresh() muss über
+    // Renders hinweg dieselbe Identität behalten, weil der Poll-Effekt weiter
+    // unten (deps [isOpen, refresh]) sonst bei jedem Render das Intervall
+    // abbaut und sofort neu aufsetzt — inklusive eines sofortigen erneuten
+    // refresh()-Aufrufs, der wiederum einen Render auslöst. Genau das hat den
+    // Test-Worker in eine Endlosschleife gehängt, als hier noch `t()`
+    // aufgerufen wurde: react-i18next liefert `t` zwar pro Sprache stabil,
+    // aber unter dem Test-Mock ändert sich die Identität bei jedem Render —
+    // deshalb lebt der Fehlertext jetzt nur als Schlüssel (siehe `ErrorKey`)
+    // und wird erst beim Rendern übersetzt, nie hier drin.
   }, []);
 
   useEffect(() => {
@@ -134,10 +145,15 @@ export function DisplayMenu() {
       await refresh();
     } catch (err: unknown) {
       const statusCode = (err as { response?: { status?: number } })?.response?.status;
-      setError(statusCode === 409 ? t('conflictError') : t('saveError'));
       if (statusCode === 409) {
+        // Der Refetch MUSS vor dem Setzen der Meldung laufen: refresh()
+        // setzt bei Erfolg selbst setError(null) — danach gesetzt, würde die
+        // Konflikt-Meldung sich im selben Atemzug wieder löschen.
         dirty.current = false;
         await refresh();
+        setError('conflictError');
+      } else {
+        setError('saveError');
       }
     } finally {
       setBusy(false);
@@ -153,7 +169,14 @@ export function DisplayMenu() {
       <button
         type="button"
         aria-label={t('title')}
-        onClick={() => setIsOpen((open) => !open)}
+        onClick={() => {
+          // Schließt sich das Popover gerade (isOpen war true), verwirft der
+          // Klick einen angefangenen, ungespeicherten Entwurf — sonst würde
+          // er beim nächsten Öffnen dem Server-Poll im Weg stehen, obwohl der
+          // Nutzer gar nicht mehr mitten in der Bearbeitung ist.
+          if (isOpen) dirty.current = false;
+          setIsOpen((open) => !open);
+        }}
         className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-800 text-slate-400 transition hover:border-sky-500/50 hover:text-sky-400"
       >
         {anyLit ? <Monitor className="h-5 w-5" /> : <MonitorOff className="h-5 w-5" />}
@@ -230,7 +253,7 @@ export function DisplayMenu() {
               {nothingSelected && (
                 <p className="mb-2 text-xs text-amber-400">{t('keepOneSelected')}</p>
               )}
-              {error && <p className="mb-2 text-xs text-rose-400">{error}</p>}
+              {error && <p className="mb-2 text-xs text-rose-400">{t(error)}</p>}
 
               <button
                 type="button"

--- a/client/src/components/topbar/DisplayMenu.tsx
+++ b/client/src/components/topbar/DisplayMenu.tsx
@@ -1,0 +1,249 @@
+/**
+ * Displaysteuerung in der Topbar.
+ *
+ * Zeigt ein Monitor-Symbol; im Popover steht pro Ausgang die KWin-Wahl und
+ * ein Auswahlfeld für den Video-Modus.
+ *
+ * Drei Eigenheiten, die Absicht sind:
+ * - Der Zustand wird nur abgefragt, solange das Popover offen ist. Eine
+ *   Fernbedienung, die im Hintergrund pollt, kostet Anfragen ohne Gegenwert.
+ * - „gewählt" (KWin) und „leuchtet" (DRM) sind getrennte Aussagen. Beides in
+ *   ein Abzeichen zu falten, ist die Verwechslung, die dieses Feature auflöst.
+ * - Der globale Ein/Aus-Schalter fehlt bewusst: er steht zwei Symbole weiter
+ *   im Systemmenü, und zwei Komponenten für denselben Zustand driften.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Monitor, MonitorOff } from 'lucide-react';
+import {
+  applyDisplayLayout,
+  formatMode,
+  getDisplayLayout,
+  type DisplayLayout,
+  type DisplayOutputWish,
+} from '../../api/displayOutput';
+import { getMyPowerPermissions } from '../../api/powerPermissions';
+
+/** Abfragetakt, solange das Popover offen ist. */
+const POLL_MS = 5000;
+
+/** Der bearbeitete Wunsch je Ausgang, bevor „Anwenden" ihn abschickt. */
+interface Draft {
+  selected: boolean;
+  modeId: string | null;
+}
+
+export function DisplayMenu() {
+  const { t, i18n } = useTranslation('display');
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [layout, setLayout] = useState<DisplayLayout | null>(null);
+  const [draft, setDraft] = useState<Record<string, Draft>>({});
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const inFlight = useRef(false);
+  const dirty = useRef(false);
+
+  useEffect(() => {
+    let active = true;
+    getMyPowerPermissions()
+      .then((perms) => active && setAllowed(perms.can_manage_displays))
+      .catch(() => active && setAllowed(false));
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    // Läuft noch eine Antwort, wird übersprungen — sonst stauen sich bei
+    // langsamer Verbindung die Anfragen.
+    if (inFlight.current) return;
+    inFlight.current = true;
+    try {
+      const next = await getDisplayLayout();
+      setLayout(next);
+      // Einen angefangenen Entwurf NICHT überschreiben — sonst springt die
+      // Auswahl beim nächsten Takt auf den Serverwert zurück.
+      if (!dirty.current) {
+        setDraft(
+          Object.fromEntries(
+            next.outputs.map((o) => [o.name, { selected: o.selected, modeId: o.current_mode_id }]),
+          ),
+        );
+      }
+      setError(null);
+    } catch {
+      setError(t('loadError'));
+    } finally {
+      inFlight.current = false;
+    }
+    // `t` bewusst NICHT in den Deps: t() wechselt bei jedem Render die
+    // Identität (react-i18next liefert nur pro Sprache eine stabile
+    // Referenz), refresh() hängt aber am Poll-Intervall — eine instabile
+    // Dependency würde das Intervall bei jedem Render neu aufsetzen und
+    // sofort erneut abfragen (Endlosschleife).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    void refresh();
+    const id = setInterval(() => void refresh(), POLL_MS);
+    return () => clearInterval(id);
+  }, [isOpen, refresh]);
+
+  useEffect(() => {
+    const onClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+        dirty.current = false;
+      }
+    };
+    if (isOpen) document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, [isOpen]);
+
+  const wishes: DisplayOutputWish[] = useMemo(() => {
+    if (!layout) return [];
+    return layout.outputs.map((output) => {
+      const entry = draft[output.name] ?? { selected: output.selected, modeId: output.current_mode_id };
+      const mode = output.modes.find((m) => m.id === entry.modeId);
+      const wish: DisplayOutputWish = { name: output.name, selected: entry.selected };
+      // id und name reisen immer gemeinsam — das Backend lehnt eine einzelne
+      // Hälfte ab, weil die Gegenprobe sonst abschaltbar wäre.
+      if (entry.selected && mode) {
+        wish.mode_id = mode.id;
+        wish.mode_name = mode.name;
+      }
+      return wish;
+    });
+  }, [layout, draft]);
+
+  const nothingSelected =
+    layout !== null &&
+    layout.outputs.some((o) => o.connected) &&
+    !layout.outputs.some((o) => o.connected && (draft[o.name]?.selected ?? o.selected));
+
+  const handleApply = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await applyDisplayLayout(wishes);
+      dirty.current = false;
+      await refresh();
+    } catch (err: unknown) {
+      const statusCode = (err as { response?: { status?: number } })?.response?.status;
+      setError(statusCode === 409 ? t('conflictError') : t('saveError'));
+      if (statusCode === 409) {
+        dirty.current = false;
+        await refresh();
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!allowed) return null;
+
+  const anyLit = layout?.outputs.some((o) => o.lit === true) ?? false;
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        type="button"
+        aria-label={t('title')}
+        onClick={() => setIsOpen((open) => !open)}
+        className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-800 text-slate-400 transition hover:border-sky-500/50 hover:text-sky-400"
+      >
+        {anyLit ? <Monitor className="h-5 w-5" /> : <MonitorOff className="h-5 w-5" />}
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 z-50 mt-2 w-96 rounded-xl border border-slate-800 bg-slate-900/95 p-4 shadow-xl backdrop-blur-xl">
+          {layout && !layout.available && (
+            <p className="text-sm text-slate-400">{t('unavailable')}</p>
+          )}
+
+          {layout?.available && (
+            <>
+              <p className="mb-2 text-xs uppercase tracking-wide text-slate-500">{t('outputs')}</p>
+
+              {layout.outputs.map((output) => {
+                const entry = draft[output.name] ?? {
+                  selected: output.selected,
+                  modeId: output.current_mode_id,
+                };
+                return (
+                  <div key={output.name} className="mb-4 border-b border-slate-800 pb-3 last:border-0">
+                    <div className="mb-1 flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        id={`display-${output.name}`}
+                        aria-label={t('outputs') + ':' + output.name}
+                        checked={entry.selected}
+                        onChange={(e) => {
+                          dirty.current = true;
+                          setDraft((prev) => ({
+                            ...prev,
+                            [output.name]: { ...entry, selected: e.target.checked },
+                          }));
+                        }}
+                      />
+                      <label htmlFor={`display-${output.name}`} className="text-sm text-slate-200">
+                        {output.name}
+                      </label>
+                      <span className="ml-auto text-xs text-slate-500">
+                        {output.selected ? t('selected') : t('notSelected')}
+                      </span>
+                      <span className="text-xs text-slate-500">
+                        {output.lit === null ? t('litUnknown') : output.lit ? t('lit') : t('dark')}
+                      </span>
+                    </div>
+
+                    <select
+                      aria-label={t('mode', { output: output.name })}
+                      value={entry.modeId ?? ''}
+                      disabled={!entry.selected}
+                      onChange={(e) => {
+                        dirty.current = true;
+                        setDraft((prev) => ({
+                          ...prev,
+                          [output.name]: { ...entry, modeId: e.target.value },
+                        }));
+                      }}
+                      className="w-full rounded-lg border border-slate-700 bg-slate-800 px-2 py-1 text-sm text-slate-200 disabled:opacity-50"
+                    >
+                      {output.modes.map((mode) => (
+                        <option key={mode.id} value={mode.id}>
+                          {formatMode(mode, i18n.language)}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                );
+              })}
+
+              {!layout.displays_powered && (
+                <p className="mb-2 text-xs text-amber-400">{t('allDark')}</p>
+              )}
+              {nothingSelected && (
+                <p className="mb-2 text-xs text-amber-400">{t('keepOneSelected')}</p>
+              )}
+              {error && <p className="mb-2 text-xs text-rose-400">{error}</p>}
+
+              <button
+                type="button"
+                onClick={() => void handleApply()}
+                disabled={busy || nothingSelected}
+                className="w-full rounded-lg bg-sky-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-sky-500 disabled:opacity-50"
+              >
+                {busy ? t('applying') : t('apply')}
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/topbar/DisplayMenu.tsx
+++ b/client/src/components/topbar/DisplayMenu.tsx
@@ -104,6 +104,12 @@ export function DisplayMenu() {
 
   useEffect(() => {
     if (!isOpen) return;
+    // Eine saveError/conflictError aus einer vorigen Sitzung gehört nicht in
+    // ein frisch geöffnetes Popover — der Nutzer sieht sonst eine Klage über
+    // eine Interaktion, die er längst verlassen hat. Der Poll-Takt selbst
+    // löscht bewusst nur `loadError` (siehe refresh()); das hier ist der
+    // einzige Ort, an dem auch saveError/conflictError geräumt wird.
+    setError(null);
     void refresh();
     const id = setInterval(() => void refresh(), POLL_MS);
     return () => clearInterval(id);
@@ -151,9 +157,10 @@ export function DisplayMenu() {
     } catch (err: unknown) {
       const statusCode = (err as { response?: { status?: number } })?.response?.status;
       if (statusCode === 409) {
-        // Der Refetch MUSS vor dem Setzen der Meldung laufen: refresh()
-        // setzt bei Erfolg selbst setError(null) — danach gesetzt, würde die
-        // Konflikt-Meldung sich im selben Atemzug wieder löschen.
+        // Der Refetch MUSS vor dem Setzen der Meldung laufen: er holt eine
+        // frische Modus-Liste und setzt den Entwurf zurück — die Meldung soll
+        // den Zustand beschreiben, in dem der Nutzer danach landet, nicht den,
+        // den er verlassen hat.
         dirty.current = false;
         await refresh();
         setError('conflictError');

--- a/client/src/components/topbar/DisplayMenu.tsx
+++ b/client/src/components/topbar/DisplayMenu.tsx
@@ -79,7 +79,12 @@ export function DisplayMenu() {
           ),
         );
       }
-      setError(null);
+      // Nur den eigenen Fehler löschen: eine apply-Fehlermeldung
+      // (saveError/conflictError) soll bis zur nächsten Nutzeraktion stehen
+      // bleiben, nicht beim nächsten Poll-Takt verschwinden — sonst würde
+      // dieser refresh() genau die Meldung wieder wegwischen, die handleApply
+      // absichtlich erst nach dem Refetch gesetzt hat.
+      setError((prev) => (prev === 'loadError' ? null : prev));
     } catch {
       setError('loadError');
     } finally {
@@ -163,6 +168,11 @@ export function DisplayMenu() {
   if (!allowed) return null;
 
   const anyLit = layout?.outputs.some((o) => o.lit === true) ?? false;
+  // Vor dem ersten geladenen Layout ist "leuchtet keiner" nicht beantwortet,
+  // sondern schlicht noch nicht gefragt — dasselbe Falschaussage-Muster wie
+  // bei `lit`. Erst nach einem geladenen Layout darf das Symbol wirklich
+  // "dunkel" behaupten.
+  const showLitIcon = layout === null || anyLit;
 
   return (
     <div className="relative" ref={dropdownRef}>
@@ -179,7 +189,7 @@ export function DisplayMenu() {
         }}
         className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-800 text-slate-400 transition hover:border-sky-500/50 hover:text-sky-400"
       >
-        {anyLit ? <Monitor className="h-5 w-5" /> : <MonitorOff className="h-5 w-5" />}
+        {showLitIcon ? <Monitor className="h-5 w-5" /> : <MonitorOff className="h-5 w-5" />}
       </button>
 
       {isOpen && (

--- a/client/src/components/user-management/PowerPermissionsSection.tsx
+++ b/client/src/components/user-management/PowerPermissionsSection.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Moon, Sun, Power, Wifi, MonitorOff, LockOpen, Volume2, Loader2 } from 'lucide-react';
+import { Moon, Sun, Power, Wifi, MonitorOff, Monitor, LockOpen, Volume2, Loader2 } from 'lucide-react';
 import {
   getUserPowerPermissions,
   updateUserPowerPermissions,
@@ -32,6 +32,7 @@ const FIELD_TO_I18N: Record<keyof UserPowerPermissionsUpdate, string> = {
   can_toggle_desktop: 'toggleDesktop',
   can_unlock_session: 'unlockSession',
   can_control_audio: 'controlAudio',
+  can_manage_displays: 'manageDisplays',
 };
 
 const PERMISSION_TOGGLES: PermissionToggle[] = [
@@ -42,6 +43,7 @@ const PERMISSION_TOGGLES: PermissionToggle[] = [
   { key: 'can_toggle_desktop', icon: <MonitorOff className="h-4 w-4" /> },
   { key: 'can_unlock_session', icon: <LockOpen className="h-4 w-4" /> },
   { key: 'can_control_audio', icon: <Volume2 className="h-4 w-4" /> },
+  { key: 'can_manage_displays', icon: <Monitor className="h-4 w-4" /> },
 ];
 
 export function PowerPermissionsSection({ userId, userRole }: PowerPermissionsSectionProps) {

--- a/client/src/i18n/index.ts
+++ b/client/src/i18n/index.ts
@@ -43,6 +43,8 @@ import statusBarDe from './locales/de/statusBar.json';
 import statusBarEn from './locales/en/statusBar.json';
 import audioDe from './locales/de/audio.json';
 import audioEn from './locales/en/audio.json';
+import displayDe from './locales/de/display.json';
+import displayEn from './locales/en/display.json';
 
 const resources = {
   de: {
@@ -66,6 +68,7 @@ const resources = {
     pihole: piholeDe,
     statusBar: statusBarDe,
     audio: audioDe,
+    display: displayDe,
   },
   en: {
     common: commonEn,
@@ -88,6 +91,7 @@ const resources = {
     pihole: piholeEn,
     statusBar: statusBarEn,
     audio: audioEn,
+    display: displayEn,
   },
 };
 
@@ -98,7 +102,7 @@ i18n
     resources,
     fallbackLng: 'de',
     defaultNS: 'common',
-    ns: ['common', 'dashboard', 'fileManager', 'settings', 'admin', 'login', 'system', 'shares', 'plugins', 'devices', 'scheduler', 'notifications', 'updates', 'remoteServers', 'apiDocs', 'manual', 'setup', 'pihole', 'statusBar', 'audio'],
+    ns: ['common', 'dashboard', 'fileManager', 'settings', 'admin', 'login', 'system', 'shares', 'plugins', 'devices', 'scheduler', 'notifications', 'updates', 'remoteServers', 'apiDocs', 'manual', 'setup', 'pihole', 'statusBar', 'audio', 'display'],
     
     detection: {
       // Order of language detection methods

--- a/client/src/i18n/locales/de/admin.json
+++ b/client/src/i18n/locales/de/admin.json
@@ -95,7 +95,8 @@
           "label": "Session entsperren",
           "desc": "Beim Einschalten der Displays die Desktop-Sitzung mit entsperren (nur aus dem Heimnetz oder VPN)"
         },
-        "controlAudio": { "label": "Audio", "desc": "Lautstärke, Ausgabegerät und Anwendungs-Mixer steuern" }
+        "controlAudio": { "label": "Audio", "desc": "Lautstärke, Ausgabegerät und Anwendungs-Mixer steuern" },
+        "manageDisplays": { "label": "Displays", "desc": "Bildschirm-Ausgang und Auflösung wählen" }
       }
     }
   },

--- a/client/src/i18n/locales/de/display.json
+++ b/client/src/i18n/locales/de/display.json
@@ -1,7 +1,7 @@
 {
   "title": "Displays",
   "outputs": "Ausgänge",
-  "mode": "Auflösung",
+  "mode": "Auflösung — {{output}}",
   "selected": "gewählt",
   "notSelected": "nicht gewählt",
   "lit": "leuchtet",

--- a/client/src/i18n/locales/de/display.json
+++ b/client/src/i18n/locales/de/display.json
@@ -1,0 +1,19 @@
+{
+  "title": "Displays",
+  "outputs": "Ausgänge",
+  "mode": "Auflösung",
+  "selected": "gewählt",
+  "notSelected": "nicht gewählt",
+  "lit": "leuchtet",
+  "dark": "dunkel",
+  "litUnknown": "Zustand unbekannt",
+  "allDark": "Alle Bildschirme sind dunkel. Im Systemmenü lassen sie sich einschalten.",
+  "apply": "Anwenden",
+  "applying": "Wird angewendet …",
+  "applied": "Übernommen",
+  "unavailable": "Die Displaysteuerung ist nicht erreichbar. Läuft die Desktop-Sitzung?",
+  "loadError": "Displayzustand konnte nicht geladen werden",
+  "saveError": "Änderung konnte nicht übernommen werden",
+  "conflictError": "Die Modusliste hat sich geändert. Bitte erneut versuchen.",
+  "keepOneSelected": "Mindestens ein Ausgang muss gewählt bleiben."
+}

--- a/client/src/i18n/locales/de/display.json
+++ b/client/src/i18n/locales/de/display.json
@@ -10,7 +10,6 @@
   "allDark": "Alle Bildschirme sind dunkel. Im Systemmenü lassen sie sich einschalten.",
   "apply": "Anwenden",
   "applying": "Wird angewendet …",
-  "applied": "Übernommen",
   "unavailable": "Die Displaysteuerung ist nicht erreichbar. Läuft die Desktop-Sitzung?",
   "loadError": "Displayzustand konnte nicht geladen werden",
   "saveError": "Änderung konnte nicht übernommen werden",

--- a/client/src/i18n/locales/en/admin.json
+++ b/client/src/i18n/locales/en/admin.json
@@ -95,7 +95,8 @@
           "label": "Unlock session",
           "desc": "Also unlock the desktop session when turning the displays on (home network or VPN only)"
         },
-        "controlAudio": { "label": "Audio", "desc": "Control volume, output device and the per-app mixer" }
+        "controlAudio": { "label": "Audio", "desc": "Control volume, output device and the per-app mixer" },
+        "manageDisplays": { "label": "Displays", "desc": "Choose the display output and resolution" }
       }
     }
   },

--- a/client/src/i18n/locales/en/display.json
+++ b/client/src/i18n/locales/en/display.json
@@ -1,7 +1,7 @@
 {
   "title": "Displays",
   "outputs": "Outputs",
-  "mode": "Resolution",
+  "mode": "Resolution — {{output}}",
   "selected": "selected",
   "notSelected": "not selected",
   "lit": "lit",

--- a/client/src/i18n/locales/en/display.json
+++ b/client/src/i18n/locales/en/display.json
@@ -1,0 +1,19 @@
+{
+  "title": "Displays",
+  "outputs": "Outputs",
+  "mode": "Resolution",
+  "selected": "selected",
+  "notSelected": "not selected",
+  "lit": "lit",
+  "dark": "dark",
+  "litUnknown": "state unknown",
+  "allDark": "All screens are dark. Turn them on from the system menu.",
+  "apply": "Apply",
+  "applying": "Applying …",
+  "applied": "Applied",
+  "unavailable": "Display control is unreachable. Is the desktop session running?",
+  "loadError": "Could not load display state",
+  "saveError": "Could not apply the change",
+  "conflictError": "The mode list changed. Please try again.",
+  "keepOneSelected": "At least one output must stay selected."
+}

--- a/client/src/i18n/locales/en/display.json
+++ b/client/src/i18n/locales/en/display.json
@@ -10,7 +10,6 @@
   "allDark": "All screens are dark. Turn them on from the system menu.",
   "apply": "Apply",
   "applying": "Applying …",
-  "applied": "Applied",
   "unavailable": "Display control is unreachable. Is the desktop session running?",
   "loadError": "Could not load display state",
   "saveError": "Could not apply the change",

--- a/docs/superpowers/plans/2026-09-08-display-output-control.md
+++ b/docs/superpowers/plans/2026-09-08-display-output-control.md
@@ -1,0 +1,319 @@
+# Plan: Display-Output-Steuerung in der BaluHost-Webapp
+
+**Datum:** 2026-09-08
+**Host:** BaluNode (Debian 13, KDE Plasma 6 / KWin Wayland, Backend als `User=sven`)
+**Status:** Plan — noch nicht umgesetzt, keine Code-Änderung erfolgt.
+**Teilweise überholt:** die Architektur- (Core statt Plugin) und
+Adressierungsentscheidungen (Modus über `name`) dieses Dokuments wurden durch
+Messungen widerlegt bzw. neu entschieden. Maßgeblich ist
+`docs/superpowers/specs/2026-09-08-display-output-plugin-design.md`, Abschnitt 17
+listet jede Abweichung. Dieses Dokument bleibt als Diagnose-Grundlage erhalten.
+**Verwandt:** #589 (stale Mode-IDs in `deploy/scripts/display-switch`),
+`/home/sven/docs/superpowers/specs/2026-05-09-display-switch-design.md`,
+`/home/sven/docs/superpowers/specs/2026-05-20-display-switch-nas-mode-design.md`
+
+---
+
+## 1. Ziel
+
+Die Webapp soll die angeschlossenen Displays erkennen und den Ausgang anpassen
+können: pro DRM-/KWin-Connector aktivieren/deaktivieren und den Video-Mode
+(Auflösung + Bildwiederholrate) wählen. Generische Output-Verwaltung, keine
+festen Profile.
+
+## 2. Status quo (Diagnose vom 2026-09-08)
+
+### 2.1 Was schon existiert
+
+| Baustein | Datei | Kann heute |
+|---|---|---|
+| DRM-Connector-Zähler | `backend/app/services/power/gpu/display_detector.py` | zählt aktive Connectoren aus sysfs — **nur eine Zahl**, keine Namen, keine Modi |
+| DPMS-Backend | `backend/app/services/power/desktop_backend.py` | `kscreen-doctor --dpms on\|off` über `wayland_session_env()` |
+| Service-Factory | `backend/app/services/power/desktop.py` | dev-/linux-Backend-Auswahl, Singleton |
+| Routes | `backend/app/api/routes/desktop.py` | `/api/system/sleep/desktop/{status,enable,disable,unlock}` |
+| Frontend | `client/src/components/power/DesktopTogglePanel.tsx` | Ein/Aus-Button auf der Sleep-Seite |
+| Audio | `backend/app/plugins/installed/audio_control/pactl.py` | Sinks auflisten, Default-Sink setzen |
+
+Der Weg **Backend → KWin ist damit schon offen und erprobt**: der Dienst läuft
+als `User=sven`, also derselbe User wie die Plasma-Session, und
+`wayland_session_env()` ergänzt `XDG_RUNTIME_DIR` + `WAYLAND_DISPLAY`.
+
+**Es fehlt genau die Mitte:** Output-Enumeration (Name, connected, enabled,
+Modenliste) und ein Endpoint zum Setzen.
+
+### 2.2 Live-Zustand BaluNode
+
+```
+card0-DP-1        disconnected
+card0-DP-2        disconnected
+card0-DP-3        connected   DRM enabled=disabled   KWin enabled=true,  priority 1, 3840x2160@120
+card0-HDMI-A-1    connected   DRM enabled=disabled   KWin enabled=false, priority 0, 2560x1440@144
+```
+
+Tools vorhanden: `kscreen-doctor`, `xrandr`, `wayland-info`. Nicht vorhanden:
+`ddcutil`, `wlr-randr` (für KWin auch nicht nötig).
+
+### 2.3 Das zentrale Zustands-Problem: zwei Ebenen von „an"
+
+- **KWin-Ebene** (`kscreen-doctor`) = die Ausgangs*wahl*. DP-3 enabled,
+  HDMI-A-1 disabled.
+- **DRM-Ebene** (sysfs `enabled`) = ob tatsächlich Pixel getrieben werden.
+  Bei DPMS-off sind **alle** Connectoren `disabled`.
+
+Deshalb meldet `DesktopTogglePanel` gerade „Gestoppt", während KWin DP-3 für
+aktiv hält. Das ist kein Bug, sondern der Zustand, den `display-switch status`
+`mode=ambiguous` nennt. Jede neue UI muss beide Ebenen **getrennt** anzeigen,
+sonst behauptet sie „DP-3 aktiv" und „Displays aus" gleichzeitig.
+
+### 2.4 `kscreen-doctor -j` — tatsächliche Struktur
+
+Verifiziert auf BaluNode. Pro Output:
+
+```
+name, id, connected, enabled, currentModeId, preferredModes[],
+priority, scale, rotation, pos{x,y}, size{w,h}, sizeMM{w,h},
+type, vrrPolicy, hdr, wcg, sdr-brightness, overscan,
+clones[], replicationSource, followPreferredMode,
+modes[ { id, name, refreshRate, size{width,height} } ]
+```
+
+**Wichtigster Befund:** jedes Mode-Objekt trägt schon ein `name` wie
+`"2560x1440@144"`. Das ist der stabile Schlüssel. `kscreen-doctor` akzeptiert
+ihn direkt (`output.DP-3.mode.3840x2160@120`, per `--help` bestätigt).
+Mode-**IDs** sind dagegen global über alle Outputs vergeben und instabil — genau
+der Defekt in #589. **Die Implementierung adressiert Modi ausschließlich über
+`name`, niemals über `id`.**
+
+> **Nachtrag 2026-09-08 (widerlegt).** Der vollständige `-j`-Mitschnitt zeigt,
+> dass `name` **nicht eindeutig** ist: `libkscreen`'s `findMode()` bildet ihn mit
+> `qRound(refreshRate)`, weshalb 119,88 und 120,000 beide `3840x2160@120` heißen
+> (DP-3, id 57/58), und HDMI-A-1 sechs mehrfach belegte Namen trägt. Dieselbe
+> Codestelle belegt zudem, dass die Mode-ID sehr wohl ein gültiges Argument ist.
+> Die Nachfolge-Spec adressiert Modi deshalb über die **lebende** ID plus
+> Namensabgleich. Siehe Spec Abschnitt 4.1 und 7.
+
+### 2.5 Das bestehende `display-switch`-Skript
+
+`deploy/scripts/display-switch` (byte-identisch mit `~/.local/bin/display-switch`),
+Branch `feat/display-switch-desktop-guard` ist in `main`. Kann `tv`, `monitor`,
+`status`, `__test`; schaltet Display **und** Audio-Sink und startet vorher sddm.
+`nas` aus Spec 2026-05-20 ist nicht implementiert; `/etc/sudoers.d/display-switch`
+existiert nicht. `tv`/`monitor` brechen aktuell wegen #589 ab.
+
+Das Skript bleibt als CLI unabhängig bestehen. Dieses Feature ersetzt es nicht.
+
+---
+
+## 3. Nicht-Ziele (YAGNI)
+
+- **Kein VRR und kein HDR in der UI.** Auf diesem Host verursacht VRR an
+  HDMI-A-1 einen Blackout (dokumentiert als `MON_VRR="never"` MUSS im
+  display-switch-Plan). Ein Schalter, dessen falsche Stellung das Bild killt,
+  gehört nicht in v1.
+- **Kein Positions-Editor / kein Layout-Arrangement.** Mehrere gleichzeitig
+  aktive Outputs werden unterstützt, aber die Anordnung bleibt KWins Sache.
+- **Kein Stoppen von sddm / kein NAS-Modus.** Bewusst: laut
+  `desktop_backend.py` lichtet der fbcon nach `systemctl stop sddm` alle
+  Outputs und nagelt die dGPU bei ~78 W.
+- **Keine Audio-Kopplung in v1.** Siehe offene Punkte.
+- **Kein Hotplug-Push / kein WebSocket.** Polling wie beim bestehenden Panel.
+- **Kein Profil-/Preset-System.** Explizit verworfen zugunsten generischer
+  Verwaltung.
+
+---
+
+## 4. Getroffene Entscheidungen
+
+| Frage | Entscheidung |
+|---|---|
+| Bedienmodell | Generische Output-Verwaltung — alle Connectoren enumeriert, je Output enable/disable + Mode-Auswahl |
+| Ausführung | `kscreen-doctor` direkt aus Python, analog `LinuxDesktopBackend`. Kein Aufruf von `display-switch`, kein sudo |
+| UI-Zustandsmodell | Eine neue Seite „Displays": globaler DPMS-Schalter **plus** pro Output die KWin-Wahl. Das bestehende `DesktopTogglePanel` auf der Sleep-Seite bleibt unverändert als Schnellzugriff |
+
+---
+
+## 5. Architektur
+
+Spiegelt exakt das vorhandene Desktop-Toggle-Muster — Backends getrennt von der
+Service-Fassade, Singleton-Factory, dev-/linux-Auswahl über
+`settings.is_dev_mode`.
+
+```
+routes/display.py
+   └─ services/power/display.py          DisplayService  (Fassade, Singleton)
+        ├─ DevDisplayBackend             In-Memory, zwei Fake-Outputs
+        └─ LinuxDisplayBackend           kscreen-doctor -j / kscreen-doctor output.*
+             ├─ wayland_session_env()            (vorhanden, wiederverwendet)
+             └─ display_detector.get_…_count()   (vorhanden, für die DRM-Ebene)
+```
+
+Ein `apply` ist **ein einziger** `kscreen-doctor`-Aufruf mit allen Argumenten —
+das Tool wendet atomar an („all settings are applied in a single command").
+Kein Teilzustand bei Fehlern.
+
+### 5.1 Dateien
+
+| Pfad | Verantwortung | Status |
+|---|---|---|
+| `backend/app/schemas/display.py` | `DisplayMode`, `DisplayOutput`, `DisplayLayout`, `DisplayApplyRequest` | neu |
+| `backend/app/services/power/display_backend.py` | Protocol + `DevDisplayBackend` + `LinuxDisplayBackend` (inkl. JSON-Parser) | neu |
+| `backend/app/services/power/display.py` | `DisplayService`, `get_display_service()`, Validierung | neu |
+| `backend/app/api/routes/display.py` | `GET /`, `POST /apply` | neu |
+| `backend/app/api/routes/__init__.py` | Router unter `/system/displays` registrieren | Änderung |
+| `backend/tests/services/test_display_backend.py` | Parser gegen Fixture, Validierung | neu |
+| `backend/tests/api/test_display_routes.py` | Auth-/Admin-Gate, Fehlerabbildung | neu |
+| `backend/tests/fixtures/kscreen_baluNode.json` | echter `kscreen-doctor -j`-Mitschnitt | neu |
+| `client/src/api/display.ts` | API-Client | neu |
+| `client/src/components/power/DisplayOutputsPanel.tsx` | Output-Liste + Apply | neu |
+| `client/src/pages/DisplaysPage.tsx` | Seite, bindet Panel + DPMS-Schalter | neu |
+| `client/src/i18n/locales/{de,en}/power.json` | Strings im bestehenden `power`-Namespace | Änderung |
+
+Fixture erzeugen: `XDG_RUNTIME_DIR=/run/user/1000 kscreen-doctor -j`.
+
+### 5.2 Schemas (Skizze)
+
+```python
+class DisplayMode(BaseModel):
+    name: str          # "3840x2160@120" — der stabile Schluessel
+    width: int
+    height: int
+    refresh_rate: float
+
+class DisplayOutput(BaseModel):
+    name: str                      # "DP-3"
+    connected: bool
+    selected: bool                 # KWin-Ebene (kscreen "enabled")
+    lit: bool                      # DRM-Ebene (sysfs "enabled") -> DPMS
+    current_mode: Optional[str]
+    preferred_mode: Optional[str]
+    scale: float
+    priority: int
+    modes: list[DisplayMode]
+
+class DisplayLayout(BaseModel):
+    outputs: list[DisplayOutput]
+    displays_powered: bool         # globaler DPMS-Zustand
+    detail: Optional[str]
+```
+
+`selected` / `lit` statt zweimal `enabled` — die Namensgleichheit ist die
+Ursache der Verwirrung aus 2.3 und soll nicht ins Schema wandern.
+
+### 5.3 API
+
+- `GET /api/system/displays` → `DisplayLayout`. Jeder authentifizierte User.
+- `POST /api/system/displays/apply` → `{success, message}`. Body:
+  `{"outputs": [{"name": "DP-3", "selected": true, "mode": "3840x2160@120", "scale": 2.5}, ...]}`
+
+Registrierung unter Prefix `/system/displays`, Tag `displays`.
+
+---
+
+## 6. Sicherheit & Validierung
+
+Gegen `.claude/rules/security-agent.md` geprüft:
+
+- **Auth:** `GET` → `Depends(get_current_user)`. `POST /apply` →
+  `Depends(get_current_admin)` (siehe offene Punkte).
+- **Rate-Limit:** `@user_limiter.limit(get_limit("admin_operations"))` auf beiden
+  Routen, wie in `routes/desktop.py`.
+- **Pydantic-Schema** für den Body, kein rohes `dict`.
+- **Audit:** `get_audit_logger_db().log_event(event_type="POWER",
+  action="display_apply", …)` mit dem angewendeten Argument-Vektor in `details`.
+- **Subprocess:** `subprocess.run()` mit Argument-Liste, `shell=False`, Timeout.
+  Kein `sudo`.
+- **Whitelist statt Interpolation — die eigentliche Schutzmaßnahme:** Jeder
+  `name` aus dem Request muss gegen die **live enumerierten** Output-Namen
+  matchen, jeder `mode` gegen die Modenliste **genau dieses** Outputs. Was nicht
+  in der Enumeration steht, wird nie zu einem Argument. Damit kann kein
+  benutzerkontrollierter String in den argv wandern, selbst wenn
+  `kscreen-doctor` künftig eigene Argument-Syntax dazulernt.
+- **`scale`** auf 0.5–3.0 begrenzt; alles andere → 400.
+
+### 6.1 Invariante: nie alle Outputs abwählen
+
+Ein `apply`, nach dem kein einzelner verbundener Output mehr `selected` wäre,
+wird mit 400 abgelehnt. Begründung: „nichts soll leuchten" ist legitim, aber der
+richtige Weg dafür ist der **DPMS-Schalter** — der lässt die KWin-Wahl intact
+und ist reversibel. Alle Outputs abzuwählen wirft dagegen die Konfiguration weg.
+
+### 6.2 Warum kein Confirm/Revert-Timer
+
+Der klassische Footgun („Mode gesetzt, Bild schwarz, keine Maus mehr") greift
+hier nicht: die Bedienoberfläche ist die Webapp über Netzwerk, nicht der
+betroffene Desktop. Ein nicht synchronisierender Mode macht den Schirm schwarz,
+die Webapp bleibt erreichbar, der nächste `apply` korrigiert. Ein
+15-Sekunden-Rückfall-Timer wäre zusätzliche Zustandsmaschine ohne Nutzen → YAGNI.
+
+---
+
+## 7. Dev-Mode
+
+`DevDisplayBackend` mit zwei Fake-Outputs, die BaluNode nachbilden (DP-3 mit
+4K-Modi, HDMI-A-1 mit WQHD-Modi) plus einem `disconnected` DP-1. In-Memory-State,
+damit das Frontend unter Windows ohne KDE vollständig bedienbar ist — gleiches
+Muster wie `DevDesktopBackend`.
+
+---
+
+## 8. Tests
+
+- **Parser** gegen `kscreen_baluNode.json`: Output-Namen, `selected`,
+  `current_mode` als `name` (nicht `id`) aufgelöst, Modenliste vollständig.
+- **Validierung:** unbekannter Output → 400; Mode eines *anderen* Outputs → 400
+  (das ist #589 als Testfall); alle Outputs abwählen → 400; `scale` außerhalb
+  Bereich → 400.
+- **Kommando-Bau:** ein erwarteter argv-Vektor für eine Mehrfach-Änderung,
+  damit die Atomizität (ein Aufruf) festgenagelt ist.
+- **Routen:** 401 ohne Token, 403 für Non-Admin auf `apply`, `GET` für User ok.
+- **DevBackend:** `apply` verändert den nachfolgenden `GET`.
+
+Keine Tests, die echtes `kscreen-doctor` aufrufen — der CI-Runner hat keine
+Wayland-Session.
+
+---
+
+## 9. Offene Punkte (vor Umsetzung entscheiden)
+
+1. **Rechte-Modell.** Vorschlag: `apply` admin-only über
+   `Depends(get_current_admin)`. Das vermeidet eine Alembic-Migration plus
+   Erweiterung von `power_permissions.py`, Admin-UI und Mobile-Schema.
+   Alternative: neues `can_manage_displays` analog `can_toggle_desktop`, falls
+   delegierte User das dürfen sollen.
+2. **Audio-Kopplung.** `display-switch` zieht beim Output-Wechsel den
+   PipeWire-Default-Sink mit (TV → HDMI-Sink, Monitor → BT oder S/PDIF). Das
+   `audio_control`-Plugin kapselt dieselbe Mechanik schon in `pactl.py`. Soll
+   `apply` das mitmachen? Vorschlag: **v1 nein** — Display und Audio bleiben
+   getrennt bedienbar; Kopplung wäre eine eigene, bewusst entschiedene Funktion.
+3. **Verhältnis zu `display-switch`.** Bleibt das Skript dauerhaft als CLI
+   (dann #589 fixen) oder wird es nach diesem Feature zurückgebaut? Vorschlag:
+   bleibt — es deckt den Fall „vom Sofa ohne Webapp" ab und kann sddm starten,
+   was das Backend bewusst nicht tut.
+4. **Eigene Seite oder Unterbereich?** Entschieden ist „neue Seite Displays".
+   Offen bleibt, ob sie im Menü unter Power/System einsortiert wird oder
+   eigenständig.
+
+---
+
+## 10. Tasks
+
+- [ ] **T1** Fixture `backend/tests/fixtures/kscreen_baluNode.json` von BaluNode ziehen und einchecken
+- [ ] **T2** `backend/app/schemas/display.py` — Schemas nach 5.2, `selected`/`lit` getrennt
+- [ ] **T3** Parser-Tests gegen die Fixture schreiben (rot)
+- [ ] **T4** `display_backend.py` — `LinuxDisplayBackend.list_outputs()`: `kscreen-doctor -j` parsen, Modi über `name`, DRM-Ebene über `display_detector` ergänzen (grün)
+- [ ] **T5** Validierungs-Tests nach Abschnitt 8 schreiben (rot)
+- [ ] **T6** `display.py` — `DisplayService` mit Whitelist-Validierung und Invariante 6.1 (grün)
+- [ ] **T7** Kommando-Bau-Test: ein argv-Vektor für Mehrfach-Änderung (rot → grün)
+- [ ] **T8** `LinuxDisplayBackend.apply()` — ein `kscreen-doctor`-Aufruf, Timeout, Fehler als `(False, message)`
+- [ ] **T9** `DevDisplayBackend` nach Abschnitt 7 + Test
+- [ ] **T10** Routen-Tests (401/403/200) schreiben (rot)
+- [ ] **T11** `routes/display.py` + Registrierung unter `/system/displays`, Rate-Limit, Audit (grün)
+- [ ] **T12** `client/src/api/display.ts` — typisierter Client
+- [ ] **T13** `DisplayOutputsPanel.tsx` — Output-Liste, Mode-Dropdown, Apply; Muster von `DesktopTogglePanel.tsx`
+- [ ] **T14** `DisplaysPage.tsx` — DPMS-Schalter oben, Panel darunter; Route + Menüeintrag
+- [ ] **T15** i18n de/en im `power`-Namespace
+- [ ] **T16** Verifikation auf BaluNode: enumerieren, HDMI-A-1 aktivieren, Mode setzen, zurück auf DP-3
+- [ ] **T17** `backend/app/services/CLAUDE.md` und `client/src/pages/CLAUDE.md` nachziehen
+
+T16 ist der eigentliche Abnahmetest und braucht physischen Blick auf die
+Schirme — bis dahin sagt kein grüner Test, dass das Bild wirklich kommt.

--- a/docs/superpowers/plans/2026-09-08-display-output-plugin-implementation.md
+++ b/docs/superpowers/plans/2026-09-08-display-output-plugin-implementation.md
@@ -1,0 +1,3301 @@
+# Display-Output-Plugin — Implementierungsplan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ein bundled Plugin `display_output`, das die KWin-Ausgänge von BaluNode
+enumeriert und Auswahl plus Video-Modus über einen einzigen `kscreen-doctor`-Aufruf
+setzt, bedient über ein Popover in der Topbar.
+
+**Architecture:** Layout und Schichtung spiegeln `audio_control` Datei für Datei —
+ein Modul kapselt das externe Werkzeug (`kscreen.py`), ein Protocol trennt Dev- von
+Linux-Backend, ein Service-Singleton hält die Auswahl, der Router hängt im Plugin.
+Modi werden über die **lebende** Mode-ID aus derselben Enumeration adressiert und
+beim Anwenden gegen den mitgeschickten Namen gegengeprüft; die UI ist eine
+Core-Komponente, die nur prüft, ob das Plugin aktiv ist.
+
+**Tech Stack:** Python 3.11+, FastAPI, Pydantic v2, SQLAlchemy 2.0 + Alembic,
+pytest; React 18 + TypeScript, Tailwind, i18next, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-display-output-plugin-design.md`
+**Vorgänger-Diagnose:** `docs/superpowers/plans/2026-09-08-display-output-control.md`
+**Issue:** #590
+
+## Global Constraints
+
+- **Kein `from __future__ import annotations` in `backend/app/plugins/installed/display_output/__init__.py`.** In allen anderen Modulen des Plugins gehört es an den Anfang. Grund: zusammen mit Pydantic v2 und FastAPIs Body-Erkennung durch den `@user_limiter.limit`-Wrapper werden aufgeschobene Annotationen zu ForwardRefs, die FastAPI nicht mehr auflöst — der Request-Body würde als Query-Parameter gelesen und jedes `POST` antwortete 422.
+- **`get_ui_manifest()` muss überschrieben werden** und `PluginUIManifest(enabled=True)` liefern. Ohne Override ist das Plugin im Frontend dauerhaft „aus", ohne Fehler und ohne Logzeile.
+- **Kein `shell=True`, ausschließlich Listen-Argumente, immer mit Timeout.** `KSCREEN_TIMEOUT_SECONDS = 10`.
+- **`subprocess.run` immer in `asyncio.to_thread`.** Ein blockierender Aufruf auf dem Event-Loop legt den ganzen Worker lahm.
+- **stdout/stderr von `kscreen-doctor` erreichen nie eine Client-Antwort.** Sie tragen EDID-Namen und Pfade; sie werden geloggt, die Antwort trägt eine kuratierte Meldung.
+- **Kein Wert aus dem Request wird zu einem argv-Element, ohne vorher in der Live-Enumeration gestanden zu haben.**
+- **Modi werden über `id` adressiert, niemals über `name`.** `libkscreen`'s `findMode()` bildet den Namen mit `qRound(refreshRate)`; 119,88 und 120,000 heißen beide `3840x2160@120`, und der erste Treffer gewinnt.
+- **Die neue Alembic-Migration setzt auf `down_revision = "e2f81c4a7b93"`** — das ist der einzige echte Head (Stand 2026-09-08, aus den Dateien berechnet). **Nicht** den Head der lokalen Dev-DB verwenden.
+- **Neue Rate-Limit-Kategorie:** `"display_output": "60/minute"`.
+- **Alle Routen** tragen `Depends(require_power_manage_displays)` **und** `@user_limiter.limit(get_limit("display_output"))` — die lesende eingeschlossen.
+- Backend-Docstrings auf Deutsch ohne Umlaute (`ue`, `ae`, `oe`, `ss`), wie in `audio_control`. Kommentare im Frontend dürfen Umlaute tragen.
+- **Die volle Backend-Suite läuft auf Windows nicht durch** (bekannter Hänger). Führe nur die in den Schritten genannten Testdateien aus; die volle Suite ist Sache der CI.
+
+---
+
+## Dateistruktur
+
+| Pfad | Verantwortung |
+|---|---|
+| `backend/app/plugins/installed/display_output/__init__.py` | Plugin-Klasse, Router, Audit, Fehlerabbildung |
+| `backend/app/plugins/installed/display_output/models.py` | Pydantic-Modelle = API-Vertrag |
+| `backend/app/plugins/installed/display_output/kscreen.py` | Einziger Ort, der `kscreen-doctor` kennt: Parser, Runner, argv-Bau |
+| `backend/app/plugins/installed/display_output/backend.py` | Protocol, `DevDisplayBackend`, `KWinDisplayBackend` |
+| `backend/app/plugins/installed/display_output/service.py` | `DisplayService`, Validierung, Singleton |
+| `backend/app/plugins/installed/display_output/CLAUDE.md` | Invarianten und Fallen dieses Plugins |
+| `backend/app/services/power/gpu/display_detector.py` | **Änderung:** `get_connector_states()` ergänzen |
+| `backend/alembic/versions/<neu>_add_can_manage_displays_permission.py` | Migration |
+| `client/src/api/displayOutput.ts` | Typisierter API-Client |
+| `client/src/components/topbar/DisplayMenu.tsx` | Popover |
+| `client/src/i18n/locales/{de,en}/display.json` | Eigener Namensraum |
+
+---
+
+## Task 1: Fixture, Modelle und der Mode-Parser
+
+**Files:**
+- Create: `backend/tests/plugins/fixtures/kscreen_balunode.json`
+- Create: `backend/app/plugins/installed/display_output/__init__.py` (vorerst leer)
+- Create: `backend/app/plugins/installed/display_output/models.py`
+- Create: `backend/app/plugins/installed/display_output/kscreen.py`
+- Test: `backend/tests/plugins/test_display_output_parser.py`
+
+**Interfaces:**
+- Consumes: nichts.
+- Produces:
+```python
+# models.py
+class DisplayMode(BaseModel):
+    id: str
+    name: str
+    width: int
+    height: int
+    refresh_rate: float
+
+class DisplayOutput(BaseModel):
+    name: str
+    connected: bool
+    selected: bool
+    lit: Optional[bool] = None
+    current_mode_id: Optional[str] = None
+    preferred_mode_id: Optional[str] = None
+    scale: float = 1.0
+    priority: int = 0
+    modes: List[DisplayMode] = Field(default_factory=list)
+
+class DisplayLayout(BaseModel):
+    outputs: List[DisplayOutput] = Field(default_factory=list)
+    displays_powered: bool = False
+    available: bool = True
+    detail: Optional[str] = None
+
+class DisplayOutputRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=64)
+    selected: bool
+    mode_id: Optional[str] = Field(default=None, max_length=32)
+    mode_name: Optional[str] = Field(default=None, max_length=64)
+
+class DisplayApplyRequest(BaseModel):
+    outputs: List[DisplayOutputRequest] = Field(..., min_length=1)
+
+# kscreen.py
+def parse_modes(raw_modes: list) -> list[DisplayMode]
+def parse_outputs(payload: object) -> list[DisplayOutput]
+```
+
+- [ ] **Step 1: Fixture bereitstellen**
+
+Die Fixture ist ein **gemessener** Mitschnitt von BaluNode, kein erfundener
+Payload. Sie wird dort erzeugt mit:
+
+```
+XDG_RUNTIME_DIR=/run/user/1000 WAYLAND_DISPLAY=wayland-0 kscreen-doctor -j
+```
+
+Die Ausgabe **unverändert** (alle Felder, alle Modi) nach
+`backend/tests/plugins/fixtures/kscreen_balunode.json` speichern. Der Mitschnitt
+vom 2026-09-08 liegt im Gesprächsverlauf dieser Sitzung; ist er dort nicht mehr
+greifbar, den Befehl erneut ausführen lassen.
+
+Die Fixture muss diese Eigenschaften erfüllen — sie sind die Grundlage aller
+folgenden Zusicherungen:
+
+| Eigenschaft | Wert |
+|---|---|
+| Ausgänge | genau 2: `HDMI-A-1`, `DP-3` |
+| `HDMI-A-1` | `enabled: false`, `currentModeId: "1"`, 55 Modi, 45 verschiedene Namen |
+| `DP-3` | `enabled: true`, `currentModeId: "57"`, `scale: 2.5`, 58 Modi |
+| Namenskollision | `DP-3` id 57 (`refreshRate` 120) und id 58 (119.87999725341797), beide `"3840x2160@120"` |
+| Exakte Dublette | `HDMI-A-1` id 9 und id 10, beide `1920x1080`, `refreshRate` 60 |
+| Feldlücke | `DP-3` hat **kein** `vrrPolicy`, `HDMI-A-1` hat es |
+| Nicht enthalten | `DP-1`, `DP-2` — `kscreen-doctor` listet unverbundene Ausgänge nicht |
+
+Zusätzlich anlegen: `backend/tests/plugins/fixtures/__init__.py` ist **nicht**
+nötig (reines Datenverzeichnis).
+
+- [ ] **Step 2: Write the failing test**
+
+Create `backend/tests/plugins/test_display_output_parser.py`:
+
+```python
+"""Parser-Tests gegen den gemessenen kscreen-doctor-Mitschnitt von BaluNode."""
+import json
+from pathlib import Path
+
+import pytest
+
+from app.plugins.installed.display_output.kscreen import parse_modes, parse_outputs
+
+FIXTURE = Path(__file__).parent / "fixtures" / "kscreen_balunode.json"
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def outputs(payload):
+    return parse_outputs(payload)
+
+
+class TestOutputs:
+    def test_lists_both_connected_outputs(self, outputs):
+        assert [o.name for o in outputs] == ["HDMI-A-1", "DP-3"]
+
+    def test_selected_mirrors_kwin_enabled(self, outputs):
+        by_name = {o.name: o for o in outputs}
+        assert by_name["DP-3"].selected is True
+        assert by_name["HDMI-A-1"].selected is False
+
+    def test_lit_is_unknown_until_the_drm_layer_is_merged(self, outputs):
+        # Der Parser kennt sysfs nicht. None heisst "nicht beantwortet",
+        # nicht "aus" - siehe Spec 5.
+        assert all(o.lit is None for o in outputs)
+
+    def test_current_and_preferred_are_mode_ids(self, outputs):
+        by_name = {o.name: o for o in outputs}
+        assert by_name["DP-3"].current_mode_id == "57"
+        assert by_name["DP-3"].preferred_mode_id == "56"
+        assert by_name["HDMI-A-1"].current_mode_id == "1"
+
+    def test_scale_is_read(self, outputs):
+        by_name = {o.name: o for o in outputs}
+        assert by_name["DP-3"].scale == 2.5
+
+    def test_a_missing_optional_field_does_not_break_the_parser(self, outputs):
+        # DP-3 traegt kein vrrPolicy. Ein direkter Indexzugriff kippte hier.
+        assert len(outputs) == 2
+
+
+class TestModes:
+    def test_exact_duplicates_collapse_and_distinct_rates_survive(self, outputs):
+        hdmi = next(o for o in outputs if o.name == "HDMI-A-1")
+        # 55 Roheintraege, fuenf exakte Dubletten fallen weg.
+        assert len(hdmi.modes) == 50
+
+    def test_the_collapsed_duplicate_keeps_the_lower_id(self, outputs):
+        hdmi = next(o for o in outputs if o.name == "HDMI-A-1")
+        fullhd_60 = [
+            m for m in hdmi.modes
+            if m.width == 1920 and m.height == 1080 and round(m.refresh_rate, 2) == 60.0
+        ]
+        assert len(fullhd_60) == 1
+        assert fullhd_60[0].id == "9"
+
+    def test_the_120hz_pair_is_kept_apart(self, outputs):
+        dp3 = next(o for o in outputs if o.name == "DP-3")
+        uhd = [m for m in dp3.modes if m.width == 3840 and m.height == 2160]
+        rates = sorted(round(m.refresh_rate, 2) for m in uhd if round(m.refresh_rate, 2) >= 119)
+        assert rates == [119.88, 120.0]
+
+    def test_both_of_the_pair_carry_the_same_ambiguous_name(self, outputs):
+        dp3 = next(o for o in outputs if o.name == "DP-3")
+        pair = {m.id: m.name for m in dp3.modes if m.id in ("57", "58")}
+        assert pair == {"57": "3840x2160@120", "58": "3840x2160@120"}
+
+    def test_modes_are_sorted_by_area_then_refresh_descending(self, outputs):
+        dp3 = next(o for o in outputs if o.name == "DP-3")
+        keys = [(-(m.width * m.height), -m.refresh_rate) for m in dp3.modes]
+        assert keys == sorted(keys)
+
+    def test_the_refresh_rate_is_not_rounded(self, outputs):
+        dp3 = next(o for o in outputs if o.name == "DP-3")
+        mode58 = next(m for m in dp3.modes if m.id == "58")
+        assert mode58.refresh_rate == pytest.approx(119.87999725, rel=1e-9)
+
+
+class TestParseModesInIsolation:
+    def test_a_mode_without_size_is_skipped(self):
+        modes = parse_modes([
+            {"id": "1", "name": "1920x1080@60", "refreshRate": 60,
+             "size": {"width": 1920, "height": 1080}},
+            {"id": "2", "name": "broken"},
+        ])
+        assert [m.id for m in modes] == ["1"]
+
+    def test_an_empty_list_yields_no_modes(self):
+        assert parse_modes([]) == []
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd backend ; python -m pytest tests/plugins/test_display_output_parser.py -q --no-cov`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.plugins.installed.display_output'`
+
+- [ ] **Step 4: Paketdatei und Modelle anlegen**
+
+Create `backend/app/plugins/installed/display_output/__init__.py` mit vorerst nur
+einem Docstring (der Router folgt in Task 7):
+
+```python
+"""Displaysteuerung — bundled Plugin.
+
+Enumeriert die KWin-Ausgaenge und setzt Auswahl und Video-Modus ueber
+kscreen-doctor. Laeuft als bundled Plugin im Host-Prozess und damit unter
+derselben UID wie die Desktop-Session; ein Sandbox-Plugin kaeme nicht an den
+Wayland-Socket.
+"""
+```
+
+Create `backend/app/plugins/installed/display_output/models.py`:
+
+```python
+"""Pydantic-Modelle der Displaysteuerung.
+
+Die Feldnamen sind zugleich der API-Vertrag zum Frontend.
+
+``selected`` und ``lit`` heissen absichtlich nicht beide ``enabled``: KWin und
+DRM meinen mit diesem Wort verschiedene Dinge (die Ausgangswahl gegen "es
+werden wirklich Pixel getrieben"), und die Namensgleichheit ist die Ursache
+der Verwirrung, die dieses Feature aufloesen soll.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class DisplayMode(BaseModel):
+    """Ein waehlbarer Video-Modus eines Ausgangs."""
+
+    id: str = Field(..., description="Lebende KWin-Mode-ID; nur innerhalb dieses Vorgangs gueltig")
+    name: str = Field(..., description="'3840x2160@120' — NICHT eindeutig, dient nur der Gegenpruefung")
+    width: int
+    height: int
+    refresh_rate: float = Field(..., description="Ungerundet, z. B. 119.87999725341797")
+
+
+class DisplayOutput(BaseModel):
+    """Ein von KWin gemeldeter Ausgang."""
+
+    name: str = Field(..., description="Connector-Name, z. B. 'DP-3'")
+    connected: bool
+    selected: bool = Field(..., description="KWin-Ebene: ist dieser Ausgang gewaehlt?")
+    lit: Optional[bool] = Field(
+        default=None,
+        description="DRM-Ebene: werden Pixel getrieben? None = nicht zuordenbar",
+    )
+    current_mode_id: Optional[str] = None
+    preferred_mode_id: Optional[str] = None
+    scale: float = Field(default=1.0, description="Nur Anzeige; in v1 nicht setzbar")
+    priority: int = 0
+    modes: List[DisplayMode] = Field(default_factory=list)
+
+
+class DisplayLayout(BaseModel):
+    """Gesamtzustand, wie ihn GET /state liefert."""
+
+    outputs: List[DisplayOutput] = Field(default_factory=list)
+    displays_powered: bool = Field(
+        default=False, description="Globaler DPMS-Zustand: leuchtet mindestens ein Ausgang?"
+    )
+    available: bool = Field(default=True, description="False, wenn KWin nicht erreichbar ist")
+    detail: Optional[str] = Field(default=None, description="Kurzer Hinweis fuer die UI")
+
+
+class DisplayOutputRequest(BaseModel):
+    """Gewuenschter Zustand eines Ausgangs."""
+
+    name: str = Field(..., min_length=1, max_length=64)
+    selected: bool
+    mode_id: Optional[str] = Field(default=None, max_length=32)
+    mode_name: Optional[str] = Field(
+        default=None,
+        max_length=64,
+        description="Pflicht, sobald mode_id gesetzt ist — die Gegenprobe zur ID",
+    )
+
+
+class DisplayApplyRequest(BaseModel):
+    """Rumpf von POST /apply."""
+
+    outputs: List[DisplayOutputRequest] = Field(..., min_length=1)
+```
+
+- [ ] **Step 5: Parser schreiben**
+
+Create `backend/app/plugins/installed/display_output/kscreen.py`:
+
+```python
+"""Der einzige Ort, der weiss, dass es kscreen-doctor gibt.
+
+Kapselt Aufruf, Auswertung und Argumentbau. Ein spaeterer Wechsel auf die
+KScreen-D-Bus-Schnittstelle beruehrt nur diese Datei.
+
+**Modi werden ueber ihre ID adressiert, niemals ueber den Namen.** libkscreen
+bildet den Namen in ``findMode()`` mit ``qRound(refreshRate)``, weshalb 119,88
+und 120,000 beide ``3840x2160@120`` heissen; die Funktion nimmt den ersten
+Treffer und bricht ab. Eine Adressierung ueber den Namen setzt also je nach
+Listenreihenfolge einen anderen Modus — ohne Fehlermeldung.
+"""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from app.plugins.installed.display_output.models import DisplayMode, DisplayOutput
+
+logger = logging.getLogger(__name__)
+
+# Auf wie viele Nachkommastellen zwei Bildwiederholraten als gleich gelten.
+# Feiner zu unterscheiden hiesse, Gleitkomma-Rauschen zu Modi zu erklaeren.
+_RATE_PRECISION = 3
+
+
+def parse_modes(raw_modes: object) -> List[DisplayMode]:
+    """Wandelt die Modenliste eines Ausgangs in eine anzeigbare Liste.
+
+    Drei Schritte, alle drei aus gemessenen Daten begruendet:
+
+    1. **Exakte Dubletten zusammenfassen** (gleiche Breite, Hoehe und
+       Bildwiederholrate). Auf BaluNode traegt HDMI-A-1 fuenf solcher Paare;
+       sie unterscheiden sich nur in DRM-Timing-Flags (CEA gegen DMT), was
+       sich einem Menschen nicht sinnvoll anzeigen laesst. Die kleinere ID
+       gewinnt.
+    2. **Absteigend nach Flaeche, dann nach Rate sortieren.** kscreen-doctor
+       liefert lexikografisch nach ID-String ("1", "10", "11", ..., "2", "20").
+    3. Die Rate bleibt **ungerundet** — ``119.88`` und ``120.00`` sind der
+       einzige Unterschied, an dem ein Mensch die beiden 4K-Modi von DP-3
+       auseinanderhaelt.
+
+    Args:
+        raw_modes: Die ``modes``-Liste eines Ausgangs aus ``kscreen-doctor -j``.
+
+    Returns:
+        Sortierte, entdoppelte Modi. Unbrauchbare Eintraege werden
+        uebersprungen, nicht als Fehler gemeldet — ein defekter Modus darf
+        die Enumeration nicht scheitern lassen.
+    """
+    if not isinstance(raw_modes, list):
+        return []
+
+    seen: dict[tuple, DisplayMode] = {}
+    for raw in raw_modes:
+        if not isinstance(raw, dict):
+            continue
+        size = raw.get("size")
+        mode_id = raw.get("id")
+        if not isinstance(size, dict) or mode_id is None:
+            logger.debug("Modus ohne Groesse oder ID uebersprungen: %r", raw)
+            continue
+        width = size.get("width")
+        height = size.get("height")
+        if not isinstance(width, int) or not isinstance(height, int):
+            continue
+        try:
+            rate = float(raw.get("refreshRate", 0.0))
+        except (TypeError, ValueError):
+            continue
+
+        mode = DisplayMode(
+            id=str(mode_id),
+            name=str(raw.get("name", "")),
+            width=width,
+            height=height,
+            refresh_rate=rate,
+        )
+        key = (width, height, round(rate, _RATE_PRECISION))
+        existing = seen.get(key)
+        # Kleinere ID gewinnt. IDs sind Zeichenketten, deshalb numerisch
+        # vergleichen, wo moeglich - sonst waere "10" kleiner als "9".
+        if existing is None or _id_sort_key(mode.id) < _id_sort_key(existing.id):
+            seen[key] = mode
+
+    return sorted(seen.values(), key=lambda m: (-(m.width * m.height), -m.refresh_rate, m.id))
+
+
+def _id_sort_key(mode_id: str) -> tuple:
+    """Sortierschluessel, der numerische IDs numerisch ordnet."""
+    return (0, int(mode_id)) if mode_id.isdigit() else (1, mode_id)
+
+
+def parse_outputs(payload: object) -> List[DisplayOutput]:
+    """Liest die Ausgangsliste aus der JSON-Struktur von ``kscreen-doctor -j``.
+
+    ``lit`` bleibt hier ``None``: dieses Modul kennt sysfs nicht. Die
+    DRM-Ebene ergaenzt das Backend (Task 4).
+
+    Jeder Feldzugriff laeuft ueber ``.get()``. Die Felder sind nicht bei jedem
+    Ausgang vorhanden — auf BaluNode traegt HDMI-A-1 ein ``vrrPolicy``, DP-3
+    nicht.
+    """
+    if not isinstance(payload, dict):
+        return []
+    raw_outputs = payload.get("outputs")
+    if not isinstance(raw_outputs, list):
+        return []
+
+    outputs: List[DisplayOutput] = []
+    for raw in raw_outputs:
+        if not isinstance(raw, dict):
+            continue
+        name = raw.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        preferred = raw.get("preferredModes")
+        preferred_id: Optional[str] = None
+        if isinstance(preferred, list) and preferred:
+            preferred_id = str(preferred[0])
+        current = raw.get("currentModeId")
+
+        outputs.append(
+            DisplayOutput(
+                name=name,
+                connected=bool(raw.get("connected", False)),
+                selected=bool(raw.get("enabled", False)),
+                lit=None,
+                current_mode_id=str(current) if current is not None else None,
+                preferred_mode_id=preferred_id,
+                scale=float(raw.get("scale", 1.0) or 1.0),
+                priority=int(raw.get("priority", 0) or 0),
+                modes=parse_modes(raw.get("modes")),
+            )
+        )
+    return outputs
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd backend ; python -m pytest tests/plugins/test_display_output_parser.py -q --no-cov`
+Expected: PASS (alle Tests)
+
+Schlägt `test_exact_duplicates_collapse_and_distinct_rates_survive` mit einer
+anderen Zahl als 50 fehl, **zuerst die Fixture prüfen** — die Zahl stammt aus
+der Messung, nicht aus einer Schätzung. Weicht die Fixture ab, ist sie die
+Wahrheit und die Zahl im Test wird korrigiert; das ist dann eine bewusste
+Änderung, kein Anpassen bis grün.
+
+- [ ] **Step 7: Lint und Commit**
+
+```bash
+cd backend && python -m ruff check app/plugins/installed/display_output tests/plugins/test_display_output_parser.py
+git add backend/app/plugins/installed/display_output backend/tests/plugins/test_display_output_parser.py backend/tests/plugins/fixtures/kscreen_balunode.json
+git commit -m "feat(display-output): Modelle und kscreen-doctor-Parser mit Modus-Entdopplung"
+```
+
+---
+
+## Task 2: Runner und Argumentbau
+
+**Files:**
+- Modify: `backend/app/plugins/installed/display_output/kscreen.py` (anfügen)
+- Test: `backend/tests/plugins/test_display_output_kscreen.py`
+
+**Interfaces:**
+- Consumes: `DisplayOutput` aus Task 1.
+- Produces:
+```python
+KSCREEN_TIMEOUT_SECONDS: int = 10
+KSCREEN_BINARY: str = "kscreen-doctor"
+def run_kscreen(args: list[str]) -> tuple[bool, str]
+def run_kscreen_json() -> Optional[object]
+def build_apply_args(
+    wanted: dict[str, tuple[bool, Optional[str]]],
+    live_outputs: list[DisplayOutput],
+) -> list[str]
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/plugins/test_display_output_kscreen.py`:
+
+```python
+"""Runner und Argumentbau: kein Wert ohne Enumeration, ein Aufruf, kein Hang."""
+import subprocess
+from unittest.mock import patch
+
+from app.plugins.installed.display_output import kscreen
+from app.plugins.installed.display_output.models import DisplayMode, DisplayOutput
+
+
+def _output(name: str, selected: bool, mode_ids: list[str]) -> DisplayOutput:
+    return DisplayOutput(
+        name=name,
+        connected=True,
+        selected=selected,
+        modes=[
+            DisplayMode(id=i, name=f"m{i}", width=1920, height=1080, refresh_rate=60.0)
+            for i in mode_ids
+        ],
+    )
+
+
+LIVE = [_output("HDMI-A-1", False, ["1", "9"]), _output("DP-3", True, ["57", "58"])]
+
+
+class TestBuildApplyArgs:
+    def test_one_call_carries_every_change(self):
+        args = kscreen.build_apply_args(
+            {"DP-3": (True, "57"), "HDMI-A-1": (False, None)}, LIVE
+        )
+        assert args == [
+            "kscreen-doctor",
+            "output.HDMI-A-1.disable",
+            "output.DP-3.enable",
+            "output.DP-3.mode.57",
+        ]
+
+    def test_order_follows_the_enumeration_not_the_request(self):
+        # Deterministisch, damit der Vektor pruefbar ist - und unabhaengig
+        # davon, in welcher Reihenfolge der Client seine Ausgaenge schickt.
+        a = kscreen.build_apply_args({"DP-3": (True, None), "HDMI-A-1": (True, None)}, LIVE)
+        b = kscreen.build_apply_args({"HDMI-A-1": (True, None), "DP-3": (True, None)}, LIVE)
+        assert a == b
+        assert a.index("output.HDMI-A-1.enable") < a.index("output.DP-3.enable")
+
+    def test_an_output_the_request_omits_is_left_alone(self):
+        args = kscreen.build_apply_args({"DP-3": (True, "58")}, LIVE)
+        assert not any("HDMI-A-1" in a for a in args)
+
+    def test_a_mode_on_a_deselected_output_is_ignored(self):
+        # Siehe Spec 7: KWin behaelt die Modus-Wahl eines abgewaehlten
+        # Ausgangs ohnehin; ein Fehler waere Schikane gegen eine UI, die
+        # schlicht den angezeigten Zustand zurueckschickt.
+        args = kscreen.build_apply_args({"HDMI-A-1": (False, "9")}, LIVE)
+        assert args == ["kscreen-doctor", "output.HDMI-A-1.disable"]
+
+    def test_mode_is_addressed_by_id_never_by_name(self):
+        args = kscreen.build_apply_args({"DP-3": (True, "58")}, LIVE)
+        assert "output.DP-3.mode.58" in args
+        assert not any("@" in a for a in args)
+
+
+class TestRunKscreen:
+    def test_a_missing_binary_is_reported_not_raised(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            ok, message = kscreen.run_kscreen(["--dpms", "on"])
+        assert ok is False
+        assert "kscreen-doctor" in message
+
+    def test_a_timeout_is_reported_not_raised(self):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("x", 10)):
+            ok, message = kscreen.run_kscreen(["-j"])
+        assert ok is False
+
+    def test_a_nonzero_exit_is_a_failure(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
+        with patch("subprocess.run", return_value=completed):
+            ok, message = kscreen.run_kscreen(["-j"])
+        assert ok is False
+        assert message == "boom"
+
+    def test_the_call_always_carries_a_timeout(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr="")
+        with patch("subprocess.run", return_value=completed) as run:
+            kscreen.run_kscreen(["-j"])
+        assert run.call_args.kwargs["timeout"] == kscreen.KSCREEN_TIMEOUT_SECONDS
+        assert run.call_args.kwargs.get("shell") in (None, False)
+
+
+class TestRunKscreenJson:
+    def test_invalid_json_yields_none_instead_of_raising(self):
+        with patch.object(kscreen, "run_kscreen", return_value=(True, "not json")):
+            assert kscreen.run_kscreen_json() is None
+
+    def test_a_failed_call_yields_none(self):
+        with patch.object(kscreen, "run_kscreen", return_value=(False, "boom")):
+            assert kscreen.run_kscreen_json() is None
+
+    def test_valid_json_is_parsed(self):
+        with patch.object(kscreen, "run_kscreen", return_value=(True, '{"outputs": []}')):
+            assert kscreen.run_kscreen_json() == {"outputs": []}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend ; python -m pytest tests/plugins/test_display_output_kscreen.py -q --no-cov`
+Expected: FAIL — `AttributeError: module 'app.plugins.installed.display_output.kscreen' has no attribute 'build_apply_args'`
+
+- [ ] **Step 3: Runner und Argumentbau anfügen**
+
+An `backend/app/plugins/installed/display_output/kscreen.py` anhängen (die
+Importe oben um `import json` und `import subprocess` sowie
+`from app.services.power.session_env import wayland_session_env` ergänzen):
+
+```python
+# kscreen-doctor darf niemals haengen bleiben und dabei einen Worker blockieren.
+KSCREEN_TIMEOUT_SECONDS = 10
+KSCREEN_BINARY = "kscreen-doctor"
+
+
+def run_kscreen(args: List[str]) -> tuple[bool, str]:
+    """Fuehrt kscreen-doctor mit Listen-Argumenten aus.
+
+    Args:
+        args: Argumente ohne den Programmnamen, etwa ``["-j"]``.
+
+    Returns:
+        (Erfolg, Ausgabe bzw. Fehlertext). Die Ausgabe ist roh und enthaelt
+        EDID-Namen und Pfade. Sie ist fuer Log und Weiterverarbeitung gedacht —
+        Aufrufer duerfen sie **nicht** in eine Client-Antwort uebernehmen.
+    """
+    try:
+        completed = subprocess.run(
+            [KSCREEN_BINARY, *args],
+            capture_output=True,
+            text=True,
+            timeout=KSCREEN_TIMEOUT_SECONDS,
+            env=wayland_session_env(),
+        )
+    except FileNotFoundError:
+        logger.warning("kscreen-doctor ist nicht installiert")
+        return False, "kscreen-doctor nicht gefunden"
+    except subprocess.TimeoutExpired:
+        logger.warning("kscreen-doctor-Zeitueberschreitung: %s", args)
+        return False, "Zeitueberschreitung"
+    except OSError as exc:
+        logger.warning("kscreen-doctor-Aufruf fehlgeschlagen: %s", exc)
+        return False, "Aufruf fehlgeschlagen"
+
+    if completed.returncode != 0:
+        logger.warning(
+            "kscreen-doctor %s endete mit %s: %s",
+            args, completed.returncode, completed.stderr.strip(),
+        )
+        return False, completed.stderr.strip() or "kscreen-doctor-Fehler"
+    return True, completed.stdout.strip()
+
+
+def run_kscreen_json() -> Optional[object]:
+    """Liest ``kscreen-doctor -j`` und gibt die geparste Struktur zurueck.
+
+    Returns:
+        Die geparste JSON-Struktur, oder None bei Fehler oder ungueltigem JSON.
+    """
+    ok, output = run_kscreen(["-j"])
+    if not ok:
+        return None
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError:
+        logger.warning("kscreen-doctor lieferte ungueltiges JSON")
+        return None
+
+
+def build_apply_args(
+    wanted: dict,
+    live_outputs: List[DisplayOutput],
+) -> List[str]:
+    """Baut den vollstaendigen Argumentvektor fuer **einen** Aufruf.
+
+    kscreen-doctor wendet alle Argumente eines Aufrufs gemeinsam an. Genau ein
+    Unterprozess heisst deshalb: kein Teilzustand, wenn etwas schiefgeht.
+
+    Die Reihenfolge folgt der **Enumeration**, nicht dem Request. Das macht den
+    Vektor deterministisch und damit pruefbar, und es nimmt dem Client jeden
+    Einfluss auf die Abarbeitungsreihenfolge.
+
+    Args:
+        wanted: Abbildung Ausgangsname -> (selected, mode_id oder None). Nur
+            Ausgaenge, die der Aufrufer bereits validiert hat.
+        live_outputs: Die aktuelle Enumeration; bestimmt Reihenfolge und
+            Zugehoerigkeit.
+
+    Returns:
+        Der vollstaendige argv inklusive Programmname.
+    """
+    args: List[str] = [KSCREEN_BINARY]
+    for output in live_outputs:
+        if output.name not in wanted:
+            continue
+        selected, mode_id = wanted[output.name]
+        if not selected:
+            args.append(f"output.{output.name}.disable")
+            continue
+        args.append(f"output.{output.name}.enable")
+        if mode_id:
+            args.append(f"output.{output.name}.mode.{mode_id}")
+    return args
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend ; python -m pytest tests/plugins/test_display_output_kscreen.py -q --no-cov`
+Expected: PASS
+
+- [ ] **Step 5: Lint und Commit**
+
+```bash
+cd backend && python -m ruff check app/plugins/installed/display_output tests/plugins/test_display_output_kscreen.py
+git add backend/app/plugins/installed/display_output/kscreen.py backend/tests/plugins/test_display_output_kscreen.py
+git commit -m "feat(display-output): kscreen-doctor-Runner und atomarer Argumentbau"
+```
+
+---
+
+## Task 3: DRM-Connector-Zustände im Core
+
+**Files:**
+- Modify: `backend/app/services/power/gpu/display_detector.py`
+- Test: `backend/tests/test_display_detector_connector_states.py`
+
+**Interfaces:**
+- Consumes: nichts.
+- Produces:
+```python
+def get_connector_states_sync(sysfs_root: Path = Path("/")) -> dict[str, bool]
+async def get_connector_states(sysfs_root: Path = Path("/")) -> dict[str, bool]
+```
+Schlüssel ist der KWin-Name (`DP-3`), nicht der sysfs-Name (`card0-DP-3`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_display_detector_connector_states.py`:
+
+```python
+"""Pro-Connector-Zustaende aus sysfs, mit KWin-kompatiblen Namen."""
+import pytest
+
+from app.services.power.gpu.display_detector import (
+    get_connector_states,
+    get_connector_states_sync,
+)
+
+
+def _connector(root, name: str, status: str, enabled: str) -> None:
+    d = root / "sys" / "class" / "drm" / name
+    d.mkdir(parents=True)
+    (d / "status").write_text(status)
+    (d / "enabled").write_text(enabled)
+
+
+class TestConnectorStates:
+    def test_strips_the_card_prefix_to_match_kwin_names(self, tmp_path):
+        _connector(tmp_path, "card0-DP-3", "connected", "enabled")
+        assert get_connector_states_sync(tmp_path) == {"DP-3": True}
+
+    def test_a_dark_connector_is_false_not_absent(self, tmp_path):
+        # DPMS-off: verbunden, aber es werden keine Pixel getrieben.
+        _connector(tmp_path, "card0-DP-3", "connected", "disabled")
+        assert get_connector_states_sync(tmp_path) == {"DP-3": False}
+
+    def test_a_disconnected_connector_is_reported_as_dark(self, tmp_path):
+        _connector(tmp_path, "card0-DP-1", "disconnected", "disabled")
+        assert get_connector_states_sync(tmp_path) == {"DP-1": False}
+
+    def test_a_writeback_connector_is_never_lit(self, tmp_path):
+        # Gemessen auf BaluNode: status=unknown, enabled=disabled. Ein
+        # Writeback-Connector ist kein Bildschirm.
+        _connector(tmp_path, "card0-Writeback-1", "unknown", "disabled")
+        assert get_connector_states_sync(tmp_path) == {"Writeback-1": False}
+
+    def test_entries_that_are_not_connectors_are_skipped(self, tmp_path):
+        drm = tmp_path / "sys" / "class" / "drm" / "renderD128"
+        drm.mkdir(parents=True)
+        _connector(tmp_path, "card0-DP-3", "connected", "enabled")
+        assert list(get_connector_states_sync(tmp_path)) == ["DP-3"]
+
+    def test_a_missing_drm_directory_yields_an_empty_map(self, tmp_path):
+        assert get_connector_states_sync(tmp_path) == {}
+
+    @pytest.mark.asyncio
+    async def test_the_async_variant_agrees_with_the_sync_one(self, tmp_path):
+        _connector(tmp_path, "card0-HDMI-A-1", "connected", "enabled")
+        assert await get_connector_states(tmp_path) == get_connector_states_sync(tmp_path)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend ; python -m pytest tests/test_display_detector_connector_states.py -q --no-cov`
+Expected: FAIL — `ImportError: cannot import name 'get_connector_states'`
+
+- [ ] **Step 3: Die beiden Funktionen ergänzen**
+
+An `backend/app/services/power/gpu/display_detector.py` anhängen:
+
+```python
+def _states_sync(sysfs_root: Path) -> dict:
+    """Liest je Connector, ob er tatsaechlich Pixel treibt."""
+    drm = sysfs_root / "sys" / "class" / "drm"
+    if not drm.exists():
+        return {}
+    states: dict = {}
+    for entry in sorted(drm.iterdir()):
+        if not _CONNECTOR_RE.match(entry.name):
+            continue
+        status_file = entry / "status"
+        enabled_file = entry / "enabled"
+        if not status_file.exists() or not enabled_file.exists():
+            continue
+        try:
+            status = status_file.read_text().strip()
+            enabled = enabled_file.read_text().strip()
+        except OSError as exc:
+            logger.debug("Cannot read %s: %s", entry.name, exc)
+            continue
+        # KWin kennt den Connector ohne das "card<N>-" davor.
+        states[_CONNECTOR_RE.sub("", entry.name)] = (
+            status == "connected" and enabled == "enabled"
+        )
+    return states
+
+
+def get_connector_states_sync(sysfs_root: Path = Path("/")) -> dict:
+    """Per-connector 'is this driving pixels?', keyed by the KWin name.
+
+    Same sysfs pass as get_active_display_count(), but keeps the names. The
+    display_output plugin needs to say WHICH output is lit, not how many are -
+    and a second sysfs reader for the same question would be the worse answer.
+    """
+    return _states_sync(sysfs_root)
+
+
+async def get_connector_states(sysfs_root: Path = Path("/")) -> dict:
+    """Async variant, for callers already on an event loop."""
+    return await asyncio.to_thread(_states_sync, sysfs_root)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend ; python -m pytest tests/test_display_detector_connector_states.py -q --no-cov`
+Expected: PASS
+
+- [ ] **Step 5: Regression der bestehenden Zähler-Tests**
+
+Run: `cd backend ; python -m pytest tests/ -q --no-cov -k display_detector`
+Expected: PASS, keine neuen Fehler.
+
+- [ ] **Step 6: Lint und Commit**
+
+```bash
+cd backend && python -m ruff check app/services/power/gpu/display_detector.py tests/test_display_detector_connector_states.py
+git add backend/app/services/power/gpu/display_detector.py backend/tests/test_display_detector_connector_states.py
+git commit -m "feat(power): DRM-Connector-Zustaende mit Namen, nicht nur als Anzahl"
+```
+
+---
+
+## Task 4: Backends
+
+**Files:**
+- Create: `backend/app/plugins/installed/display_output/backend.py`
+- Test: `backend/tests/plugins/test_display_output_backend.py`
+
+**Interfaces:**
+- Consumes: `parse_outputs`, `run_kscreen`, `run_kscreen_json`, `build_apply_args` (Tasks 1–2); `get_connector_states` (Task 3).
+- Produces:
+```python
+class DisplayBackend(Protocol):
+    async def get_layout(self) -> DisplayLayout: ...
+    async def apply(self, wanted: dict, live_outputs: list) -> tuple[bool, str]: ...
+
+class DevDisplayBackend: ...
+class KWinDisplayBackend: ...
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/plugins/test_display_output_backend.py`:
+
+```python
+"""Dev-Backend und die DRM-Verschmelzung des KWin-Backends."""
+import pytest
+
+from app.plugins.installed.display_output.backend import DevDisplayBackend, KWinDisplayBackend
+
+
+class TestDevBackend:
+    @pytest.mark.asyncio
+    async def test_mirrors_balunode_with_two_connected_outputs(self):
+        layout = await DevDisplayBackend().get_layout()
+        assert [o.name for o in layout.outputs] == ["HDMI-A-1", "DP-3"]
+        assert all(o.connected for o in layout.outputs)
+
+    @pytest.mark.asyncio
+    async def test_carries_the_ambiguous_120hz_pair(self):
+        # Ohne diese Dublette laesst sich die Beschriftungslogik unter Windows
+        # nicht bedienen - und genau sie ist der Grund fuer die ID-Adressierung.
+        layout = await DevDisplayBackend().get_layout()
+        dp3 = next(o for o in layout.outputs if o.name == "DP-3")
+        names = [m.name for m in dp3.modes if m.name == "3840x2160@120"]
+        assert len(names) == 2
+
+    @pytest.mark.asyncio
+    async def test_apply_changes_what_the_next_read_returns(self):
+        backend = DevDisplayBackend()
+        live = (await backend.get_layout()).outputs
+        ok, _ = await backend.apply({"HDMI-A-1": (True, "1"), "DP-3": (False, None)}, live)
+        assert ok is True
+        after = {o.name: o for o in (await backend.get_layout()).outputs}
+        assert after["HDMI-A-1"].selected is True
+        assert after["DP-3"].selected is False
+        assert after["HDMI-A-1"].current_mode_id == "1"
+
+    @pytest.mark.asyncio
+    async def test_lit_follows_selected_in_dev_mode(self):
+        backend = DevDisplayBackend()
+        layout = await backend.get_layout()
+        for output in layout.outputs:
+            assert output.lit == output.selected
+        assert layout.displays_powered is True
+
+
+class TestKWinBackend:
+    @pytest.mark.asyncio
+    async def test_an_unreachable_session_is_reported_not_raised(self):
+        with patch(
+            "app.plugins.installed.display_output.backend.run_kscreen_json", return_value=None
+        ):
+            layout = await KWinDisplayBackend().get_layout()
+        assert layout.available is False
+        assert layout.outputs == []
+
+    @pytest.mark.asyncio
+    async def test_merges_the_drm_layer_into_lit(self):
+        payload = {"outputs": [{
+            "name": "DP-3", "connected": True, "enabled": True, "currentModeId": "57",
+            "modes": [{"id": "57", "name": "3840x2160@120", "refreshRate": 120,
+                       "size": {"width": 3840, "height": 2160}}],
+        }]}
+        with patch(
+            "app.plugins.installed.display_output.backend.run_kscreen_json", return_value=payload
+        ), patch(
+            "app.plugins.installed.display_output.backend.get_connector_states",
+            return_value={"DP-3": True},
+        ):
+            layout = await KWinDisplayBackend().get_layout()
+        assert layout.outputs[0].lit is True
+        assert layout.displays_powered is True
+
+    @pytest.mark.asyncio
+    async def test_an_unmappable_output_stays_unknown_not_dark(self):
+        payload = {"outputs": [{
+            "name": "DP-9", "connected": True, "enabled": True,
+            "modes": [{"id": "1", "name": "1920x1080@60", "refreshRate": 60,
+                       "size": {"width": 1920, "height": 1080}}],
+        }]}
+        with patch(
+            "app.plugins.installed.display_output.backend.run_kscreen_json", return_value=payload
+        ), patch(
+            "app.plugins.installed.display_output.backend.get_connector_states",
+            return_value={"DP-3": True},
+        ):
+            layout = await KWinDisplayBackend().get_layout()
+        assert layout.outputs[0].lit is None
+
+    @pytest.mark.asyncio
+    async def test_the_selection_is_dark_when_no_connector_is_lit(self):
+        payload = {"outputs": [{
+            "name": "DP-3", "connected": True, "enabled": True,
+            "modes": [{"id": "1", "name": "1920x1080@60", "refreshRate": 60,
+                       "size": {"width": 1920, "height": 1080}}],
+        }]}
+        with patch(
+            "app.plugins.installed.display_output.backend.run_kscreen_json", return_value=payload
+        ), patch(
+            "app.plugins.installed.display_output.backend.get_connector_states",
+            return_value={"DP-3": False},
+        ):
+            layout = await KWinDisplayBackend().get_layout()
+        # Genau der Zustand, der DesktopTogglePanel "Gestoppt" melden laesst,
+        # waehrend KWin DP-3 fuer gewaehlt haelt. Kein Widerspruch, zwei Ebenen.
+        assert layout.outputs[0].selected is True
+        assert layout.outputs[0].lit is False
+        assert layout.displays_powered is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend ; python -m pytest tests/plugins/test_display_output_backend.py -q --no-cov`
+Expected: FAIL — `ModuleNotFoundError: ... display_output.backend`
+
+- [ ] **Step 3: Backends schreiben**
+
+Create `backend/app/plugins/installed/display_output/backend.py`:
+
+```python
+"""Display-Backends: ein Protokoll, eine Attrappe, eine echte Umsetzung.
+
+Der Aufbau spiegelt ``services/power/desktop_backend.py`` und
+``audio_control/backend.py``: ein Protocol, ein Dev-Backend fuer Windows und
+Entwicklungsbetrieb, ein Linux-Backend, das mit der realen Session spricht.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, List, Optional, Protocol, Tuple
+
+from app.plugins.installed.display_output.kscreen import (
+    build_apply_args,
+    parse_outputs,
+    run_kscreen,
+    run_kscreen_json,
+)
+from app.plugins.installed.display_output.models import (
+    DisplayLayout,
+    DisplayMode,
+    DisplayOutput,
+)
+from app.services.power.gpu.display_detector import get_connector_states
+
+
+class DisplayBackend(Protocol):
+    async def get_layout(self) -> DisplayLayout: ...
+    async def apply(
+        self, wanted: Dict[str, Tuple[bool, Optional[str]]], live_outputs: List[DisplayOutput]
+    ) -> Tuple[bool, str]: ...
+
+
+def _dev_modes(entries: List[tuple]) -> List[DisplayMode]:
+    return [
+        DisplayMode(id=i, name=n, width=w, height=h, refresh_rate=r)
+        for i, n, w, h, r in entries
+    ]
+
+
+class DevDisplayBackend:
+    """Zustand im Speicher, damit das Feature auf Windows entwickelbar ist.
+
+    Bildet BaluNode nach: **zwei** verbundene Ausgaenge. Ein
+    ``disconnected``-Ausgang gehoert bewusst nicht dazu — kscreen-doctor listet
+    unverbundene Connectoren gar nicht erst, ein solcher Eintrag waere also ein
+    Zustand, den das echte Backend nie liefert.
+
+    Die namensgleichen Modus-Paare sind Absicht: an ihnen haengt die gesamte
+    Begruendung fuer die ID-Adressierung, und ohne sie liesse sich die
+    Beschriftung unter Windows nicht pruefen.
+    """
+
+    def __init__(self) -> None:
+        self._outputs: List[DisplayOutput] = [
+            DisplayOutput(
+                name="HDMI-A-1", connected=True, selected=False,
+                current_mode_id="1", preferred_mode_id="1", scale=1.0, priority=0,
+                modes=_dev_modes([
+                    ("1", "2560x1440@144", 2560, 1440, 143.99899291992188),
+                    ("8", "1920x1200@144", 1920, 1200, 143.99899291992188),
+                    ("9", "1920x1080@60", 1920, 1080, 60.0),
+                    ("11", "1920x1080@60", 1920, 1080, 59.939998626708984),
+                    ("50", "1920x1080@144", 1920, 1080, 143.8820037841797),
+                ]),
+            ),
+            DisplayOutput(
+                name="DP-3", connected=True, selected=True,
+                current_mode_id="57", preferred_mode_id="56", scale=2.5, priority=1,
+                modes=_dev_modes([
+                    ("57", "3840x2160@120", 3840, 2160, 120.0),
+                    ("58", "3840x2160@120", 3840, 2160, 119.87999725341797),
+                    ("56", "3840x2160@60", 3840, 2160, 60.0),
+                    ("67", "2560x1440@120", 2560, 1440, 119.99800109863281),
+                    ("69", "1920x1080@120", 1920, 1080, 120.0),
+                ]),
+            ),
+        ]
+
+    async def get_layout(self) -> DisplayLayout:
+        outputs = [o.model_copy(update={"lit": o.selected}) for o in self._outputs]
+        return DisplayLayout(
+            outputs=outputs,
+            displays_powered=any(o.lit for o in outputs),
+            available=True,
+            detail="Dev-Backend (im Speicher)",
+        )
+
+    async def apply(
+        self, wanted: Dict[str, Tuple[bool, Optional[str]]], live_outputs: List[DisplayOutput]
+    ) -> Tuple[bool, str]:
+        for output in self._outputs:
+            if output.name not in wanted:
+                continue
+            selected, mode_id = wanted[output.name]
+            output.selected = selected
+            if selected and mode_id:
+                output.current_mode_id = mode_id
+        return True, "Angewendet (Dev)"
+
+
+class KWinDisplayBackend:
+    """Spricht ueber kscreen-doctor mit der KWin-Instanz der Desktop-Session.
+
+    Das Backend laeuft unter derselben UID wie die Session, deshalb genuegt die
+    Umgebung aus ``wayland_session_env()``; es wird kein Sudo benoetigt.
+    """
+
+    async def get_layout(self) -> DisplayLayout:
+        payload = await asyncio.to_thread(run_kscreen_json)
+        if payload is None:
+            return DisplayLayout(available=False, detail="KWin nicht erreichbar")
+
+        outputs = parse_outputs(payload)
+        states = await get_connector_states()
+        merged = [
+            # .get() statt [] : ein Name ohne Connector ist "unbekannt",
+            # nicht "aus". Eine unbekannte Antwort als aus auszugeben waere
+            # eine Falschaussage.
+            o.model_copy(update={"lit": states.get(o.name)})
+            for o in outputs
+        ]
+        return DisplayLayout(
+            outputs=merged,
+            displays_powered=any(o.lit is True for o in merged),
+            available=True,
+        )
+
+    async def apply(
+        self, wanted: Dict[str, Tuple[bool, Optional[str]]], live_outputs: List[DisplayOutput]
+    ) -> Tuple[bool, str]:
+        args = build_apply_args(wanted, live_outputs)
+        # Genau ein Aufruf: kscreen-doctor wendet alle Argumente gemeinsam an.
+        return await asyncio.to_thread(run_kscreen, args[1:])
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend ; python -m pytest tests/plugins/test_display_output_backend.py -q --no-cov`
+Expected: PASS
+
+- [ ] **Step 5: Lint und Commit**
+
+```bash
+cd backend && python -m ruff check app/plugins/installed/display_output tests/plugins/test_display_output_backend.py
+git add backend/app/plugins/installed/display_output/backend.py backend/tests/plugins/test_display_output_backend.py
+git commit -m "feat(display-output): Dev- und KWin-Backend mit getrennter KWin-/DRM-Ebene"
+```
+
+---
+
+## Task 5: Service mit Whitelist-Validierung
+
+**Files:**
+- Create: `backend/app/plugins/installed/display_output/service.py`
+- Test: `backend/tests/plugins/test_display_output_service.py`
+
+**Interfaces:**
+- Consumes: Backends aus Task 4, Modelle aus Task 1.
+- Produces:
+```python
+class DisplayError(Exception): ...
+class DisplayUnavailable(DisplayError): ...
+class InvalidRequest(DisplayError): ...        # -> 400
+class ModeMismatch(DisplayError): ...          # -> 409
+
+class DisplayService:
+    def __init__(self, backend: Optional[DisplayBackend] = None) -> None
+    async def get_layout(self) -> DisplayLayout
+    async def apply(self, request: DisplayApplyRequest) -> tuple[bool, str]
+
+def get_display_service() -> DisplayService
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/plugins/test_display_output_service.py`:
+
+```python
+"""Validierung: kein Wert wird zum Argument, der nicht enumeriert wurde."""
+import pytest
+
+from app.plugins.installed.display_output.backend import DevDisplayBackend
+from app.plugins.installed.display_output.models import DisplayApplyRequest
+from app.plugins.installed.display_output.service import (
+    DisplayService,
+    DisplayUnavailable,
+    InvalidRequest,
+    ModeMismatch,
+)
+
+
+def _req(outputs: list) -> DisplayApplyRequest:
+    return DisplayApplyRequest(outputs=outputs)
+
+
+@pytest.fixture
+def service() -> DisplayService:
+    return DisplayService(backend=DevDisplayBackend())
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_a_valid_change_is_applied(self, service):
+        ok, _ = await service.apply(_req([
+            {"name": "HDMI-A-1", "selected": True, "mode_id": "1", "mode_name": "2560x1440@144"},
+            {"name": "DP-3", "selected": False},
+        ]))
+        assert ok is True
+        layout = await service.get_layout()
+        assert {o.name: o.selected for o in layout.outputs} == {"HDMI-A-1": True, "DP-3": False}
+
+    @pytest.mark.asyncio
+    async def test_selecting_without_a_mode_keeps_the_current_one(self, service):
+        ok, _ = await service.apply(_req([{"name": "DP-3", "selected": True}]))
+        assert ok is True
+        dp3 = next(o for o in (await service.get_layout()).outputs if o.name == "DP-3")
+        assert dp3.current_mode_id == "57"
+
+
+class TestWhitelist:
+    @pytest.mark.asyncio
+    async def test_an_unknown_output_is_rejected(self, service):
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([{"name": "DP-99", "selected": True}]))
+
+    @pytest.mark.asyncio
+    async def test_a_mode_belonging_to_another_output_is_rejected(self, service):
+        # Das ist #589 als Testfall: Mode-IDs sind global vergeben, also
+        # existiert "57" - aber nicht an HDMI-A-1.
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([{
+                "name": "HDMI-A-1", "selected": True,
+                "mode_id": "57", "mode_name": "3840x2160@120",
+            }]))
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_mode_id_is_rejected(self, service):
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([{
+                "name": "DP-3", "selected": True, "mode_id": "9999", "mode_name": "x",
+            }]))
+
+    @pytest.mark.asyncio
+    async def test_a_duplicate_output_in_one_request_is_rejected(self, service):
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([
+                {"name": "DP-3", "selected": True},
+                {"name": "DP-3", "selected": False},
+            ]))
+
+
+class TestModeCrossCheck:
+    @pytest.mark.asyncio
+    async def test_a_mode_id_without_a_name_is_rejected(self, service):
+        # Sonst waere die Gegenprobe vom Client abschaltbar.
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([{"name": "DP-3", "selected": True, "mode_id": "58"}]))
+
+    @pytest.mark.asyncio
+    async def test_a_name_without_an_id_is_rejected(self, service):
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([{
+                "name": "DP-3", "selected": True, "mode_name": "3840x2160@120",
+            }]))
+
+    @pytest.mark.asyncio
+    async def test_a_stale_name_for_a_live_id_is_a_conflict(self, service):
+        with pytest.raises(ModeMismatch):
+            await service.apply(_req([{
+                "name": "DP-3", "selected": True,
+                "mode_id": "58", "mode_name": "1920x1080@60",
+            }]))
+
+    @pytest.mark.asyncio
+    async def test_the_ambiguous_pair_is_addressable_member_by_member(self, service):
+        # Beide heissen "3840x2160@120". Ueber die ID sind sie trotzdem
+        # unterscheidbar - der ganze Punkt des Entwurfs.
+        for mode_id in ("57", "58"):
+            ok, _ = await service.apply(_req([{
+                "name": "DP-3", "selected": True,
+                "mode_id": mode_id, "mode_name": "3840x2160@120",
+            }]))
+            assert ok is True
+            dp3 = next(o for o in (await service.get_layout()).outputs if o.name == "DP-3")
+            assert dp3.current_mode_id == mode_id
+
+
+class TestInvariant:
+    @pytest.mark.asyncio
+    async def test_deselecting_every_connected_output_is_rejected(self, service):
+        with pytest.raises(InvalidRequest):
+            await service.apply(_req([
+                {"name": "HDMI-A-1", "selected": False},
+                {"name": "DP-3", "selected": False},
+            ]))
+
+    @pytest.mark.asyncio
+    async def test_an_omitted_output_still_counts_as_selected(self, service):
+        # DP-3 steht nicht im Request und bleibt gewaehlt - also ist das
+        # Abwaehlen von HDMI-A-1 erlaubt.
+        ok, _ = await service.apply(_req([{"name": "HDMI-A-1", "selected": False}]))
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_a_mode_on_a_deselected_output_is_ignored_not_rejected(self, service):
+        ok, _ = await service.apply(_req([{
+            "name": "HDMI-A-1", "selected": False,
+            "mode_id": "1", "mode_name": "2560x1440@144",
+        }]))
+        assert ok is True
+
+
+class TestUnavailable:
+    @pytest.mark.asyncio
+    async def test_an_unreachable_session_raises_before_anything_is_applied(self):
+        from app.plugins.installed.display_output.models import DisplayLayout
+
+        class _Dead:
+            async def get_layout(self):
+                return DisplayLayout(available=False, detail="KWin nicht erreichbar")
+
+            async def apply(self, wanted, live_outputs):
+                raise AssertionError("apply darf bei toter Session nicht laufen")
+
+        dead = DisplayService(backend=_Dead())
+        with pytest.raises(DisplayUnavailable):
+            await dead.apply(_req([{"name": "DP-3", "selected": True}]))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend ; python -m pytest tests/plugins/test_display_output_service.py -q --no-cov`
+Expected: FAIL — `ModuleNotFoundError: ... display_output.service`
+
+- [ ] **Step 3: Service schreiben**
+
+Create `backend/app/plugins/installed/display_output/service.py`:
+
+```python
+"""Service-Schicht der Displaysteuerung.
+
+Waehlt das Backend, haelt die Auswahl als Singleton und traegt die gesamte
+Validierung. Der Aufbau spiegelt ``audio_control/service.py``.
+
+**Die Validierung ist die eigentliche Schutzmassnahme.** Listen-Argumente
+schliessen eine Shell-Injektion ohnehin aus; hier wird sichergestellt, dass
+ueberhaupt nur Werte in den Argumentvektor gelangen, die zuvor in der
+Live-Enumeration standen.
+"""
+from __future__ import annotations
+
+import logging
+import platform
+from typing import Dict, Optional, Tuple
+
+from app.core.config import settings
+from app.plugins.installed.display_output.backend import (
+    DevDisplayBackend,
+    DisplayBackend,
+    KWinDisplayBackend,
+)
+from app.plugins.installed.display_output.models import DisplayApplyRequest, DisplayLayout
+
+logger = logging.getLogger(__name__)
+
+_service: Optional["DisplayService"] = None
+
+
+class DisplayError(Exception):
+    """Basis der Fehler, die die Route in Statuscodes uebersetzt."""
+
+
+class DisplayUnavailable(DisplayError):
+    """KWin ist nicht erreichbar — wird zu 502."""
+
+
+class InvalidRequest(DisplayError):
+    """Der Wunsch ist nicht erfuellbar — wird zu 400."""
+
+
+class ModeMismatch(DisplayError):
+    """Die ID meint inzwischen einen anderen Modus — wird zu 409."""
+
+
+class DisplayService:
+    """Duenne Huelle um das gewaehlte Backend, plus Validierung."""
+
+    def __init__(self, backend: Optional[DisplayBackend] = None) -> None:
+        if backend is not None:
+            self._backend: DisplayBackend = backend
+        elif getattr(settings, "is_dev_mode", False) or platform.system() != "Linux":
+            # kscreen-doctor gibt es auf Windows nicht, und im Dev-Modus soll
+            # nichts an einer echten Session herumstellen.
+            self._backend = DevDisplayBackend()
+        else:
+            self._backend = KWinDisplayBackend()
+
+    async def get_layout(self) -> DisplayLayout:
+        """Liest Ausgaenge, Modi und den globalen DPMS-Zustand."""
+        return await self._backend.get_layout()
+
+    async def apply(self, request: DisplayApplyRequest) -> Tuple[bool, str]:
+        """Prueft den Wunsch gegen die Live-Enumeration und wendet ihn an.
+
+        Raises:
+            DisplayUnavailable: KWin antwortet nicht.
+            InvalidRequest: unbekannter Ausgang, unbekannte oder fremde
+                Mode-ID, doppelter Ausgang, unvollstaendige Modusangabe, oder
+                ein Ergebnis ohne einen einzigen gewaehlten Ausgang.
+            ModeMismatch: die ID existiert, meint aber einen anderen Modus als
+                der mitgeschickte Name.
+        """
+        layout = await self._backend.get_layout()
+        if not layout.available:
+            raise DisplayUnavailable(layout.detail or "KWin nicht erreichbar")
+
+        by_name = {o.name: o for o in layout.outputs}
+        wanted: Dict[str, Tuple[bool, Optional[str]]] = {}
+
+        for item in request.outputs:
+            if item.name in wanted:
+                raise InvalidRequest(f"Ausgang doppelt im Wunsch: {item.name}")
+            output = by_name.get(item.name)
+            if output is None:
+                raise InvalidRequest(f"Unbekannter Ausgang: {item.name}")
+
+            mode_id: Optional[str] = None
+            if item.mode_id is not None or item.mode_name is not None:
+                if item.mode_id is None or item.mode_name is None:
+                    # Ohne beide Haelften waere die Gegenprobe abschaltbar.
+                    raise InvalidRequest("mode_id und mode_name gehoeren zusammen")
+                if item.selected:
+                    mode = next((m for m in output.modes if m.id == item.mode_id), None)
+                    if mode is None:
+                        raise InvalidRequest(
+                            f"Modus {item.mode_id} gehoert nicht zu {item.name}"
+                        )
+                    if mode.name != item.mode_name:
+                        raise ModeMismatch(
+                            f"Modus {item.mode_id} heisst inzwischen {mode.name}"
+                        )
+                    mode_id = mode.id
+                # Bei selected=False bleibt mode_id None: KWin behaelt die
+                # Modus-Wahl eines abgewaehlten Ausgangs ohnehin.
+
+            wanted[item.name] = (item.selected, mode_id)
+
+        self._assert_something_stays_selected(by_name, wanted)
+
+        logger.info("Display-Wunsch: %s", wanted)
+        return await self._backend.apply(wanted, layout.outputs)
+
+    @staticmethod
+    def _assert_something_stays_selected(by_name: dict, wanted: dict) -> None:
+        """Verbietet ein apply, nach dem kein Ausgang mehr gewaehlt waere.
+
+        "Nichts soll leuchten" ist ein legitimer Wunsch, aber der Weg dafuer
+        ist der DPMS-Schalter: der ist reversibel und wirft die
+        KWin-Konfiguration nicht weg. Alle Ausgaenge abzuwaehlen wuerde sie
+        wegwerfen.
+
+        Ausgaenge, die der Wunsch nicht nennt, behalten ihren Zustand und
+        zaehlen deshalb mit.
+        """
+        for name, output in by_name.items():
+            if not output.connected:
+                continue
+            selected = wanted[name][0] if name in wanted else output.selected
+            if selected:
+                return
+        raise InvalidRequest("Mindestens ein verbundener Ausgang muss gewaehlt bleiben")
+
+
+def get_display_service() -> DisplayService:
+    """Liefert die Service-Instanz und legt sie beim ersten Aufruf an."""
+    global _service
+    if _service is None:
+        _service = DisplayService()
+    return _service
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend ; python -m pytest tests/plugins/test_display_output_service.py -q --no-cov`
+Expected: PASS
+
+- [ ] **Step 5: Lint und Commit**
+
+```bash
+cd backend && python -m ruff check app/plugins/installed/display_output tests/plugins/test_display_output_service.py
+git add backend/app/plugins/installed/display_output/service.py backend/tests/plugins/test_display_output_service.py
+git commit -m "feat(display-output): Service mit Whitelist, Modus-Gegenprobe und Auswahl-Invariante"
+```
+
+---
+
+## Task 6: Recht `can_manage_displays`
+
+**Files:**
+- Create: `backend/alembic/versions/b8c41d92e7f5_add_can_manage_displays_permission.py`
+- Modify: `backend/app/models/power_permissions.py` (nach `can_control_audio`)
+- Modify: `backend/app/schemas/power_permissions.py` (3 Klassen)
+- Modify: `backend/app/services/power_permissions.py` (`_ACTION_FIELD_MAP` und 4 Wertelisten)
+- Modify: `backend/app/api/deps.py:404` (eine Zeile anfügen)
+- Modify: `backend/app/api/routes/sleep.py:360-376`
+- Test: `backend/tests/test_power_permissions_manage_displays.py`
+
+**Interfaces:**
+- Consumes: nichts.
+- Produces: `app.api.deps.require_power_manage_displays`, Spalte `user_power_permissions.can_manage_displays`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_power_permissions_manage_displays.py`:
+
+```python
+"""Das neue Power-Recht: Standard aus, Admin implizit, sauber verdrahtet."""
+import pytest
+
+from app.schemas.power_permissions import (
+    MyPowerPermissionsResponse,
+    UserPowerPermissionsResponse,
+    UserPowerPermissionsUpdate,
+)
+from app.services.power_permissions import _ACTION_FIELD_MAP
+
+
+class TestWiring:
+    def test_the_action_maps_to_the_column(self):
+        assert _ACTION_FIELD_MAP["manage_displays"] == "can_manage_displays"
+
+    def test_the_dependency_exists(self):
+        from app.api import deps
+        assert hasattr(deps, "require_power_manage_displays")
+
+    def test_the_model_has_the_column(self):
+        from app.models.power_permissions import UserPowerPermission
+        assert hasattr(UserPowerPermission, "can_manage_displays")
+
+
+class TestSchemas:
+    def test_it_defaults_to_denied(self):
+        assert UserPowerPermissionsResponse(user_id=1).can_manage_displays is False
+        assert MyPowerPermissionsResponse().can_manage_displays is False
+
+    def test_the_update_schema_leaves_it_untouched_by_default(self):
+        # None heisst "nicht angefasst" - nicht "entziehen".
+        assert UserPowerPermissionsUpdate().can_manage_displays is None
+
+    def test_the_update_schema_accepts_it(self):
+        assert UserPowerPermissionsUpdate(can_manage_displays=True).can_manage_displays is True
+
+
+class TestGrantAndRevoke:
+    def test_granting_and_revoking_round_trip(self, db_session, test_user, admin_user):
+        from app.services.power_permissions import check_permission, update_permissions
+
+        assert check_permission(db_session, test_user.id, "manage_displays") is False
+
+        update_permissions(
+            db_session, test_user.id,
+            UserPowerPermissionsUpdate(can_manage_displays=True),
+            granted_by=admin_user.id,
+        )
+        assert check_permission(db_session, test_user.id, "manage_displays") is True
+
+        update_permissions(
+            db_session, test_user.id,
+            UserPowerPermissionsUpdate(can_manage_displays=False),
+            granted_by=admin_user.id,
+        )
+        assert check_permission(db_session, test_user.id, "manage_displays") is False
+
+    def test_it_does_not_drag_other_permissions_along(self, db_session, test_user, admin_user):
+        # Es steht neben den Sleep-Ketten und ist bewusst nicht in
+        # _apply_implications - wie can_control_audio.
+        from app.services.power_permissions import get_permissions, update_permissions
+
+        update_permissions(
+            db_session, test_user.id,
+            UserPowerPermissionsUpdate(can_manage_displays=True),
+            granted_by=admin_user.id,
+        )
+        perms = get_permissions(db_session, test_user.id)
+        assert perms.can_manage_displays is True
+        assert perms.can_suspend is False
+        assert perms.can_toggle_desktop is False
+```
+
+Die Fixtures `db_session`, `test_user` und `admin_user` stehen bereits in
+`backend/tests/conftest.py` (nachgeprüft am 2026-09-08) — keine neuen anlegen.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend ; python -m pytest tests/test_power_permissions_manage_displays.py -q --no-cov`
+Expected: FAIL — `KeyError: 'manage_displays'`
+
+- [ ] **Step 3: Migration anlegen**
+
+Create `backend/alembic/versions/b8c41d92e7f5_add_can_manage_displays_permission.py`:
+
+```python
+"""add can_manage_displays permission
+
+Revision ID: b8c41d92e7f5
+Revises: e2f81c4a7b93
+Create Date: 2026-09-08 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b8c41d92e7f5'
+down_revision: Union[str, Sequence[str], None] = 'e2f81c4a7b93'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Fuegt can_manage_displays zu user_power_permissions hinzu (standardmaessig aus)."""
+    op.add_column(
+        'user_power_permissions',
+        sa.Column('can_manage_displays', sa.Boolean(), nullable=False, server_default='0'),
+    )
+
+
+def downgrade() -> None:
+    """Entfernt can_manage_displays."""
+    op.drop_column('user_power_permissions', 'can_manage_displays')
+```
+
+**Vor dem Weitermachen prüfen**, dass `e2f81c4a7b93` immer noch der einzige Head
+ist (sonst entsteht ein Multi-Head, der den Prod-Deploy zerlegt):
+
+Run: `cd backend ; python -m alembic heads`
+Expected: genau eine Zeile, und sie nennt `b8c41d92e7f5` nach dem Anlegen.
+
+- [ ] **Step 4: Modell und Schemas ergänzen**
+
+In `backend/app/models/power_permissions.py` **direkt nach** der Zeile
+`can_control_audio: Mapped[bool] = ...` einfügen:
+
+```python
+    can_manage_displays: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
+```
+
+In `backend/app/schemas/power_permissions.py` an drei Stellen ergänzen —
+in `UserPowerPermissionsResponse` und `MyPowerPermissionsResponse` jeweils nach
+`can_control_audio: bool = False`:
+
+```python
+    can_manage_displays: bool = False
+```
+
+und in `UserPowerPermissionsUpdate` nach der `can_control_audio`-Zeile:
+
+```python
+    can_manage_displays: Optional[bool] = Field(default=None, description="Allow choosing display outputs and video modes")
+```
+
+- [ ] **Step 5: Service verdrahten**
+
+In `backend/app/services/power_permissions.py` vier Stellen ergänzen.
+
+`_ACTION_FIELD_MAP` um einen Eintrag:
+
+```python
+    "manage_displays": "can_manage_displays",
+```
+
+In `get_permissions()` im `UserPowerPermissionsResponse(...)`-Aufruf nach
+`can_control_audio=perm.can_control_audio,`:
+
+```python
+        can_manage_displays=perm.can_manage_displays,
+```
+
+In `update_permissions()` in **beiden** Wörterbüchern (`old_values` und
+`new_values`) nach der `can_control_audio`-Zeile:
+
+```python
+        "can_manage_displays": perm.can_manage_displays,
+```
+
+Und im Block der expliziten Aktualisierungen nach
+`if update.can_control_audio is not None:`-Block:
+
+```python
+    if update.can_manage_displays is not None:
+        perm.can_manage_displays = update.can_manage_displays
+```
+
+**Nicht** in `_apply_implications` aufnehmen — das Recht steht neben den
+Sleep-Ketten, genau wie `can_control_audio`.
+
+- [ ] **Step 6: Dependency und Admin-Implikation**
+
+In `backend/app/api/deps.py` nach Zeile 404 anfügen:
+
+```python
+require_power_manage_displays = _make_power_dependency("manage_displays")
+```
+
+In `backend/app/api/routes/sleep.py` in `get_my_power_permissions()` beide
+Rückgaben ergänzen — im Admin-Zweig nach `can_control_audio=True,`:
+
+```python
+            can_manage_displays=True,
+```
+
+und im Nutzer-Zweig nach `can_control_audio=perms.can_control_audio,`:
+
+```python
+        can_manage_displays=perms.can_manage_displays,
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+```
+cd backend ; python -m pytest tests/test_power_permissions_manage_displays.py -q --no-cov
+```
+Expected: PASS
+
+Dann die bestehenden Berechtigungs-Tests auf Regressionen:
+
+```
+cd backend ; python -m pytest tests/ -q --no-cov -k power_permission
+```
+Expected: PASS, keine neuen Fehler.
+
+- [ ] **Step 8: Lint und Commit**
+
+```bash
+cd backend && python -m ruff check app/models/power_permissions.py app/schemas/power_permissions.py app/services/power_permissions.py app/api/deps.py app/api/routes/sleep.py alembic/versions/b8c41d92e7f5_add_can_manage_displays_permission.py tests/test_power_permissions_manage_displays.py
+git add backend/alembic/versions/b8c41d92e7f5_add_can_manage_displays_permission.py backend/app/models/power_permissions.py backend/app/schemas/power_permissions.py backend/app/services/power_permissions.py backend/app/api/deps.py backend/app/api/routes/sleep.py backend/tests/test_power_permissions_manage_displays.py
+git commit -m "feat(power): Recht can_manage_displays, standardmaessig verweigert"
+```
+
+---
+
+## Task 7: Router, Plugin-Klasse und Fehlerabbildung
+
+**Files:**
+- Modify: `backend/app/plugins/installed/display_output/__init__.py` (vollständig ersetzen)
+- Modify: `backend/app/core/rate_limiter.py` (Kategorie ergänzen)
+- Test: `backend/tests/plugins/test_display_output_routes.py`
+- Test: `backend/tests/plugins/test_display_output_ui_manifest.py`
+
+**Interfaces:**
+- Consumes: `DisplayService` und die Fehlerklassen (Task 5), `require_power_manage_displays` (Task 6).
+- Produces: `DisplayOutputPlugin`, Routen `GET /state` und `POST /apply` unter `/api/plugins/display_output`.
+
+- [ ] **Step 1: Rate-Limit-Kategorie ergänzen**
+
+In `backend/app/core/rate_limiter.py` unmittelbar **vor** der schließenden
+Klammer des Limit-Wörterbuchs (nach der `"audio_control"`-Zeile) einfügen:
+
+```python
+
+    # Displaysteuerung — das Popover fragt nur im geoeffneten Zustand alle 5 s
+    # ab (~12/Minute). admin_operations (30/Minute) waere bei zwei offenen
+    # Tabs bereits knapp.
+    "display_output": "60/minute",
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `backend/tests/plugins/test_display_output_routes.py`:
+
+```python
+"""Routen-Tests: Berechtigung, Statuscodes, keine Interna in der Antwort."""
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.deps import require_power_manage_displays
+from app.plugins.installed.display_output import DisplayOutputPlugin
+from app.plugins.installed.display_output import service as service_module
+from app.plugins.installed.display_output.backend import DevDisplayBackend
+from app.plugins.installed.display_output.models import DisplayLayout
+from app.plugins.installed.display_output.service import DisplayService
+
+BASE = "/api/plugins/display_output"
+
+
+class _User:
+    username = "admin"
+    role = "admin"
+    id = 1
+
+
+def _app(service: DisplayService) -> TestClient:
+    app = FastAPI()
+    app.include_router(DisplayOutputPlugin().get_router(), prefix=BASE)
+    app.dependency_overrides[require_power_manage_displays] = lambda: _User()
+    return TestClient(app)
+
+
+@pytest.fixture
+def client(monkeypatch) -> TestClient:
+    service = DisplayService(backend=DevDisplayBackend())
+    monkeypatch.setattr(service_module, "get_display_service", lambda: service)
+    return _app(service)
+
+
+class TestStateRoute:
+    def test_returns_both_outputs_with_their_modes(self, client):
+        body = client.get(f"{BASE}/state").json()
+        assert body["available"] is True
+        assert [o["name"] for o in body["outputs"]] == ["HDMI-A-1", "DP-3"]
+        assert body["outputs"][1]["modes"]
+
+    def test_the_two_levels_are_separate_fields(self, client):
+        output = client.get(f"{BASE}/state").json()["outputs"][0]
+        assert "selected" in output and "lit" in output
+        assert "enabled" not in output
+
+    def test_a_mode_carries_id_name_and_unrounded_rate(self, client):
+        dp3 = client.get(f"{BASE}/state").json()["outputs"][1]
+        mode = next(m for m in dp3["modes"] if m["id"] == "58")
+        assert mode["name"] == "3840x2160@120"
+        assert mode["refresh_rate"] == pytest.approx(119.87999725, rel=1e-9)
+
+
+class TestApplyRoute:
+    def test_a_valid_change_succeeds(self, client):
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "HDMI-A-1", "selected": True, "mode_id": "1", "mode_name": "2560x1440@144"},
+        ]})
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+    def test_an_unknown_output_is_400(self, client):
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "DP-99", "selected": True},
+        ]})
+        assert resp.status_code == 400
+
+    def test_a_foreign_mode_is_400(self, client):
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "HDMI-A-1", "selected": True,
+             "mode_id": "57", "mode_name": "3840x2160@120"},
+        ]})
+        assert resp.status_code == 400
+
+    def test_a_stale_mode_name_is_409(self, client):
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "DP-3", "selected": True,
+             "mode_id": "58", "mode_name": "1920x1080@60"},
+        ]})
+        assert resp.status_code == 409
+
+    def test_deselecting_everything_is_400(self, client):
+        resp = client.post(f"{BASE}/apply", json={"outputs": [
+            {"name": "HDMI-A-1", "selected": False},
+            {"name": "DP-3", "selected": False},
+        ]})
+        assert resp.status_code == 400
+
+    def test_an_empty_body_is_422(self, client):
+        assert client.post(f"{BASE}/apply", json={"outputs": []}).status_code == 422
+
+    def test_a_raw_dict_body_is_rejected(self, client):
+        assert client.post(f"{BASE}/apply", json={"nonsense": 1}).status_code == 422
+
+
+class TestFailureMapping:
+    def test_an_unreachable_session_reads_as_available_false_not_an_error(self, monkeypatch):
+        class _Dead:
+            async def get_layout(self):
+                return DisplayLayout(available=False, detail="KWin nicht erreichbar")
+
+            async def apply(self, wanted, live_outputs):
+                raise AssertionError("darf nicht laufen")
+
+        service = DisplayService(backend=_Dead())
+        monkeypatch.setattr(service_module, "get_display_service", lambda: service)
+        resp = _app(service).get(f"{BASE}/state")
+        # Lesen liefert available=false statt eines Fehlers: die UI soll den
+        # Zustand anzeigen koennen, nicht nur eine Fehlermeldung.
+        assert resp.status_code == 200
+        assert resp.json()["available"] is False
+
+    def test_an_unreachable_session_is_502_on_write(self, monkeypatch):
+        class _Dead:
+            async def get_layout(self):
+                return DisplayLayout(available=False, detail="KWin nicht erreichbar")
+
+            async def apply(self, wanted, live_outputs):
+                raise AssertionError("darf nicht laufen")
+
+        service = DisplayService(backend=_Dead())
+        monkeypatch.setattr(service_module, "get_display_service", lambda: service)
+        resp = _app(service).post(f"{BASE}/apply", json={"outputs": [
+            {"name": "DP-3", "selected": True},
+        ]})
+        assert resp.status_code == 502
+
+    def test_no_kscreen_output_reaches_the_client(self, monkeypatch):
+        secret = "/sys/devices/pci0000:00/EDID-Geheimnis"
+
+        class _Chatty:
+            async def get_layout(self):
+                return (await DevDisplayBackend().get_layout())
+
+            async def apply(self, wanted, live_outputs):
+                return False, secret
+
+        service = DisplayService(backend=_Chatty())
+        monkeypatch.setattr(service_module, "get_display_service", lambda: service)
+        resp = _app(service).post(f"{BASE}/apply", json={"outputs": [
+            {"name": "DP-3", "selected": True},
+        ]})
+        assert resp.status_code == 502
+        assert secret not in resp.text
+
+
+class TestPermission:
+    def test_the_read_route_is_gated_too(self):
+        # Die Ausgangsliste verraet die angeschlossene Hardware.
+        app = FastAPI()
+        app.include_router(DisplayOutputPlugin().get_router(), prefix=BASE)
+        # Ohne dependency_overrides greift die echte Abhaengigkeit und
+        # scheitert mangels Token.
+        assert TestClient(app).get(f"{BASE}/state").status_code in (401, 403)
+```
+
+Create `backend/tests/plugins/test_display_output_ui_manifest.py`:
+
+```python
+"""Ohne diese Ueberschreibung ist das Plugin im Frontend unsichtbar."""
+from app.plugins.installed.display_output import DisplayOutputPlugin
+
+
+class TestUiManifest:
+    def test_the_manifest_is_present_and_enabled(self):
+        manifest = DisplayOutputPlugin().get_ui_manifest()
+        assert manifest is not None
+        assert manifest.enabled is True
+
+    def test_it_contributes_no_nav_item(self):
+        # Ein Nav-Eintrag erzeugte eine Route und damit einen bundle.js-Abruf.
+        # Die Bedienung sitzt in der Topbar.
+        assert DisplayOutputPlugin().get_ui_manifest().nav_items == []
+
+    def test_the_metadata_name_matches_the_route_prefix(self):
+        assert DisplayOutputPlugin().metadata.name == "display_output"
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd backend ; python -m pytest tests/plugins/test_display_output_routes.py tests/plugins/test_display_output_ui_manifest.py -q --no-cov`
+Expected: FAIL — `ImportError: cannot import name 'DisplayOutputPlugin'`
+
+- [ ] **Step 4: Router und Plugin-Klasse schreiben**
+
+`backend/app/plugins/installed/display_output/__init__.py` **vollständig
+ersetzen** durch:
+
+```python
+"""Displaysteuerung — bundled Plugin.
+
+Enumeriert die KWin-Ausgaenge und setzt Auswahl und Video-Modus ueber
+kscreen-doctor. Laeuft als bundled Plugin im Host-Prozess und damit unter
+derselben UID wie die Desktop-Session; ein Sandbox-Plugin kaeme nicht an den
+Wayland-Socket.
+"""
+# NB: kein ``from __future__ import annotations`` hier (vgl. audio_control).
+# Zusammen mit Pydantic v2 + FastAPIs Body-Erkennung durch slowapis
+# ``@user_limiter.limit``-Wrapper werden aufgeschobene Annotationen zu
+# ForwardRefs, die FastAPI nicht mehr als Pydantic-Modell aufloest — der
+# Request-Body wuerde als Query-Parameter fehlinterpretiert und jedes
+# POST liefert 422.
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+
+from app.api.deps import require_power_manage_displays
+from app.core.rate_limiter import get_limit, user_limiter
+from app.plugins.base import PluginBase, PluginMetadata, PluginUIManifest
+from app.plugins.installed.display_output import service as service_module
+from app.plugins.installed.display_output.models import DisplayApplyRequest, DisplayLayout
+from app.plugins.installed.display_output.service import (
+    DisplayUnavailable,
+    InvalidRequest,
+    ModeMismatch,
+)
+from app.schemas.user import UserPublic
+from app.services.audit.logger_db import get_audit_logger_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_LIMIT = get_limit("display_output")
+
+
+def _audit(user: UserPublic, success: bool, wanted: dict) -> None:
+    """Schreibt einen Audit-Eintrag fuer jede Aenderung der Ausgangswahl.
+
+    Anders als bei den Pegeln der Audiosteuerung ist hier jeder Vorgang
+    interessant: ein apply schaltet Bildschirme.
+    """
+    audit_logger = get_audit_logger_db()
+    audit_logger.log_event(
+        event_type="POWER",
+        action="display_apply",
+        user=user.username,
+        resource="displays",
+        success=success,
+        details={"wanted": {k: list(v) for k, v in wanted.items()}},
+    )
+    if getattr(user, "role", None) != "admin":
+        audit_logger.log_security_event(
+            action="delegated_power_action",
+            user=user.username,
+            resource="manage_displays",
+            details={"action": "display_apply"},
+            success=True,
+        )
+
+
+@router.get("/state", response_model=DisplayLayout)
+@user_limiter.limit(_LIMIT)
+async def get_display_state(
+    request: Request,
+    response: Response,
+    current_user=Depends(require_power_manage_displays),
+) -> DisplayLayout:
+    """Liefert alle Ausgaenge, ihre Modi und den globalen DPMS-Zustand.
+
+    Hinter derselben Berechtigung wie die Schreibroute: die Ausgangsliste
+    verraet die angeschlossene Hardware samt EDID-Groessenangaben.
+
+    Eine unerreichbare Session ist hier **kein** Fehler, sondern
+    ``available=false`` — die UI soll das anzeigen koennen, statt nur eine
+    Fehlermeldung zu bekommen.
+    """
+    return await service_module.get_display_service().get_layout()
+
+
+@router.post("/apply")
+@user_limiter.limit(_LIMIT)
+async def apply_display_layout(
+    body: DisplayApplyRequest,
+    request: Request,
+    response: Response,
+    current_user=Depends(require_power_manage_displays),
+) -> dict:
+    """Setzt Auswahl und Modus in genau einem kscreen-doctor-Aufruf.
+
+    Jeder Name und jede Mode-ID aus dem Rumpf wird zuvor gegen die live
+    enumerierten Werte **dieses** Ausgangs geprueft (im Service). Was dort
+    nicht steht, wird nie zu einem argv-Element.
+    """
+    service = service_module.get_display_service()
+    wanted = {o.name: (o.selected, o.mode_id) for o in body.outputs}
+    try:
+        ok, message = await service.apply(body)
+    except InvalidRequest as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    except ModeMismatch as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+    except DisplayUnavailable:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY, detail="Displays nicht erreichbar"
+        )
+
+    _audit(current_user, ok, wanted)
+
+    if ok:
+        return {"success": True}
+
+    # `message` stammt roh aus kscreen-doctor und kann EDID-Namen und Pfade
+    # enthalten. Es wird geloggt, aber nie ausgeliefert.
+    logger.warning("Display-Anwendung fehlgeschlagen: %s", message)
+    raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY, detail="Aktion fehlgeschlagen"
+    )
+
+
+class DisplayOutputPlugin(PluginBase):
+    """Bundled Plugin fuer die Displaysteuerung."""
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="display_output",
+            version="1.0.0",
+            display_name="Displaysteuerung",
+            description=(
+                "Angeschlossene Bildschirme erkennen, den Ausgang waehlen und "
+                "Aufloesung samt Bildwiederholrate setzen."
+            ),
+            author="Xveyn",
+            category="system",
+        )
+
+    def get_router(self) -> APIRouter:
+        return router
+
+    def get_ui_manifest(self) -> PluginUIManifest:
+        """Meldet das Plugin ans Frontend, ohne einen Nav-Eintrag beizusteuern.
+
+        **Ohne diese Ueberschreibung ist das Feature unsichtbar.**
+        ``PluginBase`` liefert hier ``None``, und
+        ``PluginManager.get_ui_manifest()`` nimmt nur Plugins mit einem aktiven
+        Manifest in ``/api/plugins/ui/manifest`` auf — genau die Liste, aus der
+        ``usePluginEnabled`` speist. Ohne Manifest gilt das Plugin dort
+        dauerhaft als abgeschaltet, und die Topbar rendert das Monitor-Symbol
+        nie: kein Fehler, keine Logzeile.
+
+        ``nav_items`` bleibt leer: die Bedienung sitzt in der Topbar. Ein
+        leeres ``nav_items`` erzeugt keine Route, also wird auch kein
+        ``bundle.js`` nachgeladen.
+        """
+        return PluginUIManifest(enabled=True)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend ; python -m pytest tests/plugins/test_display_output_routes.py tests/plugins/test_display_output_ui_manifest.py -q --no-cov`
+Expected: PASS
+
+- [ ] **Step 6: Gesamte Plugin-Suite auf Regressionen**
+
+Run: `cd backend ; python -m pytest tests/plugins -q --no-cov`
+Expected: PASS, keine neuen Fehler.
+
+- [ ] **Step 7: Lint und Commit**
+
+```bash
+cd backend && python -m ruff check app/plugins/installed/display_output app/core/rate_limiter.py tests/plugins/test_display_output_routes.py tests/plugins/test_display_output_ui_manifest.py
+git add backend/app/plugins/installed/display_output/__init__.py backend/app/core/rate_limiter.py backend/tests/plugins/test_display_output_routes.py backend/tests/plugins/test_display_output_ui_manifest.py
+git commit -m "feat(display-output): Router, Plugin-Klasse und Fehlerabbildung (400/409/502)"
+```
+
+---
+
+## Task 8: API-Client und i18n
+
+**Files:**
+- Create: `client/src/api/displayOutput.ts`
+- Create: `client/src/i18n/locales/de/display.json`
+- Create: `client/src/i18n/locales/en/display.json`
+- Modify: `client/src/i18n/index.ts` (3 Stellen)
+
+**Interfaces:**
+- Consumes: die Backend-Routen aus Task 7.
+- Produces:
+```ts
+export interface DisplayMode { id, name, width, height, refresh_rate }
+export interface DisplayOutput { name, connected, selected, lit, current_mode_id, preferred_mode_id, scale, priority, modes }
+export interface DisplayLayout { outputs, displays_powered, available, detail }
+export interface DisplayOutputWish { name, selected, mode_id?, mode_name? }
+export async function getDisplayLayout(): Promise<DisplayLayout>
+export async function applyDisplayLayout(outputs: DisplayOutputWish[]): Promise<void>
+export function formatMode(mode: DisplayMode, locale: string): string
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/api/displayOutput.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { formatMode } from '../../api/displayOutput';
+
+const MODE_120 = { id: '57', name: '3840x2160@120', width: 3840, height: 2160, refresh_rate: 120 };
+const MODE_11988 = {
+  id: '58', name: '3840x2160@120', width: 3840, height: 2160,
+  refresh_rate: 119.87999725341797,
+};
+
+describe('formatMode', () => {
+  it('trennt das Paar, das denselben Namen traegt', () => {
+    // Genau hier scheitert die Adressierung ueber den Namen: beide heissen
+    // "3840x2160@120". Zwei Nachkommastellen machen sie unterscheidbar.
+    expect(formatMode(MODE_120, 'de')).not.toBe(formatMode(MODE_11988, 'de'));
+  });
+
+  it('rundet auf zwei Nachkommastellen', () => {
+    expect(formatMode(MODE_11988, 'en')).toContain('119.88');
+    expect(formatMode(MODE_120, 'en')).toContain('120.00');
+  });
+
+  it('nutzt das Dezimaltrennzeichen der Sprache', () => {
+    expect(formatMode(MODE_11988, 'de')).toContain('119,88');
+  });
+
+  it('nennt Aufloesung und Einheit', () => {
+    expect(formatMode(MODE_120, 'en')).toBe('3840 × 2160 @ 120.00 Hz');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client ; npx vitest run src/__tests__/api/displayOutput.test.ts`
+Expected: FAIL — Modul nicht gefunden.
+
+- [ ] **Step 3: API-Client schreiben**
+
+Create `client/src/api/displayOutput.ts`:
+
+```ts
+/**
+ * API-Client der Displaysteuerung (bundled Plugin `display_output`).
+ *
+ * Alle Routen liegen hinter dem Recht `can_manage_displays` — auch die
+ * lesende, weil die Ausgangsliste die angeschlossene Hardware verrät.
+ *
+ * Modi werden über `id` adressiert, nie über `name`: KWin bildet den Namen mit
+ * gerundeter Bildwiederholrate, weshalb 119,88 und 120,00 Hz beide
+ * „3840x2160@120" heißen. `mode_name` reist nur als Gegenprobe mit.
+ */
+
+import { apiClient } from '../lib/api';
+
+const BASE = '/api/plugins/display_output';
+
+export interface DisplayMode {
+  /** Lebende KWin-Mode-ID. Nie speichern — sie gilt nur für diesen Abruf. */
+  id: string;
+  /** "3840x2160@120" — NICHT eindeutig. */
+  name: string;
+  width: number;
+  height: number;
+  /** Ungerundet, z. B. 119.87999725341797. */
+  refresh_rate: number;
+}
+
+export interface DisplayOutput {
+  name: string;
+  connected: boolean;
+  /** KWin-Ebene: ist dieser Ausgang gewählt? */
+  selected: boolean;
+  /** DRM-Ebene: werden Pixel getrieben? null = nicht zuordenbar. */
+  lit: boolean | null;
+  current_mode_id: string | null;
+  preferred_mode_id: string | null;
+  scale: number;
+  priority: number;
+  modes: DisplayMode[];
+}
+
+export interface DisplayLayout {
+  outputs: DisplayOutput[];
+  displays_powered: boolean;
+  available: boolean;
+  detail: string | null;
+}
+
+export interface DisplayOutputWish {
+  name: string;
+  selected: boolean;
+  mode_id?: string;
+  /** Pflicht, sobald mode_id gesetzt ist. */
+  mode_name?: string;
+}
+
+/** Liest Ausgänge, Modi und den globalen DPMS-Zustand in einem Rundlauf. */
+export async function getDisplayLayout(): Promise<DisplayLayout> {
+  const { data } = await apiClient.get<DisplayLayout>(`${BASE}/state`);
+  return data;
+}
+
+/** Setzt Auswahl und Modus — ein Aufruf, den das Backend atomar anwendet. */
+export async function applyDisplayLayout(outputs: DisplayOutputWish[]): Promise<void> {
+  await apiClient.post(`${BASE}/apply`, { outputs });
+}
+
+/**
+ * Beschriftet einen Modus für das Auswahlfeld.
+ *
+ * Zwei Nachkommastellen sind nicht Kosmetik: sie sind das Einzige, woran ein
+ * Mensch die beiden 4K-Modi von DP-3 auseinanderhält. Formatiert wird hier und
+ * nicht im Backend, weil das Dezimaltrennzeichen sprachabhängig ist.
+ */
+export function formatMode(mode: DisplayMode, locale: string): string {
+  const hz = new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(mode.refresh_rate);
+  return `${mode.width} × ${mode.height} @ ${hz} Hz`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd client ; npx vitest run src/__tests__/api/displayOutput.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: i18n-Dateien anlegen**
+
+Create `client/src/i18n/locales/de/display.json`:
+
+```json
+{
+  "title": "Displays",
+  "outputs": "Ausgänge",
+  "mode": "Auflösung",
+  "selected": "gewählt",
+  "notSelected": "nicht gewählt",
+  "lit": "leuchtet",
+  "dark": "dunkel",
+  "litUnknown": "Zustand unbekannt",
+  "allDark": "Alle Bildschirme sind dunkel. Im Systemmenü lassen sie sich einschalten.",
+  "apply": "Anwenden",
+  "applying": "Wird angewendet …",
+  "applied": "Übernommen",
+  "unavailable": "Die Displaysteuerung ist nicht erreichbar. Läuft die Desktop-Sitzung?",
+  "loadError": "Displayzustand konnte nicht geladen werden",
+  "saveError": "Änderung konnte nicht übernommen werden",
+  "conflictError": "Die Modusliste hat sich geändert. Bitte erneut versuchen.",
+  "keepOneSelected": "Mindestens ein Ausgang muss gewählt bleiben."
+}
+```
+
+Create `client/src/i18n/locales/en/display.json`:
+
+```json
+{
+  "title": "Displays",
+  "outputs": "Outputs",
+  "mode": "Resolution",
+  "selected": "selected",
+  "notSelected": "not selected",
+  "lit": "lit",
+  "dark": "dark",
+  "litUnknown": "state unknown",
+  "allDark": "All screens are dark. Turn them on from the system menu.",
+  "apply": "Apply",
+  "applying": "Applying …",
+  "applied": "Applied",
+  "unavailable": "Display control is unreachable. Is the desktop session running?",
+  "loadError": "Could not load display state",
+  "saveError": "Could not apply the change",
+  "conflictError": "The mode list changed. Please try again.",
+  "keepOneSelected": "At least one output must stay selected."
+}
+```
+
+- [ ] **Step 6: Namensraum registrieren**
+
+In `client/src/i18n/index.ts` drei Stellen ergänzen — nach den beiden
+`audio`-Importzeilen (Z. 44–45):
+
+```ts
+import displayDe from './locales/de/display.json';
+import displayEn from './locales/en/display.json';
+```
+
+im deutschen Ressourcenblock nach `audio: audioDe,`:
+
+```ts
+    display: displayDe,
+```
+
+im englischen nach `audio: audioEn,`:
+
+```ts
+    display: displayEn,
+```
+
+und in der `ns`-Liste `'audio'` zu `'audio', 'display'` erweitern.
+
+- [ ] **Step 7: Build und Lint**
+
+```
+cd client ; npx eslint src/api/displayOutput.ts src/i18n/index.ts
+```
+Expected: keine Fehler.
+
+```
+cd client ; npm run build
+```
+Expected: Erfolg. (`npm run build` fährt `tsc -b` über alle Projekte — ein reines
+`tsc --noEmit` würde den Fehler übersehen, an dem die CI dann scheitert.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add client/src/api/displayOutput.ts client/src/i18n/locales/de/display.json client/src/i18n/locales/en/display.json client/src/i18n/index.ts client/src/__tests__/api/displayOutput.test.ts
+git commit -m "feat(display-output): API-Client mit sprachrichtiger Modus-Beschriftung und i18n"
+```
+
+---
+
+## Task 9: Topbar-Popover
+
+**Files:**
+- Create: `client/src/components/topbar/DisplayMenu.tsx`
+- Modify: `client/src/components/layout/LayoutHeader.tsx` (3 Zeilen)
+- Test: `client/src/__tests__/components/topbar/DisplayMenu.test.tsx`
+
+**Interfaces:**
+- Consumes: `getDisplayLayout`, `applyDisplayLayout`, `formatMode` (Task 8); `getMyPowerPermissions` (Task 6).
+- Produces: `export function DisplayMenu()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/components/topbar/DisplayMenu.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      const values = options ? Object.values(options).join('/') : '';
+      return values ? `${ns}:${key}:${values}` : `${ns}:${key}`;
+    },
+    i18n: { language: 'de' },
+  }),
+}));
+
+vi.mock('../../../api/displayOutput', async () => {
+  const actual = await vi.importActual<typeof import('../../../api/displayOutput')>(
+    '../../../api/displayOutput',
+  );
+  return {
+    ...actual,
+    getDisplayLayout: vi.fn(),
+    applyDisplayLayout: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('../../../api/powerPermissions', () => ({
+  getMyPowerPermissions: vi.fn(),
+}));
+
+import { DisplayMenu } from '../../../components/topbar/DisplayMenu';
+import { getDisplayLayout, applyDisplayLayout } from '../../../api/displayOutput';
+import { getMyPowerPermissions } from '../../../api/powerPermissions';
+
+const LAYOUT = {
+  available: true,
+  detail: null,
+  displays_powered: false,
+  outputs: [
+    {
+      name: 'HDMI-A-1', connected: true, selected: false, lit: false,
+      current_mode_id: '1', preferred_mode_id: '1', scale: 1, priority: 0,
+      modes: [{ id: '1', name: '2560x1440@144', width: 2560, height: 1440, refresh_rate: 143.999 }],
+    },
+    {
+      name: 'DP-3', connected: true, selected: true, lit: false,
+      current_mode_id: '57', preferred_mode_id: '56', scale: 2.5, priority: 1,
+      modes: [
+        { id: '57', name: '3840x2160@120', width: 3840, height: 2160, refresh_rate: 120 },
+        { id: '58', name: '3840x2160@120', width: 3840, height: 2160, refresh_rate: 119.87999725 },
+      ],
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.mocked(getMyPowerPermissions).mockResolvedValue({ can_manage_displays: true } as never);
+  vi.mocked(getDisplayLayout).mockResolvedValue(structuredClone(LAYOUT) as never);
+});
+
+async function open() {
+  render(<DisplayMenu />);
+  const button = await screen.findByLabelText('display:title');
+  fireEvent.click(button);
+  await waitFor(() => expect(getDisplayLayout).toHaveBeenCalled());
+}
+
+describe('DisplayMenu', () => {
+  it('bleibt unsichtbar ohne das Recht', async () => {
+    vi.mocked(getMyPowerPermissions).mockResolvedValue({ can_manage_displays: false } as never);
+    const { container } = render(<DisplayMenu />);
+    await waitFor(() => expect(getMyPowerPermissions).toHaveBeenCalled());
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('fragt erst ab, wenn das Popover offen ist', async () => {
+    render(<DisplayMenu />);
+    await screen.findByLabelText('display:title');
+    expect(getDisplayLayout).not.toHaveBeenCalled();
+  });
+
+  it('listet beide Ausgaenge', async () => {
+    await open();
+    expect(await screen.findByText('DP-3')).toBeTruthy();
+    expect(screen.getByText('HDMI-A-1')).toBeTruthy();
+  });
+
+  it('zeigt gewaehlt und leuchtet als getrennte Aussagen', async () => {
+    // Der mehrdeutige Zustand von BaluNode: KWin haelt DP-3 fuer gewaehlt,
+    // DRM meldet dunkel. Beides muss sichtbar sein, sonst widerspricht sich
+    // die Oberflaeche.
+    await open();
+    expect(screen.getAllByText('display:selected').length).toBe(1);
+    expect(screen.getAllByText('display:dark').length).toBe(2);
+  });
+
+  it('unterscheidet die beiden namensgleichen 4K-Modi im Auswahlfeld', async () => {
+    await open();
+    const select = screen.getByLabelText('display:mode:DP-3') as HTMLSelectElement;
+    const labels = Array.from(select.options).map((o) => o.textContent);
+    expect(new Set(labels).size).toBe(labels.length);
+    expect(labels.some((l) => l?.includes('119,88'))).toBe(true);
+  });
+
+  it('schickt id und name zusammen', async () => {
+    await open();
+    const select = screen.getByLabelText('display:mode:DP-3') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '58' } });
+    fireEvent.click(screen.getByText('display:apply'));
+    await waitFor(() => expect(applyDisplayLayout).toHaveBeenCalled());
+    const wishes = vi.mocked(applyDisplayLayout).mock.calls[0][0];
+    const dp3 = wishes.find((w) => w.name === 'DP-3');
+    expect(dp3).toEqual({
+      name: 'DP-3', selected: true, mode_id: '58', mode_name: '3840x2160@120',
+    });
+  });
+
+  it('sperrt Anwenden, wenn nichts mehr gewaehlt waere', async () => {
+    await open();
+    fireEvent.click(screen.getByLabelText('display:outputs:DP-3'));
+    const apply = screen.getByText('display:apply').closest('button') as HTMLButtonElement;
+    expect(apply.disabled).toBe(true);
+  });
+
+  it('meldet eine unerreichbare Sitzung statt einer leeren Liste', async () => {
+    vi.mocked(getDisplayLayout).mockResolvedValue({
+      ...LAYOUT, available: false, outputs: [],
+    } as never);
+    await open();
+    expect(await screen.findByText('display:unavailable')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client ; npx vitest run src/__tests__/components/topbar/DisplayMenu.test.tsx`
+Expected: FAIL — Modul nicht gefunden.
+
+- [ ] **Step 3: Popover schreiben**
+
+Create `client/src/components/topbar/DisplayMenu.tsx`:
+
+```tsx
+/**
+ * Displaysteuerung in der Topbar.
+ *
+ * Zeigt ein Monitor-Symbol; im Popover steht pro Ausgang die KWin-Wahl und
+ * ein Auswahlfeld für den Video-Modus.
+ *
+ * Drei Eigenheiten, die Absicht sind:
+ * - Der Zustand wird nur abgefragt, solange das Popover offen ist. Eine
+ *   Fernbedienung, die im Hintergrund pollt, kostet Anfragen ohne Gegenwert.
+ * - „gewählt" (KWin) und „leuchtet" (DRM) sind getrennte Aussagen. Beides in
+ *   ein Abzeichen zu falten, ist die Verwechslung, die dieses Feature auflöst.
+ * - Der globale Ein/Aus-Schalter fehlt bewusst: er steht zwei Symbole weiter
+ *   im Systemmenü, und zwei Komponenten für denselben Zustand driften.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Monitor, MonitorOff } from 'lucide-react';
+import {
+  applyDisplayLayout,
+  formatMode,
+  getDisplayLayout,
+  type DisplayLayout,
+  type DisplayOutputWish,
+} from '../../api/displayOutput';
+import { getMyPowerPermissions } from '../../api/powerPermissions';
+
+/** Abfragetakt, solange das Popover offen ist. */
+const POLL_MS = 5000;
+
+/** Der bearbeitete Wunsch je Ausgang, bevor „Anwenden" ihn abschickt. */
+interface Draft {
+  selected: boolean;
+  modeId: string | null;
+}
+
+export function DisplayMenu() {
+  const { t, i18n } = useTranslation('display');
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [layout, setLayout] = useState<DisplayLayout | null>(null);
+  const [draft, setDraft] = useState<Record<string, Draft>>({});
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const inFlight = useRef(false);
+  const dirty = useRef(false);
+
+  useEffect(() => {
+    let active = true;
+    getMyPowerPermissions()
+      .then((perms) => active && setAllowed(perms.can_manage_displays))
+      .catch(() => active && setAllowed(false));
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (inFlight.current) return;
+    inFlight.current = true;
+    try {
+      const next = await getDisplayLayout();
+      setLayout(next);
+      // Einen angefangenen Entwurf NICHT überschreiben — sonst springt die
+      // Auswahl beim nächsten Takt auf den Serverwert zurück.
+      if (!dirty.current) {
+        setDraft(
+          Object.fromEntries(
+            next.outputs.map((o) => [o.name, { selected: o.selected, modeId: o.current_mode_id }]),
+          ),
+        );
+      }
+      setError(null);
+    } catch {
+      setError(t('loadError'));
+    } finally {
+      inFlight.current = false;
+    }
+  }, [t]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    void refresh();
+    const id = setInterval(() => void refresh(), POLL_MS);
+    return () => clearInterval(id);
+  }, [isOpen, refresh]);
+
+  useEffect(() => {
+    const onClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+        dirty.current = false;
+      }
+    };
+    if (isOpen) document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, [isOpen]);
+
+  const wishes: DisplayOutputWish[] = useMemo(() => {
+    if (!layout) return [];
+    return layout.outputs.map((output) => {
+      const entry = draft[output.name] ?? { selected: output.selected, modeId: output.current_mode_id };
+      const mode = output.modes.find((m) => m.id === entry.modeId);
+      const wish: DisplayOutputWish = { name: output.name, selected: entry.selected };
+      // id und name reisen immer gemeinsam — das Backend lehnt eine einzelne
+      // Hälfte ab, weil die Gegenprobe sonst abschaltbar wäre.
+      if (entry.selected && mode) {
+        wish.mode_id = mode.id;
+        wish.mode_name = mode.name;
+      }
+      return wish;
+    });
+  }, [layout, draft]);
+
+  const nothingSelected =
+    layout !== null &&
+    layout.outputs.some((o) => o.connected) &&
+    !layout.outputs.some((o) => o.connected && (draft[o.name]?.selected ?? o.selected));
+
+  const handleApply = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await applyDisplayLayout(wishes);
+      dirty.current = false;
+      await refresh();
+    } catch (err: unknown) {
+      const statusCode = (err as { response?: { status?: number } })?.response?.status;
+      setError(statusCode === 409 ? t('conflictError') : t('saveError'));
+      if (statusCode === 409) {
+        dirty.current = false;
+        await refresh();
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!allowed) return null;
+
+  const anyLit = layout?.outputs.some((o) => o.lit === true) ?? false;
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        type="button"
+        aria-label={t('title')}
+        onClick={() => setIsOpen((open) => !open)}
+        className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-800 text-slate-400 transition hover:border-sky-500/50 hover:text-sky-400"
+      >
+        {anyLit ? <Monitor className="h-5 w-5" /> : <MonitorOff className="h-5 w-5" />}
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 z-50 mt-2 w-96 rounded-xl border border-slate-800 bg-slate-900/95 p-4 shadow-xl backdrop-blur-xl">
+          {layout && !layout.available && (
+            <p className="text-sm text-slate-400">{t('unavailable')}</p>
+          )}
+
+          {layout?.available && (
+            <>
+              <p className="mb-2 text-xs uppercase tracking-wide text-slate-500">{t('outputs')}</p>
+
+              {layout.outputs.map((output) => {
+                const entry = draft[output.name] ?? {
+                  selected: output.selected,
+                  modeId: output.current_mode_id,
+                };
+                return (
+                  <div key={output.name} className="mb-4 border-b border-slate-800 pb-3 last:border-0">
+                    <div className="mb-1 flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        id={`display-${output.name}`}
+                        aria-label={t('outputs') + ':' + output.name}
+                        checked={entry.selected}
+                        onChange={(e) => {
+                          dirty.current = true;
+                          setDraft((prev) => ({
+                            ...prev,
+                            [output.name]: { ...entry, selected: e.target.checked },
+                          }));
+                        }}
+                      />
+                      <label htmlFor={`display-${output.name}`} className="text-sm text-slate-200">
+                        {output.name}
+                      </label>
+                      <span className="ml-auto text-xs text-slate-500">
+                        {output.selected ? t('selected') : t('notSelected')}
+                      </span>
+                      <span className="text-xs text-slate-500">
+                        {output.lit === null ? t('litUnknown') : output.lit ? t('lit') : t('dark')}
+                      </span>
+                    </div>
+
+                    <select
+                      aria-label={t('mode', { output: output.name })}
+                      value={entry.modeId ?? ''}
+                      disabled={!entry.selected}
+                      onChange={(e) => {
+                        dirty.current = true;
+                        setDraft((prev) => ({
+                          ...prev,
+                          [output.name]: { ...entry, modeId: e.target.value },
+                        }));
+                      }}
+                      className="w-full rounded-lg border border-slate-700 bg-slate-800 px-2 py-1 text-sm text-slate-200 disabled:opacity-50"
+                    >
+                      {output.modes.map((mode) => (
+                        <option key={mode.id} value={mode.id}>
+                          {formatMode(mode, i18n.language)}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                );
+              })}
+
+              {!layout.displays_powered && (
+                <p className="mb-2 text-xs text-amber-400">{t('allDark')}</p>
+              )}
+              {nothingSelected && (
+                <p className="mb-2 text-xs text-amber-400">{t('keepOneSelected')}</p>
+              )}
+              {error && <p className="mb-2 text-xs text-rose-400">{error}</p>}
+
+              <button
+                type="button"
+                onClick={() => void handleApply()}
+                disabled={busy || nothingSelected}
+                className="w-full rounded-lg bg-sky-600 px-3 py-2 text-sm font-medium text-white transition hover:bg-sky-500 disabled:opacity-50"
+              >
+                {busy ? t('applying') : t('apply')}
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: In die Topbar einhängen**
+
+In `client/src/components/layout/LayoutHeader.tsx` drei Änderungen.
+
+Nach Zeile 5 (`import { AudioMenu } ...`):
+
+```tsx
+import { DisplayMenu } from '../topbar/DisplayMenu';
+```
+
+In der Komponente nach `const audioEnabled = usePluginEnabled('audio_control');`:
+
+```tsx
+  const displaysEnabled = usePluginEnabled('display_output');
+```
+
+Und in „Header Right" **vor** der `AudioMenu`-Zeile:
+
+```tsx
+          {!isPi && displaysEnabled && <DisplayMenu />}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```
+cd client ; npx vitest run src/__tests__/components/topbar/DisplayMenu.test.tsx src/__tests__/components/layout/LayoutHeader.test.tsx
+```
+Expected: PASS. Die bestehende `LayoutHeader`-Suite muss grün bleiben; bricht sie
+mit „usePlugins must be used within a PluginProvider", fehlt in ihr der Mock für
+den neuen `usePluginEnabled`-Aufruf — dort ergänzen, nicht die Komponente ändern.
+
+- [ ] **Step 6: Lint und Build**
+
+```
+cd client ; npx eslint .
+```
+Expected: 0 Fehler (die CI setzt hier ein hartes Gate).
+
+```
+cd client ; npm run build
+```
+Expected: Erfolg.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add client/src/components/topbar/DisplayMenu.tsx client/src/components/layout/LayoutHeader.tsx client/src/__tests__/components/topbar/DisplayMenu.test.tsx
+git commit -m "feat(display-output): Topbar-Popover mit getrennter KWin-/DRM-Anzeige"
+```
+
+---
+
+## Task 10: Recht in der Nutzerverwaltung
+
+**Files:**
+- Modify: `client/src/api/powerPermissions.ts` (3 Schnittstellen)
+- Modify: `client/src/components/user-management/PowerPermissionsSection.tsx` (2 Stellen)
+- Modify: `client/src/i18n/locales/de/admin.json`, `client/src/i18n/locales/en/admin.json`
+- Test: `client/src/__tests__/components/user-management/PowerPermissionsSection.displays.test.tsx`
+
+**Interfaces:**
+- Consumes: das Backend-Recht aus Task 6.
+- Produces: nichts, worauf spätere Tasks aufbauen.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `client/src/__tests__/components/user-management/PowerPermissionsSection.displays.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns: string) => ({
+    t: (key: string) => `${ns}:${key}`,
+    i18n: { language: 'de' },
+  }),
+}));
+
+vi.mock('../../../api/powerPermissions', () => ({
+  getUserPowerPermissions: vi.fn(),
+  updateUserPowerPermissions: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Die Komponente zieht beides unbedingt herein; ohne Mock scheitert der
+// Import, nicht die Zusicherung.
+vi.mock('react-hot-toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../../lib/errorHandling', () => ({
+  handleApiError: vi.fn(),
+}));
+
+import { PowerPermissionsSection } from '../../../components/user-management/PowerPermissionsSection';
+import { getUserPowerPermissions } from '../../../api/powerPermissions';
+
+const PERMS = {
+  user_id: 7,
+  can_soft_sleep: false, can_wake: false, can_suspend: false, can_wol: false,
+  can_toggle_desktop: false, can_unlock_session: false, can_control_audio: false,
+  can_manage_displays: false,
+  granted_by: null, granted_by_username: null, granted_at: null,
+};
+
+beforeEach(() => {
+  vi.mocked(getUserPowerPermissions).mockResolvedValue(structuredClone(PERMS) as never);
+});
+
+describe('PowerPermissionsSection — Displays', () => {
+  it('bietet den Schalter fuer can_manage_displays an', async () => {
+    render(<PowerPermissionsSection userId={7} userRole="user" />);
+    await waitFor(() => expect(getUserPowerPermissions).toHaveBeenCalled());
+    expect(
+      await screen.findByText('admin:users.systemPermissions.items.manageDisplays.label'),
+    ).toBeTruthy();
+  });
+});
+```
+
+Nachgeprüft am 2026-09-08: die Komponente nimmt genau
+`{ userId: number; userRole: string }`, und der i18n-Pfad der Einträge lautet
+`users.systemPermissions.items.*` im Namensraum `admin`. Für diese Komponente
+existiert bisher **keine** Testdatei — dies ist die erste, das Verzeichnis
+`client/src/__tests__/components/user-management/` wird mit angelegt.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd client ; npx vitest run src/__tests__/components/user-management/PowerPermissionsSection.displays.test.tsx`
+Expected: FAIL — der Eintrag fehlt.
+
+- [ ] **Step 3: Typen ergänzen**
+
+In `client/src/api/powerPermissions.ts` in allen drei Schnittstellen nach der
+`can_control_audio`-Zeile ergänzen:
+
+```ts
+  can_manage_displays: boolean;
+```
+
+(in `UserPowerPermissionsUpdate` als `can_manage_displays?: boolean;`)
+
+- [ ] **Step 4: Schalter ergänzen**
+
+In `client/src/components/user-management/PowerPermissionsSection.tsx`:
+
+`FIELD_TO_I18N` um einen Eintrag nach `can_control_audio: 'controlAudio',`:
+
+```ts
+  can_manage_displays: 'manageDisplays',
+```
+
+`PERMISSION_TOGGLES` um einen Eintrag nach der `can_control_audio`-Zeile:
+
+```tsx
+  { key: 'can_manage_displays', icon: <Monitor className="h-4 w-4" /> },
+```
+
+und `Monitor` zum `lucide-react`-Import der Datei hinzufügen.
+
+- [ ] **Step 5: i18n ergänzen**
+
+In `client/src/i18n/locales/de/admin.json` in
+`users.systemPermissions.items` nach dem `controlAudio`-Eintrag:
+
+```json
+        "manageDisplays": { "label": "Displays", "desc": "Bildschirm-Ausgang und Auflösung wählen" }
+```
+
+In `client/src/i18n/locales/en/admin.json` an der entsprechenden Stelle:
+
+```json
+        "manageDisplays": { "label": "Displays", "desc": "Choose the display output and resolution" }
+```
+
+Auf das Komma am Ende der vorherigen Zeile achten.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```
+cd client ; npx vitest run src/__tests__/components/user-management
+```
+Expected: PASS.
+
+- [ ] **Step 7: Lint, Build, Commit**
+
+```
+cd client ; npx eslint . ; npm run build
+```
+Expected: 0 eslint-Fehler, Build erfolgreich.
+
+```bash
+git add client/src/api/powerPermissions.ts client/src/components/user-management/PowerPermissionsSection.tsx client/src/i18n/locales/de/admin.json client/src/i18n/locales/en/admin.json client/src/__tests__/components/user-management/PowerPermissionsSection.displays.test.tsx
+git commit -m "feat(display-output): can_manage_displays in der Nutzerverwaltung"
+```
+
+---
+
+## Task 11: Dokumentation
+
+**Files:**
+- Create: `backend/app/plugins/installed/display_output/CLAUDE.md`
+- Modify: `backend/app/plugins/CLAUDE.md` (Verzeichnisbaum unter `installed/`)
+- Modify: `.claude/rules/architecture.md` (API-Liste)
+- Modify: `CLAUDE.md` (Quick Reference)
+
+**Interfaces:**
+- Consumes: alles Vorige.
+- Produces: nichts.
+
+- [ ] **Step 1: Plugin-CLAUDE.md schreiben**
+
+Create `backend/app/plugins/installed/display_output/CLAUDE.md`:
+
+```markdown
+# Display Output Plugin
+
+Bundled (in-process, fully trusted) plugin: enumerates the KWin outputs, picks
+which one is active and sets its video mode, driven from a popover in the topbar.
+Ships its own FastAPI router; the UI is a **core** component, not a sandbox bundle.
+
+Trust tier, lifecycle and the `PluginBase` contract are in `../../CLAUDE.md` —
+this file only covers what is specific to this plugin.
+
+## Layout
+
+| File | Contents |
+|---|---|
+| `__init__.py` | `DisplayOutputPlugin`, the router, the audit helper, the error mapping |
+| `kscreen.py` | The **only** module that knows `kscreen-doctor` exists: parser, runner, argv builder |
+| `backend.py` | `DisplayBackend` protocol, `DevDisplayBackend`, `KWinDisplayBackend` |
+| `service.py` | `DisplayService` — backend choice, the whole validation, module singleton |
+| `models.py` | Pydantic models; the field names are the API contract to the frontend |
+
+Frontend counterparts: `client/src/components/topbar/DisplayMenu.tsx`,
+`client/src/api/displayOutput.ts`, `client/src/i18n/locales/{de,en}/display.json`.
+
+## Why it must be a bundled plugin
+
+Same reason as `audio_control`: the plugin runs in the host process and therefore
+under the same UID as the desktop session, which is what gets it to the KWin
+socket through `wayland_session_env()` alone — no sudo, no wrapper. A **sandbox
+plugin would not reach the socket at all**: it runs as `baluhost-plugin` in its
+own network namespace.
+
+Measured proof of the env's necessity: `kscreen-doctor -j` from an SSH session
+without `XDG_RUNTIME_DIR`/`WAYLAND_DISPLAY` aborts — Qt falls back to the `xcb`
+platform plugin and finds no display.
+
+## Mode names are ambiguous — address modes by ID
+
+`libkscreen`'s `findMode()` builds a mode's name with `qRound(refreshRate)`:
+
+    "%1x%2@%3".arg(width, height, qRound(mode->refreshRate()))
+    if (mode->id() == query || name == query) return mode;
+
+So 119.88 and 120.000 are **both** called `3840x2160@120`, and the function
+returns the first match and stops. Measured on BaluNode: HDMI-A-1 has 55 modes
+but only 45 distinct names; DP-3's ids 57 and 58 are exactly that pair.
+
+Addressing by name would therefore set an arbitrary member of the group, with no
+error. The same code line proves the ID **is** a valid argument, so that is what
+is used.
+
+**But never a stored ID.** That is the defect in #589, where a hard-coded id in
+`deploy/scripts/display-switch` outlives the reboot that renumbered it. Here the
+id comes from the enumeration of the same request cycle and `apply` re-reads and
+cross-checks it against the client-supplied `mode_name` — a mismatch is a 409,
+not a silently wrong mode. `mode_id` and `mode_name` are all-or-nothing on the
+wire; accepting one without the other would make the cross-check optional.
+
+## Two levels of "on"
+
+| Level | Source | Field |
+|---|---|---|
+| KWin | `kscreen-doctor -j`, `enabled` | `selected` |
+| DRM | sysfs `enabled` per connector | `lit` |
+
+With DPMS off **every** DRM connector is `disabled` while KWin keeps its choice —
+that is why `DesktopTogglePanel` can say "stopped" while KWin holds DP-3 active.
+Not a bug, two truths about different things. They are never folded into one
+field, and a name that maps to no connector yields `lit=None`, not `False`:
+reporting an unknown answer as "off" would be a false statement.
+
+`get_connector_states()` lives in `services/power/gpu/display_detector.py`, not
+here — `desktop_backend` and `steam_gaming` already read that sysfs tree.
+
+## `kscreen-doctor` lists only connected outputs
+
+`/sys/class/drm/` shows `card0-DP-1` and `card0-DP-2` on BaluNode; the JSON does
+not mention them. `connected` stays in the schema but is true in practice, and
+`DevDisplayBackend` deliberately serves **no** disconnected output — it would be
+a state the real backend never produces.
+
+Field presence also varies between outputs: HDMI-A-1 carries `vrrPolicy`, DP-3
+does not. Every field access goes through `.get()`.
+
+## Security invariants
+
+- **Every route** carries `require_power_manage_displays` — the reading one
+  included. The output list reveals the attached hardware, EDID sizes included.
+- **Every route** carries `@user_limiter.limit(get_limit("display_output"))`,
+  its own category at `60/minute`: the popover polls only while open, every 5 s.
+- **Nothing from the request becomes an argv element without having appeared in
+  the live enumeration first.** Names and mode ids are matched against measured
+  values, not escaped or filtered. List-args already rule out shell injection —
+  this is the belt to that suspender.
+- **`kscreen-doctor` output never reaches a client.** stdout/stderr carry EDID
+  names and paths; they are logged, and a success answers `{"success": true}`.
+- **An `apply` after which no connected output would be selected is rejected.**
+  "Nothing should be lit" belongs on the DPMS switch in `PowerMenu` — reversible,
+  and it does not throw the KWin configuration away.
+- One `apply` is exactly **one** `kscreen-doctor` invocation; the tool applies
+  all arguments together, so there is no partial state on failure. The argument
+  order follows the enumeration, not the request — deterministic and beyond
+  client influence.
+
+## The two traps inherited from `audio_control`
+
+**No `from __future__ import annotations` in `__init__.py`.** With Pydantic v2
+and FastAPI's body detection through slowapi's `@user_limiter.limit` wrapper,
+deferred annotations become ForwardRefs FastAPI no longer resolves — the request
+body is mistaken for query parameters and every `POST` answers 422.
+
+**`get_ui_manifest()` must be overridden.** `PluginBase` returns `None`, and only
+plugins with a truthy manifest appear in `GET /api/plugins/ui/manifest` — exactly
+the list `usePluginEnabled('display_output')` reads. Without it the plugin counts
+as disabled forever and the topbar stays empty, with no error and no log line.
+
+## Routes
+
+| Method | Path | Body |
+|---|---|---|
+| GET | `/state` | — (returns outputs, `displays_powered`, `available`, `detail`) |
+| POST | `/apply` | `{"outputs": [{"name", "selected", "mode_id"?, "mode_name"?}]}` |
+
+Failure mapping: validation → 400, stale `mode_name` for a live `mode_id` → 409,
+KWin unreachable on a write → 502. A **read** with an unreachable session is not
+an error — it answers 200 with `available: false` so the UI can show that state.
+
+Because the plugin contributes a router, it is mounted **once at startup**
+(`core/lifespan.py`). Enabling it at runtime leaves these paths at 404 until
+`baluhost-backend` restarts.
+
+## Permission
+
+`can_manage_displays` (table `user_power_permissions`, migration `b8c41d92e7f5`,
+`server_default="0"` — denied by default). It stands **beside** the sleep/suspend
+chains and is deliberately absent from `_apply_implications`; admins get it
+implicitly.
+
+## Tests
+
+`backend/tests/plugins/test_display_output_{parser,kscreen,backend,service,routes,ui_manifest}.py`
+plus `backend/tests/test_display_detector_connector_states.py`.
+
+The fixture `backend/tests/plugins/fixtures/kscreen_balunode.json` is a
+**measured** `kscreen-doctor -j` recording from BaluNode (2026-09-08), not an
+invented payload. The duplicate and ambiguous modes in it are the test subject —
+re-measure rather than hand-edit. No test invokes real `kscreen-doctor`; the CI
+runner has no Wayland session.
+```
+
+- [ ] **Step 2: Verzeichnisbaum nachziehen**
+
+In `backend/app/plugins/CLAUDE.md` im Baum unter `installed/` nach der
+`audio_control`-Zeile einfügen:
+
+```
+    ├── display_output/      # KWin-Ausgangswahl und Video-Modus (kscreen-doctor)
+```
+
+- [ ] **Step 3: API-Liste und Quick Reference**
+
+In `.claude/rules/architecture.md` in der API-Liste nach der
+`/api/plugins/audio_control/*`-Zeile:
+
+```
+- `/api/plugins/display_output/*` - Displaysteuerung (Ausgangswahl, Video-Modus)
+```
+
+In `CLAUDE.md` unter „Quick Reference: Finding Things" nach der
+`**Audio control**`-Zeile:
+
+```
+**Display outputs**: `backend/app/plugins/installed/display_output/` (bundled Plugin; `kscreen.py` kapselt den gesamten kscreen-doctor-Kontakt)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/plugins/installed/display_output/CLAUDE.md backend/app/plugins/CLAUDE.md .claude/rules/architecture.md CLAUDE.md
+git commit -m "docs(display-output): Plugin-CLAUDE.md und Verweise im Kontext-Baum"
+```
+
+---
+
+## Task 12: Abnahme auf BaluNode
+
+**Files:** keine.
+
+**Interfaces:**
+- Consumes: alles Vorige.
+- Produces: die Bestätigung, dass wirklich ein Bild kommt.
+
+Bis hierhin belegen grüne Tests die Logik, nicht das Bild. Diese Aufgabe braucht
+physischen Blick auf die Schirme und läuft **nach** dem Deploy des Branches.
+
+- [ ] **Step 1: Migration und Neustart**
+
+Das Plugin bringt einen Router mit, der nur beim Start gemountet wird. Nach dem
+Deploy:
+
+```
+sudo systemctl restart baluhost-backend
+```
+
+- [ ] **Step 2: Plugin aktivieren und Recht vergeben**
+
+In der Webapp unter Plugins `display_output` aktivieren. Als Admin ist das Recht
+implizit da; für einen delegierten Test einem Nicht-Admin `can_manage_displays`
+in der Nutzerverwaltung geben.
+
+- [ ] **Step 3: Enumeration prüfen**
+
+Popover öffnen. Erwartet: **zwei** Ausgänge (`HDMI-A-1`, `DP-3`), kein DP-1/DP-2.
+Bei DP-3 müssen im Auswahlfeld zwei unterscheidbare 4K-Einträge stehen —
+`3840 × 2160 @ 120,00 Hz` und `3840 × 2160 @ 119,88 Hz`. Stehen sie identisch da,
+greift `formatMode` nicht.
+
+- [ ] **Step 4: Die `lit`-Annahme bestätigen**
+
+Vergleiche für jeden Ausgang das Abzeichen „leuchtet"/„dunkel" mit dem, was
+wirklich auf den Schirmen zu sehen ist. Steht dort dauerhaft „Zustand unbekannt",
+hält die Präfix-Annahme `card0-DP-3` → `DP-3` auf diesem Host nicht und der Fund
+gehört gemeldet — **nicht** durch Raten geschlossen.
+
+- [ ] **Step 5: Umschalten und zurück**
+
+HDMI-A-1 wählen, DP-3 abwählen, Anwenden. Das Bild muss auf dem Monitor
+erscheinen. Dann Modus auf einen anderen Eintrag setzen, Anwenden. Danach zurück
+auf DP-3 mit `3840 × 2160 @ 120,00 Hz`.
+
+- [ ] **Step 6: Die Invariante prüfen**
+
+Beide Ausgänge abwählen — „Anwenden" muss gesperrt sein. Wird der Aufruf doch
+abgesetzt (etwa direkt gegen die API), muss er 400 liefern.
+
+- [ ] **Step 7: Audit-Eintrag prüfen**
+
+Unter Logging muss je Anwendung ein `display_apply`-Eintrag stehen, und bei einem
+Nicht-Admin zusätzlich ein `delegated_power_action`.
+
+- [ ] **Step 8: Ergebnis festhalten**
+
+Das Ergebnis in #590 kommentieren, insbesondere ob Schritt 4 die
+Präfix-Annahme bestätigt hat.
+
+---
+
+## Reihenfolge und Abhängigkeiten
+
+```
+T1 (Fixture, Modelle, Parser)
+ └─ T2 (Runner, argv)
+     └─ T4 (Backends) ← T3 (DRM-Connector-Zustände)
+         └─ T5 (Service, Validierung)
+             └─ T7 (Router) ← T6 (Recht can_manage_displays)
+                 └─ T8 (API-Client, i18n)
+                     └─ T9 (Popover)   T10 (Nutzerverwaltung)
+                         └─ T11 (Doku)
+                             └─ T12 (Abnahme auf BaluNode)
+```
+
+T3, T6 und T10 hängen an nichts aus dem Plugin und können vorgezogen werden.

--- a/docs/superpowers/specs/2026-09-08-display-output-plugin-design.md
+++ b/docs/superpowers/specs/2026-09-08-display-output-plugin-design.md
@@ -1,0 +1,441 @@
+# Display-Output-Steuerung als bundled Plugin — Design
+
+**Datum:** 2026-09-08
+**Status:** Entwurf zur Prüfung
+**Issue:** [#590](https://github.com/Xveyn/BaluHost/issues/590)
+**Vorgänger:** `docs/superpowers/plans/2026-09-08-display-output-control.md` (Diagnose vom
+selben Tag, auf BaluNode geschrieben). Dieses Dokument **ersetzt** dessen
+Architektur- und Adressierungsentscheidungen; siehe Abschnitt 11.
+**Host der Messungen:** BaluNode (Debian 13, KDE Plasma 6 / KWin Wayland, Backend als `User=sven`)
+
+---
+
+## 1. Problem
+
+Die Webapp kann Displays heute nur global an- und ausschalten
+(`kscreen-doctor --dpms on|off` über `PowerMenu`). Sie kann nicht sagen, **welche**
+Ausgänge es gibt, welcher gewählt ist, oder in welchem Video-Modus er läuft — und
+sie kann nichts davon ändern. Wer vom TV (DP-3) auf den Monitor (HDMI-A-1)
+wechseln will, braucht heute eine SSH-Sitzung und `deploy/scripts/display-switch`.
+
+## 2. Lösung in einem Satz
+
+Ein bundled Plugin `display_output` enumeriert die KWin-Ausgänge und setzt Auswahl
+und Video-Modus über einen einzigen `kscreen-doctor`-Aufruf; bedient wird es über
+ein Popover in der Topbar, direkt neben der Audiosteuerung.
+
+## 3. Warum bundled und in-process
+
+Dieselbe Begründung wie bei `audio_control`, und sie ist keine Bequemlichkeit,
+sondern die technische Untergrenze:
+
+Das Plugin läuft im Host-Prozess und damit unter derselben UID wie die
+Plasma-Session. Nur deshalb erreicht `wayland_session_env()` (`XDG_RUNTIME_DIR` +
+`WAYLAND_DISPLAY`) den KWin-Socket. Ein **Sandbox-Plugin** läuft als
+`baluhost-plugin` in einer eigenen Netzwerk-Namespace und käme an diesen Socket
+**nie** heran.
+
+Belegt am Gegenbeispiel: `kscreen-doctor -j` aus einer SSH-Sitzung ohne diese
+Variablen bricht ab — Qt fällt auf das `xcb`-Plugin zurück und findet kein
+Display. Der Env-Helfer ist also tragend, nicht dekorativ.
+
+**Kein Kernfeature**, weil nicht jede Installation einen Desktop hat: ein
+kopfloses NAS hat keine KWin-Session, und ein Feature, das dort dauerhaft
+„nicht verfügbar" meldet, gehört abschaltbar.
+
+## 4. Gemessene Grundlage
+
+`kscreen-doctor -j` auf BaluNode, 35 066 Bytes, 2026-09-08. Fünf Befunde, die den
+Entwurf tragen:
+
+### 4.1 Mode-Namen sind mehrdeutig — der zentrale Befund
+
+`libkscreen/src/doctor/doctor.cpp`, `findMode()`:
+
+```cpp
+auto name = QStringLiteral("%1x%2@%3")
+    .arg(QString::number(mode->size().width()),
+         QString::number(mode->size().height()),
+         QString::number(qRound(mode->refreshRate())));
+if (mode->id() == query || name == query) {
+    return mode;
+}
+```
+
+Der Name entsteht durch **`qRound()`** der Bildwiederholrate. 119,88 und 120,000
+werden damit beide zu `3840x2160@120`. Die Kollision steckt im Namensschema, nicht
+in den Daten dieses Hosts.
+
+Gemessen auf HDMI-A-1: 55 Modi, 43 verschiedene Namen. Sechs Namen sind mehrfach
+belegt (`720x480@60` viermal, `1920x1080@60` und `1280x720@60` je dreimal,
+`3840x2160@60`, `640x480@60`, `720x576@50` je zweimal).
+
+Auf DP-3 trifft es den praktisch wichtigen Fall:
+
+```
+id 57  "3840x2160@120"  refreshRate 120.000   <- aktuell aktiv
+id 58  "3840x2160@120"  refreshRate 119.880
+```
+
+`findMode()` gibt beim ersten Treffer zurück und bricht ab. Ein Aufruf über den
+Namen setzt also einen der beiden — welchen, entscheidet die Listenreihenfolge.
+Ohne Fehlermeldung.
+
+**Zugleich beweist dieselbe Codezeile: die Mode-ID ist ein gültiges Argument**
+(`mode->id() == query`). `output.DP-3.mode.57` funktioniert.
+
+### 4.2 Nur angeschlossene Ausgänge werden gelistet
+
+`/sys/class/drm/` kennt `card0-DP-1` und `card0-DP-2`; im JSON tauchen sie
+**nicht** auf. `connected` bleibt im Schema, ist praktisch aber immer `true`.
+Ein Dev-Backend, das einen `disconnected`-Ausgang liefert, würde einen Zustand
+nachbilden, den das echte Backend nie erzeugt.
+
+### 4.3 Feldpräsenz schwankt zwischen Ausgängen
+
+HDMI-A-1 trägt `vrrPolicy`, DP-3 **nicht**. Der Parser greift durchgehend über
+`.get()` zu; ein direkter Indexzugriff kippt am zweiten Ausgang.
+
+### 4.4 `currentModeId` und `preferredModes` sind IDs
+
+Beides sind ID-Strings (`"57"`, `["56"]`), keine Namen. Die Auflösung zum
+anzeigbaren Modus läuft ohnehin über die ID-Tabelle.
+
+### 4.5 Die Modenliste ist lexikografisch nach ID-String sortiert
+
+`"1", "10", "11", …, "2", "20"`. Ungefiltert ins Dropdown gekippt unbrauchbar.
+
+### 4.6 Zwei geprüfte Nicht-Befunde
+
+- **Die `lit`-Zuordnung trägt.** `card0-DP-3` → `DP-3`, `card0-HDMI-A-1` →
+  `HDMI-A-1`. Präfix-Strip (`^card\d+-`) trifft die KWin-Namen exakt.
+- **`card0-Writeback-1` ist harmlos.** Gemessen: `status=unknown`,
+  `enabled=disabled`. Der Filter in `display_detector.py` verlangt
+  `status == "connected"` **und** `enabled == "enabled"`; ein
+  Writeback-Connector meldet nie `connected` und wird deshalb nie mitgezählt.
+  Notiert, damit der nächste Leser der Regex diese Runde nicht wiederholt.
+
+## 5. Die zwei Ebenen von „an"
+
+Der Kern der Zustandsdarstellung, und die Ursache der bestehenden Verwirrung:
+
+| Ebene | Quelle | Bedeutung |
+|---|---|---|
+| **KWin** | `kscreen-doctor -j`, Feld `enabled` | die Ausgangs**wahl** |
+| **DRM** | sysfs `enabled` je Connector | ob tatsächlich Pixel getrieben werden |
+
+Bei DPMS-off sind **alle** DRM-Connectoren `disabled`, während KWin seine Wahl
+behält. Genau dieser Zustand liegt auf BaluNode aktuell vor und lässt
+`DesktopTogglePanel` „Gestoppt" melden, obwohl KWin DP-3 für aktiv hält. Kein
+Bug — nur zwei Wahrheiten über verschiedene Dinge.
+
+Im Schema heißen sie deshalb **`selected`** (KWin) und **`lit`** (DRM), nicht
+zweimal `enabled`. Die Namensgleichheit ist die Ursache der Verwirrung und soll
+nicht ins Schema wandern.
+
+`display_detector.py` liefert heute nur eine *Zahl*. Es bekommt
+`get_connector_states() -> dict[str, bool]` dazu — derselbe sysfs-Lauf, nur mit
+Namen. Der Reader bleibt im Core, weil `desktop_backend` und `steam_gaming` ihn
+schon nutzen; zwei sysfs-Leser für dieselbe Frage wären die schlechtere Antwort.
+
+Lässt sich ein KWin-Name keinem Connector zuordnen, ist `lit` **`None`** — nicht
+`False`. Eine unbekannte Antwort als „aus" auszugeben wäre eine Falschaussage.
+
+## 6. Architektur
+
+```
+plugins/installed/display_output/
+  __init__.py   DisplayOutputPlugin, Router, Audit, Fehlerabbildung
+  kscreen.py    einziger Ort, der kscreen-doctor kennt: Parser + run_kscreen{,_json}
+  backend.py    DisplayBackend-Protocol, DevDisplayBackend, KWinDisplayBackend
+  service.py    DisplayService, Singleton, Validierung
+  models.py     Pydantic-Modelle (= API-Vertrag zum Frontend)
+  CLAUDE.md
+```
+
+Spiegelt `audio_control` Datei für Datei. Zwei Fallen von dort werden übernommen:
+
+- **Kein `from __future__ import annotations` in `__init__.py`.** Zusammen mit
+  Pydantic v2 und FastAPIs Body-Erkennung durch den `@user_limiter.limit`-Wrapper
+  werden aufgeschobene Annotationen zu ForwardRefs; der Request-Body würde als
+  Query-Parameter gelesen und jedes `POST` antwortete 422.
+- **`get_ui_manifest()` muss überschrieben werden** mit
+  `PluginUIManifest(enabled=True)` und leerer `nav_items`-Liste. `PluginBase`
+  liefert dort `None`, und `GET /api/plugins/ui/manifest` listet nur Plugins mit
+  wahrhaftigem Manifest — genau die Liste, die `usePluginEnabled` liest. Ohne
+  Override ist das Plugin im Frontend für immer „aus", ohne Fehler und ohne
+  Logzeile. Leere `nav_items` heißt: keine Route, also wird nie ein `bundle.js`
+  geholt.
+
+## 7. Adressierung: Ausgang über Namen, Modus über lebende ID
+
+Die Regel in einem Satz: **niemals eine gespeicherte ID, immer eine aus derselben
+Enumeration.**
+
+| Was | Wie adressiert | Warum |
+|---|---|---|
+| Ausgang | Connector-Name (`DP-3`) | stabile Hardware-Identität, deckungsgleich mit DRM |
+| Modus | Mode-**ID** aus der aktuellen Enumeration (`57`) | der Name ist nach 4.1 mehrdeutig |
+
+`GET /state` liefert die IDs der laufenden Enumeration. `POST /apply` schickt
+`mode_id` **und** `mode_name` zurück. Der Server liest frisch und prüft:
+
+1. `name` steht in der live enumerierten Ausgangsliste — sonst **400**
+2. `mode_id` steht in der Modenliste **genau dieses** Ausgangs — sonst **400**
+   *(das ist #589 als Testfall)*
+3. der Modus hinter `mode_id` trägt noch `mode_name` — sonst **409**
+
+Schritt 3 schließt das Fenster zwischen `GET` und `POST`: schiebt sich ein
+Hotplug dazwischen und werden IDs neu vergeben, meldet der Server einen Konflikt,
+statt still den falschen Modus zu setzen. Dieselbe Haltung, mit der
+`audio_control` volatile PipeWire-Indizes behandelt — 404 statt Raten, die UI
+lädt neu.
+
+**Abgrenzung zu #589:** dort steht eine ID als **Konstante im Shell-Skript** und
+überlebt Neustarts, an denen KWin neu nummeriert. Hier lebt die ID Sekunden und
+wird gegengeprüft. Der Unterschied ist nicht die ID, sondern ihre Haltbarkeit.
+
+### 7.1 Modenliste fürs Dropdown
+
+Roh sind 55 Einträge in ID-String-Reihenfolge, mit Dubletten. Der Parser:
+
+1. fasst **exakte** Dubletten zusammen (gleiche Breite, Höhe **und**
+   `refreshRate`, etwa HDMI-A-1 id 9 und 10) und behält die kleinste ID.
+   Solche Paare unterscheiden sich nur in DRM-Timing-Flags (CEA gegen DMT) —
+   ein Unterschied, der sich einem Menschen nicht sinnvoll anzeigen lässt;
+2. sortiert absteigend nach Fläche, dann nach `refreshRate`;
+3. beschriftet mit zwei Nachkommastellen: `3840×2160 @ 120,00 Hz` neben
+   `3840×2160 @ 119,88 Hz`.
+
+Aus 55 Roheinträgen werden so 49 unterscheidbare, und die Beschriftung ist
+innerhalb eines Ausgangs eindeutig.
+
+## 8. API
+
+Alle Routen unter `/api/plugins/display_output/`, beide gegated mit
+`Depends(require_power_manage_displays)` und
+`@user_limiter.limit(get_limit("display_output"))`:
+
+| Methode | Pfad | Body | Antwort |
+|---|---|---|---|
+| GET | `/state` | — | `DisplayLayout` |
+| POST | `/apply` | `DisplayApplyRequest` | `{"success": bool, "message": str}` |
+
+```python
+class DisplayMode(BaseModel):
+    id: str                 # lebende KWin-Mode-ID, nur innerhalb dieses Vorgangs gueltig
+    name: str               # "3840x2160@120" - NICHT eindeutig, nur zur Gegenpruefung
+    width: int
+    height: int
+    refresh_rate: float     # exakt, ungerundet: 119.88 vs 120.0
+    label: str              # "3840x2160 @ 119,88 Hz" - fuer das Dropdown
+
+class DisplayOutput(BaseModel):
+    name: str               # "DP-3"
+    connected: bool
+    selected: bool          # KWin-Ebene
+    lit: Optional[bool]     # DRM-Ebene; None = nicht zuordenbar
+    current_mode_id: Optional[str]
+    preferred_mode_id: Optional[str]
+    scale: float            # nur Anzeige, in v1 nicht setzbar
+    priority: int
+    modes: list[DisplayMode]
+
+class DisplayLayout(BaseModel):
+    outputs: list[DisplayOutput]
+    displays_powered: bool  # globaler DPMS-Zustand (mindestens ein Connector leuchtet)
+    available: bool
+    detail: Optional[str]
+
+class DisplayOutputRequest(BaseModel):
+    name: str
+    selected: bool
+    mode_id: Optional[str] = None
+    mode_name: Optional[str] = None   # Gegenprobe zu mode_id
+
+class DisplayApplyRequest(BaseModel):
+    outputs: list[DisplayOutputRequest]
+```
+
+**Neue Limit-Kategorie** `display_output` in `core/rate_limiter.py` bei
+**60/minute**: das Popover fragt nur im geöffneten Zustand alle 5 s ab (≈12/min);
+`admin_operations` mit 30/min wäre bei zwei offenen Tabs bereits knapp.
+
+**Auch der Lesezugriff ist gegated** — die Ausgangsliste verrät die angeschlossene
+Hardware samt EDID-Größenangaben.
+
+## 9. `apply`: ein Aufruf, Whitelist davor
+
+```
+kscreen-doctor output.DP-3.enable output.DP-3.mode.57 output.HDMI-A-1.disable
+```
+
+`kscreen-doctor` wendet alle Argumente eines Aufrufs gemeinsam an — kein
+Teilzustand bei Fehlern. Das ist der Grund, warum `apply` **genau einen**
+Unterprozess startet und nicht mehrere.
+
+Vor dem Bau des argv gilt: **kein Zeichen aus dem Request wird zu einem
+argv-Element, ohne vorher in der Enumeration gestanden zu haben.** Namen und IDs
+werden nicht escaped oder gefiltert, sondern gegen gemessene Werte abgeglichen;
+was nicht dort steht, existiert für den Aufruf nicht. Listen-Argumente schließen
+Shell-Injektion ohnehin aus — das hier ist der Gurt zum Hosenträger, und er hält
+auch dann, wenn `kscreen-doctor` künftig eigene Argument-Syntax dazulernt.
+
+### 9.1 Invariante: nie alle Ausgänge abwählen
+
+Bliebe nach dem `apply` kein verbundener Ausgang `selected`, → **400**. „Nichts
+soll leuchten" ist ein legitimer Wunsch, aber der Weg dafür ist der DPMS-Schalter
+im `PowerMenu`: reversibel, und er wirft die KWin-Konfiguration nicht weg.
+
+### 9.2 Kein Confirm/Revert-Timer
+
+Der klassische Footgun — Modus gesetzt, Bild schwarz, keine Bedienung mehr —
+greift hier nicht: bedient wird über Netz, nicht am betroffenen Schirm. Ein nicht
+synchronisierender Modus macht den Schirm dunkel, die Webapp bleibt erreichbar,
+der nächste `apply` korrigiert. Ein Rückfall-Timer wäre eine zusätzliche
+Zustandsmaschine ohne Nutzen.
+
+### 9.3 Fehlerabbildung
+
+| Fall | Status |
+|---|---|
+| unbekannter Ausgang, fremde/unbekannte Mode-ID, alles abgewählt | 400 |
+| `mode_name` passt nicht mehr zu `mode_id` | 409 |
+| `kscreen-doctor` fehlt, Zeitüberschreitung, Session weg | 502 |
+| Erfolg | 200 `{"success": true}` |
+
+**stdout/stderr von `kscreen-doctor` erreichen nie den Client** — sie tragen
+EDID-Namen und Pfade. Sie werden geloggt; die Antwort trägt eine kuratierte
+Meldung.
+
+Audit-Eintrag `display_apply` (event_type `POWER`) mit dem angewendeten
+argv-Vektor in `details`, dazu — wie bei `audio_control` — ein
+`delegated_power_action`-Sicherheitseintrag, wenn der Aufrufer kein Admin ist.
+
+## 10. Frontend
+
+`client/src/components/topbar/DisplayMenu.tsx`, Monitor-Symbol links neben dem
+Lautsprecher. Eingehängt in `layout/LayoutHeader.tsx` neben Zeile 44:
+
+```tsx
+{!isPi && displaysEnabled && <DisplayMenu />}
+```
+
+`displaysEnabled = usePluginEnabled('display_output')`; zusätzlich prüft die
+Komponente clientseitig `can_manage_displays` über `getMyPowerPermissions()` —
+exakt das Muster von `AudioMenu.tsx`.
+
+Pro Ausgang eine Zeile: Name · zwei **getrennte** Abzeichen „gewählt" (KWin) und
+„leuchtet" / „dunkel — DPMS aus" (DRM) · Mode-Dropdown · Auswahlschalter. Unten
+ein „Anwenden", das genau einen `apply` auslöst; danach Refetch.
+
+Übernommen von `AudioMenu`: Abfrage **nur solange das Popover offen ist** (eine
+Fernbedienung, die im Hintergrund pollt, kostet Anfragen ohne Gegenwert) und ein
+`inFlight`-Wächter, damit sich bei langsamer Verbindung keine Anfragen stauen.
+
+**Bewusst nicht enthalten: der globale DPMS-Schalter.** Er steht zwei Symbole
+weiter im `PowerMenu`; ihn zu duplizieren hieße, zwei Komponenten besitzen
+denselben Zustand. Ist alles dunkel, zeigt das Popover einen Hinweis dorthin.
+
+Eigener i18n-Namensraum `display` (de/en), wie `audio`.
+
+## 11. Rechte
+
+Neues Power-Recht **`can_manage_displays`**, gebaut wie `can_control_audio`
+(2026-08-27, Migration `a7d3c9f18e42`):
+
+- Migration auf `user_power_permissions`, `server_default='0'` — standardmäßig
+  verweigert. Sie muss auf den echten `alembic heads` aufsetzen, nicht auf dem
+  veralteten Dev-DB-Head; das hat schon einmal einen Prod-Deploy zerlegt.
+- `models/power_permissions.py`, `schemas/power_permissions.py` (3 Stellen),
+  `services/power_permissions.py` (Map `"manage_displays"` → Spalte, 4 weitere
+  Stellen)
+- `api/deps.py`: `require_power_manage_displays = _make_power_dependency("manage_displays")`
+- `api/routes/sleep.py:364,375` — Admins bekommen es implizit
+- Frontend: `api/powerPermissions.ts`, `components/user-management/PowerPermissionsSection.tsx`
+
+Es steht **neben** den Sleep-/Suspend-Ketten und bleibt aus `_apply_implications`
+heraus, ebenso wie `can_control_audio`.
+
+## 12. Dev-Modus
+
+`DevDisplayBackend` bildet BaluNode nach — **zwei** Ausgänge, beide `connected`
+(nach 4.2 gibt es keine anderen): DP-3 mit 4K-Modi inklusive des Paars
+120,000/119,88, HDMI-A-1 mit WQHD-Modi und mehreren namensgleichen 1080p-Modi.
+Genau diese Dubletten müssen im Dev-Modus vorkommen, sonst lässt sich die
+Beschriftungslogik unter Windows nicht bedienen. `apply` verändert den
+In-Memory-Zustand, sodass das Popover ohne KDE vollständig durchspielbar ist.
+
+Auswahl wie bei `AudioService`: Dev-Backend in `NAS_MODE=dev` und auf jeder
+Nicht-Linux-Plattform, sonst `KWinDisplayBackend`.
+
+## 13. Nicht-Ziele (v1)
+
+- **Kein VRR, kein HDR.** VRR an HDMI-A-1 verursacht auf diesem Host einen
+  Blackout (im display-switch-Plan als `MON_VRR="never"` MUSS vermerkt). Ein
+  Schalter, dessen falsche Stellung das Bild killt, gehört nicht in v1.
+- **Kein `scale`.** KWin merkt sich die Skalierung je Ausgang (DP-3 steht auf
+  2,5, HDMI-A-1 auf 1,0); wer nur den Ausgang wechselt, braucht sie nicht. Ein
+  Feld ohne Regler gehört nicht in den Body. `scale` wird angezeigt, nicht gesetzt.
+- Kein Positions-/Layout-Editor, kein sddm-Stop, kein NAS-Modus, keine
+  Audio-Kopplung, kein Hotplug-Push, kein Profil-System.
+- **#589 bleibt unangetastet.** `deploy/scripts/display-switch` bleibt als CLI
+  bestehen (es kann sddm starten, was das Backend bewusst nicht tut) und wird
+  separat repariert.
+
+## 14. Betriebsfakten
+
+- **Das Plugin bringt einen Router mit.** Router werden nur beim Start gemountet
+  (`core/lifespan.py`), also antworten `/api/plugins/display_output/*` nach dem
+  Aktivieren 404 bis zum `baluhost-backend`-Neustart.
+  `GET /api/plugins/display_output` meldet das als `restart_required`. Die
+  bestehenden Displays-an/aus-Knöpfe im `PowerMenu` sind davon nicht betroffen —
+  das ist Core-Code.
+- Die Migration läuft mit dem Deploy.
+
+## 15. Tests
+
+`backend/tests/plugins/test_display_output_{parser,service,routes,ui_manifest}.py`,
+Fixture `backend/tests/plugins/fixtures/kscreen_balunode.json` — ein **gemessener**
+Mitschnitt von BaluNode, auf die relevanten Felder gekürzt, nicht erfunden. Die
+Dubletten aus 4.1 bleiben in der Fixture; sie sind der Testgegenstand.
+
+| Gegenstand | Zusicherung |
+|---|---|
+| Parser | Ausgangsnamen, `selected`, `current_mode_id`, vollständige Modenliste; DP-3 ohne `vrrPolicy` kippt ihn nicht (4.3) |
+| Dubletten | id 9/10 werden zu einem Eintrag, id 57/58 bleiben zwei; Beschriftungen innerhalb eines Ausgangs eindeutig |
+| Sortierung | absteigend nach Fläche, dann Frequenz — nicht die ID-String-Reihenfolge (4.5) |
+| Validierung | unbekannter Ausgang → 400; **Mode-ID eines anderen Ausgangs → 400 (#589)**; alle abgewählt → 400; `mode_name` passt nicht → 409 |
+| argv-Bau | ein erwarteter Vektor für eine Mehrfach-Änderung, nagelt die Atomizität fest |
+| `lit` | Connector-Zuordnung; unbekannter Name → `None`, nicht `False` |
+| Routen | 401 ohne Token, 403 ohne `can_manage_displays`, 200 mit |
+| Fehler | kein `kscreen-doctor` → 502; stdout/stderr taucht in keiner Antwort auf |
+| Dev-Backend | `apply` verändert das nachfolgende `GET` |
+| UI-Manifest | `get_ui_manifest()` liefert `enabled=True` (die Falle aus Abschnitt 6) |
+
+Kein Test ruft echtes `kscreen-doctor` auf — der CI-Runner hat keine
+Wayland-Session, und auf ihm liefe der Aufruf in denselben xcb-Abbruch wie in
+Abschnitt 3.
+
+## 16. Abnahme
+
+Grüne Tests belegen die Logik, nicht das Bild. Die Abnahme ist manuell auf
+BaluNode: enumerieren, HDMI-A-1 aktivieren, Modus setzen, zurück auf DP-3 —
+mit physischem Blick auf die Schirme. Dabei wird auch die Präfix-Annahme aus
+4.6 bestätigt (`lit` muss dem entsprechen, was wirklich leuchtet).
+
+## 17. Was dieses Dokument gegenüber dem Vorgängerplan ändert
+
+| Der Plan sagte | Gemessen / entschieden |
+|---|---|
+| Core-Feature unter `/api/system/displays` | bundled Plugin unter `/api/plugins/display_output` |
+| Eigene Seite „Displays" mit globalem DPMS-Schalter | Topbar-Popover; DPMS bleibt im `PowerMenu` |
+| „Modi über `name`, nie über `id`" | Namen sind mehrdeutig (4.1) → lebende ID + Namensabgleich |
+| `apply` nimmt `scale` entgegen | `scale` nur Anzeige (13) |
+| Dev-Backend mit einem `disconnected` DP-1 | zwei verbundene Ausgänge — anderes liefert KWin nicht (4.2) |
+| Rechte offen (admin-only vorgeschlagen) | neues `can_manage_displays` |
+| `lit` je Ausgang, Quelle offen | `display_detector.get_connector_states()` im Core |
+
+Richtig bleiben, unverändert übernommen: die Trennung `selected`/`lit`, ein
+einziger atomarer `kscreen-doctor`-Aufruf, Whitelist statt Interpolation, die
+Invariante „nie alles abwählen", kein Revert-Timer, und die Nicht-Ziele.

--- a/docs/superpowers/specs/2026-09-08-display-output-plugin-design.md
+++ b/docs/superpowers/specs/2026-09-08-display-output-plugin-design.md
@@ -66,9 +66,10 @@ Der Name entsteht durch **`qRound()`** der Bildwiederholrate. 119,88 und 120,000
 werden damit beide zu `3840x2160@120`. Die Kollision steckt im Namensschema, nicht
 in den Daten dieses Hosts.
 
-Gemessen auf HDMI-A-1: 55 Modi, 43 verschiedene Namen. Sechs Namen sind mehrfach
-belegt (`720x480@60` viermal, `1920x1080@60` und `1280x720@60` je dreimal,
-`3840x2160@60`, `640x480@60`, `720x576@50` je zweimal).
+Gemessen auf HDMI-A-1: 55 Modi, **45** verschiedene Namen. Sechs Namen sind
+mehrfach belegt (`720x480@60` viermal, `1920x1080@60` und `1280x720@60` je
+dreimal, `3840x2160@60`, `640x480@60`, `720x576@50` je zweimal) — zehn Modi
+verstecken sich also hinter einem fremden Namen.
 
 Auf DP-3 trifft es den praktisch wichtigen Fall:
 
@@ -185,6 +186,13 @@ Enumeration.**
    *(das ist #589 als Testfall)*
 3. der Modus hinter `mode_id` trägt noch `mode_name` — sonst **409**
 
+Zwei Randfälle, damit sie nicht offenbleiben: `mode_name` ist **Pflicht, sobald
+`mode_id` gesetzt ist** (nur eines von beiden → 400, sonst wäre die Gegenprobe
+abschaltbar). Und ein Modus an einem Ausgang mit `selected: false` wird
+**ignoriert**, nicht abgelehnt — KWin behält die Modus-Wahl eines abgewählten
+Ausgangs ohnehin, und ein 400 dafür wäre eine Schikane gegenüber einer UI, die
+schlicht den zuletzt angezeigten Zustand zurückschickt.
+
 Schritt 3 schließt das Fenster zwischen `GET` und `POST`: schiebt sich ein
 Hotplug dazwischen und werden IDs neu vergeben, meldet der Server einen Konflikt,
 statt still den falschen Modus zu setzen. Dieselbe Haltung, mit der
@@ -207,8 +215,10 @@ Roh sind 55 Einträge in ID-String-Reihenfolge, mit Dubletten. Der Parser:
 3. beschriftet mit zwei Nachkommastellen: `3840×2160 @ 120,00 Hz` neben
    `3840×2160 @ 119,88 Hz`.
 
-Aus 55 Roheinträgen werden so 49 unterscheidbare, und die Beschriftung ist
-innerhalb eines Ausgangs eindeutig.
+Aus 55 Roheinträgen werden so **50** unterscheidbare (fünf exakte Dubletten
+fallen weg: je eine bei `1920x1080@60`, `1280x720@60` und `720x576@50`, zwei bei
+`720x480@60`), und die Beschriftung ist innerhalb eines Ausgangs eindeutig.
+Die Zahlen sind Testgegenstand, nicht Prosa — die Fixture muss sie hergeben.
 
 ## 8. API
 

--- a/docs/superpowers/specs/2026-09-08-display-output-plugin-design.md
+++ b/docs/superpowers/specs/2026-09-08-display-output-plugin-design.md
@@ -212,8 +212,14 @@ Roh sind 55 Einträge in ID-String-Reihenfolge, mit Dubletten. Der Parser:
    Solche Paare unterscheiden sich nur in DRM-Timing-Flags (CEA gegen DMT) —
    ein Unterschied, der sich einem Menschen nicht sinnvoll anzeigen lässt;
 2. sortiert absteigend nach Fläche, dann nach `refreshRate`;
-3. beschriftet mit zwei Nachkommastellen: `3840×2160 @ 120,00 Hz` neben
-   `3840×2160 @ 119,88 Hz`.
+3. liefert `width`, `height` und die **ungerundete** `refresh_rate`; die
+   Beschriftung baut das Frontend daraus mit zwei Nachkommastellen —
+   `3840×2160 @ 120,00 Hz` neben `3840×2160 @ 119,88 Hz`.
+
+Die Beschriftung entsteht bewusst **nicht** im Backend. Sie enthält ein
+Dezimaltrennzeichen, und das ist sprachabhängig (`119,88` gegen `119.88`); ein
+serverseitig gebauter String wäre in einer der beiden Sprachen falsch. Das
+Backend liefert Zahlen, das Frontend formatiert sie mit `Intl.NumberFormat`.
 
 Aus 55 Roheinträgen werden so **50** unterscheidbare (fünf exakte Dubletten
 fallen weg: je eine bei `1920x1080@60`, `1280x720@60` und `720x576@50`, zwei bei
@@ -237,8 +243,7 @@ class DisplayMode(BaseModel):
     name: str               # "3840x2160@120" - NICHT eindeutig, nur zur Gegenpruefung
     width: int
     height: int
-    refresh_rate: float     # exakt, ungerundet: 119.88 vs 120.0
-    label: str              # "3840x2160 @ 119,88 Hz" - fuer das Dropdown
+    refresh_rate: float     # exakt, ungerundet: 119.87999725341797
 
 class DisplayOutput(BaseModel):
     name: str               # "DP-3"


### PR DESCRIPTION
## Summary

Bundled Plugin `display_output`: die Webapp erkennt die angeschlossenen Bildschirme, zeigt pro Ausgang getrennt an, ob KWin ihn *gewählt* hat und ob er *leuchtet*, und setzt Auswahl plus Video-Modus über genau einen `kscreen-doctor`-Aufruf. Bedient über ein Popover in der Topbar, neben der Audiosteuerung.

Schließt #590. Spec: `docs/superpowers/specs/2026-09-08-display-output-plugin-design.md`.

## Changes

- **Neues bundled Plugin** `backend/app/plugins/installed/display_output/` — Layout und Schichtung spiegeln `audio_control`: `kscreen.py` ist der einzige Ort, der `kscreen-doctor` kennt (Parser, Runner, argv-Bau), `backend.py` trennt Dev- von KWin-Backend, `service.py` trägt die gesamte Validierung, `__init__.py` Router und Fehlerabbildung.
- **Routen** `GET /api/plugins/display_output/state` und `POST .../apply`, beide hinter dem neuen Recht und einer eigenen Rate-Limit-Kategorie (`60/minute`).
- **Neues Power-Recht `can_manage_displays`** (Migration `b8c41d92e7f5`, `server_default='0'`, standardmäßig verweigert), verdrahtet wie `can_control_audio` — inklusive Schalter in der Nutzerverwaltung.
- **`display_detector.py`** liefert die DRM-Connector-Zustände jetzt *mit Namen* statt nur als Anzahl. Zähler und Karte leiten sich aus einem gemeinsamen Generator ab, damit sie nicht auseinanderdriften können.
- **Frontend**: `DisplayMenu.tsx` (Topbar-Popover), typisierter API-Client, eigener i18n-Namensraum `display` in de/en.
- **Doku**: Plugin-`CLAUDE.md` mit den Invarianten und Fallen, plus die Verweise im Kontext-Baum.

## Die drei Entscheidungen, die den Entwurf tragen

**Modi werden über die ID adressiert, nie über den Namen.** `libkscreen`s `findMode()` baut den Namen mit `qRound(refreshRate)` und nimmt den ersten Treffer:

```cpp
auto name = QStringLiteral("%1x%2@%3")
    .arg(width, height, QString::number(qRound(mode->refreshRate())));
if (mode->id() == query || name == query) return mode;
```

Auf BaluNode heißen deshalb **id 57 (120,000 Hz) und id 58 (119,88 Hz) beide `3840x2160@120`**, und HDMI-A-1 hat 55 Modi bei nur 45 verschiedenen Namen. Eine Adressierung über den Namen hätte still einen beliebigen der beiden gesetzt. Die ID stammt immer aus der Enumeration desselben Vorgangs und wird beim Anwenden gegen den mitgeschickten Namen gegengeprüft — Abweichung ist 409, nicht der falsche Modus. Eine *gespeicherte* ID ist genau der Defekt in #589.

**`selected` und `lit` sind zwei verschiedene Wahrheiten.** KWin wählt den Ausgang; DRM sagt, ob Pixel getrieben werden. Bei DPMS-off meldet jeder Connector `disabled`, während KWin seine Wahl behält — genau der Zustand, in dem BaluNode gerade ist. Beides in ein Feld zu falten wäre die Verwirrung, die dieses Feature auflösen soll. Eine nicht zuordenbare Zuordnung ergibt `lit=None`, nie `False`.

**Whitelist statt Escaping.** Kein Wert aus einer Anfrage wird zu einem argv-Element, ohne vorher in der Live-Enumeration gestanden zu haben. Der zweite Riegel: `build_apply_args` interpoliert den Ausgangsnamen *aus der Enumeration*, nie den aus der Anfrage.

## Type

- [x] New feature

## Testing

- [x] Backend tests pass — Plugin-Suite plus betroffene Kernsuites: **942 passed, 7 skipped**. Der volle `pytest tests/`-Lauf hängt reproduzierbar auf Windows und gehört der CI.
- [x] Frontend builds (`npm run build`) — dazu voller Vitest-Lauf: **278 Dateien, 1368 Tests**, und `eslint .` mit 0 Fehlern.
- [x] Manual testing on dev mode — `DevDisplayBackend` bildet BaluNode nach, inklusive der namensgleichen Modus-Paare, damit das Popover unter Windows vollständig bedienbar ist.
- [ ] **Tested on production NAS** — steht aus, siehe unten.

Die Fixture `backend/tests/plugins/fixtures/kscreen_balunode.json` ist ein **gemessener** `kscreen-doctor -j`-Mitschnitt von BaluNode (2026-09-08), kein erfundener Payload. Die Dubletten darin sind der Testgegenstand.

## Vor dem Merge wissen

- **Nach dem Aktivieren des Plugins braucht es einen `baluhost-backend`-Neustart**, sonst antworten seine Routen 404 — Plugin-Router werden nur beim Start gemountet. `GET /api/plugins/display_output` meldet das als `restart_required`. Die bestehenden Displays-an/aus-Knöpfe im PowerMenu sind Core und davon nicht betroffen.
- **Die Abnahme auf Hardware steht noch aus** (Task 12 des Plans): enumerieren, HDMI-A-1 aktivieren, Modus setzen, zurück auf DP-3 — mit Blick auf die Schirme. Bis dahin sagt kein grüner Test, dass das Bild wirklich kommt. Dabei ist auch die letzte offene Annahme zu prüfen: dass `card0-DP-3` dem Ausgang entspricht, den `DP-3` leuchten lässt (gemessen, aber nicht physisch bestätigt).

## Bewusst nicht enthalten (v1)

Kein VRR, kein HDR (VRR an HDMI-A-1 verursacht auf diesem Host einen Blackout), kein `scale`-Regler, kein Positions-Editor, kein sddm-Stop, keine Audio-Kopplung, kein Hotplug-Push, keine Profile. Der globale Ein/Aus-Schalter bleibt im PowerMenu — zwei Komponenten für denselben Zustand driften.

`deploy/scripts/display-switch` bleibt als CLI bestehen; #589 wird separat behoben.

## Nebenbefund

Bei der Review fiel auf, dass `audio_control` 502-Antworten mit `HTTPException` statt `BadGatewayError` wirft und die kuratierten Meldungen deshalb vom globalen 5xx-Scrubber überschrieben werden. Angelegt als **#591**, hier nicht mitgefixt.

## Checklist

- [x] Code follows existing patterns and conventions
- [x] No secrets or credentials committed
- [x] Security review (if touching auth, files, or system commands) — die Validierungsschicht wurde in zwei getrennten Durchgängen adversarisch geprüft (zusammen rund zwanzig konstruierte Request-Formen, darunter `mode_id = "57 --dpms off"`, fremde Modus-IDs, Doppelnennungen und der Versuch, alle verbundenen Ausgänge abzuwählen). Kein Durchbruch.
- [x] Database migrations included — eine additive Spalte, `down_revision` auf den damals einzigen Head gekettet, `downgrade()` exakt invers. Nach dem Commit als einziger Head verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5Bov4YyuW8HEScgv9kBzU
