### PR TITLE
feat(power): Sitzung aus dem PowerMenu sperren, nicht nur entsperren

### DIFF
--- a/backend/app/api/routes/desktop.py
+++ b/backend/app/api/routes/desktop.py
@@ -11,7 +11,7 @@ from app.api.deps import get_current_user, get_db, require_power_toggle_desktop
 from app.core.rate_limiter import user_limiter, get_limit
 from app.schemas.desktop import DesktopStatus
 from app.services.power.desktop import get_desktop_service
-from app.services.power.session_lock import current_lock_state, unlock_if_permitted
+from app.services.power.session_lock import current_lock_state, lock_if_permitted, unlock_if_permitted
 from app.services.notifications.events import emit_desktop_disabled, emit_desktop_enabled
 from app.services.audit.logger_db import get_audit_logger_db
 
@@ -64,6 +64,41 @@ async def desktop_unlock(
     except Exception:  # a failed unlock is an outcome, never a 5xx
         logger.exception("Session unlock failed unexpectedly")
         ok, message = False, "unlock failed unexpectedly"
+    return {"success": ok, "message": message}
+
+
+@router.post("/lock")
+@user_limiter.limit(get_limit("admin_operations"))
+async def desktop_lock(
+    request: Request,
+    response: Response,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Lock the graphical desktop session, leaving the displays alone.
+
+    The mirror of ``/unlock``, worth having separately from "disable desktop":
+    turning the displays off (DPMS) does NOT lock the session, so someone
+    standing at the dark screen can still move the mouse and see the desktop.
+    This closes that gap - e.g. locking remotely after leaving without
+    locking, or reacting to a compromised account.
+
+    Authorization is deliberately NOT a route dependency, for the same reason
+    as ``/unlock``: ``lock_if_permitted`` is the single place the permission
+    gate is evaluated and audited. Unlike ``/unlock`` it carries no network
+    gate - locking only closes the desktop, so a stolen web account gains
+    nothing from being able to lock it from anywhere. A refusal is therefore
+    a 200 with ``success: false``, not a 403.
+    """
+    try:
+        ok, message = await lock_if_permitted(
+            user=current_user,
+            client_host=request.client.host if request.client else None,
+            db=db,
+        )
+    except Exception:  # a failed lock is an outcome, never a 5xx
+        logger.exception("Session lock failed unexpectedly")
+        ok, message = False, "lock failed unexpectedly"
     return {"success": ok, "message": message}
 
 

--- a/backend/app/services/power/session_lock.py
+++ b/backend/app/services/power/session_lock.py
@@ -1,9 +1,10 @@
-"""Unlock the graphical KDE session via systemd-logind.
+"""Lock and unlock the graphical KDE session via systemd-logind.
 
-`loginctl unlock-session` emits an Unlock signal that kscreenlocker obeys -
-the same path fingerprint readers and smartcards use. Measured on the box: it
-works as the session owner WITHOUT sudo, and the backend already runs as that
-user, so this needs no sudoers rule and no new root path.
+`loginctl unlock-session` / `loginctl lock-session` emit Unlock/Lock signals
+that kscreenlocker obeys - the same path fingerprint readers and smartcards
+use. Measured on the box (2026-09-08): both work as the session owner WITHOUT
+sudo, and the backend already runs as that user, so this needs no sudoers
+rule and no new root path.
 """
 from __future__ import annotations
 
@@ -38,10 +39,14 @@ _COMMAND_TIMEOUT_SECONDS = 3
 
 
 class SessionLockBackend(Protocol):
-    """Anything that can unlock the user's graphical session."""
+    """Anything that can lock or unlock the user's graphical session."""
 
     def unlock(self) -> Tuple[bool, str]:
         """Unlock the session; returns (ok, detail)."""
+        ...
+
+    def lock(self) -> Tuple[bool, str]:
+        """Lock the session; returns (ok, detail)."""
         ...
 
     def is_locked(self) -> Optional[bool]:
@@ -59,6 +64,11 @@ class DevSessionLockBackend:
         """Pretend to unlock - there is no logind on a dev box."""
         self._locked = False
         return True, "session unlocked (dev)"
+
+    def lock(self) -> Tuple[bool, str]:
+        """Pretend to lock - there is no logind on a dev box."""
+        self._locked = True
+        return True, "session locked (dev)"
 
     def is_locked(self) -> Optional[bool]:
         """Start out locked, so the unlock button is reachable in dev mode."""
@@ -150,18 +160,25 @@ class LinuxSessionLockBackend:
         except subprocess.TimeoutExpired:
             return None
 
-    def unlock(self) -> Tuple[bool, str]:
-        """Unlock the graphical session and VERIFY it actually unlocked.
+    def _transition(self, verb: str, want_locked: bool) -> Tuple[bool, str]:
+        """Run one loginctl verb against the session and VERIFY the outcome.
 
-        Returns (ok, detail). ok=True means LockedHint reads "no" afterwards -
-        loginctl's exit code alone only says the signal was dispatched.
+        Shared by :meth:`lock` and :meth:`unlock` - the two would otherwise be
+        near-identical: find the session, run the verb, then poll LockedHint
+        until it reads the wanted value. Only the verb and the wanted hint
+        differ.
+
+        Returns (ok, detail). ok=True means LockedHint reads the wanted value
+        afterwards - loginctl's exit code alone only says the signal was
+        dispatched, never that kscreenlocker actually acted on it.
         """
+        state_word = "locked" if want_locked else "unlocked"
         try:
             session_id = self._graphical_session_id()
             if not session_id:
                 return False, "no graphical session found"
 
-            result = self._run(["loginctl", "unlock-session", session_id])
+            result = self._run(["loginctl", verb, session_id])
             if result.returncode != 0:
                 detail = (result.stderr or "").strip() or f"exit {result.returncode}"
                 return False, detail
@@ -170,20 +187,38 @@ class LinuxSessionLockBackend:
             last_hint: Optional[bool] = None
             while True:
                 last_hint = self._locked_hint(session_id)
-                if last_hint is False:
-                    return True, f"session {session_id} unlocked"
+                if last_hint is want_locked:
+                    return True, f"session {session_id} {state_word}"
                 if self._monotonic() >= deadline:
-                    reason = (
-                        "still reports LockedHint=yes"
-                        if last_hint is True
-                        else "LockedHint could not be read"
-                    )
+                    # Distinguish "still reports the old state" (hint read
+                    # fine, just not the wanted value) from "hint could not
+                    # be read at all" (the lock state is genuinely unknown).
+                    if last_hint is None:
+                        reason = "LockedHint could not be read"
+                    else:
+                        reason = f"still reports LockedHint={'yes' if last_hint else 'no'}"
                     return False, f"session {session_id} {reason}"
                 self._sleep(_POLL_INTERVAL_SECONDS)
         except FileNotFoundError:
             return False, "loginctl not found"
         except subprocess.TimeoutExpired:
             return False, "loginctl timed out"
+
+    def unlock(self) -> Tuple[bool, str]:
+        """Unlock the graphical session and VERIFY it actually unlocked.
+
+        Returns (ok, detail). ok=True means LockedHint reads "no" afterwards -
+        loginctl's exit code alone only says the signal was dispatched.
+        """
+        return self._transition("unlock-session", want_locked=False)
+
+    def lock(self) -> Tuple[bool, str]:
+        """Lock the graphical session and VERIFY it actually locked.
+
+        Returns (ok, detail). ok=True means LockedHint reads "yes" afterwards -
+        loginctl's exit code alone only says the signal was dispatched.
+        """
+        return self._transition("lock-session", want_locked=True)
 
 
 _backend: Optional[SessionLockBackend] = None
@@ -215,11 +250,51 @@ async def current_lock_state() -> Optional[bool]:
         return None
 
 
-def _may_unlock(user: UserPublic, db: Session) -> bool:
-    """Admins pass by role, like every other power permission."""
+def _may_operate_session_lock(user: UserPublic, db: Session) -> bool:
+    """Admins pass by role, like every other power permission.
+
+    One capability gates both directions - ``can_unlock_session`` covers
+    locking too. Whoever is trusted to dismiss the lock screen is trusted to
+    put it back up.
+    """
     if user.role == "admin":
         return True
     return check_permission(db, user.id, "unlock_session")
+
+
+def _audit_session_lock_action(
+    *, action: str, user: UserPublic, client_host: Optional[str], ok: bool, detail: str
+) -> None:
+    """Shared audit-writing tail for :func:`lock_if_permitted` and
+    :func:`unlock_if_permitted`.
+
+    A REFUSED gate stays unaudited on purpose - the caller decides that
+    *before* reaching here, and auditing every refusal would drown the real
+    entries. An ATTEMPTED action (the gates were passed) always gets an entry,
+    both outcomes, so nothing on the trail requires cross-referencing loginctl
+    logs to know whether it worked. The ``delegated_power_action`` security
+    event fires only for a non-admin AND only on success, mirroring the
+    sibling desktop routes.
+    """
+    audit_logger = get_audit_logger_db()
+    audit_logger.log_event(
+        event_type="POWER",
+        action=action,
+        user=user.username,
+        resource="desktop",
+        success=ok,
+        ip_address=client_host,
+        details={"message": detail},
+    )
+    if ok and user.role != "admin":
+        audit_logger.log_security_event(
+            action="delegated_power_action",
+            user=user.username,
+            resource="unlock_session",
+            details={"action": action, "client_host": client_host},
+            success=True,
+            ip_address=client_host,
+        )
 
 
 async def unlock_if_permitted(
@@ -246,7 +321,7 @@ async def unlock_if_permitted(
         return False, "not permitted from this network"
 
     try:
-        permitted = _may_unlock(user, db)
+        permitted = _may_operate_session_lock(user, db)
     except Exception:
         # A database hiccup must not turn "displays on" into a 500, and it is
         # not an unlock attempt - so it stays out of the audit trail, like any
@@ -266,31 +341,64 @@ async def unlock_if_permitted(
         logger.exception("session unlock raised for %s", user.username)
         ok, detail = False, "unlock failed unexpectedly"
 
-    # A REFUSED gate above stays unaudited on purpose - that is the normal case
-    # for anyone without the permission and would drown the real entries. An
-    # ATTEMPTED unlock is different: the gates were passed, so both outcomes
-    # belong in the trail, same as the sibling desktop routes.
-    audit_logger = get_audit_logger_db()
-    audit_logger.log_event(
-        event_type="POWER",
-        action="desktop_unlock_session",
-        user=user.username,
-        resource="desktop",
-        success=ok,
-        ip_address=client_host,
-        details={"message": detail},
+    _audit_session_lock_action(
+        action="desktop_unlock_session", user=user, client_host=client_host, ok=ok, detail=detail
     )
     if not ok:
         logger.warning("session unlock failed for %s: %s", user.username, detail)
         return False, detail
+    return True, detail
 
-    if user.role != "admin":
-        audit_logger.log_security_event(
-            action="delegated_power_action",
-            user=user.username,
-            resource="unlock_session",
-            details={"action": "desktop_unlock_session", "client_host": client_host},
-            success=True,
-            ip_address=client_host,
-        )
+
+async def lock_if_permitted(
+    *, user: UserPublic, client_host: Optional[str], db: Session
+) -> Tuple[bool, str]:
+    """Lock the desktop session if the permission gate allows it.
+
+    Deliberately asymmetric with :func:`unlock_if_permitted`: there is NO
+    network gate here. The LAN/VPN check on unlock exists so a stolen web
+    account cannot OPEN a physical desktop from the internet - locking is the
+    safe direction, it only CLOSES the desktop, and the situation that calls
+    for a remote lock (forgot to lock before leaving, reacting to a
+    compromised account) is exactly the case of NOT being in front of the
+    machine. Do not "fix" this into symmetry with unlock; the asymmetry is
+    the point. ``client_host`` is still accepted and still recorded in the
+    audit entry - it just never decides anything here.
+
+    Args:
+        user: The authenticated caller.
+        client_host: The request's client IP, or None. Audited only.
+        db: SQLAlchemy session.
+
+    Returns:
+        (locked, detail). ``locked`` describes the state afterwards; on a
+        refused gate loginctl is never called and the real lock state is
+        unknown, so it is False with the reason in ``detail``.
+    """
+    try:
+        permitted = _may_operate_session_lock(user, db)
+    except Exception:
+        # A database hiccup must not become a 500, and it is not a lock
+        # attempt - so it stays out of the audit trail, like any other
+        # refused gate.
+        logger.exception("session lock: permission check failed for %s", user.username)
+        return False, "permission check failed"
+    if not permitted:
+        return False, "permission required: power:unlock_session"
+
+    try:
+        ok, detail = await asyncio.to_thread(get_session_lock_backend().lock)
+    except Exception:
+        # Same defensive posture as unlock: the backend catches
+        # FileNotFoundError/TimeoutExpired itself, but not e.g. an OSError
+        # from a failing fork. The caller must not die of it.
+        logger.exception("session lock raised for %s", user.username)
+        ok, detail = False, "lock failed unexpectedly"
+
+    _audit_session_lock_action(
+        action="desktop_lock_session", user=user, client_host=client_host, ok=ok, detail=detail
+    )
+    if not ok:
+        logger.warning("session lock failed for %s: %s", user.username, detail)
+        return False, detail
     return True, detail

--- a/backend/app/services/power/session_lock.py
+++ b/backend/app/services/power/session_lock.py
@@ -30,11 +30,12 @@ logger = logging.getLogger(__name__)
 # would sporadically still say "yes" and report a failure that never happened.
 _POLL_INTERVAL_SECONDS = 0.2
 _POLL_TIMEOUT_SECONDS = 3.0
-# Per COMMAND, and one unlock runs up to four of them (show-user, optionally
-# list-sessions, unlock-session, the first show-session). At 10s that is a
-# 40s worst case, which would blow the 20s budget of a plugin menu action and
-# leave Big Picture unstarted. loginctl answers in milliseconds; anything that
-# needs three seconds will not become useful at ten.
+# Per COMMAND, and one transition runs up to four of them (show-user,
+# optionally list-sessions, the lock-/unlock-session itself, the first
+# show-session). At 10s that is a 40s worst case, which would blow the 20s
+# budget of a plugin menu action and leave Big Picture unstarted. loginctl
+# answers in milliseconds; anything that needs three seconds will not become
+# useful at ten.
 _COMMAND_TIMEOUT_SECONDS = 3
 
 

--- a/backend/tests/api/test_desktop_unlock.py
+++ b/backend/tests/api/test_desktop_unlock.py
@@ -208,3 +208,72 @@ class TestUnlockRoute:
         assert response.status_code == 200, response.text
         assert response.json()["success"] is False
         gate.assert_awaited_once()
+
+
+class TestLockRoute:
+    def test_admin_can_lock(self, client, admin_headers):
+        with patch(
+            "app.api.routes.desktop.lock_if_permitted",
+            AsyncMock(return_value=(True, "session 2 locked")),
+        ):
+            response = client.post(
+                "/api/system/sleep/desktop/lock", headers=admin_headers
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["success"] is True
+
+    def test_a_refused_lock_is_a_200_with_success_false(self, client, admin_headers):
+        """The gate lives in the policy; a refusal is an outcome, not an error."""
+        with patch(
+            "app.api.routes.desktop.lock_if_permitted",
+            AsyncMock(return_value=(False, "permission required: power:unlock_session")),
+        ):
+            response = client.post(
+                "/api/system/sleep/desktop/lock", headers=admin_headers
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["success"] is False
+        assert body["message"] == "permission required: power:unlock_session"
+
+    def test_a_raising_policy_does_not_500(self, client, admin_headers):
+        with patch(
+            "app.api.routes.desktop.lock_if_permitted",
+            AsyncMock(side_effect=OSError("boom")),
+        ):
+            response = client.post(
+                "/api/system/sleep/desktop/lock", headers=admin_headers
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["success"] is False
+
+    def test_the_client_ip_reaches_the_gate(self, client, admin_headers):
+        gate = AsyncMock(return_value=(True, "locked"))
+        with patch("app.api.routes.desktop.lock_if_permitted", gate):
+            client.post("/api/system/sleep/desktop/lock", headers=admin_headers)
+
+        assert gate.await_args.kwargs["client_host"] is not None
+
+    def test_anonymous_callers_are_rejected(self, client):
+        response = client.post("/api/system/sleep/desktop/lock")
+
+        assert response.status_code in (401, 403)
+
+    def test_a_plain_user_reaches_the_policy_rather_than_a_role_gate(
+        self, client, user_headers
+    ):
+        """Deliberately NOT gated on admin at the route, same reasoning as
+        /unlock: lock_if_permitted is the single place the permission is
+        evaluated and audited."""
+        gate = AsyncMock(return_value=(False, "permission required: power:unlock_session"))
+        with patch("app.api.routes.desktop.lock_if_permitted", gate):
+            response = client.post(
+                "/api/system/sleep/desktop/lock", headers=user_headers
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["success"] is False
+        gate.assert_awaited_once()

--- a/backend/tests/services/power/test_session_lock.py
+++ b/backend/tests/services/power/test_session_lock.py
@@ -200,6 +200,124 @@ class TestDevBackend:
         assert "dev" in detail
 
 
+class TestLockVerification:
+    """Mirrors TestUnlockVerification: same _transition, opposite verb/hint."""
+
+    def test_argv_is_exactly_lock_session(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "lock-session", "2"): _proc(),
+            "locked_hint": _proc(stdout="yes\n"),
+        })
+
+        _backend(runner).lock()
+
+        assert ["loginctl", "lock-session", "2"] in runner.calls
+
+    def test_success_requires_locked_hint_to_flip_to_yes(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "lock-session", "2"): _proc(),
+            "locked_hint": _proc(stdout="yes\n"),
+        })
+
+        ok, detail = _backend(runner).lock()
+
+        assert ok is True
+        assert "locked" in detail
+
+    def test_a_locker_that_never_reports_locked_is_a_reported_failure(self):
+        """loginctl exits 0 as soon as the signal is SENT. Without reading the
+        hint back the API would claim 'locked' over an open screen."""
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "lock-session", "2"): _proc(),
+            "locked_hint": _proc(stdout="no\n"),
+        })
+
+        ok, detail = _backend(runner, monotonic_values=[0.0, 0.0, 1.0, 2.0, 9.0]).lock()
+
+        assert ok is False
+        assert "LockedHint" in detail
+
+    def test_polls_until_the_hint_flips_to_yes(self):
+        hints = iter([_proc(stdout="no\n"), _proc(stdout="no\n"), _proc(stdout="yes\n")])
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "lock-session", "2"): _proc(),
+            "locked_hint": lambda: next(hints),
+        })
+
+        ok, _detail = _backend(runner).lock()
+
+        assert ok is True
+
+    def test_an_unreadable_hint_is_reported_as_such(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "lock-session", "2"): _proc(),
+            "locked_hint": _proc(returncode=1, stderr="no such session"),
+        })
+
+        ok, detail = _backend(runner, monotonic_values=[0.0, 0.0, 9.0]).lock()
+
+        assert ok is False
+        assert "could not be read" in detail
+
+    def test_nonzero_exit_is_reported(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="2\n"),
+            ("loginctl", "lock-session", "2"): _proc(returncode=1, stderr="Access denied"),
+        })
+
+        ok, detail = _backend(runner).lock()
+
+        assert ok is False
+        assert "Access denied" in detail
+
+    def test_missing_loginctl_is_reported_not_raised(self):
+        def _raise(_cmd):
+            raise FileNotFoundError()
+
+        ok, detail = _backend(_raise).lock()
+
+        assert ok is False
+        assert "loginctl not found" in detail
+
+    def test_timeout_is_reported_not_raised(self):
+        def _raise(_cmd):
+            raise subprocess.TimeoutExpired(cmd="loginctl", timeout=10)
+
+        ok, detail = _backend(_raise).lock()
+
+        assert ok is False
+        assert "timed out" in detail
+
+    def test_no_graphical_session_is_a_clean_failure(self):
+        runner = FakeRunner({
+            tuple(SHOW_USER): _proc(stdout="\n"),
+            tuple(LIST_SESSIONS): _proc(stdout="         1  993 ci-runner - 1975 manager-early - no -\n"),
+        })
+
+        ok, detail = _backend(runner).lock()
+
+        assert ok is False
+        assert "no graphical session" in detail
+
+
+class TestDevBackendLock:
+    def test_lock_then_is_locked(self):
+        backend = DevSessionLockBackend()
+        backend.unlock()
+        assert backend.is_locked() is False
+
+        ok, detail = backend.lock()
+
+        assert ok is True
+        assert "dev" in detail
+        assert backend.is_locked() is True
+
+
 class TestLockStateRead:
     """Reading the lock state - the half of logind the unlock path never used.
 

--- a/backend/tests/services/power/test_session_unlock_policy.py
+++ b/backend/tests/services/power/test_session_unlock_policy.py
@@ -38,6 +38,15 @@ def unlock_called():
         yield backend
 
 
+@pytest.fixture
+def lock_called():
+    """Replaces the backend so no loginctl is ever invoked."""
+    backend = MagicMock()
+    backend.lock.return_value = (True, "session 2 locked")
+    with patch.object(session_lock, "get_session_lock_backend", return_value=backend):
+        yield backend
+
+
 @pytest.fixture(autouse=True)
 def _silent_audit():
     with patch.object(session_lock, "get_audit_logger_db") as factory:
@@ -208,3 +217,153 @@ class TestNeverRaises:
         assert "permission check failed" in detail
         _silent_audit.log_event.assert_not_called()
         unlock_called.unlock.assert_not_called()
+
+
+class TestLockUnlockAsymmetry:
+    """Pins the deliberate asymmetry as behaviour, not just as a comment:
+    locking has no network gate, unlocking does. The reasoning: the LAN gate
+    on unlock exists so a stolen web account cannot OPEN a physical desktop
+    from the internet. Locking is the safe direction - it only CLOSES the
+    desktop, and the situation that calls for a remote lock is exactly not
+    being in front of the machine."""
+
+    async def test_locking_succeeds_from_a_public_ip_while_unlocking_is_refused(
+        self, db_session, lock_called
+    ):
+        lock_ok, _lock_detail = await session_lock.lock_if_permitted(
+            user=_admin(), client_host=PUBLIC, db=db_session
+        )
+        unlock_ok, unlock_detail = await session_lock.unlock_if_permitted(
+            user=_admin(), client_host=PUBLIC, db=db_session
+        )
+
+        assert lock_ok is True
+        assert unlock_ok is False
+        assert "network" in unlock_detail
+
+
+class TestLockPermissionGate:
+    async def test_admin_from_a_public_ip_locks(self, db_session, lock_called):
+        ok, _detail = await session_lock.lock_if_permitted(
+            user=_admin(), client_host=PUBLIC, db=db_session
+        )
+
+        assert ok is True
+        lock_called.lock.assert_called_once()
+
+    async def test_delegated_user_with_the_permission_locks(
+        self, db_session, regular_user, lock_called
+    ):
+        db_session.add(
+            UserPowerPermission(user_id=regular_user.id, can_unlock_session=True)
+        )
+        db_session.commit()
+
+        ok, _detail = await session_lock.lock_if_permitted(
+            user=_user(regular_user.id), client_host=PUBLIC, db=db_session
+        )
+
+        assert ok is True
+        lock_called.lock.assert_called_once()
+
+    async def test_user_without_the_permission_is_refused(
+        self, db_session, regular_user, lock_called
+    ):
+        ok, detail = await session_lock.lock_if_permitted(
+            user=_user(regular_user.id), client_host=PUBLIC, db=db_session
+        )
+
+        assert ok is False
+        assert "permission" in detail
+        lock_called.lock.assert_not_called()
+
+
+class TestLockAuditTrail:
+    async def test_successful_lock_is_audited(
+        self, db_session, lock_called, _silent_audit
+    ):
+        await session_lock.lock_if_permitted(
+            user=_admin(), client_host=PUBLIC, db=db_session
+        )
+
+        _silent_audit.log_event.assert_called_once()
+        kwargs = _silent_audit.log_event.call_args.kwargs
+        assert kwargs["action"] == "desktop_lock_session"
+        assert kwargs["event_type"] == "POWER"
+
+    async def test_a_failed_lock_is_audited_as_a_failure(
+        self, db_session, lock_called, _silent_audit
+    ):
+        """Gates passed, loginctl did not deliver. Without this the function
+        would report success=True over a still-unlocked screen."""
+        lock_called.lock.return_value = (False, "session 2 still reports LockedHint=no")
+
+        ok, _detail = await session_lock.lock_if_permitted(
+            user=_admin(), client_host=PUBLIC, db=db_session
+        )
+
+        assert ok is False
+        kwargs = _silent_audit.log_event.call_args.kwargs
+        assert kwargs["success"] is False
+
+    async def test_a_refused_lock_writes_no_audit_noise(
+        self, db_session, regular_user, lock_called, _silent_audit
+    ):
+        await session_lock.lock_if_permitted(
+            user=_user(regular_user.id), client_host=PUBLIC, db=db_session
+        )
+
+        _silent_audit.log_event.assert_not_called()
+
+    async def test_delegated_user_also_gets_a_security_event(
+        self, db_session, regular_user, lock_called, _silent_audit
+    ):
+        db_session.add(
+            UserPowerPermission(user_id=regular_user.id, can_unlock_session=True)
+        )
+        db_session.commit()
+
+        await session_lock.lock_if_permitted(
+            user=_user(regular_user.id), client_host=PUBLIC, db=db_session
+        )
+
+        _silent_audit.log_security_event.assert_called_once()
+
+    async def test_an_admin_gets_no_delegated_security_event(
+        self, db_session, lock_called, _silent_audit
+    ):
+        await session_lock.lock_if_permitted(
+            user=_admin(), client_host=PUBLIC, db=db_session
+        )
+
+        _silent_audit.log_security_event.assert_not_called()
+
+
+class TestLockNeverRaises:
+    async def test_a_raising_backend_is_swallowed_and_audited(
+        self, db_session, lock_called, _silent_audit
+    ):
+        lock_called.lock.side_effect = OSError("fork failed under memory pressure")
+
+        ok, detail = await session_lock.lock_if_permitted(
+            user=_admin(), client_host=PUBLIC, db=db_session
+        )
+
+        assert ok is False
+        assert "unexpectedly" in detail
+        assert _silent_audit.log_event.call_args.kwargs["success"] is False
+
+    async def test_a_failing_permission_check_is_swallowed_without_audit(
+        self, db_session, lock_called, _silent_audit
+    ):
+        with patch.object(
+            session_lock, "check_permission", side_effect=RuntimeError("db gone")
+        ):
+            ok, detail = await session_lock.lock_if_permitted(
+                user=_user(1234), client_host=PUBLIC, db=db_session
+            )
+
+        assert ok is False
+        assert "permission check failed" in detail
+        _silent_audit.log_event.assert_not_called()
+        lock_called.lock.assert_not_called()

--- a/client/src/__tests__/components/PowerMenu.test.tsx
+++ b/client/src/__tests__/components/PowerMenu.test.tsx
@@ -21,6 +21,7 @@ vi.mock('../../api/desktop', () => ({
   disableDesktop: vi.fn(),
   enableDesktop: vi.fn(),
   unlockSession: vi.fn(),
+  lockSession: vi.fn(),
 }));
 
 vi.mock('../../contexts/PluginContext', () => ({
@@ -29,7 +30,7 @@ vi.mock('../../contexts/PluginContext', () => ({
 
 import PowerMenu from '../../components/PowerMenu';
 import { getSleepStatus } from '../../api/sleep';
-import { getDesktopStatus, disableDesktop, enableDesktop, unlockSession } from '../../api/desktop';
+import { getDesktopStatus, disableDesktop, enableDesktop, unlockSession, lockSession } from '../../api/desktop';
 import toast from 'react-hot-toast';
 
 const baseProps = {
@@ -331,6 +332,100 @@ describe('PowerMenu — unlock session quick action', () => {
     render(<PowerMenu {...baseProps} />);
     openMenu();
     fireEvent.click(await screen.findByText('Unlock session'));
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+  });
+});
+
+
+describe('PowerMenu — lock session quick action', () => {
+  const mockStatus = (state: string, sessionLocked: boolean | null) => {
+    (getDesktopStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state, display_manager: 'sddm', detail: null, session_locked: sessionLocked,
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getSleepStatus as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({});
+  });
+
+  it('shows "Lock session" when displays are on and the session is unlocked', async () => {
+    mockStatus('running', false);
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    expect(await screen.findByText('Lock session')).toBeInTheDocument();
+  });
+
+  it('hides it when the session is already locked', async () => {
+    mockStatus('running', true);
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    await waitFor(() => {
+      expect(getDesktopStatus).toHaveBeenCalled();
+      expect(screen.queryByText('Lock session')).not.toBeInTheDocument();
+    });
+  });
+
+  it('hides it when the lock state is unknown', async () => {
+    // null must not be treated as "unlocked" - showing the button on a host
+    // logind cannot answer for would be a dead end.
+    mockStatus('running', null);
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    await waitFor(() => {
+      expect(getDesktopStatus).toHaveBeenCalled();
+      expect(screen.queryByText('Lock session')).not.toBeInTheDocument();
+    });
+  });
+
+  it('hides it while the displays are off', async () => {
+    mockStatus('stopped', false);
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    await waitFor(() => {
+      expect(screen.findByText('Enable desktop')).toBeTruthy();
+      expect(screen.queryByText('Lock session')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show it for non-admins', async () => {
+    mockStatus('running', false);
+    render(<PowerMenu {...baseProps} isAdmin={false} />);
+    openMenu();
+    await act(async () => {});
+    expect(screen.queryByText('Lock session')).not.toBeInTheDocument();
+    expect(getDesktopStatus).not.toHaveBeenCalled();
+  });
+
+  it('clicking it calls lockSession and shows a success toast', async () => {
+    mockStatus('running', false);
+    (lockSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true, message: 'session 2 locked',
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByText('Lock session'));
+    await waitFor(() => expect(lockSession).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+  });
+
+  it('shows a translated error when the lock is refused', async () => {
+    mockStatus('running', false);
+    (lockSession as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false, message: 'permission required: power:unlock_session',
+    });
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByText('Lock session'));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Failed to lock the session'));
+  });
+
+  it('shows an error toast when the request itself fails', async () => {
+    mockStatus('running', false);
+    (lockSession as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('offline'));
+    render(<PowerMenu {...baseProps} />);
+    openMenu();
+    fireEvent.click(await screen.findByText('Lock session'));
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
   });
 });

--- a/client/src/api/desktop.ts
+++ b/client/src/api/desktop.ts
@@ -62,3 +62,16 @@ export async function unlockSession(): Promise<DesktopActionResult> {
   const { data } = await apiClient.post<DesktopActionResult>('/api/system/sleep/desktop/unlock');
   return data;
 }
+
+/**
+ * Lock the KDE session, leaving the displays alone.
+ *
+ * The mirror of `unlockSession()`. Unlike unlock, the server side carries no
+ * network gate on this action - locking only closes the desktop, so it needs
+ * no LAN/VPN restriction. A refusal (missing permission) comes back as
+ * `success: false`, not as an HTTP error.
+ */
+export async function lockSession(): Promise<DesktopActionResult> {
+  const { data } = await apiClient.post<DesktopActionResult>('/api/system/sleep/desktop/lock');
+  return data;
+}

--- a/client/src/components/PowerMenu.tsx
+++ b/client/src/components/PowerMenu.tsx
@@ -1,9 +1,9 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Power, PowerOff, RotateCcw, LogOut, Moon, Pause, MonitorOff, Monitor, Plug, Unlock } from 'lucide-react';
+import { Power, PowerOff, RotateCcw, LogOut, Moon, Pause, MonitorOff, Monitor, Plug, Unlock, Lock } from 'lucide-react';
 import { ConfirmDialog } from './ui/ConfirmDialog';
 import { getSleepStatus, enterSoftSleep, enterSuspend } from '../api/sleep';
-import { getDesktopStatus, disableDesktop, enableDesktop, unlockSession, type DesktopState } from '../api/desktop';
+import { getDesktopStatus, disableDesktop, enableDesktop, unlockSession, lockSession, type DesktopState } from '../api/desktop';
 import { usePlugins } from '../contexts/PluginContext';
 import { runPluginMenuAction } from '../api/plugins';
 import { resolvePluginString } from '../lib/pluginI18n';
@@ -159,6 +159,21 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
     }
   };
 
+  const handleLockSession = async () => {
+    setIsOpen(false);
+    try {
+      const result = await lockSession();
+      if (result.success) {
+        toast.success(t('powerMenu.sessionLocked', 'Session locked'));
+      } else {
+        // result.message is an English debug string and stays out of the UI (#406).
+        toast.error(t('powerMenu.sessionLockFailed', 'Failed to lock the session'));
+      }
+    } catch {
+      toast.error(t('powerMenu.sessionLockFailed', 'Failed to lock the session'));
+    }
+  };
+
   const handlePluginAction = async (item: (typeof pluginMenuItems)[number]) => {
     const key = `${item._pluginName}:${item.id}`;
     setRunningAction(key);
@@ -270,6 +285,24 @@ export default function PowerMenu({ isAdmin, onShutdown, onRestart, onLogout }: 
                       <div>
                         <p className="text-sm font-medium text-slate-100">{t('powerMenu.unlockSession', 'Unlock session')}</p>
                         <p className="text-xs text-slate-400">{t('powerMenu.unlockSessionDesc', 'Dismiss the KDE lock screen')}</p>
+                      </div>
+                    </button>
+                  )}
+
+                  {/* Mirror of the entry above - only one of the two can ever
+                      show. sessionLocked === null (server couldn't tell) shows
+                      neither, same as the unlock entry. */}
+                  {desktopState === 'running' && sessionLocked === false && (
+                    <button
+                      onClick={handleLockSession}
+                      className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition hover:bg-indigo-500/10"
+                    >
+                      <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-indigo-500/30 bg-indigo-500/10">
+                        <Lock className="h-4 w-4 text-indigo-400" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium text-slate-100">{t('powerMenu.lockSession', 'Lock session')}</p>
+                        <p className="text-xs text-slate-400">{t('powerMenu.lockSessionDesc', 'Show the KDE lock screen')}</p>
                       </div>
                     </button>
                   )}

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -269,6 +269,10 @@
     "unlockSessionDesc": "KDE-Sperrbildschirm schließen",
     "sessionUnlocked": "Sitzung entsperrt",
     "sessionUnlockFailed": "Sitzung konnte nicht entsperrt werden",
+    "lockSession": "Sitzung sperren",
+    "lockSessionDesc": "KDE-Sperrbildschirm anzeigen",
+    "sessionLocked": "Sitzung gesperrt",
+    "sessionLockFailed": "Sitzung konnte nicht gesperrt werden",
     "pluginActionFailed": "Aktion fehlgeschlagen"
   },
   "adminOnly": "Nur für Admins",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -269,6 +269,10 @@
     "unlockSessionDesc": "Dismiss the KDE lock screen",
     "sessionUnlocked": "Session unlocked",
     "sessionUnlockFailed": "Failed to unlock the session",
+    "lockSession": "Lock session",
+    "lockSessionDesc": "Show the KDE lock screen",
+    "sessionLocked": "Session locked",
+    "sessionLockFailed": "Failed to lock the session",
     "pluginActionFailed": "Action failed"
   },
   "adminOnly": "Admin only",


### PR DESCRIPTION
## Summary

Die grafische Sitzung lässt sich aus dem PowerMenu jetzt auch **sperren**, nicht nur entsperren. Der Knopf erscheint genau dann, wenn die Displays an sind und die Sitzung offen ist — also spiegelbildlich zum bestehenden „Sitzung entsperren".

Schließt die Lücke, dass „Displays aus" die Schirme abschaltet, die Sitzung aber offen lässt: wer davorsteht und die Maus bewegt, sieht den Desktop.

## Changes

- **`services/power/session_lock.py`**: `lock()` auf Protokoll, Dev- und Linux-Backend. `lock()` und `unlock()` teilen sich einen extrahierten `_transition(verb, want_locked)` statt den Ablauf zweimal zu enthalten.
- **`lock_if_permitted()`** als Spiegel von `unlock_if_permitted()` — mit **einer bewussten Abweichung**, siehe unten. Der gemeinsame Audit-Schwanz beider Funktionen liegt jetzt in einem Helfer.
- **`POST /api/system/sleep/desktop/lock`**, gleiche Form wie `/unlock`: Autorisierung liegt nicht an der Route, sondern an genau einer Stelle; eine Ablehnung ist 200 mit `success: false`, kein 403; ein Fehlschlag ist ein Ergebnis, nie ein 5xx.
- **Frontend**: `lockSession()` im API-Client, Eintrag im PowerMenu bei `desktopState === 'running' && sessionLocked === false`, i18n in de + en.

Kein neues Recht, keine Migration.

## Die bewusste Asymmetrie: Sperren hat kein Netz-Tor

Entsperren verlangt zwei Tore — LAN/VPN **und** `can_unlock_session`. Sperren verlangt nur das Recht.

Der Grund steht im Code selbst: das LAN-Tor beim Entsperren existiert, damit ein gestohlenes Web-Konto keinen physischen Desktop aus dem Internet **öffnen** kann. Sperren ist die sichere Richtung — es schließt den Desktop, und der Anlass dafür ist gerade, *nicht* vor der Maschine zu sitzen. Ein Netz-Tor hätte dort keine Schutzwirkung, nur eine Einschränkung.

`client_host` wird auf dem Sperr-Pfad weiterhin **protokolliert**, es entscheidet nur nichts mehr.

Damit die nächste Person das nicht „der Symmetrie halber" wegräumt, ist es nicht nur kommentiert, sondern **als Verhalten festgenagelt**: ein Test ruft Sperren und Entsperren mit derselben öffentlichen IP auf und erwartet Erfolg beim einen, Ablehnung beim anderen. Baut jemand das Tor beim Sperren ein, fällt der Test; entfernt jemand es beim Entsperren, fällt er auch.

## Gemessen, nicht angenommen

`loginctl lock-session` geht auf dem Host als Sitzungseigner **ohne sudo** — derselbe Weg, den `unlock-session` schon nimmt. Kein neuer sudoers-Eintrag, kein neuer Root-Pfad:

```
$ loginctl show-user 1000 -p Display --value
2
$ loginctl lock-session 2
$ loginctl show-session 2 -p LockedHint --value
yes
```

Wie beim Entsperren gilt: Exit-Code 0 sagt nur, dass das Signal abging. Über Erfolg entscheidet der gepollte `LockedHint`.

## Type

- [x] New feature

## Testing

- [x] Backend tests pass — 77 in den drei betroffenen Suiten. Der volle `pytest tests/`-Lauf hängt reproduzierbar auf Windows und gehört der CI.
- [x] Frontend builds (`npm run build`) — dazu PowerMenu-Suite 30 grün und `eslint .` mit 0 Fehlern.
- [x] Manual testing on dev mode — `DevSessionLockBackend` deckt beide Richtungen ab.
- [ ] Tested on production NAS — der `loginctl`-Weg ist auf der Box gemessen (oben), der Knopf selbst noch nicht.

## Beim Review beachten

Der eigentliche Risikopunkt ist **nicht** die neue Funktion, sondern der Umbau: `unlock()` war funktionierender, verifizierter Code und teilt sich jetzt einen Pfad mit `lock()`. Die Review hat jede Garantie einzeln nachgerechnet — Verifikation über den gepollten Hint statt über den Exit-Code, die Unterscheidung zwischen „meldet noch den alten Zustand" und „Hint nicht lesbar", das Timeout-Budget, jeder Ausnahmepfad. Alle erhalten; für `want_locked=False` reduziert sich der verallgemeinerte Zweig exakt auf die alten Bedingungen.

`resource="unlock_session"` im `delegated_power_action`-Eintrag ist auch beim Sperren richtig: das Feld benennt das ausgeübte **Recht**, genau wie die Nachbarrouten dort `toggle_desktop` schreiben. Unterschieden werden die beiden über `action` (`desktop_lock_session` gegen `desktop_unlock_session`).

## Bewusst nicht enthalten

„Displays aus" sperrt weiterhin **nicht** mit. Zwei Knöpfe, zwei Wirkungen: das eine ist eine Strommaßnahme (dGPU von ~78 W auf ~18 W), das andere eine Sicherheitsmaßnahme. Eine bestehende Aktion still um eine Nebenwirkung zu erweitern, wäre die schlechtere Antwort — die Kopplung ist eine eigene Entscheidung für einen eigenen Anlass.

Kein Auto-Sperr-Timer, kein Zeitplan.

## Checklist

- [x] Code follows existing patterns and conventions
- [x] No secrets or credentials committed
- [x] Security review — die Autorisierung liegt an genau einer Stelle (`lock_if_permitted`), eine Route-Abhängigkeit wäre eine zweite, still auseinanderlaufende Regel. Das Netz-Tor beim Entsperren ist unangetastet.
- [x] Database migrations included — keine nötig

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5Bov4YyuW8HEScgv9kBzU
