### PR TITLE
fix(hardware): RAID-Backend lazy aufloesen, SMART meldet Prod-Ausfall ehrlich (#543)

### DIFF
--- a/backend/app/core/lifespan.py
+++ b/backend/app/core/lifespan.py
@@ -289,13 +289,19 @@ def _log_dev_mode_summary() -> None:
                 return "not started"
         return type(obj).__name__
 
-    from app.services.hardware.raid.api import _backend as raid_backend
+    from app.services.hardware.raid.api import RaidUnavailableError, _get_backend
     from app.services.power.manager import PowerManagerService
     from app.services.power.fan_control import FanControlService
     from app.services.power.sleep import SleepManagerService
 
     lines = ["Dev mode backends active:"]
-    lines.append(f"  RAID: {type(raid_backend).__name__}")
+    try:
+        raid_backend_name = type(_get_backend()).__name__
+    except RaidUnavailableError:
+        # No mdadm on this host -- the banner must never be the thing that
+        # keeps the service from starting (#543).
+        raid_backend_name = "unavailable"
+    lines.append(f"  RAID: {raid_backend_name}")
     lines.append(f"  Power: {_backend_name(lambda: PowerManagerService._instance, '_backend')}")
     lines.append(f"  Fans: {_backend_name(lambda: FanControlService._instance, '_backend')}")
     lines.append(f"  Sleep: {_backend_name(lambda: SleepManagerService._instance, '_backend')}")

--- a/backend/app/services/hardware/__init__.py
+++ b/backend/app/services/hardware/__init__.py
@@ -9,6 +9,7 @@ Provides hardware management with:
 
 from app.services.hardware.raid import (
     RaidBackend,
+    RaidUnavailableError,
     DevRaidBackend,
     MdadmRaidBackend,
     MdstatInfo,
@@ -74,6 +75,7 @@ __all__ = [
     "stop_scrub_scheduler",
     "get_scrub_scheduler_status",
     # SMART
+    "RaidUnavailableError",
     "SmartUnavailableError",
     "get_smart_status",
     "get_cached_smart_status",

--- a/backend/app/services/hardware/raid/__init__.py
+++ b/backend/app/services/hardware/raid/__init__.py
@@ -24,7 +24,8 @@ from app.services.hardware.raid.mdadm_backend import MdadmRaidBackend
 # --- Public API ---
 from app.services.hardware.raid.api import (
     _audit_event,
-    _backend,
+    RaidUnavailableError,
+    _get_backend,
     _payload_to_dict,
     _select_backend,
     add_mock_disk,
@@ -66,9 +67,11 @@ def __getattr__(name: str):
 
     Tests that do ``raid._backend`` or ``raid.settings`` after monkey-patching
     will be redirected to the canonical location in ``api.py`` / ``config``.
+    ``_backend`` resolves lazily now and raises RaidUnavailableError on a host
+    without mdadm -- reading it is a call, not a plain module attribute (#543).
     """
     if name == "_backend":
-        return _api_module._backend
+        return _api_module._get_backend()
     if name == "settings":
         from app.core.config import settings as _s
         return _s
@@ -100,7 +103,8 @@ __all__ = [
     "delete_array",
     "add_mock_disk",
     "find_raid_mountpoint",
-    "_backend",
+    "RaidUnavailableError",
+    "_get_backend",
     "_select_backend",
     "_payload_to_dict",
     "_audit_event",

--- a/backend/app/services/hardware/raid/api.py
+++ b/backend/app/services/hardware/raid/api.py
@@ -8,6 +8,7 @@ from datetime import timezone
 from pathlib import Path
 
 from app.core.config import settings
+from app.core.exceptions import ServiceUnavailableError
 from app.schemas.system import (
     AvailableDisksResponse,
     CreateArrayRequest,
@@ -45,6 +46,15 @@ def find_raid_mountpoint(raid_name: str) -> str | None:
     return None
 
 
+class RaidUnavailableError(ServiceUnavailableError):
+    """No RAID backend on this host (mdadm missing) -> routes answer 503."""
+
+    public_message = "RAID support is not available on this system"
+
+
+_backend_cache: RaidBackend | None = None
+
+
 def _select_backend() -> RaidBackend:
     # Respect explicit override in settings first (useful for tests or CI)
     if getattr(settings, "raid_force_dev_backend", False):
@@ -66,10 +76,22 @@ def _select_backend() -> RaidBackend:
         logger.info("Using mdadm RAID backend")
         return MdadmRaidBackend()
 
-    raise RuntimeError("No supported RAID backend available on this system")
+    raise RaidUnavailableError()
 
 
-_backend = _select_backend()
+def _get_backend() -> RaidBackend:
+    """Resolve the RAID backend on first use and cache it.
+
+    Deliberately NOT resolved at import time. mdadm is an optional dependency
+    (the installer defaults to ENABLE_RAID=false), and a module-level
+    ``_backend = _select_backend()`` turned a missing mdadm into an ImportError
+    that propagated through app.services.hardware into app.main -- the service
+    refused to start at all instead of degrading (#543).
+    """
+    global _backend_cache
+    if _backend_cache is None:
+        _backend_cache = _select_backend()
+    return _backend_cache
 
 
 def _payload_to_dict(payload: object) -> object:
@@ -108,17 +130,28 @@ def _audit_event(action: str, payload: object | None = None, dry_run: bool = Fal
 
 
 def get_status() -> RaidStatusResponse:
-    return _backend.get_status()
+    """Current RAID status, or an empty one when the host has no RAID support.
+
+    The read path degrades instead of failing: a box without mdadm genuinely
+    has no arrays, and dashboards/health already render that state. Mutating
+    calls below deliberately do NOT degrade -- they let RaidUnavailableError
+    through, which the global handler turns into a 503 (#543).
+    """
+    try:
+        return _get_backend().get_status()
+    except RaidUnavailableError:
+        logger.warning("RAID status requested but no backend is available; reporting no arrays")
+        return RaidStatusResponse(arrays=[])
 
 
 def simulate_failure(payload: RaidSimulationRequest) -> RaidActionResponse:
     _audit_event("simulate_failure", payload, dry_run=getattr(settings, "raid_dry_run", False))
-    if getattr(settings, "raid_dry_run", False) and not isinstance(_backend, DevRaidBackend):
+    if getattr(settings, "raid_dry_run", False) and not isinstance(_get_backend(), DevRaidBackend):
         dev = DevRaidBackend()
         resp = dev.degrade(payload)
         resp.message = "[DRY-RUN] " + resp.message
         return resp
-    resp = _backend.degrade(payload)
+    resp = _get_backend().degrade(payload)
     try:
         from app.services.notifications.events import emit_raid_degraded_sync
         emit_raid_degraded_sync(payload.array, details="Manuell ausgelöst (simulate_failure)")
@@ -129,22 +162,22 @@ def simulate_failure(payload: RaidSimulationRequest) -> RaidActionResponse:
 
 def simulate_rebuild(payload: RaidSimulationRequest) -> RaidActionResponse:
     _audit_event("simulate_rebuild", payload, dry_run=getattr(settings, "raid_dry_run", False))
-    if getattr(settings, "raid_dry_run", False) and not isinstance(_backend, DevRaidBackend):
+    if getattr(settings, "raid_dry_run", False) and not isinstance(_get_backend(), DevRaidBackend):
         dev = DevRaidBackend()
         resp = dev.rebuild(payload)
         resp.message = "[DRY-RUN] " + resp.message
         return resp
-    return _backend.rebuild(payload)
+    return _get_backend().rebuild(payload)
 
 
 def finalize_rebuild(payload: RaidSimulationRequest) -> RaidActionResponse:
     _audit_event("finalize_rebuild", payload, dry_run=getattr(settings, "raid_dry_run", False))
-    if getattr(settings, "raid_dry_run", False) and not isinstance(_backend, DevRaidBackend):
+    if getattr(settings, "raid_dry_run", False) and not isinstance(_get_backend(), DevRaidBackend):
         dev = DevRaidBackend()
         resp = dev.finalize(payload)
         resp.message = "[DRY-RUN] " + resp.message
         return resp
-    resp = _backend.finalize(payload)
+    resp = _get_backend().finalize(payload)
     try:
         from app.services.notifications.events import emit_raid_rebuilt_sync
         emit_raid_rebuilt_sync(payload.array)
@@ -155,50 +188,50 @@ def finalize_rebuild(payload: RaidSimulationRequest) -> RaidActionResponse:
 
 def configure_array(payload: RaidOptionsRequest) -> RaidActionResponse:
     _audit_event("configure_array", payload, dry_run=getattr(settings, "raid_dry_run", False))
-    if getattr(settings, "raid_dry_run", False) and not isinstance(_backend, DevRaidBackend):
+    if getattr(settings, "raid_dry_run", False) and not isinstance(_get_backend(), DevRaidBackend):
         dev = DevRaidBackend()
         resp = dev.configure(payload)
         resp.message = "[DRY-RUN] " + resp.message
         return resp
-    return _backend.configure(payload)
+    return _get_backend().configure(payload)
 
 
 def get_available_disks() -> AvailableDisksResponse:
-    return _backend.get_available_disks()
+    return _get_backend().get_available_disks()
 
 
 def format_disk(payload: FormatDiskRequest) -> RaidActionResponse:
     _audit_event("format_disk", payload, dry_run=getattr(settings, "raid_dry_run", False))
-    if getattr(settings, "raid_dry_run", False) and not isinstance(_backend, DevRaidBackend):
+    if getattr(settings, "raid_dry_run", False) and not isinstance(_get_backend(), DevRaidBackend):
         dev = DevRaidBackend()
         resp = dev.format_disk(payload)
         resp.message = "[DRY-RUN] " + resp.message
         return resp
-    return _backend.format_disk(payload)
+    return _get_backend().format_disk(payload)
 
 
 def create_array(payload: CreateArrayRequest) -> RaidActionResponse:
     _audit_event("create_array", payload, dry_run=getattr(settings, "raid_dry_run", False))
-    if getattr(settings, "raid_dry_run", False) and not isinstance(_backend, DevRaidBackend):
+    if getattr(settings, "raid_dry_run", False) and not isinstance(_get_backend(), DevRaidBackend):
         dev = DevRaidBackend()
         resp = dev.create_array(payload)
         resp.message = "[DRY-RUN] " + resp.message
         return resp
-    return _backend.create_array(payload)
+    return _get_backend().create_array(payload)
 
 
 def delete_array(payload: DeleteArrayRequest) -> RaidActionResponse:
     _audit_event("delete_array", payload, dry_run=getattr(settings, "raid_dry_run", False))
-    if getattr(settings, "raid_dry_run", False) and not isinstance(_backend, DevRaidBackend):
+    if getattr(settings, "raid_dry_run", False) and not isinstance(_get_backend(), DevRaidBackend):
         dev = DevRaidBackend()
         resp = dev.delete_array(payload)
         resp.message = "[DRY-RUN] " + resp.message
         return resp
-    return _backend.delete_array(payload)
+    return _get_backend().delete_array(payload)
 
 
 def add_mock_disk(letter: str, size_gb: int, name: str, purpose: str) -> RaidActionResponse:
     """Dev-Mode only: Add a mock disk dynamically."""
-    if not isinstance(_backend, DevRaidBackend):
+    if not isinstance(_get_backend(), DevRaidBackend):
         raise RuntimeError("Mock disk management is only available in dev mode")
-    return _backend.add_mock_disk(letter, size_gb, name, purpose)
+    return _get_backend().add_mock_disk(letter, size_gb, name, purpose)

--- a/backend/app/services/hardware/raid/scrub.py
+++ b/backend/app/services/hardware/raid/scrub.py
@@ -53,17 +53,17 @@ def scrub_now(array: str | None = None) -> RaidActionResponse:
 
     When `array` is None, all known arrays will be triggered.
     """
-    from app.services.hardware.raid.api import _backend
+    from app.services.hardware.raid.api import _get_backend
 
     # Build payload(s) using RaidOptionsRequest
     if array:
         payload = RaidOptionsRequest(array=array, trigger_scrub=True)
-        return _backend.configure(payload)
+        return _get_backend().configure(payload)
 
     # Trigger scrub for all arrays
     status = None
     try:
-        status = _backend.get_status()
+        status = _get_backend().get_status()
     except Exception:
         # If get_status fails (e.g., no arrays), raise a clear error
         raise RuntimeError("Unable to determine RAID arrays for scrubbing")
@@ -72,7 +72,7 @@ def scrub_now(array: str | None = None) -> RaidActionResponse:
     for arr in status.arrays:
         try:
             payload = RaidOptionsRequest(array=arr.name, trigger_scrub=True)
-            resp = _backend.configure(payload)
+            resp = _get_backend().configure(payload)
             messages.append(resp.message)
         except Exception as exc:
             logger.warning("Failed to trigger scrub on %s: %s", arr.name, exc)

--- a/backend/app/services/hardware/smart/api.py
+++ b/backend/app/services/hardware/smart/api.py
@@ -5,6 +5,7 @@ Depends on: cache, collector, mock_data.
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 
 from app.core.config import settings
 from app.schemas.system import SmartStatusResponse
@@ -56,6 +57,11 @@ def _check_smart_for_notifications(status: SmartStatusResponse) -> None:
         logger.debug("Failed to check SMART notifications: %s", exc)
 
 
+def _empty_status() -> SmartStatusResponse:
+    """No SMART data available on this host (smartctl missing / unreadable)."""
+    return SmartStatusResponse(checked_at=datetime.now(tz=timezone.utc), devices=[])
+
+
 def get_smart_status() -> SmartStatusResponse:
     """Return SMART diagnostics information.
 
@@ -91,7 +97,11 @@ def get_smart_status() -> SmartStatusResponse:
                 _cache._set_smart_cache(mock)
                 return mock
 
-    # Production: Versuche echte Daten, Fallback zu Mock
+    # Production: echte Daten -- und sonst eine LEERE Antwort, niemals Mock.
+    # smartmontools ist optional (ENABLE_SMART=false per Default); ohne das
+    # Werkzeug zeigte der Fallback erfundene Platten ("BaluHost Dev Disk 5GB",
+    # status PASSED) auf einer Prod-Box. Keine Daten ist ehrlicher als
+    # erfundene gesunde Hardware (#543).
     try:
         data = _read_real_smart_data()
         if not data.devices:
@@ -100,15 +110,15 @@ def get_smart_status() -> SmartStatusResponse:
         _check_smart_for_notifications(data)
         return data
     except _cache.SmartUnavailableError as e:
-        logger.warning("SMART fallback to mock: %s", e)
-        mock = _mock_status()
-        _cache._set_smart_cache(mock)
-        return mock
+        logger.warning("SMART unavailable, reporting no devices: %s", e)
+        empty = _empty_status()
+        _cache._set_smart_cache(empty)
+        return empty
     except Exception as e:
-        logger.error("SMART unexpected error fallback: %s", e)
-        mock = _mock_status()
-        _cache._set_smart_cache(mock)
-        return mock
+        logger.error("SMART unexpected error, reporting no devices: %s", e)
+        empty = _empty_status()
+        _cache._set_smart_cache(empty)
+        return empty
 
 
 def get_smart_device_models() -> dict[str, str]:

--- a/backend/tests/raid/test_optional_tool_degradation.py
+++ b/backend/tests/raid/test_optional_tool_degradation.py
@@ -80,6 +80,25 @@ class TestRaidBackendUnavailable:
             raid_api.create_array(CreateArrayRequest(name="md9", level="1", devices=["sda", "sdb"]))
 
 
+    def test_dev_mode_banner_survives_without_mdadm(self, monkeypatch):
+        """The startup banner must never be what keeps the service from starting.
+
+        core/lifespan.py pulled ``_backend`` out of raid.api at call time. After
+        the lazy refactor that name was gone, so app startup raised ImportError
+        and every TestClient-based test errored out -- the exact failure mode
+        this fix set out to remove, reintroduced one layer up.
+        """
+        from app.core import lifespan as lifespan_mod
+
+        def _boom():
+            raise raid_api.RaidUnavailableError()
+
+        monkeypatch.setattr(settings, "is_dev_mode", True)
+        monkeypatch.setattr(raid_api, "_get_backend", _boom)
+
+        lifespan_mod._log_dev_mode_summary()  # must not raise
+
+
 class TestSmartUnavailableInProduction:
     def test_prod_without_smartctl_returns_empty_not_mock(self, monkeypatch):
         """Production must report "no data", never invented disks.

--- a/backend/tests/raid/test_optional_tool_degradation.py
+++ b/backend/tests/raid/test_optional_tool_degradation.py
@@ -1,0 +1,106 @@
+"""RAID/SMART degrade gracefully when their optional system tool is missing (#543).
+
+mdadm and smartmontools are optional in the installer (ENABLE_RAID / ENABLE_SMART
+default to false), so a self-hosted box may legitimately run without them.
+"""
+import importlib
+import platform
+from unittest import mock
+
+import pytest
+
+from app.core.config import settings
+from app.core.exceptions import ServiceUnavailableError
+from app.schemas.system import CreateArrayRequest
+import app.services.hardware.raid.api as raid_api
+
+
+def _no_raid_backend():
+    """Context: Linux host, prod mode, mdadm not installed."""
+    return [
+        mock.patch.object(settings, "raid_force_dev_backend", False),
+        mock.patch.object(settings, "is_dev_mode", False),
+        mock.patch.object(platform, "system", return_value="Linux"),
+        mock.patch("shutil.which", return_value=None),
+    ]
+
+
+class TestRaidBackendUnavailable:
+    def test_import_survives_without_mdadm(self):
+        """Importing the module must not resolve the backend (#543).
+
+        _backend = _select_backend() ran at module level, so a missing mdadm
+        raised during import. 14 modules outside the package import
+        app.services.hardware top-level (lifespan, routes/system, the
+        monitoring collectors), so the whole backend refused to start.
+        """
+        patches = _no_raid_backend()
+        for p in patches:
+            p.start()
+        try:
+            importlib.reload(raid_api)
+            assert raid_api._backend_cache is None
+        finally:
+            for p in reversed(patches):
+                p.stop()
+            importlib.reload(raid_api)
+
+    def test_select_backend_raises_raid_unavailable(self):
+        patches = _no_raid_backend()
+        for p in patches:
+            p.start()
+        try:
+            with pytest.raises(raid_api.RaidUnavailableError):
+                raid_api._select_backend()
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+    def test_raid_unavailable_maps_to_503(self):
+        """Routes need no try/except: the global ServiceError handler answers 503."""
+        assert issubclass(raid_api.RaidUnavailableError, ServiceUnavailableError)
+        assert raid_api.RaidUnavailableError().http_status == 503
+
+    def test_get_status_degrades_to_empty(self, monkeypatch):
+        """Read path stays usable: no arrays instead of a 500 (or invented ones)."""
+        def _boom():
+            raise raid_api.RaidUnavailableError()
+
+        monkeypatch.setattr(raid_api, "_get_backend", _boom)
+        status = raid_api.get_status()
+        assert status.arrays == []
+
+    def test_mutating_call_raises_unavailable(self, monkeypatch):
+        """Write path must fail loudly -- an empty answer would be a lie."""
+        def _boom():
+            raise raid_api.RaidUnavailableError()
+
+        monkeypatch.setattr(raid_api, "_get_backend", _boom)
+        with pytest.raises(raid_api.RaidUnavailableError):
+            raid_api.create_array(CreateArrayRequest(name="md9", level="1", devices=["sda", "sdb"]))
+
+
+class TestSmartUnavailableInProduction:
+    def test_prod_without_smartctl_returns_empty_not_mock(self, monkeypatch):
+        """Production must report "no data", never invented disks.
+
+        The prod path fell back to _mock_status() -- "BaluHost Dev Disk 5GB",
+        status PASSED -- so a box without smartmontools showed healthy hardware
+        that does not exist.
+        """
+        from app.services.hardware.smart import api as smart_api
+        from app.services.hardware.smart import cache as smart_cache
+
+        smart_cache.invalidate_smart_cache()
+        monkeypatch.setattr(settings, "is_dev_mode", False)
+
+        def _unavailable():
+            raise smart_cache.SmartUnavailableError("smartctl not found in PATH")
+
+        monkeypatch.setattr(smart_api, "_read_real_smart_data", _unavailable)
+        try:
+            status = smart_api.get_smart_status()
+            assert status.devices == []
+            assert not any("Dev Disk" in d.model for d in status.devices)
+        finally:
+            smart_cache.invalidate_smart_cache()

--- a/backend/tests/raid/test_raid_dry_run.py
+++ b/backend/tests/raid/test_raid_dry_run.py
@@ -41,7 +41,7 @@ def test_raid_dry_run_audit_and_response(tmp_path):
         assert record.get("dry_run") is True
 
         # If the real backend was not already the dev backend, the wrapper should return a DRY-RUN message
-        if not isinstance(raid._backend, DevRaidBackend):
+        if not isinstance(raid._get_backend(), DevRaidBackend):
             assert resp.message.startswith("[DRY-RUN]"), resp.message
 
     finally:

--- a/client/src/components/monitoring/HealthTab.tsx
+++ b/client/src/components/monitoring/HealthTab.tsx
@@ -196,7 +196,7 @@ export function HealthTab() {
             <div className="space-y-2 text-xs text-slate-400">
               <p>of {formatBytes(health.system.disk.total)} total</p>
               <p>{formatBytes(health.system.disk.free)} free</p>
-              {health.smart?.devices.length && (
+              {health.smart && health.smart.devices.length > 0 && (
                 <p>{health.smart.devices.length} drive{health.smart.devices.length > 1 ? 's' : ''} detected</p>
               )}
             </div>


### PR DESCRIPTION
Behebt #543.

## Der Defekt

`raid/api.py` loeste das Backend auf **Modulebene** auf (`_backend = _select_backend()`). Auf einem Linux-Host mit `NAS_MODE=prod` **ohne** installiertes `mdadm` greift keiner der drei Vorab-Zweige, der `RuntimeError` fliegt beim **Import** -- und 14 Module ausserhalb des Pakets importieren `app.services.hardware` top-level (`core/lifespan.py`, `api/routes/system.py`, die Monitoring-Kollektoren). Der Dienst startete also gar nicht.

Der Repro im Issue zeigt nur, dass `_select_backend()` wirft. Ich habe die eigentliche Severity-Behauptung nachgemessen (Linux + `is_dev_mode=False` + `shutil.which` -> `None`):

```
vorher:   IMPORT FAILED: RuntimeError: No supported RAID backend available on this system
          ROUTES IMPORT FAILED: RuntimeError: ...
nachher:  IMPORT OK
          ROUTES IMPORT OK
```

Kein Prod-Incident -- auf BaluNode ist `mdadm` installiert. Relevant ist es, weil der eigene Installer RAID als optionale Funktion fuehrt (`ENABLE_RAID:=false`): wer sie abwaehlt, bekommt eine Box, auf der das Backend nicht hochkommt.

## RAID-Fix

- `_get_backend()` loest beim ersten Gebrauch auf und cacht; kein Modul-Level-Aufruf mehr.
- `RaidUnavailableError` erbt von `ServiceUnavailableError`, damit der globale `ServiceError`-Handler **ohne Routen-Aenderung** 503 mit kuratierter Meldung liefert (statt eines 500 mit Traceback).
- `get_status()` degradiert bewusst zu `arrays=[]` -- eine Box ohne mdadm hat wirklich keine Arrays, und `RaidSummaryCard` wie `get_system_health` rendern diesen Zustand bereits. **Mutierende** Aufrufe (create-array, format-disk, degrade, ...) lassen den Fehler durch: eine leere Antwort waere dort gelogen.
- `raid/__init__.py` re-exportierte `_backend` per From-Import; das `__getattr__`-Shim reicht es jetzt lazy weiter, `scrub.py` nutzt den Accessor.

## SMART-Korrektur (gleicher PR, auf Zuruf)

Das Issue haelt SMART als sauberes Gegenbeispiel hoch. Das stimmt nur zur Haelfte -- SMART sprengt den Import nicht, aber sein Prod-Pfad erfand Daten:

```python
# smart/api.py -- Kommentar im Code: "Production: Versuche echte Daten, Fallback zu Mock"
except _cache.SmartUnavailableError as e:
    mock = _mock_status()   # -> "BaluHost Dev Disk 5GB (Mirror A)", status="PASSED"
```

Eine Box ohne `smartmontools` (ebenfalls `ENABLE_SMART:=false` per Default) zeigte damit kerngesunde Hardware, die es nicht gibt. Der Prod-Pfad liefert jetzt eine leere Geraeteliste; der Dev-Mode-Mock bleibt unangetastet. Das Ergebnis wird weiterhin gecacht, damit ein vorhandenes, aber scheiterndes `smartctl` nicht pro Request in sein 10-s-Timeout laeuft.

**Folgeaenderung im Frontend:** `HealthTab.tsx:199` prueft `health.smart?.devices.length && (...)` -- bei 0 rendert React eine nackte `0` in die Seite. Vorher praktisch unerreichbar (Prod hatte immer Mock-Geraete), durch die Aenderung oben jetzt erreichbar, deshalb hier mitkorrigiert (die Variante mit `?? 0` faellt beim `tsc -b` durch, weil die alte Truthiness-Pruefung auch den Typ verengt hat).

## Tests

`backend/tests/raid/test_optional_tool_degradation.py` -- 6 Tests, **alle vorher rot**:

| Test | prueft |
|---|---|
| `test_import_survives_without_mdadm` | `importlib.reload` unter gepatchtem platform/which |
| `test_select_backend_raises_raid_unavailable` | eigener Fehlertyp statt nacktem RuntimeError |
| `test_raid_unavailable_maps_to_503` | `http_status == 503` ueber die ServiceError-Hierarchie |
| `test_get_status_degrades_to_empty` | Lese-Pfad liefert `arrays == []` |
| `test_mutating_call_raises_unavailable` | Schreib-Pfad wirft |
| `test_prod_without_smartctl_returns_empty_not_mock` | keine "Dev Disk"-Geraete in Prod |

```
256 passed, 2 skipped   tests/raid/, tests/monitoring/, tests/tui/,
                        test_smart_devices_import_history
ruff: All checks passed!

Frontend:  eslint . -> 0 errors (280 Warnungen, alle vorbestehend)
           vitest  -> 287 Dateien, 1430 Tests passed
           npm run build -> built in 7.68s
```

Volle Backend-Suite: CI (haengt unter Windows).

## Bewusst nicht drin

Das optionale zweite Kapitel des Issues (dasselbe Capability-Muster fuer `wireguard-tools`, `rclone`) -- separat, falls gewuenscht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S5sYDfvoqTacrTUFZvPSK
