### PR TITLE
fix(notifications): 3-Versuche-Sperre fuer Ablaufwarnungen greift wieder (#231)

### DIFF
--- a/backend/app/services/notifications/scheduler.py
+++ b/backend/app/services/notifications/scheduler.py
@@ -179,29 +179,33 @@ class NotificationScheduler:
         if now < warning_time:
             return False, "Not yet due"
 
-        # Already handled for this exact expiry (sent or superseded)?
-        existing_notification = db.query(ExpirationNotification).filter(
+        # Already handled for this exact expiry? Ask for a successful row
+        # specifically -- _send_warning appends a row per attempt and
+        # _record_superseded writes success=True, so failure rows may sit
+        # alongside it. Matching on "any row" and reading its success flag
+        # would re-send to a user who already got the warning.
+        sent_notification = db.query(ExpirationNotification).filter(
             ExpirationNotification.device_id == device.id,
             ExpirationNotification.notification_type == warning_type,
-            ExpirationNotification.device_expires_at == device.expires_at
+            ExpirationNotification.device_expires_at == device.expires_at,
+            ExpirationNotification.success == True
         ).first()
 
-        if existing_notification:
-            # Retry previously failed notifications (up to 3 attempts)
-            if not existing_notification.success:
-                fail_count = db.query(ExpirationNotification).filter(
-                    ExpirationNotification.device_id == device.id,
-                    ExpirationNotification.notification_type == warning_type,
-                    ExpirationNotification.device_expires_at == device.expires_at,
-                    ExpirationNotification.success == False
-                ).count()
-                if fail_count < 3:
-                    # Delete failed record so _send_warning creates a fresh one
-                    db.delete(existing_notification)
-                    db.flush()
-                    return True, ""
-                return False, f"Max retries reached ({fail_count} failures)"
+        if sent_notification:
             return False, "Warning already sent"
+
+        # Retry previously failed notifications (up to 3 attempts). The failure
+        # rows are kept so this count grows 1 -> 2 -> 3 across ticks; deleting
+        # the row before each retry pinned it at 1 and made the cap below
+        # unreachable, retrying a dead FCM token until the device expired (#231).
+        fail_count = db.query(ExpirationNotification).filter(
+            ExpirationNotification.device_id == device.id,
+            ExpirationNotification.notification_type == warning_type,
+            ExpirationNotification.device_expires_at == device.expires_at,
+            ExpirationNotification.success == False
+        ).count()
+        if fail_count >= 3:
+            return False, f"Max retries reached ({fail_count} failures)"
 
         return True, ""
     

--- a/backend/tests/services/test_notification_scheduler_catchup.py
+++ b/backend/tests/services/test_notification_scheduler_catchup.py
@@ -163,3 +163,72 @@ class TestCheckAndSendWarnings:
         # Less-urgent warnings must NOT be superseded — they retry next tick.
         assert "3_days" not in rows
         assert "7_days" not in rows
+
+    def test_failed_send_stops_after_three_attempts(self, db_session, admin_user, monkeypatch):
+        """The 3-attempt cap must actually stop the retries (#231).
+
+        _should_send_warning deleted the failed row before each retry, so
+        fail_count was pinned at 1, "Max retries reached" was dead code, and a
+        permanently broken FCM token was retried on every tick (hourly plus
+        every resume/startup catch-up) until the device expired.
+        """
+        calls = []
+
+        def _send_fail(device_token, device_name, expires_at, warning_type, server_url):
+            calls.append(warning_type)
+            return {"success": False, "message_id": None, "error": "token expired"}
+
+        monkeypatch.setattr(
+            "app.services.notifications.firebase.FirebaseService.send_expiration_warning",
+            staticmethod(_send_fail),
+        )
+        now = datetime.now(timezone.utc)
+        device = _make_device(db_session, admin_user, now + timedelta(minutes=30))
+
+        for _ in range(5):
+            NotificationScheduler.check_and_send_warnings(db_session)
+
+        assert calls == ["1_hour"] * 3
+        failed = [
+            r for r in self._rows(db_session, device)
+            if r.notification_type == "1_hour" and not r.success
+        ]
+        assert len(failed) == 3
+
+        should_send, reason = NotificationScheduler._should_send_warning(
+            db=db_session, device=device, warning_type="1_hour",
+            warning_time=now - timedelta(minutes=1), now=now,
+        )
+        assert should_send is False
+        assert "Max retries reached" in reason
+
+    def test_no_resend_after_a_retry_succeeds(self, db_session, admin_user, monkeypatch):
+        """A succeeded retry ends it -- kept failure rows must not re-trigger.
+
+        Guard for the naive #231 fix (just drop the delete and let failure rows
+        accumulate): _should_send_warning picked an arbitrary row via .first()
+        and only read its success flag, so a lingering failure row made every
+        later tick re-send a warning the user had already received.
+        """
+        state = {"fail": True}
+        sends = []
+
+        def _send(device_token, device_name, expires_at, warning_type, server_url):
+            if state["fail"]:
+                return {"success": False, "message_id": None, "error": "transient"}
+            sends.append(warning_type)
+            return {"success": True, "message_id": "mid-retry", "error": None}
+
+        monkeypatch.setattr(
+            "app.services.notifications.firebase.FirebaseService.send_expiration_warning",
+            staticmethod(_send),
+        )
+        now = datetime.now(timezone.utc)
+        device = _make_device(db_session, admin_user, now + timedelta(minutes=30))
+
+        NotificationScheduler.check_and_send_warnings(db_session)  # attempt 1 fails
+        state["fail"] = False
+        for _ in range(4):
+            NotificationScheduler.check_and_send_warnings(db_session)
+
+        assert sends == ["1_hour"]


### PR DESCRIPTION
Behebt #231.

## Problem

`_should_send_warning` loeschte die fehlgeschlagene `ExpirationNotification`-Zeile, bevor `_send_warning` pro Versuch eine **neue** anlegte. Damit war `fail_count` bei jedem Tick genau 1, `1 < 3` immer wahr und der Zweig `Max retries reached` toter Code.

Nachgestellt (5 Ticks, dauerhaft fehlschlagender FCM-Send):

```
FCM-Versuche ueber 5 Ticks:           5     <- Cap von 3 greift nie
ExpirationNotification-Zeilen danach: 1     <- delete + neu pro Tick
```

Ein dauerhaft kaputtes Token wurde so bei jedem Tick (stuendlich plus jeder Resume-/Startup-Catch-up) erneut ueber Firebase versucht, bis das Geraet ablief.

## Warum nicht der im Issue empfohlene Fix

Das Issue empfiehlt Option 1: `db.delete(...)` entfernen und die Fehlversuchszeilen akkumulieren lassen. Das allein macht es **schlimmer**. `_should_send_warning` nahm irgendeine Zeile via `.first()` (ohne `order_by`) und las nur deren `success`-Flag. Bleibt die alte Fehlzeile liegen, findet `.first()` weiterhin sie -- also wird jeden Tick erneut gesendet, obwohl laengst eine Erfolgszeile existiert.

Gemessen mit genau dieser Aenderung (Tick 1 schlaegt fehl, danach gelingen alle Sends):

```
ERFOLGREICHE Pushes an den Nutzer: 4   (erwartet: 1)
Zeilen: [(1_hour, False), (1_hour, True), (1_hour, True), (1_hour, True), (1_hour, True)]
```

Aus "verschwendete FCM-Calls" (Severity niedrig-mittel) waere damit "der Nutzer bekommt die Ablaufwarnung stuendlich erneut aufs Handy" geworden.

## Der Fix

Die Existenzpruefung wird umgedreht, statt nur das `delete` zu streichen:

1. Gibt es eine Zeile mit `success == True`? -> fertig (`Warning already sent`). Deckt auch `_record_superseded` ab, das bewusst `success=True` schreibt.
2. Sonst Fehlversuche zaehlen -- die Zeilen bleiben stehen, `fail_count` waechst echt 1 -> 2 -> 3 -- und ab 3 aufgeben.

Zeilen bleiben damit auf max. 3 pro (Geraet, Warnungstyp, Ablaufdatum) begrenzt; der im Issue erwaehnte Cleanup ist nicht noetig. `get_notification_history()` (limit=10) zeigt die Fehlversuche jetzt als Verlauf -- aus meiner Sicht eine Verbesserung, kein Bruch.

## Tests

- `test_failed_send_stops_after_three_attempts` -- 5 Ticks, dauerhafter Fehler: genau 3 FCM-Versuche, 3 Fehlerzeilen, danach `Max retries reached`.
  Vorher rot: `assert ['1_hour'] * 5 == ['1_hour'] * 3`
- `test_no_resend_after_a_retry_succeeds` -- Guard gegen den naiven Fix: nach einem gelungenen Retry genau ein Push.

```
74 passed   notification_scheduler_catchup, expiry_catchup_on_resume,
            mobile_device_expiry_notification, notification_service,
            notification_events, mobile_timezone_columns
ruff: All checks passed!
```

Volle Backend-Suite: CI (haengt unter Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S5sYDfvoqTacrTUFZvPSK
