### PR TITLE
fix(power): CPU ehrlich messen und fremde Schlafsperren respektieren

### DIFF
--- a/backend/app/api/routes/metrics.py
+++ b/backend/app/api/routes/metrics.py
@@ -24,6 +24,8 @@ from prometheus_client import (
 )
 import logging
 import psutil
+
+from app.services.cpu_percent_sampler import measure_cpu_percent
 import time
 
 from app.api import deps
@@ -342,7 +344,9 @@ def collect_system_metrics():
     """Collect system resource metrics."""
     try:
         # CPU
-        cpu_percent = psutil.cpu_percent(interval=0.1)
+        # Self-contained blocking measurement (#600): psutil.cpu_percent(0.1)
+        # would reset the process-global reference point the telemetry loop uses.
+        cpu_percent = measure_cpu_percent(0.1)
         cpu_usage_percent.set(cpu_percent)
         cpu_count.set(psutil.cpu_count() or 0)
 

--- a/backend/app/schemas/sleep.py
+++ b/backend/app/schemas/sleep.py
@@ -114,6 +114,18 @@ class GamingStatus(BaseModel):
     suppressing_suspend: bool = Field(default=False, description="True when gaming currently blocks auto-suspend")
 
 
+class ForeignInhibitorStatus(BaseModel):
+    """A third-party logind block inhibitor currently keeping the box awake.
+
+    Surfaced so "the box will not sleep" comes with a name attached — without
+    it the behaviour is indistinguishable from a hang (issue #602).
+    """
+    what: str = Field(..., description="Colon-separated logind lock types, e.g. 'sleep:idle'")
+    who: str = Field(..., description="Program holding the lock")
+    why: str = Field(..., description="Reason the program gave")
+    pid: int = Field(..., description="PID of the holder, so it can be found")
+
+
 # ---------------------------------------------------------------------------
 # OS Sleep Inspector
 # ---------------------------------------------------------------------------
@@ -153,6 +165,9 @@ class SleepStatusResponse(BaseModel):
     always_awake: AlwaysAwakeStatus = Field(default_factory=AlwaysAwakeStatus)
     presence: PresenceStatus = Field(default_factory=PresenceStatus)
     gaming: GamingStatus = Field(default_factory=GamingStatus)
