### PR TITLE
test(e2e): Firefox als zweite Engine aufnehmen (#545)

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -122,7 +122,12 @@ jobs:
                 "v$have"|"v$have"-*) ;;
                 *) echo "::error::Playwright version drift: package-lock has $have, image is $want — bump PLAYWRIGHT_IMAGE"; exit 1 ;;
               esac
-              npx playwright test --project=chromium --reporter=list --workers=2
+              # Kein --project-Filter: die Projektliste in client/playwright.config.ts
+              # ist die einzige Quelle (chromium + firefox, #545). Ein Filter hier
+              # wuerde ein neu aufgenommenes Projekt stillschweigend uebergehen —
+              # genau das war der Fall, als firefox dazukam.
+              # Die Browser liegen fertig in /ms-playwright des Images, auch firefox.
+              npx playwright test --reporter=list --workers=2
             '
 
   live-e2e:

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -12,8 +12,15 @@ export default defineConfig({
     actionTimeout: 10_000,
     locale: 'en-US',
   },
+  // Zwei Engines, damit engine-spezifische Layout-/API-Unterschiede auffallen (#545).
+  // Beide Device-Profile bringen 1280x720 mit und ueberschreiben damit `use.viewport`
+  // oben — der Viewport ist bewusst identisch, hier geht es nur um die Engine.
+  // Ein zusaetzlicher Viewport folgt separat; 1920x1080 waere wirkungslos (zwischen
+  // 1280 und 1920 unterscheiden sich genau drei `2xl:`-Utilities in CpuTab.tsx,
+  // die keine Spec anfasst) — die ungetestete Flaeche liegt unter 640px.
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
   ],
   webServer: {
     command: 'npm run dev -- --port 5173',


### PR DESCRIPTION
Erster Schritt aus #545: eine zweite Engine. Der zweite Viewport folgt separat — in der im Issue vorgeschlagenen Form wäre er messbar wirkungslos (Begründung unten).

## Änderung

**`client/playwright.config.ts`** — `firefox` als zweites Projekt (`devices['Desktop Firefox']`, gleicher Viewport wie chromium: beide Device-Profile bringen 1280×720 mit).

**`.github/workflows/playwright-e2e.yml`** — der `--project=chromium`-Filter in `mock-e2e` fällt weg. Ohne das hätte die CI das neue Projekt stillschweigend übergangen; die Projektliste in der Config ist jetzt die einzige Quelle. Die Browser liegen fertig in `/ms-playwright` des gepinnten Playwright-Images, auch Firefox — kein zusätzlicher Download, keine Änderung an der Podman-Isolation (Layer B unverändert: der Aufruf bleibt im `podman run bash -c`). `live-e2e` behält seinen expliziten `--project=chromium` (eine einzelne Spec, zweite Engine dort ohne Nutzen).

## Verifikation

Keine Spec musste angepasst werden — Firefox läuft out-of-the-box durch:

| Lauf | Tests | Zeit |
|---|---|---|
| vorher (chromium) | 24 passed, 1 skipped | 9,7 s |
| nachher (chromium + firefox) | 48 passed, 2 skipped | 26,2 s |

Weitere Gates lokal: `npx eslint .` → 0 errors (280 vorbestehende Warnings), `npm run build` (tsc -b) → grün.

## Was bewusst nicht drin ist

Der in #545 vorgeschlagene `chromium-fhd`-Viewport (1920×1080). Gemessen bringt der heute nichts:

- Breakpoint-Zählung über `client/src`: `sm: 1570, lg: 106, md: 47, xl: 16, 2xl: 3` — Tailwind-Defaults, keine eigenen `screens`. Bei 1280 sind `sm`/`md`/`lg`/`xl` bereits alle aktiv.
- Zwischen 1280 und 1920 ändern sich damit genau **drei** Utilities im gesamten Frontend: `2xl:grid-cols-6` in `client/src/components/system-monitor/CpuTab.tsx:321,370,416`. Keine Spec fasst CpuTab an.
- Probelauf mit allen drei Projekten: 72/72 grün, der FHD-Lauf eine exakte Kopie des chromium-Laufs.

Die tatsächlich ungetestete responsive Fläche liegt **unter 640 px** (1570 `sm:`-Utilities, `@media (max-width: 639px)` in `src/index.css`, Hamburger-/Off-Canvas-Navigation) — dorthin gehört das nächste Viewport-Projekt, nicht nach 1920.

## Zwei Nebenbefunde in #545 (nicht in diesem PR)

1. Der effektive Viewport ist **1280×720**, nicht 1280×800 wie im Issue beschrieben: `devices['Desktop Chrome']` bringt einen eigenen Viewport mit, und `projects[].use` überschreibt das Top-Level-`use`. Die Zeile `viewport: { width: 1280, height: 800 }` in `playwright.config.ts:9` ist tote Konfiguration, und der Kommentar in `client/tests/e2e/local-only.spec.ts:88` wiederholt denselben Irrtum.
2. Für den TV-Betriebsfall (#523) misst ein größerer Viewport bei `deviceScaleFactor: 1` nichts — das ist dasselbe CSS-Pixel-Layout, nur mehr davon. Schriftgröße und Trefferfläche auf drei Meter hängen an der Skalierung.

Closes #545 nicht — der Viewport-Teil bleibt offen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxdKsB3ywUyzYkUpa9ckvf
