### PR TITLE
fix(sleep): waehrend des Spielens nicht mehr suspendieren

### DIFF
--- a/backend/alembic/versions/c3a7f0d51b64_add_block_suspend_in_gaming_mode.py
+++ b/backend/alembic/versions/c3a7f0d51b64_add_block_suspend_in_gaming_mode.py
@@ -1,0 +1,43 @@
+"""add block_suspend_in_gaming_mode to sleep_config
+
+Governs whether Big Picture alone suppresses an automatic suspend. A running
+game suppresses unconditionally and has no setting.
+
+Default true: the column exists because the box suspended out from under a
+running session, so shipping it off by default would leave the reported
+problem unfixed until someone found the toggle.
+
+Revision ID: c3a7f0d51b64
+Revises: b8c41d92e7f5
+Create Date: 2026-09-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c3a7f0d51b64'
+down_revision: Union[str, Sequence[str], None] = 'b8c41d92e7f5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Fuegt block_suspend_in_gaming_mode zu sleep_config hinzu (standardmaessig an)."""
+    op.add_column(
+        'sleep_config',
+        sa.Column(
+            'block_suspend_in_gaming_mode',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Entfernt block_suspend_in_gaming_mode."""
+    op.drop_column('sleep_config', 'block_suspend_in_gaming_mode')

--- a/backend/app/models/sleep.py
+++ b/backend/app/models/sleep.py
@@ -57,6 +57,12 @@ class SleepConfig(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    # Gaming-aware suspend: a running game always suppresses suspend (no
+    # setting); this governs only the Big Picture case, where no game runs.
+    block_suspend_in_gaming_mode: Mapped[bool] = mapped_column(
+        Boolean, default=True, server_default="true", nullable=False
+    )
+
     # Presence-aware suspend (issue #214)
     presence_enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     presence_mode: Mapped[str] = mapped_column(String(20), default="active", nullable=False)  # "active" | "session"

--- a/backend/app/plugins/installed/steam_gaming/__init__.py
+++ b/backend/app/plugins/installed/steam_gaming/__init__.py
@@ -40,7 +40,6 @@ from app.plugins.installed.steam_gaming.launcher import close_big_picture, open_
 from app.plugins.installed.steam_gaming.poller import SteamSessionPoller
 from app.services.power.desktop import get_desktop_service
 from app.services.power.desktop_windows import show_desktop
-from app.services.power.gpu.display_detector import get_active_display_count_sync
 from app.services.power.session_lock import unlock_if_permitted
 
 logger = logging.getLogger(__name__)
@@ -139,16 +138,19 @@ def _displays_on() -> bool:
     small sysfs reads, the async sibling only wraps the same helper in a
     thread. Unreadable sysfs counts as "off": that steers the menu to the
     start action, which is the harmless one to offer wrongly.
+
+    The implementation lives in services/power/gaming_presence.py because the
+    sleep service asks the identical question when deciding whether Big
+    Picture should suppress a suspend - two copies of this policy would drift.
+
+    Imported inside the function on purpose: gaming_presence imports this
+    package's detector at module level, so a top-level import here would be a
+    cycle - and the loser of that cycle is the detector, which silently
+    degrades to "no game is ever running".
     """
-    if settings.is_dev_mode:
-        # No DRM connectors on a Windows dev box, so the count would pin the
-        # menu to "start" forever and the toggle could not be tried locally.
-        return True
-    try:
-        return get_active_display_count_sync() > 0
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.debug("display count unreadable: %s", exc)
-        return False
+    from app.services.power.gaming_presence import displays_on  # noqa: PLC0415
+
+    return displays_on()
 
 
 def _end_action_is_current() -> bool:

--- a/backend/app/schemas/sleep.py
+++ b/backend/app/schemas/sleep.py
@@ -102,6 +102,18 @@ class PresenceStatus(BaseModel):
     suppressing_suspend: bool = Field(default=False, description="True when presence currently blocks true suspend")
 
 
+class GamingStatus(BaseModel):
+    """Snapshot of the gaming suppressor.
+
+    Two separate flags because they are governed differently: a running game
+    blocks unconditionally, Big Picture only when the setting allows it.
+    """
+    game_running: bool = Field(default=False, description="A Steam game is running")
+    gaming_mode: bool = Field(default=False, description="Big Picture is up and a display is lit")
+    block_in_gaming_mode: bool = Field(default=True, description="Whether Big Picture alone may block suspend")
+    suppressing_suspend: bool = Field(default=False, description="True when gaming currently blocks auto-suspend")
+
+
 # ---------------------------------------------------------------------------
 # OS Sleep Inspector
 # ---------------------------------------------------------------------------
@@ -140,6 +152,7 @@ class SleepStatusResponse(BaseModel):
     core_uptime: CoreUptimeStatus = Field(default_factory=CoreUptimeStatus)
     always_awake: AlwaysAwakeStatus = Field(default_factory=AlwaysAwakeStatus)
     presence: PresenceStatus = Field(default_factory=PresenceStatus)
+    gaming: GamingStatus = Field(default_factory=GamingStatus)
 
 
 # ---------------------------------------------------------------------------
@@ -206,6 +219,12 @@ class SleepConfigResponse(BaseModel):
     always_awake_until: Optional[datetime] = Field(
         default=None, description="UTC expiry, None = permanent"
     )
+    # Gaming-aware suspend
+    block_suspend_in_gaming_mode: bool = Field(
+        default=True,
+        description="Block auto-suspend while Big Picture is up (a running game always blocks)",
+    )
+
     # Presence-aware suspend (issue #214)
     presence_enabled: bool = Field(default=True, description="Block auto-suspend while a user is present")
     presence_mode: PresenceMode = Field(default=PresenceMode.ACTIVE)
@@ -237,6 +256,7 @@ class SleepConfigUpdate(BaseModel):
     always_awake_until: Optional[datetime] = Field(
         default=None, description="UTC expiry for always-awake override; None = permanent"
     )
+    block_suspend_in_gaming_mode: Optional[bool] = None
     presence_enabled: Optional[bool] = None
     presence_mode: Optional[PresenceMode] = None
     presence_timeout_minutes: Optional[int] = Field(default=None, ge=1, le=60)

--- a/backend/app/services/power/gaming_presence.py
+++ b/backend/app/services/power/gaming_presence.py
@@ -1,0 +1,122 @@
+"""Gaming as a suspend suppressor.
+
+The fourth suppressor next to always-awake, core uptime and presence
+(`presence.py`). Presence answers "is a human in the web app?" by reading
+heartbeats; this module answers "is a human at the box, playing?".
+
+Why this exists: `SleepManagerService._is_system_idle()` decides whether a
+human is around by looking at NAS load — CPU percent, disk I/O, HTTP requests.
+A game produces none of those reliably, and on 2026-09-08 that cost a running
+session: the box suspended out from under DiRT Rally 2.0 sixteen minutes after
+the core-uptime window ended. Asking the game detector is a direct answer to
+the question the load metrics were being asked to guess at.
+
+Two signals, because Big Picture mode itself is not observable from outside
+(measured on 2026-07-24, see the steam_gaming design doc):
+
+- a running game — a `/proc` scan for Steam's `SteamLaunch AppId=` wrapper.
+  Blocks suspend unconditionally.
+- gaming mode on screen — BaluHost started Big Picture and has not ended it,
+  AND a display is lit. Governed by `block_suspend_in_gaming_mode`.
+
+This module is the only place the sleep service knows about the steam_gaming
+plugin, so a move or rename of the plugin lands here and nowhere else.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+from app.core.config import settings
+from app.services.power.gpu.display_detector import get_active_display_count_sync
+
+logger = logging.getLogger(__name__)
+
+# The bundled plugin is removable, and a missing plugin must not stop the
+# backend from booting — the sleep service imports this module at startup.
+# `detector` is a dependency-free /proc scanner, so importing it pulls in no
+# plugin framework.
+detect_running_app_id: Optional[Callable[[], Optional[str]]]
+try:
+    from app.plugins.installed.steam_gaming.detector import detect_running_app_id
+except ImportError:  # pragma: no cover - only when the plugin is deleted
+    detect_running_app_id = None
+    logger.warning(
+        "steam_gaming detector unavailable — a running game will NOT block suspend"
+    )
+
+
+def _marker_is_active() -> bool:
+    """Whether BaluHost started Big Picture and has not ended it.
+
+    Imported lazily: `gaming_state` reads the storage root through settings,
+    which the detector does not, and this keeps that cost off the import path.
+    """
+    try:
+        from app.plugins.installed.steam_gaming import gaming_state
+    except ImportError:  # pragma: no cover - only when the plugin is deleted
+        return False
+    return gaming_state.is_active()
+
+
+def displays_on() -> bool:
+    """True while at least one display is lit.
+
+    Unreadable sysfs counts as "off". For the gaming gate that is the harmless
+    direction: it lets a suspend through rather than pinning the box awake on a
+    reading nobody can verify.
+    """
+    if settings.is_dev_mode:
+        # No DRM connectors on a Windows dev box, so the count would be 0
+        # forever and the Big Picture branch could never be tried locally.
+        return True
+    try:
+        return get_active_display_count_sync() > 0
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("display count unreadable: %s", exc)
+        return False
+
+
+def game_is_running() -> bool:
+    """True while a Steam game is running.
+
+    Deliberately calls the raw detector rather than
+    `detection.current_app_id()`: that wrapper substitutes a placeholder AppID
+    on a box without `/proc`, which would make every dev machine claim a game
+    is running and never sleep.
+
+    Fails toward energy saving, matching `SleepManagerService._is_user_present`
+    — a broken detector must not pin the box awake indefinitely.
+    """
+    if detect_running_app_id is None:
+        return False
+    try:
+        return detect_running_app_id() is not None
+    except Exception as exc:
+        logger.warning("Game detection failed (allowing suspend): %s", exc)
+        return False
+
+
+def gaming_mode_on_screen() -> bool:
+    """True while Big Picture is up as far as we can tell.
+
+    The marker alone would survive a Big Picture that was left running and
+    then abandoned; requiring a lit display is what lets that stale state
+    expire on its own.
+    """
+    return _marker_is_active() and displays_on()
+
+
+def blocks_suspend(config) -> bool:
+    """Whether gaming activity should suppress an automatic suspend.
+
+    A running game always blocks. Big Picture without a game blocks only when
+    `block_suspend_in_gaming_mode` is set.
+    """
+    if game_is_running():
+        return True
+    raw = getattr(config, "block_suspend_in_gaming_mode", None)
+    # None covers both a missing config row and a SleepConfig built without
+    # the column; either way the column's database default applies.
+    enabled = True if raw is None else bool(raw)
+    return enabled and gaming_mode_on_screen()

--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -329,8 +329,11 @@ class SleepManagerService:
         """Converge the logind block-sleep inhibitor to the desired state.
 
         The inhibitor is held while ANY of these is in effect: an active
-        core-uptime window, an active Always-Awake override, or an active
-        user presence (issue #214). All three block third-party suspend
+        core-uptime window, an active Always-Awake override, an active
+        user presence (issue #214), or gaming activity. Gaming matters here
+        beyond BaluHost's own guards: a gamepad in Big Picture never resets
+        the Wayland idle timer, so KDE PowerDevil would otherwise suspend a
+        live session all by itself. All four block third-party suspend
         (logind idle, desktop daemons, manual systemctl suspend) at the
         logind layer. Soft sleep is unaffected — the block lock only
         prevents kernel suspend. Releasing/acquiring is idempotent.
@@ -344,7 +347,8 @@ class SleepManagerService:
         core_active = bool(in_core)
         aa_active = self._is_always_awake(config)
         presence_active = self._is_user_present(config)
-        should_hold = core_active or aa_active or presence_active
+        gaming_active = self._is_gaming_active(config)
+        should_hold = core_active or aa_active or presence_active or gaming_active
 
         if should_hold and not self._core_uptime_inhibitor.is_held():
             parts = []
@@ -354,6 +358,8 @@ class SleepManagerService:
                 parts.append("always_awake")
             if presence_active:
                 parts.append("user_present")
+            if gaming_active:
+                parts.append("gaming")
             reason = "_and_".join(parts) + "_active"
             self._core_uptime_inhibitor.acquire(reason)
         elif not should_hold and self._core_uptime_inhibitor.is_held():
@@ -480,6 +486,24 @@ class SleepManagerService:
             logger.warning("Presence check failed (failing open toward suspend): %s", e)
             return False
 
+    def _is_gaming_active(self, config) -> bool:
+        """True while gaming should suppress an automatic suspend.
+
+        The fourth suppressor next to always-awake, core uptime and presence.
+        Presence asks whether a human is in the web app; this asks whether one
+        is at the box, playing — a question `_is_system_idle` cannot answer,
+        because it measures NAS load and a game produces none of it.
+
+        Fails toward energy saving (returns False) on any error, matching
+        `_is_user_present`: a broken detector must not pin the box awake.
+        """
+        try:
+            from app.services.power import gaming_presence
+            return gaming_presence.blocks_suspend(config)
+        except Exception as e:
+            logger.warning("Gaming check failed (failing open toward suspend): %s", e)
+            return False
+
     async def _idle_detection_loop(self) -> None:
         """Background loop that checks system idle status every 30 seconds."""
         check_interval = 30  # seconds
@@ -500,6 +524,13 @@ class SleepManagerService:
                     continue
 
                 if self._is_always_awake(config):
+                    self._consecutive_idle_checks = 0
+                    self._idle_seconds = 0.0
+                    continue
+
+                # Soft sleep locks the CPU to the IDLE profile — the last
+                # thing a running game needs.
+                if self._is_gaming_active(config):
                     self._consecutive_idle_checks = 0
                     self._idle_seconds = 0.0
                     continue
@@ -607,6 +638,7 @@ class SleepManagerService:
                     and config is not None
                     and not self._is_always_awake(config)
                     and not self._is_user_present(config)
+                    and not self._is_gaming_active(config)
                     and self._is_system_idle(config, self._get_activity_metrics())
                 ):
                     logger.info(
@@ -698,6 +730,11 @@ class SleepManagerService:
             # Skip escalation while a user is present (issue #214)
             if self._is_user_present(config):
                 logger.info("Auto-escalation skipped: user presence active")
+                return
+
+            # Skip escalation while someone is gaming at the box
+            if self._is_gaming_active(config):
+                logger.info("Auto-escalation skipped: gaming activity")
                 return
 
             logger.info("Auto-escalation: soft sleep -> true suspend after %d minutes",
@@ -1089,6 +1126,15 @@ class SleepManagerService:
             )
             return False
 
+        # Gaming guard: same shape as the presence guard above. A manual
+        # suspend from the UI still wins — the admin can see the box.
+        if trigger != SleepTrigger.MANUAL and self._is_gaming_active(config_check):
+            logger.info(
+                "enter_true_suspend blocked: gaming activity (trigger=%s, reason=%s)",
+                trigger.value, reason,
+            )
+            return False
+
         # Enter soft sleep first if awake
         if self._current_state == SleepState.AWAKE:
             ok = await self.enter_soft_sleep(reason, trigger)
@@ -1284,6 +1330,22 @@ class SleepManagerService:
                 except Exception as e:
                     logger.warning("Presence status read failed: %s", e)
 
+        # Gaming status — split so the UI can say "a game is running" rather
+        # than only "something is keeping the box awake".
+        from app.schemas.sleep import GamingStatus
+        gaming_status = GamingStatus()
+        try:
+            from app.services.power import gaming_presence
+            raw = getattr(config, "block_suspend_in_gaming_mode", None)
+            gaming_status.block_in_gaming_mode = True if raw is None else bool(raw)
+            gaming_status.game_running = gaming_presence.game_is_running()
+            gaming_status.gaming_mode = gaming_presence.gaming_mode_on_screen()
+            gaming_status.suppressing_suspend = gaming_status.game_running or (
+                gaming_status.block_in_gaming_mode and gaming_status.gaming_mode
+            )
+        except Exception as e:
+            logger.warning("Gaming status read failed: %s", e)
+
         return SleepStatusResponse(
             current_state=self._current_state,
             state_since=self._state_since,
@@ -1298,6 +1360,7 @@ class SleepManagerService:
             core_uptime=core_status,
             always_awake=always_awake_status,
             presence=presence_status,
+            gaming=gaming_status,
         )
 
     def get_config(self) -> SleepConfigResponse:
@@ -1334,6 +1397,14 @@ class SleepManagerService:
             presence_enabled=bool(config.presence_enabled),
             presence_mode=PresenceMode(config.presence_mode or "active"),
             presence_timeout_minutes=config.presence_timeout_minutes or 3,
+            # None (column absent on a legacy object) means the database
+            # default, which is True — unlike the presence flags above, where
+            # None means "off". Reading it as False here would silently ship
+            # the feature disabled.
+            block_suspend_in_gaming_mode=(
+                True if config.block_suspend_in_gaming_mode is None
+                else bool(config.block_suspend_in_gaming_mode)
+            ),
         )
 
     def update_config(self, update: SleepConfigUpdate) -> SleepConfigResponse:

--- a/backend/tests/services/power/test_gaming_presence.py
+++ b/backend/tests/services/power/test_gaming_presence.py
@@ -1,0 +1,109 @@
+"""Tests for the gaming suspend suppressor.
+
+Companion to test_presence_service.py: presence answers "is a human in the web
+app?", this module answers "is a human at the box, playing?". Both feed the
+same suspend gates in SleepManagerService.
+"""
+from unittest.mock import patch
+
+from app.models.sleep import SleepConfig
+from app.services.power import gaming_presence
+
+
+def _config(block_in_gaming_mode=True):
+    """A SleepConfig carrying only what this module reads."""
+    return SleepConfig(id=1, block_suspend_in_gaming_mode=block_in_gaming_mode)
+
+
+def test_detector_import_actually_resolved():
+    """Guards the import cycle gaming_presence <-> steam_gaming/__init__.
+
+    The plugin package imports this module for its display helper. If that
+    import were made at module level, this import would lose the cycle and
+    `detect_running_app_id` would fall back to None — leaving the fix in place
+    but permanently inert, with only a log line to show for it.
+    """
+    assert gaming_presence.detect_running_app_id is not None
+
+
+class TestGameIsRunning:
+    def test_true_when_detector_reports_an_app_id(self):
+        with patch.object(gaming_presence, "detect_running_app_id", return_value="690790"):
+            assert gaming_presence.game_is_running() is True
+
+    def test_false_when_detector_reports_nothing(self):
+        with patch.object(gaming_presence, "detect_running_app_id", return_value=None):
+            assert gaming_presence.game_is_running() is False
+
+    def test_false_when_detector_is_unavailable(self):
+        """Plugin removed: fail toward energy saving, like the presence check."""
+        with patch.object(gaming_presence, "detect_running_app_id", None):
+            assert gaming_presence.game_is_running() is False
+
+    def test_false_when_detector_raises(self):
+        with patch.object(
+            gaming_presence, "detect_running_app_id", side_effect=OSError("no /proc")
+        ):
+            assert gaming_presence.game_is_running() is False
+
+    def test_dev_mode_does_not_invent_a_game(self):
+        """Must read the raw detector, not detection.current_app_id().
+
+        The latter substitutes DEV_APP_ID on a box without /proc, which would
+        make every Windows dev machine claim a game is running and never sleep.
+        """
+        with patch.object(gaming_presence.settings, "is_dev_mode", True), \
+             patch.object(gaming_presence, "detect_running_app_id", return_value=None):
+            assert gaming_presence.game_is_running() is False
+
+
+class TestGamingModeOnScreen:
+    def test_true_when_marker_set_and_a_display_is_lit(self):
+        with patch.object(gaming_presence, "_marker_is_active", return_value=True), \
+             patch.object(gaming_presence, "displays_on", return_value=True):
+            assert gaming_presence.gaming_mode_on_screen() is True
+
+    def test_false_when_marker_set_but_screens_are_dark(self):
+        """A stale marker must not block suspend forever."""
+        with patch.object(gaming_presence, "_marker_is_active", return_value=True), \
+             patch.object(gaming_presence, "displays_on", return_value=False):
+            assert gaming_presence.gaming_mode_on_screen() is False
+
+    def test_false_when_marker_absent(self):
+        with patch.object(gaming_presence, "_marker_is_active", return_value=False), \
+             patch.object(gaming_presence, "displays_on", return_value=True):
+            assert gaming_presence.gaming_mode_on_screen() is False
+
+
+class TestBlocksSuspend:
+    def test_running_game_blocks_even_with_the_setting_off(self):
+        """The game block is unconditional; the setting only governs Big Picture."""
+        with patch.object(gaming_presence, "game_is_running", return_value=True), \
+             patch.object(gaming_presence, "gaming_mode_on_screen", return_value=False):
+            assert gaming_presence.blocks_suspend(_config(block_in_gaming_mode=False)) is True
+
+    def test_gaming_mode_blocks_when_the_setting_is_on(self):
+        with patch.object(gaming_presence, "game_is_running", return_value=False), \
+             patch.object(gaming_presence, "gaming_mode_on_screen", return_value=True):
+            assert gaming_presence.blocks_suspend(_config(block_in_gaming_mode=True)) is True
+
+    def test_gaming_mode_does_not_block_when_the_setting_is_off(self):
+        with patch.object(gaming_presence, "game_is_running", return_value=False), \
+             patch.object(gaming_presence, "gaming_mode_on_screen", return_value=True):
+            assert gaming_presence.blocks_suspend(_config(block_in_gaming_mode=False)) is False
+
+    def test_idle_box_does_not_block(self):
+        with patch.object(gaming_presence, "game_is_running", return_value=False), \
+             patch.object(gaming_presence, "gaming_mode_on_screen", return_value=False):
+            assert gaming_presence.blocks_suspend(_config()) is False
+
+    def test_unset_column_is_read_as_the_database_default(self):
+        """Configs built without the column (older tests) must behave as `true`."""
+        with patch.object(gaming_presence, "game_is_running", return_value=False), \
+             patch.object(gaming_presence, "gaming_mode_on_screen", return_value=True):
+            assert gaming_presence.blocks_suspend(SleepConfig(id=1)) is True
+
+    def test_missing_config_still_blocks_gaming_mode(self):
+        with patch.object(gaming_presence, "game_is_running", return_value=False), \
+             patch.object(gaming_presence, "gaming_mode_on_screen", return_value=True):
+            assert gaming_presence.blocks_suspend(None) is True

--- a/backend/tests/services/test_sleep_gaming_integration.py
+++ b/backend/tests/services/test_sleep_gaming_integration.py
@@ -1,0 +1,271 @@
+"""Integration tests: SleepManagerService does not suspend while gaming.
+
+Regression cover for 2026-09-08, when the box suspended sixteen minutes after
+the core-uptime window ended while DiRT Rally 2.0 was running: the suspend-on-
+exit gate asks `_is_system_idle()`, which measures NAS load (CPU percent, disk
+I/O, HTTP requests) and cannot see a game.
+
+Mirrors test_sleep_presence_integration.py — gaming is the fourth suppressor
+next to core uptime, always-awake and presence.
+"""
+import contextlib
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models.sleep import CoreUptimeWindow as CW, SleepConfig
+from app.schemas.sleep import SleepState, SleepTrigger
+from app.services.power.sleep import SleepManagerService
+from app.services.power.sleep_backend_dev import DevSleepBackend
+
+
+def _build_service():
+    SleepManagerService._instance = None  # reset singleton
+    return SleepManagerService(DevSleepBackend())
+
+
+def _config(suspend_on_exit=True, auto_escalation_enabled=False, auto_idle_enabled=False):
+    return SleepConfig(
+        id=1,
+        auto_idle_enabled=auto_idle_enabled,
+        idle_timeout_minutes=1,
+        idle_cpu_threshold=8.0,
+        idle_disk_io_threshold=1.0,
+        idle_http_threshold=5.0,
+        auto_escalation_enabled=auto_escalation_enabled,
+        escalation_after_minutes=1,
+        schedule_enabled=False,
+        schedule_sleep_time="23:00",
+        schedule_wake_time="06:00",
+        schedule_mode="suspend",
+        wol_mac_address=None,
+        wol_broadcast_address=None,
+        pause_monitoring=False,
+        pause_disk_io=False,
+        reduced_telemetry_interval=30.0,
+        disk_spindown_enabled=False,
+        core_uptime_enabled=True,
+        core_uptime_suspend_on_exit=suspend_on_exit,
+        always_awake_enabled=False,
+        always_awake_until=None,
+        block_suspend_in_gaming_mode=True,
+        presence_enabled=False,
+        presence_mode="active",
+        presence_timeout_minutes=3,
+    )
+
+
+def _window() -> CW:
+    return CW(id=1, enabled=True, label="Werktags",
+              start_time="19:00", end_time="23:30", weekdays="0,1,2,3,4")
+
+
+def _drive_schedule_loop(svc, cfg, *, gaming, ticks=2):
+    """Run _schedule_check_loop for `ticks` ticks with the window just ended."""
+    return [
+        patch.object(svc, "_load_config", return_value=cfg),
+        patch.object(svc, "_load_core_uptime", return_value=(True, [_window()])),
+        patch("app.services.power.sleep.core_uptime_helpers.is_in_core_uptime",
+              return_value=(False, None)),
+        patch.object(svc, "_is_system_idle", return_value=True),
+        patch.object(svc, "_is_user_present", return_value=False),
+        patch.object(svc, "_is_always_awake", return_value=False),
+        patch.object(svc, "_is_gaming_active", return_value=gaming),
+        patch.object(svc, "_reconcile_sleep_inhibitor"),
+    ]
+
+
+class TestIsGamingActive:
+    def test_delegates_to_the_gaming_presence_module(self):
+        svc = _build_service()
+        cfg = _config()
+        with patch("app.services.power.gaming_presence.blocks_suspend",
+                   return_value=True) as mock:
+            assert svc._is_gaming_active(cfg) is True
+        mock.assert_called_once_with(cfg)
+
+    def test_false_when_the_detector_blows_up(self):
+        """Fails toward energy saving, like the presence check."""
+        svc = _build_service()
+        with patch("app.services.power.gaming_presence.blocks_suspend",
+                   side_effect=RuntimeError("boom")):
+            assert svc._is_gaming_active(_config()) is False
+
+
+@pytest.mark.asyncio
+async def test_suspend_on_exit_blocked_while_gaming():
+    """The 2026-09-08 regression: window ended, game running, box must stay up."""
+    svc = _build_service()
+    cfg = _config()
+    suspend_calls = []
+
+    async def fake_suspend(*a, **k):
+        suspend_calls.append(a)
+        return True
+
+    with contextlib.ExitStack() as stack:
+        for p in _drive_schedule_loop(svc, cfg, gaming=True):
+            stack.enter_context(p)
+        svc.enter_true_suspend = fake_suspend
+        svc._is_running = True
+        svc._current_state = SleepState.AWAKE
+        svc._was_in_core_uptime = True
+
+        calls = [0]
+
+        async def stop_after_two(*_a, **_k):
+            calls[0] += 1
+            if calls[0] >= 2:
+                svc._is_running = False
+
+        stack.enter_context(
+            patch("app.services.power.sleep.asyncio.sleep", side_effect=stop_after_two)
+        )
+        await svc._schedule_check_loop()
+
+    assert suspend_calls == []
+    # Gaming is a gate, not a disarm: the suspend must still happen once the
+    # game ends, exactly as presence behaves.
+    assert svc._core_uptime_exit_pending is True
+
+
+@pytest.mark.asyncio
+async def test_suspend_on_exit_still_fires_when_no_game_runs():
+    """Control: without gaming the existing behaviour is untouched."""
+    svc = _build_service()
+    cfg = _config()
+    suspend_calls = []
+
+    async def fake_suspend(*a, **k):
+        suspend_calls.append(a)
+        return True
+
+    with contextlib.ExitStack() as stack:
+        for p in _drive_schedule_loop(svc, cfg, gaming=False):
+            stack.enter_context(p)
+        svc.enter_true_suspend = fake_suspend
+        svc._is_running = True
+        svc._current_state = SleepState.AWAKE
+        svc._was_in_core_uptime = True
+
+        calls = [0]
+
+        async def stop_after_two(*_a, **_k):
+            calls[0] += 1
+            if calls[0] >= 2:
+                svc._is_running = False
+
+        stack.enter_context(
+            patch("app.services.power.sleep.asyncio.sleep", side_effect=stop_after_two)
+        )
+        await svc._schedule_check_loop()
+
+    assert len(suspend_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_escalation_skipped_while_gaming():
+    svc = _build_service()
+    cfg = _config(auto_escalation_enabled=True)
+    svc._current_state = SleepState.SOFT_SLEEP
+    svc._is_running = True
+
+    with patch.object(svc, "_load_config", return_value=cfg), \
+         patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
+         patch.object(svc, "_is_always_awake", return_value=False), \
+         patch.object(svc, "_is_user_present", return_value=False), \
+         patch.object(svc, "_is_gaming_active", return_value=True), \
+         patch.object(svc, "enter_true_suspend", new=AsyncMock()) as mock_suspend, \
+         patch("app.services.power.sleep.asyncio.sleep", new=AsyncMock()):
+        await svc._escalation_monitor()
+
+    mock_suspend.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_idle_loop_does_not_soft_sleep_while_gaming():
+    """Soft sleep locks the CPU to the IDLE profile — not during a game."""
+    svc = _build_service()
+    cfg = _config(auto_idle_enabled=True)
+    svc._is_running = True
+    svc._current_state = SleepState.AWAKE
+    svc._consecutive_idle_checks = 999  # threshold long since exceeded
+
+    async def stop_loop(*_a, **_k):
+        svc._is_running = False
+
+    with patch.object(svc, "_load_config", return_value=cfg), \
+         patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
+         patch.object(svc, "_is_always_awake", return_value=False), \
+         patch.object(svc, "_is_system_idle", return_value=True), \
+         patch.object(svc, "_is_gaming_active", return_value=True), \
+         patch.object(svc, "enter_soft_sleep", new=AsyncMock()) as mock_soft, \
+         patch("app.services.power.sleep.asyncio.sleep", side_effect=stop_loop):
+        await svc._idle_detection_loop()
+
+    mock_soft.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("trigger", [
+    SleepTrigger.AUTO_IDLE, SleepTrigger.SCHEDULE,
+    SleepTrigger.AUTO_ESCALATION, SleepTrigger.CORE_UPTIME_EXIT,
+])
+async def test_enter_true_suspend_blocks_non_manual_while_gaming(trigger):
+    svc = _build_service()
+    cfg = _config()
+    svc._current_state = SleepState.AWAKE
+
+    with patch.object(svc, "_load_config", return_value=cfg), \
+         patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
+         patch.object(svc, "_is_always_awake", return_value=False), \
+         patch.object(svc, "_is_user_present", return_value=False), \
+         patch.object(svc, "_is_gaming_active", return_value=True), \
+         patch.object(svc, "enter_soft_sleep", new=AsyncMock()) as mock_soft:
+        ok = await svc.enter_true_suspend("test", trigger)
+
+    assert ok is False
+    mock_soft.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enter_true_suspend_allows_manual_while_gaming():
+    """An admin pressing suspend always wins over the automatic guards."""
+    svc = _build_service()
+    cfg = _config()
+    svc._current_state = SleepState.SOFT_SLEEP
+
+    with patch.object(svc, "_load_config", return_value=cfg), \
+         patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
+         patch.object(svc, "_is_always_awake", return_value=False), \
+         patch.object(svc, "_is_user_present", return_value=False), \
+         patch.object(svc, "_is_gaming_active", return_value=True), \
+         patch("app.services.power.sleep.SessionLocal"), \
+         patch("app.services.notifications.events.emit_system_suspend",
+               new=AsyncMock(return_value=None)), \
+         patch.object(svc._backend, "suspend_system",
+                      new=AsyncMock(return_value=True)) as mock_suspend:
+        await svc.enter_true_suspend("manual", SleepTrigger.MANUAL)
+
+    mock_suspend.assert_awaited()
+
+
+def test_inhibitor_is_held_while_gaming():
+    """Holding the logind lock is what stops KDE PowerDevil from suspending.
+
+    A gamepad in Big Picture does not reset the Wayland idle timer, so the
+    desktop's own idle-suspend is a real path to losing the session — and
+    BaluHost's per-loop guards do not cover it.
+    """
+    svc = _build_service()
+    cfg = _config()
+
+    with patch.object(svc, "_is_always_awake", return_value=False), \
+         patch.object(svc, "_is_user_present", return_value=False), \
+         patch.object(svc, "_is_gaming_active", return_value=True), \
+         patch.object(svc._core_uptime_inhibitor, "is_held", return_value=False), \
+         patch.object(svc._core_uptime_inhibitor, "acquire") as mock_acquire:
+        svc._reconcile_sleep_inhibitor(cfg, in_core=False)
+
+    mock_acquire.assert_called_once()
+    assert "gaming" in mock_acquire.call_args.args[0]

--- a/backend/tests/services/test_sleep_gaming_status.py
+++ b/backend/tests/services/test_sleep_gaming_status.py
@@ -1,0 +1,97 @@
+"""The sleep status and config must expose the gaming suppressor.
+
+Without this the UI shows a box that refuses to sleep and no reason why, which
+reads as a hang rather than as the feature working.
+"""
+from unittest.mock import patch
+
+from app.models.sleep import SleepConfig
+from app.services.power.sleep import SleepManagerService
+from app.services.power.sleep_backend_dev import DevSleepBackend
+from app.schemas.sleep import SleepConfigUpdate
+
+
+def _build_service():
+    SleepManagerService._instance = None
+    return SleepManagerService(DevSleepBackend())
+
+
+def _config(block_in_gaming_mode=True):
+    return SleepConfig(
+        id=1,
+        auto_idle_enabled=False,
+        idle_timeout_minutes=15,
+        idle_cpu_threshold=8.0,
+        idle_disk_io_threshold=1.0,
+        idle_http_threshold=5.0,
+        auto_escalation_enabled=False,
+        escalation_after_minutes=60,
+        schedule_enabled=False,
+        schedule_sleep_time="23:00",
+        schedule_wake_time="06:00",
+        schedule_mode="soft",
+        wol_mac_address=None,
+        wol_broadcast_address=None,
+        pause_monitoring=False,
+        pause_disk_io=False,
+        reduced_telemetry_interval=30.0,
+        disk_spindown_enabled=False,
+        core_uptime_enabled=False,
+        core_uptime_suspend_on_exit=False,
+        always_awake_enabled=False,
+        always_awake_until=None,
+        block_suspend_in_gaming_mode=block_in_gaming_mode,
+        presence_enabled=False,
+        presence_mode="active",
+        presence_timeout_minutes=3,
+    )
+
+
+def test_status_reports_a_running_game_as_suppressing_suspend():
+    svc = _build_service()
+    with patch.object(svc, "_load_config", return_value=_config()), \
+         patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
+         patch("app.services.power.gaming_presence.game_is_running", return_value=True), \
+         patch("app.services.power.gaming_presence.gaming_mode_on_screen", return_value=False):
+        status = svc.get_status()
+
+    assert status.gaming.game_running is True
+    assert status.gaming.suppressing_suspend is True
+
+
+def test_status_reports_big_picture_separately_from_a_game():
+    svc = _build_service()
+    with patch.object(svc, "_load_config", return_value=_config()), \
+         patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
+         patch("app.services.power.gaming_presence.game_is_running", return_value=False), \
+         patch("app.services.power.gaming_presence.gaming_mode_on_screen", return_value=True):
+        status = svc.get_status()
+
+    assert status.gaming.game_running is False
+    assert status.gaming.gaming_mode is True
+    assert status.gaming.suppressing_suspend is True
+
+
+def test_status_does_not_suppress_when_the_setting_is_off_and_no_game_runs():
+    svc = _build_service()
+    with patch.object(svc, "_load_config", return_value=_config(block_in_gaming_mode=False)), \
+         patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
+         patch("app.services.power.gaming_presence.game_is_running", return_value=False), \
+         patch("app.services.power.gaming_presence.gaming_mode_on_screen", return_value=True):
+        status = svc.get_status()
+
+    assert status.gaming.gaming_mode is True
+    assert status.gaming.suppressing_suspend is False
+
+
+def test_config_response_exposes_the_setting():
+    svc = _build_service()
+    with patch.object(svc, "_load_config", return_value=_config(block_in_gaming_mode=False)):
+        cfg = svc.get_config()
+
+    assert cfg.block_suspend_in_gaming_mode is False
+
+
+def test_config_update_accepts_the_setting():
+    update = SleepConfigUpdate(block_suspend_in_gaming_mode=False)
+    assert update.block_suspend_in_gaming_mode is False

--- a/client/src/__tests__/components/power/SleepConfigPanel.test.tsx
+++ b/client/src/__tests__/components/power/SleepConfigPanel.test.tsx
@@ -28,6 +28,7 @@ const config: SleepConfigResponse = {
   schedule_mode: 'soft', wol_mac_address: null, wol_broadcast_address: null,
   pause_monitoring: true, pause_disk_io: true, reduced_telemetry_interval: 30,
   disk_spindown_enabled: true, core_uptime_enabled: false, core_uptime_suspend_on_exit: false,
+  block_suspend_in_gaming_mode: true,
   presence_enabled: true, presence_mode: 'active', presence_timeout_minutes: 3,
 };
 const caps: SleepCapabilities = {

--- a/client/src/__tests__/components/power/sleep-config/GamingCard.test.tsx
+++ b/client/src/__tests__/components/power/sleep-config/GamingCard.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { GamingCard } from '../../../../components/power/sleep-config/GamingCard';
+import type { GamingStatus } from '../../../../api/sleep';
+
+const status = (over: Partial<GamingStatus> = {}): GamingStatus => ({
+  game_running: false,
+  gaming_mode: false,
+  block_in_gaming_mode: true,
+  suppressing_suspend: false,
+  ...over,
+});
+
+const base = { blockSuspendInGamingMode: true, update: vi.fn(), gamingStatus: null };
+
+describe('GamingCard', () => {
+  it('renders the Big Picture toggle', () => {
+    render(<GamingCard {...base} />);
+    expect(screen.getByText('sleep.gaming.title')).toBeInTheDocument();
+    expect(screen.getByText('sleep.gaming.bigPictureLabel')).toBeInTheDocument();
+  });
+
+  it('toggling the setting calls update', () => {
+    const update = vi.fn();
+    render(<GamingCard {...base} update={update} />);
+    fireEvent.click(screen.getAllByRole('button')[0]);
+    expect(update).toHaveBeenCalledWith({ blockSuspendInGamingMode: false });
+  });
+
+  it('says a running game is holding the box awake', () => {
+    render(
+      <GamingCard
+        {...base}
+        gamingStatus={status({ game_running: true, suppressing_suspend: true })}
+      />,
+    );
+    expect(screen.getByText('sleep.gaming.gameRunning')).toBeInTheDocument();
+  });
+
+  it('distinguishes Big Picture from a running game', () => {
+    render(
+      <GamingCard
+        {...base}
+        gamingStatus={status({ gaming_mode: true, suppressing_suspend: true })}
+      />,
+    );
+    expect(screen.getByText('sleep.gaming.bigPictureActive')).toBeInTheDocument();
+    expect(screen.queryByText('sleep.gaming.gameRunning')).not.toBeInTheDocument();
+  });
+
+  it('says Big Picture is being ignored when the toggle is off', () => {
+    render(
+      <GamingCard
+        {...base}
+        blockSuspendInGamingMode={false}
+        gamingStatus={status({ gaming_mode: true, suppressing_suspend: false })}
+      />,
+    );
+    expect(screen.getByText('sleep.gaming.bigPictureIgnored')).toBeInTheDocument();
+  });
+
+  it('stays quiet when nothing is holding the box awake', () => {
+    render(<GamingCard {...base} gamingStatus={status()} />);
+    expect(screen.queryByText('sleep.gaming.gameRunning')).not.toBeInTheDocument();
+    expect(screen.queryByText('sleep.gaming.bigPictureActive')).not.toBeInTheDocument();
+  });
+
+  it('always announces a running game, even with the toggle off', () => {
+    render(
+      <GamingCard
+        {...base}
+        blockSuspendInGamingMode={false}
+        gamingStatus={status({ game_running: true, suppressing_suspend: true })}
+      />,
+    );
+    expect(screen.getByText('sleep.gaming.gameRunning')).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/hooks/useSleepConfigForm.test.ts
+++ b/client/src/__tests__/hooks/useSleepConfigForm.test.ts
@@ -13,6 +13,7 @@ const response: SleepConfigResponse = {
   pause_monitoring: false, pause_disk_io: false, reduced_telemetry_interval: 45,
   disk_spindown_enabled: false,
   core_uptime_enabled: false, core_uptime_suspend_on_exit: false,
+  block_suspend_in_gaming_mode: false,
   presence_enabled: false, presence_mode: 'session', presence_timeout_minutes: 5,
 };
 
@@ -37,6 +38,7 @@ describe('useSleepConfigForm', () => {
       wol_mac_address: 'AA:BB:CC:DD:EE:FF', wol_broadcast_address: '10.0.0.255',
       pause_monitoring: false, pause_disk_io: false, reduced_telemetry_interval: 45,
       disk_spindown_enabled: false,
+      block_suspend_in_gaming_mode: false,
       presence_enabled: false, presence_mode: 'session', presence_timeout_minutes: 5,
     };
     expect(result.current.toPayload()).toEqual(expected);

--- a/client/src/api/sleep.ts
+++ b/client/src/api/sleep.ts
@@ -63,6 +63,13 @@ export interface AlwaysAwakeStatus {
 
 export type PresenceMode = 'active' | 'session';
 
+export interface GamingStatus {
+  game_running: boolean;
+  gaming_mode: boolean;
+  block_in_gaming_mode: boolean;
+  suppressing_suspend: boolean;
+}
+
 export interface PresenceStatus {
   enabled: boolean;
   mode: PresenceMode;
@@ -112,6 +119,7 @@ export interface SleepStatusResponse {
   core_uptime: CoreUptimeStatus;
   always_awake?: AlwaysAwakeStatus;
   presence?: PresenceStatus;
+  gaming?: GamingStatus;
 }
 
 export interface SleepConfigResponse {
@@ -136,6 +144,7 @@ export interface SleepConfigResponse {
   core_uptime_suspend_on_exit: boolean;
   always_awake_enabled?: boolean;
   always_awake_until?: string | null;
+  block_suspend_in_gaming_mode: boolean;
   presence_enabled: boolean;
   presence_mode: PresenceMode;
   presence_timeout_minutes: number;
@@ -163,6 +172,7 @@ export interface SleepConfigUpdate {
   core_uptime_suspend_on_exit?: boolean;
   always_awake_enabled?: boolean;
   always_awake_until?: string | null;
+  block_suspend_in_gaming_mode?: boolean;
   presence_enabled?: boolean;
   presence_mode?: PresenceMode;
   presence_timeout_minutes?: number;

--- a/client/src/components/power/SleepConfigPanel.tsx
+++ b/client/src/components/power/SleepConfigPanel.tsx
@@ -15,6 +15,7 @@ import {
   getSleepCapabilities,
   type SleepCapabilities,
   type PresenceStatus,
+  type GamingStatus,
 } from '../../api/sleep';
 import { getFritzBoxConfig, updateFritzBoxConfig } from '../../api/fritzbox';
 import { useSleepConfigForm } from '../../hooks/useSleepConfigForm';
@@ -24,6 +25,7 @@ import {
   IdleDetectionCard,
   EscalationCard,
   PresenceCard,
+  GamingCard,
   ScheduleCard,
   WolCard,
   FritzBoxCard,
@@ -38,6 +40,7 @@ export function SleepConfigPanel() {
   const [coreUptimeMasterOn, setCoreUptimeMasterOn] = useState(false);
   const [alwaysAwakeOn, setAlwaysAwakeOn] = useState(false);
   const [presenceStatus, setPresenceStatus] = useState<PresenceStatus | null>(null);
+  const [gamingStatus, setGamingStatus] = useState<GamingStatus | null>(null);
 
   const sleepForm = useSleepConfigForm();
   const fbForm = useFritzBoxForm();
@@ -67,6 +70,7 @@ export function SleepConfigPanel() {
         setCoreUptimeMasterOn(st.core_uptime?.enabled ?? false);
         setAlwaysAwakeOn(st.always_awake?.enabled ?? false);
         setPresenceStatus(st.presence ?? null);
+        setGamingStatus(st.gaming ?? null);
       } catch {
         // ignore — status is best-effort here
       }
@@ -117,6 +121,7 @@ export function SleepConfigPanel() {
       <IdleDetectionCard {...sleepForm.form} update={sleepForm.update} />
       <EscalationCard {...sleepForm.form} update={sleepForm.update} />
       <PresenceCard {...sleepForm.form} update={sleepForm.update} presenceStatus={presenceStatus} />
+      <GamingCard {...sleepForm.form} update={sleepForm.update} gamingStatus={gamingStatus} />
       <ScheduleCard {...sleepForm.form} update={sleepForm.update} coreUptimeMasterOn={coreUptimeMasterOn} alwaysAwakeOn={alwaysAwakeOn} />
       <WolCard {...sleepForm.form} update={sleepForm.update} capabilities={capabilities} />
       <FritzBoxCard {...fbForm.form} update={fbForm.update} config={fbForm.config} testing={fbForm.testing} onTest={fbForm.test} capabilities={capabilities} />

--- a/client/src/components/power/sleep-config/GamingCard.tsx
+++ b/client/src/components/power/sleep-config/GamingCard.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from 'react-i18next';
+import { Gamepad2 } from 'lucide-react';
+import { Toggle } from './SleepFormControls';
+import type { SleepConfigForm } from '../../../hooks/useSleepConfigForm';
+import type { GamingStatus } from '../../../api/sleep';
+
+type GamingCardProps = Pick<SleepConfigForm, 'blockSuspendInGamingMode'> & {
+  update: (patch: Partial<SleepConfigForm>) => void;
+  gamingStatus: GamingStatus | null;
+};
+
+/**
+ * Gaming as a suspend suppressor.
+ *
+ * A running game always blocks and therefore has no toggle — the toggle
+ * governs only Big Picture with no game behind it, which is the ambiguous
+ * case (someone browsing the library vs. a screen left on).
+ */
+export function GamingCard({ blockSuspendInGamingMode, update, gamingStatus }: GamingCardProps) {
+  const { t } = useTranslation('system');
+  const gameRunning = gamingStatus?.game_running ?? false;
+  // Big Picture is only worth reporting on its own; with a game running the
+  // game is the more specific and more useful statement.
+  const bigPictureOnly = !gameRunning && (gamingStatus?.gaming_mode ?? false);
+
+  return (
+    <div className="card border-slate-700/50 p-4 sm:p-6 space-y-4">
+      <h4 className="text-sm font-medium text-white flex items-center gap-2">
+        <Gamepad2 className="h-4 w-4 text-violet-400" />
+        {t('sleep.gaming.title')}
+      </h4>
+      <p className="text-xs text-slate-400">{t('sleep.gaming.description')}</p>
+
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-sm text-white">{t('sleep.gaming.bigPictureLabel')}</p>
+          <p className="text-xs text-slate-500">{t('sleep.gaming.bigPictureHint')}</p>
+        </div>
+        <Toggle
+          checked={blockSuspendInGamingMode}
+          onChange={(v) => update({ blockSuspendInGamingMode: v })}
+        />
+      </div>
+
+      {gameRunning && (
+        <div className="rounded border border-violet-500/20 bg-violet-500/10 p-2 text-xs text-violet-300">
+          {t('sleep.gaming.gameRunning')}
+        </div>
+      )}
+      {bigPictureOnly && (
+        <div className="rounded border border-violet-500/20 bg-violet-500/10 p-2 text-xs text-violet-300">
+          {gamingStatus?.suppressing_suspend
+            ? t('sleep.gaming.bigPictureActive')
+            : t('sleep.gaming.bigPictureIgnored')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/power/sleep-config/index.ts
+++ b/client/src/components/power/sleep-config/index.ts
@@ -2,6 +2,7 @@ export { CapabilitiesCard } from './CapabilitiesCard';
 export { IdleDetectionCard } from './IdleDetectionCard';
 export { EscalationCard } from './EscalationCard';
 export { PresenceCard } from './PresenceCard';
+export { GamingCard } from './GamingCard';
 export { ScheduleCard } from './ScheduleCard';
 export { WolCard } from './WolCard';
 export { FritzBoxCard } from './FritzBoxCard';

--- a/client/src/hooks/useSleepConfigForm.ts
+++ b/client/src/hooks/useSleepConfigForm.ts
@@ -19,6 +19,7 @@ export interface SleepConfigForm {
   pauseDiskIo: boolean;
   reducedTelemetry: number;
   diskSpindown: boolean;
+  blockSuspendInGamingMode: boolean;
   presenceEnabled: boolean;
   presenceMode: PresenceMode;
   presenceTimeout: number;
@@ -42,6 +43,7 @@ const DEFAULT_FORM: SleepConfigForm = {
   pauseDiskIo: true,
   reducedTelemetry: 30,
   diskSpindown: true,
+  blockSuspendInGamingMode: true,
   presenceEnabled: true,
   presenceMode: 'active',
   presenceTimeout: 3,
@@ -80,6 +82,7 @@ export function useSleepConfigForm(): UseSleepConfigFormResult {
       pauseDiskIo: c.pause_disk_io,
       reducedTelemetry: c.reduced_telemetry_interval,
       diskSpindown: c.disk_spindown_enabled,
+      blockSuspendInGamingMode: c.block_suspend_in_gaming_mode,
       presenceEnabled: c.presence_enabled,
       presenceMode: c.presence_mode,
       presenceTimeout: c.presence_timeout_minutes,
@@ -104,6 +107,7 @@ export function useSleepConfigForm(): UseSleepConfigFormResult {
     pause_disk_io: form.pauseDiskIo,
     reduced_telemetry_interval: form.reducedTelemetry,
     disk_spindown_enabled: form.diskSpindown,
+    block_suspend_in_gaming_mode: form.blockSuspendInGamingMode,
     presence_enabled: form.presenceEnabled,
     presence_mode: form.presenceMode,
     presence_timeout_minutes: form.presenceTimeout,

--- a/client/src/i18n/locales/de/system.json
+++ b/client/src/i18n/locales/de/system.json
@@ -795,6 +795,15 @@
       "modeHint": "\"Aktive Nutzung\" spart Energie: Ein vergessener Hintergrund-Tab hält den Server nicht wach.",
       "timeoutLabel": "Timeout (Minuten)",
       "suppressing": "True Suspend blockiert: {{count}} aktive Sitzung(en)"
+    },
+    "gaming": {
+      "title": "Gaming",
+      "description": "Solange auf der Box gespielt wird, wird kein automatischer Suspend ausgeloest — auch nicht nach dem Ende der Kernbetriebszeit. Ein laufendes Spiel blockiert immer.",
+      "bigPictureLabel": "Big Picture haelt die Box wach",
+      "bigPictureHint": "Gilt, wenn Big Picture laeuft, aber gerade kein Spiel gestartet ist.",
+      "gameRunning": "Ein Spiel laeuft — automatischer Suspend ist ausgesetzt.",
+      "bigPictureActive": "Big Picture laeuft — automatischer Suspend ist ausgesetzt.",
+      "bigPictureIgnored": "Big Picture laeuft, haelt die Box laut Einstellung aber nicht wach."
     }
   },
   "fanControl": {

--- a/client/src/i18n/locales/en/system.json
+++ b/client/src/i18n/locales/en/system.json
@@ -800,6 +800,15 @@
       "modeHint": "\"Active interaction\" saves energy: a forgotten background tab does not keep the server awake.",
       "timeoutLabel": "Timeout (minutes)",
       "suppressing": "True suspend blocked: {{count}} active session(s)"
+    },
+    "gaming": {
+      "title": "Gaming",
+      "description": "While someone is playing on the box, no automatic suspend is triggered — not even after core operating hours end. A running game always blocks.",
+      "bigPictureLabel": "Big Picture keeps the box awake",
+      "bigPictureHint": "Applies while Big Picture is up but no game has been started.",
+      "gameRunning": "A game is running — automatic suspend is suspended.",
+      "bigPictureActive": "Big Picture is up — automatic suspend is suspended.",
+      "bigPictureIgnored": "Big Picture is up, but per your setting it does not keep the box awake."
     }
   },
   "fanControl": {


### PR DESCRIPTION
## Was passiert ist

Am 2026-09-08 um 23:45:37 hat sich BaluNode mitten in einer laufenden Runde DiRT Rally 2.0 schlafen gelegt. Auf der Box nachgemessen:

```
steam_sessions:   DiRT Rally 2.0   23:29:09 -> 23:46:44
sleep_state_logs: 23:45:37.580  soft_sleep    core_uptime_exit
                  23:45:37.731  true_suspend  core_uptime_exit
logind:           23:46:49      "The system will suspend now!"
```

Das Kernzeit-Fenster "Wochentags" endete um 23:30. Die fallende Flanke stellt Suspend-on-Exit scharf, danach prüft der Schedule-Loop im Minutentakt. **Vierzehn Ticks hielten korrekt dagegen, der fünfzehnte kippte** — bei unveränderter Spiellast.

## Warum

Das Gate entscheidet über `_is_system_idle()`, und das misst ausschließlich NAS-Last: CPU-Prozent, Disk-I/O, aktive Uploads, HTTP-Requests. Ein Spiel erzeugt davon nichts zuverlässig — es rechnet auf der GPU, lädt nichts vom NAS und stellt keine HTTP-Requests.

Erschwerend: der Monitoring-Kollektor mass zur selben Sekunde **19,4 %** bei einer Schwelle von 8. Die Suspend-Entscheidung liest aber `get_latest_cpu_usage()` aus dem Telemetrie-Dienst, nicht die `cpu_samples` des Kollektors — zwei Kollektoren, derselbe Moment, unvereinbare Werte. Warum sie auseinanderlaufen, ist hier **nicht** aufgeklärt (siehe Nebenbefunde unten).

Dieser PR behebt das eine Stockwerk darüber: „ist ein Mensch an der Kiste?" lässt sich aus Lastkennzahlen nicht erschließen. Die Frage wird jetzt direkt gestellt.

## Was gebaut wurde

Ein vierter Suspend-Suppressor neben Always-Awake, Kernzeit und Presence, in genau deren Form:

- **Ein laufendes Spiel blockiert bedingungslos**, ohne Schalter. Erkannt über den `/proc`-Scan des `steam_gaming`-Plugins nach `SteamLaunch AppId=`.
- **Big Picture ohne laufendes Spiel** blockiert nur, wenn die neue Einstellung `block_suspend_in_gaming_mode` gesetzt ist (Default an).

Big Picture ist von außen nicht erkennbar — das wurde am 2026-07-24 auf BaluNode ausgemessen und steht als Warnung im Plugin-Code. Der belegbare Ersatz ist deshalb: BaluHost hat den Modus selbst gestartet **und** ein Display ist an. Die Display-Prüfung ist das, was einen vergessenen Marker von allein verfallen lässt.

Verdrahtet an denselben fünf Stellen wie Presence:

| Stelle | Warum |
|---|---|
| Suspend-on-Exit | Der Pfad, der am 8.9. gefeuert hat |
| Idle-Loop | Soft Sleep sperrt die CPU aufs IDLE-Profil — nicht mitten im Spiel |
| Eskalation | Soft Sleep -> Suspend nach 30 min |
| `enter_true_suspend` | Defense-in-Depth; manueller Suspend bleibt erlaubt |
| logind-Inhibitor | **Wirkt auch gegen KDE**: ein Gamepad in Big Picture setzt den Wayland-Idle-Timer nicht zurück, PowerDevil könnte also ganz ohne BaluHost suspendieren |

`services/power/gaming_presence.py` ist die einzige Stelle, die den Plugin kennt. Sie liest bewusst den **rohen Detektor** statt `detection.current_app_id()` — letzteres liefert auf Boxen ohne `/proc` einen Platzhalter, womit jede Dev-Maschine behaupten würde, es laufe ein Spiel, und nie mehr schliefe.

## Tests

32 neue Backend-Tests, 7 neue Frontend-Tests. Zwei davon sind mehr als Abdeckung:

- **Der zentrale Regressionstest ist per Red-Green geprüft.** Ohne das Gate feuert er mit exakt dem Produktionssymptom: `('core_uptime_exit', SleepTrigger.CORE_UPTIME_EXIT)` bei laufendem Spiel.
- **Ein Test sichert den Importzyklus** zwischen `gaming_presence` und dem Plugin-Paket ab. Der Zyklus war während der Entwicklung real da: der Detektor fiel still auf `None`, der Fix wäre vollständig wirkungslos gewesen und hätte nur eine Logzeile hinterlassen.

Lokal grün: `pytest tests/services` (1455), `pytest tests/api tests/plugins tests/models tests/schemas tests/migrations` (1431), `npx vitest run` (1383), `npx eslint .` (0 Fehler), `npm run build`. Die volle Backend-Suite läuft in der CI.

## Migration

`c3a7f0d51b64`, angehängt an den echten `alembic heads` (`b8c41d92e7f5`). Default `true`: die Spalte existiert, weil die Box unter einer laufenden Sitzung weggeschlafen ist — sie ausgeschaltet auszuliefern ließe das gemeldete Problem bestehen, bis jemand den Schalter findet.

## Bewusst nicht in diesem PR

- **Die auseinanderlaufenden CPU-Messwerte.** Vier Aufrufer teilen sich in `psutil.cpu_percent()` einen prozessweiten Referenzpunkt (`telemetry.py:108`, `monitoring/cpu_collector.py:160`, `metrics.py:345`, `system.py:216`); zwei davon „primen" psutil sogar getrennt und setzen dabei gegenseitig den Referenzpunkt des anderen zurück. Das betrifft auch die Monitoring-Anzeige und die übrigen Idle-Pfade. Eigener Fehler, eigenes Risiko.
- **Zwei gleichzeitige `BaluHost`-Inhibitoren** auf der Box (PID 26294 und 27115), obwohl `CoreUptimeInhibitor` ein Singleton sein soll.
- **Kein Cache im Detektor.** Bei offener Sleep-Seite bedeutet das einen `/proc`-Scan alle 5 s. Der Status-Pill des Plugins tut mit 10 s dasselbe; falls es je auffällt, ist ein TTL-Cache die naheliegende Ergänzung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxdKsB3ywUyzYkUpa9ckvf