+    foreign_inhibitor: Optional[ForeignInhibitorStatus] = Field(
+        default=None, description="Third-party sleep inhibitor blocking auto-suspend, if any"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/cpu_percent_sampler.py
+++ b/backend/app/services/cpu_percent_sampler.py
@@ -1,0 +1,101 @@
+"""CPU usage sampling with a per-consumer reference point (issue #600).
+
+`psutil.cpu_percent(interval=None)` keeps **one** reference point per process
+and returns the load since the last call *from anywhere* in it. The backend had
+four independent callers sharing it — two of them (`system.py`, `metrics.py`)
+blocking on `interval=0.1` from request paths, which silently reset the
+reference point for the telemetry loop whose value drives the sleep decision.
+A `/api/system/info` request landing just before a telemetry tick left that tick
+measuring a millisecond-wide window.
+
+Each consumer holds its own `CpuPercentSampler` here, so no call can affect
+another. The arithmetic mirrors psutil's own (`_cpu_busy_time` /
+`_cpu_tot_time`) so the reported numbers stay comparable to what the app
+reported before:
+
+- guest and guest_nice are subtracted from the total (Linux counts them inside
+  user/nice already, so leaving them in would double-count),
+- idle and iowait are not busy.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Callable, Optional
+
+import psutil
+
+logger = logging.getLogger(__name__)
+
+TimesProvider = Callable[[], object]
+
+
+def _total_time(times) -> float:
+    """Total CPU time, with Linux' double-counted guest time removed."""
+    total = float(sum(times))
+    total -= float(getattr(times, "guest", 0.0) or 0.0)
+    total -= float(getattr(times, "guest_nice", 0.0) or 0.0)
+    return total
+
+
+def _busy_time(times) -> float:
+    """Time the CPU actually spent working."""
+    busy = _total_time(times)
+    busy -= float(getattr(times, "idle", 0.0) or 0.0)
+    busy -= float(getattr(times, "iowait", 0.0) or 0.0)
+    return busy
+
+
+def _percent_between(previous, current) -> float:
+    """Busy share of the interval between two readings, in percent.
+
+    Returns 0.0 when no time elapsed or the counters moved backwards — the
+    latter is reachable across a suspend/resume, and a negative percentage
+    would be worse than admitting we cannot tell.
+    """
+    total_delta = _total_time(current) - _total_time(previous)
+    busy_delta = _busy_time(current) - _busy_time(previous)
+    if total_delta <= 0 or busy_delta < 0:
+        return 0.0
+    return min(100.0, max(0.0, (busy_delta / total_delta) * 100.0))
+
+
+class CpuPercentSampler:
+    """CPU load since *this* sampler's previous call.
+
+    Give every consumer its own instance. Sharing one would recreate exactly
+    the problem this module exists to solve.
+    """
+
+    def __init__(self, times_provider: TimesProvider = psutil.cpu_times) -> None:
+        self._times_provider = times_provider
+        self._previous = None
+
+    def sample(self) -> Optional[float]:
+        """Percent since the last call, or None on the very first one.
+
+        None means "no reference point yet", not "zero load" — callers must not
+        collapse the two, or a fresh process looks fully idle for one tick.
+        """
+        current = self._times_provider()
+        previous, self._previous = self._previous, current
+        if previous is None:
+            return None
+        return _percent_between(previous, current)
+
+
+def measure_cpu_percent(
+    interval: float,
+    times_provider: TimesProvider = psutil.cpu_times,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> float:
+    """Blocking measurement over *interval* seconds, self-contained.
+
+    For request paths that need an answer right now and have no earlier
+    reading to compare against. Holds no state, so it cannot disturb any
+    sampler — which is precisely what `psutil.cpu_percent(interval=0.1)` did.
+    """
+    before = times_provider()
+    sleeper(interval)
+    after = times_provider()
+    return _percent_between(before, after)

--- a/backend/app/services/monitoring/cpu_collector.py
+++ b/backend/app/services/monitoring/cpu_collector.py
@@ -17,6 +17,8 @@ from typing import Any, Optional, Tuple, Type
 
 import psutil
 
+from app.services.cpu_percent_sampler import CpuPercentSampler
+
 from app.models.monitoring import CpuSample
 from app.schemas.monitoring import CpuSampleSchema
 from app.services.monitoring.base import MetricCollector
@@ -145,9 +147,11 @@ class CpuMetricCollector(MetricCollector[CpuSampleSchema]):
             buffer_size=buffer_size,
             persist_interval=persist_interval,
         )
-        # Prime psutil CPU stats for accurate first reading
+        # Own reference point rather than psutil's process-global one (#600),
+        # so no other caller in this process can reset it under us.
+        self._cpu_sampler = CpuPercentSampler()
         try:
-            psutil.cpu_percent(interval=None)
+            self._cpu_sampler.sample()  # prime for an accurate first reading
         except Exception:
             pass
 
@@ -157,7 +161,11 @@ class CpuMetricCollector(MetricCollector[CpuSampleSchema]):
             timestamp = datetime.now(timezone.utc)
 
             # Get CPU usage
-            usage = psutil.cpu_percent(interval=None)
+            usage = self._cpu_sampler.sample()
+            if usage is None:
+                # Priming failed and this is the first reading — no reference
+                # point, so there is no honest number to report yet.
+                return None
 
             # Get per-thread CPU usage
             try:

--- a/backend/app/services/power/foreign_inhibitors.py
+++ b/backend/app/services/power/foreign_inhibitors.py
@@ -1,0 +1,182 @@
+"""Respect logind block inhibitors held by other programs (issue #602).
+
+BaluHost suspends with `sudo rtcwake -m mem` (`sleep_backend_linux.py`), which
+writes straight to the kernel and never passes logind. Inhibitors other
+programs hold are therefore NOT enforced against us — logind never sees the
+suspend to refuse it. Proven on 2026-09-08: `steam-bpm-inhibit` held a
+`block` on `sleep:idle` for the whole DiRT Rally session and BaluHost
+suspended anyway, mid-game.
+
+Since the OS cannot stop us, we ask ourselves. This module reads the inhibitor
+list and the sleep loops treat a foreign block as a suspend suppressor, the
+same way they treat presence or gaming.
+
+Read over D-Bus via `busctl --json=short`, deliberately NOT by parsing
+`systemd-inhibit --list`: that output is localised (a German box prints
+"Bildschirmsperre" and German reasons) and truncated to terminal width.
+
+Only `block` counts. `delay` merely postpones a suspend by a few seconds so a
+daemon can prepare — treating it as a refusal would mean NetworkManager and
+UPower keep the box awake forever.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_BUSCTL = "busctl"
+_TIMEOUT_SECONDS = 5.0
+# Long enough that a 5s status poll does not spawn a subprocess per request,
+# short enough that a game starting is noticed within one loop tick.
+_CACHE_TTL_SECONDS = 4.0
+
+# Our own inhibitors, by the --who we pass in core_uptime_inhibitor.py and
+# core_uptime_rtc_guard.py. Refusing to suspend because of our own lock would
+# deadlock every automatic suspend.
+_OWN_WHO = "BaluHost"
+
+_cache: Optional[tuple[float, list["Inhibitor"]]] = None
+_binary_missing_logged = False
+
+
+@dataclass(frozen=True)
+class Inhibitor:
+    """One entry from org.freedesktop.login1.Manager.ListInhibitors."""
+
+    what: str
+    who: str
+    why: str
+    mode: str
+    uid: int
+    pid: int
+
+    def covers(self, kind: str) -> bool:
+        """Whether this inhibitor applies to *kind* (e.g. "sleep", "idle").
+
+        `what` is a colon-separated list, so this compares whole segments:
+        PowerDevil's "handle-power-key:handle-suspend-key" must not read as a
+        sleep inhibitor just because "suspend" appears inside a segment.
+        """
+        return kind in self.what.split(":")
+
+
+def reset_cache() -> None:
+    """Drop the cached reading (tests, and after a state change)."""
+    global _cache
+    _cache = None
+
+
+def parse_inhibitors(payload: str) -> list[Inhibitor]:
+    """Parse `busctl --json=short` output. Returns [] on anything unexpected.
+
+    Failing to an empty list means "nothing is holding us back", i.e. suspend
+    stays allowed — the same fail-toward-energy-saving direction the presence
+    and gaming checks use.
+    """
+    try:
+        parsed = json.loads(payload)
+        data = parsed["data"]
+        rows = data[0] if data and isinstance(data[0], list) else []
+    except (ValueError, KeyError, TypeError, IndexError) as exc:
+        logger.debug("Could not parse inhibitor list: %s", exc)
+        return []
+
+    out: list[Inhibitor] = []
+    for row in rows:
+        # A short or malformed row is skipped rather than discarding the whole
+        # list — one odd entry must not blind us to a real inhibitor.
+        if not isinstance(row, (list, tuple)) or len(row) < 6:
+            logger.debug("Skipping malformed inhibitor row: %r", row)
+            continue
+        try:
+            out.append(
+                Inhibitor(
+                    what=str(row[0]),
+                    who=str(row[1]),
+                    why=str(row[2]),
+                    mode=str(row[3]),
+                    uid=int(row[4]),
+                    pid=int(row[5]),
+                )
+            )
+        except (TypeError, ValueError) as exc:
+            logger.debug("Skipping unreadable inhibitor row %r: %s", row, exc)
+    return out
+
+
+def _run_busctl() -> str:
+    """Ask logind for the inhibitor list. Raises on failure."""
+    global _binary_missing_logged
+    binary = shutil.which(_BUSCTL)
+    if binary is None:
+        if not _binary_missing_logged:
+            logger.warning(
+                "%s not found — third-party sleep inhibitors cannot be read and "
+                "will NOT prevent automatic suspend.",
+                _BUSCTL,
+            )
+            _binary_missing_logged = True
+        raise FileNotFoundError(_BUSCTL)
+    result = subprocess.run(
+        [
+            binary, "--json=short", "call",
+            "org.freedesktop.login1",
+            "/org/freedesktop/login1",
+            "org.freedesktop.login1.Manager",
+            "ListInhibitors",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT_SECONDS,
+        check=True,
+    )
+    return result.stdout
+
+
+def list_foreign_blocks(
+    runner: Optional[Callable[[], str]] = None,
+    now: Callable[[], float] = time.monotonic,
+) -> list[Inhibitor]:
+    """Foreign `block`-mode inhibitors, cached for a few seconds."""
+    global _cache
+    timestamp = now()
+    if _cache is not None and timestamp - _cache[0] < _CACHE_TTL_SECONDS:
+        return _cache[1]
+
+    try:
+        payload = (runner or _run_busctl)()
+    except Exception as exc:
+        logger.debug("Could not read inhibitor list (allowing suspend): %s", exc)
+        _cache = (timestamp, [])
+        return []
+
+    rows = [
+        i for i in parse_inhibitors(payload)
+        if i.mode == "block" and i.who != _OWN_WHO
+    ]
+    _cache = (timestamp, rows)
+    return rows
+
+
+def first_blocking(
+    kind: str,
+    runner: Optional[Callable[[], str]] = None,
+    now: Callable[[], float] = time.monotonic,
+) -> Optional[Inhibitor]:
+    """The first foreign block inhibitor covering *kind*, or None.
+
+    Returning the inhibitor rather than a bool so the caller can say WHO is
+    keeping the box awake — "the box will not sleep" without a name is the
+    kind of status that reads as a hang.
+    """
+    for inhibitor in list_foreign_blocks(runner=runner, now=now):
+        if inhibitor.covers(kind):
+            return inhibitor
+    return None

--- a/backend/app/services/power/sleep.py
+++ b/backend/app/services/power/sleep.py
@@ -504,6 +504,29 @@ class SleepManagerService:
             logger.warning("Gaming check failed (failing open toward suspend): %s", e)
             return False
 
+    def _foreign_inhibitor(self, kind: str):
+        """A third-party logind block inhibitor covering *kind*, or None.
+
+        Issue #602: BaluHost suspends via `rtcwake -m mem`, which bypasses
+        logind, so inhibitors other programs hold are never enforced against
+        us by the OS. We consult them ourselves and treat a foreign block as
+        a suppressor — otherwise BaluHost silently overrules every other
+        program's "do not sleep".
+
+        *kind* is a segment of the inhibitor's `what` field: "sleep" for the
+        true-suspend paths, "idle" for soft sleep.
+
+        Fails toward energy saving (returns None), like the other suppressors.
+        """
+        try:
+            from app.services.power import foreign_inhibitors
+            return foreign_inhibitors.first_blocking(kind)
+        except Exception as e:
+            logger.warning(
+                "Foreign inhibitor check failed (failing open toward suspend): %s", e
+            )
+            return None
+
     async def _idle_detection_loop(self) -> None:
         """Background loop that checks system idle status every 30 seconds."""
         check_interval = 30  # seconds
@@ -531,6 +554,18 @@ class SleepManagerService:
                 # Soft sleep locks the CPU to the IDLE profile — the last
                 # thing a running game needs.
                 if self._is_gaming_active(config):
+                    self._consecutive_idle_checks = 0
+                    self._idle_seconds = 0.0
+                    continue
+
+                # A foreign `idle` block inhibitor means another program asked
+                # for the machine to stay responsive (#602).
+                foreign_idle = self._foreign_inhibitor("idle")
+                if foreign_idle is not None:
+                    logger.debug(
+                        "Soft sleep suppressed by %s: %s",
+                        foreign_idle.who, foreign_idle.why,
+                    )
                     self._consecutive_idle_checks = 0
                     self._idle_seconds = 0.0
                     continue
@@ -639,6 +674,7 @@ class SleepManagerService:
                     and not self._is_always_awake(config)
                     and not self._is_user_present(config)
                     and not self._is_gaming_active(config)
+                    and self._foreign_inhibitor("sleep") is None
                     and self._is_system_idle(config, self._get_activity_metrics())
                 ):
                     logger.info(
@@ -735,6 +771,15 @@ class SleepManagerService:
             # Skip escalation while someone is gaming at the box
             if self._is_gaming_active(config):
                 logger.info("Auto-escalation skipped: gaming activity")
+                return
+
+            # Skip escalation while another program blocks sleep (#602)
+            foreign = self._foreign_inhibitor("sleep")
+            if foreign is not None:
+                logger.info(
+                    "Auto-escalation skipped: %s blocks sleep (%s)",
+                    foreign.who, foreign.why,
+                )
                 return
 
             logger.info("Auto-escalation: soft sleep -> true suspend after %d minutes",
@@ -1135,6 +1180,18 @@ class SleepManagerService:
             )
             return False
 
+        # Foreign inhibitor guard (#602). rtcwake would sail straight past
+        # logind, so this is the only place the refusal can happen.
+        if trigger != SleepTrigger.MANUAL:
+            foreign = self._foreign_inhibitor("sleep")
+            if foreign is not None:
+                logger.info(
+                    "enter_true_suspend blocked: %s holds a sleep inhibitor (%s) "
+                    "(trigger=%s, reason=%s)",
+                    foreign.who, foreign.why, trigger.value, reason,
+                )
+                return False
+
         # Enter soft sleep first if awake
         if self._current_state == SleepState.AWAKE:
             ok = await self.enter_soft_sleep(reason, trigger)
@@ -1346,6 +1403,15 @@ class SleepManagerService:
         except Exception as e:
             logger.warning("Gaming status read failed: %s", e)
 
+        # Foreign inhibitor status (#602) — names who is keeping us awake.
+        from app.schemas.sleep import ForeignInhibitorStatus
+        foreign_status = None
+        foreign = self._foreign_inhibitor("sleep") or self._foreign_inhibitor("idle")
+        if foreign is not None:
+            foreign_status = ForeignInhibitorStatus(
+                what=foreign.what, who=foreign.who, why=foreign.why, pid=foreign.pid,
+            )
+
         return SleepStatusResponse(
             current_state=self._current_state,
             state_since=self._state_since,
@@ -1361,6 +1427,7 @@ class SleepManagerService:
             always_awake=always_awake_status,
             presence=presence_status,
             gaming=gaming_status,
+            foreign_inhibitor=foreign_status,
         )
 
     def get_config(self) -> SleepConfigResponse:

--- a/backend/app/services/system.py
+++ b/backend/app/services/system.py
@@ -8,6 +8,8 @@ import time
 from typing import List, Tuple
 
 import psutil
+
+from app.services.cpu_percent_sampler import measure_cpu_percent
 from cachetools import TTLCache
 
 from app.core.config import settings
@@ -213,7 +215,8 @@ def get_system_info() -> SystemInfo:
         )
 
     try:
-        cpu_usage = psutil.cpu_percent(interval=0.1)
+        # Self-contained blocking measurement (#600) — see metrics.py.
+        cpu_usage = measure_cpu_percent(0.1)
         cpu_count = psutil.cpu_count(logical=True) or 1
         
         # Use sensor service for frequency and temperature

--- a/backend/app/services/telemetry.py
+++ b/backend/app/services/telemetry.py
@@ -11,6 +11,7 @@ from typing import List, Optional, Tuple
 import psutil
 
 from app.core.config import settings
+from app.services.cpu_percent_sampler import CpuPercentSampler
 from app.schemas.system import (
     CpuTelemetrySample,
     MemoryTelemetrySample,
@@ -71,9 +72,13 @@ _previous_network_totals: Optional[Tuple[float, int, int]] = None
 _monitor_task: Optional[asyncio.Task] = None
 _lock = Lock()
 
+# Own reference point, not psutil's process-global one (#600): request paths
+# calling psutil.cpu_percent(interval=0.1) used to reset that shared point and
+# leave this loop measuring a millisecond-wide window.
+_cpu_sampler = CpuPercentSampler()
 try:
-    # Prime the internal psutil CPU statistics so the first real sample is meaningful
-    psutil.cpu_percent(interval=None)
+    # Prime it so the first real sample has something to compare against.
+    _cpu_sampler.sample()
 except Exception as exc:  # pragma: no cover - platform quirks
     logger.debug("Unable to prime CPU stats: %s", exc)
 
@@ -105,7 +110,14 @@ def _sample_once() -> None:
     timestamp_ms = int(timestamp_seconds * 1000)
 
     try:
-        cpu_usage = _round(float(psutil.cpu_percent(interval=None)))
+        sampled = _cpu_sampler.sample()
+        if sampled is None:
+            # No reference point yet (priming failed). Carry the last known
+            # value forward rather than reporting a fictitious 0 %, which the
+            # sleep logic would read as "idle".
+            cpu_usage = _latest_cpu_usage if _latest_cpu_usage is not None else 0.0
+        else:
+            cpu_usage = _round(float(sampled))
     except Exception as exc:  # pragma: no cover - psutil edge cases
         logger.debug("CPU percent unavailable: %s", exc)
         cpu_usage = _latest_cpu_usage if _latest_cpu_usage is not None else 0.0

--- a/backend/tests/api/test_metrics_collection_logging.py
+++ b/backend/tests/api/test_metrics_collection_logging.py
@@ -19,7 +19,11 @@ def _explode(*args, **kwargs):
 
 
 def _break_system(monkeypatch):
-    monkeypatch.setattr(metrics.psutil, "cpu_percent", _explode)
+    # Patches the CPU seam the collector actually uses. It moved from
+    # psutil.cpu_percent to measure_cpu_percent in #600 (per-consumer
+    # reference point); patching the old name left this test green while
+    # exercising nothing.
+    monkeypatch.setattr(metrics, "measure_cpu_percent", _explode)
     return metrics.collect_system_metrics
 
 

--- a/backend/tests/services/power/test_foreign_inhibitors.py
+++ b/backend/tests/services/power/test_foreign_inhibitors.py
@@ -1,0 +1,165 @@
+"""Tests for respecting third-party logind block inhibitors (issue #602).
+
+BaluHost suspends via `rtcwake -m mem`, which bypasses logind entirely — so
+inhibitors other programs hold are not enforced against us by the OS. We have
+to consult them ourselves. Proven on 2026-09-08: steam-bpm-inhibit held a
+block on sleep:idle throughout a game session and BaluHost suspended anyway.
+"""
+import json
+
+import pytest
+
+from app.services.power import foreign_inhibitors as fi
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    fi.reset_cache()
+    yield
+    fi.reset_cache()
+
+
+def _payload(*rows):
+    """busctl --json=short shape: one output argument holding an array."""
+    return json.dumps({"type": "a(ssssuu)", "data": [list(rows)]})
+
+
+STEAM = ["sleep:idle", "steam-bpm-inhibit", "Steam BPM oder Spiel aktiv", "block", 1000, 102863]
+BALU_BLOCK = ["sleep", "BaluHost", "always_awake_active", "block", 1000, 84655]
+BALU_DELAY = ["sleep", "BaluHost", "Set RTC wake at next core uptime window start", "delay", 1000, 84593]
+NM_DELAY = ["sleep", "NetworkManager", "NetworkManager needs to turn off networks", "delay", 0, 1195]
+POWERDEVIL = ["handle-power-key:handle-suspend-key", "PowerDevil", "KDE handles power events", "block", 1000, 3506]
+
+
+# Captured verbatim from BaluNode on 2026-09-09 while a game was running.
+# Every filter this module implements is represented here: delay entries, a
+# block that covers no sleep lock, both of BaluHost's own, and exactly one
+# foreign block that must survive.
+REAL_PAYLOAD = (
+    '{"type":"a(ssssuu)","data":[[["sleep","Bildschirmsperre","Stellt sicher, dass der '
+    'Bildschirm vor dem Herunterfahren gesperrt wird","delay",1000,2903],'
+    '["sleep","UPower","Pause device polling","delay",0,3451],'
+    '["sleep","BaluHost","Set RTC wake at next core uptime window start","delay",1000,3180],'
+    '["sleep","NetworkManager","NetworkManager needs to turn off networks","delay",0,1196],'
+    '["sleep","ModemManager","ModemManager needs to reset devices","delay",0,1227],'
+    '["handle-power-key:handle-suspend-key:handle-hibernate-key:handle-lid-switch",'
+    '"PowerDevil","KDE handles power events","block",1000,3526],'
+    '["sleep:idle","steam-bpm-inhibit","Steam BPM oder Spiel aktiv","block",1000,9364],'
+    '["sleep","BaluHost","core_uptime_and_user_present_active","block",1000,3211]]]}'
+)
+
+
+class TestRealProductionPayload:
+    """Guards the parser against the actual shape busctl emits.
+
+    The synthesised fixtures below could all agree with each other and still be
+    the wrong shape; this one cannot.
+    """
+
+    def test_all_eight_entries_are_parsed(self):
+        assert len(fi.parse_inhibitors(REAL_PAYLOAD)) == 8
+
+    def test_exactly_the_steam_inhibitor_survives_filtering(self):
+        found = fi.first_blocking("sleep", runner=lambda: REAL_PAYLOAD)
+        assert found is not None
+        assert found.who == "steam-bpm-inhibit"
+        assert found.pid == 9364
+
+    def test_powerdevils_block_is_not_mistaken_for_a_sleep_lock(self):
+        """Its `what` contains "handle-suspend-key" but no `sleep` segment."""
+        blocks = fi.list_foreign_blocks(runner=lambda: REAL_PAYLOAD)
+        powerdevil = next(i for i in blocks if i.who == "PowerDevil")
+        assert powerdevil.covers("sleep") is False
+
+    def test_baluhosts_own_block_is_excluded(self):
+        blocks = fi.list_foreign_blocks(runner=lambda: REAL_PAYLOAD)
+        assert all(i.who != "BaluHost" for i in blocks)
+
+
+class TestParse:
+    def test_reads_the_busctl_payload(self):
+        rows = fi.parse_inhibitors(_payload(STEAM))
+        assert len(rows) == 1
+        assert rows[0].who == "steam-bpm-inhibit"
+        assert rows[0].why == "Steam BPM oder Spiel aktiv"
+        assert rows[0].mode == "block"
+        assert rows[0].pid == 102863
+
+    def test_empty_list(self):
+        assert fi.parse_inhibitors(_payload()) == []
+
+    def test_malformed_payload_yields_nothing(self):
+        """Fail toward energy saving, like the other suppressors."""
+        assert fi.parse_inhibitors("not json at all") == []
+        assert fi.parse_inhibitors(json.dumps({"unexpected": True})) == []
+
+    def test_short_row_is_skipped_not_fatal(self):
+        payload = json.dumps({"type": "a(ssssuu)", "data": [[["sleep", "x"], STEAM]]})
+        rows = fi.parse_inhibitors(payload)
+        assert [r.who for r in rows] == ["steam-bpm-inhibit"]
+
+
+class TestCovers:
+    def test_matches_a_segment_of_the_colon_list(self):
+        steam = fi.parse_inhibitors(_payload(STEAM))[0]
+        assert steam.covers("sleep") is True
+        assert steam.covers("idle") is True
+
+    def test_does_not_match_a_substring_of_another_segment(self):
+        """`handle-suspend-key` must not count as `sleep`, nor as a prefix match."""
+        pd = fi.parse_inhibitors(_payload(POWERDEVIL))[0]
+        assert pd.covers("sleep") is False
+        assert pd.covers("handle-power-key") is True
+
+
+class TestBlockingLookup:
+    def test_finds_a_foreign_block_inhibitor_on_sleep(self):
+        runner = lambda: _payload(STEAM, NM_DELAY, POWERDEVIL)
+        found = fi.first_blocking("sleep", runner=runner)
+        assert found is not None and found.who == "steam-bpm-inhibit"
+
+    def test_ignores_delay_mode(self):
+        """delay only postpones suspend; it is not a refusal."""
+        assert fi.first_blocking("sleep", runner=lambda: _payload(NM_DELAY, BALU_DELAY)) is None
+
+    def test_ignores_baluhosts_own_block(self):
+        """Our own inhibitor must not make us refuse our own suspend."""
+        assert fi.first_blocking("sleep", runner=lambda: _payload(BALU_BLOCK)) is None
+
+    def test_ignores_a_block_that_does_not_cover_the_kind(self):
+        assert fi.first_blocking("sleep", runner=lambda: _payload(POWERDEVIL)) is None
+
+    def test_idle_kind_is_matched_separately(self):
+        runner = lambda: _payload(STEAM)
+        assert fi.first_blocking("idle", runner=runner) is not None
+
+    def test_runner_failure_allows_suspend(self):
+        def boom():
+            raise OSError("busctl not found")
+        assert fi.first_blocking("sleep", runner=boom) is None
+
+
+class TestCache:
+    def test_repeated_lookups_do_not_respawn_the_subprocess(self):
+        calls = []
+
+        def runner():
+            calls.append(1)
+            return _payload(STEAM)
+
+        fi.first_blocking("sleep", runner=runner)
+        fi.first_blocking("idle", runner=runner)
+        fi.first_blocking("sleep", runner=runner)
+        assert len(calls) == 1
+
+    def test_cache_expires(self):
+        calls = []
+
+        def runner():
+            calls.append(1)
+            return _payload(STEAM)
+
+        fi.first_blocking("sleep", runner=runner, now=lambda: 100.0)
+        # Far beyond the TTL, so the second lookup must go out again.
+        fi.first_blocking("sleep", runner=runner, now=lambda: 999.0)
+        assert len(calls) == 2

--- a/backend/tests/services/power/test_foreign_inhibitors.py
+++ b/backend/tests/services/power/test_foreign_inhibitors.py
@@ -114,7 +114,9 @@ class TestCovers:
 
 class TestBlockingLookup:
     def test_finds_a_foreign_block_inhibitor_on_sleep(self):
-        runner = lambda: _payload(STEAM, NM_DELAY, POWERDEVIL)
+        def runner():
+            return _payload(STEAM, NM_DELAY, POWERDEVIL)
+
         found = fi.first_blocking("sleep", runner=runner)
         assert found is not None and found.who == "steam-bpm-inhibit"
 
@@ -130,7 +132,9 @@ class TestBlockingLookup:
         assert fi.first_blocking("sleep", runner=lambda: _payload(POWERDEVIL)) is None
 
     def test_idle_kind_is_matched_separately(self):
-        runner = lambda: _payload(STEAM)
+        def runner():
+            return _payload(STEAM)
+
         assert fi.first_blocking("idle", runner=runner) is not None
 
     def test_runner_failure_allows_suspend(self):

--- a/backend/tests/services/test_cpu_percent_sampler.py
+++ b/backend/tests/services/test_cpu_percent_sampler.py
@@ -1,0 +1,139 @@
+"""Tests for the per-consumer CPU sampler (issue #600).
+
+The point of the module is that two consumers do NOT influence each other —
+`psutil.cpu_percent(interval=None)` keeps ONE reference point per process, so
+four callers were resetting it under each other. `test_two_samplers_are_independent`
+is the regression test for exactly that.
+"""
+from collections import namedtuple
+
+import pytest
+
+from app.services.cpu_percent_sampler import CpuPercentSampler, measure_cpu_percent
+
+# Mirrors psutil's Linux scputimes so `sum(times)` and the guest/iowait fields
+# behave like the real thing.
+Times = namedtuple(
+    "Times",
+    "user nice system idle iowait irq softirq steal guest guest_nice",
+)
+
+
+def _t(user=0.0, idle=0.0, iowait=0.0, guest=0.0, guest_nice=0.0, nice=0.0):
+    return Times(user, nice, 0.0, idle, iowait, 0.0, 0.0, 0.0, guest, guest_nice)
+
+
+class _FakeClock:
+    """Hands out a scripted sequence of cpu_times() readings."""
+
+    def __init__(self, *readings):
+        self._readings = list(readings)
+        self.calls = 0
+
+    def __call__(self):
+        self.calls += 1
+        return self._readings.pop(0)
+
+
+class TestSample:
+    def test_first_sample_has_no_reference_point(self):
+        sampler = CpuPercentSampler(times_provider=_FakeClock(_t(user=10, idle=90)))
+        assert sampler.sample() is None
+
+    def test_second_sample_is_the_delta_since_the_first(self):
+        clock = _FakeClock(_t(user=10, idle=90), _t(user=35, idle=165))
+        sampler = CpuPercentSampler(times_provider=clock)
+        sampler.sample()
+        # 25 busy of 100 total elapsed
+        assert sampler.sample() == pytest.approx(25.0)
+
+    def test_fully_busy_is_100(self):
+        clock = _FakeClock(_t(user=0, idle=0), _t(user=50, idle=0))
+        sampler = CpuPercentSampler(times_provider=clock)
+        sampler.sample()
+        assert sampler.sample() == pytest.approx(100.0)
+
+    def test_fully_idle_is_zero(self):
+        clock = _FakeClock(_t(user=0, idle=0), _t(user=0, idle=50))
+        sampler = CpuPercentSampler(times_provider=clock)
+        sampler.sample()
+        assert sampler.sample() == pytest.approx(0.0)
+
+    def test_iowait_does_not_count_as_busy(self):
+        """Matches psutil: iowait is time the CPU does nothing."""
+        clock = _FakeClock(_t(user=0, idle=0, iowait=0), _t(user=25, idle=25, iowait=50))
+        sampler = CpuPercentSampler(times_provider=clock)
+        sampler.sample()
+        assert sampler.sample() == pytest.approx(25.0)
+
+    def test_guest_time_is_excluded_from_the_total(self):
+        """Matches psutil on Linux: guest time is already counted inside user."""
+        clock = _FakeClock(
+            _t(user=0, idle=0, guest=0),
+            _t(user=50, idle=50, guest=20),
+        )
+        sampler = CpuPercentSampler(times_provider=clock)
+        sampler.sample()
+        # total = 120 - 20 guest = 100; busy = 100 - 50 idle = 50
+        assert sampler.sample() == pytest.approx(50.0)
+
+    def test_no_elapsed_time_yields_zero_instead_of_dividing_by_zero(self):
+        reading = _t(user=10, idle=90)
+        clock = _FakeClock(reading, reading)
+        sampler = CpuPercentSampler(times_provider=clock)
+        sampler.sample()
+        assert sampler.sample() == 0.0
+
+    def test_counter_going_backwards_yields_zero(self):
+        """A suspend/resume can make the accounting look like it moved back."""
+        clock = _FakeClock(_t(user=100, idle=100), _t(user=10, idle=10))
+        sampler = CpuPercentSampler(times_provider=clock)
+        sampler.sample()
+        assert sampler.sample() == 0.0
+
+    def test_two_samplers_are_independent(self):
+        """The whole reason this module exists (issue #600).
+
+        With psutil's shared reference point, B's read would reset A's, and A's
+        next sample would cover a near-zero window. Each sampler must keep its
+        own previous reading.
+        """
+        readings = [
+            _t(user=0, idle=0),      # A primes
+            _t(user=0, idle=0),      # B primes
+            _t(user=10, idle=10),    # B samples: 50% over its own window
+            _t(user=10, idle=10),    # A samples: must ALSO see its full window
+        ]
+        shared = _FakeClock(*readings)
+        a = CpuPercentSampler(times_provider=shared)
+        b = CpuPercentSampler(times_provider=shared)
+
+        a.sample()
+        b.sample()
+        assert b.sample() == pytest.approx(50.0)
+        assert a.sample() == pytest.approx(50.0)
+
+
+class TestMeasureBlocking:
+    def test_measures_across_the_interval(self):
+        clock = _FakeClock(_t(user=0, idle=0), _t(user=30, idle=70))
+        slept = []
+        value = measure_cpu_percent(
+            0.1, times_provider=clock, sleeper=slept.append
+        )
+        assert value == pytest.approx(30.0)
+        assert slept == [0.1]
+
+    def test_does_not_disturb_a_samplers_reference_point(self):
+        """The blocking call is what poisoned the non-blocking ones before."""
+        readings = [
+            _t(user=0, idle=0),      # sampler primes
+            _t(user=5, idle=5),      # blocking measure start
+            _t(user=10, idle=10),    # blocking measure end
+            _t(user=20, idle=20),    # sampler samples over ITS window
+        ]
+        clock = _FakeClock(*readings)
+        sampler = CpuPercentSampler(times_provider=clock)
+        sampler.sample()
+        measure_cpu_percent(0.1, times_provider=clock, sleeper=lambda _s: None)
+        assert sampler.sample() == pytest.approx(50.0)

--- a/backend/tests/services/test_sleep_foreign_inhibitor_integration.py
+++ b/backend/tests/services/test_sleep_foreign_inhibitor_integration.py
@@ -1,12 +1,9 @@
-"""Integration tests: SleepManagerService does not suspend while gaming.
+"""Integration tests: SleepManagerService respects foreign block inhibitors (#602).
 
-Regression cover for 2026-09-08, when the box suspended sixteen minutes after
-the core-uptime window ended while DiRT Rally 2.0 was running: the suspend-on-
-exit gate asks `_is_system_idle()`, which measures NAS load (CPU percent, disk
-I/O, HTTP requests) and cannot see a game.
-
-Mirrors test_sleep_presence_integration.py — gaming is the fourth suppressor
-next to core uptime, always-awake and presence.
+The regression this covers: on 2026-09-08 steam-bpm-inhibit held a
+`block` on `sleep:idle` for the whole game session, and BaluHost suspended
+anyway — because `rtcwake -m mem` never goes through logind, so nothing
+enforced that inhibitor against us.
 """
 import contextlib
 from unittest.mock import AsyncMock, patch
@@ -15,16 +12,26 @@ import pytest
 
 from app.models.sleep import CoreUptimeWindow as CW, SleepConfig
 from app.schemas.sleep import SleepState, SleepTrigger
+from app.services.power.foreign_inhibitors import Inhibitor
 from app.services.power.sleep import SleepManagerService
 from app.services.power.sleep_backend_dev import DevSleepBackend
 
+STEAM = Inhibitor(
+    what="sleep:idle",
+    who="steam-bpm-inhibit",
+    why="Steam BPM oder Spiel aktiv",
+    mode="block",
+    uid=1000,
+    pid=102863,
+)
+
 
 def _build_service():
-    SleepManagerService._instance = None  # reset singleton
+    SleepManagerService._instance = None
     return SleepManagerService(DevSleepBackend())
 
 
-def _config(suspend_on_exit=True, auto_escalation_enabled=False, auto_idle_enabled=False):
+def _config(auto_escalation_enabled=False, auto_idle_enabled=False):
     return SleepConfig(
         id=1,
         auto_idle_enabled=auto_idle_enabled,
@@ -45,7 +52,7 @@ def _config(suspend_on_exit=True, auto_escalation_enabled=False, auto_idle_enabl
         reduced_telemetry_interval=30.0,
         disk_spindown_enabled=False,
         core_uptime_enabled=True,
-        core_uptime_suspend_on_exit=suspend_on_exit,
+        core_uptime_suspend_on_exit=True,
         always_awake_enabled=False,
         always_awake_until=None,
         block_suspend_in_gaming_mode=True,
@@ -60,41 +67,24 @@ def _window() -> CW:
               start_time="19:00", end_time="23:30", weekdays="0,1,2,3,4")
 
 
-def _drive_schedule_loop(svc, cfg, *, gaming, ticks=2):
-    """Run _schedule_check_loop for `ticks` ticks with the window just ended."""
-    return [
-        patch.object(svc, "_load_config", return_value=cfg),
-        patch.object(svc, "_load_core_uptime", return_value=(True, [_window()])),
-        patch("app.services.power.sleep.core_uptime_helpers.is_in_core_uptime",
-              return_value=(False, None)),
-        patch.object(svc, "_is_system_idle", return_value=True),
-        patch.object(svc, "_is_user_present", return_value=False),
-        patch.object(svc, "_is_always_awake", return_value=False),
-        patch.object(svc, "_is_gaming_active", return_value=gaming),
-        patch.object(svc, "_reconcile_sleep_inhibitor"),
-    ]
-
-
-class TestIsGamingActive:
-    def test_delegates_to_the_gaming_presence_module(self):
+class TestLookupHelper:
+    def test_delegates_to_the_foreign_inhibitor_module(self):
         svc = _build_service()
-        cfg = _config()
-        with patch("app.services.power.gaming_presence.blocks_suspend",
-                   return_value=True) as mock:
-            assert svc._is_gaming_active(cfg) is True
-        mock.assert_called_once_with(cfg)
+        with patch("app.services.power.foreign_inhibitors.first_blocking",
+                   return_value=STEAM) as mock:
+            assert svc._foreign_inhibitor("sleep") is STEAM
+        mock.assert_called_once_with("sleep")
 
-    def test_false_when_the_detector_blows_up(self):
-        """Fails toward energy saving, like the presence check."""
+    def test_none_when_the_lookup_blows_up(self):
+        """Fails toward energy saving, like every other suppressor."""
         svc = _build_service()
-        with patch("app.services.power.gaming_presence.blocks_suspend",
-                   side_effect=RuntimeError("boom")):
-            assert svc._is_gaming_active(_config()) is False
+        with patch("app.services.power.foreign_inhibitors.first_blocking",
+                   side_effect=RuntimeError("busctl exploded")):
+            assert svc._foreign_inhibitor("sleep") is None
 
 
 @pytest.mark.asyncio
-async def test_suspend_on_exit_blocked_while_gaming():
-    """The 2026-09-08 regression: window ended, game running, box must stay up."""
+async def test_suspend_on_exit_blocked_by_a_foreign_inhibitor():
     svc = _build_service()
     cfg = _config()
     suspend_calls = []
@@ -103,8 +93,20 @@ async def test_suspend_on_exit_blocked_while_gaming():
         suspend_calls.append(a)
         return True
 
+    patches = [
+        patch.object(svc, "_load_config", return_value=cfg),
+        patch.object(svc, "_load_core_uptime", return_value=(True, [_window()])),
+        patch("app.services.power.sleep.core_uptime_helpers.is_in_core_uptime",
+              return_value=(False, None)),
+        patch.object(svc, "_is_system_idle", return_value=True),
+        patch.object(svc, "_is_user_present", return_value=False),
+        patch.object(svc, "_is_always_awake", return_value=False),
+        patch.object(svc, "_is_gaming_active", return_value=False),
+        patch.object(svc, "_foreign_inhibitor", return_value=STEAM),
+        patch.object(svc, "_reconcile_sleep_inhibitor"),
+    ]
     with contextlib.ExitStack() as stack:
-        for p in _drive_schedule_loop(svc, cfg, gaming=True):
+        for p in patches:
             stack.enter_context(p)
         svc.enter_true_suspend = fake_suspend
         svc._is_running = True
@@ -124,47 +126,11 @@ async def test_suspend_on_exit_blocked_while_gaming():
         await svc._schedule_check_loop()
 
     assert suspend_calls == []
-    # Gaming is a gate, not a disarm: the suspend must still happen once the
-    # game ends, exactly as presence behaves.
-    assert svc._core_uptime_exit_pending is True
+    assert svc._core_uptime_exit_pending is True  # a gate, not a disarm
 
 
 @pytest.mark.asyncio
-async def test_suspend_on_exit_still_fires_when_no_game_runs():
-    """Control: without gaming the existing behaviour is untouched."""
-    svc = _build_service()
-    cfg = _config()
-    suspend_calls = []
-
-    async def fake_suspend(*a, **k):
-        suspend_calls.append(a)
-        return True
-
-    with contextlib.ExitStack() as stack:
-        for p in _drive_schedule_loop(svc, cfg, gaming=False):
-            stack.enter_context(p)
-        svc.enter_true_suspend = fake_suspend
-        svc._is_running = True
-        svc._current_state = SleepState.AWAKE
-        svc._was_in_core_uptime = True
-
-        calls = [0]
-
-        async def stop_after_two(*_a, **_k):
-            calls[0] += 1
-            if calls[0] >= 2:
-                svc._is_running = False
-
-        stack.enter_context(
-            patch("app.services.power.sleep.asyncio.sleep", side_effect=stop_after_two)
-        )
-        await svc._schedule_check_loop()
-
-    assert len(suspend_calls) == 1
-
-
-@pytest.mark.asyncio
-async def test_escalation_skipped_while_gaming():
+async def test_escalation_skipped_while_a_foreign_inhibitor_blocks():
     svc = _build_service()
     cfg = _config(auto_escalation_enabled=True)
     svc._current_state = SleepState.SOFT_SLEEP
@@ -174,7 +140,8 @@ async def test_escalation_skipped_while_gaming():
          patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
          patch.object(svc, "_is_always_awake", return_value=False), \
          patch.object(svc, "_is_user_present", return_value=False), \
-         patch.object(svc, "_is_gaming_active", return_value=True), \
+         patch.object(svc, "_is_gaming_active", return_value=False), \
+         patch.object(svc, "_foreign_inhibitor", return_value=STEAM), \
          patch.object(svc, "enter_true_suspend", new=AsyncMock()) as mock_suspend, \
          patch("app.services.power.sleep.asyncio.sleep", new=AsyncMock()):
         await svc._escalation_monitor()
@@ -183,13 +150,13 @@ async def test_escalation_skipped_while_gaming():
 
 
 @pytest.mark.asyncio
-async def test_idle_loop_does_not_soft_sleep_while_gaming():
-    """Soft sleep locks the CPU to the IDLE profile — not during a game."""
+async def test_idle_loop_respects_an_idle_inhibitor():
+    """`what` is honoured per segment: idle guards soft sleep, sleep guards suspend."""
     svc = _build_service()
     cfg = _config(auto_idle_enabled=True)
     svc._is_running = True
     svc._current_state = SleepState.AWAKE
-    svc._consecutive_idle_checks = 999  # threshold long since exceeded
+    svc._consecutive_idle_checks = 999
 
     calls = [0]
 
@@ -202,16 +169,24 @@ async def test_idle_loop_does_not_soft_sleep_while_gaming():
         if calls[0] >= 2:
             svc._is_running = False
 
+    seen = []
+
+    def lookup(kind):
+        seen.append(kind)
+        return STEAM
+
     with patch.object(svc, "_load_config", return_value=cfg), \
          patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
          patch.object(svc, "_is_always_awake", return_value=False), \
+         patch.object(svc, "_is_gaming_active", return_value=False), \
          patch.object(svc, "_is_system_idle", return_value=True), \
-         patch.object(svc, "_is_gaming_active", return_value=True), \
+         patch.object(svc, "_foreign_inhibitor", side_effect=lookup), \
          patch.object(svc, "enter_soft_sleep", new=AsyncMock()) as mock_soft, \
          patch("app.services.power.sleep.asyncio.sleep", side_effect=stop_loop):
         await svc._idle_detection_loop()
 
     mock_soft.assert_not_called()
+    assert "idle" in seen
 
 
 @pytest.mark.asyncio
@@ -219,16 +194,16 @@ async def test_idle_loop_does_not_soft_sleep_while_gaming():
     SleepTrigger.AUTO_IDLE, SleepTrigger.SCHEDULE,
     SleepTrigger.AUTO_ESCALATION, SleepTrigger.CORE_UPTIME_EXIT,
 ])
-async def test_enter_true_suspend_blocks_non_manual_while_gaming(trigger):
+async def test_enter_true_suspend_blocks_non_manual(trigger):
     svc = _build_service()
-    cfg = _config()
     svc._current_state = SleepState.AWAKE
 
-    with patch.object(svc, "_load_config", return_value=cfg), \
+    with patch.object(svc, "_load_config", return_value=_config()), \
          patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
          patch.object(svc, "_is_always_awake", return_value=False), \
          patch.object(svc, "_is_user_present", return_value=False), \
-         patch.object(svc, "_is_gaming_active", return_value=True), \
+         patch.object(svc, "_is_gaming_active", return_value=False), \
+         patch.object(svc, "_foreign_inhibitor", return_value=STEAM), \
          patch.object(svc, "enter_soft_sleep", new=AsyncMock()) as mock_soft:
         ok = await svc.enter_true_suspend("test", trigger)
 
@@ -237,17 +212,17 @@ async def test_enter_true_suspend_blocks_non_manual_while_gaming(trigger):
 
 
 @pytest.mark.asyncio
-async def test_enter_true_suspend_allows_manual_while_gaming():
-    """An admin pressing suspend always wins over the automatic guards."""
+async def test_enter_true_suspend_allows_manual():
+    """An admin at the machine may overrule a foreign inhibitor."""
     svc = _build_service()
-    cfg = _config()
     svc._current_state = SleepState.SOFT_SLEEP
 
-    with patch.object(svc, "_load_config", return_value=cfg), \
+    with patch.object(svc, "_load_config", return_value=_config()), \
          patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
          patch.object(svc, "_is_always_awake", return_value=False), \
          patch.object(svc, "_is_user_present", return_value=False), \
-         patch.object(svc, "_is_gaming_active", return_value=True), \
+         patch.object(svc, "_is_gaming_active", return_value=False), \
+         patch.object(svc, "_foreign_inhibitor", return_value=STEAM), \
          patch("app.services.power.sleep.SessionLocal"), \
          patch("app.services.notifications.events.emit_system_suspend",
                new=AsyncMock(return_value=None)), \
@@ -258,22 +233,27 @@ async def test_enter_true_suspend_allows_manual_while_gaming():
     mock_suspend.assert_awaited()
 
 
-def test_inhibitor_is_held_while_gaming():
-    """Holding the logind lock is what stops KDE PowerDevil from suspending.
-
-    A gamepad in Big Picture does not reset the Wayland idle timer, so the
-    desktop's own idle-suspend is a real path to losing the session — and
-    BaluHost's per-loop guards do not cover it.
-    """
+def test_status_names_who_is_holding_the_box_awake():
     svc = _build_service()
-    cfg = _config()
+    with patch.object(svc, "_load_config", return_value=_config()), \
+         patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
+         patch("app.services.power.gaming_presence.game_is_running", return_value=False), \
+         patch("app.services.power.gaming_presence.gaming_mode_on_screen", return_value=False), \
+         patch.object(svc, "_foreign_inhibitor", return_value=STEAM):
+        status = svc.get_status()
 
-    with patch.object(svc, "_is_always_awake", return_value=False), \
-         patch.object(svc, "_is_user_present", return_value=False), \
-         patch.object(svc, "_is_gaming_active", return_value=True), \
-         patch.object(svc._core_uptime_inhibitor, "is_held", return_value=False), \
-         patch.object(svc._core_uptime_inhibitor, "acquire") as mock_acquire:
-        svc._reconcile_sleep_inhibitor(cfg, in_core=False)
+    assert status.foreign_inhibitor is not None
+    assert status.foreign_inhibitor.who == "steam-bpm-inhibit"
+    assert status.foreign_inhibitor.why == "Steam BPM oder Spiel aktiv"
 
-    mock_acquire.assert_called_once()
-    assert "gaming" in mock_acquire.call_args.args[0]
+
+def test_status_has_no_inhibitor_when_nothing_blocks():
+    svc = _build_service()
+    with patch.object(svc, "_load_config", return_value=_config()), \
+         patch.object(svc, "_load_core_uptime", return_value=(False, [])), \
+         patch("app.services.power.gaming_presence.game_is_running", return_value=False), \
+         patch("app.services.power.gaming_presence.gaming_mode_on_screen", return_value=False), \
+         patch.object(svc, "_foreign_inhibitor", return_value=None):
+        status = svc.get_status()
+
+    assert status.foreign_inhibitor is None

--- a/client/src/__tests__/components/power/sleep-config/ForeignInhibitorNotice.test.tsx
+++ b/client/src/__tests__/components/power/sleep-config/ForeignInhibitorNotice.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { ForeignInhibitorNotice } from '../../../../components/power/sleep-config/ForeignInhibitorNotice';
+import type { ForeignInhibitorStatus } from '../../../../api/sleep';
+
+const steam: ForeignInhibitorStatus = {
+  what: 'sleep:idle',
+  who: 'steam-bpm-inhibit',
+  why: 'Steam BPM oder Spiel aktiv',
+  pid: 102863,
+};
+
+describe('ForeignInhibitorNotice', () => {
+  it('renders nothing when no foreign inhibitor is held', () => {
+    const { container } = render(<ForeignInhibitorNotice inhibitor={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('names the program and its reason', () => {
+    render(<ForeignInhibitorNotice inhibitor={steam} />);
+    expect(screen.getByText('steam-bpm-inhibit')).toBeInTheDocument();
+    expect(screen.getByText(/Steam BPM oder Spiel aktiv/)).toBeInTheDocument();
+  });
+
+  it('shows the pid so the holder can be tracked down', () => {
+    render(<ForeignInhibitorNotice inhibitor={steam} />);
+    expect(screen.getByText(/102863/)).toBeInTheDocument();
+  });
+});

--- a/client/src/api/sleep.ts
+++ b/client/src/api/sleep.ts
@@ -63,6 +63,13 @@ export interface AlwaysAwakeStatus {
 
 export type PresenceMode = 'active' | 'session';
 
+export interface ForeignInhibitorStatus {
+  what: string;
+  who: string;
+  why: string;
+  pid: number;
+}
+
 export interface GamingStatus {
   game_running: boolean;
   gaming_mode: boolean;
@@ -120,6 +127,7 @@ export interface SleepStatusResponse {
   always_awake?: AlwaysAwakeStatus;
   presence?: PresenceStatus;
   gaming?: GamingStatus;
+  foreign_inhibitor?: ForeignInhibitorStatus | null;
 }
 
 export interface SleepConfigResponse {

--- a/client/src/components/power/SleepConfigPanel.tsx
+++ b/client/src/components/power/SleepConfigPanel.tsx
@@ -16,6 +16,7 @@ import {
   type SleepCapabilities,
   type PresenceStatus,
   type GamingStatus,
+  type ForeignInhibitorStatus,
 } from '../../api/sleep';
 import { getFritzBoxConfig, updateFritzBoxConfig } from '../../api/fritzbox';
 import { useSleepConfigForm } from '../../hooks/useSleepConfigForm';
@@ -26,6 +27,7 @@ import {
   EscalationCard,
   PresenceCard,
   GamingCard,
+  ForeignInhibitorNotice,
   ScheduleCard,
   WolCard,
   FritzBoxCard,
@@ -41,6 +43,7 @@ export function SleepConfigPanel() {
   const [alwaysAwakeOn, setAlwaysAwakeOn] = useState(false);
   const [presenceStatus, setPresenceStatus] = useState<PresenceStatus | null>(null);
   const [gamingStatus, setGamingStatus] = useState<GamingStatus | null>(null);
+  const [foreignInhibitor, setForeignInhibitor] = useState<ForeignInhibitorStatus | null>(null);
 
   const sleepForm = useSleepConfigForm();
   const fbForm = useFritzBoxForm();
@@ -71,6 +74,7 @@ export function SleepConfigPanel() {
         setAlwaysAwakeOn(st.always_awake?.enabled ?? false);
         setPresenceStatus(st.presence ?? null);
         setGamingStatus(st.gaming ?? null);
+        setForeignInhibitor(st.foreign_inhibitor ?? null);
       } catch {
         // ignore — status is best-effort here
       }
@@ -122,6 +126,7 @@ export function SleepConfigPanel() {
       <EscalationCard {...sleepForm.form} update={sleepForm.update} />
       <PresenceCard {...sleepForm.form} update={sleepForm.update} presenceStatus={presenceStatus} />
       <GamingCard {...sleepForm.form} update={sleepForm.update} gamingStatus={gamingStatus} />
+      <ForeignInhibitorNotice inhibitor={foreignInhibitor} />
       <ScheduleCard {...sleepForm.form} update={sleepForm.update} coreUptimeMasterOn={coreUptimeMasterOn} alwaysAwakeOn={alwaysAwakeOn} />
       <WolCard {...sleepForm.form} update={sleepForm.update} capabilities={capabilities} />
       <FritzBoxCard {...fbForm.form} update={fbForm.update} config={fbForm.config} testing={fbForm.testing} onTest={fbForm.test} capabilities={capabilities} />

--- a/client/src/components/power/sleep-config/ForeignInhibitorNotice.tsx
+++ b/client/src/components/power/sleep-config/ForeignInhibitorNotice.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next';
+import { Lock } from 'lucide-react';
+import type { ForeignInhibitorStatus } from '../../../api/sleep';
+
+type ForeignInhibitorNoticeProps = {
+  inhibitor: ForeignInhibitorStatus | null;
+};
+
+/**
+ * Names the third-party program currently blocking automatic suspend (#602).
+ *
+ * Without this the box simply never sleeps and nothing says why, which reads
+ * as a hang rather than as another program getting its way. The PID is shown
+ * because that is what you need to track the holder down.
+ *
+ * `who`, `why` and `pid` are rendered as plain nodes rather than through
+ * interpolation: a missing placeholder in a locale file is invisible in tests,
+ * since the i18n mock fabricates interpolation that the real JSON may not have.
+ */
+export function ForeignInhibitorNotice({ inhibitor }: ForeignInhibitorNoticeProps) {
+  const { t } = useTranslation('system');
+  if (!inhibitor) return null;
+
+  return (
+    <div className="card border-amber-500/30 bg-amber-500/5 p-4 sm:p-6 space-y-2">
+      <h4 className="text-sm font-medium text-amber-300 flex items-center gap-2">
+        <Lock className="h-4 w-4" />
+        {t('sleep.foreignInhibitor.title')}
+      </h4>
+      <p className="text-xs text-slate-400">{t('sleep.foreignInhibitor.description')}</p>
+      <p className="text-sm text-white">
+        <span className="font-mono">{inhibitor.who}</span>
+        {' — '}
+        {inhibitor.why}
+      </p>
+      <p className="text-xs text-slate-500">
+        {t('sleep.foreignInhibitor.detailsLabel')}{' '}
+        <span className="font-mono">{inhibitor.what}</span>
+        {', PID '}
+        <span className="font-mono">{inhibitor.pid}</span>
+      </p>
+    </div>
+  );
+}

--- a/client/src/components/power/sleep-config/index.ts
+++ b/client/src/components/power/sleep-config/index.ts
@@ -3,6 +3,7 @@ export { IdleDetectionCard } from './IdleDetectionCard';
 export { EscalationCard } from './EscalationCard';
 export { PresenceCard } from './PresenceCard';
 export { GamingCard } from './GamingCard';
+export { ForeignInhibitorNotice } from './ForeignInhibitorNotice';
 export { ScheduleCard } from './ScheduleCard';
 export { WolCard } from './WolCard';
 export { FritzBoxCard } from './FritzBoxCard';

--- a/client/src/i18n/locales/de/system.json
+++ b/client/src/i18n/locales/de/system.json
@@ -804,6 +804,11 @@
       "gameRunning": "Ein Spiel laeuft — automatischer Suspend ist ausgesetzt.",
       "bigPictureActive": "Big Picture laeuft — automatischer Suspend ist ausgesetzt.",
       "bigPictureIgnored": "Big Picture laeuft, haelt die Box laut Einstellung aber nicht wach."
+    },
+    "foreignInhibitor": {
+      "title": "Ein anderes Programm hält die Box wach",
+      "description": "Automatischer Suspend ist ausgesetzt, solange dieses Programm seine Sperre hält. Manuelles Schlafenlegen bleibt möglich.",
+      "detailsLabel": "Sperre:"
     }
   },
   "fanControl": {

--- a/client/src/i18n/locales/en/system.json
+++ b/client/src/i18n/locales/en/system.json
@@ -809,6 +809,11 @@
       "gameRunning": "A game is running — automatic suspend is suspended.",
       "bigPictureActive": "Big Picture is up — automatic suspend is suspended.",
       "bigPictureIgnored": "Big Picture is up, but per your setting it does not keep the box awake."
+    },
+    "foreignInhibitor": {
+      "title": "Another program is keeping the box awake",
+      "description": "Automatic suspend is paused while this program holds its lock. Suspending by hand still works.",
+      "detailsLabel": "Lock:"
     }
   },
   "fanControl": {


### PR DESCRIPTION
Beide Nebenbefunde aus der Diagnose zu #599, die dort bewusst ausgeklammert wurden.

Closes #600
Closes #602

---

## #600 — vier Aufrufer, ein geteilter Referenzpunkt

`psutil.cpu_percent(interval=None)` liefert die Last **seit dem letzten Aufruf von irgendwo im Prozess**, nicht seit dem letzten Aufruf des jeweiligen Moduls. Vier Aufrufer teilten sich diesen einen Punkt:

| Fundort | Aufruf | Wann |
|---|---|---|
| `services/telemetry.py` | `interval=None` | alle 3 s |
| `services/monitoring/cpu_collector.py` | `interval=None` | Kollektor-Takt |
| `services/system.py` | `interval=0.1` | jedes `/api/system/info` |
| `api/routes/metrics.py` | `interval=0.1` | jeder Prometheus-Scrape |

Die beiden blockierenden Aufrufe liefern für sich *korrekte* Werte, überschreiben dabei aber den geteilten Punkt. Und sie sitzen in Request-Pfaden: **das Dashboard pollt `/api/system/info`**. Ein Telemetrie-Tick unmittelbar danach misst über ein Millisekunden-Fenster und meldet nahezu null — und genau dieser Wert ist der, den die Schlafentscheidung liest.

Dass es ein Missverständnis war und keine Absicht, stand im Code selbst: `telemetry.py` und `cpu_collector.py` „primten" psutil **jeweils separat**, mit dem Kommentar, das mache die erste Messung genauer. Tatsächlich zerstörte jeder Prime den Punkt, den der andere gerade gesetzt hatte.

**Neu:** `services/cpu_percent_sampler.py` — jeder Verbraucher hält seinen eigenen `cpu_times()`-Vorwert. Zwei Betriebsarten, damit sich an keiner Fundstelle das Verhalten ändert:

- `CpuPercentSampler.sample()` — nicht-blockierend, für Telemetrie und Kollektor
- `measure_cpu_percent(interval)` — blockierend und **zustandslos**, für die beiden Request-Pfade; kann per Konstruktion keinen Sampler mehr stören

Die Arithmetik spiegelt psutils eigene (`guest`/`guest_nice` aus dem Total, `idle` und `iowait` nicht busy), damit die angezeigten Zahlen vergleichbar zu vorher bleiben. `psutil.cpu_percent()` kommt im App-Code nicht mehr vor — einzige Ausnahme ist der `percpu=True`-Aufruf, der einen **separaten** psutil-Referenzpunkt nutzt und genau einen Aufrufer hat.

Ein Detail, das ich bewusst nicht geglättet habe: `sample()` gibt beim allerersten Aufruf `None` zurück, nicht `0.0`. „Noch kein Referenzpunkt" und „keine Last" dürfen nicht dasselbe sein — sonst sieht ein frisch gestarteter Prozess für einen Tick vollständig idle aus, und das ist exakt die Fehlerklasse, die diesen PR ausgelöst hat.

## #602 — rtcwake umgeht alle fremden Schlafsperren

BaluHost suspendiert mit `sudo rtcwake -m mem` (`sleep_backend_linux.py:68`). Das schreibt direkt an den Kernel und passiert logind nie — Inhibitoren anderer Programme werden also gar nicht erst gegen uns durchgesetzt.

**Belegt am Vorfall vom 2026-09-08:**

```
Sep 08 22:50:24  Started steam-bpm-inhibit.service   ← danach kein Stop im Boot
23:29:09         DiRT Rally startet  → SteamLaunch im Prozessbaum
~23:29:39        Skript hält block auf sleep:idle    (15-s-Takt)
23:45:37         BaluHost suspendiert trotzdem
```

Die Schutzschicht existierte, griff, und wurde überfahren.

Da das Betriebssystem uns nicht stoppen kann, fragen wir uns selbst. **Neu:** `services/power/foreign_inhibitors.py`, gelesen über D-Bus:

```
busctl --json=short call org.freedesktop.login1 /org/freedesktop/login1 \
  org.freedesktop.login1.Manager ListInhibitors
```

Bewusst **nicht** `systemd-inhibit --list` geparst: dessen Ausgabe ist lokalisiert (auf der Box steht „Bildschirmsperre" und deutsche Begründungen) und auf Terminalbreite abgeschnitten — an genau dieser abgeschnittenen Spalte bin ich bei der Diagnose schon einmal falsch abgebogen (#601).

Zwei Filter, beide gegen die echte Ausgabe der Box validiert:

- Nur `block` zählt. `delay` verschiebt einen Suspend um Sekunden, damit ein Daemon sich vorbereiten kann — als Verweigerung gelesen hielten NetworkManager und UPower die Box für immer wach.
- `what` wird **segmentweise** ausgewertet, nicht als Teilstring. PowerDevils `handle-power-key:handle-suspend-key:...` enthält „suspend", ist aber keine Schlafsperre.

Von den acht Einträgen auf BaluNode überlebt damit genau einer: `steam-bpm-inhibit`.

Verdrahtet als fünfter Suppressor an vier Stellen — Suspend-on-Exit, Idle-Loop, Eskalation, `enter_true_suspend`. Bewusst **nicht** im Inhibitor-Reconcile: einen eigenen Inhibitor zu holen, weil ein fremder existiert, wäre sinnlos. Manueller Suspend bleibt erlaubt.

`what` wird auch beim Anwenden respektiert: `sleep` sperrt die Suspend-Pfade, `idle` zusätzlich Soft Sleep (das die CPU aufs IDLE-Profil sperrt). Der Status nennt Name, Grund und PID — „schläft nicht" ohne Namen liest sich wie ein Hänger.

**Keine Einstellung**, wie besprochen: fremde Block-Inhibitoren werden immer respektiert. Wer wach hält, steht im Status und lässt sich gezielt beenden.

## Zwei Tests, die nichts geprüft haben

Beim Bauen aufgefallen und mitrepariert — beide waren grün, ohne etwas auszuführen:

- **`test_idle_loop_does_not_soft_sleep_while_gaming`** aus PR #599: `asyncio.sleep` war so gepatcht, dass die Schleife im ersten Durchlauf abbrach, **bevor der Rumpf lief**. Damit war `assert_not_called()` trivial erfüllt und das Gaming-Gate im Idle-Loop seit dem Merge ungetestet. Jetzt läuft Iteration 1 vollständig — und per Red-Green geprüft: entfernt man das Gate, fällt der Test.
- **`test_collector_failure_is_logged[_break_system]`**: patchte `metrics.psutil.cpu_percent`, eine Naht, die dieser PR verschiebt. Auf `measure_cpu_percent` umgezogen, damit er weiterhin misst, was er messen soll.

## Tests

47 neue Tests. Zwei tragen mehr als Abdeckung:

- **`test_two_samplers_are_independent`** ist der Regressionstest für #600 in einem Satz: zwei Sampler an derselben Uhr, beide müssen ihr volles Fenster sehen.
- **Der Parser wird gegen die wörtliche `busctl`-Ausgabe von BaluNode getestet**, nicht nur gegen nachgebaute Fixtures. Synthetische Fixtures können sich untereinander einig und trotzdem die falsche Form sein; diese kann es nicht.

Lokal grün: `pytest tests/services tests/monitoring tests/api tests/schemas tests/models tests/plugins tests/migrations` (2946 passed, 7 skipped), `npx vitest run` (1386), `npx eslint .` (0 Fehler), `npm run build`. Volle Backend-Suite in der CI.

Keine Migration, kein Schema-Bruch — `foreign_inhibitor` ist optional und fehlt einfach, wenn nichts blockiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxdKsB3ywUyzYkUpa9ckvf
