### PR TITLE
fix(display): Topbar-Symbol behauptet nicht mehr "an", solange es nichts weiß

### DIFF
--- a/client/src/__tests__/components/topbar/DisplayMenu.test.tsx
+++ b/client/src/__tests__/components/topbar/DisplayMenu.test.tsx
@@ -54,6 +54,10 @@ const LAYOUT = {
 };
 
 beforeEach(() => {
+  // Weder vite.config.ts noch setup.ts setzen `clearMocks`, die Zaehler
+  // ueberleben also den einzelnen Test. Ohne das hier misst jede Aussage der
+  // Form "genau einmal abgefragt" die Aufrufe aller vorherigen Tests mit.
+  vi.clearAllMocks();
   vi.mocked(getMyPowerPermissions).mockResolvedValue({ can_manage_displays: true } as never);
   vi.mocked(getDisplayLayout).mockResolvedValue(structuredClone(LAYOUT) as never);
 });
@@ -81,9 +85,31 @@ describe('DisplayMenu', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('fragt erst ab, wenn das Popover offen ist', async () => {
+  it('fragt einmal beim Mounten ab, damit das Symbol nicht raet', async () => {
+    // Frueher wurde erst beim Oeffnen gefragt. Dadurch behauptete das Symbol
+    // nach jedem Seitenaufbau "an", bis jemand einmal geklickt hatte.
     render(<DisplayMenu />);
     await screen.findByLabelText('display:title');
+    await waitFor(() => expect(getDisplayLayout).toHaveBeenCalledTimes(1));
+  });
+
+  it('pollt nicht weiter, solange das Popover zu bleibt', async () => {
+    // Der eine Abruf beim Mounten ersetzt kein Hintergrund-Polling: eine
+    // Fernbedienung, die im Hintergrund taktet, kostet Anfragen ohne Wert.
+    render(<DisplayMenu />);
+    await screen.findByLabelText('display:title');
+    await waitFor(() => expect(getDisplayLayout).toHaveBeenCalledTimes(1));
+    vi.useFakeTimers();
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(getDisplayLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it('fragt nichts ab ohne das Recht', async () => {
+    // Sonst feuert jeder Nutzer ohne Recht bei jedem Seitenaufbau eine
+    // Anfrage, die nur mit 403 zurueckkommt.
+    vi.mocked(getMyPowerPermissions).mockResolvedValue({ can_manage_displays: false } as never);
+    render(<DisplayMenu />);
+    await waitFor(() => expect(getMyPowerPermissions).toHaveBeenCalled());
     expect(getDisplayLayout).not.toHaveBeenCalled();
   });
 
@@ -138,22 +164,32 @@ describe('DisplayMenu', () => {
     expect(await screen.findByText('display:unavailable')).toBeTruthy();
   });
 
-  it('zeigt das neutrale Monitor-Symbol vor dem ersten Laden, nicht "dunkel"', async () => {
-    // Vor dem ersten Oeffnen wurde nie gefragt, ob etwas leuchtet - "dunkel"
-    // zu behaupten waere hier dieselbe Falschaussage wie bei `lit === null`.
+  it('zeichnet das Symbol gedaempft, solange der Zustand unbekannt ist', async () => {
+    // Vor der ersten Antwort ist "leuchtet" nicht beantwortet, sondern noch
+    // nicht gefragt. `Monitor` allein ist dafuer nicht neutral - es ist das
+    // An-Symbol. Die Daempfung macht den Unterschied sichtbar.
+    let resolveLayout: (value: unknown) => void = () => {};
+    vi.mocked(getDisplayLayout).mockReturnValue(
+      new Promise((resolve) => {
+        resolveLayout = resolve;
+      }) as never,
+    );
     const { container } = render(<DisplayMenu />);
     await screen.findByLabelText('display:title');
-    expect(container.querySelector('.lucide-monitor-off')).toBeNull();
-    expect(container.querySelector('.lucide-monitor')).toBeTruthy();
+    expect(container.querySelector('.lucide-monitor')?.getAttribute('class')).toContain('opacity-40');
+    resolveLayout(structuredClone(LAYOUT));
+    await waitFor(() =>
+      expect(container.querySelector('.lucide-monitor-off')?.getAttribute('class')).not.toContain(
+        'opacity-40',
+      ),
+    );
   });
 
-  it('zeigt MonitorOff erst, nachdem ein geladenes Layout nichts Leuchtendes zeigt', async () => {
-    // LAYOUT hat beide Ausgaenge mit lit: false - jetzt ist "dunkel"
-    // tatsaechlich beantwortet, nicht nur unbekannt.
+  it('zeigt MonitorOff ohne Klick, sobald das Layout nichts Leuchtendes meldet', async () => {
+    // LAYOUT hat beide Ausgaenge mit lit: false. Frueher blieb das Symbol
+    // bis zum ersten Oeffnen auf "an" stehen - genau der gemeldete Fehler.
     const { container } = render(<DisplayMenu />);
-    const button = await screen.findByLabelText('display:title');
-    fireEvent.click(button);
-    await waitFor(() => expect(getDisplayLayout).toHaveBeenCalled());
+    await screen.findByLabelText('display:title');
     await waitFor(() => expect(container.querySelector('.lucide-monitor-off')).toBeTruthy());
   });
 

--- a/client/src/components/topbar/DisplayMenu.tsx
+++ b/client/src/components/topbar/DisplayMenu.tsx
@@ -5,8 +5,10 @@
  * ein Auswahlfeld für den Video-Modus.
  *
  * Drei Eigenheiten, die Absicht sind:
- * - Der Zustand wird nur abgefragt, solange das Popover offen ist. Eine
- *   Fernbedienung, die im Hintergrund pollt, kostet Anfragen ohne Gegenwert.
+ * - Abgefragt wird einmal beim Mounten und danach nur, solange das Popover
+ *   offen ist. Eine Fernbedienung, die im Hintergrund taktet, kostet Anfragen
+ *   ohne Gegenwert; der eine Abruf dagegen verhindert, dass das Symbol bis
+ *   zum ersten Klick einen Zustand behauptet, den niemand erfragt hat.
  * - „gewählt" (KWin) und „leuchtet" (DRM) sind getrennte Aussagen. Beides in
  *   ein Abzeichen zu falten, ist die Verwechslung, die dieses Feature auflöst.
  * - Der globale Ein/Aus-Schalter fehlt bewusst: er steht zwei Symbole weiter
@@ -102,6 +104,17 @@ export function DisplayMenu() {
     // und wird erst beim Rendern übersetzt, nie hier drin.
   }, []);
 
+  // Ein einziger Abruf, sobald das Recht feststeht. Ohne ihn bliebe das
+  // Symbol bis zum ersten Öffnen auf „unbekannt" stehen — und weil es dafür
+  // kein eigenes Zeichen gibt, las sich das als „an", auch wenn alles dunkel
+  // war. Kein Intervall: Hintergrund-Takt kostet Anfragen ohne Gegenwert.
+  // Gated auf `allowed === true`, sonst feuert jeder Nutzer ohne Recht bei
+  // jedem Seitenaufbau eine Anfrage, die nur mit 403 zurückkommt.
+  useEffect(() => {
+    if (allowed !== true) return;
+    void refresh();
+  }, [allowed, refresh]);
+
   useEffect(() => {
     if (!isOpen) return;
     // Eine saveError/conflictError aus einer vorigen Sitzung gehört nicht in
@@ -175,11 +188,13 @@ export function DisplayMenu() {
   if (!allowed) return null;
 
   const anyLit = layout?.outputs.some((o) => o.lit === true) ?? false;
-  // Vor dem ersten geladenen Layout ist "leuchtet keiner" nicht beantwortet,
-  // sondern schlicht noch nicht gefragt — dasselbe Falschaussage-Muster wie
-  // bei `lit`. Erst nach einem geladenen Layout darf das Symbol wirklich
-  // "dunkel" behaupten.
-  const showLitIcon = layout === null || anyLit;
+  // Drei Zustände, zwei Symbole: „unbekannt" darf weder als „dunkel" noch als
+  // „an" durchgehen. `MonitorOff` bleibt dem beantworteten Fall vorbehalten,
+  // und solange die Antwort aussteht, dämpft `unknown` das Symbol — sonst
+  // behauptet die ungedämpfte `Monitor`-Form „an" (der gemeldete Fehler).
+  const unknown = layout === null;
+  const showLitIcon = unknown || anyLit;
+  const iconClass = `h-5 w-5${unknown ? ' opacity-40' : ''}`;
 
   return (
     <div className="relative" ref={dropdownRef}>
@@ -196,7 +211,7 @@ export function DisplayMenu() {
         }}
         className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-800 text-slate-400 transition hover:border-sky-500/50 hover:text-sky-400"
       >
-        {showLitIcon ? <Monitor className="h-5 w-5" /> : <MonitorOff className="h-5 w-5" />}
+        {showLitIcon ? <Monitor className={iconClass} /> : <MonitorOff className={iconClass} />}
       </button>
 
       {isOpen && (


### PR DESCRIPTION
Das Display-Symbol in der Topbar zeigte „an", obwohl alle Ausgänge dunkel waren — und stimmte erst, nachdem man das Popover einmal geöffnet hatte. Auf BaluNode gemeldet.

## Ursache

`DisplayMenu` kennt drei Zustände — **unbekannt**, **leuchtet**, **dunkel** — hatte aber nur zwei Symbole:

```ts
const showLitIcon = layout === null || anyLit;   // unbekannt → Monitor ("an")
```

`layout` wurde ausschließlich geladen, solange das Popover offen war. Nach jedem Seitenaufbau war *unbekannt* damit nicht ein kurzes Flackern, sondern der **Dauerzustand** — das Symbol behauptete durchgehend „an".

Die ursprüngliche Absicht war richtig und stand auch so im Kommentar: „dunkel" darf man nicht behaupten, solange niemand gefragt hat. Sie vermied nur genau eine der beiden möglichen Falschaussagen und ersetzte sie durch die andere. Der zugehörige Test nannte `Monitor` „das neutrale Monitor-Symbol" — das ist es nicht: es unterscheidet sich von `MonitorOff` ausschließlich dadurch, dass es „an" bedeutet.

## Änderung

- **Ein einziger Abruf**, sobald das Recht feststeht. Kein Hintergrund-Takt — die Begründung gegen Polling im Docstring bleibt gültig und ist dort präzisiert. Gated auf `allowed === true`, sonst löst jeder Nutzer ohne `can_manage_displays` bei jedem Seitenaufbau eine Anfrage aus, die nur mit 403 zurückkommt.
- **Gedämpftes Symbol** (`opacity-40`), solange keine Antwort da ist — statt in voller Form „an" zu behaupten. Das Zeitfenster ist jetzt kurz, aber der Zustand existiert weiter und soll nicht lügen.

`MonitorOff` bleibt wie bisher dem beantworteten Fall vorbehalten.

## Tests

Zwei Tests kodierten das alte Verhalten und sind ersetzt:

| vorher | jetzt |
|---|---|
| „fragt erst ab, wenn das Popover offen ist" | „fragt einmal beim Mounten ab" + „pollt nicht weiter, solange das Popover zu bleibt" (Fake-Timer über 30 s) |
| „zeigt das neutrale Monitor-Symbol vor dem ersten Laden" | „zeichnet das Symbol gedämpft, solange der Zustand unbekannt ist" (hängendes Promise, dann aufgelöst) |

Neu dazu: „fragt nichts ab ohne das Recht" und „zeigt MonitorOff **ohne Klick**, sobald das Layout nichts Leuchtendes meldet" — Letzteres ist der gemeldete Fehler als Regressionstest.

## Nebenbefund, mitbehoben

Weder `vite.config.ts` noch `src/__tests__/setup.ts` setzen `clearMocks`/`restoreMocks`, und `setup.ts` hat keinen globalen `beforeEach`. Die Aufrufzähler der Modul-Mocks überleben damit den einzelnen Test. Der alte `expect(getDisplayLayout).not.toHaveBeenCalled()` kam nur durch, weil er zufällig früh in der Datei stand. Der `beforeEach` dieser Datei räumt jetzt mit `vi.clearAllMocks()` auf — ohne das misst jede Aussage der Form „genau einmal abgefragt" die Aufrufe aller vorherigen Tests mit.

Das betrifft potenziell weitere Testdateien, die Modul-Mocks teilen; global umzustellen ist hier aber out of scope.

## Verifikation

- `npx vitest run src/__tests__/components/topbar/DisplayMenu.test.tsx` — 15/15 grün
- `npx vitest run` — 1420 Tests in 285 Dateien grün
- `npx eslint .` — 0 Fehler
- `npm run build` — sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URkDnpT8unFAsBejQ3kGRp
