### PR TITLE
fix: Testisolation (SKIP_APP_INIT) + optionale Werkzeuge einheitlich als 503 (#543)

### DIFF
--- a/backend/app/core/capabilities.py
+++ b/backend/app/core/capabilities.py
@@ -1,0 +1,31 @@
+"""Uniform handling for optional external tools.
+
+RAID (mdadm), VPN (wireguard-tools) and cloud import (rclone) are optional in
+the installer -- the ENABLE_* switches default to false and the package is only
+installed when the feature is selected. A box that deselected a feature must
+say so in plain words instead of failing with an opaque 500 or a raw
+``FileNotFoundError`` (#543).
+"""
+from __future__ import annotations
+
+import shutil
+
+from app.core.exceptions import ServiceUnavailableError
+
+
+class ToolUnavailableError(ServiceUnavailableError):
+    """A required external tool is not installed on this host (-> HTTP 503)."""
+
+
+def require_tool(binary: str, feature: str, package: str | None = None) -> str:
+    """Return the absolute path of ``binary``, or raise ToolUnavailableError.
+
+    The message names the feature *and* the package to install: whoever reads
+    it sees a 503 in the UI or an error string on a failed job, never the
+    traceback that would say which binary was missing.
+    """
+    path = shutil.which(binary)
+    if path is None:
+        hint = f" -- install {package}" if package else ""
+        raise ToolUnavailableError(f"{feature} is not available on this system{hint}")
+    return path

--- a/backend/app/services/cloud/adapters/rclone.py
+++ b/backend/app/services/cloud/adapters/rclone.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Callable, Optional
 
+from app.core.capabilities import require_tool
 from app.services.cloud.adapters.base import CloudAdapter, CloudFile, DownloadResult, UploadResult
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ class RcloneAdapter(CloudAdapter):
 
     async def _run_rclone(self, *args: str, timeout: int = 300) -> str:
         """Run an rclone command via subprocess_exec (no shell) and return stdout."""
+        require_tool("rclone", "Cloud import/export", "rclone")
         config_path = self._get_config_path()
         cmd = ["rclone", "--config", config_path, *args]
 

--- a/backend/app/services/vpn/service.py
+++ b/backend/app/services/vpn/service.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 from app.core.config import settings
+from app.core.capabilities import require_tool
 from app.models.vpn import VPNClient, VPNConfig
 from app.schemas.vpn import VPNConfigResponse
 
@@ -453,7 +454,12 @@ class VPNService:
             private_key = base64.b64encode(secrets.token_bytes(32)).decode()
             public_key = base64.b64encode(secrets.token_bytes(32)).decode()
             return private_key, public_key
-        
+
+        # Checked before the try below: that block converts every exception into
+        # a RuntimeError, which the route turns into an opaque 500. A missing
+        # package deserves a 503 that names it.
+        require_tool("wg", "WireGuard VPN", "wireguard-tools")
+
         try:
             # Generate private key
             private_result = subprocess.run(
@@ -483,7 +489,9 @@ class VPNService:
         """Generate WireGuard preshared key for additional security."""
         if settings.is_dev_mode:
             return base64.b64encode(secrets.token_bytes(32)).decode()
-        
+
+        require_tool("wg", "WireGuard VPN", "wireguard-tools")
+
         try:
             result = subprocess.run(
                 ["wg", "genpsk"],

--- a/backend/tests/integration/test_sync_integration.py
+++ b/backend/tests/integration/test_sync_integration.py
@@ -53,8 +53,11 @@ async def async_client():
         finally:
             pass
 
-    # Ensure app startup does not perform global init/seed
-    os.environ.setdefault("SKIP_APP_INIT", "1")
+    # Ensure app startup does not perform global init/seed. Remember the
+    # previous value: conftest sets SKIP_APP_INIT for the whole session, and
+    # dropping it here leaks into every later test (see teardown).
+    _prev_skip_app_init = os.environ.get("SKIP_APP_INIT")
+    os.environ["SKIP_APP_INIT"] = "1"
     app.dependency_overrides[get_db] = override_get_db
 
     # Patch SessionLocal in modules that call it directly (bypassing get_db).
@@ -106,10 +109,15 @@ async def async_client():
     if _orig_session_local is not None:
         _db_mod.SessionLocal = _orig_session_local
         _meta_mod.SessionLocal = _orig_session_local
-    try:
-        del os.environ["SKIP_APP_INIT"]
-    except Exception:
-        pass
+    # Restore instead of delete. conftest only ``setdefault``s SKIP_APP_INIT
+    # once at import, so an unconditional delete here disarmed it for the rest
+    # of the session: every later test that booted the app ran the real
+    # _startup(). That turned one stale import in core/lifespan.py into 57
+    # errors across unrelated suites in CI, invisible in any partial run (#543).
+    if _prev_skip_app_init is None:
+        os.environ.pop("SKIP_APP_INIT", None)
+    else:
+        os.environ["SKIP_APP_INIT"] = _prev_skip_app_init
 
 
 @pytest.fixture(scope="function")
@@ -621,3 +629,16 @@ class TestSyncPerformance:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])
+
+
+def test_skip_app_init_survives_the_async_client_fixture():
+    """SKIP_APP_INIT must still be armed after this module's fixtures ran.
+
+    Placed last on purpose: pytest executes tests in file order, so by the time
+    this runs the async_client fixture above has been set up and torn down
+    several times. Its teardown used to ``del`` the variable outright, which
+    left every later test in the session booting the real _startup().
+    """
+    import os
+
+    assert os.environ.get("SKIP_APP_INIT") == "1"

--- a/backend/tests/services/test_optional_tool_capabilities.py
+++ b/backend/tests/services/test_optional_tool_capabilities.py
@@ -1,0 +1,85 @@
+"""Optional external tools degrade uniformly (#543, second step).
+
+mdadm was the only one that broke at import time (fixed separately). VPN and
+cloud import resolve their tool at call time -- but failed opaquely: a missing
+wireguard-tools produced HTTP 500 "Failed to generate VPN configuration", and a
+missing rclone a raw FileNotFoundError on the import job.
+"""
+import shutil
+
+import pytest
+
+from app.core.capabilities import ToolUnavailableError, require_tool
+from app.core.config import settings
+from app.core.exceptions import ServiceUnavailableError
+
+
+class TestRequireTool:
+    def test_returns_path_when_present(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda _b: "/usr/bin/thing")
+        assert require_tool("thing", "Thing") == "/usr/bin/thing"
+
+    def test_raises_503_naming_feature_and_package(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda _b: None)
+        with pytest.raises(ToolUnavailableError) as exc:
+            require_tool("wg", "WireGuard VPN", "wireguard-tools")
+        assert exc.value.http_status == 503
+        assert "WireGuard VPN" in str(exc.value)
+        assert "wireguard-tools" in str(exc.value)
+        assert isinstance(exc.value, ServiceUnavailableError)
+
+
+class TestVpnWithoutWireguardTools:
+    def test_keypair_raises_tool_unavailable_not_runtime_error(self, monkeypatch):
+        """Must NOT be a RuntimeError.
+
+        routes/vpn.py catches RuntimeError and answers 500 "Failed to generate
+        VPN configuration". Staying outside that type is what lets the global
+        ServiceError handler answer 503 with the real reason -- so the check
+        also has to sit before the blanket ``except Exception -> RuntimeError``
+        inside the generator.
+        """
+        from app.services.vpn.service import VPNService
+
+        monkeypatch.setattr(settings, "is_dev_mode", False)
+        monkeypatch.setattr(shutil, "which", lambda _b: None)
+
+        with pytest.raises(ToolUnavailableError) as exc:
+            VPNService.generate_wireguard_keypair()
+        assert not isinstance(exc.value, RuntimeError)
+        assert "wireguard-tools" in str(exc.value)
+
+    def test_preshared_key_raises_tool_unavailable(self, monkeypatch):
+        from app.services.vpn.service import VPNService
+
+        monkeypatch.setattr(settings, "is_dev_mode", False)
+        monkeypatch.setattr(shutil, "which", lambda _b: None)
+
+        with pytest.raises(ToolUnavailableError):
+            VPNService.generate_preshared_key()
+
+    def test_dev_mode_still_mocks_keys(self, monkeypatch):
+        """Dev mode never needed the binary and must stay that way."""
+        from app.services.vpn.service import VPNService
+
+        monkeypatch.setattr(settings, "is_dev_mode", True)
+        monkeypatch.setattr(shutil, "which", lambda _b: None)
+
+        private_key, public_key = VPNService.generate_wireguard_keypair()
+        assert private_key and public_key and private_key != public_key
+
+
+class TestRcloneWithoutBinary:
+    @pytest.mark.asyncio
+    async def test_run_rclone_raises_tool_unavailable(self, monkeypatch):
+        """The job record shows this string (export_service stores str(e)),
+        so it must read as a reason, not as "[Errno 2] ... 'rclone'".
+        """
+        from app.services.cloud.adapters.rclone import RcloneAdapter
+
+        adapter = RcloneAdapter.__new__(RcloneAdapter)
+        monkeypatch.setattr(shutil, "which", lambda _b: None)
+
+        with pytest.raises(ToolUnavailableError) as exc:
+            await adapter._run_rclone("lsjson", "remote:")
+        assert "rclone" in str(exc.value)


### PR DESCRIPTION
Zwei unabhaengige Nachzuegler, als zwei getrennte Commits lesbar.

## 1. Testisolation: SKIP_APP_INIT wird wiederhergestellt

`tests/integration/test_sync_integration.py` loeschte `SKIP_APP_INIT` im Fixture-Teardown bedingungslos, waehrend `tests/conftest.py` die Variable nur **einmal per `setdefault`** beim Import setzt. Niemand stellte sie zurueck -- ab diesem Punkt der Session lief jeder Test, der die App hochfaehrt, durch den echten `_startup()`.

Das ist reihenfolgeabhaengig und in Teillaeufen unsichtbar. Was es kostet, hat der vorige PR vorgefuehrt: ein einziger veralteter Import in `core/lifespan.py` wurde dadurch zu **57 CI-Errors** quer durch `tests/{logging,security,setup}`, `test_sleep.py` und die RAID-Scheduler -- Dateien ohne jeden Bezug zur Aenderung -- waehrend genau dieselben Dateien lokal gruen waren.

Die Fixture merkt sich jetzt den vorherigen Wert und stellt ihn wieder her. Der Guard-Test steht bewusst als letzter Test der Datei, damit er die Teardowns davor beobachtet; ohne den Fix: `AssertionError: assert None == '1'`.

## 2. Optionale Werkzeuge: einheitlich 503 statt opakem 500

Das optionale zweite Kapitel aus #543. **Vor dem Bauen gemessen, was ueberhaupt kaputt ist** -- und das Ergebnis weicht von der Issue-Erwartung ab:

Die Import-Abbruch-Fehlerklasse gab es **nur bei RAID** (im vorigen PR behoben). VPN und rclone loesen ihr Werkzeug zur Laufzeit auf, nicht beim Import. Ihr Defekt ist derselbe eine Ebene spaeter -- sie scheitern unverstaendlich:

| Feature | ohne Paket heute | Folge |
|---|---|---|
| VPN (`wireguard-tools`) | `FileNotFoundError` -> `RuntimeError` -> `routes/vpn.py` faengt `RuntimeError` | **HTTP 500** "Failed to generate VPN configuration" |
| Cloud (`rclone`) | `FileNotFoundError` aus `create_subprocess_exec`, gefangen wird nur `TimeoutError` / `returncode != 0` | `export_service` speichert `str(e)` -> **"[Errno 2] No such file or directory: 'rclone'"** im Job-Fehlerfeld |

Neu: `app/core/capabilities.py` mit `require_tool(binary, feature, package)` und `ToolUnavailableError(ServiceUnavailableError)`. Der globale `ServiceError`-Handler macht daraus **503 mit kuratierter Meldung -- ohne Aenderung an einer einzigen Route**.

Zwei Details, die nicht offensichtlich sind:

- Die VPN-Pruefung sitzt **vor** dem `try`. Innerhalb wuerde das blanket `except Exception -> RuntimeError` sie sofort wieder in ein 500 verwandeln. Ein Test sichert genau das ab (`assert not isinstance(exc.value, RuntimeError)`).
- Bei rclone reicht ein einziger Punkt: `_run_rclone`, durch den alle neun Aufrufe laufen.

**Bewusst nicht angefasst:** die `wg-quick`-Pfade in `vpn/service.py` geben bereits `(False, "Failed to ...")`-Tupel zurueck statt zu werfen -- sie degradieren schon, nur mit vager Meldung. Und der Dev-Mode-Mock bleibt unberuehrt; er brauchte das Binary noch nie (eigener Test).

## Tests

```
1532 passed   tests/services/ (komplett)
 177 passed, 2 skipped   vpn-, cloud-, integration- und raid-Suites
ruff: All checks passed!
```

Neu: `test_optional_tool_capabilities.py` (6) und der Isolations-Guard (1).

Und diesmal repo-weit gegengeprueft, wer die geaenderten Symbole nutzt (`generate_wireguard_keypair`, `generate_preshared_key`, `_run_rclone`) -- ausserhalb von `VPNService` selbst und den neuen Tests: niemand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S5sYDfvoqTacrTUFZvPSK
