### PR TITLE
fix(power): Dynamic-Mode-Zustand ueber Worker und Neustart hinweg korrigieren

### DIFF
--- a/backend/app/services/power/config_store.py
+++ b/backend/app/services/power/config_store.py
@@ -127,10 +127,10 @@ def load_dynamic_mode_config() -> Optional[DynamicModeConfig]:
                     min_freq_mhz=db_config.min_freq_mhz,
                     max_freq_mhz=db_config.max_freq_mhz,
                 )
-                logger.info(f"Loaded dynamic mode config from DB: enabled={config.enabled}")
+                logger.debug(f"Loaded dynamic mode config from DB: enabled={config.enabled}")
                 return config
             else:
-                logger.info("No dynamic mode config in DB, using defaults")
+                logger.debug("No dynamic mode config in DB, using defaults")
                 return DynamicModeConfig()  # type: ignore[call-arg]
         finally:
             db.close()

--- a/backend/app/services/power/manager.py
+++ b/backend/app/services/power/manager.py
@@ -219,17 +219,27 @@ class PowerManagerService:
             return False, "Failed to enqueue command"
         return await command_queue.wait_for_completion(cmd_id)
 
-    async def _primary_disable_dynamic_mode(self) -> Tuple[bool, Optional[str]]:
+    async def _mark_dynamic_mode_off(self) -> None:
+        """Clear dynamic mode locally and in both shared stores.
+
+        ``power_dynamic_mode_config`` keeps the governor and frequency window so
+        a later re-enable starts from the user's settings; only ``enabled``
+        flips. The flag must be cleared before any profile is applied:
+        ``_apply_profile_internal()`` and ``_check_auto_scaling()`` both
+        early-return while it is set.
+        """
         async with self._state_lock:
             self._dynamic_mode_enabled = False
             self._dynamic_mode_config = None
 
-        # Save disabled state
         saved_config = load_dynamic_mode_config()
         if saved_config:
             saved_config.enabled = False
             save_dynamic_mode_config(saved_config)
         update_runtime_state(dynamic_mode_enabled=False)
+
+    async def _primary_disable_dynamic_mode(self) -> Tuple[bool, Optional[str]]:
+        await self._mark_dynamic_mode_off()
 
         # Recalculate and apply the appropriate profile
         async with self._state_lock:
@@ -431,7 +441,16 @@ class PowerManagerService:
         if dynamic_config and dynamic_config.enabled:
             success, error = await self._primary_enable_dynamic_mode(dynamic_config)
             if not success:
-                logger.warning(f"Failed to restore dynamic mode on start: {error}, falling back to IDLE")
+                logger.warning(
+                    f"Failed to restore dynamic mode on start: {error} - "
+                    "turning dynamic mode off and falling back to IDLE"
+                )
+                # _hydrate_from_runtime_state() already set the flag from the
+                # shared state. Leaving it set after a failed restore left the
+                # box with no power management at all: dynamic mode was never
+                # applied, while the flag made _apply_profile_internal() skip
+                # the IDLE fallback and _check_auto_scaling() return early.
+                await self._mark_dynamic_mode_off()
                 await self._primary_apply_profile(PowerProfile.IDLE, reason="service_start")
         else:
             await self._primary_apply_profile(PowerProfile.IDLE, reason="service_start")
@@ -465,6 +484,18 @@ class PowerManagerService:
         self._manual_override_until = state.get("manual_override_until")
         self._cooldown_until = state.get("cooldown_until")
         self._dynamic_mode_enabled = bool(state.get("dynamic_mode_enabled"))
+        # The runtime-state row carries only the on/off flag. Governor and
+        # frequency window live in power_dynamic_mode_config, written by
+        # _primary_enable_dynamic_mode() in the same breath as the flag -- but
+        # only the primary ever fills the local field. Without this re-read a
+        # follower answers with dynamic_mode_config=None, which shows up as a
+        # bare "Dynamic" pill and skips the dynamic-mode freq-range override in
+        # get_power_status(). Read per call so a governor change on the primary
+        # reaches followers at once.
+        if self._dynamic_mode_enabled:
+            self._dynamic_mode_config = load_dynamic_mode_config() or self._dynamic_mode_config
+        else:
+            self._dynamic_mode_config = None
         self._last_profile_change = state.get("last_profile_change")
 
     async def stop(self) -> None:

--- a/backend/tests/services/test_power_manager.py
+++ b/backend/tests/services/test_power_manager.py
@@ -488,6 +488,63 @@ class TestPowerManagerServiceStartStop:
             await service.stop()
 
     @pytest.mark.asyncio
+    async def test_failed_dynamic_mode_restore_reports_disabled(self):
+        """A dynamic-mode restore that fails on start must not leave the flag on.
+
+        start() hydrates ``_dynamic_mode_enabled=True`` from
+        ``power_runtime_state`` before attempting the restore. When
+        ``_primary_enable_dynamic_mode()`` then fails -- e.g. the configured
+        governor no longer exists after a kernel/driver change -- the code falls
+        back to the IDLE profile, but the flag stayed True. Status (and with it
+        the topbar pill) kept claiming dynamic mode while profile scaling was
+        actually running.
+        """
+        from app.schemas.power import DynamicModeConfig
+        from app.services.power.config_store import (
+            load_runtime_state,
+            update_runtime_state,
+        )
+
+        stored = DynamicModeConfig(
+            enabled=True,
+            governor="nonexistent-gov",  # not in DevCpuPowerBackend's governor list
+            min_freq_mhz=800,
+            max_freq_mhz=3200,
+        )
+        update_runtime_state(dynamic_mode_enabled=True)
+
+        service = PowerManagerService()
+        saved = MagicMock(return_value=True)
+        with patch('app.services.power.manager.load_auto_scaling_config', return_value=AutoScalingConfig()),              patch('app.services.power.manager.load_dynamic_mode_config', return_value=stored),              patch('app.services.power.manager.save_dynamic_mode_config', saved):
+            await service.start()
+
+        try:
+            assert service._current_profile == PowerProfile.IDLE
+            assert service._dynamic_mode_enabled is False
+            assert service._dynamic_mode_config is None
+            assert load_runtime_state()["dynamic_mode_enabled"] is False
+
+            status = await service.get_power_status()
+            assert status.dynamic_mode_enabled is False
+            assert status.dynamic_mode_config is None
+
+            # Profile scaling must work again afterwards. While the stale flag
+            # was set, _apply_profile_internal() short-circuited with "Skipping
+            # profile change - dynamic mode active" and _check_auto_scaling()
+            # early-returned on the same flag, so the box ran with neither
+            # dynamic mode nor profile scaling until the next restart.
+            await service._primary_apply_profile(PowerProfile.MEDIUM, reason="post_restore")
+            assert service._current_profile == PowerProfile.MEDIUM
+
+            # The user's governor/frequency choice survives; only the flag flips
+            assert saved.call_args is not None
+            persisted = saved.call_args.args[0]
+            assert persisted.enabled is False
+            assert persisted.governor == "nonexistent-gov"
+        finally:
+            await service.stop()
+
+    @pytest.mark.asyncio
     async def test_stop_cleans_up(self):
         """Test that stop() cleans up properly."""
         service = PowerManagerService()
@@ -635,6 +692,59 @@ class TestPowerManagerServiceStatus:
         assert resp.available_governors == ["powersave", "performance", "schedutil"]
         assert resp.system_min_freq_mhz == 400
         assert resp.system_max_freq_mhz == 4600
+
+    @pytest.mark.asyncio
+    async def test_follower_power_status_restores_dynamic_mode_config(self):
+        """A follower must report the dynamic-mode config, not only the flag.
+
+        Regression (multi-worker): ``_hydrate_from_runtime_state`` synced
+        ``_dynamic_mode_enabled`` from ``power_runtime_state`` but never
+        ``_dynamic_mode_config``, which only ``_primary_enable_dynamic_mode``
+        ever set. With 4 Uvicorn workers a status request landing on one of the
+        3 followers returned ``dynamic_mode_config=None``, so the topbar power
+        pill flapped between "Dynamic - <governor>" (primary) and a bare
+        "Dynamic" (follower), and the dynamic-mode override of
+        ``target_frequency_range`` never fired there either.
+        """
+        from app.schemas.power import DynamicModeConfig
+        from app.services.power.config_store import (
+            save_dynamic_mode_config,
+            update_runtime_state,
+        )
+
+        save_dynamic_mode_config(
+            DynamicModeConfig(
+                enabled=True,
+                governor="powersave",
+                min_freq_mhz=800,
+                max_freq_mhz=3200,
+            )
+        )
+        update_runtime_state(dynamic_mode_enabled=True)
+        try:
+            follower = PowerManagerService()
+            follower._is_running = True
+            follower._primary = False
+            follower._backend = None  # follower owns no hardware backend
+            follower._dynamic_mode_config = None  # never set outside the primary
+
+            status = await follower.get_power_status()
+
+            assert status.dynamic_mode_enabled is True
+            assert status.dynamic_mode_config is not None
+            assert status.dynamic_mode_config.governor == "powersave"
+            # The dynamic-mode freq-range override must fire on followers too
+            assert status.target_frequency_range == "800-3200 MHz"
+        finally:
+            update_runtime_state(dynamic_mode_enabled=False)
+            save_dynamic_mode_config(
+                DynamicModeConfig(
+                    enabled=False,
+                    governor="powersave",
+                    min_freq_mhz=800,
+                    max_freq_mhz=3200,
+                )
+            )
 
     @pytest.mark.asyncio
     async def test_primary_writes_capabilities_into_shm(self, service):


### PR DESCRIPTION
## Problem

Die Topbar-Power-Pill sprang zwischen `Dynamic - powersave` und einem nackten `Dynamic`. Die Untersuchung fand zwei unabhaengige Fehler im geteilten Dynamic-Mode-Zustand des `PowerManagerService`.

### 1. Follower-Worker kennen die Dynamic-Mode-Config nicht

`_hydrate_from_runtime_state()` synchronisiert das Flag `dynamic_mode_enabled` aus `power_runtime_state`, aber nie `_dynamic_mode_config` -- das setzt ausschliesslich `_primary_enable_dynamic_mode()` prozesslokal. In `start()` wird die Config zwar geladen, der Follower-Zweig kehrt aber vorher zurueck, ohne sie zuzuweisen.

Prod laeuft mit `--workers 4` (1 Primary + 3 Follower). Ein Status-Request traf damit in ~75 % der Faelle einen Worker mit `dynamic_mode_enabled=True, dynamic_mode_config=None`:

```python
# collectors.py:35-41
if getattr(status, "dynamic_mode_enabled", False):
    gov = getattr(getattr(status, "dynamic_mode_config", None), "governor", None)
    if gov:  -> "Dynamic - powersave"
    else:    -> "Dynamic"          # <- Follower
```

Zweites Symptom aus derselben Ursache: der Dynamic-Mode-Override von `target_frequency_range` (`manager.py`) feuerte auf Followern nie, der Energie-Tab zeigte dort den stale Preset-Frequenzbereich.

**Fix:** bei gesetztem Flag die Config aus `power_dynamic_mode_config` nachlesen. Gleicher Kanal und dieselbe Schreibtransaktion wie das Flag (`_primary_enable_dynamic_mode()` schreibt `save_dynamic_mode_config()` + `update_runtime_state()` direkt hintereinander), und derselbe Fallback, den `get_dynamic_mode_config()` fuer dieses Feld schon benutzt. Pro Aufruf gelesen, nicht gecacht -- ein Governor-Wechsel aendert das Flag nicht, ein Cache wuerde also veralten. SHM waere der falsche Kanal: zweite Wahrheitsquelle plus 15-s-Verfall, der den nackten Pill periodisch zurueckbraechte.

### 2. Fehlgeschlagene Wiederherstellung legt die Energieverwaltung lahm

Beim Review von (1) gefunden, auf Wunsch mitgefixt.

Schlaegt `_primary_enable_dynamic_mode()` in `start()` fehl -- realistisch: der konfigurierte Governor existiert nach einem Kernel-/Treiberwechsel nicht mehr -- loggt der Code eine Warnung und faellt auf IDLE zurueck. Aber `_hydrate_from_runtime_state()` hat das Flag kurz zuvor aus dem Runtime-State gesetzt, und `_apply_profile_internal()` hat selbst einen Guard:

```python
# Skip profile changes while dynamic mode is active
if self._dynamic_mode_enabled:
    return True, None
```

Der IDLE-Fallback war damit ein No-op, und `_check_auto_scaling()` kehrt am selben Flag frueh zurueck. Die Box lief bis zum naechsten Neustart mit **weder** Dynamic Mode (nie angewandt) **noch** Profil-Scaling -- und meldete dabei nach aussen "Dynamic".

**Fix:** der Zustandsuebergang aus `_primary_disable_dynamic_mode()` ist als `_mark_dynamic_mode_off()` herausgezogen und laeuft im Fehlerzweig vor dem IDLE-Fallback. Governor und Frequenzen bleiben in `power_dynamic_mode_config` erhalten, nur `enabled` kippt -- Wiedereinschalten ist ein Klick mit den alten Einstellungen.

## Tests

Zwei Regressionstests in `backend/tests/services/test_power_manager.py`, beide vorher gegen den unveraenderten Code als rot verifiziert:

- `test_follower_power_status_restores_dynamic_mode_config` -- Follower (`_primary=False`, `_backend=None`) gegen DB-State; prueft Governor **und** `target_frequency_range == "800-3200 MHz"`.
  Vorher: `AssertionError: assert None is not None`
- `test_failed_dynamic_mode_restore_reports_disabled` -- Start mit unbekanntem Governor; prueft lokales Flag, Runtime-State, Status-Response, dass ein spaeterer Profilwechsel wieder greift, und dass nur `enabled` persistiert kippt.
  Vorher: `AssertionError: assert True is False`

```
211 passed   power_{manager,command_queue,enforcement,presets,permissions},
             power_routes, power_authority_routes,
             status_bar_{collectors,service,routes}
ruff: All checks passed!
```

Volle Backend-Suite: CI (haengt unter Windows).

## Nebenwirkung

`load_dynamic_mode_config()` laeuft jetzt pro Status-Request auf den Followern (eine Single-Row-Query; die Methode macht ohnehin schon `load_auto_scaling_config()` + `list_active_demands()`). Damit das nicht ins Prod-Log spamt, sind seine beiden INFO-Zeilen auf DEBUG gesenkt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S5sYDfvoqTacrTUFZvPSK
